### PR TITLE
Add user stats page with metrics and visualizations

### DIFF
--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -1,0 +1,47 @@
+from datetime import date
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class VelocityWeekData(BaseModel):
+    """Weekly velocity data showing tasks assigned vs completed."""
+
+    week_start: date = Field(..., description="Start date of the week")
+    assigned: int = Field(..., description="Number of tasks assigned to user this week")
+    completed: int = Field(..., description="Number of tasks completed this week")
+
+
+class HeatmapDayData(BaseModel):
+    """Daily activity data for heatmap visualization."""
+
+    day: date = Field(..., description="Date of activity", serialization_alias="date")
+    activity_count: int = Field(..., description="Number of task activities on this date")
+
+
+class GuildTaskBreakdown(BaseModel):
+    """Task completion breakdown by guild."""
+
+    guild_id: int = Field(..., description="Guild ID")
+    guild_name: str = Field(..., description="Guild name")
+    completed_count: int = Field(..., description="Number of completed tasks in this guild")
+
+
+class UserStatsResponse(BaseModel):
+    """Comprehensive user statistics response."""
+
+    streak: int = Field(..., description="Current streak of consecutive work days (Mon-Fri) with task activity")
+    on_time_rate: float = Field(
+        ..., ge=0, le=100, description="Percentage of completed tasks finished before due date"
+    )
+    avg_completion_days: Optional[float] = Field(
+        None, description="Average days from start_date to completion (only tasks with start_date)"
+    )
+    tasks_completed_total: int = Field(..., description="Total number of completed tasks")
+    tasks_completed_this_week: int = Field(..., description="Number of tasks completed this week")
+    backlog_trend: Literal["Growing", "Shrinking"] = Field(
+        ..., description="Trend based on tasks assigned vs completed this week"
+    )
+    velocity_data: List[VelocityWeekData] = Field(..., description="Weekly velocity data for last 12 weeks")
+    heatmap_data: List[HeatmapDayData] = Field(..., description="Daily activity data for last 365 days")
+    guild_breakdown: List[GuildTaskBreakdown] = Field(..., description="Task completion breakdown by guild")

--- a/backend/app/services/stats_service.py
+++ b/backend/app/services/stats_service.py
@@ -1,0 +1,583 @@
+"""
+Service for calculating user statistics and metrics.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from typing import List, Literal, Optional, Set
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.initiative import Initiative
+from app.models.project import Project
+from app.models.task import Task, TaskAssignee, TaskStatus, TaskStatusCategory
+from app.models.user import User
+from app.schemas.stats import (
+    GuildTaskBreakdown,
+    HeatmapDayData,
+    UserStatsResponse,
+    VelocityWeekData,
+)
+
+
+def _resolve_timezone(timezone_str: str) -> ZoneInfo:
+    """Resolve timezone string to ZoneInfo object, falling back to UTC if invalid."""
+    try:
+        return ZoneInfo(timezone_str)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("UTC")
+
+
+def _get_week_start(dt: date, week_starts_on: int) -> date:
+    """
+    Calculate the start date of the week for a given date.
+
+    Args:
+        dt: The date to calculate week start for
+        week_starts_on: 0=Sunday, 1=Monday, ..., 6=Saturday
+
+    Returns:
+        The date of the week start
+    """
+    days_since_week_start = (dt.weekday() + 1 - week_starts_on) % 7
+    return dt - timedelta(days=days_since_week_start)
+
+
+def _get_week_boundaries(
+    user_tz: ZoneInfo, week_starts_on: int, num_weeks: int = 12
+) -> List[tuple[datetime, datetime]]:
+    """
+    Calculate week boundaries for the last N weeks.
+
+    Returns list of (week_start_datetime, week_end_datetime) tuples in user's timezone.
+    """
+    now_local = datetime.now(user_tz)
+    today_local = now_local.date()
+
+    week_start_date = _get_week_start(today_local, week_starts_on)
+
+    boundaries = []
+    for i in range(num_weeks):
+        week_start = week_start_date - timedelta(weeks=i)
+        week_end = week_start + timedelta(days=7)
+
+        # Convert to datetime at start/end of day in user's timezone
+        start_dt = datetime.combine(week_start, datetime.min.time()).replace(tzinfo=user_tz)
+        end_dt = datetime.combine(week_end, datetime.min.time()).replace(tzinfo=user_tz)
+
+        boundaries.append((start_dt, end_dt))
+
+    return list(reversed(boundaries))  # Return oldest to newest
+
+
+async def calculate_user_streak(
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str,
+    guild_id: Optional[int] = None,
+) -> int:
+    """
+    Calculate the user's current streak of consecutive work days (Mon-Fri) with task activity.
+
+    Task activity includes: task creation dates and task updates for tasks user is assigned to.
+    Weekends do not break the streak.
+    """
+    user_tz = _resolve_timezone(user_timezone)
+    now_local = datetime.now(user_tz)
+    today = now_local.date()
+
+    # Query: Get all dates of task activity (created_at and updated_at) for user's assigned tasks
+    activity_stmt = (
+        select(Task.created_at, Task.updated_at)
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .where(TaskAssignee.user_id == user_id)
+    )
+
+    if guild_id:
+        activity_stmt = (
+            activity_stmt.join(Project, Project.id == Task.project_id)
+            .join(Initiative, Initiative.id == Project.initiative_id)
+            .where(Initiative.guild_id == guild_id)
+        )
+
+    activity_result = await session.exec(activity_stmt)
+    rows = activity_result.all()
+
+    # Collect all activity dates (both created_at and updated_at)
+    activity_dates: Set[date] = set()
+    for created_at, updated_at in rows:
+        if created_at:
+            activity_dates.add(created_at.astimezone(user_tz).date())
+        if updated_at:
+            activity_dates.add(updated_at.astimezone(user_tz).date())
+
+    # Filter to weekdays only (Mon-Fri)
+    weekday_activity = {d for d in activity_dates if d.weekday() < 5}
+
+    if not weekday_activity:
+        return 0
+
+    # Walk backwards from today, counting consecutive work days with activity
+    streak = 0
+    current_date = today
+
+    # Skip if today is weekend
+    if current_date.weekday() >= 5:  # Saturday or Sunday
+        # Go back to Friday
+        days_to_subtract = current_date.weekday() - 4
+        current_date = current_date - timedelta(days=days_to_subtract)
+
+    while True:
+        # If current date is a weekday and has activity
+        if current_date.weekday() < 5:
+            if current_date in weekday_activity:
+                streak += 1
+                current_date = current_date - timedelta(days=1)
+            else:
+                # No activity on this work day, streak is broken
+                break
+        else:
+            # Skip weekends
+            current_date = current_date - timedelta(days=1)
+
+        # Safety check: don't go back more than a year
+        if (today - current_date).days > 365:
+            break
+
+    return streak
+
+
+async def calculate_on_time_rate(
+    session: AsyncSession,
+    user_id: int,
+    guild_id: Optional[int] = None,
+) -> float:
+    """
+    Calculate the percentage of completed tasks that were finished before their due date.
+
+    Returns a percentage between 0 and 100.
+    """
+    stmt = (
+        select(
+            func.count(Task.id).label("total"),
+            func.sum(case((Task.updated_at <= Task.due_date, 1), else_=0)).label("on_time"),
+        )
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .join(TaskStatus, TaskStatus.id == Task.task_status_id)
+        .where(
+            TaskAssignee.user_id == user_id,
+            TaskStatus.category == TaskStatusCategory.done,
+            Task.due_date.is_not(None),
+        )
+    )
+
+    if guild_id:
+        stmt = (
+            stmt.join(Project, Project.id == Task.project_id)
+            .join(Initiative, Initiative.id == Project.initiative_id)
+            .where(Initiative.guild_id == guild_id)
+        )
+
+    result = await session.exec(stmt)
+    row = result.one()
+
+    total = row.total or 0
+    on_time = row.on_time or 0
+
+    if total == 0:
+        return 0.0
+
+    return (on_time / total) * 100.0
+
+
+async def calculate_avg_completion_days(
+    session: AsyncSession,
+    user_id: int,
+    guild_id: Optional[int] = None,
+) -> Optional[float]:
+    """
+    Calculate average days from start_date to completion.
+
+    Only includes tasks that have a start_date set.
+    Returns None if no tasks with start_date are completed.
+    """
+    stmt = (
+        select(func.avg(func.extract("epoch", Task.updated_at - Task.start_date) / 86400))
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .join(TaskStatus, TaskStatus.id == Task.task_status_id)
+        .where(
+            TaskAssignee.user_id == user_id,
+            TaskStatus.category == TaskStatusCategory.done,
+            Task.start_date.is_not(None),
+        )
+    )
+
+    if guild_id:
+        stmt = (
+            stmt.join(Project, Project.id == Task.project_id)
+            .join(Initiative, Initiative.id == Project.initiative_id)
+            .where(Initiative.guild_id == guild_id)
+        )
+
+    result = await session.exec(stmt)
+    avg_days = result.scalar()
+
+    if avg_days is None:
+        return None
+
+    return float(avg_days)
+
+
+async def get_completed_counts(
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str,
+    week_starts_on: int,
+    guild_id: Optional[int] = None,
+) -> tuple[int, int]:
+    """
+    Get total completed tasks and tasks completed this week.
+
+    Returns (total_completed, this_week_completed)
+    """
+    user_tz = _resolve_timezone(user_timezone)
+    now_local = datetime.now(user_tz)
+    today = now_local.date()
+
+    # Calculate this week's boundaries
+    week_start_date = _get_week_start(today, week_starts_on)
+    week_start_dt = datetime.combine(week_start_date, datetime.min.time()).replace(tzinfo=user_tz)
+    week_end_dt = week_start_dt + timedelta(days=7)
+
+    # Convert to UTC for database query
+    week_start_utc = week_start_dt.astimezone(timezone.utc)
+    week_end_utc = week_end_dt.astimezone(timezone.utc)
+
+    base_stmt = (
+        select(
+            func.count(Task.id).label("total"),
+            func.sum(
+                case(
+                    (
+                        (Task.updated_at >= week_start_utc) & (Task.updated_at < week_end_utc),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ).label("this_week"),
+        )
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .join(TaskStatus, TaskStatus.id == Task.task_status_id)
+        .where(TaskAssignee.user_id == user_id, TaskStatus.category == TaskStatusCategory.done)
+    )
+
+    if guild_id:
+        base_stmt = (
+            base_stmt.join(Project, Project.id == Task.project_id)
+            .join(Initiative, Initiative.id == Project.initiative_id)
+            .where(Initiative.guild_id == guild_id)
+        )
+
+    result = await session.exec(base_stmt)
+    row = result.one()
+
+    total = row.total or 0
+    this_week = row.this_week or 0
+
+    return (total, this_week)
+
+
+async def get_velocity_data(
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str,
+    week_starts_on: int,
+    guild_id: Optional[int] = None,
+) -> List[VelocityWeekData]:
+    """
+    Get weekly velocity data for the last 12 weeks.
+
+    Returns list of VelocityWeekData with assigned and completed counts per week.
+    Note: "Assigned" counts tasks created in the week (assumes assignment at creation).
+    """
+    user_tz = _resolve_timezone(user_timezone)
+    week_boundaries = _get_week_boundaries(user_tz, week_starts_on, num_weeks=12)
+
+    velocity_data: List[VelocityWeekData] = []
+
+    for week_start_local, week_end_local in week_boundaries:
+        week_start_utc = week_start_local.astimezone(timezone.utc)
+        week_end_utc = week_end_local.astimezone(timezone.utc)
+
+        # Count assigned tasks this week (using task created_at as proxy for assignment)
+        assigned_stmt = (
+            select(func.count(Task.id))
+            .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+            .where(
+                TaskAssignee.user_id == user_id,
+                Task.created_at >= week_start_utc,
+                Task.created_at < week_end_utc,
+            )
+        )
+
+        if guild_id:
+            assigned_stmt = (
+                assigned_stmt.join(Project, Project.id == Task.project_id)
+                .join(Initiative, Initiative.id == Project.initiative_id)
+                .where(Initiative.guild_id == guild_id)
+            )
+
+        assigned_result = await session.exec(assigned_stmt)
+        assigned_count = assigned_result.scalar() or 0
+
+        # Count completed tasks this week
+        completed_stmt = (
+            select(func.count(Task.id))
+            .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+            .join(TaskStatus, TaskStatus.id == Task.task_status_id)
+            .where(
+                TaskAssignee.user_id == user_id,
+                TaskStatus.category == TaskStatusCategory.done,
+                Task.updated_at >= week_start_utc,
+                Task.updated_at < week_end_utc,
+            )
+        )
+
+        if guild_id:
+            completed_stmt = (
+                completed_stmt.join(Project, Project.id == Task.project_id)
+                .join(Initiative, Initiative.id == Project.initiative_id)
+                .where(Initiative.guild_id == guild_id)
+            )
+
+        completed_result = await session.exec(completed_stmt)
+        completed_count = completed_result.scalar() or 0
+
+        velocity_data.append(
+            VelocityWeekData(
+                week_start=week_start_local.date(),
+                assigned=assigned_count,
+                completed=completed_count,
+            )
+        )
+
+    return velocity_data
+
+
+async def get_heatmap_data(
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str,
+    guild_id: Optional[int] = None,
+) -> List[HeatmapDayData]:
+    """
+    Get daily activity counts for the last 365 days.
+
+    Activity includes task creation and task updates for user's assigned tasks.
+    """
+    user_tz = _resolve_timezone(user_timezone)
+    now_local = datetime.now(user_tz)
+    today = now_local.date()
+
+    # Calculate date range (last 365 days)
+    start_date = today - timedelta(days=365)
+    start_dt = datetime.combine(start_date, datetime.min.time()).replace(tzinfo=user_tz)
+    end_dt = datetime.combine(today + timedelta(days=1), datetime.min.time()).replace(tzinfo=user_tz)
+
+    # Convert to UTC
+    start_utc = start_dt.astimezone(timezone.utc)
+    end_utc = end_dt.astimezone(timezone.utc)
+
+    # Query task activity (created_at and updated_at) for user's assigned tasks
+    activity_stmt = (
+        select(Task.created_at, Task.updated_at)
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .where(TaskAssignee.user_id == user_id)
+    )
+
+    if guild_id:
+        activity_stmt = (
+            activity_stmt.join(Project, Project.id == Task.project_id)
+            .join(Initiative, Initiative.id == Project.initiative_id)
+            .where(Initiative.guild_id == guild_id)
+        )
+
+    result = await session.exec(activity_stmt)
+    rows = result.all()
+
+    # Combine and count by date
+    activity_by_date: dict[date, int] = {}
+    for created_at, updated_at in rows:
+        # Count created_at if in range
+        if created_at and start_utc <= created_at < end_utc:
+            local_date = created_at.astimezone(user_tz).date()
+            activity_by_date[local_date] = activity_by_date.get(local_date, 0) + 1
+
+        # Count updated_at if in range
+        if updated_at and start_utc <= updated_at < end_utc:
+            local_date = updated_at.astimezone(user_tz).date()
+            activity_by_date[local_date] = activity_by_date.get(local_date, 0) + 1
+
+    # Build result with all dates (including zero-activity days)
+    heatmap_data: List[HeatmapDayData] = []
+    current_date = start_date
+    while current_date <= today:
+        activity_count = activity_by_date.get(current_date, 0)
+        heatmap_data.append(HeatmapDayData(day=current_date, activity_count=activity_count))
+        current_date = current_date + timedelta(days=1)
+
+    return heatmap_data
+
+
+async def get_guild_breakdown(
+    session: AsyncSession,
+    user_id: int,
+) -> List[GuildTaskBreakdown]:
+    """
+    Get task completion breakdown by guild.
+
+    Returns count of completed tasks per guild for the user.
+    """
+    from app.models.guild import Guild
+
+    stmt = (
+        select(Guild.id, Guild.name, func.count(Task.id).label("completed_count"))
+        .join(Initiative, Initiative.guild_id == Guild.id)
+        .join(Project, Project.initiative_id == Initiative.id)
+        .join(Task, Task.project_id == Project.id)
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .join(TaskStatus, TaskStatus.id == Task.task_status_id)
+        .where(TaskAssignee.user_id == user_id, TaskStatus.category == TaskStatusCategory.done)
+        .group_by(Guild.id, Guild.name)
+        .order_by(func.count(Task.id).desc())
+    )
+
+    result = await session.exec(stmt)
+    rows = result.all()
+
+    return [
+        GuildTaskBreakdown(guild_id=guild_id, guild_name=guild_name, completed_count=count)
+        for guild_id, guild_name, count in rows
+    ]
+
+
+async def get_backlog_trend(
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str,
+    week_starts_on: int,
+    guild_id: Optional[int] = None,
+) -> Literal["Growing", "Shrinking"]:
+    """
+    Determine if backlog is growing or shrinking this week.
+
+    Returns "Growing" if more tasks assigned than completed this week, else "Shrinking".
+    Note: "Assigned" counts tasks created this week (assumes assignment at creation).
+    """
+    user_tz = _resolve_timezone(user_timezone)
+    now_local = datetime.now(user_tz)
+    today = now_local.date()
+
+    # Calculate this week's boundaries
+    week_start_date = _get_week_start(today, week_starts_on)
+    week_start_dt = datetime.combine(week_start_date, datetime.min.time()).replace(tzinfo=user_tz)
+    week_end_dt = week_start_dt + timedelta(days=7)
+
+    # Convert to UTC
+    week_start_utc = week_start_dt.astimezone(timezone.utc)
+    week_end_utc = week_end_dt.astimezone(timezone.utc)
+
+    # Count assigned this week (using task created_at as proxy for assignment)
+    assigned_stmt = (
+        select(func.count(Task.id))
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .where(
+            TaskAssignee.user_id == user_id,
+            Task.created_at >= week_start_utc,
+            Task.created_at < week_end_utc,
+        )
+    )
+
+    if guild_id:
+        assigned_stmt = (
+            assigned_stmt.join(Project, Project.id == Task.project_id)
+            .join(Initiative, Initiative.id == Project.initiative_id)
+            .where(Initiative.guild_id == guild_id)
+        )
+
+    assigned_result = await session.exec(assigned_stmt)
+    assigned_count = assigned_result.scalar() or 0
+
+    # Count completed this week
+    completed_stmt = (
+        select(func.count(Task.id))
+        .join(TaskAssignee, TaskAssignee.task_id == Task.id)
+        .join(TaskStatus, TaskStatus.id == Task.task_status_id)
+        .where(
+            TaskAssignee.user_id == user_id,
+            TaskStatus.category == TaskStatusCategory.done,
+            Task.updated_at >= week_start_utc,
+            Task.updated_at < week_end_utc,
+        )
+    )
+
+    if guild_id:
+        completed_stmt = (
+            completed_stmt.join(Project, Project.id == Task.project_id)
+            .join(Initiative, Initiative.id == Project.initiative_id)
+            .where(Initiative.guild_id == guild_id)
+        )
+
+    completed_result = await session.exec(completed_stmt)
+    completed_count = completed_result.scalar() or 0
+
+    return "Growing" if assigned_count > completed_count else "Shrinking"
+
+
+async def get_user_stats(
+    session: AsyncSession,
+    user: User,
+    guild_id: Optional[int] = None,
+    days: int = 90,
+) -> UserStatsResponse:
+    """
+    Get comprehensive user statistics.
+
+    Args:
+        session: Database session
+        user: User object
+        guild_id: Optional guild ID to filter stats
+        days: Number of days to include in analysis (not currently used, for future extension)
+
+    Returns:
+        UserStatsResponse with all metrics
+    """
+    # Execute all metric calculations sequentially
+    # Note: SQLAlchemy async sessions don't support concurrent operations on the same session
+    streak = await calculate_user_streak(session, user.id, user.timezone, guild_id)
+    on_time_rate = await calculate_on_time_rate(session, user.id, guild_id)
+    avg_completion_days = await calculate_avg_completion_days(session, user.id, guild_id)
+    tasks_completed_total, tasks_completed_this_week = await get_completed_counts(
+        session, user.id, user.timezone, user.week_starts_on, guild_id
+    )
+    velocity_data = await get_velocity_data(session, user.id, user.timezone, user.week_starts_on, guild_id)
+    heatmap_data = await get_heatmap_data(session, user.id, user.timezone, guild_id)
+    guild_breakdown = await get_guild_breakdown(session, user.id)
+    backlog_trend = await get_backlog_trend(session, user.id, user.timezone, user.week_starts_on, guild_id)
+
+    # If guild_id is specified, filter guild_breakdown to only show that guild
+    if guild_id:
+        guild_breakdown = [g for g in guild_breakdown if g.guild_id == guild_id]
+
+    return UserStatsResponse(
+        streak=streak,
+        on_time_rate=round(on_time_rate, 1),
+        avg_completion_days=round(avg_completion_days, 1) if avg_completion_days is not None else None,
+        tasks_completed_total=tasks_completed_total,
+        tasks_completed_this_week=tasks_completed_this_week,
+        backlog_trend=backlog_trend,
+        velocity_data=velocity_data,
+        heatmap_data=heatmap_data,
+        guild_breakdown=guild_breakdown,
+    )

--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -133,6 +133,11 @@ const UserSettingsDangerZonePage = lazy(() =>
     default: module.UserSettingsDangerZonePage,
   }))
 );
+const UserStatsPage = lazy(() =>
+  import("./pages/UserStatsPage").then((module) => ({
+    default: module.UserStatsPage,
+  }))
+);
 
 export const PageRoutes = () => {
   const location = useLocation();
@@ -210,6 +215,7 @@ export const PageRoutes = () => {
             </>
           )}
         </Route>
+        <Route path="/user-stats" element={<UserStatsPage />} />
         <Route path="/settings" element={<Navigate to="/settings/guild" replace />} />
         <Route path="/settings/guild/*" element={<GuildSettingsLayout />}>
           <Route index element={<SettingsGuildPage />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -316,6 +316,9 @@ export const AppSidebar = () => {
                   <DropdownMenuLabel>My Account</DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
+                    <Link to="/user-stats">My Stats</Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
                     <Link to="/profile">User Settings</Link>
                   </DropdownMenuItem>
                   {isGuildAdmin && (

--- a/frontend/src/components/stats/GuildBreakdownChart.tsx
+++ b/frontend/src/components/stats/GuildBreakdownChart.tsx
@@ -1,0 +1,85 @@
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartContainer, ChartTooltipContent } from "@/components/ui/chart";
+import type { GuildTaskBreakdown } from "@/types/api";
+
+interface GuildBreakdownChartProps {
+  data: GuildTaskBreakdown[];
+}
+
+const COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+export function GuildBreakdownChart({ data }: GuildBreakdownChartProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Tasks by Guild</CardTitle>
+          <CardDescription>Completed tasks breakdown by guild</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground flex h-[300px] items-center justify-center text-sm">
+            No guild data available
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const chartConfig = data.reduce(
+    (acc, guild, index) => {
+      acc[`guild_${guild.guild_id}`] = {
+        label: guild.guild_name,
+        color: COLORS[index % COLORS.length],
+      };
+      return acc;
+    },
+    {} as Record<string, { label: string; color: string }>
+  );
+
+  // Format data for pie chart
+  const pieData = data.map((guild) => ({
+    name: guild.guild_name,
+    value: guild.completed_count,
+    guild_id: guild.guild_id,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Tasks by Guild</CardTitle>
+        <CardDescription>Completed tasks breakdown by guild</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-[300px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={pieData}
+                cx="50%"
+                cy="50%"
+                labelLine={false}
+                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
+                outerRadius={80}
+                fill="#8884d8"
+                dataKey="value"
+              >
+                {pieData.map((entry, index) => (
+                  <Cell key={`cell-${entry.guild_id}`} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip content={<ChartTooltipContent />} />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/stats/HeatmapChart.tsx
+++ b/frontend/src/components/stats/HeatmapChart.tsx
@@ -1,0 +1,91 @@
+import { parseISO } from "date-fns";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { HeatmapDayData } from "@/types/api";
+import { cn } from "@/lib/utils";
+
+interface HeatmapChartProps {
+  data: HeatmapDayData[];
+}
+
+export function HeatmapChart({ data }: HeatmapChartProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Activity Heatmap</CardTitle>
+          <CardDescription>Task activity over the past year</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+            No activity data available
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Find max activity for scaling
+  const maxActivity = Math.max(...data.map((d) => d.activity_count), 1);
+
+  // Get intensity level based on activity count
+  const getIntensity = (count: number): string => {
+    if (count === 0) return "bg-muted";
+    const ratio = count / maxActivity;
+    if (ratio < 0.25) return "bg-green-200 dark:bg-green-900/40";
+    if (ratio < 0.5) return "bg-green-400 dark:bg-green-700/60";
+    if (ratio < 0.75) return "bg-green-600 dark:bg-green-500/80";
+    return "bg-green-700 dark:bg-green-400";
+  };
+
+  // Group data by weeks (7 days per week)
+  const weeks: HeatmapDayData[][] = [];
+  for (let i = 0; i < data.length; i += 7) {
+    weeks.push(data.slice(i, i + 7));
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Activity Heatmap</CardTitle>
+        <CardDescription>Task activity over the past year</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <div className="inline-flex gap-1">
+            {weeks.map((week, weekIndex) => (
+              <div key={weekIndex} className="flex flex-col gap-1">
+                {week.map((day, dayIndex) => {
+                  const date = parseISO(day.date);
+                  const dateStr = date.toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  });
+
+                  return (
+                    <div
+                      key={dayIndex}
+                      className={cn(
+                        "hover:ring-primary h-3 w-3 rounded-sm transition-colors hover:ring-2",
+                        getIntensity(day.activity_count)
+                      )}
+                      title={`${dateStr}: ${day.activity_count} ${day.activity_count === 1 ? "activity" : "activities"}`}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="text-muted-foreground mt-4 flex items-center gap-2 text-xs">
+          <span>Less</span>
+          <div className="bg-muted h-3 w-3 rounded-sm" />
+          <div className="h-3 w-3 rounded-sm bg-green-200 dark:bg-green-900/40" />
+          <div className="h-3 w-3 rounded-sm bg-green-400 dark:bg-green-700/60" />
+          <div className="h-3 w-3 rounded-sm bg-green-600 dark:bg-green-500/80" />
+          <div className="h-3 w-3 rounded-sm bg-green-700 dark:bg-green-400" />
+          <span>More</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/stats/StatsMetricCard.tsx
+++ b/frontend/src/components/stats/StatsMetricCard.tsx
@@ -1,0 +1,48 @@
+import { LucideIcon } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface StatsMetricCardProps {
+  icon: LucideIcon;
+  title: string;
+  value: number | string | null;
+  unit?: string;
+  subtitle?: string;
+  variant?: "default" | "success" | "warning" | "danger";
+}
+
+export function StatsMetricCard({
+  icon: Icon,
+  title,
+  value,
+  unit,
+  subtitle,
+  variant = "default",
+}: StatsMetricCardProps) {
+  const displayValue = value ?? "N/A";
+
+  const variantStyles = {
+    default: "text-foreground",
+    success: "text-green-600 dark:text-green-400",
+    warning: "text-yellow-600 dark:text-yellow-400",
+    danger: "text-red-600 dark:text-red-400",
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="text-muted-foreground h-4 w-4" />
+      </CardHeader>
+      <CardContent>
+        <div className={cn("text-2xl font-bold", variantStyles[variant])}>
+          {displayValue}
+          {unit && value !== null && (
+            <span className="text-muted-foreground ml-1 text-sm">{unit}</span>
+          )}
+        </div>
+        {subtitle && <p className="text-muted-foreground mt-1 text-xs">{subtitle}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/stats/VelocityChart.tsx
+++ b/frontend/src/components/stats/VelocityChart.tsx
@@ -1,0 +1,82 @@
+import { format, parseISO } from "date-fns";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartContainer, ChartTooltipContent } from "@/components/ui/chart";
+import type { VelocityWeekData } from "@/types/api";
+
+interface VelocityChartProps {
+  data: VelocityWeekData[];
+}
+
+const chartConfig = {
+  assigned: {
+    label: "Assigned",
+    color: "var(--chart-1)",
+  },
+  completed: {
+    label: "Completed",
+    color: "var(--chart-2)",
+  },
+};
+
+export function VelocityChart({ data }: VelocityChartProps) {
+  // Format data for display
+  const formattedData = data.map((week) => ({
+    ...week,
+    weekLabel: format(parseISO(week.week_start), "MMM d"),
+  }));
+
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Velocity</CardTitle>
+          <CardDescription>Tasks assigned vs completed per week</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground flex h-[300px] items-center justify-center text-sm">
+            No velocity data available
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Velocity</CardTitle>
+        <CardDescription>Tasks assigned vs completed per week (last 12 weeks)</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-[300px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={formattedData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="weekLabel"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
+              <Tooltip content={<ChartTooltipContent />} />
+              <Legend />
+              <Bar dataKey="assigned" fill="var(--color-assigned)" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="completed" fill="var(--color-completed)" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useUserStats.ts
+++ b/frontend/src/hooks/useUserStats.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/api/client";
+import type { UserStatsResponse } from "@/types/api";
+
+export function useUserStats(guildId?: number | null) {
+  return useQuery({
+    queryKey: ["users", "me", "stats", guildId],
+    queryFn: async () => {
+      const params: Record<string, number> = {};
+      if (guildId) {
+        params.guild_id = guildId;
+      }
+
+      const response = await apiClient.get<UserStatsResponse>("/users/me/stats", { params });
+      return response.data;
+    },
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  });
+}

--- a/frontend/src/pages/UserStatsPage.tsx
+++ b/frontend/src/pages/UserStatsPage.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { Loader2, Flame, Target, Clock, TrendingUp, TrendingDown } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useUserStats } from "@/hooks/useUserStats";
+import { useGuilds } from "@/hooks/useGuilds";
+import { StatsMetricCard } from "@/components/stats/StatsMetricCard";
+import { VelocityChart } from "@/components/stats/VelocityChart";
+import { GuildBreakdownChart } from "@/components/stats/GuildBreakdownChart";
+import { HeatmapChart } from "@/components/stats/HeatmapChart";
+
+const GUILD_FILTER_ALL = "all";
+
+export function UserStatsPage() {
+  const [selectedGuildId, setSelectedGuildId] = useState<string>(GUILD_FILTER_ALL);
+  const { guilds } = useGuilds();
+
+  const guildIdParam = selectedGuildId === GUILD_FILTER_ALL ? null : Number(selectedGuildId);
+  const { data: stats, isLoading, error } = useUserStats(guildIdParam);
+
+  const handleGuildChange = (value: string) => {
+    setSelectedGuildId(value);
+  };
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      {/* Header with Guild filter */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">My Stats</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Track your productivity and task completion metrics
+          </p>
+        </div>
+        <div className="w-full sm:w-[200px]">
+          <Select value={selectedGuildId} onValueChange={handleGuildChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select guild" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={GUILD_FILTER_ALL}>All Guilds</SelectItem>
+              {guilds.map((guild) => (
+                <SelectItem key={guild.id} value={String(guild.id)}>
+                  {guild.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading stats...
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>Failed to load stats. Please try again later.</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Stats content */}
+      {stats && (
+        <>
+          {/* Top Metrics Row - 4 cards */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <StatsMetricCard
+              icon={Flame}
+              title="Current Streak"
+              value={stats.streak}
+              unit="days"
+              subtitle="Consecutive work days"
+              variant={stats.streak >= 7 ? "success" : stats.streak >= 3 ? "warning" : "default"}
+            />
+            <StatsMetricCard
+              icon={Target}
+              title="On-Time Rate"
+              value={stats.on_time_rate.toFixed(1)}
+              unit="%"
+              subtitle="Tasks completed before due date"
+              variant={
+                stats.on_time_rate >= 80
+                  ? "success"
+                  : stats.on_time_rate >= 60
+                    ? "warning"
+                    : "danger"
+              }
+            />
+            <StatsMetricCard
+              icon={Clock}
+              title="Avg Completion"
+              value={stats.avg_completion_days?.toFixed(1) ?? null}
+              unit={stats.avg_completion_days !== null ? "days" : undefined}
+              subtitle="From start to completion"
+            />
+            <StatsMetricCard
+              icon={stats.backlog_trend === "Growing" ? TrendingUp : TrendingDown}
+              title="Backlog Trend"
+              value={stats.backlog_trend}
+              subtitle="This week"
+              variant={stats.backlog_trend === "Shrinking" ? "success" : "warning"}
+            />
+          </div>
+
+          {/* Tasks Completed Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Tasks Completed</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-6 sm:flex-row sm:gap-12">
+                <div>
+                  <div className="text-3xl font-bold">{stats.tasks_completed_total}</div>
+                  <div className="text-muted-foreground mt-1 text-sm">All time</div>
+                </div>
+                <div>
+                  <div className="text-3xl font-bold">{stats.tasks_completed_this_week}</div>
+                  <div className="text-muted-foreground mt-1 text-sm">This week</div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Charts Row */}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <VelocityChart data={stats.velocity_data} />
+            <GuildBreakdownChart data={stats.guild_breakdown} />
+          </div>
+
+          {/* Heatmap Full Width */}
+          <HeatmapChart data={stats.heatmap_data} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -395,3 +395,32 @@ export interface NotificationListResponse {
 export interface NotificationCountResponse {
   unread_count: number;
 }
+
+export interface VelocityWeekData {
+  week_start: string;
+  assigned: number;
+  completed: number;
+}
+
+export interface HeatmapDayData {
+  date: string;
+  activity_count: number;
+}
+
+export interface GuildTaskBreakdown {
+  guild_id: number;
+  guild_name: string;
+  completed_count: number;
+}
+
+export interface UserStatsResponse {
+  streak: number;
+  on_time_rate: number;
+  avg_completion_days: number | null;
+  tasks_completed_total: number;
+  tasks_completed_this_week: number;
+  backlog_trend: "Growing" | "Shrinking";
+  velocity_data: VelocityWeekData[];
+  heatmap_data: HeatmapDayData[];
+  guild_breakdown: GuildTaskBreakdown[];
+}


### PR DESCRIPTION
- Backend: /api/v1/users/me/stats endpoint with comprehensive metrics
- Frontend: /user-stats route with dashboard layout
- Metrics: streak, on-time rate, avg completion time, velocity, heatmap
- Guild filtering: view stats across all guilds or filter by specific guild
- Charts: velocity bar chart, guild breakdown pie chart, activity heatmap