### PR TITLE
Fix tags transfer from templates and race condition in recent views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Backlinks section shows documents that link to the current document
   - Document titles must be unique within each initiative
 
+### Fixed
+
+- Race condition in recording recent project views causing duplicate key errors
+
 ## [0.20.1] - 2026-02-03
 
 ### Changed

--- a/backend/app/services/documents.py
+++ b/backend/app/services/documents.py
@@ -176,17 +176,17 @@ async def duplicate_document(
     session.add(owner_permission)
 
     # Copy tags from source document
-    if hasattr(source, "tag_links") and source.tag_links:
+    source_tag_links = getattr(source, "tag_links", None) or []
+    if source_tag_links:
         session.add_all([
             DocumentTag(
                 document_id=duplicated.id,
                 tag_id=link.tag_id,
             )
-            for link in source.tag_links
+            for link in source_tag_links
         ])
 
     await session.commit()
-    await session.refresh(duplicated)
     return duplicated
 
 


### PR DESCRIPTION
## Summary

- Fix tags not copying when creating documents/projects from templates
- Fix race condition in `_record_recent_project_view` causing duplicate key errors

## Changes

- Use defensive `getattr()` for accessing `tag_links` relationships to handle async loading edge cases
- Add missing tag copying when creating projects from templates (only `duplicate_project` was copying tags, not `create_project`)
- Replace select-then-insert pattern with PostgreSQL upsert in `_record_recent_project_view` to prevent race conditions

## Test plan

- [x] Create a document template with tags, create new document from template → tags should transfer
- [x] Create a project template with tags, create new project from template → tags should transfer  
- [x] Rapidly click on projects to trigger concurrent view recordings → no duplicate key errors