### PR TITLE
fix: prevent guild switching flashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Guild switching no longer flashes back and forth between old and new guild before settling
+
 ## [0.23.0] - 2026-02-05
 
 ### Added

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -240,7 +240,7 @@ export const GuildSidebar = () => {
     [guilds, activeDragId]
   );
 
-  const handleGuildSwitch = async (guildId: number) => {
+  const handleGuildSwitch = (guildId: number) => {
     if (guildId === activeGuildId) return;
 
     const currentPath = location.pathname;
@@ -256,7 +256,9 @@ export const GuildSidebar = () => {
         const match = subPath.match(/^\/([^/]+)/);
         targetSubPath = match ? `/${match[1]}` : "/projects";
       }
-      await switchGuild(guildId);
+      // Fire both in the same tick so URL and context update together,
+      // preventing GuildLayout's useEffect from seeing a mismatch.
+      void switchGuild(guildId);
       router.navigate({ to: guildPath(guildId, targetSubPath) });
       return;
     }
@@ -276,7 +278,7 @@ export const GuildSidebar = () => {
       targetPath = currentPath;
     }
 
-    await switchGuild(guildId);
+    void switchGuild(guildId);
 
     if (targetPath !== "/") {
       router.navigate({ to: targetPath });


### PR DESCRIPTION
## Summary

- Fix guild sidebar switching causing the UI to flash back and forth between old and new guild before settling
- Fire `switchGuild()` and `router.navigate()` in the same synchronous tick so React 18 batches both state updates together, preventing `GuildLayout`'s URL-sync effect from seeing a context/URL mismatch
- Change `applyGuildState` to use a functional state update that preserves the current `activeGuildId` when it's still valid, instead of unconditionally resetting from localStorage on every background refresh

## Test plan

- [x] Switch guilds from the sidebar — should transition immediately with no flashing
- [x] Switch guilds while on a detail page (e.g. `/g/1/projects/5`) — should redirect to the list page in the new guild
- [x] Right-click guild context menu actions (view members, settings) still work
- [x] Refresh the page — correct guild is restored from localStorage
- [x] Open a direct guild URL in a new tab — correct guild loads