### PR TITLE
fix tags not carrying over on recurring tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Duplicate rows appearing in task table when sorting with filters applied
 - Guild switching no longer flashes back and forth between old and new guild before settling
+- Tags now carry over when recurring tasks create their next instance
 
 ## [0.23.0] - 2026-02-05
 


### PR DESCRIPTION
## Summary

- When a recurring task advances to its next instance, tags from the original task are now copied to the new task
- Mirrors the existing pattern used in the duplicate-task handler

## Test plan

- [ ] Create a task with tags and a recurrence rule
- [ ] Mark the task as done so recurrence fires
- [ ] Verify the new recurring instance has the same tags