### PR TITLE
Fix user endpoints returning empty data under RLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- My Stats page returning all zeros after RLS enforcement (endpoint now uses UserSessionDep for proper RLS context)
+- User profile and self-update endpoints returning empty initiative roles under RLS enforcement
+
 ## [0.26.0] - 2026-02-08
 
 ### Added

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -97,7 +97,7 @@ def _normalize_week_starts_on(value: int | str | None) -> int | None:
 
 
 @router.get("/me", response_model=UserRead)
-async def read_users_me(session: SessionDep, current_user: Annotated[User, Depends(get_current_active_user)]) -> User:
+async def read_users_me(session: UserSessionDep, current_user: Annotated[User, Depends(get_current_active_user)]) -> User:
     await initiatives_service.load_user_initiative_roles(session, [current_user])
     return current_user
 
@@ -187,7 +187,7 @@ async def create_user(
 @router.patch("/me", response_model=UserRead)
 async def update_users_me(
     user_in: UserSelfUpdate,
-    session: SessionDep,
+    session: UserSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> User:
     update_data = user_in.dict(exclude_unset=True)


### PR DESCRIPTION
## Summary

- **`/users/me/stats`** used `SessionDep` (no RLS context), so all stats queries on guild-scoped tables returned zeros
- **`GET /users/me`** and **`PATCH /users/me`** had the same issue — `load_user_initiative_roles()` queries `InitiativeMember` + `Initiative` (guild-scoped) and returned empty results
- Switched all three endpoints from `SessionDep` → `UserSessionDep`, which sets `app.user_id` + `app.is_superadmin` RLS context without requiring a guild

## Test plan

- [x] My Stats page shows data (all guilds and filtered by guild)
- [x] `GET /users/me` response includes populated `initiative_roles`
- [x] `PATCH /users/me` response includes populated `initiative_roles`
- [x] `ruff check app` passes