### PR TITLE
Fix env variables being ignored in docker-compose.example.yml

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -31,11 +31,11 @@ services:
       - ./uploads:/app/uploads
     environment:
       # RLS-enforced connection (app_user role, no BYPASSRLS)
-      DATABASE_URL_APP: postgresql+asyncpg://app_user:${APP_USER_PASSWORD:-app_user_password}@db:5432/initiative
+      DATABASE_URL_APP: postgresql+asyncpg://app_user:${APP_USER_PASSWORD:-app_user_password}@db:5432/${POSTGRES_DB:-initiative}
       # Admin connection for migrations and background jobs (app_admin role, BYPASSRLS)
-      DATABASE_URL_ADMIN: postgresql+asyncpg://app_admin:${APP_ADMIN_PASSWORD:-app_admin_password}@db:5432/initiative
+      DATABASE_URL_ADMIN: postgresql+asyncpg://app_admin:${APP_ADMIN_PASSWORD:-app_admin_password}@db:5432/${POSTGRES_DB:-initiative}
       # Fallback URL (used if DATABASE_URL_APP not set; existing setups keep working)
-      DATABASE_URL: postgresql+asyncpg://initiative:initiative@db:5432/initiative
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-initiative}:${POSTGRES_PASSWORD:-initiative}@db:5432/${POSTGRES_DB:-initiative}
       SECRET_KEY: super-secret-key
       ACCESS_TOKEN_EXPIRE_MINUTES: 10080
       APP_URL: ${APP_URL:-http://localhost:8173}


### PR DESCRIPTION
The DB name variable is being ignored in `DATABASE_URL_APP`, `DATABASE_URL_ADMIN`, and `DATABASE_URL`. Additionally, the Postgres user and password variables are being ignored in `DATABASE_URL`.