### PR TITLE
Fix OIDC, access control, and zero-guild issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Supports guild and initiative target types with role selection
   - OIDC-managed memberships tracked separately from manual assignments; manual memberships are never overwritten
   - Stale OIDC-managed memberships automatically removed when claims change
+- PKCE (S256) support for OIDC authentication, required by many identity providers
+- No-guild empty state for users with no guild membership after login, with options to create a guild, redeem an invite, or log out
+- "Source" column in guild and initiative member tables showing whether membership is managed by OIDC or manual
+- Role-based write users now appear in task assignee dropdowns (previously only explicit user permissions were considered)
+
+### Changed
+
+- Renamed `OIDC_DISCOVERY_URL` env variable to `OIDC_ISSUER` (old name still works as fallback); issuer URL no longer requires `/.well-known/openid-configuration` suffix
+- Guild deletion now uses a name-confirmation dialog instead of browser prompt
+- Logout now clears the React Query cache to prevent stale data when switching accounts
 
 ### Fixed
 
 - `BEHIND_PROXY=true` now passes `--proxy-headers` and `--forwarded-allow-ips` to Uvicorn so real client IPs appear in logs and `request.client.host` (#92)
+- Users with no guild membership no longer get 500 errors; backend returns 403 with descriptive message
+- Documents on project dashboard are now filtered by user's document-level permissions (guild admins see all)
+- Project settings button in sidebar now correctly appears for users with role-based write access
+- Removing a user from a guild or initiative now clears their task assignments
+- OIDC sync membership removal now cleans up task assignments
+- Fixed loading state flicker on no-guild screen caused by `useGuilds` dependency cycle
 
 ## [0.28.0] - 2026-02-11
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,7 +32,7 @@ BEHIND_PROXY=false
 
 # OIDC (optional)
 OIDC_ENABLED=false
-OIDC_DISCOVERY_URL=https://accounts.example.com/.well-known/openid-configuration
+OIDC_ISSUER=https://accounts.example.com
 OIDC_CLIENT_ID=your-client-id
 OIDC_CLIENT_SECRET=your-client-secret
 OIDC_PROVIDER_NAME=Example SSO

--- a/backend/alembic/versions/20260212_0050_rename_oidc_discovery_url_to_oidc_issuer.py
+++ b/backend/alembic/versions/20260212_0050_rename_oidc_discovery_url_to_oidc_issuer.py
@@ -1,0 +1,21 @@
+"""Rename oidc_discovery_url to oidc_issuer
+
+Revision ID: 20260212_0050
+Revises: 20260211_0049
+Create Date: 2026-02-12
+"""
+
+from alembic import op
+
+revision = "20260212_0050"
+down_revision = "20260211_0049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("app_settings", "oidc_discovery_url", new_column_name="oidc_issuer")
+
+
+def downgrade() -> None:
+    op.alter_column("app_settings", "oidc_issuer", new_column_name="oidc_discovery_url")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -129,6 +129,11 @@ async def get_guild_membership(
         user=current_user,
         guild_id=requested_guild_id,
     )
+    if guild_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No guild membership. Join or create a guild to continue.",
+        )
     membership = await guilds_service.get_membership(
         session,
         guild_id=guild_id,

--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -75,7 +75,7 @@ async def get_oidc_settings(
     settings_obj = await app_settings_service.get_app_settings(session)
     return OIDCSettingsResponse(
         enabled=settings_obj.oidc_enabled,
-        discovery_url=settings_obj.oidc_discovery_url,
+        issuer=settings_obj.oidc_issuer,
         client_id=settings_obj.oidc_client_id,
         redirect_uri=_backend_redirect_uri(),
         post_login_redirect=_frontend_redirect_uri(),
@@ -94,7 +94,7 @@ async def update_oidc_settings(
     updated = await app_settings_service.update_oidc_settings(
         session,
         enabled=payload.enabled,
-        discovery_url=payload.discovery_url,
+        issuer=payload.issuer,
         client_id=payload.client_id,
         client_secret=payload.client_secret,
         provider_name=payload.provider_name,
@@ -102,7 +102,7 @@ async def update_oidc_settings(
     )
     return OIDCSettingsResponse(
         enabled=updated.oidc_enabled,
-        discovery_url=updated.oidc_discovery_url,
+        issuer=updated.oidc_issuer,
         client_id=updated.oidc_client_id,
         redirect_uri=_backend_redirect_uri(),
         post_login_redirect=_frontend_redirect_uri(),

--- a/backend/app/models/app_setting.py
+++ b/backend/app/models/app_setting.py
@@ -20,7 +20,7 @@ class AppSetting(SQLModel, table=True):
     id: int = Field(default=1, primary_key=True)
 
     oidc_enabled: bool = Field(default=False, nullable=False)
-    oidc_discovery_url: Optional[str] = None
+    oidc_issuer: Optional[str] = None
     oidc_client_id: Optional[str] = None
     oidc_client_secret: Optional[str] = None
     oidc_provider_name: Optional[str] = None

--- a/backend/app/schemas/initiative.py
+++ b/backend/app/schemas/initiative.py
@@ -107,6 +107,7 @@ class InitiativeMemberRead(BaseModel):
     joined_at: datetime
     # Legacy field for backward compatibility
     role: InitiativeRole = InitiativeRole.member
+    oidc_managed: bool = False
     # Permission flags for UI filtering
     can_view_docs: bool = True
     can_view_projects: bool = True
@@ -196,6 +197,7 @@ def serialize_initiative(initiative: "Initiative") -> InitiativeRead:
                 is_manager=is_manager,
                 joined_at=membership.joined_at,
                 role=legacy_role,
+                oidc_managed=membership.oidc_managed,
                 can_view_docs=can_view_docs,
                 can_view_projects=can_view_projects,
                 can_create_docs=can_create_docs,

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, EmailStr, Field
 
 class OIDCSettingsResponse(BaseModel):
     enabled: bool
-    discovery_url: Optional[str] = None
+    issuer: Optional[str] = None
     client_id: Optional[str] = None
     redirect_uri: Optional[str] = None
     post_login_redirect: Optional[str] = None
@@ -15,7 +15,7 @@ class OIDCSettingsResponse(BaseModel):
 
 class OIDCSettingsUpdate(BaseModel):
     enabled: bool
-    discovery_url: Optional[str] = None
+    issuer: Optional[str] = None
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     redirect_uri: Optional[str] = None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -57,6 +57,7 @@ class UserGuildMember(UserPublic):
     """User information for guild member management (includes role/status but not personal settings)"""
     role: UserRole  # Platform role
     guild_role: Optional[str] = None  # Guild role (admin/member) - set by endpoint
+    oidc_managed: bool = False  # Whether membership is managed via OIDC claim mappings
     is_active: bool
     email_verified: bool
     created_at: datetime

--- a/backend/app/services/app_settings.py
+++ b/backend/app/services/app_settings.py
@@ -80,8 +80,8 @@ async def _ensure_app_settings(session: AsyncSession) -> AppSetting:
         if app_config.OIDC_ENABLED and not settings_row.oidc_enabled:
             settings_row.oidc_enabled = True
             updated = True
-        if not settings_row.oidc_discovery_url and app_config.OIDC_DISCOVERY_URL:
-            settings_row.oidc_discovery_url = _normalize_optional_string(app_config.OIDC_DISCOVERY_URL)
+        if not settings_row.oidc_issuer and app_config.OIDC_ISSUER:
+            settings_row.oidc_issuer = _normalize_optional_string(app_config.OIDC_ISSUER)
             updated = True
         if not settings_row.oidc_client_id and app_config.OIDC_CLIENT_ID:
             settings_row.oidc_client_id = _normalize_optional_string(app_config.OIDC_CLIENT_ID)
@@ -105,7 +105,7 @@ async def _ensure_app_settings(session: AsyncSession) -> AppSetting:
     app_settings = AppSetting(
         id=GLOBAL_SETTINGS_ID,
         oidc_enabled=bool(app_config.OIDC_ENABLED),
-        oidc_discovery_url=_normalize_optional_string(app_config.OIDC_DISCOVERY_URL),
+        oidc_issuer=_normalize_optional_string(app_config.OIDC_ISSUER),
         oidc_client_id=_normalize_optional_string(app_config.OIDC_CLIENT_ID),
         oidc_client_secret=_normalize_optional_string(app_config.OIDC_CLIENT_SECRET),
         oidc_provider_name=_normalize_optional_string(app_config.OIDC_PROVIDER_NAME),
@@ -143,7 +143,7 @@ async def update_oidc_settings(
     session: AsyncSession,
     *,
     enabled: bool,
-    discovery_url: str | None,
+    issuer: str | None,
     client_id: str | None,
     client_secret: str | None,
     provider_name: str | None,
@@ -151,7 +151,7 @@ async def update_oidc_settings(
 ) -> AppSetting:
     settings_row = await _ensure_app_settings(session)
     settings_row.oidc_enabled = enabled
-    settings_row.oidc_discovery_url = _normalize_optional_string(discovery_url)
+    settings_row.oidc_issuer = _normalize_optional_string(issuer)
     settings_row.oidc_client_id = _normalize_optional_string(client_id)
     if client_secret is not None:
         settings_row.oidc_client_secret = _normalize_optional_string(client_secret)

--- a/backend/app/services/guilds.py
+++ b/backend/app/services/guilds.py
@@ -58,7 +58,7 @@ async def resolve_user_guild_id(
     *,
     user,
     guild_id: int | None = None,
-) -> int:
+) -> int | None:
     if guild_id is not None:
         return guild_id
     if user and getattr(user, "id", None):
@@ -68,8 +68,7 @@ async def resolve_user_guild_id(
         membership_guild_id = result.first()
         if membership_guild_id:
             return membership_guild_id
-    guild = await get_primary_guild(session)
-    return guild.id
+    return None
 
 
 async def ensure_membership(

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -41,7 +41,7 @@ services:
       APP_URL: ${APP_URL:-http://localhost:8173}
       # Optional: Enable OIDC authentication
       # OIDC_ENABLED: true
-      # OIDC_DISCOVERY_URL: https://your-oidc-provider/.well-known/openid-configuration
+      # OIDC_ISSUER: https://your-oidc-provider
       # OIDC_CLIENT_ID: your-client-id
       # OIDC_CLIENT_SECRET: your-client-secret
       # OIDC_PROVIDER_NAME: Your Provider Name

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -531,8 +531,8 @@ const InitiativeSection = ({
   // Pure DAC: check if user has write access to a specific project
   const canManageProject = (project: Project): boolean => {
     if (!userId) return false;
-    const permission = project.permissions?.find((p) => p.user_id === userId);
-    return permission?.level === "owner" || permission?.level === "write";
+    const level = project.my_permission_level;
+    return level === "owner" || level === "write";
   };
   // Load initial state from storage, default to true if not found
   const [isOpen, setIsOpen] = useState(() => {

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -4,6 +4,7 @@ import { Capacitor } from "@capacitor/core";
 
 import { apiClient, setAuthToken, AUTH_UNAUTHORIZED_EVENT } from "@/api/client";
 import { getItem, setItem, removeItem } from "@/lib/storage";
+import { queryClient } from "@/lib/queryClient";
 import { User } from "../types/api";
 
 interface LoginPayload {
@@ -173,6 +174,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setAuthToken(null);
     removeItem(TOKEN_STORAGE_KEY);
     removeItem(DEVICE_TOKEN_KEY);
+    queryClient.clear();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/hooks/useGuilds.tsx
+++ b/frontend/src/hooks/useGuilds.tsx
@@ -71,6 +71,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
   const [error, setError] = useState<string | null>(null);
   const reorderDebounceRef = useRef<number | null>(null);
   const pendingOrderRef = useRef<number[] | null>(null);
+  const hasFetchedRef = useRef(false);
 
   const canCreateGuilds = user?.can_create_guilds ?? true;
 
@@ -112,11 +113,12 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
     }
 
     // Only show loading indicator on initial load, not background refreshes
-    if (guilds.length === 0) setLoading(true);
+    if (!hasFetchedRef.current) setLoading(true);
 
     setError(null);
     try {
       const response = await apiClient.get<Guild[]>("/guilds/");
+      hasFetchedRef.current = true;
       applyGuildState(response.data);
     } catch (err) {
       console.error("Failed to load guilds", err);
@@ -126,7 +128,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
     } finally {
       setLoading(false);
     }
-  }, [token, user, applyGuildState, guilds.length]);
+  }, [token, user, applyGuildState]);
 
   const flushPendingOrder = useCallback(async () => {
     if (!pendingOrderRef.current) {
@@ -181,6 +183,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
       setActiveGuildId(null);
       setError(null);
       setLoading(false);
+      hasFetchedRef.current = false;
       return;
     }
     void refreshGuilds();

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -529,6 +529,19 @@ export const InitiativeSettingsPage = () => {
         },
       },
       {
+        accessorKey: "oidc_managed",
+        header: "Source",
+        cell: ({ row }) => {
+          return row.original.oidc_managed ? (
+            <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-2 py-1 text-sm font-medium">
+              OIDC
+            </span>
+          ) : (
+            <span className="text-muted-foreground text-sm">Manual</span>
+          );
+        },
+      },
+      {
         id: "actions",
         header: "",
         cell: ({ row }) => {

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -89,6 +89,7 @@ export const ProjectDetailPage = () => {
   }, [viewedProjectId, activeGuildId]);
 
   // Pure DAC: only users with write access (owner or write level) can be assigned tasks
+  // Includes both explicit user permissions and role-based permissions
   const userOptions = useMemo(() => {
     const project = projectQuery.data;
     const allUsers = usersQuery.data ?? [];
@@ -100,11 +101,27 @@ export const ProjectDetailPage = () => {
     }
 
     const allowed = new Set<number>();
+    // Explicit user permissions
     project?.permissions?.forEach((permission) => {
       if (permission.level === "owner" || permission.level === "write") {
         allowed.add(permission.user_id);
       }
     });
+
+    // Role-based permissions: find roles with write access,
+    // then include initiative members with those roles
+    const writeRoleIds = new Set(
+      project.role_permissions
+        ?.filter((rp) => rp.level === "write")
+        .map((rp) => rp.initiative_role_id) ?? []
+    );
+    if (writeRoleIds.size > 0) {
+      project.initiative?.members?.forEach((member) => {
+        if (member.role_id && writeRoleIds.has(member.role_id)) {
+          allowed.add(member.user.id);
+        }
+      });
+    }
 
     return allUsers
       .filter((item) => allowed.has(item.id))

--- a/frontend/src/pages/SettingsAuthPage.tsx
+++ b/frontend/src/pages/SettingsAuthPage.tsx
@@ -19,7 +19,7 @@ import { OidcClaimMappingsSection } from "@/components/admin/OidcClaimMappingsSe
 
 interface OidcSettings {
   enabled: boolean;
-  discovery_url?: string | null;
+  issuer?: string | null;
   client_id?: string | null;
   redirect_uri?: string | null;
   post_login_redirect?: string | null;
@@ -34,7 +34,7 @@ export const SettingsAuthPage = () => {
   const [clientSecret, setClientSecret] = useState("");
   const [formState, setFormState] = useState({
     enabled: false,
-    discovery_url: "",
+    issuer: "",
     client_id: "",
     provider_name: "",
     scopes: "openid profile email",
@@ -65,7 +65,7 @@ export const SettingsAuthPage = () => {
       const settings = oidcQuery.data;
       setFormState({
         enabled: settings.enabled,
-        discovery_url: settings.discovery_url ?? "",
+        issuer: settings.issuer ?? "",
         client_id: settings.client_id ?? "",
         provider_name: settings.provider_name ?? "",
         scopes: settings.scopes.join(" "),
@@ -100,7 +100,7 @@ export const SettingsAuthPage = () => {
     event.preventDefault();
     updateOidcSettings.mutate({
       enabled: formState.enabled,
-      discovery_url: formState.discovery_url || null,
+      issuer: formState.issuer || null,
       client_id: formState.client_id || null,
       provider_name: formState.provider_name || null,
       scopes: formState.scopes.split(/[\s,]+/).filter(Boolean),
@@ -138,14 +138,15 @@ export const SettingsAuthPage = () => {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="discovery-url">Discovery URL</Label>
+              <Label htmlFor="issuer">Issuer</Label>
               <Input
-                id="discovery-url"
+                id="issuer"
                 type="url"
-                value={formState.discovery_url}
+                value={formState.issuer}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, discovery_url: event.target.value }))
+                  setFormState((prev) => ({ ...prev, issuer: event.target.value }))
                 }
+                placeholder="https://accounts.example.com"
               />
             </div>
             <div className="space-y-2">

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -208,6 +208,19 @@ export const SettingsUsersPage = () => {
       },
     },
     {
+      accessorKey: "oidc_managed",
+      header: "Source",
+      cell: ({ row }) => {
+        return row.original.oidc_managed ? (
+          <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-2 py-1 text-sm font-medium">
+            OIDC
+          </span>
+        ) : (
+          <span className="text-muted-foreground text-sm">Manual</span>
+        );
+      },
+    },
+    {
       id: "actions",
       header: "Actions",
       cell: ({ row }) => {
@@ -387,6 +400,7 @@ export const SettingsUsersPage = () => {
             filterInputColumnKey="email"
             filterInputPlaceholder="Filter by email..."
             enableResetSorting
+            enablePagination
           />
         </CardContent>
       </Card>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -16,6 +16,7 @@ export interface UserPublic {
 export interface UserGuildMember extends UserPublic {
   role: UserRole;
   guild_role?: GuildRole;
+  oidc_managed?: boolean;
   is_active: boolean;
   email_verified: boolean;
   created_at: string;
@@ -105,6 +106,7 @@ export interface InitiativeMember {
   role_name?: string | null;
   role_display_name?: string | null;
   is_manager?: boolean;
+  oidc_managed?: boolean;
   joined_at: string;
   can_view_docs?: boolean;
   can_view_projects?: boolean;


### PR DESCRIPTION
## Summary

Addresses feedback from community testing of OIDC integration ([#63](https://github.com/Morelitea/initiative/issues/63)):

- **PKCE support**: OIDC login now includes S256 code challenge/verifier, required by many IdPs (Keycloak, Azure AD)
- **Rename `OIDC_DISCOVERY_URL` to `OIDC_ISSUER`**: Follows convention; old env var still works as fallback. App appends `/.well-known/openid-configuration` internally
- **Zero-guild 500 errors**: Users with no guild membership now get a 403 from the backend and a friendly empty state in the frontend with create/invite/logout options
- **Document permission filtering**: Documents on project dashboard are filtered by user's document-level permissions (guild admins see all)
- **Role-based assignees**: Users with write access via initiative role permissions now appear in task assignee dropdowns
- **OIDC membership visibility**: Guild and initiative member tables show "OIDC" or "Manual" source column
- **Task cleanup on membership removal**: Removing a user from a guild/initiative (or via OIDC sync) now clears their task assignments
- **Guild delete UX**: Uses name-confirmation dialog matching initiative delete flow
- **Logout cache clear**: `queryClient.clear()` on logout prevents stale data when switching accounts
- **Loading flicker fix**: Resolved dependency cycle in `useGuilds` that caused spinner/no-guild state to flash

## Test plan

- [x] OIDC login with IdP that requires PKCE (e.g., Keycloak with PKCE enforced)
- [x] Set `OIDC_ISSUER=https://example.com` (no `.well-known` suffix) — login works; old `OIDC_DISCOVERY_URL` env var still works
- [x] Log in as user with no guild memberships — see no-guild state, no 500s in network tab
- [x] Create guild from no-guild state, redeem invite code
- [x] User with explicit project permission but `can_view_projects=false` on role — can access project via direct link/recent tabs, sidebar hides Projects nav
- [x] Documents on project dashboard only show those the user has permission for
- [x] User with role-based write permission appears in assignee dropdown
- [x] Guild/initiative member tables show OIDC badge for OIDC-managed memberships
- [x] Remove user from initiative — their task assignments are cleared
- [x] OIDC claim removal on re-login — stale memberships and task assignments cleaned up
- [x] Delete guild — name confirmation dialog appears, deletion works
- [x] Log out and log in as different user — no stale sidebar/data from previous session