### PR TITLE
Fix build and lint for test config

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,1 +1,1 @@
-cd frontend && npx lint-staged
+cd frontend && pnpm lint-staged

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -15,6 +15,7 @@ export default defineConfig([
     ignores: [
       "vite.config.ts",
       "vite.config.js",
+      "vitest.config.*",
       "capacitor.config.*",
       "dist/**",
       "public/**",
@@ -33,7 +34,7 @@ export default defineConfig([
       parserOptions: {
         ecmaVersion: "latest",
         sourceType: "module",
-        project: ["./tsconfig.json", "./tsconfig.node.json"],
+        project: ["./tsconfig.json", "./tsconfig.node.json", "./tsconfig.test.json"],
         tsconfigRootDir,
       },
     },

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/__tests__"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "types": [
+      "vite/client",
+      "vitest/globals"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Remove `allowObjectInHTMLChildren` from i18next type declaration that caused `ReactI18NextChildren` to conflict with Radix UI's `SlotProps` (sidebar.tsx, toggle-group.tsx)
- Exclude `src/__tests__` from production `tsc` build since test files use Vitest's `vi` global
- Add `tsconfig.test.json` so ESLint can still type-check test files
- Ignore vitest config files in ESLint (not part of any tsconfig project)

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with zero warnings
- [ ] CI pipeline passes