### PR TITLE
Add guild dashboard landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Guild Dashboard landing page at `/g/:guildId/` with project health, velocity chart, upcoming tasks, recent projects, and initiative overview
+- Guild switching now navigates to the dashboard instead of preserving the previous sub-path
 - "All Projects" and "All Documents" links in the sidebar between favorites and initiatives
 
 ## [0.30.0] - 2026-02-15

--- a/backend/app/schemas/comment.py
+++ b/backend/app/schemas/comment.py
@@ -64,6 +64,19 @@ class CommentRead(CommentBase):
         from_attributes = True
 
 
+class RecentActivityEntry(BaseModel):
+    comment_id: int
+    content: str
+    created_at: datetime
+    author: Optional[CommentAuthor] = None
+    task_id: Optional[int] = None
+    task_title: Optional[str] = None
+    document_id: Optional[int] = None
+    document_title: Optional[str] = None
+    project_id: Optional[int] = None
+    project_name: Optional[str] = None
+
+
 class MentionSuggestion(BaseModel):
     """A suggestion for mention autocomplete."""
 

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1,0 +1,60 @@
+{
+  "title": "Guild Overview",
+  "subtitle": "Guild overview and activity",
+  "loading": "Loading dashboard\u2026",
+  "error": "Failed to load dashboard data. Please try again later.",
+  "quickActions": {
+    "projects": "Projects",
+    "initiatives": "Initiatives",
+    "documents": "Documents"
+  },
+  "metrics": {
+    "tasksThisWeek": "Tasks This Week",
+    "onTimeRate": "On-Time Rate",
+    "currentStreak": "Current Streak",
+    "backlogTrend": "Backlog Trend",
+    "days": "days",
+    "growing": "Growing",
+    "shrinking": "Shrinking"
+  },
+  "projectHealth": {
+    "title": "Project Health",
+    "description": "Task completion progress by project",
+    "noProjects": "No projects yet",
+    "viewAll": "View all",
+    "tasks_one": "{{count}} task",
+    "tasks_other": "{{count}} tasks"
+  },
+  "upcomingTasks": {
+    "title": "Upcoming Tasks",
+    "description": "Tasks sorted by urgency",
+    "noTasks": "No upcoming tasks",
+    "overdue": "Overdue",
+    "today": "Today",
+    "upcoming": "Upcoming",
+    "viewAll": "View all"
+  },
+  "recentComments": {
+    "title": "Recent Comments",
+    "description": "Latest comments across the guild",
+    "noComments": "No comments yet",
+    "onTask": "on {{taskTitle}}",
+    "onDocument": "on {{documentTitle}}",
+    "inProject": "in {{projectName}}"
+  },
+  "recentProjects": {
+    "title": "Recent Projects",
+    "description": "Recently updated projects",
+    "noProjects": "No recent projects"
+  },
+  "initiatives": {
+    "title": "Initiatives",
+    "description": "Active initiatives in this guild",
+    "noInitiatives": "No initiatives yet",
+    "viewAll": "View all",
+    "member_one": "{{count}} member",
+    "member_other": "{{count}} members",
+    "project_one": "{{count}} project",
+    "project_other": "{{count}} projects"
+  }
+}

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1,0 +1,60 @@
+{
+  "title": "Resumen del Gremio",
+  "subtitle": "Resumen y actividad del gremio",
+  "loading": "Cargando panel\u2026",
+  "error": "Error al cargar los datos del panel. Int\u00e9ntalo de nuevo m\u00e1s tarde.",
+  "quickActions": {
+    "projects": "Proyectos",
+    "initiatives": "Iniciativas",
+    "documents": "Documentos"
+  },
+  "metrics": {
+    "tasksThisWeek": "Tareas esta semana",
+    "onTimeRate": "Tasa de puntualidad",
+    "currentStreak": "Racha actual",
+    "backlogTrend": "Tendencia del backlog",
+    "days": "d\u00edas",
+    "growing": "Creciendo",
+    "shrinking": "Reduci\u00e9ndose"
+  },
+  "projectHealth": {
+    "title": "Estado de proyectos",
+    "description": "Progreso de tareas por proyecto",
+    "noProjects": "A\u00fan no hay proyectos",
+    "viewAll": "Ver todos",
+    "tasks_one": "{{count}} tarea",
+    "tasks_other": "{{count}} tareas"
+  },
+  "upcomingTasks": {
+    "title": "Pr\u00f3ximas tareas",
+    "description": "Tareas ordenadas por urgencia",
+    "noTasks": "No hay tareas pr\u00f3ximas",
+    "overdue": "Atrasada",
+    "today": "Hoy",
+    "upcoming": "Pr\u00f3xima",
+    "viewAll": "Ver todas"
+  },
+  "recentComments": {
+    "title": "Comentarios recientes",
+    "description": "Últimos comentarios en el gremio",
+    "noComments": "Aún no hay comentarios",
+    "onTask": "en {{taskTitle}}",
+    "onDocument": "en {{documentTitle}}",
+    "inProject": "en {{projectName}}"
+  },
+  "recentProjects": {
+    "title": "Proyectos recientes",
+    "description": "Proyectos actualizados recientemente",
+    "noProjects": "No hay proyectos recientes"
+  },
+  "initiatives": {
+    "title": "Iniciativas",
+    "description": "Iniciativas activas en este gremio",
+    "noInitiatives": "A\u00fan no hay iniciativas",
+    "viewAll": "Ver todas",
+    "member_one": "{{count}} miembro",
+    "member_other": "{{count}} miembros",
+    "project_one": "{{count}} proyecto",
+    "project_other": "{{count}} proyectos"
+  }
+}

--- a/frontend/src/components/dashboard/InitiativeOverview.tsx
+++ b/frontend/src/components/dashboard/InitiativeOverview.tsx
@@ -1,0 +1,79 @@
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { Layers } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGuildPath } from "@/lib/guildUrl";
+import type { Initiative, Project } from "@/types/api";
+
+interface InitiativeOverviewProps {
+  initiatives: Initiative[];
+  projects: Project[];
+  isLoading?: boolean;
+}
+
+export function InitiativeOverview({ initiatives, projects, isLoading }: InitiativeOverviewProps) {
+  const { t } = useTranslation("dashboard");
+  const gp = useGuildPath();
+
+  const items = initiatives.map((initiative) => ({
+    ...initiative,
+    projectCount: projects.filter((p) => p.initiative_id === initiative.id && !p.is_archived)
+      .length,
+  }));
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle>{t("initiatives.title")}</CardTitle>
+          <CardDescription>{t("initiatives.description")}</CardDescription>
+        </div>
+        <Button variant="ghost" size="sm" asChild>
+          <Link to={gp("/initiatives")}>{t("initiatives.viewAll")}</Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 w-full" />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="text-muted-foreground flex h-[120px] items-center justify-center text-sm">
+            <div className="flex flex-col items-center gap-2">
+              <Layers className="h-8 w-8 opacity-50" />
+              <span>{t("initiatives.noInitiatives")}</span>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {items.map((initiative) => (
+              <Link
+                key={initiative.id}
+                to={gp(`/initiatives/${initiative.id}`)}
+                className="hover:bg-accent flex items-start gap-3 rounded-lg border p-3 transition-colors"
+              >
+                <div
+                  className="mt-0.5 h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: initiative.color || "var(--muted)" }}
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{initiative.name}</p>
+                  <div className="text-muted-foreground mt-1 flex items-center gap-2 text-xs">
+                    <span>{t("initiatives.member", { count: initiative.members.length })}</span>
+                    <span aria-hidden="true">&middot;</span>
+                    <span>{t("initiatives.project", { count: initiative.projectCount })}</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/ProjectHealthList.tsx
+++ b/frontend/src/components/dashboard/ProjectHealthList.tsx
@@ -1,0 +1,94 @@
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { FolderKanban } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGuildPath } from "@/lib/guildUrl";
+import type { Project } from "@/types/api";
+
+interface ProjectHealthListProps {
+  projects: Project[];
+  isLoading?: boolean;
+}
+
+function getHealthPercent(project: Project): number {
+  const summary = project.task_summary;
+  if (!summary || summary.total === 0) return 0;
+  return Math.round((summary.completed / summary.total) * 100);
+}
+
+export function ProjectHealthList({ projects, isLoading }: ProjectHealthListProps) {
+  const { t } = useTranslation("dashboard");
+  const gp = useGuildPath();
+
+  const sorted = [...projects]
+    .filter((p) => !p.is_archived && p.task_summary && p.task_summary.total > 0)
+    .sort((a, b) => getHealthPercent(a) - getHealthPercent(b))
+    .slice(0, 6);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle>{t("projectHealth.title")}</CardTitle>
+          <CardDescription>{t("projectHealth.description")}</CardDescription>
+        </div>
+        <Button variant="ghost" size="sm" asChild>
+          <Link to={gp("/projects")}>{t("projectHealth.viewAll")}</Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-2 w-full" />
+              </div>
+            ))}
+          </div>
+        ) : sorted.length === 0 ? (
+          <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+            <div className="flex flex-col items-center gap-2">
+              <FolderKanban className="h-8 w-8 opacity-50" />
+              <span>{t("projectHealth.noProjects")}</span>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {sorted.map((project) => {
+              const percent = getHealthPercent(project);
+              const total = project.task_summary?.total ?? 0;
+              return (
+                <Link
+                  key={project.id}
+                  to={gp(`/projects/${project.id}`)}
+                  className="hover:bg-accent block space-y-1.5 rounded-md p-2 transition-colors"
+                >
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2 font-medium">
+                      {project.icon && <span>{project.icon}</span>}
+                      {project.name}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {t("projectHealth.tasks", { count: total })}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Progress value={percent} className="h-2 flex-1" />
+                    <span className="text-muted-foreground w-10 text-right text-xs">
+                      {percent}%
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/RecentCommentsList.tsx
+++ b/frontend/src/components/dashboard/RecentCommentsList.tsx
@@ -1,0 +1,133 @@
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { formatDistanceToNow, parseISO } from "date-fns";
+import { MessageSquare } from "lucide-react";
+
+import { CommentContent } from "@/components/comments/CommentContent";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGuildPath } from "@/lib/guildUrl";
+import type { RecentActivityEntry } from "@/types/api";
+
+interface RecentCommentsListProps {
+  comments: RecentActivityEntry[];
+  isLoading?: boolean;
+}
+
+function getInitials(name?: string | null, email?: string): string {
+  if (name) {
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2);
+  }
+  return (email ?? "?")[0].toUpperCase();
+}
+
+export function RecentCommentsList({ comments, isLoading }: RecentCommentsListProps) {
+  const { t } = useTranslation("dashboard");
+  const gp = useGuildPath();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("recentComments.title")}</CardTitle>
+        <CardDescription>{t("recentComments.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex gap-3">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <div className="flex-1 space-y-1">
+                  <Skeleton className="h-3 w-1/3" />
+                  <Skeleton className="h-4 w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : comments.length === 0 ? (
+          <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+            <div className="flex flex-col items-center gap-2">
+              <MessageSquare className="h-8 w-8 opacity-50" />
+              <span>{t("recentComments.noComments")}</span>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {comments.map((entry) => {
+              const linkTo = entry.task_id
+                ? gp(`/tasks/${entry.task_id}`)
+                : entry.document_id
+                  ? gp(`/documents/${entry.document_id}`)
+                  : undefined;
+
+              const contextParts: string[] = [];
+              if (entry.task_title) {
+                contextParts.push(t("recentComments.onTask", { taskTitle: entry.task_title }));
+              } else if (entry.document_title) {
+                contextParts.push(
+                  t("recentComments.onDocument", { documentTitle: entry.document_title })
+                );
+              }
+              if (entry.project_name) {
+                contextParts.push(
+                  t("recentComments.inProject", { projectName: entry.project_name })
+                );
+              }
+
+              const content = (
+                <div className="flex gap-3">
+                  <Avatar className="h-8 w-8 shrink-0">
+                    <AvatarImage
+                      src={entry.author?.avatar_url ?? entry.author?.avatar_base64 ?? undefined}
+                    />
+                    <AvatarFallback className="text-xs">
+                      {getInitials(entry.author?.full_name, entry.author?.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline gap-2">
+                      <span className="truncate text-sm font-medium">
+                        {entry.author?.full_name ?? entry.author?.email ?? "Unknown"}
+                      </span>
+                      <span className="text-muted-foreground shrink-0 text-xs">
+                        {formatDistanceToNow(parseISO(entry.created_at), { addSuffix: true })}
+                      </span>
+                    </div>
+                    {contextParts.length > 0 && (
+                      <p className="text-muted-foreground truncate text-xs">
+                        {contextParts.join(" ")}
+                      </p>
+                    )}
+                    <p className="mt-0.5 line-clamp-2 text-sm">
+                      <CommentContent content={entry.content} />
+                    </p>
+                  </div>
+                </div>
+              );
+
+              return linkTo ? (
+                <Link
+                  key={entry.comment_id}
+                  to={linkTo}
+                  className="hover:bg-accent block rounded-md p-2 transition-colors"
+                >
+                  {content}
+                </Link>
+              ) : (
+                <div key={entry.comment_id} className="p-2">
+                  {content}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/UpcomingTasksList.tsx
+++ b/frontend/src/components/dashboard/UpcomingTasksList.tsx
@@ -1,0 +1,122 @@
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { format, parseISO, isToday, isBefore, startOfDay } from "date-fns";
+import { CalendarClock } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGuildPath } from "@/lib/guildUrl";
+import type { Task } from "@/types/api";
+
+interface UpcomingTasksListProps {
+  tasks: Task[];
+  isLoading?: boolean;
+}
+
+function getDueBadgeVariant(
+  dueDate: string | undefined
+): "destructive" | "default" | "secondary" | null {
+  if (!dueDate) return null;
+  const due = parseISO(dueDate);
+  const now = new Date();
+  if (isBefore(due, startOfDay(now))) return "destructive";
+  if (isToday(due)) return "default";
+  return "secondary";
+}
+
+function getDueBadgeLabelKey(dueDate: string | undefined): string | null {
+  if (!dueDate) return null;
+  const due = parseISO(dueDate);
+  const now = new Date();
+  if (isBefore(due, startOfDay(now))) return "upcomingTasks.overdue";
+  if (isToday(due)) return "upcomingTasks.today";
+  return "upcomingTasks.upcoming";
+}
+
+const priorityOrder: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  none: 4,
+};
+
+export function UpcomingTasksList({ tasks, isLoading }: UpcomingTasksListProps) {
+  const { t } = useTranslation("dashboard");
+  const gp = useGuildPath();
+
+  const sorted = [...tasks].sort((a, b) => {
+    // Overdue first, then by due date, then by priority
+    const aDate = a.due_date ? parseISO(a.due_date).getTime() : Infinity;
+    const bDate = b.due_date ? parseISO(b.due_date).getTime() : Infinity;
+    if (aDate !== bDate) return aDate - bDate;
+    return (priorityOrder[a.priority] ?? 4) - (priorityOrder[b.priority] ?? 4);
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("upcomingTasks.title")}</CardTitle>
+        <CardDescription>{t("upcomingTasks.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="h-4 flex-1" />
+                <Skeleton className="h-5 w-16" />
+              </div>
+            ))}
+          </div>
+        ) : sorted.length === 0 ? (
+          <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+            <div className="flex flex-col items-center gap-2">
+              <CalendarClock className="h-8 w-8 opacity-50" />
+              <span>{t("upcomingTasks.noTasks")}</span>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {sorted.map((task) => {
+              const badgeVariant = getDueBadgeVariant(task.due_date);
+              const badgeLabelKey = getDueBadgeLabelKey(task.due_date);
+              return (
+                <Link
+                  key={task.id}
+                  to={gp(`/tasks/${task.id}`)}
+                  className="hover:bg-accent flex items-center gap-3 rounded-md px-2 py-2 transition-colors"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{task.title}</p>
+                    {task.project_name && (
+                      <p className="text-muted-foreground truncate text-xs">{task.project_name}</p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {task.due_date && (
+                      <span className="text-muted-foreground text-xs">
+                        {format(parseISO(task.due_date), "MMM d")}
+                      </span>
+                    )}
+                    {badgeVariant && badgeLabelKey && (
+                      <Badge variant={badgeVariant} className="text-xs">
+                        {t(
+                          badgeLabelKey as
+                            | "upcomingTasks.overdue"
+                            | "upcomingTasks.today"
+                            | "upcomingTasks.upcoming"
+                        )}
+                      </Badge>
+                    )}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -23,6 +23,7 @@ export const namespaces = [
   "landing",
   "errors",
   "dates",
+  "dashboard",
 ] as const;
 
 const LANGUAGE_STORAGE_KEY = "initiative-language";

--- a/frontend/src/pages/GuildDashboardPage.tsx
+++ b/frontend/src/pages/GuildDashboardPage.tsx
@@ -1,0 +1,264 @@
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import {
+  CheckCircle2,
+  Clock,
+  Flame,
+  ListTodo,
+  Users,
+  ScrollText,
+  TrendingDown,
+  TrendingUp,
+} from "lucide-react";
+
+import { apiClient } from "@/api/client";
+import { useGuilds } from "@/hooks/useGuilds";
+import { useUserStats } from "@/hooks/useUserStats";
+import { useGuildPath } from "@/lib/guildUrl";
+import { StatsMetricCard } from "@/components/stats/StatsMetricCard";
+import { VelocityChart } from "@/components/stats/VelocityChart";
+import { ProjectHealthList } from "@/components/dashboard/ProjectHealthList";
+import { UpcomingTasksList } from "@/components/dashboard/UpcomingTasksList";
+import { InitiativeOverview } from "@/components/dashboard/InitiativeOverview";
+import { RecentCommentsList } from "@/components/dashboard/RecentCommentsList";
+import { ProgressCircle } from "@/components/ui/progress-circle";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { FavoriteProjectButton } from "@/components/projects/FavoriteProjectButton";
+import type { Initiative, Project, RecentActivityEntry, TaskListResponse } from "@/types/api";
+
+export function GuildDashboardPage() {
+  const { t } = useTranslation("dashboard");
+  const { activeGuildId, activeGuild } = useGuilds();
+  const gp = useGuildPath();
+
+  const statsQuery = useUserStats(activeGuildId);
+
+  const projectsQuery = useQuery<Project[]>({
+    queryKey: ["projects", activeGuildId],
+    queryFn: async () => {
+      const response = await apiClient.get<Project[]>("/projects/");
+      return response.data;
+    },
+    staleTime: 60_000,
+    enabled: Boolean(activeGuild),
+  });
+
+  const initiativesQuery = useQuery<Initiative[]>({
+    queryKey: ["initiatives", activeGuildId],
+    queryFn: async () => {
+      const response = await apiClient.get<Initiative[]>("/initiatives/");
+      return response.data;
+    },
+    staleTime: 60_000,
+    enabled: Boolean(activeGuild),
+  });
+
+  const upcomingTasksQuery = useQuery<TaskListResponse>({
+    queryKey: ["tasks", "dashboard-upcoming", activeGuildId],
+    queryFn: async () => {
+      const response = await apiClient.get<TaskListResponse>("/tasks/", {
+        params: {
+          status_category: ["backlog", "todo", "in_progress"],
+          sort_by: "due_date",
+          sort_dir: "asc",
+          page_size: 10,
+        },
+      });
+      return response.data;
+    },
+    staleTime: 60_000,
+    enabled: Boolean(activeGuild),
+  });
+
+  const recentCommentsQuery = useQuery<RecentActivityEntry[]>({
+    queryKey: ["comments", "recent", activeGuildId],
+    queryFn: async () => {
+      const response = await apiClient.get<RecentActivityEntry[]>("/comments/recent", {
+        params: { limit: 10 },
+      });
+      return response.data;
+    },
+    staleTime: 60_000,
+    enabled: Boolean(activeGuild),
+  });
+
+  const stats = statsQuery.data;
+
+  const onTimeVariant =
+    stats?.on_time_rate == null
+      ? "default"
+      : stats.on_time_rate >= 80
+        ? "success"
+        : stats.on_time_rate >= 50
+          ? "warning"
+          : "danger";
+
+  // Recent projects sorted by updated_at
+  const recentProjects = [...(projectsQuery.data ?? [])]
+    .filter((p) => !p.is_archived)
+    .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+    .slice(0, 6);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+            {activeGuild?.name ?? t("title")}
+          </h1>
+          <p className="text-muted-foreground">{t("subtitle")}</p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link to={gp("/initiatives")}>
+              <Users className="h-4 w-4" />
+              {t("quickActions.initiatives")}
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link to={gp("/projects")}>
+              <ListTodo className="h-4 w-4" />
+              {t("quickActions.projects")}
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link to={gp("/documents")}>
+              <ScrollText className="h-4 w-4" />
+              {t("quickActions.documents")}
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Metrics Row */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <StatsMetricCard
+          icon={CheckCircle2}
+          title={t("metrics.tasksThisWeek")}
+          value={stats?.tasks_completed_this_week ?? null}
+        />
+        <StatsMetricCard
+          icon={Clock}
+          title={t("metrics.onTimeRate")}
+          value={stats?.on_time_rate != null ? Math.round(stats.on_time_rate) : null}
+          unit="%"
+          variant={onTimeVariant as "default" | "success" | "warning" | "danger"}
+        />
+        <StatsMetricCard
+          icon={Flame}
+          title={t("metrics.currentStreak")}
+          value={stats?.streak ?? null}
+          unit={t("metrics.days")}
+        />
+        <StatsMetricCard
+          icon={stats?.backlog_trend === "Growing" ? TrendingUp : TrendingDown}
+          title={t("metrics.backlogTrend")}
+          value={
+            stats?.backlog_trend
+              ? stats.backlog_trend === "Growing"
+                ? t("metrics.growing")
+                : t("metrics.shrinking")
+              : null
+          }
+          variant={stats?.backlog_trend === "Growing" ? "warning" : "success"}
+        />
+      </div>
+
+      {/* Charts Row */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <VelocityChart data={stats?.velocity_data ?? []} />
+        <ProjectHealthList
+          projects={projectsQuery.data ?? []}
+          isLoading={projectsQuery.isLoading}
+        />
+      </div>
+
+      {/* Activity Row */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <UpcomingTasksList
+          tasks={upcomingTasksQuery.data?.items ?? []}
+          isLoading={upcomingTasksQuery.isLoading}
+        />
+
+        {/* Recent Projects */}
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("recentProjects.title")}</CardTitle>
+            <CardDescription>{t("recentProjects.description")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {projectsQuery.isLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-3">
+                    <Skeleton className="h-10 w-10 rounded-full" />
+                    <Skeleton className="h-4 flex-1" />
+                  </div>
+                ))}
+              </div>
+            ) : recentProjects.length === 0 ? (
+              <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+                <div className="flex flex-col items-center gap-2">
+                  <ListTodo className="h-8 w-8 opacity-50" />
+                  <span>{t("recentProjects.noProjects")}</span>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-1">
+                {recentProjects.map((project) => {
+                  const percent =
+                    project.task_summary && project.task_summary.total > 0
+                      ? Math.round(
+                          (project.task_summary.completed / project.task_summary.total) * 100
+                        )
+                      : 0;
+                  return (
+                    <div
+                      key={project.id}
+                      className="hover:bg-accent flex items-center gap-3 rounded-md px-2 py-2 transition-colors"
+                    >
+                      <Link
+                        to={gp(`/projects/${project.id}`)}
+                        className="flex min-w-0 flex-1 items-center gap-3"
+                      >
+                        <ProgressCircle value={percent} className="h-10 w-10 shrink-0" />
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium">
+                            {project.icon && <span className="mr-1">{project.icon}</span>}
+                            {project.name}
+                          </p>
+                        </div>
+                      </Link>
+                      <FavoriteProjectButton
+                        projectId={project.id}
+                        isFavorited={project.is_favorited ?? false}
+                        suppressNavigation
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Initiatives & Comments Row */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <InitiativeOverview
+          initiatives={initiativesQuery.data ?? []}
+          projects={projectsQuery.data ?? []}
+          isLoading={initiativesQuery.isLoading}
+        />
+        <RecentCommentsList
+          comments={recentCommentsQuery.data ?? []}
+          isLoading={recentCommentsQuery.isLoading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdRouteImport } from './route
 import { Route as ServerRequiredAuthenticatedDocumentsDocumentIdRouteImport } from './routes/_serverRequired/_authenticated/documents_.$documentId'
 import { Route as ServerRequiredAuthenticatedSettingsGuildIndexRouteImport } from './routes/_serverRequired/_authenticated/settings/guild/index'
 import { Route as ServerRequiredAuthenticatedSettingsAdminIndexRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/index'
+import { Route as ServerRequiredAuthenticatedGGuildIdIndexRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/index'
 import { Route as ServerRequiredAuthenticatedSettingsGuildUsersRouteImport } from './routes/_serverRequired/_authenticated/settings/guild/users'
 import { Route as ServerRequiredAuthenticatedSettingsGuildAiRouteImport } from './routes/_serverRequired/_authenticated/settings/guild/ai'
 import { Route as ServerRequiredAuthenticatedSettingsAdminUsersRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/users'
@@ -287,6 +288,12 @@ const ServerRequiredAuthenticatedSettingsAdminIndexRoute =
     path: '/',
     getParentRoute: () => ServerRequiredAuthenticatedSettingsAdminRoute,
   } as any)
+const ServerRequiredAuthenticatedGGuildIdIndexRoute =
+  ServerRequiredAuthenticatedGGuildIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
+  } as any)
 const ServerRequiredAuthenticatedSettingsGuildUsersRoute =
   ServerRequiredAuthenticatedSettingsGuildUsersRouteImport.update({
     id: '/users',
@@ -492,6 +499,7 @@ export interface FileRoutesByFullPath {
   '/settings/admin/users': typeof ServerRequiredAuthenticatedSettingsAdminUsersRoute
   '/settings/guild/ai': typeof ServerRequiredAuthenticatedSettingsGuildAiRoute
   '/settings/guild/users': typeof ServerRequiredAuthenticatedSettingsGuildUsersRoute
+  '/g/$guildId/': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
   '/settings/admin/': typeof ServerRequiredAuthenticatedSettingsAdminIndexRoute
   '/settings/guild/': typeof ServerRequiredAuthenticatedSettingsGuildIndexRoute
   '/g/$guildId/documents/$documentId': typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
@@ -525,7 +533,6 @@ export interface FileRoutesByTo {
   '/invite/$code': typeof ServerRequiredInviteCodeRoute
   '/oidc/callback': typeof ServerRequiredOidcCallbackRoute
   '/documents/$documentId': typeof ServerRequiredAuthenticatedDocumentsDocumentIdRoute
-  '/g/$guildId': typeof ServerRequiredAuthenticatedGGuildIdRouteWithChildren
   '/initiatives/$initiativeId': typeof ServerRequiredAuthenticatedInitiativesInitiativeIdRoute
   '/profile/ai': typeof ServerRequiredAuthenticatedProfileAiRoute
   '/profile/danger': typeof ServerRequiredAuthenticatedProfileDangerRoute
@@ -550,6 +557,7 @@ export interface FileRoutesByTo {
   '/settings/admin/users': typeof ServerRequiredAuthenticatedSettingsAdminUsersRoute
   '/settings/guild/ai': typeof ServerRequiredAuthenticatedSettingsGuildAiRoute
   '/settings/guild/users': typeof ServerRequiredAuthenticatedSettingsGuildUsersRoute
+  '/g/$guildId': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
   '/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminIndexRoute
   '/settings/guild': typeof ServerRequiredAuthenticatedSettingsGuildIndexRoute
   '/g/$guildId/documents/$documentId': typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
@@ -615,6 +623,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/settings/admin/users': typeof ServerRequiredAuthenticatedSettingsAdminUsersRoute
   '/_serverRequired/_authenticated/settings/guild/ai': typeof ServerRequiredAuthenticatedSettingsGuildAiRoute
   '/_serverRequired/_authenticated/settings/guild/users': typeof ServerRequiredAuthenticatedSettingsGuildUsersRoute
+  '/_serverRequired/_authenticated/g/$guildId/': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
   '/_serverRequired/_authenticated/settings/admin/': typeof ServerRequiredAuthenticatedSettingsAdminIndexRoute
   '/_serverRequired/_authenticated/settings/guild/': typeof ServerRequiredAuthenticatedSettingsGuildIndexRoute
   '/_serverRequired/_authenticated/g/$guildId/documents_/$documentId': typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
@@ -679,6 +688,7 @@ export interface FileRouteTypes {
     | '/settings/admin/users'
     | '/settings/guild/ai'
     | '/settings/guild/users'
+    | '/g/$guildId/'
     | '/settings/admin/'
     | '/settings/guild/'
     | '/g/$guildId/documents/$documentId'
@@ -712,7 +722,6 @@ export interface FileRouteTypes {
     | '/invite/$code'
     | '/oidc/callback'
     | '/documents/$documentId'
-    | '/g/$guildId'
     | '/initiatives/$initiativeId'
     | '/profile/ai'
     | '/profile/danger'
@@ -737,6 +746,7 @@ export interface FileRouteTypes {
     | '/settings/admin/users'
     | '/settings/guild/ai'
     | '/settings/guild/users'
+    | '/g/$guildId'
     | '/settings/admin'
     | '/settings/guild'
     | '/g/$guildId/documents/$documentId'
@@ -801,6 +811,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/settings/admin/users'
     | '/_serverRequired/_authenticated/settings/guild/ai'
     | '/_serverRequired/_authenticated/settings/guild/users'
+    | '/_serverRequired/_authenticated/g/$guildId/'
     | '/_serverRequired/_authenticated/settings/admin/'
     | '/_serverRequired/_authenticated/settings/guild/'
     | '/_serverRequired/_authenticated/g/$guildId/documents_/$documentId'
@@ -1081,6 +1092,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/settings/admin/'
       preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsAdminIndexRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedSettingsAdminRoute
+    }
+    '/_serverRequired/_authenticated/g/$guildId/': {
+      id: '/_serverRequired/_authenticated/g/$guildId/'
+      path: '/'
+      fullPath: '/g/$guildId/'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdIndexRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
     }
     '/_serverRequired/_authenticated/settings/guild/users': {
       id: '/_serverRequired/_authenticated/settings/guild/users'
@@ -1388,6 +1406,7 @@ interface ServerRequiredAuthenticatedGGuildIdRouteChildren {
   ServerRequiredAuthenticatedGGuildIdInitiativesRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesRoute
   ServerRequiredAuthenticatedGGuildIdProjectsRoute: typeof ServerRequiredAuthenticatedGGuildIdProjectsRoute
   ServerRequiredAuthenticatedGGuildIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren
+  ServerRequiredAuthenticatedGGuildIdIndexRoute: typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
   ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute: typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
   ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute
   ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute: typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute
@@ -1408,6 +1427,8 @@ const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedGGuildIdProjectsRoute,
     ServerRequiredAuthenticatedGGuildIdSettingsRoute:
       ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren,
+    ServerRequiredAuthenticatedGGuildIdIndexRoute:
+      ServerRequiredAuthenticatedGGuildIdIndexRoute,
     ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute:
       ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute,
     ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/index.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/GuildDashboardPage").then((m) => ({ default: m.GuildDashboardPage }))
+  ),
+});

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -531,6 +531,19 @@ export interface ProjectActivityResponse {
   project_id?: number;
 }
 
+export interface RecentActivityEntry {
+  comment_id: number;
+  content: string;
+  created_at: string;
+  author?: CommentAuthor | null;
+  task_id?: number | null;
+  task_title?: string | null;
+  document_id?: number | null;
+  document_title?: string | null;
+  project_id?: number | null;
+  project_name?: string | null;
+}
+
 export interface TaskReorderPayload {
   project_id: number;
   items: {

--- a/frontend/src/types/i18next.d.ts
+++ b/frontend/src/types/i18next.d.ts
@@ -2,6 +2,7 @@ import "i18next";
 
 import type auth from "../../public/locales/en/auth.json";
 import type common from "../../public/locales/en/common.json";
+import type dashboard from "../../public/locales/en/dashboard.json";
 import type dates from "../../public/locales/en/dates.json";
 import type documents from "../../public/locales/en/documents.json";
 import type errors from "../../public/locales/en/errors.json";
@@ -26,6 +27,7 @@ declare module "i18next" {
     resources: {
       auth: typeof auth;
       common: typeof common;
+      dashboard: typeof dashboard;
       dates: typeof dates;
       documents: typeof documents;
       errors: typeof errors;


### PR DESCRIPTION
## Summary

- Adds a PM-focused Guild Dashboard at `/g/:guildId/` that becomes the guild landing page
- Shows metrics (tasks this week, on-time rate, streak, backlog trend), velocity chart, project health bars, upcoming tasks, recent projects, recent comments, and initiatives overview
- Guild switching now always navigates to the dashboard instead of preserving the previous sub-path
- New `GET /comments/recent` backend endpoint for guild-wide recent comment activity

## Notable changes

**Frontend (new files):**
- `pages/GuildDashboardPage.tsx` — main page orchestrating all queries and sections
- `components/dashboard/ProjectHealthList.tsx` — project progress bars sorted worst-first
- `components/dashboard/UpcomingTasksList.tsx` — tasks sorted by urgency with due date badges
- `components/dashboard/RecentCommentsList.tsx` — recent comments with mention rendering
- `components/dashboard/InitiativeOverview.tsx` — initiative cards with member/project counts
- Route file, i18n namespace, translation files (en + es)

**Frontend (modified):**
- `GuildSidebar.tsx` — simplified `handleGuildSwitch` to always navigate to dashboard

**Backend (modified):**
- `comments.py` endpoint — new `GET /comments/recent` with guild_id scoping
- `comment.py` schema — new `RecentActivityEntry` schema

## Test plan

- [ ] Navigate between guilds — should land on dashboard each time
- [ ] Click the active guild — should return to dashboard
- [ ] Verify metrics, velocity chart, project health, upcoming tasks render with data
- [ ] Verify recent comments render mentions correctly (not raw `#doc[Name](id)`)
- [ ] Verify superadmin only sees current guild's comments
- [ ] Check empty states when guild has no data
- [ ] Check responsive layout at mobile/tablet/desktop breakpoints
- [ ] `pnpm build` succeeds, `pnpm lint` passes, `npx tsc --noEmit` clean