### PR TITLE
Speed up Build and Release CI workflow

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -36,5 +36,5 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/initiative:dev-${{ steps.sha.outputs.short }}
           build-args: |
             VITE_VERSION_SUFFIX=-dev-${{ steps.sha.outputs.short }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,scope=docker-build,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,22 +107,15 @@ jobs:
           name: android-apk
           path: artifacts/*.apk
 
-  build-and-push:
-    needs: build-android
+  build-docker:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Download Android APK
-        uses: actions/download-artifact@v4
-        with:
-          name: android-apk
-          path: artifacts
 
       - name: Check for required secrets
         run: |
@@ -132,7 +125,7 @@ jobs:
             echo "::error::See .github/DOCKER_SETUP.md for instructions"
             exit 1
           fi
-          echo "✓ Required secrets are configured"
+          echo "Required secrets are configured"
 
       - name: Extract version from tag
         id: version
@@ -182,12 +175,40 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             VITE_API_URL=/api/v1
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,scope=docker-build,mode=max
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest
         run: echo "Image pushed with digest ${{ steps.build.outputs.digest }}"
+
+  release:
+    needs: [build-android, build-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download Android APK
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk
+          path: artifacts
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION=$(cat VERSION)
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Extract changelog for version
         id: changelog


### PR DESCRIPTION
## Summary

- Share Docker layer cache between dev-build and docker-publish workflows so release builds hit warm cache from frequent dev builds
- Parallelize Android APK build and Docker image build (previously sequential)
- Split into 3 jobs: `build-android`, `build-docker` (run in parallel), `release` (waits for both)

## Changes

**Shared cache scope** (`dev-build.yml` + `docker-publish.yml`):
- Both now use `scope=docker-build` for GHA cache instead of workflow-scoped defaults
- Dev builds run frequently and keep the cache warm; release builds now benefit from those cached layers

**Parallel jobs** (`docker-publish.yml`):
- `build-android` and `build-docker` run simultaneously instead of `build-docker` waiting for Android
- New `release` job (needs both) handles GitHub Release creation, changelog extraction, and Discord notification
- Docker image doesn't need the APK, so there's no reason to block it

## Expected impact

- Release Docker build should drop from ~15min to ~6-8min (matching dev build times)
- Total release workflow time reduced by running Android + Docker in parallel

## Test plan

- [ ] Trigger a manual workflow_dispatch run to verify all three jobs execute correctly
- [ ] Verify Docker image is pushed with correct tags
- [ ] Verify GitHub Release is created with APK and changelog
- [ ] Verify Discord notification fires