### PR TITLE
Fix stale i18n translations after deploy

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -68,6 +68,7 @@ void i18n
     },
     backend: {
       loadPath: "/locales/{{lng}}/{{ns}}.json",
+      queryStringParams: { v: __APP_VERSION__ },
     },
     react: {
       useSuspense: true,


### PR DESCRIPTION
## Summary

- Translation JSON files were cached by the browser across deploys, causing newly added keys (e.g. `myDocuments.title`) to render as raw strings
- Adds `?v=<version>` query param to all `i18next-http-backend` fetch requests so each release busts the cache

## Change

`frontend/src/i18n.ts` — added `queryStringParams: { v: __APP_VERSION__ }` to the backend config.

Requests change from:
```
/locales/en/documents.json
```
to:
```
/locales/en/documents.json?v=0.31.0
```

## Test plan

- [ ] Deploy and verify translation keys render as translated text without hard refresh
- [ ] Verify no regression in language switching