### PR TITLE
Fix template dropdown not showing role-accessible templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Template document dropdown in CreateDocumentDialog not showing templates accessible via role-based permissions (only showed templates with explicit user permissions)
+
 ## [0.31.2] - 2026-02-19
 
 ### Added

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -49,7 +49,6 @@ import {
   type RoleGrant,
   type UserGrant,
 } from "@/components/access/CreateAccessControl";
-import { useAuth } from "@/hooks/useAuth";
 import { formatBytes, getFileTypeLabel } from "@/lib/fileUtils";
 import type { DocumentRead, DocumentSummary, Initiative } from "@/types/api";
 
@@ -78,7 +77,6 @@ export const CreateDocumentDialog = ({
   initiatives = [],
 }: CreateDocumentDialogProps) => {
   const { t } = useTranslation(["documents", "common"]);
-  const { user } = useAuth();
 
   const [createDialogTab, setCreateDialogTab] = useState<"new" | "upload">("new");
   const [newTitle, setNewTitle] = useState("");
@@ -125,15 +123,11 @@ export const CreateDocumentDialog = ({
     enabled: open,
   });
 
-  // Filter templates user can access
+  // Filter templates — backend already enforces access control via RLS
   const manageableTemplates = useMemo(() => {
-    if (!templateDocumentsQuery.data || !user) return [];
-    return templateDocumentsQuery.data.filter((doc) => {
-      if (!doc.is_template) return false;
-      const permission = (doc.permissions ?? []).find((p) => p.user_id === user.id);
-      return Boolean(permission);
-    });
-  }, [templateDocumentsQuery.data, user]);
+    if (!templateDocumentsQuery.data) return [];
+    return templateDocumentsQuery.data.filter((doc) => doc.is_template);
+  }, [templateDocumentsQuery.data]);
 
   // Reset form when dialog closes, or set default initiative when dialog opens
   useEffect(() => {


### PR DESCRIPTION
## Summary
- The "Start from template" dropdown in `CreateDocumentDialog` only showed templates where the user had an explicit `DocumentPermission` row, hiding templates accessible via role-based permissions (`DocumentRolePermission`)
- Simplified the `manageableTemplates` filter to trust the backend's RLS, which already unions both user and role-based permissions
- Removed the now-unused `useAuth` import

## Test plan
- [ ] As User A, create a template document in an initiative
- [ ] Give User B's initiative role read access to the document (no explicit user permission)
- [ ] As User B, open the create document dialog — template should appear in the "Start from template" dropdown
- [ ] Verify existing explicit-permission templates still appear as before