### PR TITLE
Stop dev servers on Dev Environment cleanup

### DIFF
--- a/scripts/dev-cleanup.sh
+++ b/scripts/dev-cleanup.sh
@@ -4,9 +4,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Stop backend (uvicorn on port 8000)
-lsof -ti:8000 2>/dev/null | xargs -r kill 2>/dev/null || true
+# Stop backend (uvicorn on port 8000)
+lsof -ti:8000 2>/dev/null | { xargs kill 2>/dev/null || true; }
 # Stop frontend (Vite on port 5173)
-lsof -ti:5173 2>/dev/null | xargs -r kill 2>/dev/null || true
+lsof -ti:5173 2>/dev/null | { xargs kill 2>/dev/null || true; }
 
 cd "$SCRIPT_DIR/../backend"
 


### PR DESCRIPTION
## Summary
- Dev Environment cleanup (`postDebugTask`) now kills uvicorn (port 8000) and Vite (port 5173) processes before cleaning seed data
- VS Code task terminals close automatically once their processes exit

## Test plan
- [ ] Launch Dev Environment via VS Code debugger
- [ ] Verify backend and frontend servers start normally
- [ ] Stop the Dev Environment (Ctrl+C or stop button)
- [ ] Confirm both server terminals close and ports 8000/5173 are freed