### PR TITLE
Centralize remaining query hooks and fix subtask loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created `usePagination` hook for reusable page/pageSize state management with URL search param sync
 - Removed duplicate `TaskListResponse` and `DocumentListResponse` type definitions from `types/api.ts` in favor of Orval-generated versions
 - Deleted `src/api/notifications.ts` — all consumers migrated to `useNotifications` hooks
+- Centralized remaining inline queries — `GuildDashboardPage`, `MyProjectsPage`, `MyDocumentsPage` now use domain hooks (`useProjects`, `useInitiatives`, `useTasks`, `useRecentComments`, `useGlobalProjects`, `useGlobalDocuments`)
+- Eliminated direct `useQueryClient` usage from pages/components — added `usePrefetchTasks`, `usePrefetchGlobalProjects`, `usePrefetchGlobalDocuments`, `usePrefetchDocumentsList`, `useSetDocumentCache`, `useCommentsCache`, and `useUpdateRoleLabels` hooks
+- Added ESLint rule (`no-restricted-imports`) to prevent direct `useQuery`/`useQueryClient` imports outside `src/api/` and `src/hooks/`
 
 ### Fixed
 
 - Tasks endpoint returned no results when requesting tasks for a template project
+- Subtask checklist items failed to load ("Unable to load checklist items right now") due to double-unwrapping of API responses in `useSubtasks` hook and `TaskChecklist` mutations
 
 ## [0.31.1] - 2026-02-18
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -67,6 +67,35 @@ export default defineConfig([
     },
   },
   {
+    // Restrict direct React Query query/cache hooks to src/api and src/hooks.
+    // Pages and components should import domain hooks instead.
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "src/api/**",
+      "src/hooks/**",
+      "src/lib/queryClient.ts",
+      "src/main.tsx",
+      "src/router.tsx",
+      "src/__tests__/**",
+      "src/components/ui/editor/plugins/autocomplete-plugin.tsx",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@tanstack/react-query",
+              importNames: ["useQuery", "useQueryClient"],
+              message:
+                "Use domain hooks from @/hooks/ instead of direct React Query imports. Only src/api/ and src/hooks/ may use query hooks directly.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     settings: {
       react: {
         version: "detect",

--- a/frontend/src/components/VersionDialog.tsx
+++ b/frontend/src/components/VersionDialog.tsx
@@ -12,18 +12,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { useQuery } from "@tanstack/react-query";
-import {
-  getChangelogApiV1ChangelogGet,
-  getGetChangelogApiV1ChangelogGetQueryKey,
-} from "@/api/generated/version/version";
+import { useChangelog } from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
-
-interface ChangelogEntry {
-  version: string;
-  date: string;
-  changes: string;
-}
 
 interface VersionDialogProps {
   // For info mode (manual trigger)
@@ -66,12 +56,7 @@ export const VersionDialog = ({
     changelogParams.limit = limit;
   }
 
-  const { data, isLoading } = useQuery<{ entries: ChangelogEntry[] }>({
-    queryKey: getGetChangelogApiV1ChangelogGetQueryKey(changelogParams),
-    queryFn: () =>
-      getChangelogApiV1ChangelogGet(changelogParams) as unknown as Promise<{
-        entries: ChangelogEntry[];
-      }>,
+  const { data, isLoading } = useChangelog(changelogParams, {
     enabled: mode === "info" || (mode === "update" && Boolean(open)),
   });
 

--- a/frontend/src/components/access/CreateAccessControl.tsx
+++ b/frontend/src/components/access/CreateAccessControl.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Check, ChevronDown, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
 
-import { apiClient } from "@/api/client";
-import { getGetInitiativeApiV1InitiativesInitiativeIdGetQueryKey } from "@/api/generated/initiatives/initiatives";
 import { useAuth } from "@/hooks/useAuth";
+import { useInitiative } from "@/hooks/useInitiatives";
 import { useInitiativeRoles } from "@/hooks/useInitiativeRoles";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -28,7 +26,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import type { InitiativeRead, InitiativeRoleRead } from "@/types/api";
+import type { InitiativeRoleRead } from "@/types/api";
 
 // ─── Exported types ──────────────────────────────────────────────────────────
 
@@ -72,15 +70,7 @@ export const CreateAccessControl = ({
 
   const { data: roles = [] } = useInitiativeRoles(initiativeId);
 
-  const { data: initiative, isLoading: initiativeLoading } = useQuery<InitiativeRead>({
-    // Use the generated query key so cache invalidations align with other consumers
-    queryKey: getGetInitiativeApiV1InitiativesInitiativeIdGetQueryKey(initiativeId!),
-    queryFn: async () => {
-      const response = await apiClient.get<InitiativeRead>(`/initiatives/${initiativeId}`);
-      return response.data;
-    },
-    enabled: !!initiativeId,
-  });
+  const { data: initiative, isLoading: initiativeLoading } = useInitiative(initiativeId);
 
   useEffect(() => {
     onLoadingChange?.(initiativeLoading);

--- a/frontend/src/components/admin/AdminDeleteUserDialog.tsx
+++ b/frontend/src/components/admin/AdminDeleteUserDialog.tsx
@@ -1,17 +1,16 @@
 import { useCallback, useEffect, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { AlertCircle, ChevronLeft, Loader2, Trash2 } from "lucide-react";
 
 import {
-  checkUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGet,
-  getCheckUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGetQueryKey,
   deleteUserApiV1AdminUsersUserIdDelete,
   adminDeleteGuildApiV1AdminGuildsGuildIdDelete,
   adminUpdateGuildMemberRoleApiV1AdminGuildsGuildIdMembersUserIdRolePatch,
   adminUpdateInitiativeMemberRoleApiV1AdminInitiativesInitiativeIdMembersUserIdRolePatch,
 } from "@/api/generated/admin/admin";
+import { useUserDeletionEligibility } from "@/hooks/useAdmin";
 import { getInitiativeMembersApiV1InitiativesInitiativeIdMembersGet } from "@/api/generated/initiatives/initiatives";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -86,16 +85,8 @@ export function AdminDeleteUserDialog({
   }, [open]);
 
   // Fetch deletion eligibility
-  const { refetch: checkEligibility, isFetching: isCheckingEligibility } = useQuery({
-    queryKey: getCheckUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGetQueryKey(
-      targetUser.id
-    ),
-    queryFn: () =>
-      checkUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGet(
-        targetUser.id
-      ) as unknown as Promise<DeletionEligibilityResponse>,
-    enabled: false,
-  });
+  const { refetch: checkEligibility, isFetching: isCheckingEligibility } =
+    useUserDeletionEligibility(targetUser.id);
 
   // Fetch initiative members for project transfer
   const [initiativeMembers, setInitiativeMembers] = useState<Record<number, User[]>>({});

--- a/frontend/src/components/comments/MentionPopover.tsx
+++ b/frontend/src/components/comments/MentionPopover.tsx
@@ -1,12 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { CheckSquare, FileText, FolderKanban, User } from "lucide-react";
 
-import {
-  searchMentionablesApiV1CommentsMentionsSearchGet,
-  getSearchMentionablesApiV1CommentsMentionsSearchGetQueryKey,
-} from "@/api/generated/comments/comments";
+import { useMentionSuggestions } from "@/hooks/useComments";
 import type { MentionEntityType, MentionSuggestion } from "@/types/api";
 
 interface MentionPopoverProps {
@@ -16,19 +12,6 @@ interface MentionPopoverProps {
   onSelect: (suggestion: MentionSuggestion) => void;
   onClose: () => void;
 }
-
-const fetchSuggestions = async (
-  type: MentionEntityType,
-  initiativeId: number,
-  query: string
-): Promise<MentionSuggestion[]> => {
-  const response = await (searchMentionablesApiV1CommentsMentionsSearchGet({
-    entity_type: type,
-    initiative_id: initiativeId,
-    q: query,
-  }) as unknown as Promise<{ data: MentionSuggestion[] }>);
-  return response.data;
-};
 
 const getIcon = (type: MentionEntityType) => {
   switch (type) {
@@ -64,16 +47,7 @@ export const MentionPopover = ({
     [t]
   );
 
-  const { data: suggestions = [], isLoading } = useQuery({
-    queryKey: getSearchMentionablesApiV1CommentsMentionsSearchGetQueryKey({
-      entity_type: type,
-      initiative_id: initiativeId,
-      q: query,
-    }),
-    queryFn: () => fetchSuggestions(type, initiativeId, query),
-    staleTime: 30000,
-    enabled: initiativeId > 0,
-  });
+  const { data: suggestions = [], isLoading } = useMentionSuggestions(type, initiativeId, query);
 
   // Reset selection when suggestions change
   useEffect(() => {

--- a/frontend/src/components/documents/BulkEditAccessDialog.tsx
+++ b/frontend/src/components/documents/BulkEditAccessDialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { Check, ChevronDown, Loader2 } from "lucide-react";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -11,12 +11,11 @@ import {
   removeDocumentRolePermissionApiV1DocumentsDocumentIdRolePermissionsRoleIdDelete,
 } from "@/api/generated/documents/documents";
 import {
-  getListInitiativesApiV1InitiativesGetQueryKey,
-  listInitiativesApiV1InitiativesGet,
   getListInitiativeRolesApiV1InitiativesInitiativeIdRolesGetQueryKey,
   listInitiativeRolesApiV1InitiativesInitiativeIdRolesGet,
 } from "@/api/generated/initiatives/initiatives";
 import { invalidateAllDocuments } from "@/api/query-keys";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -47,7 +46,6 @@ import { useAuth } from "@/hooks/useAuth";
 import type {
   DocumentPermissionLevel,
   DocumentSummary,
-  Initiative,
   InitiativeMember,
   InitiativeRoleRead,
 } from "@/types/api";
@@ -108,11 +106,7 @@ export function BulkEditAccessDialog({
   }, [documents]);
 
   // Fetch initiative data to get member lists
-  const { data: initiatives = [] } = useQuery<Initiative[]>({
-    queryKey: getListInitiativesApiV1InitiativesGetQueryKey(),
-    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
-    enabled: open,
-  });
+  const { data: initiatives = [] } = useInitiatives({ enabled: open });
 
   // Fetch roles for each relevant initiative (reuses same query key as useInitiativeRoles)
   const roleQueries = useQueries({

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -1,5 +1,5 @@
 import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { FileSpreadsheet, FileText, Loader2, Plus, Presentation, Upload, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -7,14 +7,10 @@ import { toast } from "sonner";
 import {
   copyDocumentApiV1DocumentsDocumentIdCopyPost,
   createDocumentApiV1DocumentsPost,
-  getListDocumentsApiV1DocumentsGetQueryKey,
-  listDocumentsApiV1DocumentsGet,
   uploadDocumentFileApiV1DocumentsUploadPost,
 } from "@/api/generated/documents/documents";
-import {
-  getGetInitiativeApiV1InitiativesInitiativeIdGetQueryKey,
-  getInitiativeApiV1InitiativesInitiativeIdGet,
-} from "@/api/generated/initiatives/initiatives";
+import { useAllDocumentIds } from "@/hooks/useDocuments";
+import { useInitiative } from "@/hooks/useInitiatives";
 import { attachProjectDocumentApiV1ProjectsProjectIdDocumentsDocumentIdPost } from "@/api/generated/projects/projects";
 import { apiClient } from "@/api/client";
 import { invalidateAllDocuments, invalidateProject } from "@/api/query-keys";
@@ -51,7 +47,7 @@ import {
 } from "@/components/access/CreateAccessControl";
 import { useAuth } from "@/hooks/useAuth";
 import { formatBytes, getFileTypeLabel } from "@/lib/fileUtils";
-import type { DocumentRead, DocumentSummary, Initiative } from "@/types/api";
+import type { DocumentRead, Initiative } from "@/types/api";
 
 type CreateDocumentDialogProps = {
   open: boolean;
@@ -104,26 +100,14 @@ export const CreateDocumentDialog = ({
   }, [initiativeId, initiatives]);
 
   // Query the initiative if we have an ID but it's not in the passed list
-  const initiativeQuery = useQuery<Initiative>({
-    queryKey: getGetInitiativeApiV1InitiativesInitiativeIdGetQueryKey(initiativeId!),
-    queryFn: () =>
-      getInitiativeApiV1InitiativesInitiativeIdGet(initiativeId!) as unknown as Promise<Initiative>,
-    enabled: open && !!initiativeId && !lockedInitiativeFromList,
-  });
+  const initiativeQuery = useInitiative(
+    open && !!initiativeId && !lockedInitiativeFromList ? initiativeId! : null
+  );
 
   const lockedInitiative = lockedInitiativeFromList ?? initiativeQuery.data ?? null;
 
   // Query templates
-  const templateDocumentsQuery = useQuery<DocumentSummary[]>({
-    queryKey: getListDocumentsApiV1DocumentsGetQueryKey({ page_size: 0 }),
-    queryFn: async () => {
-      const response = await (listDocumentsApiV1DocumentsGet({
-        page_size: 0,
-      }) as unknown as Promise<{ items: DocumentSummary[] }>);
-      return response.items;
-    },
-    enabled: open,
-  });
+  const templateDocumentsQuery = useAllDocumentIds({ enabled: open });
 
   // Filter templates user can access
   const manageableTemplates = useMemo(() => {

--- a/frontend/src/components/documents/CreateWikilinkDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateWikilinkDocumentDialog.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -7,10 +7,9 @@ import { toast } from "sonner";
 import {
   copyDocumentApiV1DocumentsDocumentIdCopyPost,
   createDocumentApiV1DocumentsPost,
-  getListDocumentsApiV1DocumentsGetQueryKey,
-  listDocumentsApiV1DocumentsGet,
 } from "@/api/generated/documents/documents";
 import { invalidateAllDocuments } from "@/api/query-keys";
+import { useAllDocumentIds } from "@/hooks/useDocuments";
 import { Button } from "@/components/ui/button";
 import {
   AlertDialog,
@@ -30,7 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useAuth } from "@/hooks/useAuth";
-import type { DocumentRead, DocumentSummary } from "@/types/api";
+import type { DocumentRead } from "@/types/api";
 
 interface CreateWikilinkDocumentDialogProps {
   open: boolean;
@@ -59,16 +58,7 @@ export function CreateWikilinkDocumentDialog({
   const [selectedTemplateId, setSelectedTemplateId] = useState("");
 
   // Query templates
-  const templateDocumentsQuery = useQuery<DocumentSummary[]>({
-    queryKey: getListDocumentsApiV1DocumentsGetQueryKey({ page_size: 0 }),
-    queryFn: async () => {
-      const response = await (listDocumentsApiV1DocumentsGet({
-        page_size: 0,
-      }) as unknown as Promise<{ items: DocumentSummary[] }>);
-      return response.items;
-    },
-    enabled: open && canCreate,
-  });
+  const templateDocumentsQuery = useAllDocumentIds({ enabled: open && canCreate });
 
   // Filter templates user can access
   const manageableTemplates = useMemo(() => {

--- a/frontend/src/components/documents/DocumentBacklinks.tsx
+++ b/frontend/src/components/documents/DocumentBacklinks.tsx
@@ -1,14 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ChevronDown, ChevronRight, FileText, Link2 } from "lucide-react";
 import { useState } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { useTranslation } from "react-i18next";
 
-import {
-  getBacklinksApiV1DocumentsDocumentIdBacklinksGet,
-  getGetBacklinksApiV1DocumentsDocumentIdBacklinksGetQueryKey,
-} from "@/api/generated/documents/documents";
+import { useDocumentBacklinks } from "@/hooks/useDocuments";
 import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuildPath } from "@/lib/guildUrl";
 import { Button } from "@/components/ui/button";
@@ -24,14 +20,7 @@ export function DocumentBacklinks({ documentId }: DocumentBacklinksProps) {
   const [isOpen, setIsOpen] = useState(true);
   const gp = useGuildPath();
 
-  const {
-    data: backlinks = [],
-    isLoading,
-    isError,
-  } = useQuery({
-    queryKey: getGetBacklinksApiV1DocumentsDocumentIdBacklinksGetQueryKey(documentId),
-    queryFn: () => getBacklinksApiV1DocumentsDocumentIdBacklinksGet(documentId),
-  });
+  const { data: backlinks = [], isLoading, isError } = useDocumentBacklinks(documentId);
 
   if (isLoading) {
     return null;

--- a/frontend/src/components/import/TickTickImportDialog.tsx
+++ b/frontend/src/components/import/TickTickImportDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Upload, FileText, CheckCircle2, AlertCircle } from "lucide-react";
 
@@ -8,16 +8,9 @@ import {
   parseTicktickCsvApiV1ImportsTicktickParsePost,
   importFromTicktickApiV1ImportsTicktickPost,
 } from "@/api/generated/imports/imports";
-import {
-  listProjectsApiV1ProjectsGet,
-  getListProjectsApiV1ProjectsGetQueryKey,
-} from "@/api/generated/projects/projects";
-import {
-  listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet,
-  getListTaskStatusesApiV1ProjectsProjectIdTaskStatusesGetQueryKey,
-} from "@/api/generated/task-statuses/task-statuses";
 import { invalidateAllTasks } from "@/api/query-keys";
 import { useAuth } from "@/hooks/useAuth";
+import { useProjects, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -35,7 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import type { Project, ProjectTaskStatus } from "@/types/api";
+import type { ProjectTaskStatus } from "@/types/api";
 
 interface TickTickColumn {
   name: string;
@@ -118,23 +111,10 @@ export const TickTickImportDialog = ({ open, onOpenChange }: TickTickImportDialo
   }, [open]);
 
   // Fetch projects for selection
-  const projectsQuery = useQuery<Project[]>({
-    queryKey: getListProjectsApiV1ProjectsGetQueryKey(),
-    queryFn: () => listProjectsApiV1ProjectsGet() as unknown as Promise<Project[]>,
-    enabled: open,
-  });
+  const projectsQuery = useProjects(undefined, { enabled: open });
 
   // Fetch task statuses for selected target project
-  const taskStatusesQuery = useQuery<ProjectTaskStatus[]>({
-    queryKey: getListTaskStatusesApiV1ProjectsProjectIdTaskStatusesGetQueryKey(
-      selectedTargetProjectId!
-    ),
-    queryFn: () =>
-      listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet(
-        selectedTargetProjectId!
-      ) as unknown as Promise<ProjectTaskStatus[]>,
-    enabled: selectedTargetProjectId !== null,
-  });
+  const taskStatusesQuery = useProjectTaskStatuses(selectedTargetProjectId);
 
   // Get selected source list
   const selectedSourceList = parseResult?.lists.find((l) => l.name === selectedSourceListName);

--- a/frontend/src/components/import/TodoistImportDialog.tsx
+++ b/frontend/src/components/import/TodoistImportDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Upload, FileText, CheckCircle2, AlertCircle } from "lucide-react";
 
@@ -8,16 +8,9 @@ import {
   parseTodoistCsvApiV1ImportsTodoistParsePost,
   importFromTodoistApiV1ImportsTodoistPost,
 } from "@/api/generated/imports/imports";
-import {
-  listProjectsApiV1ProjectsGet,
-  getListProjectsApiV1ProjectsGetQueryKey,
-} from "@/api/generated/projects/projects";
-import {
-  listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet,
-  getListTaskStatusesApiV1ProjectsProjectIdTaskStatusesGetQueryKey,
-} from "@/api/generated/task-statuses/task-statuses";
 import { invalidateAllTasks } from "@/api/query-keys";
 import { useAuth } from "@/hooks/useAuth";
+import { useProjects, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -35,7 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import type { Project, ProjectTaskStatus } from "@/types/api";
+import type { ProjectTaskStatus } from "@/types/api";
 
 interface TodoistParseResult {
   sections: Array<{ name: string; task_count: number }>;
@@ -108,21 +101,10 @@ export const TodoistImportDialog = ({ open, onOpenChange }: TodoistImportDialogP
   }, [open]);
 
   // Fetch projects for selection
-  const projectsQuery = useQuery<Project[]>({
-    queryKey: getListProjectsApiV1ProjectsGetQueryKey(),
-    queryFn: () => listProjectsApiV1ProjectsGet() as unknown as Promise<Project[]>,
-    enabled: open,
-  });
+  const projectsQuery = useProjects(undefined, { enabled: open });
 
   // Fetch task statuses for selected project
-  const taskStatusesQuery = useQuery<ProjectTaskStatus[]>({
-    queryKey: getListTaskStatusesApiV1ProjectsProjectIdTaskStatusesGetQueryKey(selectedProjectId!),
-    queryFn: () =>
-      listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet(
-        selectedProjectId!
-      ) as unknown as Promise<ProjectTaskStatus[]>,
-    enabled: selectedProjectId !== null,
-  });
+  const taskStatusesQuery = useProjectTaskStatuses(selectedProjectId);
 
   // Initialize section mapping when statuses load
   useEffect(() => {

--- a/frontend/src/components/import/VikunjaImportDialog.tsx
+++ b/frontend/src/components/import/VikunjaImportDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Upload, FileText, CheckCircle2, AlertCircle } from "lucide-react";
 
@@ -8,16 +8,9 @@ import {
   parseVikunjaJsonApiV1ImportsVikunjaParsePost,
   importFromVikunjaApiV1ImportsVikunjaPost,
 } from "@/api/generated/imports/imports";
-import {
-  listProjectsApiV1ProjectsGet,
-  getListProjectsApiV1ProjectsGetQueryKey,
-} from "@/api/generated/projects/projects";
-import {
-  listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet,
-  getListTaskStatusesApiV1ProjectsProjectIdTaskStatusesGetQueryKey,
-} from "@/api/generated/task-statuses/task-statuses";
 import { invalidateAllTasks } from "@/api/query-keys";
 import { useAuth } from "@/hooks/useAuth";
+import { useProjects, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -35,7 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import type { Project, ProjectTaskStatus } from "@/types/api";
+import type { ProjectTaskStatus } from "@/types/api";
 
 interface VikunjaBucket {
   id: number;
@@ -120,23 +113,10 @@ export const VikunjaImportDialog = ({ open, onOpenChange }: VikunjaImportDialogP
   }, [open]);
 
   // Fetch projects for selection
-  const projectsQuery = useQuery<Project[]>({
-    queryKey: getListProjectsApiV1ProjectsGetQueryKey(),
-    queryFn: () => listProjectsApiV1ProjectsGet() as unknown as Promise<Project[]>,
-    enabled: open,
-  });
+  const projectsQuery = useProjects(undefined, { enabled: open });
 
   // Fetch task statuses for selected target project
-  const taskStatusesQuery = useQuery<ProjectTaskStatus[]>({
-    queryKey: getListTaskStatusesApiV1ProjectsProjectIdTaskStatusesGetQueryKey(
-      selectedTargetProjectId!
-    ),
-    queryFn: () =>
-      listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet(
-        selectedTargetProjectId!
-      ) as unknown as Promise<ProjectTaskStatus[]>,
-    enabled: selectedTargetProjectId !== null,
-  });
+  const taskStatusesQuery = useProjectTaskStatuses(selectedTargetProjectId);
 
   // Get selected source project
   const selectedSourceProject = parseResult?.projects.find((p) => p.id === selectedSourceProjectId);

--- a/frontend/src/components/projects/ProjectDocumentsSection.tsx
+++ b/frontend/src/components/projects/ProjectDocumentsSection.tsx
@@ -1,20 +1,17 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { getItem, setItem } from "@/lib/storage";
 import { Loader2, Link, Unlink, ChevronDown, ChevronUp, FilePlus } from "lucide-react";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 
 import {
-  listDocumentsApiV1DocumentsGet,
-  getListDocumentsApiV1DocumentsGetQueryKey,
-} from "@/api/generated/documents/documents";
-import {
   attachProjectDocumentApiV1ProjectsProjectIdDocumentsDocumentIdPost,
   detachProjectDocumentApiV1ProjectsProjectIdDocumentsDocumentIdDelete,
 } from "@/api/generated/projects/projects";
 import { invalidateAllDocuments, invalidateProject } from "@/api/query-keys";
+import { useInitiativeDocuments } from "@/hooks/useDocuments";
 import { useDateLocale } from "@/hooks/useDateLocale";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
@@ -64,19 +61,7 @@ export const ProjectDocumentsSection = ({
     return getItem(storageKey) === "true";
   });
 
-  const initiativeDocsQuery = useQuery<DocumentSummary[]>({
-    queryKey: getListDocumentsApiV1DocumentsGetQueryKey({
-      initiative_id: initiativeId,
-      page_size: 0,
-    }),
-    queryFn: async () => {
-      const response = await (listDocumentsApiV1DocumentsGet({
-        initiative_id: initiativeId,
-        page_size: 0,
-      }) as unknown as Promise<{ items: DocumentSummary[] }>);
-      return response.items;
-    },
-  });
+  const initiativeDocsQuery = useInitiativeDocuments(initiativeId);
 
   const attachedDocumentIds = useMemo(
     () => new Set(documents.map((doc) => doc.document_id)),

--- a/frontend/src/components/projects/ProjectTaskStatusesManager.tsx
+++ b/frontend/src/components/projects/ProjectTaskStatusesManager.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import {
   DndContext,
   type DragEndEvent,
@@ -20,7 +20,6 @@ import { Loader2, GripVertical, Trash2, Save } from "lucide-react";
 import { toast } from "sonner";
 
 import {
-  listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet,
   getListTaskStatusesApiV1ProjectsProjectIdTaskStatusesGetQueryKey,
   createTaskStatusApiV1ProjectsProjectIdTaskStatusesPost,
   updateTaskStatusApiV1ProjectsProjectIdTaskStatusesStatusIdPatch,
@@ -30,6 +29,7 @@ import {
 import { queryClient } from "@/lib/queryClient";
 import { invalidateProjectTaskStatuses, invalidateAllTasks } from "@/api/query-keys";
 import { getErrorMessage } from "@/lib/errorMessage";
+import { useProjectTaskStatuses } from "@/hooks/useProjects";
 import type { ProjectTaskStatus, TaskStatusCategory } from "@/types/api";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -117,14 +117,7 @@ export const ProjectTaskStatusesManager = ({
     })
   );
 
-  const statusesQuery = useQuery<ProjectTaskStatus[]>({
-    queryKey: STATUS_QUERY_KEY(projectId),
-    enabled: Number.isFinite(projectId),
-    queryFn: () =>
-      listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet(projectId) as unknown as Promise<
-        ProjectTaskStatus[]
-      >,
-  });
+  const statusesQuery = useProjectTaskStatuses(projectId);
 
   const reorderStatuses = useMutation({
     mutationFn: async (items: { id: number; position: number }[]) => {

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import {
   DragEndEvent,
   DragOverEvent,
@@ -25,8 +25,6 @@ import type { LucideIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import {
-  listTasksApiV1TasksGet,
-  getListTasksApiV1TasksGetQueryKey,
   createTaskApiV1TasksPost,
   updateTaskApiV1TasksTaskIdPatch,
   deleteTaskApiV1TasksTaskIdDelete,
@@ -34,6 +32,7 @@ import {
   archiveDoneTasksApiV1TasksArchiveDonePost,
 } from "@/api/generated/tasks/tasks";
 import type { ListTasksApiV1TasksGetParams } from "@/api/generated/initiativeAPI.schemas";
+import { useTasks } from "@/hooks/useTasks";
 import { invalidateAllTasks } from "@/api/query-keys";
 import { getItem, setItem } from "@/lib/storage";
 
@@ -42,7 +41,6 @@ import type {
   TaskRecurrenceStrategy,
   ProjectTaskStatus,
   Task,
-  TaskListResponse,
   TaskPriority,
   TaskRecurrence,
   TaskReorderPayload,
@@ -171,9 +169,7 @@ export const ProjectTasksSection = ({
     ...(showArchived && { include_archived: true }),
   };
 
-  const tasksQuery = useQuery<TaskListResponse>({
-    queryKey: getListTasksApiV1TasksGetQueryKey(taskListParams),
-    queryFn: () => listTasksApiV1TasksGet(taskListParams) as unknown as Promise<TaskListResponse>,
+  const tasksQuery = useTasks(taskListParams, {
     enabled: Number.isFinite(projectId) && filtersLoadedForProject === projectId,
   });
 

--- a/frontend/src/components/user/DeleteAccountDialog.tsx
+++ b/frontend/src/components/user/DeleteAccountDialog.tsx
@@ -1,14 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { AlertCircle, ChevronLeft, Loader2 } from "lucide-react";
 
-import {
-  checkDeletionEligibilityApiV1UsersMeDeletionEligibilityGet,
-  getCheckDeletionEligibilityApiV1UsersMeDeletionEligibilityGetQueryKey,
-  deleteOwnAccountApiV1UsersMeDeleteAccountPost,
-} from "@/api/generated/users/users";
+import { deleteOwnAccountApiV1UsersMeDeleteAccountPost } from "@/api/generated/users/users";
+import { useMyDeletionEligibility } from "@/hooks/useAdmin";
 import { getInitiativeMembersApiV1InitiativesInitiativeIdMembersGet } from "@/api/generated/initiatives/initiatives";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -93,12 +90,8 @@ export function DeleteAccountDialog({
   }, [open]);
 
   // Fetch deletion eligibility
-  const { refetch: checkEligibility, isFetching: isCheckingEligibility } = useQuery({
-    queryKey: getCheckDeletionEligibilityApiV1UsersMeDeletionEligibilityGetQueryKey(),
-    queryFn: () =>
-      checkDeletionEligibilityApiV1UsersMeDeletionEligibilityGet() as unknown as Promise<DeletionEligibilityResponse>,
-    enabled: false,
-  });
+  const { refetch: checkEligibility, isFetching: isCheckingEligibility } =
+    useMyDeletionEligibility();
 
   // Fetch initiative members for project transfer
   const [initiativeMembers, setInitiativeMembers] = useState<Record<number, User[]>>({});

--- a/frontend/src/hooks/useAISettings.ts
+++ b/frontend/src/hooks/useAISettings.ts
@@ -1,0 +1,55 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import {
+  getPlatformAiSettingsApiV1SettingsAiPlatformGet,
+  getGetPlatformAiSettingsApiV1SettingsAiPlatformGetQueryKey,
+  getGuildAiSettingsApiV1SettingsAiGuildGet,
+  getGetGuildAiSettingsApiV1SettingsAiGuildGetQueryKey,
+  getUserAiSettingsApiV1SettingsAiUserGet,
+  getGetUserAiSettingsApiV1SettingsAiUserGetQueryKey,
+} from "@/api/generated/ai-settings/ai-settings";
+import type {
+  PlatformAISettingsResponse,
+  GuildAISettingsResponse,
+  UserAISettingsResponse,
+} from "@/api/generated/initiativeAPI.schemas";
+
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+export const usePlatformAISettings = (options?: QueryOpts<PlatformAISettingsResponse>) => {
+  return useQuery<PlatformAISettingsResponse>({
+    queryKey: getGetPlatformAiSettingsApiV1SettingsAiPlatformGetQueryKey(),
+    queryFn: async () => {
+      const response =
+        await (getPlatformAiSettingsApiV1SettingsAiPlatformGet() as unknown as Promise<{
+          data: PlatformAISettingsResponse;
+        }>);
+      return response.data;
+    },
+    ...options,
+  });
+};
+
+export const useGuildAISettings = (
+  guildId: number | string | null | undefined,
+  options?: QueryOpts<GuildAISettingsResponse>
+) => {
+  const { enabled: userEnabled = true, ...rest } = options ?? {};
+  return useQuery<GuildAISettingsResponse>({
+    queryKey: [...getGetGuildAiSettingsApiV1SettingsAiGuildGetQueryKey(), guildId],
+    queryFn: () =>
+      getGuildAiSettingsApiV1SettingsAiGuildGet() as unknown as Promise<GuildAISettingsResponse>,
+    enabled: userEnabled && !!guildId,
+    ...rest,
+  });
+};
+
+export const useUserAISettings = () => {
+  return useQuery<UserAISettingsResponse>({
+    queryKey: getGetUserAiSettingsApiV1SettingsAiUserGetQueryKey(),
+    queryFn: () =>
+      getUserAiSettingsApiV1SettingsAiUserGet() as unknown as Promise<UserAISettingsResponse>,
+  });
+};

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -1,0 +1,76 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import {
+  listAllUsersApiV1AdminUsersGet,
+  getListAllUsersApiV1AdminUsersGetQueryKey,
+  getPlatformAdminCountApiV1AdminPlatformAdminCountGet,
+  getGetPlatformAdminCountApiV1AdminPlatformAdminCountGetQueryKey,
+  checkUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGet,
+  getCheckUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGetQueryKey,
+} from "@/api/generated/admin/admin";
+import {
+  checkDeletionEligibilityApiV1UsersMeDeletionEligibilityGet,
+  getCheckDeletionEligibilityApiV1UsersMeDeletionEligibilityGetQueryKey,
+} from "@/api/generated/users/users";
+import type {
+  PlatformAdminCountResponse,
+  AdminDeletionEligibilityResponse,
+  DeletionEligibilityResponse,
+} from "@/api/generated/initiativeAPI.schemas";
+import type { User } from "@/types/api";
+
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+/** Fetch all platform users (admin only). */
+export const usePlatformUsers = (options?: QueryOpts<User[]>) => {
+  return useQuery<User[]>({
+    queryKey: getListAllUsersApiV1AdminUsersGetQueryKey(),
+    queryFn: () => listAllUsersApiV1AdminUsersGet() as unknown as Promise<User[]>,
+    ...options,
+  });
+};
+
+/** Fetch the current count of platform admins (admin only). */
+export const usePlatformAdminCount = (options?: QueryOpts<PlatformAdminCountResponse>) => {
+  return useQuery<PlatformAdminCountResponse>({
+    queryKey: getGetPlatformAdminCountApiV1AdminPlatformAdminCountGetQueryKey(),
+    queryFn: () =>
+      getPlatformAdminCountApiV1AdminPlatformAdminCountGet() as unknown as Promise<PlatformAdminCountResponse>,
+    ...options,
+  });
+};
+
+/**
+ * Check whether a specific user can be deleted (admin only).
+ *
+ * Disabled by default -- call `refetch()` to trigger the eligibility check
+ * on demand.
+ */
+export const useUserDeletionEligibility = (userId: number) => {
+  return useQuery<AdminDeletionEligibilityResponse>({
+    queryKey:
+      getCheckUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGetQueryKey(userId),
+    queryFn: () =>
+      checkUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGet(
+        userId
+      ) as unknown as Promise<AdminDeletionEligibilityResponse>,
+    enabled: false,
+  });
+};
+
+/**
+ * Check whether the current (logged-in) user can delete their own account.
+ *
+ * Disabled by default -- call `refetch()` to trigger the eligibility check
+ * on demand.
+ */
+export const useMyDeletionEligibility = () => {
+  return useQuery<DeletionEligibilityResponse>({
+    queryKey: getCheckDeletionEligibilityApiV1UsersMeDeletionEligibilityGetQueryKey(),
+    queryFn: () =>
+      checkDeletionEligibilityApiV1UsersMeDeletionEligibilityGet() as unknown as Promise<DeletionEligibilityResponse>,
+    enabled: false,
+  });
+};

--- a/frontend/src/hooks/useComments.ts
+++ b/frontend/src/hooks/useComments.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -7,38 +7,96 @@ import {
   getListCommentsApiV1CommentsGetQueryKey,
   recentCommentsApiV1CommentsRecentGet,
   getRecentCommentsApiV1CommentsRecentGetQueryKey,
+  searchMentionablesApiV1CommentsMentionsSearchGet,
+  getSearchMentionablesApiV1CommentsMentionsSearchGetQueryKey,
   createCommentApiV1CommentsPost,
   updateCommentApiV1CommentsCommentIdPatch,
   deleteCommentApiV1CommentsCommentIdDelete,
 } from "@/api/generated/comments/comments";
 import { invalidateAllComments } from "@/api/query-keys";
-import type { Comment } from "@/types/api";
+import type { Comment, MentionEntityType } from "@/types/api";
 import type {
   ListCommentsApiV1CommentsGetParams,
   RecentCommentsApiV1CommentsRecentGetParams,
   RecentActivityEntry,
+  MentionSuggestion,
 } from "@/api/generated/initiativeAPI.schemas";
+
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
 
 // ── Queries ─────────────────────────────────────────────────────────────────
 
 export const useComments = (
   params: ListCommentsApiV1CommentsGetParams,
-  options?: { enabled?: boolean }
+  options?: QueryOpts<Comment[]>
 ) => {
   return useQuery<Comment[]>({
     queryKey: getListCommentsApiV1CommentsGetQueryKey(params),
     queryFn: () => listCommentsApiV1CommentsGet(params) as unknown as Promise<Comment[]>,
-    enabled: options?.enabled,
+    ...options,
   });
 };
 
-export const useRecentComments = (params?: RecentCommentsApiV1CommentsRecentGetParams) => {
+export const useRecentComments = (
+  params?: RecentCommentsApiV1CommentsRecentGetParams,
+  options?: QueryOpts<RecentActivityEntry[]>
+) => {
   return useQuery<RecentActivityEntry[]>({
     queryKey: getRecentCommentsApiV1CommentsRecentGetQueryKey(params),
     queryFn: () =>
       recentCommentsApiV1CommentsRecentGet(params) as unknown as Promise<RecentActivityEntry[]>,
     staleTime: 30 * 1000,
+    ...options,
   });
+};
+
+export const useMentionSuggestions = (
+  type: MentionEntityType,
+  initiativeId: number,
+  query: string,
+  options?: QueryOpts<MentionSuggestion[]>
+) => {
+  return useQuery<MentionSuggestion[]>({
+    queryKey: getSearchMentionablesApiV1CommentsMentionsSearchGetQueryKey({
+      entity_type: type,
+      initiative_id: initiativeId,
+      q: query,
+    }),
+    queryFn: async () => {
+      const response = await (searchMentionablesApiV1CommentsMentionsSearchGet({
+        entity_type: type,
+        initiative_id: initiativeId,
+        q: query,
+      }) as unknown as Promise<{ data: MentionSuggestion[] }>);
+      return response.data;
+    },
+    staleTime: 30_000,
+    enabled: initiativeId > 0,
+    ...options,
+  });
+};
+
+// ── Cache helpers ───────────────────────────────────────────────────────────
+
+export const useCommentsCache = (params: ListCommentsApiV1CommentsGetParams) => {
+  const qc = useQueryClient();
+  const queryKey = getListCommentsApiV1CommentsGetQueryKey(params);
+
+  const addComment = (comment: Comment) => {
+    qc.setQueryData<Comment[]>(queryKey, (prev) => (prev ? [...prev, comment] : [comment]));
+  };
+
+  const removeComment = (commentId: number) => {
+    qc.setQueryData<Comment[]>(queryKey, (prev) => prev?.filter((c) => c.id !== commentId));
+  };
+
+  const updateComment = (updated: Comment) => {
+    qc.setQueryData<Comment[]>(queryKey, (prev) =>
+      prev?.map((c) => (c.id === updated.id ? updated : c))
+    );
+  };
+
+  return { addComment, removeComment, updateComment };
 };
 
 // ── Mutations ───────────────────────────────────────────────────────────────

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -1,4 +1,10 @@
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -9,6 +15,8 @@ import {
   getReadDocumentApiV1DocumentsDocumentIdGetQueryKey,
   getDocumentCountsApiV1DocumentsCountsGet,
   getGetDocumentCountsApiV1DocumentsCountsGetQueryKey,
+  getBacklinksApiV1DocumentsDocumentIdBacklinksGet,
+  getGetBacklinksApiV1DocumentsDocumentIdBacklinksGetQueryKey,
   deleteDocumentApiV1DocumentsDocumentIdDelete,
   copyDocumentApiV1DocumentsDocumentIdCopyPost,
   updateDocumentApiV1DocumentsDocumentIdPatch,
@@ -19,7 +27,11 @@ import type {
   ListDocumentsApiV1DocumentsGetParams,
   GetDocumentCountsApiV1DocumentsCountsGetParams,
   DocumentUpdate,
+  DocumentBacklink,
+  DocumentSummary,
 } from "@/api/generated/initiativeAPI.schemas";
+
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
 
 // ── Queries ─────────────────────────────────────────────────────────────────
 
@@ -32,18 +44,20 @@ export const useDocumentsList = (params: ListDocumentsApiV1DocumentsGetParams) =
   });
 };
 
-export const useDocument = (documentId: number | null) => {
+export const useDocument = (documentId: number | null, options?: QueryOpts<DocumentRead>) => {
+  const { enabled: userEnabled = true, ...rest } = options ?? {};
   return useQuery<DocumentRead>({
     queryKey: getReadDocumentApiV1DocumentsDocumentIdGetQueryKey(documentId!),
     queryFn: () =>
       readDocumentApiV1DocumentsDocumentIdGet(documentId!) as unknown as Promise<DocumentRead>,
-    enabled: documentId !== null && Number.isFinite(documentId),
+    enabled: documentId !== null && Number.isFinite(documentId) && userEnabled,
+    ...rest,
   });
 };
 
 export const useDocumentCounts = (
   params: GetDocumentCountsApiV1DocumentsCountsGetParams,
-  options?: { enabled?: boolean }
+  options?: QueryOpts<DocumentCountsResponse>
 ) => {
   return useQuery<DocumentCountsResponse>({
     queryKey: getGetDocumentCountsApiV1DocumentsCountsGetQueryKey(params),
@@ -51,22 +65,119 @@ export const useDocumentCounts = (
       getDocumentCountsApiV1DocumentsCountsGet(
         params
       ) as unknown as Promise<DocumentCountsResponse>,
-    enabled: options?.enabled,
+    ...options,
   });
 };
 
-// ── Prefetch helper ─────────────────────────────────────────────────────────
-
-export const prefetchDocumentsList = (
-  qc: ReturnType<typeof useQueryClient>,
-  params: ListDocumentsApiV1DocumentsGetParams
-) => {
-  return qc.prefetchQuery({
-    queryKey: getListDocumentsApiV1DocumentsGetQueryKey(params),
-    queryFn: () =>
-      listDocumentsApiV1DocumentsGet(params) as unknown as Promise<DocumentListResponse>,
-    staleTime: 30_000,
+export const useAllDocumentIds = (options?: QueryOpts<DocumentSummary[]>) => {
+  return useQuery<DocumentSummary[]>({
+    queryKey: getListDocumentsApiV1DocumentsGetQueryKey({ page_size: 0 }),
+    queryFn: async () => {
+      const response = await (listDocumentsApiV1DocumentsGet({
+        page_size: 0,
+      }) as unknown as Promise<{ items: DocumentSummary[] }>);
+      return response.items;
+    },
+    ...options,
   });
+};
+
+export const useInitiativeDocuments = (
+  initiativeId: number,
+  options?: QueryOpts<DocumentSummary[]>
+) => {
+  return useQuery<DocumentSummary[]>({
+    queryKey: getListDocumentsApiV1DocumentsGetQueryKey({
+      initiative_id: initiativeId,
+      page_size: 0,
+    }),
+    queryFn: async () => {
+      const response = await (listDocumentsApiV1DocumentsGet({
+        initiative_id: initiativeId,
+        page_size: 0,
+      }) as unknown as Promise<{ items: DocumentSummary[] }>);
+      return response.items;
+    },
+    ...options,
+  });
+};
+
+export const useDocumentBacklinks = (
+  documentId: number,
+  options?: QueryOpts<DocumentBacklink[]>
+) => {
+  return useQuery<DocumentBacklink[]>({
+    queryKey: getGetBacklinksApiV1DocumentsDocumentIdBacklinksGetQueryKey(documentId),
+    queryFn: () =>
+      getBacklinksApiV1DocumentsDocumentIdBacklinksGet(documentId) as unknown as Promise<
+        DocumentBacklink[]
+      >,
+    ...options,
+  });
+};
+
+// ── Cache helpers ───────────────────────────────────────────────────────────
+
+export const useSetDocumentCache = () => {
+  const qc = useQueryClient();
+  return (
+    documentId: number,
+    data: DocumentRead | ((prev: DocumentRead | undefined) => DocumentRead | undefined)
+  ) => {
+    qc.setQueryData<DocumentRead>(
+      getReadDocumentApiV1DocumentsDocumentIdGetQueryKey(documentId),
+      typeof data === "function" ? data : () => data
+    );
+  };
+};
+
+// ── Global (cross-guild) queries ────────────────────────────────────────────
+
+import { apiClient } from "@/api/client";
+
+export const GLOBAL_DOCUMENTS_QUERY_KEY = "/api/v1/documents/" as const;
+
+export const globalDocumentsQueryFn = async (
+  params: Record<string, string | string[] | number | number[]>
+) => {
+  const response = await apiClient.get<DocumentListResponse>("/documents/", { params });
+  return response.data;
+};
+
+export const useGlobalDocuments = (
+  params: Record<string, string | string[] | number | number[]>,
+  options?: QueryOpts<DocumentListResponse>
+) => {
+  return useQuery<DocumentListResponse>({
+    queryKey: [GLOBAL_DOCUMENTS_QUERY_KEY, params],
+    queryFn: () => globalDocumentsQueryFn(params),
+    ...options,
+  });
+};
+
+export const usePrefetchGlobalDocuments = () => {
+  const qc = useQueryClient();
+  return (params: Record<string, string | string[] | number | number[]>) => {
+    return qc.prefetchQuery({
+      queryKey: [GLOBAL_DOCUMENTS_QUERY_KEY, params],
+      queryFn: () => globalDocumentsQueryFn(params),
+      staleTime: 30_000,
+    });
+  };
+};
+
+// ── Prefetch helpers ────────────────────────────────────────────────────────
+
+export const usePrefetchDocumentsList = () => {
+  const qc = useQueryClient();
+  return (params: ListDocumentsApiV1DocumentsGetParams) => {
+    return qc.prefetchQuery({
+      queryKey: getListDocumentsApiV1DocumentsGetQueryKey(params),
+      queryFn: () =>
+        listDocumentsApiV1DocumentsGet(params) as unknown as Promise<DocumentListResponse>,
+      staleTime: 30_000,
+    });
+  };
 };
 
 // ── Mutations ───────────────────────────────────────────────────────────────

--- a/frontend/src/hooks/useInitiatives.ts
+++ b/frontend/src/hooks/useInitiatives.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, type UseQueryOptions } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -25,33 +25,42 @@ import { getErrorMessage } from "@/lib/errorMessage";
 import type { Initiative } from "@/types/api";
 import type { InitiativeMemberRead } from "@/api/generated/initiativeAPI.schemas";
 
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
+
 // ── Queries ─────────────────────────────────────────────────────────────────
 
-export const useInitiatives = (options?: { enabled?: boolean }) => {
+export const useInitiatives = (options?: QueryOpts<Initiative[]>) => {
   return useQuery<Initiative[]>({
     queryKey: getListInitiativesApiV1InitiativesGetQueryKey(),
     queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
-    enabled: options?.enabled,
+    ...options,
   });
 };
 
-export const useInitiative = (initiativeId: number | null) => {
+export const useInitiative = (initiativeId: number | null, options?: QueryOpts<Initiative>) => {
+  const { enabled: userEnabled = true, ...rest } = options ?? {};
   return useQuery<Initiative>({
     queryKey: getGetInitiativeApiV1InitiativesInitiativeIdGetQueryKey(initiativeId!),
     queryFn: () =>
       getInitiativeApiV1InitiativesInitiativeIdGet(initiativeId!) as unknown as Promise<Initiative>,
-    enabled: initiativeId !== null && Number.isFinite(initiativeId),
+    enabled: initiativeId !== null && Number.isFinite(initiativeId) && userEnabled,
+    ...rest,
   });
 };
 
-export const useInitiativeMembers = (initiativeId: number | null) => {
+export const useInitiativeMembers = (
+  initiativeId: number | null,
+  options?: QueryOpts<InitiativeMemberRead[]>
+) => {
+  const { enabled: userEnabled = true, ...rest } = options ?? {};
   return useQuery<InitiativeMemberRead[]>({
     queryKey: getGetInitiativeMembersApiV1InitiativesInitiativeIdMembersGetQueryKey(initiativeId!),
     queryFn: () =>
       getInitiativeMembersApiV1InitiativesInitiativeIdMembersGet(
         initiativeId!
       ) as unknown as Promise<InitiativeMemberRead[]>,
-    enabled: initiativeId !== null && Number.isFinite(initiativeId),
+    enabled: initiativeId !== null && Number.isFinite(initiativeId) && userEnabled,
+    ...rest,
   });
 };
 

--- a/frontend/src/hooks/useRoleLabels.ts
+++ b/frontend/src/hooks/useRoleLabels.ts
@@ -1,8 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   getRoleLabelsApiV1SettingsRolesGet,
   getGetRoleLabelsApiV1SettingsRolesGetQueryKey,
+  updateRoleLabelsApiV1SettingsRolesPut,
 } from "@/api/generated/settings/settings";
 import type { RoleLabels } from "../types/api";
 
@@ -21,6 +22,20 @@ export const useRoleLabels = () =>
     placeholderData: DEFAULT_ROLE_LABELS,
     staleTime: Infinity,
   });
+
+export const useUpdateRoleLabels = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: RoleLabels) => {
+      return updateRoleLabelsApiV1SettingsRolesPut(
+        payload as Parameters<typeof updateRoleLabelsApiV1SettingsRolesPut>[0]
+      ) as unknown as Promise<RoleLabels>;
+    },
+    onSuccess: (data) => {
+      qc.setQueryData(ROLE_LABELS_QUERY_KEY, data);
+    },
+  });
+};
 
 type RoleKey = keyof RoleLabels;
 

--- a/frontend/src/hooks/useSecurity.ts
+++ b/frontend/src/hooks/useSecurity.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  listMyApiKeysApiV1UsersMeApiKeysGet,
+  getListMyApiKeysApiV1UsersMeApiKeysGetQueryKey,
+} from "@/api/generated/users/users";
+import {
+  listDeviceTokensApiV1AuthDeviceTokensGet,
+  getListDeviceTokensApiV1AuthDeviceTokensGetQueryKey,
+} from "@/api/generated/auth/auth";
+import type { ApiKeyListResponse, DeviceTokenInfo } from "@/api/generated/initiativeAPI.schemas";
+
+// ── Query Keys ──────────────────────────────────────────────────────────────
+
+export const API_KEYS_QUERY_KEY = getListMyApiKeysApiV1UsersMeApiKeysGetQueryKey();
+export const DEVICE_TOKENS_QUERY_KEY = getListDeviceTokensApiV1AuthDeviceTokensGetQueryKey();
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+export const useMyApiKeys = () => {
+  return useQuery<ApiKeyListResponse>({
+    queryKey: API_KEYS_QUERY_KEY,
+    queryFn: () => listMyApiKeysApiV1UsersMeApiKeysGet() as unknown as Promise<ApiKeyListResponse>,
+  });
+};
+
+export const useDeviceTokens = () => {
+  return useQuery<DeviceTokenInfo[]>({
+    queryKey: DEVICE_TOKENS_QUERY_KEY,
+    queryFn: () =>
+      listDeviceTokensApiV1AuthDeviceTokensGet() as unknown as Promise<DeviceTokenInfo[]>,
+  });
+};

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,0 +1,126 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import {
+  getOidcSettingsApiV1SettingsAuthGet,
+  getGetOidcSettingsApiV1SettingsAuthGetQueryKey,
+  getOidcMappingsApiV1SettingsOidcMappingsGet,
+  getGetOidcMappingsApiV1SettingsOidcMappingsGetQueryKey,
+  getOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet,
+  getGetOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGetQueryKey,
+  getEmailSettingsApiV1SettingsEmailGet,
+  getGetEmailSettingsApiV1SettingsEmailGetQueryKey,
+  getInterfaceSettingsApiV1SettingsInterfaceGet,
+  getGetInterfaceSettingsApiV1SettingsInterfaceGetQueryKey,
+  getFcmConfigApiV1SettingsFcmConfigGet,
+  getGetFcmConfigApiV1SettingsFcmConfigGetQueryKey,
+} from "@/api/generated/settings/settings";
+import {
+  getChangelogApiV1ChangelogGet,
+  getGetChangelogApiV1ChangelogGetQueryKey,
+} from "@/api/generated/version/version";
+import type {
+  OIDCSettingsResponse,
+  OIDCMappingsResponse,
+  EmailSettingsResponse,
+  InterfaceSettingsResponse,
+  FCMConfigResponse,
+  GetChangelogApiV1ChangelogGetParams,
+} from "@/api/generated/initiativeAPI.schemas";
+
+// ── Local types for untyped or loosely-typed generated responses ─────────
+
+/** Strongly-typed version of the mapping options response. */
+export interface MappingOptionItem {
+  id: number;
+  name: string;
+}
+
+export interface MappingInitiativeOption extends MappingOptionItem {
+  guild_id: number;
+}
+
+export interface MappingRoleOption extends MappingOptionItem {
+  initiative_id: number;
+}
+
+export interface MappingOptions {
+  guilds: MappingOptionItem[];
+  initiatives: MappingInitiativeOption[];
+  initiative_roles: MappingRoleOption[];
+}
+
+/** Changelog entry shape returned by the backend. */
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  changes: string;
+}
+
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+export const useOidcSettings = (options?: QueryOpts<OIDCSettingsResponse>) => {
+  return useQuery<OIDCSettingsResponse>({
+    queryKey: getGetOidcSettingsApiV1SettingsAuthGetQueryKey(),
+    queryFn: () =>
+      getOidcSettingsApiV1SettingsAuthGet() as unknown as Promise<OIDCSettingsResponse>,
+    ...options,
+  });
+};
+
+export const useOidcMappings = () => {
+  return useQuery<OIDCMappingsResponse>({
+    queryKey: getGetOidcMappingsApiV1SettingsOidcMappingsGetQueryKey(),
+    queryFn: () =>
+      getOidcMappingsApiV1SettingsOidcMappingsGet() as unknown as Promise<OIDCMappingsResponse>,
+  });
+};
+
+export const useOidcMappingOptions = () => {
+  return useQuery<MappingOptions>({
+    queryKey: getGetOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGetQueryKey(),
+    queryFn: () =>
+      getOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet() as unknown as Promise<MappingOptions>,
+  });
+};
+
+export const useEmailSettings = (options?: QueryOpts<EmailSettingsResponse>) => {
+  return useQuery<EmailSettingsResponse>({
+    queryKey: getGetEmailSettingsApiV1SettingsEmailGetQueryKey(),
+    queryFn: () =>
+      getEmailSettingsApiV1SettingsEmailGet() as unknown as Promise<EmailSettingsResponse>,
+    ...options,
+  });
+};
+
+export const useInterfaceSettings = (options?: QueryOpts<InterfaceSettingsResponse>) => {
+  return useQuery<InterfaceSettingsResponse>({
+    queryKey: getGetInterfaceSettingsApiV1SettingsInterfaceGetQueryKey(),
+    queryFn: () =>
+      getInterfaceSettingsApiV1SettingsInterfaceGet() as unknown as Promise<InterfaceSettingsResponse>,
+    ...options,
+  });
+};
+
+export const useFcmConfig = () => {
+  return useQuery<FCMConfigResponse>({
+    queryKey: getGetFcmConfigApiV1SettingsFcmConfigGetQueryKey(),
+    queryFn: () => getFcmConfigApiV1SettingsFcmConfigGet() as unknown as Promise<FCMConfigResponse>,
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export const useChangelog = (
+  params: GetChangelogApiV1ChangelogGetParams,
+  options?: QueryOpts<{ entries: ChangelogEntry[] }>
+) => {
+  return useQuery<{ entries: ChangelogEntry[] }>({
+    queryKey: getGetChangelogApiV1ChangelogGetQueryKey(params),
+    queryFn: () =>
+      getChangelogApiV1ChangelogGet(params) as unknown as Promise<{
+        entries: ChangelogEntry[];
+      }>,
+    ...options,
+  });
+};

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -1,0 +1,61 @@
+import { useQuery, useQueryClient, type UseQueryOptions } from "@tanstack/react-query";
+
+import {
+  readTaskApiV1TasksTaskIdGet,
+  getReadTaskApiV1TasksTaskIdGetQueryKey,
+  listTasksApiV1TasksGet,
+  getListTasksApiV1TasksGetQueryKey,
+  listSubtasksApiV1TasksTaskIdSubtasksGet,
+  getListSubtasksApiV1TasksTaskIdSubtasksGetQueryKey,
+} from "@/api/generated/tasks/tasks";
+import type { Task } from "@/types/api";
+import type {
+  ListTasksApiV1TasksGetParams,
+  TaskListResponse,
+  SubtaskRead,
+} from "@/api/generated/initiativeAPI.schemas";
+
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+export const useTask = (taskId: number | null, options?: QueryOpts<Task>) => {
+  const { enabled: userEnabled = true, ...rest } = options ?? {};
+  return useQuery<Task>({
+    queryKey: getReadTaskApiV1TasksTaskIdGetQueryKey(taskId!),
+    queryFn: () => readTaskApiV1TasksTaskIdGet(taskId!) as unknown as Promise<Task>,
+    enabled: taskId !== null && Number.isFinite(taskId) && userEnabled,
+    ...rest,
+  });
+};
+
+export const useTasks = (
+  params: ListTasksApiV1TasksGetParams,
+  options?: QueryOpts<TaskListResponse>
+) => {
+  return useQuery<TaskListResponse>({
+    queryKey: getListTasksApiV1TasksGetQueryKey(params),
+    queryFn: () => listTasksApiV1TasksGet(params) as unknown as Promise<TaskListResponse>,
+    ...options,
+  });
+};
+
+export const usePrefetchTasks = () => {
+  const qc = useQueryClient();
+  return (params: ListTasksApiV1TasksGetParams) => {
+    return qc.prefetchQuery({
+      queryKey: getListTasksApiV1TasksGetQueryKey(params),
+      queryFn: () => listTasksApiV1TasksGet(params) as unknown as Promise<TaskListResponse>,
+      staleTime: 30_000,
+    });
+  };
+};
+
+export const useSubtasks = (taskId: number, options?: QueryOpts<SubtaskRead[]>) => {
+  return useQuery<SubtaskRead[]>({
+    queryKey: getListSubtasksApiV1TasksTaskIdSubtasksGetQueryKey(taskId),
+    queryFn: () =>
+      listSubtasksApiV1TasksTaskIdSubtasksGet(taskId) as unknown as Promise<SubtaskRead[]>,
+    ...options,
+  });
+};

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -1,0 +1,19 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import {
+  listUsersApiV1UsersGet,
+  getListUsersApiV1UsersGetQueryKey,
+} from "@/api/generated/users/users";
+import type { UserGuildMember } from "@/api/generated/initiativeAPI.schemas";
+
+type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+export const useUsers = (options?: QueryOpts<UserGuildMember[]>) => {
+  return useQuery<UserGuildMember[]>({
+    queryKey: getListUsersApiV1UsersGetQueryKey(),
+    queryFn: () => listUsersApiV1UsersGet() as unknown as Promise<UserGuildMember[]>,
+    ...options,
+  });
+};

--- a/frontend/src/pages/ArchivePage.tsx
+++ b/frontend/src/pages/ArchivePage.tsx
@@ -1,14 +1,11 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
-import {
-  listProjectsApiV1ProjectsGet,
-  getListProjectsApiV1ProjectsGetQueryKey,
-  unarchiveProjectApiV1ProjectsProjectIdUnarchivePost,
-} from "@/api/generated/projects/projects";
+import { unarchiveProjectApiV1ProjectsProjectIdUnarchivePost } from "@/api/generated/projects/projects";
 import { invalidateAllProjects } from "@/api/query-keys";
+import { useArchivedProjects } from "@/hooks/useProjects";
 import { Markdown } from "@/components/Markdown";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,7 +19,6 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
 import { guildPath } from "@/lib/guildUrl";
-import { Project } from "@/types/api";
 
 export const ArchivePage = () => {
   const { t } = useTranslation("projects");
@@ -38,15 +34,7 @@ export const ArchivePage = () => {
   );
   const canManageProjects = user?.role === "admin" || managedInitiatives.length > 0;
 
-  const archivedProjectsQuery = useQuery<Project[]>({
-    queryKey: getListProjectsApiV1ProjectsGetQueryKey({ archived: true }),
-    queryFn: async () => {
-      const response = await (listProjectsApiV1ProjectsGet({
-        archived: true,
-      }) as unknown as Promise<{ data: Project[] }>);
-      return response.data;
-    },
-  });
+  const archivedProjectsQuery = useArchivedProjects();
 
   const unarchiveProject = useMutation({
     mutationFn: async (projectId: number) => {

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import type { SerializedEditorState } from "lexical";
 import { ImagePlus, Loader2, PanelRight, ScrollText, Settings, X } from "lucide-react";
@@ -18,14 +18,12 @@ import { useTranslation } from "react-i18next";
 
 import { API_BASE_URL } from "@/api/client";
 import {
-  getReadDocumentApiV1DocumentsDocumentIdGetQueryKey,
   updateDocumentApiV1DocumentsDocumentIdPatch,
   notifyMentionsApiV1DocumentsDocumentIdMentionsPost,
 } from "@/api/generated/documents/documents";
-import { getListCommentsApiV1CommentsGetQueryKey } from "@/api/generated/comments/comments";
 import { invalidateAllDocuments } from "@/api/query-keys";
-import { useDocument } from "@/hooks/useDocuments";
-import { useComments } from "@/hooks/useComments";
+import { useDocument, useSetDocumentCache } from "@/hooks/useDocuments";
+import { useComments, useCommentsCache } from "@/hooks/useComments";
 import { createEmptyEditorState, normalizeEditorState } from "@/components/editor/DocumentEditor";
 import { CollaborationStatusBadge } from "@/components/editor-x/CollaborationStatusBadge";
 import { CommentSection } from "@/components/comments/CommentSection";
@@ -77,7 +75,7 @@ export const DocumentDetailPage = () => {
   const { documentId } = useParams({ strict: false }) as { documentId: string };
   const parsedId = Number(documentId);
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
+  const setDocumentCache = useSetDocumentCache();
   const { user, token } = useAuth();
   const { activeGuildId } = useGuilds();
   const gp = useGuildPath();
@@ -122,7 +120,7 @@ export const DocumentDetailPage = () => {
   const documentQuery = useDocument(Number.isFinite(parsedId) ? parsedId : null);
 
   const commentsQueryParams = { document_id: parsedId };
-  const commentsQueryKey = getListCommentsApiV1CommentsGetQueryKey(commentsQueryParams);
+  const commentsCache = useCommentsCache(commentsQueryParams);
   const commentsQuery = useComments(commentsQueryParams, {
     enabled: Number.isFinite(parsedId),
   });
@@ -258,47 +256,25 @@ export const DocumentDetailPage = () => {
   );
 
   const updateDocumentCommentCount = (delta: number) => {
-    queryClient.setQueryData<DocumentRead>(
-      getReadDocumentApiV1DocumentsDocumentIdGetQueryKey(parsedId),
-      (previous) => {
-        if (!previous) {
-          return previous;
-        }
-        const nextCount = Math.max(0, (previous.comment_count ?? 0) + delta);
-        return { ...previous, comment_count: nextCount };
-      }
-    );
+    setDocumentCache(parsedId, (previous) => {
+      if (!previous) return previous;
+      const nextCount = Math.max(0, (previous.comment_count ?? 0) + delta);
+      return { ...previous, comment_count: nextCount };
+    });
   };
 
   const handleCommentCreated = (comment: Comment) => {
-    queryClient.setQueryData<Comment[]>(commentsQueryKey, (previous) => {
-      if (!previous) {
-        return [comment];
-      }
-      return [...previous, comment];
-    });
+    commentsCache.addComment(comment);
     updateDocumentCommentCount(1);
   };
 
   const handleCommentDeleted = (commentId: number) => {
-    queryClient.setQueryData<Comment[]>(commentsQueryKey, (previous) => {
-      if (!previous) {
-        return previous;
-      }
-      return previous.filter((comment) => comment.id !== commentId);
-    });
+    commentsCache.removeComment(commentId);
     updateDocumentCommentCount(-1);
   };
 
   const handleCommentUpdated = (updatedComment: Comment) => {
-    queryClient.setQueryData<Comment[]>(commentsQueryKey, (previous) => {
-      if (!previous) {
-        return previous;
-      }
-      return previous.map((comment) =>
-        comment.id === updatedComment.id ? updatedComment : comment
-      );
-    });
+    commentsCache.updateComment(updatedComment);
   };
 
   const saveDocument = useMutation({
@@ -325,10 +301,7 @@ export const DocumentDetailPage = () => {
         toast.success(t("detail.saved"));
       }
       isAutosaveRef.current = false;
-      queryClient.setQueryData(
-        getReadDocumentApiV1DocumentsDocumentIdGetQueryKey(parsedId),
-        updated
-      );
+      setDocumentCache(parsedId, updated);
       // Only invalidate the documents list (for sidebar title updates), not all project queries
       void invalidateAllDocuments();
       // Fire-and-forget: notify users who were newly mentioned

--- a/frontend/src/pages/DocumentSettingsPage.tsx
+++ b/frontend/src/pages/DocumentSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useRouter, useParams } from "@tanstack/react-router";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
 import { ArrowRightLeft, Copy, Loader2, Trash2 } from "lucide-react";
@@ -8,8 +8,6 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 
 import {
-  readDocumentApiV1DocumentsDocumentIdGet,
-  getReadDocumentApiV1DocumentsDocumentIdGetQueryKey,
   updateDocumentApiV1DocumentsDocumentIdPatch,
   deleteDocumentApiV1DocumentsDocumentIdDelete,
   duplicateDocumentApiV1DocumentsDocumentIdDuplicatePost,
@@ -23,10 +21,6 @@ import {
   updateDocumentRolePermissionApiV1DocumentsDocumentIdRolePermissionsRoleIdPatch,
   removeDocumentRolePermissionApiV1DocumentsDocumentIdRolePermissionsRoleIdDelete,
 } from "@/api/generated/documents/documents";
-import {
-  listInitiativesApiV1InitiativesGet,
-  getListInitiativesApiV1InitiativesGetQueryKey,
-} from "@/api/generated/initiatives/initiatives";
 import { invalidateAllDocuments, invalidateDocument } from "@/api/query-keys";
 import {
   Breadcrumb,
@@ -61,6 +55,8 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useDateLocale } from "@/hooks/useDateLocale";
+import { useDocument, useSetDocumentCache } from "@/hooks/useDocuments";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { useGuildPath } from "@/lib/guildUrl";
 import { useInitiativeRoles } from "@/hooks/useInitiativeRoles";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
@@ -68,7 +64,6 @@ import type {
   DocumentRead,
   DocumentPermissionLevel,
   DocumentRolePermission,
-  Initiative,
   TagSummary,
 } from "@/types/api";
 import { TagPicker } from "@/components/tags";
@@ -88,7 +83,7 @@ export const DocumentSettingsPage = () => {
   const { documentId } = useParams({ strict: false }) as { documentId: string };
   const parsedId = Number(documentId);
   const router = useRouter();
-  const queryClient = useQueryClient();
+  const setDocumentCache = useSetDocumentCache();
   const { user } = useAuth();
   const gp = useGuildPath();
 
@@ -110,22 +105,13 @@ export const DocumentSettingsPage = () => {
 
   const setDocumentTagsMutation = useSetDocumentTags();
 
-  const documentQuery = useQuery<DocumentRead>({
-    queryKey: getReadDocumentApiV1DocumentsDocumentIdGetQueryKey(parsedId),
-    queryFn: () =>
-      readDocumentApiV1DocumentsDocumentIdGet(parsedId) as unknown as Promise<DocumentRead>,
-    enabled: Number.isFinite(parsedId),
-  });
+  const documentQuery = useDocument(Number.isFinite(parsedId) ? parsedId : null);
 
   const document = documentQuery.data;
 
   const rolesQuery = useInitiativeRoles(document?.initiative_id ?? null);
 
-  const initiativesQuery = useQuery<Initiative[]>({
-    queryKey: getListInitiativesApiV1InitiativesGetQueryKey(),
-    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
-    enabled: Boolean(document) && Boolean(user),
-  });
+  const initiativesQuery = useInitiatives({ enabled: Boolean(document) && Boolean(user) });
 
   // Pure DAC: users with write or owner permission can manage the document
   const canManageDocument = useMemo(() => {
@@ -432,10 +418,7 @@ export const DocumentSettingsPage = () => {
     },
     onSuccess: (updated) => {
       setIsTemplate(updated.is_template);
-      queryClient.setQueryData(
-        getReadDocumentApiV1DocumentsDocumentIdGetQueryKey(parsedId),
-        updated
-      );
+      setDocumentCache(parsedId, updated);
       void invalidateAllDocuments();
     },
     onError: () => {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { Link, useRouter, useSearch } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import {
   ChevronDown,
@@ -27,7 +26,7 @@ import {
   useDocumentCounts,
   useDeleteDocument,
   useCopyDocument,
-  prefetchDocumentsList,
+  usePrefetchDocumentsList,
 } from "@/hooks/useDocuments";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { getItem, setItem } from "@/lib/storage";
@@ -199,7 +198,7 @@ export const DocumentsView = ({
   const { t } = useTranslation(["documents", "common"]);
   const dateLocale = useDateLocale();
   const router = useRouter();
-  const queryClient = useQueryClient();
+  const prefetchDocuments = usePrefetchDocumentsList();
   const { user } = useAuth();
   const { activeGuildId } = useGuilds();
   const gp = useGuildPath();
@@ -447,9 +446,9 @@ export const DocumentsView = ({
         ...(sortBy ? { sort_by: sortBy } : {}),
         ...(sortDir ? { sort_dir: sortDir } : {}),
       };
-      void prefetchDocumentsList(queryClient, prefetchParams);
+      void prefetchDocuments(prefetchParams);
     },
-    [initiativeFilter, searchQuery, queryTagIds, pageSize, sortBy, sortDir, queryClient]
+    [initiativeFilter, searchQuery, queryTagIds, pageSize, sortBy, sortDir, prefetchDocuments]
   );
 
   const initiativesQuery = useInitiatives();

--- a/frontend/src/pages/GuildDashboardPage.tsx
+++ b/frontend/src/pages/GuildDashboardPage.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import {
   CheckCircle2,
@@ -12,24 +11,12 @@ import {
   TrendingUp,
 } from "lucide-react";
 
-import {
-  listProjectsApiV1ProjectsGet,
-  getListProjectsApiV1ProjectsGetQueryKey,
-} from "@/api/generated/projects/projects";
-import {
-  listInitiativesApiV1InitiativesGet,
-  getListInitiativesApiV1InitiativesGetQueryKey,
-} from "@/api/generated/initiatives/initiatives";
-import {
-  listTasksApiV1TasksGet,
-  getListTasksApiV1TasksGetQueryKey,
-} from "@/api/generated/tasks/tasks";
-import {
-  recentCommentsApiV1CommentsRecentGet,
-  getRecentCommentsApiV1CommentsRecentGetQueryKey,
-} from "@/api/generated/comments/comments";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useUserStats } from "@/hooks/useUserStats";
+import { useProjects } from "@/hooks/useProjects";
+import { useInitiatives } from "@/hooks/useInitiatives";
+import { useTasks } from "@/hooks/useTasks";
+import { useRecentComments } from "@/hooks/useComments";
 import { useGuildPath } from "@/lib/guildUrl";
 import { StatsMetricCard } from "@/components/stats/StatsMetricCard";
 import { VelocityChart } from "@/components/stats/VelocityChart";
@@ -42,7 +29,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FavoriteProjectButton } from "@/components/projects/FavoriteProjectButton";
-import type { Initiative, Project, RecentActivityEntry, TaskListResponse } from "@/types/api";
 import type { ListTasksApiV1TasksGetParams } from "@/api/generated/initiativeAPI.schemas";
 import { TaskStatusCategory } from "@/api/generated/initiativeAPI.schemas";
 
@@ -66,41 +52,22 @@ export function GuildDashboardPage() {
 
   const statsQuery = useUserStats(activeGuildId);
 
-  const projectsQuery = useQuery<Project[]>({
-    queryKey: [...getListProjectsApiV1ProjectsGetQueryKey(), activeGuildId],
-    queryFn: () => listProjectsApiV1ProjectsGet() as unknown as Promise<Project[]>,
+  const projectsQuery = useProjects(undefined, {
     staleTime: 60_000,
     enabled: Boolean(activeGuild),
   });
 
-  const initiativesQuery = useQuery<Initiative[]>({
-    queryKey: [...getListInitiativesApiV1InitiativesGetQueryKey(), activeGuildId],
-    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
+  const initiativesQuery = useInitiatives({
     staleTime: 60_000,
     enabled: Boolean(activeGuild),
   });
 
-  const upcomingTasksQuery = useQuery<TaskListResponse>({
-    queryKey: [
-      ...getListTasksApiV1TasksGetQueryKey(DASHBOARD_TASK_PARAMS),
-      "dashboard-upcoming",
-      activeGuildId,
-    ],
-    queryFn: () =>
-      listTasksApiV1TasksGet(DASHBOARD_TASK_PARAMS) as unknown as Promise<TaskListResponse>,
+  const upcomingTasksQuery = useTasks(DASHBOARD_TASK_PARAMS, {
     staleTime: 60_000,
     enabled: Boolean(activeGuild),
   });
 
-  const recentCommentsQuery = useQuery<RecentActivityEntry[]>({
-    queryKey: [
-      ...getRecentCommentsApiV1CommentsRecentGetQueryKey(RECENT_COMMENTS_PARAMS),
-      activeGuildId,
-    ],
-    queryFn: () =>
-      recentCommentsApiV1CommentsRecentGet(RECENT_COMMENTS_PARAMS) as unknown as Promise<
-        RecentActivityEntry[]
-      >,
+  const recentCommentsQuery = useRecentComments(RECENT_COMMENTS_PARAMS, {
     staleTime: 60_000,
     enabled: Boolean(activeGuild),
   });

--- a/frontend/src/pages/InitiativeDetailPage.tsx
+++ b/frontend/src/pages/InitiativeDetailPage.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useState } from "react";
 import { Link, Navigate, useParams } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Loader2, Settings } from "lucide-react";
 
-import {
-  listInitiativesApiV1InitiativesGet,
-  getListInitiativesApiV1InitiativesGetQueryKey,
-} from "@/api/generated/initiatives/initiatives";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { DocumentsView } from "./DocumentsPage";
 import { ProjectsView } from "./ProjectsPage";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
@@ -23,7 +19,6 @@ import {
   canCreate,
 } from "@/hooks/useInitiativeRoles";
 import { Markdown } from "@/components/Markdown";
-import type { Initiative } from "@/types/api";
 
 export const InitiativeDetailPage = () => {
   const { initiativeId: initiativeIdParam } = useParams({ strict: false }) as {
@@ -45,11 +40,7 @@ export const InitiativeDetailPage = () => {
     hasValidInitiativeId ? initiativeId : null
   );
 
-  const initiativesQuery = useQuery<Initiative[]>({
-    queryKey: getListInitiativesApiV1InitiativesGetQueryKey(),
-    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
-    enabled: hasValidInitiativeId,
-  });
+  const initiativesQuery = useInitiatives({ enabled: hasValidInitiativeId });
 
   const initiative =
     hasValidInitiativeId && initiativesQuery.data

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, Navigate, useParams, useRouter } from "@tanstack/react-router";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useGuildPath } from "@/lib/guildUrl";
 import type { ColumnDef, Row } from "@tanstack/react-table";
@@ -8,18 +8,12 @@ import { Loader2, Lock, Pencil, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import {
-  listInitiativesApiV1InitiativesGet,
-  getListInitiativesApiV1InitiativesGetQueryKey,
   updateInitiativeApiV1InitiativesInitiativeIdPatch,
   deleteInitiativeApiV1InitiativesInitiativeIdDelete,
   addInitiativeMemberApiV1InitiativesInitiativeIdMembersPost,
   removeInitiativeMemberApiV1InitiativesInitiativeIdMembersUserIdDelete,
   updateInitiativeMemberApiV1InitiativesInitiativeIdMembersUserIdPatch,
 } from "@/api/generated/initiatives/initiatives";
-import {
-  listUsersApiV1UsersGet,
-  getListUsersApiV1UsersGetQueryKey,
-} from "@/api/generated/users/users";
 import { invalidateAllInitiatives } from "@/api/query-keys";
 import {
   Breadcrumb,
@@ -66,6 +60,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/useAuth";
+import { useInitiatives } from "@/hooks/useInitiatives";
+import { useUsers } from "@/hooks/useUsers";
 import { useGuilds } from "@/hooks/useGuilds";
 import { getRoleLabel, useRoleLabels } from "@/hooks/useRoleLabels";
 import {
@@ -82,10 +78,8 @@ import type {
   InitiativeMemberUpdate,
   InitiativeRoleRead,
   PermissionKey,
-  User,
 } from "@/types/api";
 
-const INITIATIVES_QUERY_KEY = getListInitiativesApiV1InitiativesGetQueryKey();
 const DEFAULT_INITIATIVE_COLOR = "#6366F1";
 
 export const InitiativeSettingsPage = () => {
@@ -107,11 +101,7 @@ export const InitiativeSettingsPage = () => {
   const memberLabel = getRoleLabel("member", roleLabels);
   const adminLabel = getRoleLabel("admin", roleLabels);
 
-  const initiativesQuery = useQuery<Initiative[]>({
-    queryKey: INITIATIVES_QUERY_KEY,
-    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
-    enabled: hasValidInitiativeId,
-  });
+  const initiativesQuery = useInitiatives({ enabled: hasValidInitiativeId });
 
   const initiative =
     hasValidInitiativeId && initiativesQuery.data
@@ -173,9 +163,7 @@ export const InitiativeSettingsPage = () => {
     }
   }, [rolesQuery.data, selectedRoleId]);
 
-  const usersQuery = useQuery<User[]>({
-    queryKey: getListUsersApiV1UsersGetQueryKey(),
-    queryFn: () => listUsersApiV1UsersGet() as unknown as Promise<User[]>,
+  const usersQuery = useUsers({
     enabled: canManageMembers && !!activeGuild?.id,
     staleTime: 5 * 60 * 1000,
   });

--- a/frontend/src/pages/InitiativesPage.tsx
+++ b/frontend/src/pages/InitiativesPage.tsx
@@ -1,11 +1,10 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useSearch } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
-import { getListInitiativesApiV1InitiativesGetQueryKey } from "@/api/generated/initiatives/initiatives";
+import { invalidateAllInitiatives } from "@/api/query-keys";
 import { useInitiatives, useCreateInitiative } from "@/hooks/useInitiatives";
 import { useProjects } from "@/hooks/useProjects";
 import { useDocumentsList } from "@/hooks/useDocuments";
@@ -48,14 +47,11 @@ export const InitiativesPage = () => {
   const { activeGuild } = useGuilds();
   const { data: roleLabels } = useRoleLabels();
   const gp = useGuildPath();
-  const queryClient = useQueryClient();
   const searchParams = useSearch({ strict: false }) as { create?: string };
 
-  const initiativesQueryKey = getListInitiativesApiV1InitiativesGetQueryKey();
-
   const handleRefresh = useCallback(async () => {
-    await queryClient.invalidateQueries({ queryKey: initiativesQueryKey });
-  }, [queryClient, initiativesQueryKey]);
+    await invalidateAllInitiatives();
+  }, []);
 
   const guildAdminLabel = getRoleLabel("admin", roleLabels);
   const projectManagerLabel = getRoleLabel("project_manager", roleLabels);

--- a/frontend/src/pages/MyProjectsPage.tsx
+++ b/frontend/src/pages/MyProjectsPage.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useRouter, useSearch } from "@tanstack/react-router";
-import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { ChevronDown, Filter, Loader2, Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatDistanceToNow } from "date-fns";
 import { useDateLocale } from "@/hooks/useDateLocale";
 
-import { apiClient } from "@/api/client";
 import { invalidateAllProjects } from "@/api/query-keys";
+import { useGlobalProjects, usePrefetchGlobalProjects } from "@/hooks/useProjects";
 import { getItem, setItem } from "@/lib/storage";
 import { guildPath } from "@/lib/guildUrl";
 import { Button } from "@/components/ui/button";
@@ -21,7 +21,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
 import { TagBadge } from "@/components/tags/TagBadge";
-import type { ProjectListResponse, ProjectRead } from "@/types/api";
+import type { ProjectRead } from "@/types/api";
 
 const MY_PROJECTS_FILTERS_KEY = "initiative-my-projects-filters";
 const FILTER_DEFAULTS = {
@@ -57,7 +57,7 @@ const PAGE_SIZE = 20;
 export const MyProjectsPage = () => {
   const { t } = useTranslation(["projects", "common"]);
   const { guilds } = useGuilds();
-  const localQueryClient = useQueryClient();
+  const prefetchGlobalProjects = usePrefetchGlobalProjects();
   const dateLocale = useDateLocale();
   const router = useRouter();
   const searchParams = useSearch({ strict: false }) as { page?: number };
@@ -133,14 +133,7 @@ export const MyProjectsPage = () => {
     return params;
   }, [guildFilters, debouncedSearch, page, pageSize]);
 
-  const projectsQuery = useQuery<ProjectListResponse>({
-    queryKey: ["/api/v1/projects/global", projectsGlobalParams],
-    queryFn: async () => {
-      const response = await apiClient.get<ProjectListResponse>("/projects/global", {
-        params: projectsGlobalParams,
-      });
-      return response.data;
-    },
+  const projectsQuery = useGlobalProjects(projectsGlobalParams, {
     placeholderData: keepPreviousData,
   });
 
@@ -148,19 +141,9 @@ export const MyProjectsPage = () => {
     (targetPage: number) => {
       if (targetPage < 1) return;
       const prefetchParams = { ...projectsGlobalParams, page: targetPage };
-
-      void localQueryClient.prefetchQuery({
-        queryKey: ["/api/v1/projects/global", prefetchParams],
-        queryFn: async () => {
-          const response = await apiClient.get<ProjectListResponse>("/projects/global", {
-            params: prefetchParams,
-          });
-          return response.data;
-        },
-        staleTime: 30_000,
-      });
+      void prefetchGlobalProjects(prefetchParams);
     },
-    [projectsGlobalParams, localQueryClient]
+    [projectsGlobalParams, prefetchGlobalProjects]
   );
 
   const projects = useMemo(() => projectsQuery.data?.items ?? [], [projectsQuery.data]);

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,19 +1,14 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useRouter, useParams } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
 import { Settings } from "lucide-react";
-
-import {
-  listUsersApiV1UsersGet,
-  getListUsersApiV1UsersGetQueryKey,
-} from "@/api/generated/users/users";
 import {
   invalidateAllTasks,
   invalidateProject,
   invalidateProjectTaskStatuses,
 } from "@/api/query-keys";
 import { useProject, useProjectTaskStatuses, useRecordProjectView } from "@/hooks/useProjects";
+import { useUsers } from "@/hooks/useUsers";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { ProjectOverviewCard } from "@/components/projects/ProjectOverviewCard";
 import { ProjectTasksSection } from "@/components/projects/ProjectTasksSection";
@@ -29,7 +24,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuildPath } from "@/lib/guildUrl";
-import type { User } from "@/types/api";
 
 export const ProjectDetailPage = () => {
   const { t } = useTranslation("projects");
@@ -55,10 +49,7 @@ export const ProjectDetailPage = () => {
     Number.isFinite(parsedProjectId) ? parsedProjectId : null
   );
 
-  const usersQuery = useQuery<User[]>({
-    queryKey: getListUsersApiV1UsersGetQueryKey(),
-    queryFn: () => listUsersApiV1UsersGet() as unknown as Promise<User[]>,
-  });
+  const usersQuery = useUsers();
 
   const recordViewMutation = useRecordProjectView();
   const viewedProjectId = projectQuery.data?.id;

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useParams, useRouter } from "@tanstack/react-router";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { useTranslation } from "react-i18next";
 
 import {
-  readProjectApiV1ProjectsProjectIdGet,
-  getReadProjectApiV1ProjectsProjectIdGetQueryKey,
   updateProjectApiV1ProjectsProjectIdPatch,
   deleteProjectApiV1ProjectsProjectIdDelete,
   archiveProjectApiV1ProjectsProjectIdArchivePost,
@@ -21,10 +19,6 @@ import {
   updateProjectRolePermissionApiV1ProjectsProjectIdRolePermissionsRoleIdPatch,
   removeProjectRolePermissionApiV1ProjectsProjectIdRolePermissionsRoleIdDelete,
 } from "@/api/generated/projects/projects";
-import {
-  listInitiativesApiV1InitiativesGet,
-  getListInitiativesApiV1InitiativesGetQueryKey,
-} from "@/api/generated/initiatives/initiatives";
 import { invalidateAllProjects, invalidateProject } from "@/api/query-keys";
 import {
   Breadcrumb,
@@ -59,15 +53,11 @@ import { Input } from "@/components/ui/input";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { EmojiPicker } from "@/components/EmojiPicker";
 import { useAuth } from "@/hooks/useAuth";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { useInitiativeRoles } from "@/hooks/useInitiativeRoles";
+import { useProject } from "@/hooks/useProjects";
 import { useGuildPath } from "@/lib/guildUrl";
-import {
-  Project,
-  Initiative,
-  ProjectPermissionLevel,
-  ProjectRolePermission,
-  TagSummary,
-} from "@/types/api";
+import { Project, ProjectPermissionLevel, ProjectRolePermission, TagSummary } from "@/types/api";
 import { ProjectTaskStatusesManager } from "@/components/projects/ProjectTaskStatusesManager";
 import { TagPicker } from "@/components/tags";
 import { useSetProjectTags } from "@/hooks/useTags";
@@ -110,18 +100,9 @@ export const ProjectSettingsPage = () => {
 
   const setProjectTagsMutation = useSetProjectTags();
 
-  const projectQuery = useQuery<Project>({
-    queryKey: getReadProjectApiV1ProjectsProjectIdGetQueryKey(parsedProjectId),
-    queryFn: () =>
-      readProjectApiV1ProjectsProjectIdGet(parsedProjectId) as unknown as Promise<Project>,
-    enabled: Number.isFinite(parsedProjectId),
-  });
+  const projectQuery = useProject(Number.isFinite(parsedProjectId) ? parsedProjectId : null);
 
-  const initiativesQuery = useQuery<Initiative[]>({
-    queryKey: getListInitiativesApiV1InitiativesGetQueryKey(),
-    enabled: user?.role === "admin",
-    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
-  });
+  const initiativesQuery = useInitiatives({ enabled: user?.role === "admin" });
 
   useEffect(() => {
     if (projectQuery.data) {

--- a/frontend/src/pages/SettingsAIPage.tsx
+++ b/frontend/src/pages/SettingsAIPage.tsx
@@ -1,11 +1,9 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import {
-  getPlatformAiSettingsApiV1SettingsAiPlatformGet,
-  getGetPlatformAiSettingsApiV1SettingsAiPlatformGetQueryKey,
   updatePlatformAiSettingsApiV1SettingsAiPlatformPut,
   testAiConnectionApiV1SettingsAiTestPost,
   fetchAiModelsApiV1SettingsAiModelsPost,
@@ -24,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { usePlatformAISettings } from "@/hooks/useAISettings";
 import { useAuth } from "@/hooks/useAuth";
 import { getModelsForProvider, PROVIDER_CONFIGS } from "@/lib/ai-providers";
 import type {
@@ -62,17 +61,7 @@ export const SettingsAIPage = () => {
   const [hasExistingKey, setHasExistingKey] = useState(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
 
-  const settingsQuery = useQuery<PlatformAISettings>({
-    queryKey: getGetPlatformAiSettingsApiV1SettingsAiPlatformGetQueryKey(),
-    enabled: isPlatformAdmin,
-    queryFn: async () => {
-      const response =
-        await (getPlatformAiSettingsApiV1SettingsAiPlatformGet() as unknown as Promise<{
-          data: PlatformAISettings;
-        }>);
-      return response.data;
-    },
-  });
+  const settingsQuery = usePlatformAISettings({ enabled: isPlatformAdmin });
 
   useEffect(() => {
     if (settingsQuery.data) {

--- a/frontend/src/pages/SettingsAuthPage.tsx
+++ b/frontend/src/pages/SettingsAuthPage.tsx
@@ -1,12 +1,8 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 
-import {
-  getOidcSettingsApiV1SettingsAuthGet,
-  getGetOidcSettingsApiV1SettingsAuthGetQueryKey,
-  updateOidcSettingsApiV1SettingsAuthPut,
-} from "@/api/generated/settings/settings";
+import { updateOidcSettingsApiV1SettingsAuthPut } from "@/api/generated/settings/settings";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -20,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/hooks/useAuth";
+import { useOidcSettings } from "@/hooks/useSettings";
 import { OidcClaimMappingsSection } from "@/components/admin/OidcClaimMappingsSection";
 
 interface OidcSettings {
@@ -46,11 +43,7 @@ export const SettingsAuthPage = () => {
     scopes: "openid profile email offline_access",
   });
 
-  const oidcQuery = useQuery<OidcSettings>({
-    queryKey: getGetOidcSettingsApiV1SettingsAuthGetQueryKey(),
-    enabled: isPlatformAdmin,
-    queryFn: () => getOidcSettingsApiV1SettingsAuthGet() as unknown as Promise<OidcSettings>,
-  });
+  const oidcQuery = useOidcSettings({ enabled: isPlatformAdmin });
 
   const updateOidcSettings = useMutation({
     mutationFn: async (payload: OidcSettings & { client_secret?: string }) => {

--- a/frontend/src/pages/SettingsBrandingPage.tsx
+++ b/frontend/src/pages/SettingsBrandingPage.tsx
@@ -1,14 +1,9 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import {
-  getInterfaceSettingsApiV1SettingsInterfaceGet,
-  getGetInterfaceSettingsApiV1SettingsInterfaceGetQueryKey,
-  updateInterfaceSettingsApiV1SettingsInterfacePut,
-  updateRoleLabelsApiV1SettingsRolesPut,
-} from "@/api/generated/settings/settings";
+import { updateInterfaceSettingsApiV1SettingsInterfacePut } from "@/api/generated/settings/settings";
 import { invalidateInterfaceSettings } from "@/api/query-keys";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,8 +17,9 @@ import {
 import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { DEFAULT_ROLE_LABELS, ROLE_LABELS_QUERY_KEY, useRoleLabels } from "@/hooks/useRoleLabels";
+import { DEFAULT_ROLE_LABELS, useRoleLabels, useUpdateRoleLabels } from "@/hooks/useRoleLabels";
 import { useAuth } from "@/hooks/useAuth";
+import { useInterfaceSettings } from "@/hooks/useSettings";
 import type { RoleLabels } from "@/types/api";
 
 interface InterfaceSettings {
@@ -45,19 +41,12 @@ export const SettingsBrandingPage = () => {
   const { t } = useTranslation("settings");
   const { user } = useAuth();
   const isPlatformAdmin = user?.role === "admin";
-  const queryClient = useQueryClient();
-
   const [lightColor, setLightColor] = useState("#2563eb");
   const [darkColor, setDarkColor] = useState("#60a5fa");
   const [roleFormState, setRoleFormState] = useState<RoleLabels>(DEFAULT_ROLE_LABELS);
   const [roleMessage, setRoleMessage] = useState<string | null>(null);
 
-  const interfaceQuery = useQuery<InterfaceSettings>({
-    queryKey: getGetInterfaceSettingsApiV1SettingsInterfaceGetQueryKey(),
-    enabled: isPlatformAdmin,
-    queryFn: () =>
-      getInterfaceSettingsApiV1SettingsInterfaceGet() as unknown as Promise<InterfaceSettings>,
-  });
+  const interfaceQuery = useInterfaceSettings({ enabled: isPlatformAdmin });
 
   const updateInterface = useMutation({
     mutationFn: async (payload: InterfaceSettings) => {
@@ -73,17 +62,7 @@ export const SettingsBrandingPage = () => {
 
   const roleLabelsQuery = useRoleLabels();
 
-  const updateRoleLabels = useMutation({
-    mutationFn: async (payload: RoleLabels) => {
-      return updateRoleLabelsApiV1SettingsRolesPut(
-        payload as Parameters<typeof updateRoleLabelsApiV1SettingsRolesPut>[0]
-      ) as unknown as Promise<RoleLabels>;
-    },
-    onSuccess: (data) => {
-      queryClient.setQueryData(ROLE_LABELS_QUERY_KEY, data);
-      setRoleMessage(t("branding.rolesSuccess"));
-    },
-  });
+  const updateRoleLabels = useUpdateRoleLabels();
 
   useEffect(() => {
     if (interfaceQuery.data) {
@@ -113,7 +92,9 @@ export const SettingsBrandingPage = () => {
   const handleRoleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setRoleMessage(null);
-    updateRoleLabels.mutate(roleFormState);
+    updateRoleLabels.mutate(roleFormState, {
+      onSuccess: () => setRoleMessage(t("branding.rolesSuccess")),
+    });
   };
 
   if (!isPlatformAdmin) {

--- a/frontend/src/pages/SettingsEmailPage.tsx
+++ b/frontend/src/pages/SettingsEmailPage.tsx
@@ -1,11 +1,9 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import {
-  getEmailSettingsApiV1SettingsEmailGet,
-  getGetEmailSettingsApiV1SettingsEmailGetQueryKey,
   updateEmailSettingsApiV1SettingsEmailPut,
   sendTestEmailApiV1SettingsEmailTestPost,
 } from "@/api/generated/settings/settings";
@@ -15,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/hooks/useAuth";
+import { useEmailSettings } from "@/hooks/useSettings";
 import type { EmailSettings } from "@/types/api";
 
 interface EmailPayload {
@@ -44,11 +43,7 @@ export const SettingsEmailPage = () => {
   const [formState, setFormState] = useState(DEFAULT_STATE);
   const [password, setPassword] = useState("");
   const [testRecipient, setTestRecipient] = useState("");
-  const emailQuery = useQuery<EmailSettings>({
-    queryKey: getGetEmailSettingsApiV1SettingsEmailGetQueryKey(),
-    enabled: isPlatformAdmin,
-    queryFn: () => getEmailSettingsApiV1SettingsEmailGet() as unknown as Promise<EmailSettings>,
-  });
+  const emailQuery = useEmailSettings({ enabled: isPlatformAdmin });
 
   useEffect(() => {
     if (emailQuery.data) {

--- a/frontend/src/pages/SettingsGuildAIPage.tsx
+++ b/frontend/src/pages/SettingsGuildAIPage.tsx
@@ -1,11 +1,9 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import {
-  getGuildAiSettingsApiV1SettingsAiGuildGet,
-  getGetGuildAiSettingsApiV1SettingsAiGuildGetQueryKey,
   updateGuildAiSettingsApiV1SettingsAiGuildPut,
   testAiConnectionApiV1SettingsAiTestPost,
   fetchAiModelsApiV1SettingsAiModelsPost,
@@ -23,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { useGuildAISettings } from "@/hooks/useAISettings";
 import { useGuilds } from "@/hooks/useGuilds";
 import { getModelsForProvider, PROVIDER_CONFIGS } from "@/lib/ai-providers";
 import type {
@@ -62,12 +61,7 @@ export const SettingsGuildAIPage = () => {
   const [hasExistingKey, setHasExistingKey] = useState(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
 
-  const settingsQuery = useQuery<GuildAISettings>({
-    queryKey: [...getGetGuildAiSettingsApiV1SettingsAiGuildGetQueryKey(), guildId],
-    enabled: isGuildAdmin && !!guildId,
-    queryFn: () =>
-      getGuildAiSettingsApiV1SettingsAiGuildGet() as unknown as Promise<GuildAISettings>,
-  });
+  const settingsQuery = useGuildAISettings(guildId, { enabled: isGuildAdmin });
 
   useEffect(() => {
     if (settingsQuery.data) {

--- a/frontend/src/pages/SettingsPlatformUsersPage.tsx
+++ b/frontend/src/pages/SettingsPlatformUsersPage.tsx
@@ -1,19 +1,16 @@
 import { useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Mail, Shield, ShieldOff, Trash2, UserCheck } from "lucide-react";
 
 import {
-  listAllUsersApiV1AdminUsersGet,
-  getListAllUsersApiV1AdminUsersGetQueryKey,
   triggerPasswordResetApiV1AdminUsersUserIdResetPasswordPost,
   reactivateUserApiV1AdminUsersUserIdReactivatePost,
-  getPlatformAdminCountApiV1AdminPlatformAdminCountGet,
-  getGetPlatformAdminCountApiV1AdminPlatformAdminCountGetQueryKey,
   updatePlatformRoleApiV1AdminUsersUserIdPlatformRolePatch,
 } from "@/api/generated/admin/admin";
+import { usePlatformUsers, usePlatformAdminCount } from "@/hooks/useAdmin";
 import { invalidateAdminUsers } from "@/api/query-keys";
 import { AdminDeleteUserDialog } from "@/components/admin/AdminDeleteUserDialog";
 import { Badge } from "@/components/ui/badge";
@@ -25,10 +22,6 @@ import { useRoleLabels, getRoleLabel } from "@/hooks/useRoleLabels";
 import type { User, UserRole } from "@/types/api";
 import { DataTable } from "@/components/ui/data-table";
 import { SortIcon } from "@/components/SortIcon";
-
-interface PlatformAdminCountResponse {
-  count: number;
-}
 
 export const SettingsPlatformUsersPage = () => {
   const { t } = useTranslation(["settings", "common"]);
@@ -50,18 +43,9 @@ export const SettingsPlatformUsersPage = () => {
 
   const isAdmin = user?.role === "admin";
 
-  const usersQuery = useQuery<User[]>({
-    queryKey: getListAllUsersApiV1AdminUsersGetQueryKey(),
-    enabled: isAdmin,
-    queryFn: () => listAllUsersApiV1AdminUsersGet() as unknown as Promise<User[]>,
-  });
+  const usersQuery = usePlatformUsers({ enabled: isAdmin });
 
-  const adminCountQuery = useQuery<PlatformAdminCountResponse>({
-    queryKey: getGetPlatformAdminCountApiV1AdminPlatformAdminCountGetQueryKey(),
-    enabled: isAdmin,
-    queryFn: () =>
-      getPlatformAdminCountApiV1AdminPlatformAdminCountGet() as unknown as Promise<PlatformAdminCountResponse>,
-  });
+  const adminCountQuery = usePlatformAdminCount({ enabled: isAdmin });
 
   const resetPassword = useMutation({
     mutationFn: async (userId: number) => {

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -1,15 +1,14 @@
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import {
-  listUsersApiV1UsersGet,
-  getListUsersApiV1UsersGetQueryKey,
   approveUserApiV1UsersUserIdApprovePost,
   deleteUserApiV1UsersUserIdDelete,
 } from "@/api/generated/users/users";
+import { useUsers } from "@/hooks/useUsers";
 import {
   listGuildInvitesApiV1GuildsGuildIdInvitesGet,
   createGuildInviteApiV1GuildsGuildIdInvitesPost,
@@ -98,11 +97,7 @@ export const SettingsUsersPage = () => {
 
   const inviteRows = useMemo(() => invites, [invites]);
 
-  const usersQuery = useQuery<UserGuildMember[]>({
-    queryKey: getListUsersApiV1UsersGetQueryKey(),
-    enabled: isGuildAdmin,
-    queryFn: () => listUsersApiV1UsersGet() as unknown as Promise<UserGuildMember[]>,
-  });
+  const usersQuery = useUsers({ enabled: isGuildAdmin });
 
   const approveUser = useMutation({
     mutationFn: async (userId: number) => {

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -1,14 +1,11 @@
 import { useMemo } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 
-import {
-  listProjectsApiV1ProjectsGet,
-  getListProjectsApiV1ProjectsGetQueryKey,
-  updateProjectApiV1ProjectsProjectIdPatch,
-} from "@/api/generated/projects/projects";
+import { updateProjectApiV1ProjectsProjectIdPatch } from "@/api/generated/projects/projects";
 import { invalidateAllProjects } from "@/api/query-keys";
+import { useTemplateProjects } from "@/hooks/useProjects";
 import { Markdown } from "@/components/Markdown";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,7 +19,6 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
 import { guildPath } from "@/lib/guildUrl";
-import { Project } from "@/types/api";
 
 export const TemplatesPage = () => {
   const { t } = useTranslation("projects");
@@ -38,11 +34,7 @@ export const TemplatesPage = () => {
   );
   const canManageProjects = user?.role === "admin" || managedInitiatives.length > 0;
 
-  const templatesQuery = useQuery<Project[]>({
-    queryKey: getListProjectsApiV1ProjectsGetQueryKey({ template: true }),
-    queryFn: () =>
-      listProjectsApiV1ProjectsGet({ template: true }) as unknown as Promise<Project[]>,
-  });
+  const templatesQuery = useTemplateProjects();
 
   const deactivateTemplate = useMutation({
     mutationFn: async (projectId: number) => {

--- a/frontend/src/pages/UserSettingsAIPage.tsx
+++ b/frontend/src/pages/UserSettingsAIPage.tsx
@@ -1,11 +1,9 @@
 import { FormEvent, useEffect, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import {
-  getUserAiSettingsApiV1SettingsAiUserGet,
-  getGetUserAiSettingsApiV1SettingsAiUserGetQueryKey,
   updateUserAiSettingsApiV1SettingsAiUserPut,
   testAiConnectionApiV1SettingsAiTestPost,
   fetchAiModelsApiV1SettingsAiModelsPost,
@@ -23,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { useUserAISettings } from "@/hooks/useAISettings";
 import { getModelsForProvider, PROVIDER_CONFIGS } from "@/lib/ai-providers";
 import type {
   AIModelsResponse,
@@ -56,10 +55,7 @@ export const UserSettingsAIPage = () => {
   const [hasExistingKey, setHasExistingKey] = useState(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
 
-  const settingsQuery = useQuery<UserAISettings>({
-    queryKey: getGetUserAiSettingsApiV1SettingsAiUserGetQueryKey(),
-    queryFn: () => getUserAiSettingsApiV1SettingsAiUserGet() as unknown as Promise<UserAISettings>,
-  });
+  const settingsQuery = useUserAISettings();
 
   useEffect(() => {
     if (settingsQuery.data) {

--- a/frontend/src/pages/UserSettingsNotificationsPage.tsx
+++ b/frontend/src/pages/UserSettingsNotificationsPage.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import { updateUsersMeApiV1UsersMePatch } from "@/api/generated/users/users";
-import {
-  getFcmConfigApiV1SettingsFcmConfigGet,
-  getGetFcmConfigApiV1SettingsFcmConfigGetQueryKey,
-} from "@/api/generated/settings/settings";
+import { useFcmConfig } from "@/hooks/useSettings";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -63,10 +60,6 @@ interface UserSettingsNotificationsPageProps {
   refreshUser: () => Promise<void>;
 }
 
-interface FCMConfigResponse {
-  enabled: boolean;
-}
-
 interface NotificationCategory {
   label: string;
   description: string;
@@ -85,11 +78,7 @@ export const UserSettingsNotificationsPage = ({
   const { t } = useTranslation("settings");
   const { permissionStatus, requestPermission, isSupported } = usePushNotifications();
 
-  const { data: fcmConfig } = useQuery({
-    queryKey: getGetFcmConfigApiV1SettingsFcmConfigGetQueryKey(),
-    queryFn: () => getFcmConfigApiV1SettingsFcmConfigGet() as unknown as Promise<FCMConfigResponse>,
-    staleTime: 5 * 60 * 1000,
-  });
+  const { data: fcmConfig } = useFcmConfig();
   const showPushColumn = fcmConfig?.enabled ?? false;
 
   const [timezone, setTimezone] = useState(user.timezone ?? "UTC");

--- a/frontend/src/pages/UserSettingsSecurityPage.tsx
+++ b/frontend/src/pages/UserSettingsSecurityPage.tsx
@@ -1,31 +1,26 @@
 import { FormEvent, useMemo, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Smartphone, Trash2 } from "lucide-react";
 
 import {
-  listMyApiKeysApiV1UsersMeApiKeysGet,
-  getListMyApiKeysApiV1UsersMeApiKeysGetQueryKey,
   createMyApiKeyApiV1UsersMeApiKeysPost,
   deleteMyApiKeyApiV1UsersMeApiKeysApiKeyIdDelete,
 } from "@/api/generated/users/users";
+import { revokeDeviceTokenApiV1AuthDeviceTokensTokenIdDelete } from "@/api/generated/auth/auth";
 import {
-  listDeviceTokensApiV1AuthDeviceTokensGet,
-  getListDeviceTokensApiV1AuthDeviceTokensGetQueryKey,
-  revokeDeviceTokenApiV1AuthDeviceTokensTokenIdDelete,
-} from "@/api/generated/auth/auth";
+  useMyApiKeys,
+  useDeviceTokens,
+  API_KEYS_QUERY_KEY,
+  DEVICE_TOKENS_QUERY_KEY,
+} from "@/hooks/useSecurity";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { queryClient } from "@/lib/queryClient";
-import type {
-  ApiKeyCreateResponse,
-  ApiKeyListResponse,
-  ApiKeyMetadata,
-  DeviceTokenInfo,
-} from "@/types/api";
+import type { ApiKeyCreateResponse, ApiKeyMetadata, DeviceTokenInfo } from "@/types/api";
 import { Input } from "@/components/ui/input";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
 import {
@@ -38,9 +33,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-
-const API_KEYS_QUERY_KEY = getListMyApiKeysApiV1UsersMeApiKeysGetQueryKey();
-const DEVICE_TOKENS_QUERY_KEY = getListDeviceTokensApiV1AuthDeviceTokensGetQueryKey();
 
 const formatDateTime = (value?: string | null) => {
   if (!value) {
@@ -75,10 +67,7 @@ export const UserSettingsSecurityPage = () => {
   const [revokeTarget, setRevokeTarget] = useState<DeviceTokenInfo | null>(null);
 
   // API Keys queries and mutations
-  const apiKeysQuery = useQuery<ApiKeyListResponse>({
-    queryKey: API_KEYS_QUERY_KEY,
-    queryFn: () => listMyApiKeysApiV1UsersMeApiKeysGet() as unknown as Promise<ApiKeyListResponse>,
-  });
+  const apiKeysQuery = useMyApiKeys();
 
   const createKey = useMutation({
     mutationFn: async (payload: { name: string; expires_at?: string | null }) => {
@@ -118,11 +107,7 @@ export const UserSettingsSecurityPage = () => {
   });
 
   // Device tokens queries and mutations
-  const devicesQuery = useQuery<DeviceTokenInfo[]>({
-    queryKey: DEVICE_TOKENS_QUERY_KEY,
-    queryFn: () =>
-      listDeviceTokensApiV1AuthDeviceTokensGet() as unknown as Promise<DeviceTokenInfo[]>,
-  });
+  const devicesQuery = useDeviceTokens();
 
   const revokeToken = useMutation({
     mutationFn: async (tokenId: number) => {

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -8,7 +8,7 @@ import {
   useLocation,
   useSearch,
 } from "@tanstack/react-router";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Loader2, LogOut, Menu, Plus, Ticket } from "lucide-react";
 
@@ -27,12 +27,9 @@ import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { useBackButton } from "@/hooks/useBackButton";
 import { useAuth } from "@/hooks/useAuth";
 import { useServer } from "@/hooks/useServer";
-import {
-  recentProjectsApiV1ProjectsRecentGet,
-  getRecentProjectsApiV1ProjectsRecentGetQueryKey,
-  clearProjectViewApiV1ProjectsProjectIdViewDelete,
-} from "@/api/generated/projects/projects";
+import { clearProjectViewApiV1ProjectsProjectIdViewDelete } from "@/api/generated/projects/projects";
 import { invalidateRecentProjects } from "@/api/query-keys";
+import { useRecentProjects } from "@/hooks/useProjects";
 import type { Project } from "@/types/api";
 
 /**
@@ -90,11 +87,7 @@ function AppLayout() {
   usePushNotifications();
   useBackButton();
 
-  const recentQueryKey = getRecentProjectsApiV1ProjectsRecentGetQueryKey();
-
-  const recentQuery = useQuery<Project[]>({
-    queryKey: recentQueryKey,
-    queryFn: () => recentProjectsApiV1ProjectsRecentGet() as unknown as Promise<Project[]>,
+  const recentQuery = useRecentProjects({
     enabled: activeGuildId !== null && !loading && !!token,
     staleTime: 30_000,
   });
@@ -160,7 +153,7 @@ function AppLayout() {
               />
               <div className="min-w-0 flex-1">
                 <ProjectTabsBar
-                  projects={recentQuery.data}
+                  projects={recentQuery.data as Project[] | undefined}
                   loading={recentQuery.isLoading}
                   activeProjectId={activeProjectId}
                   onClose={handleClearRecent}


### PR DESCRIPTION
## Summary

- **Centralize all remaining inline `useQuery`/`useQueryClient` usage** from pages and components into domain-specific hook files (`useProjects.ts`, `useDocuments.ts`, `useComments.ts`, `useTasks.ts`, `useRoleLabels.ts`)
- **Fix subtask checklist loading bug** — API responses were being double-unwrapped (`apiMutator` already extracts `.data`, but mutations were casting to `Promise<{ data: T }>` and accessing `.data` again, returning `undefined`)
- **Add ESLint rule** enforcing that `useQuery` and `useQueryClient` can only be imported from `src/api/` and `src/hooks/`, preventing future regression

### New hooks added
- `useGlobalProjects` / `usePrefetchGlobalProjects` — cross-guild project listing
- `useGlobalDocuments` / `usePrefetchGlobalDocuments` — cross-guild document listing
- `usePrefetchTasks` / `usePrefetchDocumentsList` — prefetch wrappers
- `useSetDocumentCache` — optimistic document cache updates
- `useCommentsCache` — optimistic comment add/remove/update
- `useUpdateRoleLabels` — role labels mutation

### Pages updated
- `GuildDashboardPage` — replaced 4 inline queries with existing hooks
- `MyProjectsPage` / `MyDocumentsPage` — replaced inline queries + prefetch
- `DocumentDetailPage` / `DocumentSettingsPage` — replaced `useQueryClient` with cache hooks
- `DocumentsPage` / `InitiativesPage` — replaced prefetch/invalidation patterns
- `SettingsBrandingPage` — replaced inline mutation with `useUpdateRoleLabels`
- `TagTasksTable` — replaced inline prefetch with `usePrefetchTasks`
- `TaskChecklist` — fixed 4 double-unwrapping bugs in subtask mutations

## Test plan
- [x] Verify guild dashboard loads all sections (metrics, projects, tasks, comments)
- [x] Verify My Projects page loads with pagination and prefetch
- [x] Verify My Documents page loads with pagination, sorting, and prefetch
- [x] Verify subtask checklist loads and create/update/reorder/delete operations work
- [x] Verify document detail page comment add/edit/delete works
- [x] Verify document settings save works
- [x] Verify branding page role label save works
- [x] Run `pnpm lint` — passes with 0 warnings
- [x] Run `pnpm tsc --noEmit` — passes