### PR TITLE
Remove complex type aliases, import Orval types directly

### DIFF
--- a/frontend/src/__tests__/factories/initiative.factory.ts
+++ b/frontend/src/__tests__/factories/initiative.factory.ts
@@ -1,5 +1,4 @@
-import type { InitiativeMemberRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Initiative } from "@/types/api";
+import type { InitiativeMemberRead, InitiativeRead } from "@/api/generated/initiativeAPI.schemas";
 import { buildUserPublic } from "./user.factory";
 
 let counter = 0;
@@ -29,10 +28,11 @@ export function buildInitiativeMember(
   };
 }
 
-export function buildInitiative(overrides: Partial<Initiative> = {}): Initiative {
+export function buildInitiative(overrides: Partial<InitiativeRead> = {}): InitiativeRead {
   counter++;
   return {
     id: counter,
+    guild_id: 1,
     name: `Initiative ${counter}`,
     description: `Description for initiative ${counter}`,
     color: "#3b82f6",

--- a/frontend/src/__tests__/factories/project.factory.ts
+++ b/frontend/src/__tests__/factories/project.factory.ts
@@ -1,9 +1,9 @@
 import type {
   ProjectPermissionRead,
+  ProjectRead,
   TaskStatusCategory,
   TaskStatusRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Project } from "@/types/api";
 
 let counter = 0;
 
@@ -64,7 +64,7 @@ export function buildProjectPermission(
   };
 }
 
-export function buildProject(overrides: Partial<Project> = {}): Project {
+export function buildProject(overrides: Partial<ProjectRead> = {}): ProjectRead {
   counter++;
   return {
     id: counter,
@@ -79,7 +79,7 @@ export function buildProject(overrides: Partial<Project> = {}): Project {
     is_template: false,
     archived_at: null,
     pinned_at: null,
-    owner: undefined,
+    owner: null,
     initiative: null,
     permissions: [],
     role_permissions: [],

--- a/frontend/src/__tests__/factories/tag.factory.ts
+++ b/frontend/src/__tests__/factories/tag.factory.ts
@@ -1,5 +1,4 @@
-import type { TagSummary } from "@/api/generated/initiativeAPI.schemas";
-import type { Tag } from "@/types/api";
+import type { TagRead, TagSummary } from "@/api/generated/initiativeAPI.schemas";
 
 let counter = 0;
 
@@ -28,7 +27,7 @@ export function buildTagSummary(overrides: Partial<TagSummary> = {}): TagSummary
   };
 }
 
-export function buildTag(overrides: Partial<Tag> = {}): Tag {
+export function buildTag(overrides: Partial<TagRead> = {}): TagRead {
   counter++;
   return {
     id: counter,

--- a/frontend/src/__tests__/factories/task.factory.ts
+++ b/frontend/src/__tests__/factories/task.factory.ts
@@ -1,9 +1,9 @@
 import type {
   TaskAssigneeSummary,
+  TaskListRead,
   TaskListResponse,
   TaskStatusRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
 
 let counter = 0;
 
@@ -24,7 +24,7 @@ export function buildTaskAssignee(
   };
 }
 
-export function buildTask(overrides: Partial<Task> = {}): Task {
+export function buildTask(overrides: Partial<TaskListRead> = {}): TaskListRead {
   counter++;
 
   const defaultStatus: TaskStatusRead = {
@@ -68,7 +68,7 @@ export function buildTask(overrides: Partial<Task> = {}): Task {
 }
 
 export function buildTaskListResponse(
-  itemsOrOverrides: Task[] | Partial<TaskListResponse> = {}
+  itemsOrOverrides: TaskListRead[] | Partial<TaskListResponse> = {}
 ): TaskListResponse {
   if (Array.isArray(itemsOrOverrides)) {
     return {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -65,7 +65,11 @@ import { resolveUploadUrl } from "@/lib/uploadUrl";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { guildPath } from "@/lib/guildUrl";
 import { buildTagTree, type TagTreeNode } from "@/lib/tagTree";
-import type { Initiative, Project, Tag as TagType } from "@/types/api";
+import type {
+  InitiativeRead,
+  ProjectRead,
+  TagRead as TagType,
+} from "@/api/generated/initiativeAPI.schemas";
 
 export const AppSidebar = () => {
   const { user, logout } = useAuth();
@@ -111,7 +115,7 @@ export const AppSidebar = () => {
   const documentsQuery = useAllDocumentIds({ enabled: Boolean(activeGuild), staleTime: 60_000 });
 
   const projectsByInitiative = useMemo(() => {
-    const map = new Map<number, Project[]>();
+    const map = new Map<number, ProjectRead[]>();
     const projects = Array.isArray(projectsQuery.data) ? projectsQuery.data : [];
     projects.forEach((project) => {
       if (!project.is_archived) {
@@ -147,7 +151,7 @@ export const AppSidebar = () => {
   }, [initiativesQuery.data, user, isGuildAdmin]);
 
   // Check if user can manage a specific initiative
-  const canManageInitiative = (initiative: Initiative): boolean => {
+  const canManageInitiative = (initiative: InitiativeRead): boolean => {
     if (isGuildAdmin) {
       return true;
     }
@@ -160,7 +164,7 @@ export const AppSidebar = () => {
   };
 
   // Get user's permissions for an initiative
-  const getUserPermissions = (initiative: Initiative) => {
+  const getUserPermissions = (initiative: InitiativeRead) => {
     if (!user) {
       return {
         canViewDocs: true,
@@ -516,8 +520,8 @@ export const AppSidebar = () => {
 };
 
 interface InitiativeSectionProps {
-  initiative: Initiative;
-  projects: Project[];
+  initiative: InitiativeRead;
+  projects: ProjectRead[];
   documentCount: number;
   canManageInitiative: boolean;
   activeProjectId: number | null;
@@ -546,7 +550,7 @@ const InitiativeSection = ({
   // Helper to create guild-scoped paths
   const gp = (path: string) => (activeGuildId ? guildPath(activeGuildId, path) : path);
   // Pure DAC: check if user has write access to a specific project
-  const canManageProject = (project: Project): boolean => {
+  const canManageProject = (project: ProjectRead): boolean => {
     if (!userId) return false;
     const level = project.my_permission_level;
     return level === "owner" || level === "write";

--- a/frontend/src/components/dashboard/InitiativeOverview.tsx
+++ b/frontend/src/components/dashboard/InitiativeOverview.tsx
@@ -6,11 +6,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGuildPath } from "@/lib/guildUrl";
-import type { Initiative, Project } from "@/types/api";
+import type { InitiativeRead, ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 
 interface InitiativeOverviewProps {
-  initiatives: Initiative[];
-  projects: Project[];
+  initiatives: InitiativeRead[];
+  projects: ProjectRead[];
   isLoading?: boolean;
 }
 

--- a/frontend/src/components/dashboard/ProjectHealthList.tsx
+++ b/frontend/src/components/dashboard/ProjectHealthList.tsx
@@ -7,14 +7,14 @@ import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGuildPath } from "@/lib/guildUrl";
-import type { Project } from "@/types/api";
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 
 interface ProjectHealthListProps {
-  projects: Project[];
+  projects: ProjectRead[];
   isLoading?: boolean;
 }
 
-function getHealthPercent(project: Project): number {
+function getHealthPercent(project: ProjectRead): number {
   const summary = project.task_summary;
   if (!summary || summary.total === 0) return 0;
   return Math.round((summary.completed / summary.total) * 100);

--- a/frontend/src/components/dashboard/UpcomingTasksList.tsx
+++ b/frontend/src/components/dashboard/UpcomingTasksList.tsx
@@ -7,10 +7,10 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGuildPath } from "@/lib/guildUrl";
-import type { Task } from "@/types/api";
+import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 
 interface UpcomingTasksListProps {
-  tasks: Task[];
+  tasks: TaskListRead[];
   isLoading?: boolean;
 }
 

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -46,8 +46,7 @@ import {
   type UserGrant,
 } from "@/components/access/CreateAccessControl";
 import { formatBytes, getFileTypeLabel } from "@/lib/fileUtils";
-import type { DocumentRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Initiative } from "@/types/api";
+import type { DocumentRead, InitiativeRead } from "@/api/generated/initiativeAPI.schemas";
 
 type CreateDocumentDialogProps = {
   open: boolean;
@@ -61,7 +60,7 @@ type CreateDocumentDialogProps = {
   /** Called after successful creation/upload */
   onSuccess?: (document: DocumentRead) => void;
   /** List of initiatives user can create documents in (required if initiativeId not provided) */
-  initiatives?: Initiative[];
+  initiatives?: InitiativeRead[];
 };
 
 export const CreateDocumentDialog = ({

--- a/frontend/src/components/projects/KanbanColumn.tsx
+++ b/frontend/src/components/projects/KanbanColumn.tsx
@@ -8,8 +8,11 @@ import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/Markdown";
-import type { TaskPriority, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
+import type {
+  TaskListRead,
+  TaskPriority,
+  TaskStatusRead,
+} from "@/api/generated/initiativeAPI.schemas";
 import { truncateText } from "@/lib/text";
 import { summarizeRecurrence } from "@/lib/recurrence";
 import type { TranslateFn } from "@/types/i18n";
@@ -21,7 +24,7 @@ import { useGuildPath } from "@/lib/guildUrl";
 
 interface KanbanColumnProps {
   status: TaskStatusRead;
-  tasks: Task[];
+  tasks: TaskListRead[];
   canWrite: boolean;
   priorityVariant: Record<TaskPriority, "default" | "secondary" | "destructive">;
   onTaskClick: (taskId: number) => void;
@@ -192,7 +195,7 @@ const CollapsedHeader = ({
 };
 
 interface KanbanTaskCardProps {
-  task: Task;
+  task: TaskListRead;
   canWrite: boolean;
   priorityVariant: Record<TaskPriority, "default" | "secondary" | "destructive">;
   onTaskClick: (taskId: number) => void;

--- a/frontend/src/components/projects/ProjectCalendarView.tsx
+++ b/frontend/src/components/projects/ProjectCalendarView.tsx
@@ -14,19 +14,19 @@ import {
 } from "date-fns";
 import { Calendar, ChevronLeft, ChevronRight, Clock } from "lucide-react";
 
-import type { Task } from "@/types/api";
+import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 
 type ProjectCalendarViewProps = {
-  tasks: Task[];
+  tasks: TaskListRead[];
   canOpenTask: boolean;
   onTaskClick: (taskId: number) => void;
 };
 
 type CalendarEntry = {
-  task: Task;
+  task: TaskListRead;
   type: "start" | "due";
 };
 

--- a/frontend/src/components/projects/ProjectGanttView.tsx
+++ b/frontend/src/components/projects/ProjectGanttView.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { addDays, differenceInCalendarDays, parseISO, startOfWeek } from "date-fns";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
-import type { Task } from "@/types/api";
+import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -17,13 +17,13 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 
 type ProjectGanttViewProps = {
-  tasks: Task[];
+  tasks: TaskListRead[];
   canOpenTask: boolean;
   onTaskClick: (taskId: number) => void;
 };
 
 type NormalizedRange = {
-  task: Task;
+  task: TaskListRead;
   start: Date;
   end: Date;
 };
@@ -43,7 +43,7 @@ const parseDate = (value?: string | null): Date | null => {
   return parsed;
 };
 
-const normalizeRanges = (tasks: Task[]): NormalizedRange[] =>
+const normalizeRanges = (tasks: TaskListRead[]): NormalizedRange[] =>
   tasks
     .map((task) => {
       const start =

--- a/frontend/src/components/projects/ProjectOverviewCard.tsx
+++ b/frontend/src/components/projects/ProjectOverviewCard.tsx
@@ -11,11 +11,11 @@ import {
   INITIATIVE_COLOR_FALLBACK,
   resolveInitiativeColor,
 } from "@/lib/initiativeColors";
-import type { Project } from "@/types/api";
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 import { Link } from "@tanstack/react-router";
 
 type ProjectOverviewCardProps = {
-  project: Project;
+  project: ProjectRead;
   projectIsArchived: boolean;
 };
 

--- a/frontend/src/components/projects/ProjectPreview.tsx
+++ b/frontend/src/components/projects/ProjectPreview.tsx
@@ -12,11 +12,10 @@ import { PinProjectButton } from "@/components/projects/PinProjectButton";
 import { TagBadge } from "@/components/tags/TagBadge";
 import { useGuilds } from "@/hooks/useGuilds";
 import { InitiativeColorDot, resolveInitiativeColor } from "@/lib/initiativeColors";
-import type { GuildRole } from "@/api/generated/initiativeAPI.schemas";
-import type { Initiative, Project } from "@/types/api";
+import type { GuildRole, InitiativeRead, ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 
 interface ProjectLinkProps {
-  project: Project;
+  project: ProjectRead;
   dragHandleProps?: HTMLAttributes<HTMLButtonElement>;
   userId?: number;
 }
@@ -25,7 +24,7 @@ interface ProjectLinkProps {
  * Check if the user can pin/unpin a project.
  * Only guild admins and initiative project managers can pin projects.
  */
-const canPinProject = (project: Project, userId?: number, guildRole?: GuildRole): boolean => {
+const canPinProject = (project: ProjectRead, userId?: number, guildRole?: GuildRole): boolean => {
   if (!userId) return false;
 
   // Guild admins can always pin
@@ -201,7 +200,7 @@ export const ProjectRowLink = ({ project, dragHandleProps, userId }: ProjectLink
   );
 };
 
-export const InitiativeLabel = ({ initiative }: { initiative?: Initiative | null }) => {
+export const InitiativeLabel = ({ initiative }: { initiative?: InitiativeRead | null }) => {
   const gp = useGuildPath();
   if (!initiative) {
     return null;
@@ -217,7 +216,7 @@ export const InitiativeLabel = ({ initiative }: { initiative?: Initiative | null
   );
 };
 
-const ProjectProgress = ({ summary }: { summary?: Project["task_summary"] }) => {
+const ProjectProgress = ({ summary }: { summary?: ProjectRead["task_summary"] }) => {
   const { t } = useTranslation("projects");
   const total = summary?.total ?? 0;
   const completed = summary?.completed ?? 0;

--- a/frontend/src/components/projects/ProjectTabsBar.tsx
+++ b/frontend/src/components/projects/ProjectTabsBar.tsx
@@ -6,12 +6,12 @@ import { cn } from "@/lib/utils";
 import { guildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
 import { useGuilds } from "@/hooks/useGuilds";
-import type { Project } from "@/types/api";
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 
 interface ProjectTabsBarProps {
-  projects?: Project[];
+  projects?: ProjectRead[];
   activeProjectId?: number | null;
   loading?: boolean;
   onClose: (projectId: number) => void;

--- a/frontend/src/components/projects/ProjectTaskComposer.tsx
+++ b/frontend/src/components/projects/ProjectTaskComposer.tsx
@@ -19,8 +19,11 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
-import type { TaskPriority, TaskRecurrenceOutput } from "@/api/generated/initiativeAPI.schemas";
-import type { TaskRecurrenceStrategy } from "@/types/api";
+import type {
+  TaskListReadRecurrenceStrategy,
+  TaskPriority,
+  TaskRecurrenceOutput,
+} from "@/api/generated/initiativeAPI.schemas";
 import { AssigneeSelector } from "@/components/projects/AssigneeSelector";
 import { useRoleLabels, getRoleLabel } from "@/hooks/useRoleLabels";
 import { TaskRecurrenceSelector } from "@/components/projects/TaskRecurrenceSelector";
@@ -39,7 +42,7 @@ interface ProjectTaskComposerProps {
   startDate: string;
   dueDate: string;
   recurrence: TaskRecurrenceOutput | null;
-  recurrenceStrategy: TaskRecurrenceStrategy;
+  recurrenceStrategy: TaskListReadRecurrenceStrategy;
   canWrite: boolean;
   isArchived: boolean;
   isSubmitting: boolean;
@@ -52,7 +55,7 @@ interface ProjectTaskComposerProps {
   onStartDateChange: (value: string) => void;
   onDueDateChange: (value: string) => void;
   onRecurrenceChange: (value: TaskRecurrenceOutput | null) => void;
-  onRecurrenceStrategyChange: (value: TaskRecurrenceStrategy) => void;
+  onRecurrenceStrategyChange: (value: TaskListReadRecurrenceStrategy) => void;
   onSubmit: () => void;
   onCancel?: () => void;
   autoFocusTitle?: boolean;

--- a/frontend/src/components/projects/ProjectTasksFilters.tsx
+++ b/frontend/src/components/projects/ProjectTasksFilters.tsx
@@ -13,8 +13,7 @@ import { MultiSelect } from "@/components/ui/multi-select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { TagPicker } from "@/components/tags/TagPicker";
 import type { DueFilterOption, UserOption } from "@/components/projects/projectTasksConfig";
-import type { TagSummary, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Tag } from "@/types/api";
+import type { TagRead, TagSummary, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
 
 export type ListStatusFilter = "all" | "incomplete" | number;
 
@@ -22,7 +21,7 @@ type ProjectTasksFiltersProps = {
   viewMode: "kanban" | "table" | "calendar" | "gantt";
   userOptions: UserOption[];
   taskStatuses: TaskStatusRead[];
-  tags: Tag[];
+  tags: TagRead[];
   assigneeFilters: string[];
   dueFilter: DueFilterOption;
   statusFilters: number[];
@@ -56,7 +55,9 @@ export const ProjectTasksFilters = ({
   // Convert tag IDs to Tag objects for TagPicker
   const selectedTags = useMemo(() => {
     const tagMap = new Map(tags.map((tag) => [tag.id, tag]));
-    return tagFilters.map((id) => tagMap.get(id)).filter((tag): tag is Tag => tag !== undefined);
+    return tagFilters
+      .map((id) => tagMap.get(id))
+      .filter((tag): tag is TagRead => tag !== undefined);
   }, [tags, tagFilters]);
 
   const handleTagsChange = (newTags: TagSummary[]) => {

--- a/frontend/src/components/projects/ProjectTasksKanbanView.tsx
+++ b/frontend/src/components/projects/ProjectTasksKanbanView.tsx
@@ -13,8 +13,11 @@ import {
 } from "@dnd-kit/core";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import type { TaskPriority, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
+import type {
+  TaskListRead,
+  TaskPriority,
+  TaskStatusRead,
+} from "@/api/generated/initiativeAPI.schemas";
 
 import { KanbanColumn } from "@/components/projects/KanbanColumn";
 import { Badge } from "@/components/ui/badge";
@@ -25,14 +28,14 @@ import { TaskChecklistProgress } from "@/components/tasks/TaskChecklistProgress"
 
 type ProjectTasksKanbanViewProps = {
   taskStatuses: TaskStatusRead[];
-  groupedTasks: Record<number, Task[]>;
+  groupedTasks: Record<number, TaskListRead[]>;
   collapsedStatusIds: Set<number>;
   canReorderTasks: boolean;
   canOpenTask: boolean;
   onTaskClick: (taskId: number) => void;
   priorityVariant: Record<TaskPriority, "default" | "secondary" | "destructive">;
   sensors: DndContextProps["sensors"];
-  activeTask: Task | null;
+  activeTask: TaskListRead | null;
   onDragStart: (event: DragStartEvent) => void;
   onDragOver: (event: DragOverEvent) => void;
   onDragEnd: (event: DragEndEvent) => void;
@@ -151,7 +154,7 @@ const TaskDragOverlay = ({
   task,
   priorityVariant,
 }: {
-  task: Task;
+  task: TaskListRead;
   priorityVariant: Record<TaskPriority, "default" | "secondary" | "destructive">;
 }) => {
   const { t } = useTranslation("projects");

--- a/frontend/src/components/projects/ProjectTasksTableView.tsx
+++ b/frontend/src/components/projects/ProjectTasksTableView.tsx
@@ -14,8 +14,7 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, MessageSquare } from "lucide-react";
 
-import type { TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
+import type { TaskListRead, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
 import { DataTable, type DataTableRowWrapperProps } from "@/components/ui/data-table";
 import { TableRow } from "@/components/ui/table";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -43,7 +42,7 @@ import { TagBadge } from "@/components/tags/TagBadge";
 import { useGuildPath } from "@/lib/guildUrl";
 
 type ProjectTasksListViewProps = {
-  tasks: Task[];
+  tasks: TaskListRead[];
   taskStatuses: TaskStatusRead[];
   sensors: DndContextProps["sensors"];
   canReorderTasks: boolean;
@@ -55,7 +54,7 @@ type ProjectTasksListViewProps = {
   onDragCancel: () => void;
   onStatusChange: (taskId: number, taskStatusId: number) => void;
   onTaskClick: (taskId: number) => void;
-  onTaskSelectionChange?: (selectedTasks: Task[]) => void;
+  onTaskSelectionChange?: (selectedTasks: TaskListRead[]) => void;
   onExitSelection?: () => void;
 };
 
@@ -74,7 +73,7 @@ const SortableRowWrapper = ({
   row,
   children,
   dragDisabled,
-}: DataTableRowWrapperProps<Task> & { dragDisabled: boolean }) => {
+}: DataTableRowWrapperProps<TaskListRead> & { dragDisabled: boolean }) => {
   const {
     attributes,
     listeners,
@@ -148,7 +147,7 @@ const ProjectTasksTableViewComponent = ({
     return { doneStatus, inProgressStatus };
   }, [taskStatuses]);
 
-  const columns = useMemo<ColumnDef<Task>[]>(
+  const columns = useMemo<ColumnDef<TaskListRead>[]>(
     () => [
       {
         id: "drag",
@@ -489,7 +488,7 @@ const DragHandleCell = () => {
 };
 
 type TaskCellProps = {
-  task: Task;
+  task: TaskListRead;
   canOpenTask: boolean;
   onTaskClick: (taskId: number) => void;
 };

--- a/frontend/src/components/projects/SortableTaskRow.tsx
+++ b/frontend/src/components/projects/SortableTaskRow.tsx
@@ -13,11 +13,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type {
+  TaskListRead,
   TaskPriority,
   TaskStatusCategory,
   TaskStatusRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
 import { truncateText } from "@/lib/text";
 import { summarizeRecurrence } from "@/lib/recurrence";
 import type { TranslateFn } from "@/types/i18n";
@@ -28,7 +28,7 @@ import { TagBadge } from "@/components/tags";
 import { useGuildPath } from "@/lib/guildUrl";
 
 interface SortableTaskRowProps {
-  task: Task;
+  task: TaskListRead;
   dragDisabled: boolean;
   statusDisabled: boolean;
   taskStatuses: TaskStatusRead[];

--- a/frontend/src/components/projects/TaskDescriptionHoverCard.tsx
+++ b/frontend/src/components/projects/TaskDescriptionHoverCard.tsx
@@ -1,13 +1,13 @@
 import { TextAlignStart } from "lucide-react";
 
-import type { Task } from "@/types/api";
+import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/Markdown";
 import { cn } from "@/lib/utils";
 
 interface TaskDescriptionHoverCardProps {
-  task: Task;
+  task: TaskListRead;
   className?: string;
 }
 

--- a/frontend/src/components/projects/TaskRecurrenceSelector.tsx
+++ b/frontend/src/components/projects/TaskRecurrenceSelector.tsx
@@ -2,11 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type {
+  TaskListReadRecurrenceStrategy,
   TaskRecurrenceOutput,
   TaskRecurrenceOutputFrequency,
   TaskRecurrenceOutputWeekdaysItem,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { TaskRecurrenceStrategy, TaskWeekPosition } from "@/types/api";
+import type { TaskWeekPosition } from "@/types/api";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -78,8 +79,8 @@ const getAnchorDate = (referenceDate?: string | null) => {
 type TaskRecurrenceSelectorProps = {
   recurrence: TaskRecurrenceOutput | null;
   onChange: (rule: TaskRecurrenceOutput | null) => void;
-  strategy: TaskRecurrenceStrategy;
-  onStrategyChange: (value: TaskRecurrenceStrategy) => void;
+  strategy: TaskListReadRecurrenceStrategy;
+  onStrategyChange: (value: TaskListReadRecurrenceStrategy) => void;
   disabled?: boolean;
   referenceDate?: string | null;
 };
@@ -618,7 +619,7 @@ export const TaskRecurrenceSelector = ({
             <Label>{t("recurrence.repeatStrategy")}</Label>
             <Select
               value={strategy}
-              onValueChange={(value) => onStrategyChange(value as TaskRecurrenceStrategy)}
+              onValueChange={(value) => onStrategyChange(value as TaskListReadRecurrenceStrategy)}
               disabled={disabled || !recurrence}
             >
               <SelectTrigger>

--- a/frontend/src/components/tags/TagPicker.tsx
+++ b/frontend/src/components/tags/TagPicker.tsx
@@ -17,8 +17,7 @@ import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
 import { TagBadge } from "./TagBadge";
 import { useTags, useCreateTag } from "@/hooks/useTags";
 import { cn } from "@/lib/utils";
-import type { TagSummary } from "@/api/generated/initiativeAPI.schemas";
-import type { Tag } from "@/types/api";
+import type { TagRead, TagSummary } from "@/api/generated/initiativeAPI.schemas";
 
 const DEFAULT_TAG_COLORS = [
   "#6366F1", // Indigo
@@ -78,7 +77,7 @@ export function TagPicker({
   const canCreateNew = search.trim() && !exactMatch;
 
   const toggleTag = useCallback(
-    (tag: Tag | TagSummary) => {
+    (tag: TagRead | TagSummary) => {
       if (selectedIds.has(tag.id)) {
         onChange(selectedTags.filter((t) => t.id !== tag.id));
       } else {

--- a/frontend/src/components/tasks/BulkEditTaskTagsDialog.tsx
+++ b/frontend/src/components/tasks/BulkEditTaskTagsDialog.tsx
@@ -16,13 +16,12 @@ import {
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TagPicker } from "@/components/tags/TagPicker";
-import type { TagSummary } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
+import type { TagSummary, TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 
 interface BulkEditTaskTagsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  tasks: Task[];
+  tasks: TaskListRead[];
   onSuccess: () => void;
 }
 

--- a/frontend/src/components/tasks/MoveTaskDialog.tsx
+++ b/frontend/src/components/tasks/MoveTaskDialog.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle } from "lucide-react";
 
-import type { Project } from "@/types/api";
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,7 +19,7 @@ type MoveTaskDialogProps = {
   trigger?: ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  projects: Project[];
+  projects: ProjectRead[];
   currentProjectId?: number | null;
   isLoading?: boolean;
   isSaving?: boolean;

--- a/frontend/src/components/tasks/TagTasksTable.tsx
+++ b/frontend/src/components/tasks/TagTasksTable.tsx
@@ -20,11 +20,11 @@ import { DataTable } from "@/components/ui/data-table";
 import { useGuilds } from "@/hooks/useGuilds";
 import { TaskDescriptionHoverCard } from "@/components/projects/TaskDescriptionHoverCard";
 import type {
+  TaskListRead,
   TaskPriority,
   TaskStatusCategory,
   TaskStatusRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
 import { SortIcon } from "@/components/SortIcon";
 import { dateSortingFn, prioritySortingFn } from "@/lib/sorting";
 import { TaskChecklistProgress } from "@/components/tasks/TaskChecklistProgress";
@@ -179,7 +179,7 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
     }) => {
       return updateTaskApiV1TasksTaskIdPatch(taskId, {
         task_status_id: taskStatusId,
-      }) as unknown as Promise<Task>;
+      }) as unknown as Promise<TaskListRead>;
     },
     onSuccess: (updatedTask) => {
       void invalidateAllTasks();
@@ -245,7 +245,7 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
   );
 
   const changeTaskStatusById = useCallback(
-    async (task: Task, targetStatusId: number) => {
+    async (task: TaskListRead, targetStatusId: number) => {
       const targetGuildId = task.guild_id ?? activeGuildId ?? null;
       if (!targetGuildId) {
         toast.error(t("errors.guildContext"));
@@ -267,7 +267,7 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
   );
 
   const changeTaskStatus = useCallback(
-    async (task: Task, targetCategory: TaskStatusCategory) => {
+    async (task: TaskListRead, targetCategory: TaskStatusCategory) => {
       const targetGuildId = task.guild_id ?? activeGuildId ?? null;
       if (!targetGuildId) {
         toast.error(t("errors.guildContext"));
@@ -287,7 +287,7 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
     [activeGuildId, changeTaskStatusById, resolveStatusIdForCategory, t]
   );
 
-  const columns: ColumnDef<Task>[] = [
+  const columns: ColumnDef<TaskListRead>[] = [
     {
       id: "completed",
       header: () => <span className="font-medium">{t("columns.done")}</span>,

--- a/frontend/src/components/tasks/TaskBulkEditDialog.tsx
+++ b/frontend/src/components/tasks/TaskBulkEditDialog.tsx
@@ -28,11 +28,12 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import type {
+  TaskListRead,
+  TaskListReadRecurrenceStrategy,
   TaskPriority,
   TaskRecurrenceOutput,
   TaskStatusRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Task, TaskRecurrenceStrategy } from "@/types/api";
 import type { UserOption } from "@/components/projects/projectTasksConfig";
 
 export type TaskBulkUpdate = {
@@ -42,11 +43,11 @@ export type TaskBulkUpdate = {
   task_status_id: number;
   priority: TaskPriority;
   recurrence: TaskRecurrenceOutput | null;
-  recurrence_strategy: TaskRecurrenceStrategy;
+  recurrence_strategy: TaskListReadRecurrenceStrategy;
 };
 
 interface TaskBulkEditDialogProps {
-  selectedTasks: Task[];
+  selectedTasks: TaskListRead[];
   taskStatuses: TaskStatusRead[];
   userOptions: UserOption[];
   isSubmitting: boolean;
@@ -69,7 +70,8 @@ export const TaskBulkEditDialog = ({
   const [statusId, setStatusId] = useState<string>("");
   const [priority, setPriority] = useState<string>("");
   const [recurrence, setRecurrence] = useState<TaskRecurrenceOutput | null>(null);
-  const [recurrenceStrategy, setRecurrenceStrategy] = useState<TaskRecurrenceStrategy>("fixed");
+  const [recurrenceStrategy, setRecurrenceStrategy] =
+    useState<TaskListReadRecurrenceStrategy>("fixed");
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/frontend/src/components/tasks/TaskBulkEditPanel.tsx
+++ b/frontend/src/components/tasks/TaskBulkEditPanel.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from "react-i18next";
 import { Archive, Pencil, Tags, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import type { Task } from "@/types/api";
+import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 
 type TaskBulkEditPanelProps = {
-  selectedTasks: Task[];
+  selectedTasks: TaskListRead[];
   onEdit: () => void;
   onEditTags: () => void;
   onArchive: () => void;

--- a/frontend/src/components/tasks/TaskPrioritySelector.tsx
+++ b/frontend/src/components/tasks/TaskPrioritySelector.tsx
@@ -14,11 +14,10 @@ import {
 import { updateTaskApiV1TasksTaskIdPatch } from "@/api/generated/tasks/tasks";
 import { invalidateAllTasks, invalidateTask } from "@/api/query-keys";
 import { priorityVariant } from "@/components/projects/projectTasksConfig";
-import type { TaskPriority } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
+import type { TaskListRead, TaskPriority } from "@/api/generated/initiativeAPI.schemas";
 
 type TaskPrioritySelectorProps = {
-  task: Task;
+  task: TaskListRead;
   /** Guild ID override. If not provided, uses the default from apiClient interceptor. */
   guildId?: number | null;
   disabled?: boolean;
@@ -41,7 +40,7 @@ export const TaskPrioritySelector = ({ task, disabled }: TaskPrioritySelectorPro
     mutationFn: async (priority: TaskPriority) => {
       return updateTaskApiV1TasksTaskIdPatch(task.id, {
         priority,
-      }) as unknown as Promise<Task>;
+      }) as unknown as Promise<TaskListRead>;
     },
     onSuccess: (updatedTask) => {
       // Invalidate relevant queries

--- a/frontend/src/components/tasks/TaskStatusSelector.tsx
+++ b/frontend/src/components/tasks/TaskStatusSelector.tsx
@@ -9,14 +9,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Task } from "@/types/api";
+import type { TaskListRead, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
 
 type TaskStatusSelectorProps = {
-  task: Task;
+  task: TaskListRead;
   activeGuildId: number | null;
   isUpdatingTaskStatus: boolean;
-  changeTaskStatusById: (task: Task, statusId: number) => Promise<void>;
+  changeTaskStatusById: (task: TaskListRead, statusId: number) => Promise<void>;
   fetchProjectStatuses: (projectId: number, guildId: number | null) => Promise<TaskStatusRead[]>;
   projectStatusCache: React.MutableRefObject<
     Map<number, { statuses: TaskStatusRead[]; complete: boolean }>

--- a/frontend/src/components/tasks/globalTaskColumns.tsx
+++ b/frontend/src/components/tasks/globalTaskColumns.tsx
@@ -17,19 +17,23 @@ import { TaskPrioritySelector } from "@/components/tasks/TaskPrioritySelector";
 import { TaskStatusSelector } from "@/components/tasks/TaskStatusSelector";
 import { TagBadge } from "@/components/tags/TagBadge";
 import { TaskAssigneeList } from "@/components/projects/TaskAssigneeList";
-import type { TaskStatusCategory, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
-import type { Project, Task } from "@/types/api";
+import type {
+  ProjectRead,
+  TaskListRead,
+  TaskStatusCategory,
+  TaskStatusRead,
+} from "@/api/generated/initiativeAPI.schemas";
 
 interface GlobalTaskColumnsOptions {
   activeGuildId: number | null;
   isUpdatingTaskStatus: boolean;
-  changeTaskStatus: (task: Task, category: TaskStatusCategory) => Promise<void>;
-  changeTaskStatusById: (task: Task, statusId: number) => Promise<void>;
+  changeTaskStatus: (task: TaskListRead, category: TaskStatusCategory) => Promise<void>;
+  changeTaskStatusById: (task: TaskListRead, statusId: number) => Promise<void>;
   fetchProjectStatuses: (projectId: number, guildId: number | null) => Promise<TaskStatusRead[]>;
   projectStatusCache: React.MutableRefObject<
     Map<number, { statuses: TaskStatusRead[]; complete: boolean }>
   >;
-  projectsById: Record<number, Project>;
+  projectsById: Record<number, ProjectRead>;
   t: TranslateFn;
   showAssignees?: boolean;
 }
@@ -44,11 +48,11 @@ export function globalTaskColumns({
   projectsById,
   t,
   showAssignees = false,
-}: GlobalTaskColumnsOptions): ColumnDef<Task>[] {
+}: GlobalTaskColumnsOptions): ColumnDef<TaskListRead>[] {
   const guildDefaultLabel = t("myTasks.noGuild");
-  const getGuildGroupLabel = (task: Task) => task.guild_name ?? guildDefaultLabel;
+  const getGuildGroupLabel = (task: TaskListRead) => task.guild_name ?? guildDefaultLabel;
 
-  const taskGuildPath = (task: Task, path: string) => {
+  const taskGuildPath = (task: TaskListRead, path: string) => {
     const guildId = task.guild_id ?? activeGuildId;
     return guildId ? guildPath(guildId, path) : path;
   };

--- a/frontend/src/hooks/useGlobalTasksTable.ts
+++ b/frontend/src/hooks/useGlobalTasksTable.ts
@@ -12,17 +12,18 @@ import {
 } from "@/api/generated/tasks/tasks";
 import { listTaskStatusesApiV1ProjectsProjectIdTaskStatusesGet } from "@/api/generated/task-statuses/task-statuses";
 import { useProjects, useTemplateProjects, useArchivedProjects } from "@/hooks/useProjects";
-import type { ListTasksApiV1TasksGetParams } from "@/api/generated/initiativeAPI.schemas";
-import { invalidateAllTasks } from "@/api/query-keys";
-import { getItem, setItem } from "@/lib/storage";
-import { useGuilds } from "@/hooks/useGuilds";
 import type {
+  ListTasksApiV1TasksGetParams,
+  ProjectRead,
+  TaskListRead,
   TaskListResponse,
   TaskPriority,
   TaskStatusCategory,
   TaskStatusRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Project, Task } from "@/types/api";
+import { invalidateAllTasks } from "@/api/query-keys";
+import { getItem, setItem } from "@/lib/storage";
+import { useGuilds } from "@/hooks/useGuilds";
 
 const statusFallbackOrder: Record<TaskStatusCategory, TaskStatusCategory[]> = {
   backlog: ["backlog"],
@@ -209,7 +210,7 @@ export function useGlobalTasksTable({ scope, storageKeyPrefix }: UseGlobalTasksT
   const archivedProjectsQuery = useArchivedProjects();
 
   const projectsById = useMemo(() => {
-    const result: Record<number, Project> = {};
+    const result: Record<number, ProjectRead> = {};
     const projects = Array.isArray(projectsQuery.data) ? projectsQuery.data : [];
     projects.forEach((project) => {
       result[project.id] = project;
@@ -248,7 +249,7 @@ export function useGlobalTasksTable({ scope, storageKeyPrefix }: UseGlobalTasksT
         taskId,
         { task_status_id: taskStatusId },
         guildId ? { headers: { "X-Guild-ID": String(guildId) } } : undefined
-      ) as unknown as Promise<Task>;
+      ) as unknown as Promise<TaskListRead>;
     },
     onSuccess: (updatedTask) => {
       void invalidateAllTasks();
@@ -326,7 +327,7 @@ export function useGlobalTasksTable({ scope, storageKeyPrefix }: UseGlobalTasksT
   );
 
   const changeTaskStatusById = useCallback(
-    async (task: Task, targetStatusId: number) => {
+    async (task: TaskListRead, targetStatusId: number) => {
       const targetGuildId = task.guild_id ?? activeGuildId ?? null;
       if (!targetGuildId) {
         toast.error(t("errors.guildContext"));
@@ -348,7 +349,7 @@ export function useGlobalTasksTable({ scope, storageKeyPrefix }: UseGlobalTasksT
   );
 
   const changeTaskStatus = useCallback(
-    async (task: Task, targetCategory: TaskStatusCategory) => {
+    async (task: TaskListRead, targetCategory: TaskStatusCategory) => {
       const targetGuildId = task.guild_id ?? activeGuildId ?? null;
       if (!targetGuildId) {
         toast.error(t("errors.guildContext"));

--- a/frontend/src/hooks/useInitiatives.ts
+++ b/frontend/src/hooks/useInitiatives.ts
@@ -22,27 +22,28 @@ import {
   invalidateInitiativeMembers,
 } from "@/api/query-keys";
 import { getErrorMessage } from "@/lib/errorMessage";
-import type { Initiative } from "@/types/api";
-import type { InitiativeMemberRead } from "@/api/generated/initiativeAPI.schemas";
+import type { InitiativeMemberRead, InitiativeRead } from "@/api/generated/initiativeAPI.schemas";
 
 type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
 
 // ── Queries ─────────────────────────────────────────────────────────────────
 
-export const useInitiatives = (options?: QueryOpts<Initiative[]>) => {
-  return useQuery<Initiative[]>({
+export const useInitiatives = (options?: QueryOpts<InitiativeRead[]>) => {
+  return useQuery<InitiativeRead[]>({
     queryKey: getListInitiativesApiV1InitiativesGetQueryKey(),
-    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<Initiative[]>,
+    queryFn: () => listInitiativesApiV1InitiativesGet() as unknown as Promise<InitiativeRead[]>,
     ...options,
   });
 };
 
-export const useInitiative = (initiativeId: number | null, options?: QueryOpts<Initiative>) => {
+export const useInitiative = (initiativeId: number | null, options?: QueryOpts<InitiativeRead>) => {
   const { enabled: userEnabled = true, ...rest } = options ?? {};
-  return useQuery<Initiative>({
+  return useQuery<InitiativeRead>({
     queryKey: getGetInitiativeApiV1InitiativesInitiativeIdGetQueryKey(initiativeId!),
     queryFn: () =>
-      getInitiativeApiV1InitiativesInitiativeIdGet(initiativeId!) as unknown as Promise<Initiative>,
+      getInitiativeApiV1InitiativesInitiativeIdGet(
+        initiativeId!
+      ) as unknown as Promise<InitiativeRead>,
     enabled: initiativeId !== null && Number.isFinite(initiativeId) && userEnabled,
     ...rest,
   });
@@ -71,7 +72,7 @@ export const useCreateInitiative = () => {
 
   return useMutation({
     mutationFn: async (data: { name: string; description?: string; color?: string }) => {
-      return createInitiativeApiV1InitiativesPost(data) as unknown as Promise<Initiative>;
+      return createInitiativeApiV1InitiativesPost(data) as unknown as Promise<InitiativeRead>;
     },
     onSuccess: (initiative) => {
       toast.success(t("createDialog.created", { name: initiative.name }));
@@ -95,7 +96,7 @@ export const useUpdateInitiative = () => {
       return updateInitiativeApiV1InitiativesInitiativeIdPatch(
         initiativeId,
         data
-      ) as unknown as Promise<Initiative>;
+      ) as unknown as Promise<InitiativeRead>;
     },
     onSuccess: (_data, { initiativeId }) => {
       void invalidateAllInitiatives();

--- a/frontend/src/hooks/useProjectFavoriteMutation.tsx
+++ b/frontend/src/hooks/useProjectFavoriteMutation.tsx
@@ -8,7 +8,7 @@ import {
   getFavoriteProjectsApiV1ProjectsFavoritesGetQueryKey,
 } from "@/api/generated/projects/projects";
 import { queryClient } from "../lib/queryClient";
-import type { Project } from "../types/api";
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 
 interface ToggleArgs {
   projectId: number;
@@ -20,7 +20,10 @@ interface ToggleResponse {
   is_favorited: boolean;
 }
 
-const updateProjectListFavorite = (projects: Project[] | undefined, response: ToggleResponse) => {
+const updateProjectListFavorite = (
+  projects: ProjectRead[] | undefined,
+  response: ToggleResponse
+) => {
   if (!projects) {
     return projects;
   }
@@ -42,18 +45,19 @@ export const useProjectFavoriteMutation = () => {
       return { project_id: projectId, is_favorited: nextState };
     },
     onSuccess: (data) => {
-      queryClient.setQueryData<Project[]>(getListProjectsApiV1ProjectsGetQueryKey(), (projects) =>
-        updateProjectListFavorite(projects, data)
+      queryClient.setQueryData<ProjectRead[]>(
+        getListProjectsApiV1ProjectsGetQueryKey(),
+        (projects) => updateProjectListFavorite(projects, data)
       );
-      queryClient.setQueryData<Project[]>(
+      queryClient.setQueryData<ProjectRead[]>(
         getListProjectsApiV1ProjectsGetQueryKey({ template: true }),
         (projects) => updateProjectListFavorite(projects, data)
       );
-      queryClient.setQueryData<Project[]>(
+      queryClient.setQueryData<ProjectRead[]>(
         getListProjectsApiV1ProjectsGetQueryKey({ archived: true }),
         (projects) => updateProjectListFavorite(projects, data)
       );
-      queryClient.setQueryData<Project>(
+      queryClient.setQueryData<ProjectRead>(
         getReadProjectApiV1ProjectsProjectIdGetQueryKey(data.project_id) as unknown as string[],
         (project) => (project ? { ...project, is_favorited: data.is_favorited } : project)
       );

--- a/frontend/src/hooks/useProjectPinMutation.ts
+++ b/frontend/src/hooks/useProjectPinMutation.ts
@@ -6,14 +6,14 @@ import {
   getReadProjectApiV1ProjectsProjectIdGetQueryKey,
 } from "@/api/generated/projects/projects";
 import { queryClient } from "@/lib/queryClient";
-import type { Project } from "@/types/api";
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 
 interface ToggleArgs {
   projectId: number;
   nextState: boolean;
 }
 
-const replaceProjectInList = (projects: Project[] | undefined, updated: Project) => {
+const replaceProjectInList = (projects: ProjectRead[] | undefined, updated: ProjectRead) => {
   if (!projects) {
     return projects;
   }
@@ -21,25 +21,26 @@ const replaceProjectInList = (projects: Project[] | undefined, updated: Project)
 };
 
 export const useProjectPinMutation = () =>
-  useMutation<Project, unknown, ToggleArgs>({
+  useMutation<ProjectRead, unknown, ToggleArgs>({
     mutationFn: async ({ projectId, nextState }) => {
       return updateProjectApiV1ProjectsProjectIdPatch(projectId, {
         pinned: nextState,
-      }) as unknown as Promise<Project>;
+      }) as unknown as Promise<ProjectRead>;
     },
     onSuccess: (data) => {
-      queryClient.setQueryData<Project[]>(getListProjectsApiV1ProjectsGetQueryKey(), (projects) =>
-        replaceProjectInList(projects, data)
+      queryClient.setQueryData<ProjectRead[]>(
+        getListProjectsApiV1ProjectsGetQueryKey(),
+        (projects) => replaceProjectInList(projects, data)
       );
-      queryClient.setQueryData<Project[]>(
+      queryClient.setQueryData<ProjectRead[]>(
         getListProjectsApiV1ProjectsGetQueryKey({ template: true }),
         (projects) => replaceProjectInList(projects, data)
       );
-      queryClient.setQueryData<Project[]>(
+      queryClient.setQueryData<ProjectRead[]>(
         getListProjectsApiV1ProjectsGetQueryKey({ archived: true }),
         (projects) => replaceProjectInList(projects, data)
       );
-      queryClient.setQueryData<Project>(
+      queryClient.setQueryData<ProjectRead>(
         getReadProjectApiV1ProjectsProjectIdGetQueryKey(data.id) as unknown as string[],
         () => data
       );

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -30,10 +30,10 @@ import {
 } from "@/api/generated/task-statuses/task-statuses";
 import { invalidateAllProjects, invalidateRecentProjects } from "@/api/query-keys";
 import { getErrorMessage } from "@/lib/errorMessage";
-import type { Project } from "@/types/api";
 import type {
   ListProjectsApiV1ProjectsGetParams,
   ProjectActivityResponse,
+  ProjectRead,
   ProjectRecentViewRead,
   ProjectActivityFeedApiV1ProjectsProjectIdActivityGetParams,
   TaskStatusRead,
@@ -45,11 +45,11 @@ type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
 
 export const useProjects = (
   params?: ListProjectsApiV1ProjectsGetParams,
-  options?: QueryOpts<Project[]>
+  options?: QueryOpts<ProjectRead[]>
 ) => {
-  return useQuery<Project[]>({
+  return useQuery<ProjectRead[]>({
     queryKey: getListProjectsApiV1ProjectsGetQueryKey(params),
-    queryFn: () => listProjectsApiV1ProjectsGet(params) as unknown as Promise<Project[]>,
+    queryFn: () => listProjectsApiV1ProjectsGet(params) as unknown as Promise<ProjectRead[]>,
     ...options,
   });
 };
@@ -62,20 +62,22 @@ export const useArchivedProjects = () => {
   return useProjects({ archived: true });
 };
 
-export const useProject = (projectId: number | null, options?: QueryOpts<Project>) => {
+export const useProject = (projectId: number | null, options?: QueryOpts<ProjectRead>) => {
   const { enabled: userEnabled = true, ...rest } = options ?? {};
-  return useQuery<Project>({
+  return useQuery<ProjectRead>({
     queryKey: getReadProjectApiV1ProjectsProjectIdGetQueryKey(projectId!),
-    queryFn: () => readProjectApiV1ProjectsProjectIdGet(projectId!) as unknown as Promise<Project>,
+    queryFn: () =>
+      readProjectApiV1ProjectsProjectIdGet(projectId!) as unknown as Promise<ProjectRead>,
     enabled: projectId !== null && Number.isFinite(projectId) && userEnabled,
     ...rest,
   });
 };
 
-export const useWritableProjects = (options?: QueryOpts<Project[]>) => {
-  return useQuery<Project[]>({
+export const useWritableProjects = (options?: QueryOpts<ProjectRead[]>) => {
+  return useQuery<ProjectRead[]>({
     queryKey: getListWritableProjectsApiV1ProjectsWritableGetQueryKey(),
-    queryFn: () => listWritableProjectsApiV1ProjectsWritableGet() as unknown as Promise<Project[]>,
+    queryFn: () =>
+      listWritableProjectsApiV1ProjectsWritableGet() as unknown as Promise<ProjectRead[]>,
     staleTime: 60 * 1000,
     ...options,
   });
@@ -91,10 +93,10 @@ export const useRecentProjects = (options?: QueryOpts<ProjectRecentViewRead[]>) 
   });
 };
 
-export const useFavoriteProjects = (options?: QueryOpts<Project[]>) => {
-  return useQuery<Project[]>({
+export const useFavoriteProjects = (options?: QueryOpts<ProjectRead[]>) => {
+  return useQuery<ProjectRead[]>({
     queryKey: getFavoriteProjectsApiV1ProjectsFavoritesGetQueryKey(),
-    queryFn: () => favoriteProjectsApiV1ProjectsFavoritesGet() as unknown as Promise<Project[]>,
+    queryFn: () => favoriteProjectsApiV1ProjectsFavoritesGet() as unknown as Promise<ProjectRead[]>,
     staleTime: 30 * 1000,
     ...options,
   });
@@ -177,7 +179,7 @@ export const useCreateProject = () => {
 
   return useMutation({
     mutationFn: async (data: Parameters<typeof createProjectApiV1ProjectsPost>[0]) => {
-      return createProjectApiV1ProjectsPost(data) as unknown as Promise<Project>;
+      return createProjectApiV1ProjectsPost(data) as unknown as Promise<ProjectRead>;
     },
     onSuccess: () => {
       void invalidateAllProjects();
@@ -201,7 +203,7 @@ export const useUpdateProject = () => {
       return updateProjectApiV1ProjectsProjectIdPatch(
         projectId,
         data
-      ) as unknown as Promise<Project>;
+      ) as unknown as Promise<ProjectRead>;
     },
     onSuccess: () => {
       void invalidateAllProjects();
@@ -260,7 +262,7 @@ export const useDuplicateProject = () => {
       return duplicateProjectApiV1ProjectsProjectIdDuplicatePost(
         projectId,
         data
-      ) as unknown as Promise<Project>;
+      ) as unknown as Promise<ProjectRead>;
     },
     onSuccess: () => {
       void invalidateAllProjects();

--- a/frontend/src/hooks/useTags.ts
+++ b/frontend/src/hooks/useTags.ts
@@ -24,24 +24,26 @@ import {
 } from "@/api/query-keys";
 import type {
   DocumentRead,
+  ProjectRead,
   TagCreate,
+  TagRead,
   TagUpdate,
   TaggedEntitiesResponse,
+  TaskListRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Project, Tag, Task } from "@/types/api";
 
 export const useTags = () => {
-  return useQuery<Tag[]>({
+  return useQuery<TagRead[]>({
     queryKey: getListTagsApiV1TagsGetQueryKey(),
-    queryFn: () => listTagsApiV1TagsGet() as unknown as Promise<Tag[]>,
+    queryFn: () => listTagsApiV1TagsGet() as unknown as Promise<TagRead[]>,
     staleTime: 60 * 1000,
   });
 };
 
 export const useTag = (tagId: number | null) => {
-  return useQuery<Tag>({
+  return useQuery<TagRead>({
     queryKey: getGetTagApiV1TagsTagIdGetQueryKey(tagId!),
-    queryFn: () => getTagApiV1TagsTagIdGet(tagId!) as unknown as Promise<Tag>,
+    queryFn: () => getTagApiV1TagsTagIdGet(tagId!) as unknown as Promise<TagRead>,
     enabled: !!tagId,
     staleTime: 60 * 1000,
   });
@@ -53,7 +55,7 @@ export const useCreateTag = () => {
 
   return useMutation({
     mutationFn: async (data: TagCreate) => {
-      return createTagApiV1TagsPost(data) as unknown as Promise<Tag>;
+      return createTagApiV1TagsPost(data) as unknown as Promise<TagRead>;
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: getListTagsApiV1TagsGetQueryKey() });
@@ -70,7 +72,7 @@ export const useUpdateTag = () => {
 
   return useMutation({
     mutationFn: async ({ tagId, data }: { tagId: number; data: TagUpdate }) => {
-      return updateTagApiV1TagsTagIdPatch(tagId, data) as unknown as Promise<Tag>;
+      return updateTagApiV1TagsTagIdPatch(tagId, data) as unknown as Promise<TagRead>;
     },
     onSuccess: () => {
       toast.success(t("updated"));
@@ -109,7 +111,7 @@ export const useSetTaskTags = () => {
     mutationFn: async ({ taskId, tagIds }: { taskId: number; tagIds: number[] }) => {
       return setTaskTagsApiV1TasksTaskIdTagsPut(taskId, {
         tag_ids: tagIds,
-      }) as unknown as Promise<Task>;
+      }) as unknown as Promise<TaskListRead>;
     },
     onSuccess: () => {
       void invalidateAllTasks();
@@ -138,7 +140,7 @@ export const useSetProjectTags = () => {
     mutationFn: async ({ projectId, tagIds }: { projectId: number; tagIds: number[] }) => {
       return setProjectTagsApiV1ProjectsProjectIdTagsPut(projectId, {
         tag_ids: tagIds,
-      }) as unknown as Promise<Project>;
+      }) as unknown as Promise<ProjectRead>;
     },
     onSuccess: () => {
       void invalidateAllProjects();

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -8,22 +8,22 @@ import {
   listSubtasksApiV1TasksTaskIdSubtasksGet,
   getListSubtasksApiV1TasksTaskIdSubtasksGetQueryKey,
 } from "@/api/generated/tasks/tasks";
-import type { Task } from "@/types/api";
 import type {
   ListTasksApiV1TasksGetParams,
-  TaskListResponse,
   SubtaskRead,
+  TaskListRead,
+  TaskListResponse,
 } from "@/api/generated/initiativeAPI.schemas";
 
 type QueryOpts<T> = Omit<UseQueryOptions<T>, "queryKey" | "queryFn">;
 
 // ── Queries ─────────────────────────────────────────────────────────────────
 
-export const useTask = (taskId: number | null, options?: QueryOpts<Task>) => {
+export const useTask = (taskId: number | null, options?: QueryOpts<TaskListRead>) => {
   const { enabled: userEnabled = true, ...rest } = options ?? {};
-  return useQuery<Task>({
+  return useQuery<TaskListRead>({
     queryKey: getReadTaskApiV1TasksTaskIdGetQueryKey(taskId!),
-    queryFn: () => readTaskApiV1TasksTaskIdGet(taskId!) as unknown as Promise<Task>,
+    queryFn: () => readTaskApiV1TasksTaskIdGet(taskId!) as unknown as Promise<TaskListRead>,
     enabled: taskId !== null && Number.isFinite(taskId) && userEnabled,
     ...rest,
   });

--- a/frontend/src/lib/recurrence.ts
+++ b/frontend/src/lib/recurrence.ts
@@ -1,9 +1,10 @@
 import type {
+  TaskListReadRecurrenceStrategy,
   TaskRecurrenceOutput,
   TaskRecurrenceOutputFrequency,
   TaskRecurrenceOutputWeekdaysItem,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { TaskRecurrenceStrategy, TaskWeekPosition } from "@/types/api";
+import type { TaskWeekPosition } from "@/types/api";
 import type { TranslateFn } from "@/types/i18n";
 
 export type RecurrencePreset =
@@ -269,7 +270,7 @@ const describeMonthlyDetail = (rule: TaskRecurrenceOutput, t?: TranslateFn) => {
 
 export const summarizeRecurrence = (
   rule: TaskRecurrenceOutput | null,
-  options?: { referenceDate?: string | null; strategy?: TaskRecurrenceStrategy },
+  options?: { referenceDate?: string | null; strategy?: TaskListReadRecurrenceStrategy },
   t?: TranslateFn
 ): string => {
   if (!rule) {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -57,9 +57,12 @@ import {
   useMyInitiativePermissions,
   canCreate as canCreatePermission,
 } from "@/hooks/useInitiativeRoles";
-import type { DocumentSummary, TagSummary } from "@/api/generated/initiativeAPI.schemas";
-import type { Tag } from "@/types/api";
-import type { ListDocumentsApiV1DocumentsGetParams } from "@/api/generated/initiativeAPI.schemas";
+import type {
+  DocumentSummary,
+  ListDocumentsApiV1DocumentsGetParams,
+  TagRead,
+  TagSummary,
+} from "@/api/generated/initiativeAPI.schemas";
 import { getFileTypeLabel } from "@/lib/fileUtils";
 import { SortIcon } from "@/components/SortIcon";
 import { dateSortingFn } from "@/lib/sorting";
@@ -318,7 +321,7 @@ export const DocumentsView = ({
   // Convert tag IDs to Tag objects for TagPicker
   const selectedTagsForFilter = useMemo(() => {
     const tagMap = new Map(allTags.map((tg) => [tg.id, tg]));
-    return tagFilters.map((id) => tagMap.get(id)).filter((tg): tg is Tag => tg !== undefined);
+    return tagFilters.map((id) => tagMap.get(id)).filter((tg): tg is TagRead => tg !== undefined);
   }, [allTags, tagFilters]);
 
   const handleTagFiltersChange = (newTags: TagSummary[]) => {

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -75,9 +75,10 @@ import {
 import type {
   InitiativeMemberRead,
   InitiativeMemberUpdate,
+  InitiativeRead,
   InitiativeRoleRead,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Initiative, PermissionKey } from "@/types/api";
+import type { PermissionKey } from "@/types/api";
 
 const DEFAULT_INITIATIVE_COLOR = "#6366F1";
 
@@ -176,11 +177,13 @@ export const InitiativeSettingsPage = () => {
   }, [usersQuery.data, initiative]);
 
   const updateInitiative = useMutation({
-    mutationFn: async (payload: Partial<Pick<Initiative, "name" | "description" | "color">>) => {
+    mutationFn: async (
+      payload: Partial<Pick<InitiativeRead, "name" | "description" | "color">>
+    ) => {
       return updateInitiativeApiV1InitiativesInitiativeIdPatch(
         initiativeId,
         payload
-      ) as unknown as Promise<Initiative>;
+      ) as unknown as Promise<InitiativeRead>;
     },
     onSuccess: () => {
       toast.success(t("settings.updated"));
@@ -212,7 +215,7 @@ export const InitiativeSettingsPage = () => {
       return addInitiativeMemberApiV1InitiativesInitiativeIdMembersPost(initiativeId, {
         user_id: userId,
         role_id: roleId,
-      }) as unknown as Promise<Initiative>;
+      }) as unknown as Promise<InitiativeRead>;
     },
     onSuccess: () => {
       toast.success(t("settings.memberAdded"));
@@ -249,7 +252,7 @@ export const InitiativeSettingsPage = () => {
         initiativeId,
         userId,
         payload
-      ) as unknown as Promise<Initiative>;
+      ) as unknown as Promise<InitiativeRead>;
     },
     onSuccess: () => {
       toast.success(t("settings.roleUpdated"));

--- a/frontend/src/pages/InitiativesPage.tsx
+++ b/frontend/src/pages/InitiativesPage.tsx
@@ -37,7 +37,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
 import { getRoleLabel, useRoleLabels } from "@/hooks/useRoleLabels";
-import type { Initiative } from "@/types/api";
+import type { InitiativeRead } from "@/api/generated/initiativeAPI.schemas";
 
 const DEFAULT_INITIATIVE_COLOR = "#6366F1";
 
@@ -144,7 +144,7 @@ export const InitiativesPage = () => {
     );
   };
 
-  const renderMembershipBadge = (initiative: Initiative) => {
+  const renderMembershipBadge = (initiative: InitiativeRead) => {
     const membership = initiative.members.find((member) => member.user.id === user?.id);
     if (membership) {
       const roleLabel = membership.role === "project_manager" ? projectManagerLabel : memberLabel;

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -59,10 +59,10 @@ import { useProject } from "@/hooks/useProjects";
 import { useGuildPath } from "@/lib/guildUrl";
 import {
   ProjectPermissionLevel,
+  ProjectRead,
   ProjectRolePermissionRead,
   TagSummary,
 } from "@/api/generated/initiativeAPI.schemas";
-import { Project } from "@/types/api";
 import { ProjectTaskStatusesManager } from "@/components/projects/ProjectTaskStatusesManager";
 import { TagPicker } from "@/components/tags";
 import { useSetProjectTags } from "@/hooks/useTags";
@@ -136,7 +136,7 @@ export const ProjectSettingsPage = () => {
       return updateProjectApiV1ProjectsProjectIdPatch(
         parsedProjectId,
         payload
-      ) as unknown as Promise<Project>;
+      ) as unknown as Promise<ProjectRead>;
     },
     onSuccess: (data) => {
       setInitiativeMessage(t("settings.initiative.updated"));
@@ -156,7 +156,7 @@ export const ProjectSettingsPage = () => {
       return updateProjectApiV1ProjectsProjectIdPatch(
         parsedProjectId,
         payload
-      ) as unknown as Promise<Project>;
+      ) as unknown as Promise<ProjectRead>;
     },
     onSuccess: (data) => {
       setIdentityMessage(t("settings.details.detailsUpdated"));
@@ -191,7 +191,7 @@ export const ProjectSettingsPage = () => {
     mutationFn: async () => {
       return updateProjectApiV1ProjectsProjectIdPatch(parsedProjectId, {
         description: descriptionText,
-      }) as unknown as Promise<Project>;
+      }) as unknown as Promise<ProjectRead>;
     },
     onSuccess: (data) => {
       setDescriptionMessage(t("settings.details.descriptionUpdated"));
@@ -205,7 +205,7 @@ export const ProjectSettingsPage = () => {
     mutationFn: async (name?: string) => {
       return duplicateProjectApiV1ProjectsProjectIdDuplicatePost(parsedProjectId, {
         name: name?.trim() || undefined,
-      }) as unknown as Promise<Project>;
+      }) as unknown as Promise<ProjectRead>;
     },
     onSuccess: (data) => {
       setDuplicateMessage(t("settings.duplicate.duplicated"));
@@ -219,7 +219,7 @@ export const ProjectSettingsPage = () => {
     mutationFn: async (nextStatus: boolean) => {
       return updateProjectApiV1ProjectsProjectIdPatch(parsedProjectId, {
         is_template: nextStatus,
-      }) as unknown as Promise<Project>;
+      }) as unknown as Promise<ProjectRead>;
     },
     onSuccess: (_data, nextStatus) => {
       setTemplateMessage(

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -81,7 +81,7 @@ import {
   useMyInitiativePermissions,
   canCreate as canCreatePermission,
 } from "@/hooks/useInitiativeRoles";
-import { Project } from "@/types/api";
+import type { ProjectRead, TagRead, TagSummary } from "@/api/generated/initiativeAPI.schemas";
 import {
   Dialog,
   DialogContent,
@@ -102,8 +102,6 @@ import {
   type RoleGrant,
   type UserGrant,
 } from "@/components/access/CreateAccessControl";
-import type { TagSummary } from "@/api/generated/initiativeAPI.schemas";
-import type { Tag } from "@/types/api";
 
 const NO_TEMPLATE_VALUE = "template-none";
 const INITIATIVE_FILTER_ALL = "all";
@@ -275,7 +273,7 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   // Convert tag IDs to Tag objects for TagPicker
   const selectedTagsForFilter = useMemo(() => {
     const tagMap = new Map(allTags.map((t) => [t.id, t]));
-    return tagFilters.map((id) => tagMap.get(id)).filter((t): t is Tag => t !== undefined);
+    return tagFilters.map((id) => tagMap.get(id)).filter((t): t is TagRead => t !== undefined);
   }, [allTags, tagFilters]);
 
   const handleTagFiltersChange = (newTags: TagSummary[]) => {
@@ -331,7 +329,7 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   }, [canCreate, filteredInitiativeId, filteredInitiativePermissions, isProjectManager]);
 
   // Helper function for per-project DAC checks
-  const hasProjectWritePermission = (project: Project): boolean => {
+  const hasProjectWritePermission = (project: ProjectRead): boolean => {
     if (!user) return false;
     const permission = project.permissions?.find((p) => p.user_id === user.id);
     return permission?.level === "owner" || permission?.level === "write";
@@ -1253,7 +1251,13 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
 
 export const ProjectsPage = () => <ProjectsView />;
 
-const SortableProjectCardLink = ({ project, userId }: { project: Project; userId?: number }) => {
+const SortableProjectCardLink = ({
+  project,
+  userId,
+}: {
+  project: ProjectRead;
+  userId?: number;
+}) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: project.id.toString(),
   });
@@ -1276,7 +1280,7 @@ const SortableProjectCardLink = ({ project, userId }: { project: Project; userId
   );
 };
 
-const SortableProjectRowLink = ({ project, userId }: { project: Project; userId?: number }) => {
+const SortableProjectRowLink = ({ project, userId }: { project: ProjectRead; userId?: number }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: project.id.toString(),
   });

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -54,10 +54,11 @@ import type {
   CommentRead,
   GenerateDescriptionResponse,
   TagSummary,
+  TaskListRead,
+  TaskListReadRecurrenceStrategy,
   TaskPriority,
   TaskRecurrenceOutput,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { Task, TaskRecurrenceStrategy } from "@/types/api";
 import { useAIEnabled } from "@/hooks/useAIEnabled";
 import { Input } from "@/components/ui/input";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
@@ -121,7 +122,8 @@ export const TaskEditPage = () => {
   const [startDate, setStartDate] = useState<string>("");
   const [dueDate, setDueDate] = useState<string>("");
   const [recurrence, setRecurrence] = useState<TaskRecurrenceOutput | null>(null);
-  const [recurrenceStrategy, setRecurrenceStrategy] = useState<TaskRecurrenceStrategy>("fixed");
+  const [recurrenceStrategy, setRecurrenceStrategy] =
+    useState<TaskListReadRecurrenceStrategy>("fixed");
   const [tags, setTags] = useState<TagSummary[]>([]);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -181,7 +183,7 @@ export const TaskEditPage = () => {
       return await (updateTaskApiV1TasksTaskIdPatch(
         parsedTaskId,
         payload as never
-      ) as unknown as Promise<Task>);
+      ) as unknown as Promise<TaskListRead>);
     },
     onSuccess: (updatedTask) => {
       setTitle(updatedTask.title);
@@ -202,7 +204,7 @@ export const TaskEditPage = () => {
     mutationFn: async () => {
       return await (duplicateTaskApiV1TasksTaskIdDuplicatePost(
         parsedTaskId
-      ) as unknown as Promise<Task>);
+      ) as unknown as Promise<TaskListRead>);
     },
     onSuccess: (newTask) => {
       toast.success(t("edit.taskDuplicated"));
@@ -222,14 +224,14 @@ export const TaskEditPage = () => {
     },
   });
 
-  const moveTask = useMutation<Task, unknown, MoveTaskVariables>({
+  const moveTask = useMutation<TaskListRead, unknown, MoveTaskVariables>({
     mutationFn: async ({ targetProjectId }) => {
       return await (moveTaskApiV1TasksTaskIdMovePost(parsedTaskId, {
         target_project_id: targetProjectId,
-      }) as unknown as Promise<Task>);
+      }) as unknown as Promise<TaskListRead>);
     },
     onSuccess: (updatedTask, variables) => {
-      queryClient.setQueryData<Task>(
+      queryClient.setQueryData<TaskListRead>(
         getReadTaskApiV1TasksTaskIdGetQueryKey(parsedTaskId),
         updatedTask
       );
@@ -262,10 +264,10 @@ export const TaskEditPage = () => {
     mutationFn: async (archive: boolean) => {
       return await (updateTaskApiV1TasksTaskIdPatch(parsedTaskId, {
         is_archived: archive,
-      } as never) as unknown as Promise<Task>);
+      } as never) as unknown as Promise<TaskListRead>);
     },
     onSuccess: (updatedTask) => {
-      queryClient.setQueryData<Task>(
+      queryClient.setQueryData<TaskListRead>(
         getReadTaskApiV1TasksTaskIdGetQueryKey(parsedTaskId),
         updatedTask
       );

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -30,7 +30,7 @@ import { useServer } from "@/hooks/useServer";
 import { clearProjectViewApiV1ProjectsProjectIdViewDelete } from "@/api/generated/projects/projects";
 import { invalidateRecentProjects } from "@/api/query-keys";
 import { useRecentProjects } from "@/hooks/useProjects";
-import type { Project } from "@/types/api";
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 
 /**
  * Loading fallback for lazy-loaded pages inside the main layout.
@@ -153,7 +153,7 @@ function AppLayout() {
               />
               <div className="min-w-0 flex-1">
                 <ProjectTabsBar
-                  projects={recentQuery.data as Project[] | undefined}
+                  projects={recentQuery.data as ProjectRead[] | undefined}
                   loading={recentQuery.isLoading}
                   activeProjectId={activeProjectId}
                   onClose={handleClearRecent}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -9,45 +9,7 @@ export * from "@/api/generated/initiativeAPI.schemas";
 // than the manual types the codebase was written against. These aliases preserve
 // existing import names and field requirements.
 
-import type {
-  InitiativeRead,
-  InitiativeMemberRead,
-  ProjectRead,
-  TaskListRead,
-  TagRead,
-  TaskAssigneeSummary,
-  ProjectPermissionRead,
-  ProjectTaskSummary as GenProjectTaskSummary,
-} from "@/api/generated/initiativeAPI.schemas";
-
-// --- Aliases where the generated type has optional fields the codebase treats as required ---
-
-/** Initiative with members guaranteed present */
-export type Initiative = Omit<InitiativeRead, "members"> & {
-  members: InitiativeMemberRead[];
-};
-
-/**
- * Unified Task type that covers both list and detail shapes.
- * The codebase treats flat guild/project/initiative fields (from TaskListRead)
- * and nested objects (from TaskRead) as all-present on a single Task type.
- */
-export type Task = Omit<TaskListRead, "assignees"> & {
-  assignees: TaskAssigneeSummary[];
-  priority: TaskListRead["priority"] & string; // ensure non-optional
-  is_archived: boolean;
-};
-
-/** Tag with required color field */
-export type Tag = Omit<TagRead, "color"> & { color: string };
-
-/** Project with required permissions array */
-export type Project = Omit<ProjectRead, "permissions"> & {
-  permissions: ProjectPermissionRead[];
-};
-
-/** ProjectTaskSummary with required fields */
-export type ProjectTaskSummary = Required<GenProjectTaskSummary>;
+import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 
 // --- Paginated response wrappers (frontend-only; not in the OpenAPI spec) ---
 // TaskListResponse and DocumentListResponse are now generated — see initiativeAPI.schemas.
@@ -63,8 +25,6 @@ export type ProjectListResponse = {
 // --- Types not in the OpenAPI spec (frontend-only constructs) ---
 
 export type TaskWeekPosition = "first" | "second" | "third" | "fourth" | "last";
-
-export type TaskRecurrenceStrategy = "fixed" | "rolling";
 
 export type PermissionKey = "docs_enabled" | "projects_enabled" | "create_docs" | "create_projects";
 


### PR DESCRIPTION
## Summary

Phase 3 of the `types/api.ts` migration — removes all complex type aliases (`Omit`/`Required` wrappers) that were no-ops, replacing them with direct imports from `@/api/generated/initiativeAPI.schemas`.

**Types migrated (48 files, 6 types):**
- **`Initiative`** → `InitiativeRead` — `members: InitiativeMemberRead[]` was already required in the generated type
- **`Project`** → `ProjectRead` — `permissions: ProjectPermissionRead[]` was already required
- **`Tag`** → `TagRead` — `color: string` was already required
- **`Task`** → `TaskListRead` — `assignees`, `priority`, `is_archived` were all already required
- **`ProjectTaskSummary`** → `ProjectTaskSummary` (generated) — `total` and `completed` were already required
- **`TaskRecurrenceStrategy`** → `TaskListReadRecurrenceStrategy` — identical `"fixed" | "rolling"` union, generated equivalent

**What remains in `types/api.ts`:**
- `CommentWithReplies` — genuinely extends `CommentRead` with recursive `replies` field (not in OpenAPI spec)
- `ProjectListResponse` — frontend-only paginated wrapper (projects endpoint isn't paginated)
- `TaskWeekPosition`, `PermissionKey`, `MentionEntityType` — no generated equivalents

**Other changes:**
- Test factories updated to match generated type shapes (`guild_id` added to initiative factory, `owner: undefined` → `owner: null` in project factory)
- Duplicate generated imports merged where files already had a partial import

## Test plan
- [x] TypeScript passes clean (`pnpm tsc --noEmit`)
- [x] ESLint passes clean (`pnpm lint`)
- [ ] Verify frontend loads and renders correctly
- [ ] Spot-check initiative, project, task, and tag CRUD flows