### PR TITLE
Fix guild switching showing stale sidebar data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Guild switching no longer shows stale sidebar data — restored query cache invalidation on guild switch that was accidentally removed during React Query migration
+
 ### Changed
 
 - Centralized inline `useMutation` hooks for tasks, subtasks, task statuses, project members, role permissions, and project documents into domain hook files (`useTasks.ts`, `useProjects.ts`) — replaces ~50 inline mutations across 15 component/page files

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -167,6 +167,20 @@ export const invalidateAllGuilds = () => invalidatePrefix("/api/v1/guilds");
 export const invalidateGuildInvites = (guildId: number) =>
   invalidateExact([`/api/v1/guilds/${guildId}/invites`]);
 
+// ── Guild Switch ────────────────────────────────────────────────────────────
+// Keys that are NOT guild-scoped and should survive a guild switch
+const GLOBAL_KEY_PREFIXES = ["/api/v1/guilds", "/api/v1/users/me", "/api/v1/version"];
+
+/** Remove all guild-scoped query data so stale cross-guild results are never shown. */
+export const resetGuildScopedQueries = () =>
+  queryClient.resetQueries({
+    predicate: (query) => {
+      const first = query.queryKey[0];
+      if (typeof first !== "string") return true;
+      return !GLOBAL_KEY_PREFIXES.some((prefix) => first.startsWith(prefix));
+    },
+  });
+
 // ── Subtasks ─────────────────────────────────────────────────────────────────
 
 export const invalidateSubtask = (subtaskId: number) =>

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId.tsx
@@ -41,14 +41,16 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId
 function GuildLayout() {
   const params = useParams({ from: "/_serverRequired/_authenticated/g/$guildId" });
   const guildId = Number(params.guildId);
-  const { guilds, activeGuildId, loading, syncGuildFromUrl } = useGuilds();
+  const { guilds, loading, syncGuildFromUrl } = useGuilds();
 
-  // Sync guild context when URL guild ID changes
+  // Sync guild context when URL guild ID changes.
+  // syncGuildFromUrl is stable (no deps) and checks the ref internally,
+  // so we only need guildId here to fire when the URL changes.
   useEffect(() => {
-    if (Number.isFinite(guildId) && guildId !== activeGuildId) {
+    if (Number.isFinite(guildId)) {
       void syncGuildFromUrl(guildId);
     }
-  }, [guildId, activeGuildId, syncGuildFromUrl]);
+  }, [guildId, syncGuildFromUrl]);
 
   // Show loading state while guilds are loading
   if (loading) {


### PR DESCRIPTION
## Summary

- Restored query cache invalidation on guild switch — clears all guild-scoped React Query caches (initiatives, projects, tasks, documents, etc.) when switching guilds, preserving only global caches (guilds list, current user, version)
- Stabilized `switchGuild` and `syncGuildFromUrl` callback references using a ref for `activeGuildId`, breaking a `useEffect` dependency cycle that prevented proper guild context sync

## Context

Query keys don't embed `guildId` — guild isolation relies on the `X-Guild-ID` header interceptor. A previous refactor removed the cache clearing with the assumption that React Query handles it automatically, but without guild-scoped keys React Query has no way to know the data is stale.

## Test plan

- [ ] Switch between guilds — sidebar should immediately show the correct guild's initiatives/projects
- [ ] Refresh the page while on a non-first guild — should load correctly, not show "not accessible"
- [ ] Verify no flash of stale data from the previous guild during transition

Closes #162