### PR TITLE
perf: lazy-load color picker and profile pages, fix mixed import warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Vendored editor color picker (~1,800 lines) — replaced with existing shadcn-io color picker + Popover in font color and background color toolbar plugins
+- Lazy-load editor color picker content so the `color` npm package is only fetched when a user opens the font/background color popover
+- Lazy-load 4 profile settings pages (profile, notifications, interface, danger zone) — reduces index bundle by ~75 kB
+- Replace pointless `React.lazy()` with static imports for `LexicalTypeaheadMenuPlugin` and `emoji-list` — both were already pinned to the editor chunk by co-located static imports, eliminating Vite "dynamically and statically imported" warnings
 - Sidebar collapsed sections (initiatives, tags) no longer mount child DOM nodes — lazy-render on expand
 - Skip `useSortable` hooks when drag-and-drop is disabled (sorting/grouping active) for better scroll performance
 - Keep previous React Query data as placeholder for snappier page navigation

--- a/frontend/src/components/ui/editor/plugins/component-picker-menu-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/component-picker-menu-plugin.tsx
@@ -1,6 +1,9 @@
-import { JSX, lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { JSX, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { useBasicTypeaheadTriggerMatch } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import {
+  LexicalTypeaheadMenuPlugin,
+  useBasicTypeaheadTriggerMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
 import { TextNode } from "lexical";
 import { createPortal } from "react-dom";
 
@@ -8,12 +11,6 @@ import { useEditorModal } from "@/components/ui/editor/editor-hooks/use-modal";
 import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
 
 import { ComponentPickerOption } from "./picker/component-picker-option";
-
-const LexicalTypeaheadMenuPlugin = lazy(() =>
-  import("@lexical/react/LexicalTypeaheadMenuPlugin").then((mod) => ({
-    default: mod.LexicalTypeaheadMenuPlugin<ComponentPickerOption>,
-  }))
-);
 
 function ComponentPickerMenu({
   options,
@@ -131,30 +128,28 @@ export function ComponentPickerMenuPlugin({
   return (
     <>
       {modal}
-      <Suspense fallback={null}>
-        <LexicalTypeaheadMenuPlugin
-          onQueryChange={setQueryString}
-          onSelectOption={onSelectOption}
-          triggerFn={checkForTriggerMatch}
-          options={options}
-          menuRenderFn={(
-            anchorElementRef,
-            { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
-          ) => {
-            return anchorElementRef.current && options.length
-              ? createPortal(
-                  <ComponentPickerMenu
-                    options={options}
-                    selectedIndex={selectedIndex}
-                    selectOptionAndCleanUp={selectOptionAndCleanUp}
-                    setHighlightedIndex={setHighlightedIndex}
-                  />,
-                  anchorElementRef.current
-                )
-              : null;
-          }}
-        />
-      </Suspense>
+      <LexicalTypeaheadMenuPlugin<ComponentPickerOption>
+        onQueryChange={setQueryString}
+        onSelectOption={onSelectOption}
+        triggerFn={checkForTriggerMatch}
+        options={options}
+        menuRenderFn={(
+          anchorElementRef,
+          { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
+        ) => {
+          return anchorElementRef.current && options.length
+            ? createPortal(
+                <ComponentPickerMenu
+                  options={options}
+                  selectedIndex={selectedIndex}
+                  selectOptionAndCleanUp={selectOptionAndCleanUp}
+                  setHighlightedIndex={setHighlightedIndex}
+                />,
+                anchorElementRef.current
+              )
+            : null;
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/components/ui/editor/plugins/mentions-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/mentions-plugin.tsx
@@ -1,6 +1,7 @@
-import { JSX, lazy, Suspense, useCallback, useMemo, useState } from "react";
+import { JSX, useCallback, useMemo, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
+  LexicalTypeaheadMenuPlugin,
   MenuOption,
   MenuTextMatch,
   useBasicTypeaheadTriggerMatch,
@@ -13,12 +14,6 @@ import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { resolveUploadUrl } from "@/lib/uploadUrl";
 import type { UserPublic } from "@/api/generated/initiativeAPI.schemas";
-
-const LexicalTypeaheadMenuPlugin = lazy(() =>
-  import("@lexical/react/LexicalTypeaheadMenuPlugin").then((mod) => ({
-    default: mod.LexicalTypeaheadMenuPlugin<MentionTypeaheadOption>,
-  }))
-);
 
 const PUNCTUATION = "\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\-\\[\\]\\\\/!%'\"~=<>_:;";
 const NAME = "\\b[A-Z][^\\s" + PUNCTUATION + "]";
@@ -218,62 +213,60 @@ export function MentionsPlugin({ mentionableUsers = [] }: MentionsPluginProps): 
   }
 
   return (
-    <Suspense fallback={null}>
-      <LexicalTypeaheadMenuPlugin
-        onQueryChange={setQueryString}
-        onSelectOption={onSelectOption}
-        triggerFn={checkForMentionMatch}
-        options={options}
-        menuRenderFn={(
-          anchorElementRef,
-          { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
-        ) => {
-          return anchorElementRef.current && options.length
-            ? createPortal(
-                <div className="absolute z-10 w-[250px] rounded-md shadow-md">
-                  <Command
-                    onKeyDown={(e) => {
-                      if (e.key === "ArrowUp") {
-                        e.preventDefault();
-                        setHighlightedIndex(
-                          selectedIndex !== null
-                            ? (selectedIndex - 1 + options.length) % options.length
-                            : options.length - 1
-                        );
-                      } else if (e.key === "ArrowDown") {
-                        e.preventDefault();
-                        setHighlightedIndex(
-                          selectedIndex !== null ? (selectedIndex + 1) % options.length : 0
-                        );
-                      }
-                    }}
-                  >
-                    <CommandList>
-                      <CommandGroup>
-                        {options.map((option, index) => (
-                          <CommandItem
-                            key={option.key}
-                            value={option.name}
-                            onSelect={() => {
-                              selectOptionAndCleanUp(option);
-                            }}
-                            className={`flex items-center gap-2 ${
-                              selectedIndex === index ? "bg-accent" : "bg-transparent!"
-                            }`}
-                          >
-                            {option.picture}
-                            <span className="truncate">{option.name}</span>
-                          </CommandItem>
-                        ))}
-                      </CommandGroup>
-                    </CommandList>
-                  </Command>
-                </div>,
-                anchorElementRef.current
-              )
-            : null;
-        }}
-      />
-    </Suspense>
+    <LexicalTypeaheadMenuPlugin<MentionTypeaheadOption>
+      onQueryChange={setQueryString}
+      onSelectOption={onSelectOption}
+      triggerFn={checkForMentionMatch}
+      options={options}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
+      ) => {
+        return anchorElementRef.current && options.length
+          ? createPortal(
+              <div className="absolute z-10 w-[250px] rounded-md shadow-md">
+                <Command
+                  onKeyDown={(e) => {
+                    if (e.key === "ArrowUp") {
+                      e.preventDefault();
+                      setHighlightedIndex(
+                        selectedIndex !== null
+                          ? (selectedIndex - 1 + options.length) % options.length
+                          : options.length - 1
+                      );
+                    } else if (e.key === "ArrowDown") {
+                      e.preventDefault();
+                      setHighlightedIndex(
+                        selectedIndex !== null ? (selectedIndex + 1) % options.length : 0
+                      );
+                    }
+                  }}
+                >
+                  <CommandList>
+                    <CommandGroup>
+                      {options.map((option, index) => (
+                        <CommandItem
+                          key={option.key}
+                          value={option.name}
+                          onSelect={() => {
+                            selectOptionAndCleanUp(option);
+                          }}
+                          className={`flex items-center gap-2 ${
+                            selectedIndex === index ? "bg-accent" : "bg-transparent!"
+                          }`}
+                        >
+                          {option.picture}
+                          <span className="truncate">{option.name}</span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </div>,
+              anchorElementRef.current
+            )
+          : null;
+      }}
+    />
   );
 }

--- a/frontend/src/components/ui/editor/plugins/toolbar/editor-color-picker-content.tsx
+++ b/frontend/src/components/ui/editor/plugins/toolbar/editor-color-picker-content.tsx
@@ -1,0 +1,38 @@
+import {
+  ColorPicker,
+  ColorPickerAlpha,
+  ColorPickerEyeDropper,
+  ColorPickerFormat,
+  ColorPickerHue,
+  ColorPickerOutput,
+  ColorPickerSelection,
+} from "@/components/ui/shadcn-io/color-picker";
+
+interface EditorColorPickerContentProps {
+  defaultValue: string;
+  onChange: (rgba: number[]) => void;
+}
+
+export default function EditorColorPickerContent({
+  defaultValue,
+  onChange,
+}: EditorColorPickerContentProps) {
+  return (
+    <ColorPicker defaultValue={defaultValue} onChange={onChange}>
+      <div className="space-y-3">
+        <ColorPickerSelection className="h-48 w-full rounded-md border" />
+        <div className="flex items-center gap-2">
+          <ColorPickerEyeDropper />
+          <div className="flex flex-1 flex-col gap-2">
+            <ColorPickerHue />
+            <ColorPickerAlpha />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <ColorPickerOutput />
+          <ColorPickerFormat className="w-full" />
+        </div>
+      </div>
+    </ColorPicker>
+  );
+}

--- a/frontend/src/components/ui/editor/plugins/toolbar/font-background-toolbar-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/toolbar/font-background-toolbar-plugin.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useRef, useState } from "react";
 import { $getSelectionStyleValueForProperty, $patchStyleText } from "@lexical/selection";
 import {
   $getSelection,
@@ -13,15 +13,8 @@ import { useToolbarContext } from "@/components/ui/editor/context/toolbar-contex
 import { useUpdateToolbarHandler } from "@/components/ui/editor/editor-hooks/use-update-toolbar";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import {
-  ColorPicker,
-  ColorPickerAlpha,
-  ColorPickerEyeDropper,
-  ColorPickerFormat,
-  ColorPickerHue,
-  ColorPickerOutput,
-  ColorPickerSelection,
-} from "@/components/ui/shadcn-io/color-picker";
+
+const EditorColorPickerContent = lazy(() => import("./editor-color-picker-content"));
 
 const rgbaToHex = (rgba: number[]) => {
   const clamp = (value: number) => Math.max(0, Math.min(255, Math.round(value)));
@@ -106,22 +99,9 @@ export function FontBackgroundToolbarPlugin() {
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80 space-y-3" align="start">
-        <ColorPicker defaultValue={bgColor} onChange={handleColorChange}>
-          <div className="space-y-3">
-            <ColorPickerSelection className="h-48 w-full rounded-md border" />
-            <div className="flex items-center gap-2">
-              <ColorPickerEyeDropper />
-              <div className="flex flex-1 flex-col gap-2">
-                <ColorPickerHue />
-                <ColorPickerAlpha />
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <ColorPickerOutput />
-              <ColorPickerFormat className="w-full" />
-            </div>
-          </div>
-        </ColorPicker>
+        <Suspense fallback={<div className="h-[280px] w-full" />}>
+          <EditorColorPickerContent defaultValue={bgColor} onChange={handleColorChange} />
+        </Suspense>
       </PopoverContent>
     </Popover>
   );

--- a/frontend/src/components/ui/editor/plugins/toolbar/font-color-toolbar-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/toolbar/font-color-toolbar-plugin.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useRef, useState } from "react";
 import { $getSelectionStyleValueForProperty, $patchStyleText } from "@lexical/selection";
 import {
   $getSelection,
@@ -13,15 +13,8 @@ import { useToolbarContext } from "@/components/ui/editor/context/toolbar-contex
 import { useUpdateToolbarHandler } from "@/components/ui/editor/editor-hooks/use-update-toolbar";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import {
-  ColorPicker,
-  ColorPickerAlpha,
-  ColorPickerEyeDropper,
-  ColorPickerFormat,
-  ColorPickerHue,
-  ColorPickerOutput,
-  ColorPickerSelection,
-} from "@/components/ui/shadcn-io/color-picker";
+
+const EditorColorPickerContent = lazy(() => import("./editor-color-picker-content"));
 
 const rgbaToHex = (rgba: number[]) => {
   const clamp = (value: number) => Math.max(0, Math.min(255, Math.round(value)));
@@ -101,22 +94,9 @@ export function FontColorToolbarPlugin() {
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80 space-y-3" align="start">
-        <ColorPicker defaultValue={fontColor} onChange={handleColorChange}>
-          <div className="space-y-3">
-            <ColorPickerSelection className="h-48 w-full rounded-md border" />
-            <div className="flex items-center gap-2">
-              <ColorPickerEyeDropper />
-              <div className="flex flex-1 flex-col gap-2">
-                <ColorPickerHue />
-                <ColorPickerAlpha />
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <ColorPickerOutput />
-              <ColorPickerFormat className="w-full" />
-            </div>
-          </div>
-        </ColorPicker>
+        <Suspense fallback={<div className="h-[280px] w-full" />}>
+          <EditorColorPickerContent defaultValue={fontColor} onChange={handleColorChange} />
+        </Suspense>
       </PopoverContent>
     </Popover>
   );

--- a/frontend/src/components/ui/editor/plugins/wikilinks-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/wikilinks-plugin.tsx
@@ -1,6 +1,10 @@
-import { JSX, lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { JSX, useCallback, useEffect, useMemo, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { MenuOption, MenuTextMatch } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  MenuTextMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
 import {
   $getNodeByKey,
   $getNearestNodeFromDOMNode,
@@ -18,12 +22,6 @@ import { FileText, Plus } from "lucide-react";
 import { $createWikilinkNode, $isWikilinkNode } from "@/components/ui/editor/nodes/wikilink-node";
 import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
 import { autocompleteDocuments, type DocumentAutocomplete } from "@/lib/documentUtils";
-
-const LexicalTypeaheadMenuPlugin = lazy(() =>
-  import("@lexical/react/LexicalTypeaheadMenuPlugin").then((mod) => ({
-    default: mod.LexicalTypeaheadMenuPlugin<WikilinkTypeaheadOption>,
-  }))
-);
 
 // Regex to match [[ followed by any characters (for partial wikilinks)
 const WIKILINK_TRIGGER_REGEX = /(?:^|\s)\[\[([^\]]{0,75})$/;
@@ -286,13 +284,12 @@ export function WikilinksPlugin({
   }
 
   return (
-    <Suspense fallback={null}>
-      <LexicalTypeaheadMenuPlugin
-        onQueryChange={setQueryString}
-        onSelectOption={onSelectOption}
-        triggerFn={checkForTriggerMatch}
-        options={options}
-        menuRenderFn={(
+    <LexicalTypeaheadMenuPlugin<WikilinkTypeaheadOption>
+      onQueryChange={setQueryString}
+      onSelectOption={onSelectOption}
+      triggerFn={checkForTriggerMatch}
+      options={options}
+      menuRenderFn={(
           anchorElementRef,
           { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
         ) => {
@@ -378,7 +375,6 @@ export function WikilinksPlugin({
             anchorElementRef.current
           );
         }}
-      />
-    </Suspense>
+    />
   );
 }

--- a/frontend/src/routes/_serverRequired/_authenticated/profile/danger.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/profile/danger.tsx
@@ -1,6 +1,12 @@
+import { lazy, Suspense } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useAuth } from "@/hooks/useAuth";
-import { UserSettingsDangerZonePage } from "@/pages/UserSettingsDangerZonePage";
+
+const UserSettingsDangerZonePage = lazy(() =>
+  import("@/pages/UserSettingsDangerZonePage").then((m) => ({
+    default: m.UserSettingsDangerZonePage,
+  }))
+);
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/profile/danger")({
   component: DangerZonePage,
@@ -9,5 +15,9 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/profile/da
 function DangerZonePage() {
   const { user, logout } = useAuth();
   if (!user) return null;
-  return <UserSettingsDangerZonePage user={user} logout={logout} />;
+  return (
+    <Suspense fallback={null}>
+      <UserSettingsDangerZonePage user={user} logout={logout} />
+    </Suspense>
+  );
 }

--- a/frontend/src/routes/_serverRequired/_authenticated/profile/index.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/profile/index.tsx
@@ -1,6 +1,12 @@
+import { lazy, Suspense } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useAuth } from "@/hooks/useAuth";
-import { UserSettingsProfilePage } from "@/pages/UserSettingsProfilePage";
+
+const UserSettingsProfilePage = lazy(() =>
+  import("@/pages/UserSettingsProfilePage").then((m) => ({
+    default: m.UserSettingsProfilePage,
+  }))
+);
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/profile/")({
   component: ProfileIndexPage,
@@ -9,5 +15,9 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/profile/")
 function ProfileIndexPage() {
   const { user, refreshUser } = useAuth();
   if (!user) return null;
-  return <UserSettingsProfilePage user={user} refreshUser={refreshUser} />;
+  return (
+    <Suspense fallback={null}>
+      <UserSettingsProfilePage user={user} refreshUser={refreshUser} />
+    </Suspense>
+  );
 }

--- a/frontend/src/routes/_serverRequired/_authenticated/profile/interface.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/profile/interface.tsx
@@ -1,6 +1,12 @@
+import { lazy, Suspense } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useAuth } from "@/hooks/useAuth";
-import { UserSettingsInterfacePage } from "@/pages/UserSettingsInterfacePage";
+
+const UserSettingsInterfacePage = lazy(() =>
+  import("@/pages/UserSettingsInterfacePage").then((m) => ({
+    default: m.UserSettingsInterfacePage,
+  }))
+);
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/profile/interface")({
   component: InterfacePage,
@@ -9,5 +15,9 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/profile/in
 function InterfacePage() {
   const { user, refreshUser } = useAuth();
   if (!user) return null;
-  return <UserSettingsInterfacePage user={user} refreshUser={refreshUser} />;
+  return (
+    <Suspense fallback={null}>
+      <UserSettingsInterfacePage user={user} refreshUser={refreshUser} />
+    </Suspense>
+  );
 }

--- a/frontend/src/routes/_serverRequired/_authenticated/profile/notifications.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/profile/notifications.tsx
@@ -1,6 +1,12 @@
+import { lazy, Suspense } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useAuth } from "@/hooks/useAuth";
-import { UserSettingsNotificationsPage } from "@/pages/UserSettingsNotificationsPage";
+
+const UserSettingsNotificationsPage = lazy(() =>
+  import("@/pages/UserSettingsNotificationsPage").then((m) => ({
+    default: m.UserSettingsNotificationsPage,
+  }))
+);
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/profile/notifications")({
   component: NotificationsPage,
@@ -9,5 +15,9 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/profile/no
 function NotificationsPage() {
   const { user, refreshUser } = useAuth();
   if (!user) return null;
-  return <UserSettingsNotificationsPage user={user} refreshUser={refreshUser} />;
+  return (
+    <Suspense fallback={null}>
+      <UserSettingsNotificationsPage user={user} refreshUser={refreshUser} />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary

- Extract the editor color picker into a shared lazy-loaded component (`EditorColorPickerContent`) so the `color` npm package is only fetched when a user opens the font/background color popover
- Lazy-load 4 profile settings pages (`profile`, `notifications`, `interface`, `danger`) using `React.lazy()` — reduces the index bundle by **~75 kB** (916 → 841 kB)
- Replace pointless `React.lazy()` with static imports for `LexicalTypeaheadMenuPlugin` (4 files) and `emoji-list` (1 file) — both modules were already pinned to the editor chunk by co-located static type/hook imports, so the dynamic imports couldn't split them out and just produced Vite warnings

### Bundle impact

| Chunk | Before | After | Delta |
|---|---|---|---|
| `index.js` | 916 kB (277 kB gz) | 841 kB (256 kB gz) | **-75 kB (-21 kB gz)** |
| `editor.js` | 931 kB (257 kB gz) | 930 kB (257 kB gz) | -1.5 kB (lazy/Suspense overhead removed) |

New lazy chunks: `UserSettingsProfilePage` (4.5 kB), `UserSettingsInterfacePage` (3.5 kB), `UserSettingsNotificationsPage` (6.7 kB), `UserSettingsDangerZonePage` (11.4 kB), `editor-color-picker-content` (0.7 kB)

## Test plan

- [ ] `pnpm build` — no Vite warnings about "dynamically imported but also statically imported"
- [ ] `pnpm tsc --noEmit && pnpm lint` — clean
- [ ] Open a document, click font color / background color button — picker loads correctly
- [ ] Navigate to each profile settings page — pages load correctly
- [ ] Editor typeahead menus (`/` commands, `:` emoji, `@` mentions, `[[` wikilinks) still work