### PR TITLE
fix: distinct 404/403 error pages, guild state bug, rate-limit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Reusable `StatusMessage` component for consistent error states across detail pages
+- Distinct 404/403 error messages on Project, Document, Tag, and Initiative detail pages using `Empty` card layout with contextual icons
+- "Guild not available" page when navigating to a guild the user isn't a member of (replaces silent redirect)
+- Rate-limit error message ("Too many requests") instead of misleading "Check your credentials" on login/register
 - Row virtualization for DataTable using `@tanstack/react-virtual` — only visible rows exist in the DOM, tested with 10k tasks
 - Virtualized Gantt view with sticky day headers and pinned task name column
 - Virtualized Kanban columns (activates above 20 tasks per column) with memoized card components and DnD compatibility
 - Collapse all / expand all buttons for sidebar initiative list and tag browser
 - Memoized virtual cell rendering to prevent expensive re-renders during scroll
+
+### Fixed
+
+- Navigating to an inaccessible guild no longer poisons the active guild state, which previously caused "Unable to load" errors on the home page after redirect
 
 ### Changed
 

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -95,7 +95,11 @@
   "detail": {
     "invalidId": "Invalid document id.",
     "loading": "Loading document\u2026",
-    "notFound": "Document not found.",
+    "notFound": "Document not found",
+    "notFoundDescription": "This document may have been deleted or you may have followed a broken link.",
+    "noAccess": "Access denied",
+    "noAccessDescription": "You don\u2019t have permission to view this document. Ask the document owner to grant you access.",
+    "backToDocuments": "\u2190 Back to documents",
     "settings": "Document settings",
     "closePanel": "Close panel",
     "openPanel": "Open panel",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -180,5 +180,6 @@
   "IMPORT_INSUFFICIENT_PERMISSION": "Insufficient permissions for this project",
   "IMPORT_INVALID_STATUS_ID": "Invalid status ID for mapping",
   "NOTIFICATION_NOT_FOUND": "Notification not found",
+  "RATE_LIMITED": "Too many requests. Please wait a moment and try again.",
   "fallback": "Something went wrong. Please try again."
 }

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -121,6 +121,11 @@
     "removeConfirmLabel": "Remove",
     "failedToUpdateRole": "Failed to update role"
   },
+  "notMember": {
+    "title": "Guild not available",
+    "description": "You\u2019re not a member of this guild. Ask a guild admin for an invite link to join.",
+    "backToHome": "\u2190 Back to home"
+  },
   "noGuild": {
     "title": "No guild membership",
     "description": "You are not a member of any guild yet. Ask a guild admin for an invite link, or create a new guild to get started.",

--- a/frontend/public/locales/en/projects.json
+++ b/frontend/public/locales/en/projects.json
@@ -137,6 +137,10 @@
     "backToProjects": "\u2190 Back to projects",
     "loading": "Loading project\u2026",
     "loadError": "Unable to load project.",
+    "notFound": "Project not found",
+    "notFoundDescription": "This project may have been deleted or you may have followed a broken link.",
+    "noAccess": "Access denied",
+    "noAccessDescription": "You don\u2019t have permission to view this project. Ask a project manager to grant you access.",
     "projectSettings": "Project Settings",
     "openProjectSettings": "Open project settings"
   },

--- a/frontend/public/locales/en/tags.json
+++ b/frontend/public/locales/en/tags.json
@@ -1,6 +1,8 @@
 {
   "detail": {
     "notFound": "Tag not found",
+    "notFoundDescription": "This tag may have been deleted or you may have followed a broken link.",
+    "backToTags": "\u2190 Back to home",
     "taggedItems_one": "{{count}} tagged item",
     "taggedItems_other": "{{count}} tagged items",
     "edit": "Edit",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -95,7 +95,11 @@
   "detail": {
     "invalidId": "ID de documento no válido.",
     "loading": "Cargando documento\u2026",
-    "notFound": "Documento no encontrado.",
+    "notFound": "Documento no encontrado",
+    "notFoundDescription": "Este documento puede haber sido eliminado o el enlace está roto.",
+    "noAccess": "Acceso denegado",
+    "noAccessDescription": "No tienes permiso para ver este documento. Pide al propietario del documento que te otorgue acceso.",
+    "backToDocuments": "\u2190 Volver a documentos",
     "settings": "Configuración del documento",
     "closePanel": "Cerrar panel",
     "openPanel": "Abrir panel",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -180,5 +180,6 @@
   "IMPORT_INSUFFICIENT_PERMISSION": "Permisos insuficientes para este proyecto",
   "IMPORT_INVALID_STATUS_ID": "ID de estado no válido para el mapeo",
   "NOTIFICATION_NOT_FOUND": "Notificación no encontrada",
+  "RATE_LIMITED": "Demasiadas solicitudes. Por favor espera un momento e intenta de nuevo.",
   "fallback": "Algo salió mal. Por favor intenta de nuevo."
 }

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -121,6 +121,11 @@
     "removeConfirmLabel": "Eliminar",
     "failedToUpdateRole": "No se pudo actualizar el rol"
   },
+  "notMember": {
+    "title": "Gremio no disponible",
+    "description": "No eres miembro de este gremio. Pide a un administrador del gremio un enlace de invitación para unirte.",
+    "backToHome": "\u2190 Volver al inicio"
+  },
   "noGuild": {
     "title": "Sin membresía de gremio",
     "description": "Aún no eres miembro de ningún gremio. Pide a un administrador de gremio un enlace de invitación o crea un nuevo gremio para comenzar.",

--- a/frontend/public/locales/es/projects.json
+++ b/frontend/public/locales/es/projects.json
@@ -130,6 +130,10 @@
     "backToProjects": "\u2190 Volver a proyectos",
     "loading": "Cargando proyecto\u2026",
     "loadError": "No se pudo cargar el proyecto.",
+    "notFound": "Proyecto no encontrado",
+    "notFoundDescription": "Este proyecto puede haber sido eliminado o el enlace está roto.",
+    "noAccess": "Acceso denegado",
+    "noAccessDescription": "No tienes permiso para ver este proyecto. Pide a un administrador del proyecto que te otorgue acceso.",
     "projectSettings": "Configuración del proyecto",
     "openProjectSettings": "Abrir configuración del proyecto"
   },

--- a/frontend/public/locales/es/tags.json
+++ b/frontend/public/locales/es/tags.json
@@ -1,6 +1,8 @@
 {
   "detail": {
     "notFound": "Etiqueta no encontrada",
+    "notFoundDescription": "Esta etiqueta puede haber sido eliminada o el enlace está roto.",
+    "backToTags": "\u2190 Volver al inicio",
     "taggedItems_one": "{{count}} elemento etiquetado",
     "taggedItems_other": "{{count}} elementos etiquetados",
     "edit": "Editar",

--- a/frontend/src/components/StatusMessage.tsx
+++ b/frontend/src/components/StatusMessage.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+interface StatusMessageProps {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  backTo?: string;
+  backLabel?: string;
+}
+
+export function StatusMessage({ icon, title, description, backTo, backLabel }: StatusMessageProps) {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">{icon}</EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        {description && <EmptyDescription>{description}</EmptyDescription>}
+      </EmptyHeader>
+      {backTo && backLabel && (
+        <Button variant="link" size="sm" asChild className="px-0">
+          <Link to={backTo}>{backLabel}</Link>
+        </Button>
+      )}
+    </Empty>
+  );
+}

--- a/frontend/src/components/ui/empty.tsx
+++ b/frontend/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -11,7 +11,8 @@ import {
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { formatDistanceToNow } from "date-fns";
 import type { SerializedEditorState } from "lexical";
-import { ImagePlus, Loader2, PanelRight, ScrollText, Settings, X } from "lucide-react";
+import { ImagePlus, Loader2, PanelRight, ScrollText, SearchX, Settings, ShieldAlert, X } from "lucide-react";
+import { StatusMessage } from "@/components/StatusMessage";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 
@@ -67,6 +68,7 @@ import { useAIEnabled } from "@/hooks/useAIEnabled";
 import { useAuth } from "@/hooks/useAuth";
 import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
+import { getHttpStatus } from "@/lib/errorMessage";
 
 export const DocumentDetailPage = () => {
   const { t } = useTranslation("documents");
@@ -486,7 +488,14 @@ export const DocumentDetailPage = () => {
   }
 
   if (documentQuery.isError || !document) {
-    return <p className="text-destructive">{t("detail.notFound")}</p>;
+    const status = getHttpStatus(documentQuery.error);
+    const backTo = gp("/documents");
+    const backLabel = t("detail.backToDocuments");
+
+    if (status === 403) {
+      return <StatusMessage icon={<ShieldAlert />} title={t("detail.noAccess")} description={t("detail.noAccessDescription")} backTo={backTo} backLabel={backLabel} />;
+    }
+    return <StatusMessage icon={<SearchX />} title={t("detail.notFound")} description={t("detail.notFoundDescription")} backTo={backTo} backLabel={backLabel} />;
   }
 
   const attachedProjects: DocumentProjectLink[] = document.projects ?? [];

--- a/frontend/src/pages/InitiativeDetailPage.tsx
+++ b/frontend/src/pages/InitiativeDetailPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link, Navigate, useParams } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Loader2, Settings } from "lucide-react";
+import { Loader2, SearchX, Settings } from "lucide-react";
+import { StatusMessage } from "@/components/StatusMessage";
 
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { DocumentsView } from "./DocumentsPage";
@@ -101,17 +102,7 @@ export const InitiativeDetailPage = () => {
   }
 
   if (!initiative) {
-    return (
-      <div className="space-y-4">
-        <Button variant="link" size="sm" asChild className="px-0">
-          <Link to="/initiatives">{t("detail.backToInitiatives")}</Link>
-        </Button>
-        <div className="rounded-lg border p-6">
-          <h1 className="text-3xl font-semibold tracking-tight">{t("detail.notFound")}</h1>
-          <p className="text-muted-foreground">{t("detail.notFoundDescription")}</p>
-        </div>
-      </div>
-    );
+    return <StatusMessage icon={<SearchX />} title={t("detail.notFound")} description={t("detail.notFoundDescription")} backTo="/initiatives" backLabel={t("detail.backToInitiatives")} />;
   }
 
   // If user has no access to any features, show a message

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -22,7 +22,7 @@ import { LogoIcon } from "@/components/LogoIcon";
 import { RegisterPage } from "./RegisterPage";
 
 export const LoginPage = () => {
-  const { t } = useTranslation(["auth", "common"]);
+  const { t } = useTranslation(["auth", "common", "errors"]);
   const router = useRouter();
   const searchParams = useSearch({ strict: false }) as { invite_code?: string };
   const { login } = useAuth();

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -24,7 +24,7 @@ interface RegisterPageProps {
 }
 
 export const RegisterPage = ({ bootstrapMode = false }: RegisterPageProps) => {
-  const { t } = useTranslation(["auth", "common"]);
+  const { t } = useTranslation(["auth", "common", "errors"]);
   const router = useRouter();
   const searchParams = useSearch({ strict: false }) as { invite_code?: string };
   const { register, login } = useAuth();

--- a/frontend/src/pages/TagDetailPage.tsx
+++ b/frontend/src/pages/TagDetailPage.tsx
@@ -6,11 +6,13 @@ import {
   Loader2,
   ScrollText,
   ListTodo,
+  SearchX,
   SquareCheckBig,
   Settings,
   Trash2,
   TagIcon,
 } from "lucide-react";
+import { StatusMessage } from "@/components/StatusMessage";
 
 import { useTag, useTagEntities, useDeleteTag, useUpdateTag } from "@/hooks/useTags";
 import { Button } from "@/components/ui/button";
@@ -70,11 +72,7 @@ export const TagDetailPage = () => {
   }
 
   if (tagError || !tag) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <p className="text-muted-foreground">{t("detail.notFound")}</p>
-      </div>
-    );
+    return <StatusMessage icon={<SearchX />} title={t("detail.notFound")} description={t("detail.notFoundDescription")} backTo="/" backLabel={t("detail.backToTags")} />;
   }
 
   const handleStartEdit = () => {


### PR DESCRIPTION
## Summary

- **StatusMessage component**: Reusable `<StatusMessage icon title description backTo backLabel />` wrapping the `Empty` card layout, replacing repeated Empty/EmptyHeader/EmptyMedia/EmptyTitle/EmptyDescription/Button/Link boilerplate across detail pages
- **Detail page error states**: Project, Document, Tag, and Initiative detail pages now show contextual error cards (SearchX for 404, ShieldAlert for 403, AlertCircle for generic) with descriptions and back links instead of bare `<p>` tags or generic messages
- **Guild route fix**: Navigating to `/g/:guildId/` for a guild the user isn't a member of no longer poisons `activeGuildId` — previously `setCurrentGuildId()` fired before membership validation, causing "Unable to load" errors on the home page after redirect. Now shows a "Guild not available" page instead
- **Rate-limit fix**: 429 responses from slowapi (which use `{"error": ...}` not `{"detail": ...}`) now map to "Too many requests" instead of falling through to "Check your credentials" on login/register. Added `errors` namespace to login/register `useTranslation` calls
- **i18n**: All new keys added in both `en` and `es` locales

## Test plan

- [x] Navigate to `/projects/999999` — shows "Project not found" card with back link
- [x] Navigate to `/documents/999999` — shows "Document not found" card with back link  
- [x] Navigate to `/tags/999999` — shows "Tag not found" card with back link
- [x] Navigate to `/initiatives/999999` — shows "Initiative not found" card
- [x] Navigate to `/g/999999/` — shows "Guild not available" page, home page still works after clicking back
- [x] Trigger rate limit on login (5 attempts in 15min) — shows "Too many requests" not "Check your credentials"
- [x] Verify Spanish translations render correctly when locale is set to `es`