### PR TITLE
Replace python-jose with PyJWT (security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uploaded files now require authentication to access; the `/uploads/*` path no longer serves files to unauthenticated users. The backend validates the user's token from the `Authorization` header (reported by Adem Kucuk).
 - Uploaded files are now restricted to members of the guild they were uploaded in. The backend tracks file→guild ownership in a new `uploads` table and returns 403 to authenticated users who are not members of the owning guild. Covers image attachments, document file uploads (PDF, DOCX, etc.), and files created by duplicate/copy/template operations. Pre-existing files without a database record remain accessible to any authenticated user for backwards compatibility.
 - Web sessions now use HttpOnly `SameSite=Lax` cookies instead of `localStorage` for JWT storage, eliminating XSS token theft risk and removing the JWT from browser history/server logs. The cookie is sent automatically for all requests including media (`<img>`, `<iframe>`); native (Capacitor) is unchanged and continues to use DeviceToken headers stored in Capacitor Preferences.
+- Replaced `python-jose` with `PyJWT` for JWT handling. `python-jose` (through 3.3.0) has an algorithm confusion vulnerability with OpenSSH ECDSA keys and other key formats (similar to CVE-2022-29217) and is no longer maintained.
 
 ### Changed
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 
 from fastapi import Cookie, Depends, Header, HTTPException, Query, Request, status
 from fastapi.security import OAuth2PasswordBearer
-from jose import JWTError, jwt
+import jwt
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -68,7 +68,7 @@ async def get_current_user(
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
         token_data = TokenPayload(**payload)
-    except JWTError as exc:  # pragma: no cover - FastAPI handles formatting
+    except jwt.PyJWTError as exc:  # pragma: no cover - FastAPI handles formatting
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=AuthMessages.COULD_NOT_VALIDATE_CREDENTIALS) from exc
 
     if not token_data.sub:
@@ -251,7 +251,7 @@ async def get_upload_user(
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
         token_data = TokenPayload(**payload)
-    except JWTError:
+    except jwt.PyJWTError:
         # JWT decode failed — if token came from query param, also try as device token
         # (native app users may pass their device token as a query param)
         if token_param and not bearer_token:

--- a/backend/app/api/v1/endpoints/collaboration.py
+++ b/backend/app/api/v1/endpoints/collaboration.py
@@ -15,7 +15,7 @@ from typing import Optional
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Request, WebSocket, WebSocketDisconnect, status
-from jose import JWTError, jwt
+import jwt
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
@@ -59,7 +59,7 @@ async def _get_user_from_token(token: str, session) -> Optional[User]:
             user = result.one_or_none()
             if user and user.is_active:
                 return user
-    except JWTError:
+    except jwt.PyJWTError:
         pass
 
     # Fall back to device token validation

--- a/backend/app/api/v1/endpoints/events.py
+++ b/backend/app/api/v1/endpoints/events.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
-from jose import JWTError, jwt
+import jwt
 from sqlmodel import select
 
 from app.api.deps import SessionDep
@@ -32,7 +32,7 @@ async def _user_from_token(token: str, session: SessionDep) -> Optional[User]:
             user = result.one_or_none()
             if user and user.is_active:
                 return user
-    except JWTError:
+    except jwt.PyJWTError:
         pass
 
     # Fall back to device token validation

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from jose import jwt
+import jwt
 from passlib.context import CryptContext
 
 from app.core.config import settings

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,7 @@ uvicorn = { extras = ["standard"], version = "^0.30.0" }
 sqlmodel = "^0.0.22"
 asyncpg = "^0.29.0"
 sqlalchemy = "^2.0.0"
-python-jose = { extras = ["cryptography"], version = "^3.3.0" }
+PyJWT = "^2.11.0"
 passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 bcrypt = "==4.0.1"
 pydantic-settings = "^2.3.4"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.30.0
 sqlmodel==0.0.22
 sqlalchemy==2.0.30
 asyncpg==0.29.0
-python-jose[cryptography]==3.3.0
+PyJWT==2.11.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 pydantic-settings==2.3.4


### PR DESCRIPTION
## Summary

- **Replaces `python-jose` with `PyJWT`** for all JWT encoding/decoding operations
- `python-jose` (through 3.3.0) has an algorithm confusion vulnerability with OpenSSH ECDSA keys and other key formats, similar to [CVE-2022-29217](https://nvd.nist.gov/vuln/detail/CVE-2022-29217). The library is deprecated and will not fix this issue.
- `PyJWT` is actively maintained, widely adopted, and has a near-identical API for HS256 operations

### Files changed

| File | Change |
|---|---|
| `backend/requirements.txt` | `python-jose[cryptography]==3.3.0` → `PyJWT==2.11.0` |
| `backend/pyproject.toml` | Same dependency swap |
| `backend/app/core/security.py` | `from jose import jwt` → `import jwt` |
| `backend/app/api/deps.py` | Import + `JWTError` → `jwt.PyJWTError` |
| `backend/app/api/v1/endpoints/events.py` | Import + `JWTError` → `jwt.PyJWTError` |
| `backend/app/api/v1/endpoints/collaboration.py` | Import + `JWTError` → `jwt.PyJWTError` |
| `CHANGELOG.md` | Added security entry under `[Unreleased]` |

## Test plan

- [x] All 374 backend tests pass
- [x] Smoke-tested `jwt.encode()` / `jwt.decode()` with HS256
- [x] Verified zero remaining references to `jose` in the codebase
- [ ] Verify login/auth flow works in staging