### PR TITLE
Fix python-multipart CVEs, add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # Backend (pip)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    target-branch: "dev"
+
+  # Frontend (npm/pnpm)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    target-branch: "dev"
+    # Dev-only build tools — vulnerabilities in these don't affect production.
+    # Security alerts for these are dismissed via auto-triage rules in
+    # Settings > Advanced Security > Dependabot rules.
+    ignore:
+      - dependency-name: "minimatch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tar"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "esbuild"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    target-branch: "dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uploaded files are now restricted to members of the guild they were uploaded in. The backend tracks file→guild ownership in a new `uploads` table and returns 403 to authenticated users who are not members of the owning guild. Covers image attachments, document file uploads (PDF, DOCX, etc.), and files created by duplicate/copy/template operations. Pre-existing files without a database record remain accessible to any authenticated user for backwards compatibility.
 - Web sessions now use HttpOnly `SameSite=Lax` cookies instead of `localStorage` for JWT storage, eliminating XSS token theft risk and removing the JWT from browser history/server logs. The cookie is sent automatically for all requests including media (`<img>`, `<iframe>`); native (Capacitor) is unchanged and continues to use DeviceToken headers stored in Capacitor Preferences.
 - Replaced `python-jose` with `PyJWT` for JWT handling. `python-jose` (through 3.3.0) has an algorithm confusion vulnerability with OpenSSH ECDSA keys and other key formats (similar to CVE-2022-29217) and is no longer maintained.
+- Upgraded `python-multipart` from 0.0.9 to 0.0.22, fixing a DoS via malformed `multipart/form-data` boundary and an arbitrary file write via non-default configuration.
+- Added Dependabot configuration (`.github/dependabot.yml`) for automated dependency update PRs on backend, frontend, and GitHub Actions.
 
 ### Changed
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ PyJWT==2.11.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 pydantic-settings==2.3.4
-python-multipart==0.0.9
+python-multipart==0.0.22
 email-validator==2.1.1
 httpx==0.27.0
 google-auth>=2.23.0


### PR DESCRIPTION
## Summary

- **Upgrades `python-multipart`** from 0.0.9 to 0.0.22, fixing two security vulnerabilities:
  - DoS via malformed `multipart/form-data` boundary (patched in 0.0.18)
  - Arbitrary file write via non-default configuration (patched in 0.0.22)
- **Adds `.github/dependabot.yml`** for automated weekly dependency update PRs targeting `dev` for pip, npm, and GitHub Actions

### Remaining Dependabot alert noise

After this PR + the python-jose PR merge to main, **4 alerts auto-close** (python-jose x2, python-multipart x2).

The remaining **13 alerts are all npm dev dependencies** (minimatch, tar, ajv, diff, esbuild, brace-expansion) — transitive deps of eslint, @capacitor/cli, orval, and vite that never ship in production. To suppress these:

1. Go to **Settings > Advanced Security > Dependabot rules**
2. Enable the preset rule **"Dismiss low impact issues for development-scoped dependencies"**
3. Optionally create custom rules to dismiss specific packages by name

## Test plan

- [x] All 374 backend tests pass
- [x] FastAPI imports successfully with python-multipart 0.0.22
- [x] Verify file upload endpoints still work in staging