### PR TITLE
Add offline mode to document editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Offline mode for the document editor
+  - Persistent mode-aware toast when the device loses network connectivity
+  - New "Offline" state in the collaboration status badge (now also shown in non-collaborative mode)
+  - Autosave is skipped while offline and automatically retries on reconnect, so edits aren't lost
+  - Uses `@capacitor/network` for accurate status on native, `navigator.onLine` on web
+
 ## [0.36.2] - 2026-04-08
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@capacitor/core": "^8.3.0",
     "@capacitor/device": "^8.0.2",
     "@capacitor/ios": "^8.3.0",
+    "@capacitor/network": "^8.0.1",
     "@capacitor/preferences": "^8.0.1",
     "@capacitor/push-notifications": "^8.0.3",
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@capacitor/ios':
         specifier: ^8.3.0
         version: 8.3.0(@capacitor/core@8.3.0)
+      '@capacitor/network':
+        specifier: ^8.0.1
+        version: 8.0.1(@capacitor/core@8.3.0)
       '@capacitor/preferences':
         specifier: ^8.0.1
         version: 8.0.1(@capacitor/core@8.3.0)
@@ -536,6 +539,11 @@ packages:
     resolution: {integrity: sha512-5Rtwv8SITKlYTt8lAZG+khnVIdzPtqbocH3eP+JkEmX1vpSMwx4TOKtT8OBz8gpQ+pUJDRp7DBYOv3U6l/obCw==}
     peerDependencies:
       '@capacitor/core': ^8.3.0
+
+  '@capacitor/network@8.0.1':
+    resolution: {integrity: sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
 
   '@capacitor/preferences@8.0.1':
     resolution: {integrity: sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ==}
@@ -6655,6 +6663,10 @@ snapshots:
       '@capacitor/core': 8.3.0
 
   '@capacitor/ios@8.3.0(@capacitor/core@8.3.0)':
+    dependencies:
+      '@capacitor/core': 8.3.0
+
+  '@capacitor/network@8.0.1(@capacitor/core@8.3.0)':
     dependencies:
       '@capacitor/core': 8.3.0
 

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -121,6 +121,10 @@
     "imageUploadError": "Failed to upload image.",
     "saved": "Document saved",
     "saveError": "Unable to save document.",
+    "offline": {
+      "collaborative": "You're offline — edits will sync when you reconnect.",
+      "nonCollaborative": "You're offline — changes aren't being saved. Reconnect to save."
+    },
     "collaborationFailed": "Collaboration connection failed",
     "collaborationFailedDescription": "Switching to offline editing mode",
     "saveChanges": "Save changes",
@@ -504,6 +508,7 @@
     "syncing": "Syncing...",
     "online": "Online",
     "offline": "Offline",
+    "networkOffline": "Offline",
     "connectionError": "Connection error",
     "activeCollaborators": "Active collaborators:",
     "viewing": "(viewing)",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -121,6 +121,10 @@
     "imageUploadError": "No se pudo subir la imagen.",
     "saved": "Documento guardado",
     "saveError": "No se pudo guardar el documento.",
+    "offline": {
+      "collaborative": "Estás sin conexión — los cambios se sincronizarán cuando vuelvas a conectarte.",
+      "nonCollaborative": "Estás sin conexión — los cambios no se están guardando. Vuelve a conectarte para guardar."
+    },
     "collaborationFailed": "La conexión de colaboración falló",
     "collaborationFailedDescription": "Cambiando al modo de edición sin conexión",
     "saveChanges": "Guardar cambios",
@@ -504,6 +508,7 @@
     "syncing": "Sincronizando...",
     "online": "En línea",
     "offline": "Sin conexión",
+    "networkOffline": "Sin conexión",
     "connectionError": "Error de conexión",
     "activeCollaborators": "Colaboradores activos:",
     "viewing": "(viendo)",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -121,6 +121,10 @@
     "imageUploadError": "Échec du téléchargement de l'image.",
     "saved": "Document enregistré",
     "saveError": "Impossible d'enregistrer le document.",
+    "offline": {
+      "collaborative": "Vous êtes hors ligne — les modifications seront synchronisées dès la reconnexion.",
+      "nonCollaborative": "Vous êtes hors ligne — les modifications ne sont pas enregistrées. Reconnectez-vous pour enregistrer."
+    },
     "collaborationFailed": "Échec de la connexion de collaboration",
     "collaborationFailedDescription": "Passage en mode d'édition hors ligne",
     "saveChanges": "Enregistrer les modifications",
@@ -504,6 +508,7 @@
     "syncing": "Synchronisation...",
     "online": "En ligne",
     "offline": "Hors ligne",
+    "networkOffline": "Hors ligne",
     "connectionError": "Erreur de connexion",
     "activeCollaborators": "Collaborateurs actifs :",
     "viewing": "(en lecture)",

--- a/frontend/src/components/documents/editor/CollaborationStatusBadge.tsx
+++ b/frontend/src/components/documents/editor/CollaborationStatusBadge.tsx
@@ -16,6 +16,8 @@ export interface CollaborationStatusBadgeProps {
   isCollaborating: boolean;
   /** Whether the collaboration provider has synced with the server */
   isSynced?: boolean;
+  /** Device-level network status. When false, overrides other states to show "Offline". */
+  isOnline?: boolean;
   className?: string;
 }
 
@@ -27,12 +29,15 @@ export function CollaborationStatusBadge({
   collaborators,
   isCollaborating,
   isSynced = true,
+  isOnline = true,
   className,
 }: CollaborationStatusBadgeProps) {
   const { t } = useTranslation("documents");
 
-  // Don't show anything if not enabled
-  if (connectionStatus === "disconnected" && collaborators.length === 0) {
+  // When explicitly offline, always render regardless of collaborator count.
+  // Otherwise keep the existing early-return so the badge stays hidden when
+  // collaboration is disabled and nobody else is here.
+  if (isOnline && connectionStatus === "disconnected" && collaborators.length === 0) {
     return null;
   }
 
@@ -67,11 +72,20 @@ export function CollaborationStatusBadge({
       color: "text-red-500",
       bgColor: "bg-red-100 dark:bg-red-900/20",
     },
+    offline: {
+      icon: WifiOff,
+      label: t("collab.networkOffline"),
+      color: "text-amber-600 dark:text-amber-500",
+      bgColor: "bg-amber-100 dark:bg-amber-900/20",
+    },
   };
 
-  // Determine effective status - show syncing when connected but not yet synced
-  const effectiveStatus =
-    connectionStatus === "connected" && !isSynced ? "syncing" : connectionStatus;
+  // Offline overrides everything. Otherwise show syncing when connected but not yet synced.
+  const effectiveStatus: keyof typeof statusConfig = !isOnline
+    ? "offline"
+    : connectionStatus === "connected" && !isSynced
+      ? "syncing"
+      : connectionStatus;
 
   const config = statusConfig[effectiveStatus];
   const StatusIcon = config.icon;
@@ -87,7 +101,7 @@ export function CollaborationStatusBadge({
             >
               <StatusIcon className={cn("h-3 w-3", config.color)} />
               <span className="text-xs">{config.label}</span>
-              {isCollaborating && collaborators.length > 0 && (
+              {isOnline && isCollaborating && collaborators.length > 0 && (
                 <span className="text-muted-foreground ml-0.5 text-xs">
                   ({collaborators.length})
                 </span>
@@ -95,7 +109,7 @@ export function CollaborationStatusBadge({
             </Badge>
 
             {/* Collaborator avatars */}
-            {isCollaborating && collaborators.length > 0 && (
+            {isOnline && isCollaborating && collaborators.length > 0 && (
               <div className="flex -space-x-2">
                 {collaborators.slice(0, 4).map((collaborator, index) => (
                   <CollaboratorAvatar

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -382,11 +382,14 @@ export const useUploadDocument = (options?: MutationOpts<DocumentRead, UploadDoc
 };
 
 export const useUpdateDocument = (
-  options?: MutationOpts<DocumentRead, { documentId: number; data: DocumentUpdate }>
+  options?: MutationOpts<DocumentRead, { documentId: number; data: DocumentUpdate }> & {
+    /** If provided and returns true, the default error toast will be skipped. */
+    suppressErrorToast?: (error: unknown) => boolean;
+  }
 ) => {
   const { t } = useTranslation("documents");
   const queryClient = useQueryClient();
-  const { onSuccess, onError, onSettled, ...rest } = options ?? {};
+  const { onSuccess, onError, onSettled, suppressErrorToast, ...rest } = options ?? {};
 
   return useMutation({
     ...rest,
@@ -406,8 +409,11 @@ export const useUpdateDocument = (
       onSuccess?.(...args);
     },
     onError: (...args) => {
-      const message = args[0] instanceof Error ? args[0].message : t("detail.saveError");
-      toast.error(message);
+      const error = args[0];
+      if (!suppressErrorToast?.(error)) {
+        const message = error instanceof Error ? error.message : t("detail.saveError");
+        toast.error(message);
+      }
       onError?.(...args);
     },
     onSettled,

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
+import { Network } from "@capacitor/network";
+
+export interface UseNetworkStatusResult {
+  isOnline: boolean;
+}
+
+/**
+ * Reports whether the device currently has network connectivity.
+ *
+ * On native (Capacitor), uses `@capacitor/network` for accurate status.
+ * On web, uses `navigator.onLine` plus `online`/`offline` window events.
+ */
+export const useNetworkStatus = (): UseNetworkStatusResult => {
+  const [isOnline, setIsOnline] = useState<boolean>(
+    typeof navigator === "undefined" ? true : navigator.onLine
+  );
+
+  useEffect(() => {
+    if (Capacitor.isNativePlatform()) {
+      let cancelled = false;
+      let handle: PluginListenerHandle | null = null;
+
+      Network.getStatus()
+        .then((status) => {
+          if (!cancelled) setIsOnline(status.connected);
+        })
+        .catch(() => {
+          // Ignore — default state already applied.
+        });
+
+      Network.addListener("networkStatusChange", (status) => {
+        if (!cancelled) setIsOnline(status.connected);
+      }).then((h) => {
+        if (cancelled) {
+          void h.remove();
+        } else {
+          handle = h;
+        }
+      });
+
+      return () => {
+        cancelled = true;
+        if (handle) void handle.remove();
+      };
+    }
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    setIsOnline(navigator.onLine);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return { isOnline };
+};

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -51,6 +51,7 @@ const FileDocumentViewer = lazy(() =>
 import { findNewMentions } from "@/lib/mentionUtils";
 import { useGuildPath } from "@/lib/guildUrl";
 import { useCollaboration } from "@/hooks/useCollaboration";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -126,6 +127,9 @@ export const DocumentDetailPage = () => {
       setCollaborationEnabled(false);
     },
   });
+
+  // Network status for offline detection
+  const { isOnline } = useNetworkStatus();
 
   const documentQuery = useDocument(Number.isFinite(parsedId) ? parsedId : null);
 
@@ -288,6 +292,9 @@ export const DocumentDetailPage = () => {
   };
 
   const saveDocument = useUpdateDocument({
+    // Suppress the default error toast when the save failed because we're offline —
+    // the persistent offline toast already explains the situation to the user.
+    suppressErrorToast: () => !navigator.onLine,
     onSuccess: () => {
       if (!isAutosaveRef.current) {
         toast.success(t("detail.saved"));
@@ -323,6 +330,11 @@ export const DocumentDetailPage = () => {
   // Autosave with debounce
   useEffect(() => {
     if (!autosaveEnabled || !canEditDocument || saveDocument.isPending) {
+      return;
+    }
+    // Skip all REST saves while offline — edits remain in local state and will
+    // be flushed when the network returns (see reconnect effect below).
+    if (!isOnline) {
       return;
     }
     // When collaborating, sync content less frequently (every 10s) to keep content column updated
@@ -367,7 +379,54 @@ export const DocumentDetailPage = () => {
     contentState,
     featuredImageUrl,
     collaboration.isCollaborating,
+    isOnline,
   ]);
+
+  // When connectivity returns after being offline, flush any pending dirty
+  // changes immediately. This handles the case where the user stopped typing
+  // while offline (so the 2s debounce already cleared) and is necessary
+  // because the autosave effect only fires on new edits.
+  const prevOnlineRef = useRef(isOnline);
+  useEffect(() => {
+    const wasOffline = !prevOnlineRef.current;
+    prevOnlineRef.current = isOnline;
+    if (!wasOffline || !isOnline) return;
+    if (!canEditDocument || !isDirty || saveDocument.isPending) return;
+    isAutosaveRef.current = true;
+    saveDocument.mutate({
+      documentId: parsedId,
+      data: {
+        title: title?.trim(),
+        content: contentState as unknown as Record<string, unknown>,
+        featured_image_url: featuredImageUrl,
+      },
+    });
+  }, [
+    isOnline,
+    canEditDocument,
+    isDirty,
+    saveDocument,
+    parsedId,
+    title,
+    contentState,
+    featuredImageUrl,
+  ]);
+
+  // Persistent offline toast with mode-aware copy
+  useEffect(() => {
+    const TOAST_ID = "editor-offline";
+    if (isOnline) {
+      toast.dismiss(TOAST_ID);
+      return;
+    }
+    const message = collaboration.isCollaborating
+      ? t("detail.offline.collaborative")
+      : t("detail.offline.nonCollaborative");
+    toast.warning(message, { id: TOAST_ID, duration: Infinity });
+    return () => {
+      toast.dismiss(TOAST_ID);
+    };
+  }, [isOnline, collaboration.isCollaborating, t]);
 
   // Ctrl+S / Cmd+S manual save shortcut
   useEffect(() => {
@@ -737,13 +796,16 @@ export const DocumentDetailPage = () => {
           </Suspense>
         ) : (
           <>
-            {/* Collaboration status - shown between featured image and editor */}
-            {collaborationEnabled && (
+            {/* Collaboration status - shown between featured image and editor.
+                Also shown when offline even in non-collaborative mode, so the
+                user sees an explicit offline indicator at the top of the editor. */}
+            {(collaborationEnabled || !isOnline) && (
               <CollaborationStatusBadge
                 connectionStatus={collaboration.connectionStatus}
                 collaborators={collaboration.collaborators}
                 isCollaborating={collaboration.isCollaborating}
                 isSynced={collaboration.isSynced}
+                isOnline={isOnline}
               />
             )}
             {/*

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -294,7 +294,9 @@ export const DocumentDetailPage = () => {
   const saveDocument = useUpdateDocument({
     // Suppress the default error toast when the save failed because we're offline —
     // the persistent offline toast already explains the situation to the user.
-    suppressErrorToast: () => !navigator.onLine,
+    // Using `isOnline` (not `navigator.onLine`) so native WebView users get the
+    // same behavior: the Capacitor Network plugin is authoritative on native.
+    suppressErrorToast: () => !isOnline,
     onSuccess: () => {
       if (!isAutosaveRef.current) {
         toast.success(t("detail.saved"));

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -394,7 +394,9 @@ export const DocumentDetailPage = () => {
     prevOnlineRef.current = isOnline;
     if (!wasOffline || !isOnline) return;
     if (!canEditDocument || !isDirty || saveDocument.isPending) return;
-    isAutosaveRef.current = true;
+    // Do NOT set isAutosaveRef here — we want the success toast to fire so
+    // users who edited while offline get explicit confirmation their work
+    // was persisted after reconnecting.
     saveDocument.mutate({
       documentId: parsedId,
       data: {


### PR DESCRIPTION
## Summary

- **Offline indicator**: Persistent sonner toast appears when the device loses network connectivity. Mode-aware copy — in collaborative mode it reassures the user edits will sync on reconnect, in non-collab it warns that changes aren't being saved.
- **Status badge**: The `CollaborationStatusBadge` now shows an explicit amber "Offline" state and is rendered even in non-collaborative mode when offline (previously it was hidden entirely unless collaboration was enabled).
- **Save queueing**: REST autosaves are skipped while offline (preventing error toast spam) and automatically retried when connectivity returns. The user's dirty edits stay in local state so they're flushed on reconnect.
- **No backend changes**: Collaborative mode already gets conflict-free merging via Yjs CRDT. Non-collaborative mode keeps last-write-wins but no longer silently fails when offline.
- New `useNetworkStatus` hook uses `@capacitor/network` on native (iOS/Android) and `navigator.onLine` + window events on web.

## Schema/env changes

- New dependency: `@capacitor/network` — run `npx cap sync` before building native apps

## Test plan

- [ ] Open a document, verify autosave works as before when online
- [ ] DevTools → Network → Offline; type into document; verify persistent orange toast with non-collab message and amber "Offline" badge
- [ ] Verify no red error toasts appear during the autosave debounce cycle while offline
- [ ] Go back online; verify toast dismisses, badge disappears, and a success toast confirms the save
- [ ] Enable live collaboration, go offline; verify different "will sync when you reconnect" toast text
- [ ] Keep typing in collab mode while offline; Yjs buffers locally; go online and verify text converges
- [ ] Navigate away from editor while offline — confirm toast dismisses (no stranded toast on other pages)
- [ ] iOS/Android simulator: toggle airplane mode and verify `@capacitor/network` fires the change