### PR TITLE
Clear yjs_state when content is saved via REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Autosave is skipped while offline and automatically retries on reconnect, so edits aren't lost
   - Uses `@capacitor/network` for accurate status on native, `navigator.onLine` on web
 
+### Fixed
+
+- Document edits saved in non-collaborative mode are no longer overwritten by a stale `yjs_state` when re-enabling live collaboration. The document update endpoint now clears `yjs_state` and invalidates any empty in-memory collaboration room whenever content is written via the REST PATCH.
+
 ## [0.36.2] - 2026-04-08
 
 ### Added

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -57,6 +57,7 @@ from app.services import initiatives as initiatives_service
 from app.services import notifications as notifications_service
 from app.services import permissions as permissions_service
 from app.services import rls as rls_service
+from app.services.collaboration import collaboration_manager
 from app.services.ai_generation import AIGenerationError, generate_document_summary
 
 logger = logging.getLogger(__name__)
@@ -874,6 +875,11 @@ async def update_document(
         document.content = documents_service.normalize_document_content(update_data["content"])
         new_content_urls = attachments_service.extract_upload_urls(document.content)
         removed_upload_urls.update(previous_content_urls - new_content_urls)
+        # Clear yjs_state so the next collaborative session bootstraps from
+        # the freshly saved content. Without this, a stale yjs_state would
+        # overwrite the editor with the previous content when the user
+        # re-enables live collaboration.
+        document.yjs_state = None
         content_updated = True
         updated = True
 
@@ -904,6 +910,11 @@ async def update_document(
             await session.exec(sa_delete(Upload).where(Upload.filename.in_(filenames)))
         await session.commit()
         await reapply_rls_context(session)
+        # Invalidate any in-memory collaboration room so the next session
+        # loads fresh state from the database. If a room has active
+        # collaborators their in-memory state wins until they disconnect.
+        if content_updated:
+            await collaboration_manager.invalidate_room_if_empty(document.id)
     hydrated = await _get_document_or_404(session, document_id=document.id, guild_id=guild_context.guild_id)
     attachments_service.delete_uploads_by_urls(removed_upload_urls)
     return serialize_document(

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -55,11 +55,10 @@ from app.services import attachments as attachments_service
 from app.services import documents as documents_service
 from app.services import initiatives as initiatives_service
 from app.services import notifications as notifications_service
+from app.services import permissions as permissions_service
 from app.services import rls as rls_service
 from app.services.ai_generation import AIGenerationError, generate_document_summary
 from app.services.collaboration import collaboration_manager
-from app.services.collaboration import collaboration_manager
-from app.services.ai_generation import AIGenerationError, generate_document_summary
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -55,8 +55,9 @@ from app.services import attachments as attachments_service
 from app.services import documents as documents_service
 from app.services import initiatives as initiatives_service
 from app.services import notifications as notifications_service
-from app.services import permissions as permissions_service
 from app.services import rls as rls_service
+from app.services.ai_generation import AIGenerationError, generate_document_summary
+from app.services.collaboration import collaboration_manager
 from app.services.collaboration import collaboration_manager
 from app.services.ai_generation import AIGenerationError, generate_document_summary
 

--- a/backend/app/api/v1/endpoints/documents_test.py
+++ b/backend/app/api/v1/endpoints/documents_test.py
@@ -393,3 +393,58 @@ async def test_download_native_document_returns_404(
 
     response = await client.get(f"/api/v1/documents/{doc_id}/download", headers=get_auth_headers(owner))
     assert response.status_code == 404
+
+
+@pytest.mark.integration
+async def test_update_content_clears_yjs_state(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """PATCH /documents/{id} with content should clear yjs_state.
+
+    Regression: editing in non-collab mode used to leave a stale yjs_state,
+    which then overwrote the freshly-saved content when the user re-enabled
+    collaboration (the CollaborationPlugin synced from the old Yjs state).
+    """
+    owner = await create_user(session)
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(session, user=owner, guild=guild)
+    initiative = await create_initiative(session, guild, owner)
+
+    headers = get_guild_headers(guild, owner)
+    create_resp = await client.post(
+        "/api/v1/documents/",
+        headers=headers,
+        json={"title": "Collab Doc", "initiative_id": initiative.id},
+    )
+    assert create_resp.status_code == 201
+    doc_id = create_resp.json()["id"]
+
+    # Simulate a prior collaborative session by writing a stale yjs_state blob
+    doc = await session.get(Document, doc_id)
+    assert doc is not None
+    doc.yjs_state = b"\x00\x01\x02 stale yjs blob"
+    session.add(doc)
+    await session.commit()
+
+    # PATCH the content via the REST endpoint (the non-collab save path)
+    patch_resp = await client.patch(
+        f"/api/v1/documents/{doc_id}",
+        headers=headers,
+        json={
+            "content": {
+                "root": {
+                    "children": [],
+                    "direction": None,
+                    "format": "",
+                    "indent": 0,
+                    "type": "root",
+                    "version": 1,
+                }
+            }
+        },
+    )
+    assert patch_resp.status_code == 200
+
+    # Re-read the document to confirm yjs_state was cleared
+    await session.refresh(doc)
+    assert doc.yjs_state is None


### PR DESCRIPTION
## Summary

Fixes a bug where edits saved in non-collaborative mode were silently overwritten after re-enabling live collaboration.

**Root cause**: When the user edits in non-collab mode, `PATCH /documents/{id}` updated `document.content` but left `document.yjs_state` untouched (still holding the old content). When the user then re-enabled live collaboration, the backend's `DocumentRoom` bootstrapped from the stale `yjs_state` and Lexical's `CollaborationPlugin` pushed that old Yjs snapshot back into the editor, wiping the fresh save.

**Fix**:
- Clear `document.yjs_state` inside `update_document` whenever content is written, so the next collab session starts fresh
- Invalidate any empty in-memory `DocumentRoom` after commit so it reloads from the database (existing `collaboration_manager.invalidate_room_if_empty` helper)

This matches the precedent at [services/documents.py:536-557](backend/app/services/documents.py#L536-L557) which already does the same yjs_state-clear + room-invalidate dance when unresolving wikilinks after a document is deleted.

**Known limitation** (unchanged): if another user is actively collaborating in the same room when the PATCH lands, the in-memory room wins and the fresh content is overwritten when the room persists on disconnect. That's a legitimate cross-session conflict outside the scope of this fix.

## Schema/env changes

None.

## Test plan

- [x] New integration test `test_update_content_clears_yjs_state` seeds a stale `yjs_state` blob, PATCHes content, and asserts `yjs_state` is cleared
- [x] All 13 document endpoint tests pass
- [x] `ruff check` clean
- [ ] Manual: open a document, disable live collaboration, edit and save, re-enable live collaboration — verify saved changes persist (they should no longer be reverted to the pre-edit state)