### PR TITLE
Fix whiteboard persistence and collaboration stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix whiteboard persistence losing edits on refresh / navigation
+  - Add localStorage write-ahead cache so unsaved scenes survive page unload regardless of keepalive PATCH timing
+  - Gate WhiteboardDocumentEditor on scene-ready state so Excalidraw's `initialData` captures the correct scene instead of the empty `useState` default
+  - Skip stale Yjs initial sync in observer — only apply live updates from other users after bootstrap
+  - Only clear `yjs_state` on PATCH when no active collaborators are in the room, preventing a data-loss window during periodic content-sync
+  - Guard the document load effect so PATCH responses don't reset the live whiteboard scene mid-edit
+
 ## [0.38.0] - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Skip stale Yjs initial sync in observer — only apply live updates from other users after bootstrap
   - Only clear `yjs_state` on PATCH when no active collaborators are in the room, preventing a data-loss window during periodic content-sync
   - Guard the document load effect so PATCH responses don't reset the live whiteboard scene mid-edit
+- Fix whiteboard cache poisoning when rejoining a live room — a user rejoining with a stale local cache no longer clobbers the live room's state. The bootstrap now applies the Y.Map state whenever other collaborators are present, and local edits are gated behind the bootstrap decision so Excalidraw's initial mount `onChange` can't broadcast the cached scene.
+- Whiteboards in collaboration mode now sync to `document.content` every 2s instead of 10s, matching the non-collab debounce. Narrows the stale-content window for non-collab readers and reduces the `yjs_state` / `content` desync window.
 
 ## [0.38.0] - 2026-04-10
 

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -884,11 +884,22 @@ async def update_document(
         )
         new_content_urls = attachments_service.extract_upload_urls(document.content)
         removed_upload_urls.update(previous_content_urls - new_content_urls)
-        # Clear yjs_state so the next collaborative session bootstraps from
-        # the freshly saved content. Without this, a stale yjs_state would
-        # overwrite the editor with the previous content when the user
-        # re-enables live collaboration.
-        document.yjs_state = None
+        # Clear yjs_state ONLY if there is no active collaboration room.
+        # Rationale: when users are actively collaborating, the in-memory
+        # room is the source of truth for Yjs state, and its full snapshot
+        # will be written back to yjs_state on the last disconnect via
+        # persist_room. Clearing yjs_state here while a room is active
+        # creates a data-loss window: if the REST PATCH lands right before
+        # all users disconnect, and the disconnect's persist_room fails or
+        # races with cleanup, yjs_state stays None and the next session
+        # bootstraps from the (potentially stale) PATCHed content column,
+        # losing any edits that were made between the PATCH and disconnect.
+        #
+        # Clearing only when the room is inactive still solves PR #347's
+        # original problem: non-collab edits need to override any stale
+        # pre-existing yjs_state the next time the user re-enables collab.
+        if not collaboration_manager.has_active_collaborators(document.id):
+            document.yjs_state = None
         content_updated = True
         updated = True
 

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -137,6 +137,7 @@ class DocumentSummary(DocumentBase):
     file_size: Optional[int] = None
     original_filename: Optional[str] = None
     my_permission_level: Optional[str] = None
+    yjs_updated_at: Optional[datetime] = None
 
 
 class DocumentListResponse(BaseModel):
@@ -257,6 +258,7 @@ def serialize_document_summary(
         file_size=document.file_size,
         original_filename=document.original_filename,
         my_permission_level=my_permission_level,
+        yjs_updated_at=document.yjs_updated_at,
     )
 
 

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -740,6 +740,7 @@ export interface DocumentSummary {
   file_size: number | null;
   original_filename: string | null;
   my_permission_level: string | null;
+  yjs_updated_at: string | null;
 }
 
 export interface DocumentListResponse {
@@ -798,6 +799,7 @@ export interface DocumentRead {
   file_size: number | null;
   original_filename: string | null;
   my_permission_level: string | null;
+  yjs_updated_at: string | null;
   content: DocumentReadContent;
 }
 

--- a/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
+++ b/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
@@ -8,7 +8,7 @@
  *   the scene key — an explicit v1 trade-off.
  * - When `yDoc` is null, edits flow through the parent's REST autosave path.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import { Excalidraw, CaptureUpdateAction, serializeAsJSON } from "@excalidraw/excalidraw";
@@ -91,10 +91,12 @@ export function WhiteboardDocumentEditor({
   // Tracks which Y.Doc we've already bootstrapped so we don't seed twice
   // (e.g. if isSynced flips false → true → false → true on reconnect).
   const seededForDocRef = useRef<Y.Doc | null>(null);
-  // Flipped true when Excalidraw hands us its imperative API. We need this
-  // as React state (not just a ref) so the bootstrap effect can re-run once
-  // the API is available — the ref itself isn't observable.
-  const [isAPIReady, setIsAPIReady] = useState(false);
+  // Gated true AFTER the post-sync bootstrap seeds the Y.Map. The observer
+  // skips all events until this is true, so the stale initial Yjs sync
+  // (from persist_room, which can be one edit behind because the last
+  // WebSocket message is lost on page unload) never overwrites the correct
+  // REST-fetched initialScene that Excalidraw is already displaying.
+  const bootstrapDoneRef = useRef(false);
 
   const collaborative = Boolean(yDoc);
 
@@ -116,13 +118,22 @@ export function WhiteboardDocumentEditor({
     if (!yDoc) return;
     const yMap = yDoc.getMap<string>("excalidraw");
     yMapRef.current = yMap;
-    // Reset the bootstrap guard whenever the Y.Doc changes (e.g. navigating
+    // Reset bootstrap guards whenever the Y.Doc changes (e.g. navigating
     // between whiteboards).
     seededForDocRef.current = null;
+    bootstrapDoneRef.current = false;
 
     const handleRemoteChange = (event: Y.YMapEvent<string>) => {
       // Skip our own writes — Excalidraw already has them
       if (event.transaction.local) return;
+      // Skip events from the initial Yjs sync. The server's yjs_state can
+      // be one edit behind document.content (the last WebSocket message is
+      // lost on page unload, while the keepalive PATCH survives). Applying
+      // the stale sync state would overwrite the correct REST-fetched scene
+      // that Excalidraw is already displaying. Only LIVE updates from other
+      // users (which arrive after the bootstrap seeds the Y.Map) should be
+      // applied.
+      if (!bootstrapDoneRef.current) return;
       const raw = yMap.get("scene");
       if (!raw || !excalidrawAPIRef.current) return;
       try {
@@ -181,69 +192,29 @@ export function WhiteboardDocumentEditor({
   }, [yDoc]);
 
   // ── Post-sync bootstrap ──────────────────────────────────────────────
-  // Apply the Y.Map's current state to Excalidraw (or seed an empty Y.Map
-  // with our initial scene) ONLY when all three are ready:
-  //   1. yDoc   — the provider is instantiated
-  //   2. isSynced — the server has confirmed initial sync (so the Y.Map
-  //      contains the authoritative state)
-  //   3. isAPIReady — Excalidraw has handed us its imperative API, so
-  //      updateScene() will actually paint
+  // After the initial Yjs sync completes, allow the observer to start
+  // processing LIVE updates from other users. We intentionally do NOT
+  // seed the Y.Map or apply the synced state to Excalidraw here.
   //
-  // Waiting for all three closes a refresh-time race: on refresh, sync
-  // often completes before Excalidraw finishes its first mount, so a
-  // naive "apply on isSynced" would silently bail at !excalidrawAPIRef
-  // and leave the user staring at the stale initialScene from document.content.
+  // Why not seed: seeding from localStorage/REST would overwrite a live
+  // room's current state, clobbering the other user's edits.
+  //
+  // Why not apply the sync state: the server's yjs_state (persisted by
+  // persist_room on disconnect) can be one edit behind document.content
+  // because the last WebSocket message is lost on page unload (WebSockets
+  // don't support keepalive). Applying it would overwrite the correct
+  // scene that Excalidraw is already displaying from localStorage cache
+  // or REST content.
+  //
+  // Trade-off: when joining a room where another user is actively editing,
+  // the joining user sees slightly stale REST/cached content until the
+  // other user's next edit arrives as a live Yjs update.
   useEffect(() => {
-    if (!yDoc || !isSynced || !isAPIReady) return;
+    if (!yDoc || !isSynced) return;
     if (seededForDocRef.current === yDoc) return;
-
-    const yMap = yDoc.getMap<string>("excalidraw");
-    if (!yMap.has("scene")) {
-      // Server confirmed empty — safe to seed with our initial scene.
-      yMap.set("scene", JSON.stringify(initialScene));
-      seededForDocRef.current = yDoc;
-      return;
-    }
-
-    // Server already has a scene — apply it to Excalidraw.
-    const raw = yMap.get("scene");
-    // Defensive guard: in practice both are guaranteed to be present here
-    // (isAPIReady is set in the same callback that assigns excalidrawAPIRef,
-    // and yMap.has("scene") was true a few lines up), but bail safely if
-    // either slot is empty so we don't crash on a surprise null.
-    if (!raw || !excalidrawAPIRef.current) return;
-    try {
-      const parsed = JSON.parse(raw) as {
-        elements: readonly OrderedExcalidrawElement[];
-        appState?: Partial<AppState>;
-        files?: BinaryFiles;
-      };
-      prevSerializedRef.current = raw;
-      applyingRemoteRef.current = true;
-      if (parsed.files) {
-        const fileArr = Object.values(parsed.files);
-        if (fileArr.length > 0) {
-          excalidrawAPIRef.current.addFiles(fileArr);
-        }
-      }
-      excalidrawAPIRef.current.updateScene({
-        elements: parsed.elements,
-        appState: parsed.appState as Partial<AppState> as AppState,
-        captureUpdate: CaptureUpdateAction.NEVER,
-      });
-      seededForDocRef.current = yDoc;
-    } catch (err) {
-      console.error("Failed to apply post-sync whiteboard state:", err);
-      applyingRemoteRef.current = false;
-      return;
-    }
-    // Clear on microtask so the flag survives into Excalidraw's async
-    // onChange echo — see comment in the Yjs observer for rationale.
-    queueMicrotask(() => {
-      applyingRemoteRef.current = false;
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [yDoc, isSynced, isAPIReady]);
+    seededForDocRef.current = yDoc;
+    bootstrapDoneRef.current = true;
+  }, [yDoc, isSynced]);
 
   // ── Local change handler ─────────────────────────────────────────────
   // Excalidraw fires onChange on every re-render (unlike Lexical which
@@ -329,7 +300,6 @@ export function WhiteboardDocumentEditor({
       <Excalidraw
         excalidrawAPI={(api) => {
           excalidrawAPIRef.current = api;
-          setIsAPIReady(true);
         }}
         initialData={initialData}
         onChange={handleExcalidrawChange}

--- a/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
+++ b/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
@@ -52,6 +52,11 @@ export interface WhiteboardDocumentEditorProps {
   yDoc?: Y.Doc | null;
   /** Whether the Yjs provider has fully synced from the server. */
   isSynced?: boolean;
+  /** True if other users are currently connected to the same Yjs room.
+   *  When true AND initialSceneFromCache is true, the cache is considered
+   *  stale (another user has continued editing while we were gone) and
+   *  the Yjs state wins on bootstrap. */
+  hasOtherCollaborators?: boolean;
 }
 
 /**
@@ -77,6 +82,7 @@ export function WhiteboardDocumentEditor({
   className,
   yDoc = null,
   isSynced = true,
+  hasOtherCollaborators = false,
 }: WhiteboardDocumentEditorProps) {
   const { t } = useTranslation("documents");
   const { resolvedTheme } = useTheme();
@@ -105,6 +111,13 @@ export function WhiteboardDocumentEditor({
   // WebSocket message is lost on page unload) never overwrites the correct
   // REST-fetched initialScene that Excalidraw is already displaying.
   const bootstrapDoneRef = useRef(false);
+  // Separate gate for LOCAL → Yjs writes. Set true after the bootstrap
+  // effect has made its decision (apply Yjs state vs keep cached scene).
+  // Without this gate, Excalidraw's first onChange on mount would write
+  // the initial scene to Yjs, which in the rejoin case would clobber a
+  // live room's state with our stale local cache — poisoning the room
+  // for all other connected users.
+  const writesAllowedRef = useRef(false);
 
   const collaborative = Boolean(yDoc);
 
@@ -200,33 +213,35 @@ export function WhiteboardDocumentEditor({
   }, [yDoc]);
 
   // ── Post-sync bootstrap ──────────────────────────────────────────────
-  // After the initial Yjs sync completes, decide whether to apply the
-  // Y.Map state to Excalidraw. The decision hinges on whether the
-  // initialScene we're already displaying came from unsaved local edits
-  // (localStorage cache) or from the server (REST content column).
+  // After initial Yjs sync, decide whether to apply the Y.Map state to
+  // Excalidraw. Three cases:
   //
-  // • initialSceneFromCache === true:
-  //     The user has unsaved local edits. Applying the Yjs state would
-  //     clobber them — the Yjs state is likely behind by one edit because
-  //     WebSockets don't support keepalive on page unload, so the last
-  //     edit never reached the server before the previous disconnect.
-  //     Skip the apply.
+  // • Other users connected: the room is live and authoritative — apply
+  //   the Y.Map state regardless of whether our initialScene came from
+  //   cache or REST. A stale local cache (from a previous visit where
+  //   another user kept editing after we left) must NOT be propagated
+  //   to Yjs, or we'd clobber the live room's state for all users.
   //
-  // • initialSceneFromCache === false:
-  //     No unsaved local work. The Yjs state in the room is authoritative
-  //     for live collaboration — if another user is connected and has
-  //     been editing, the Y.Map holds their current scene. Apply it so
-  //     the joining user catches up immediately instead of waiting for
-  //     the other user's next edit.
+  // • initialSceneFromCache === true AND alone: we have unsaved local
+  //   edits and no one else is here to correct us. Keep the cached scene
+  //   (the Yjs state is likely behind by one edit because the last
+  //   WebSocket message was lost on page unload).
   //
-  // Either way, set bootstrapDoneRef so the observer starts processing
-  // subsequent live updates from other users.
+  // • initialSceneFromCache === false AND alone: no unsaved local work.
+  //   Apply the Y.Map state if it has anything — it may be more recent
+  //   than the REST content (e.g. from a `persist_room` snapshot that
+  //   happened after the last REST PATCH).
+  //
+  // After the decision, flip writesAllowedRef so subsequent local edits
+  // flow to Yjs, and bootstrapDoneRef so remote updates flow in.
   useEffect(() => {
     if (!yDoc || !isSynced) return;
     if (seededForDocRef.current === yDoc) return;
     seededForDocRef.current = yDoc;
 
-    if (!initialSceneFromCache && excalidrawAPIRef.current) {
+    const shouldApplyYjsState = hasOtherCollaborators || !initialSceneFromCache;
+
+    if (shouldApplyYjsState && excalidrawAPIRef.current) {
       const yMap = yDoc.getMap<string>("excalidraw");
       const raw = yMap.get("scene");
       if (raw) {
@@ -260,7 +275,8 @@ export function WhiteboardDocumentEditor({
     }
 
     bootstrapDoneRef.current = true;
-  }, [yDoc, isSynced, initialSceneFromCache]);
+    writesAllowedRef.current = true;
+  }, [yDoc, isSynced, initialSceneFromCache, hasOtherCollaborators]);
 
   // ── Local change handler ─────────────────────────────────────────────
   // Excalidraw fires onChange on every re-render (unlike Lexical which
@@ -320,8 +336,12 @@ export function WhiteboardDocumentEditor({
       if (serializedWithFiles === prevSerializedRef.current) return;
       prevSerializedRef.current = serializedWithFiles;
 
-      // Mirror to Yjs when collaborative
-      if (yMapRef.current) {
+      // Mirror to Yjs when collaborative — but only after the bootstrap has
+      // decided whether to keep our cached scene or override with the live
+      // room state. Writing on the initial mount onChange would broadcast
+      // our (possibly stale) local cache to the room and clobber other
+      // users' live edits.
+      if (yMapRef.current && writesAllowedRef.current) {
         yMapRef.current.set("scene", serializedWithFiles);
       }
     },

--- a/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
+++ b/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
@@ -37,6 +37,13 @@ export interface WhiteboardScene {
 export interface WhiteboardDocumentEditorProps {
   /** Initial scene loaded from document.content (may be empty). */
   initialScene: WhiteboardScene;
+  /** True if initialScene came from the localStorage write-ahead cache,
+   *  meaning the user has unsaved local edits. When true, the bootstrap
+   *  must NOT overwrite the canvas with Yjs sync state, which would clobber
+   *  the unsaved work. When false, the bootstrap is free to apply Yjs
+   *  state to catch up to a live room where another user has been
+   *  editing. */
+  initialSceneFromCache?: boolean;
   /** Called on every change with the pruned, persistable scene. */
   onSerializedChange: (scene: WhiteboardScene) => void;
   readOnly?: boolean;
@@ -64,6 +71,7 @@ function makeInitialData(scene: WhiteboardScene): ExcalidrawInitialDataState {
 
 export function WhiteboardDocumentEditor({
   initialScene,
+  initialSceneFromCache = false,
   onSerializedChange,
   readOnly = false,
   className,
@@ -192,29 +200,67 @@ export function WhiteboardDocumentEditor({
   }, [yDoc]);
 
   // ── Post-sync bootstrap ──────────────────────────────────────────────
-  // After the initial Yjs sync completes, allow the observer to start
-  // processing LIVE updates from other users. We intentionally do NOT
-  // seed the Y.Map or apply the synced state to Excalidraw here.
+  // After the initial Yjs sync completes, decide whether to apply the
+  // Y.Map state to Excalidraw. The decision hinges on whether the
+  // initialScene we're already displaying came from unsaved local edits
+  // (localStorage cache) or from the server (REST content column).
   //
-  // Why not seed: seeding from localStorage/REST would overwrite a live
-  // room's current state, clobbering the other user's edits.
+  // • initialSceneFromCache === true:
+  //     The user has unsaved local edits. Applying the Yjs state would
+  //     clobber them — the Yjs state is likely behind by one edit because
+  //     WebSockets don't support keepalive on page unload, so the last
+  //     edit never reached the server before the previous disconnect.
+  //     Skip the apply.
   //
-  // Why not apply the sync state: the server's yjs_state (persisted by
-  // persist_room on disconnect) can be one edit behind document.content
-  // because the last WebSocket message is lost on page unload (WebSockets
-  // don't support keepalive). Applying it would overwrite the correct
-  // scene that Excalidraw is already displaying from localStorage cache
-  // or REST content.
+  // • initialSceneFromCache === false:
+  //     No unsaved local work. The Yjs state in the room is authoritative
+  //     for live collaboration — if another user is connected and has
+  //     been editing, the Y.Map holds their current scene. Apply it so
+  //     the joining user catches up immediately instead of waiting for
+  //     the other user's next edit.
   //
-  // Trade-off: when joining a room where another user is actively editing,
-  // the joining user sees slightly stale REST/cached content until the
-  // other user's next edit arrives as a live Yjs update.
+  // Either way, set bootstrapDoneRef so the observer starts processing
+  // subsequent live updates from other users.
   useEffect(() => {
     if (!yDoc || !isSynced) return;
     if (seededForDocRef.current === yDoc) return;
     seededForDocRef.current = yDoc;
+
+    if (!initialSceneFromCache && excalidrawAPIRef.current) {
+      const yMap = yDoc.getMap<string>("excalidraw");
+      const raw = yMap.get("scene");
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw) as {
+            elements: readonly OrderedExcalidrawElement[];
+            appState?: Partial<AppState>;
+            files?: BinaryFiles;
+          };
+          prevSerializedRef.current = raw;
+          applyingRemoteRef.current = true;
+          if (parsed.files) {
+            const fileArr = Object.values(parsed.files);
+            if (fileArr.length > 0) {
+              excalidrawAPIRef.current.addFiles(fileArr);
+            }
+          }
+          excalidrawAPIRef.current.updateScene({
+            elements: parsed.elements,
+            appState: parsed.appState as Partial<AppState> as AppState,
+            captureUpdate: CaptureUpdateAction.NEVER,
+          });
+          queueMicrotask(() => {
+            applyingRemoteRef.current = false;
+          });
+        } catch (err) {
+          console.error("Failed to apply post-sync whiteboard state:", err);
+          applyingRemoteRef.current = false;
+        }
+      }
+    }
+
     bootstrapDoneRef.current = true;
-  }, [yDoc, isSynced]);
+  }, [yDoc, isSynced, initialSceneFromCache]);
 
   // ── Local change handler ─────────────────────────────────────────────
   // Excalidraw fires onChange on every re-render (unlike Lexical which

--- a/frontend/src/components/projects/ProjectDocumentsSection.tsx
+++ b/frontend/src/components/projects/ProjectDocumentsSection.tsx
@@ -301,4 +301,5 @@ const createFallbackSummary = (
   file_size: null,
   original_filename: null,
   my_permission_level: null,
+  yjs_updated_at: null,
 });

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -86,6 +86,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
 import { getHttpStatus } from "@/lib/errorMessage";
+import { getItem, setItem, removeItem } from "@/lib/storage";
 
 export const DocumentDetailPage = () => {
   const { t } = useTranslation("documents");
@@ -111,6 +112,12 @@ export const DocumentDetailPage = () => {
     appState: {},
     files: {},
   }));
+  // Flipped true once the load effect has populated whiteboardScene from
+  // localStorage cache or REST content. The WhiteboardDocumentEditor must
+  // not mount until this is true — otherwise its useMemo([]) captures the
+  // empty default from useState, and Excalidraw renders a blank canvas
+  // that never updates when the real scene arrives via the load effect.
+  const [whiteboardSceneReady, setWhiteboardSceneReady] = useState(false);
   const [whiteboardYDoc, setWhiteboardYDoc] = useState<Y.Doc | null>(null);
   const [autosaveEnabled, setAutosaveEnabled] = useState(true);
   const [collaborationEnabled, setCollaborationEnabled] = useState(true);
@@ -158,10 +165,19 @@ export const DocumentDetailPage = () => {
     [document]
   );
 
+  // Track which document ID we've loaded the whiteboard scene for, so we
+  // don't re-run the load logic when `document` updates due to a PATCH
+  // response. Without this guard, a successful autosave would reset
+  // whiteboardScene from the PATCH response's content — which can be
+  // behind the user's current edits if they drew during the round-trip.
+  const loadedWhiteboardForRef = useRef<number | null>(null);
+
   // Clear content state ref when document ID changes
   // The ref now tracks which document the content belongs to
   useEffect(() => {
     contentStateRef.current = null;
+    loadedWhiteboardForRef.current = null;
+    setWhiteboardSceneReady(false);
   }, [parsedId]);
 
   useEffect(() => {
@@ -170,12 +186,55 @@ export const DocumentDetailPage = () => {
     }
     setTitle(document.title);
     if (document.document_type === "whiteboard") {
-      const raw = (document.content ?? {}) as Partial<WhiteboardScene>;
-      setWhiteboardScene({
-        elements: raw.elements ?? [],
-        appState: raw.appState ?? {},
-        files: raw.files ?? {},
-      });
+      // Only load the whiteboard scene once per document ID. Subsequent
+      // document changes (from PATCH responses, cache updates, etc.) must
+      // not overwrite the live scene state.
+      if (loadedWhiteboardForRef.current === document.id) {
+        // Still sync non-scene fields that the user can change in the
+        // metadata card (featured image, tags are handled separately).
+        setFeaturedImageUrl(document.featured_image_url ?? null);
+        setTags(document.tags ?? []);
+        return;
+      }
+      loadedWhiteboardForRef.current = document.id;
+
+      // Check the write-ahead cache first. On every edit the scene is
+      // written to localStorage synchronously (survives refresh), so if
+      // the user refreshes before the keepalive PATCH lands, we still
+      // have the latest scene. We compare timestamps: if the cached scene
+      // is newer than document.updated_at, use it instead of the (stale)
+      // REST-fetched content.
+      const cacheKey = `wb-scene-${document.id}`;
+      let scene: WhiteboardScene | null = null;
+      try {
+        const cached = getItem(cacheKey);
+        if (cached) {
+          const parsed = JSON.parse(cached) as {
+            scene: WhiteboardScene;
+            savedAt: string;
+          };
+          const cachedTs = new Date(parsed.savedAt).getTime();
+          const serverTs = new Date(document.updated_at).getTime();
+          if (cachedTs > serverTs && parsed.scene?.elements) {
+            scene = parsed.scene;
+          } else {
+            removeItem(cacheKey);
+          }
+        }
+      } catch {
+        removeItem(cacheKey);
+      }
+
+      if (!scene) {
+        const raw = (document.content ?? {}) as Partial<WhiteboardScene>;
+        scene = {
+          elements: raw.elements ?? [],
+          appState: raw.appState ?? {},
+          files: raw.files ?? {},
+        };
+      }
+      setWhiteboardScene(scene);
+      setWhiteboardSceneReady(true);
     } else {
       setContentState(normalizedDocumentContent);
     }
@@ -340,6 +399,8 @@ export const DocumentDetailPage = () => {
       if (!isAutosaveRef.current) {
         toast.success(t("detail.saved"));
       }
+      // Clear the write-ahead cache — the DB is now up-to-date.
+      removeItem(`wb-scene-${parsedId}`);
       // Fire-and-forget: notify users who were newly mentioned
       const newMentionIds = findNewMentions(normalizedDocumentContent, contentState);
       if (newMentionIds.length > 0) {
@@ -394,7 +455,9 @@ export const DocumentDetailPage = () => {
     parsedId,
   ]);
 
-  // Whiteboard scene change handler — mirrors handleContentChange for Lexical
+  // Whiteboard scene change handler — mirrors handleContentChange for Lexical.
+  // Also writes a write-ahead cache to localStorage so the scene survives
+  // a page refresh even if the keepalive PATCH hasn't landed yet.
   const handleWhiteboardChange = useCallback(
     (scene: WhiteboardScene) => {
       contentStateRef.current = {
@@ -402,6 +465,14 @@ export const DocumentDetailPage = () => {
         content: scene as unknown as SerializedEditorState,
       };
       setWhiteboardScene(scene);
+      try {
+        setItem(
+          `wb-scene-${parsedId}`,
+          JSON.stringify({ scene, savedAt: new Date().toISOString() })
+        );
+      } catch {
+        // Storage full or unavailable — best-effort
+      }
     },
     [parsedId]
   );
@@ -492,6 +563,73 @@ export const DocumentDetailPage = () => {
     contentForSave,
     featuredImageUrl,
   ]);
+
+  // ── Unmount / unload flush ──────────────────────────────────────────
+  // Mirrors the current save payload into a ref so the unmount flush has
+  // the most recent data even if the autosave debounce was cancelled
+  // mid-flight (e.g. user draws a shape and refreshes within 2 seconds).
+  // Without this, the autosave timer is cleared on unmount and the edit
+  // is lost. Especially important for whiteboards where a single drawing
+  // action comfortably fits inside the debounce window.
+  const pendingSavePayloadRef = useRef<{
+    documentId: number;
+    data: {
+      title?: string;
+      content: Record<string, unknown>;
+      featured_image_url: string | null;
+    };
+  } | null>(null);
+  useEffect(() => {
+    if (!canEditDocument || !isDirty) {
+      pendingSavePayloadRef.current = null;
+      return;
+    }
+    pendingSavePayloadRef.current = {
+      documentId: parsedId,
+      data: {
+        title: title?.trim(),
+        content: contentForSave,
+        featured_image_url: featuredImageUrl,
+      },
+    };
+  }, [canEditDocument, isDirty, parsedId, title, contentForSave, featuredImageUrl]);
+
+  useEffect(() => {
+    if (!token || !activeGuildId) return;
+    const flush = () => {
+      const pending = pendingSavePayloadRef.current;
+      if (!pending) return;
+      // Fire-and-forget PATCH with keepalive so the request survives the
+      // page unloading. Routes through the normal document update endpoint
+      // (which runs normalize_document_content server-side) so we don't
+      // need to massage the payload client-side.
+      const isAbsolute = API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://");
+      const baseUrl = isAbsolute ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
+      const url = `${baseUrl}/documents/${pending.documentId}`;
+      fetch(url, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          "X-Guild-ID": String(activeGuildId),
+        },
+        body: JSON.stringify(pending.data),
+        keepalive: true,
+      }).catch(() => {
+        // Swallow errors — the page is unloading, there's nothing to show.
+      });
+      pendingSavePayloadRef.current = null;
+    };
+
+    const handleBeforeUnload = () => flush();
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      // Runs on unmount (navigate away to another page) and on dep change
+      // (e.g. switching documents). Either way, flush any pending save.
+      flush();
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [token, activeGuildId]);
 
   // Persistent offline toast with mode-aware copy
   useEffect(() => {
@@ -901,14 +1039,20 @@ export const DocumentDetailPage = () => {
               }
             >
               {document.document_type === "whiteboard" ? (
-                <WhiteboardDocumentEditor
-                  key={parsedId}
-                  initialScene={whiteboardScene}
-                  onSerializedChange={handleWhiteboardChange}
-                  readOnly={!canEditDocument}
-                  yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}
-                  isSynced={collaboration.isSynced}
-                />
+                whiteboardSceneReady ? (
+                  <WhiteboardDocumentEditor
+                    key={parsedId}
+                    initialScene={whiteboardScene}
+                    onSerializedChange={handleWhiteboardChange}
+                    readOnly={!canEditDocument}
+                    yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}
+                    isSynced={collaboration.isSynced}
+                  />
+                ) : (
+                  <div className="flex h-96 items-center justify-center rounded-xl border">
+                    <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+                  </div>
+                )
               ) : (
                 <Editor
                   key={parsedId}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -496,9 +496,15 @@ export const DocumentDetailPage = () => {
     if (!isOnline) {
       return;
     }
-    // When collaborating, sync content less frequently (every 10s) to keep content column updated
-    // When not collaborating, use normal autosave behavior (2s debounce when dirty)
+    // When collaborating, sync content periodically to keep the content
+    // column updated for non-collab readers. Native Lexical docs use 10s
+    // (users type many characters per second, a shorter window would
+    // hammer the backend). Whiteboards use the same 2s debounce as
+    // non-collab mode — a single drawing action fits in 10s, so a longer
+    // window leaves document.content stale for external REST readers
+    // and increases the yjs_state/content desync window.
     if (collaboration.isCollaborating) {
+      const collabDebounceMs = document?.document_type === "whiteboard" ? 2000 : 10000;
       const timer = setTimeout(() => {
         isAutosaveRef.current = true;
         saveDocument.mutate({
@@ -509,7 +515,7 @@ export const DocumentDetailPage = () => {
             featured_image_url: featuredImageUrl,
           },
         });
-      }, 10000);
+      }, collabDebounceMs);
       return () => clearTimeout(timer);
     } else {
       if (!isDirty) {
@@ -539,6 +545,7 @@ export const DocumentDetailPage = () => {
     featuredImageUrl,
     collaboration.isCollaborating,
     isOnline,
+    document?.document_type,
   ]);
 
   // When connectivity returns after being offline, flush any pending dirty
@@ -1062,6 +1069,7 @@ export const DocumentDetailPage = () => {
                     readOnly={!canEditDocument}
                     yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}
                     isSynced={collaboration.isSynced}
+                    hasOtherCollaborators={collaboration.collaborators.length > 0}
                   />
                 ) : (
                   <div className="flex h-96 items-center justify-center rounded-xl border">

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -118,6 +118,11 @@ export const DocumentDetailPage = () => {
   // empty default from useState, and Excalidraw renders a blank canvas
   // that never updates when the real scene arrives via the load effect.
   const [whiteboardSceneReady, setWhiteboardSceneReady] = useState(false);
+  // True when the initial whiteboard scene was loaded from the localStorage
+  // write-ahead cache (i.e. the user has unsaved local edits). Passed down
+  // so the editor's post-sync bootstrap knows NOT to overwrite the canvas
+  // with the Yjs state (which would clobber the unsaved local work).
+  const [whiteboardSceneFromCache, setWhiteboardSceneFromCache] = useState(false);
   const [whiteboardYDoc, setWhiteboardYDoc] = useState<Y.Doc | null>(null);
   const [autosaveEnabled, setAutosaveEnabled] = useState(true);
   const [collaborationEnabled, setCollaborationEnabled] = useState(true);
@@ -178,6 +183,7 @@ export const DocumentDetailPage = () => {
     contentStateRef.current = null;
     loadedWhiteboardForRef.current = null;
     setWhiteboardSceneReady(false);
+    setWhiteboardSceneFromCache(false);
   }, [parsedId]);
 
   useEffect(() => {
@@ -206,6 +212,7 @@ export const DocumentDetailPage = () => {
       // REST-fetched content.
       const cacheKey = `wb-scene-${document.id}`;
       let scene: WhiteboardScene | null = null;
+      let fromCache = false;
       try {
         const cached = getItem(cacheKey);
         if (cached) {
@@ -217,6 +224,7 @@ export const DocumentDetailPage = () => {
           const serverTs = new Date(document.updated_at).getTime();
           if (cachedTs > serverTs && parsed.scene?.elements) {
             scene = parsed.scene;
+            fromCache = true;
           } else {
             removeItem(cacheKey);
           }
@@ -234,6 +242,7 @@ export const DocumentDetailPage = () => {
         };
       }
       setWhiteboardScene(scene);
+      setWhiteboardSceneFromCache(fromCache);
       setWhiteboardSceneReady(true);
     } else {
       setContentState(normalizedDocumentContent);
@@ -1048,6 +1057,7 @@ export const DocumentDetailPage = () => {
                   <WhiteboardDocumentEditor
                     key={parsedId}
                     initialScene={whiteboardScene}
+                    initialSceneFromCache={whiteboardSceneFromCache}
                     onSerializedChange={handleWhiteboardChange}
                     readOnly={!canEditDocument}
                     yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -594,15 +594,24 @@ export const DocumentDetailPage = () => {
     };
   }, [canEditDocument, isDirty, parsedId, title, contentForSave, featuredImageUrl]);
 
+  // Hold token and activeGuildId in refs so the flush closure always sees
+  // the latest values without the effect needing to re-run on JWT rotation.
+  // Without this, a token refresh would trigger the cleanup → flush() →
+  // null the pending ref, and the ref-populating effect wouldn't re-run
+  // (its deps didn't change), silently dropping the next pending save.
+  const tokenRef = useRef(token);
+  const activeGuildIdRef = useRef(activeGuildId);
   useEffect(() => {
-    if (!token || !activeGuildId) return;
+    tokenRef.current = token;
+  }, [token]);
+  useEffect(() => {
+    activeGuildIdRef.current = activeGuildId;
+  }, [activeGuildId]);
+
+  useEffect(() => {
     const flush = () => {
       const pending = pendingSavePayloadRef.current;
-      if (!pending) return;
-      // Fire-and-forget PATCH with keepalive so the request survives the
-      // page unloading. Routes through the normal document update endpoint
-      // (which runs normalize_document_content server-side) so we don't
-      // need to massage the payload client-side.
+      if (!pending || !tokenRef.current || !activeGuildIdRef.current) return;
       const isAbsolute = API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://");
       const baseUrl = isAbsolute ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
       const url = `${baseUrl}/documents/${pending.documentId}`;
@@ -610,26 +619,22 @@ export const DocumentDetailPage = () => {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-          "X-Guild-ID": String(activeGuildId),
+          Authorization: `Bearer ${tokenRef.current}`,
+          "X-Guild-ID": String(activeGuildIdRef.current),
         },
         body: JSON.stringify(pending.data),
         keepalive: true,
-      }).catch(() => {
-        // Swallow errors — the page is unloading, there's nothing to show.
-      });
+      }).catch(() => {});
       pendingSavePayloadRef.current = null;
     };
 
     const handleBeforeUnload = () => flush();
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => {
-      // Runs on unmount (navigate away to another page) and on dep change
-      // (e.g. switching documents). Either way, flush any pending save.
       flush();
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [token, activeGuildId]);
+  }, []);
 
   // Persistent offline toast with mode-aware copy
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes multiple interrelated bugs where whiteboard edits were lost on refresh, navigation, or when re-entering a collaboration room.

### Root causes addressed

1. **Blank canvas on mount**: `WhiteboardDocumentEditor`'s `useMemo(() => makeInitialData(initialScene), [])` captured the empty `useState` default because the load effect hadn't run yet. Fixed by gating the editor mount on `whiteboardSceneReady`.

2. **Stale Yjs sync overwrites fresh content**: On page unload, the last Yjs WebSocket message is lost (WebSockets don't support `keepalive`), so `persist_room` captures a state that's one edit behind. On reconnect, the stale sync would overwrite the correct REST-fetched scene. Fixed by gating the observer on `bootstrapDoneRef` — it skips all initial sync events and only applies live updates from other users.

3. **Keepalive PATCH race with page reload**: The `fetch(keepalive: true)` PATCH fires during unload but the new page's REST fetch can complete first, returning stale data. Fixed with a localStorage write-ahead cache that persists the scene synchronously on every edit.

4. **PATCH responses resetting live scene**: The document load effect re-ran on PATCH responses, overwriting `whiteboardScene` with the (slightly behind) response content. Fixed with `loadedWhiteboardForRef` guard.

5. **`yjs_state` cleared during active collab**: The periodic 10-second content-sync PATCH unconditionally cleared `yjs_state`, creating a data-loss window when racing with user disconnects. Fixed by checking `has_active_collaborators` first.

### Schema change

- `yjs_updated_at` is now exposed in `DocumentSummary` / `DocumentRead` (nullable datetime). No migration needed — the column already exists.

## Test plan

- [ ] Draw shapes → refresh immediately → shapes persist (localStorage cache)
- [ ] Draw shapes → wait 3s → refresh → shapes persist (autosave PATCH)
- [ ] Draw shapes → navigate away → come back → shapes persist
- [ ] Two users on same whiteboard → both see live updates
- [ ] User A draws, User B refreshes → User B sees User A's shapes
- [ ] Native text documents are unaffected