### PR TITLE
Auto-redirect to login when the session expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-redirect to the welcome/login page when the access token expires, instead of leaving the app in a broken state until the user manually refreshes. Shows a "Your session has expired" toast before the redirect.
   - Backend now returns `401 Unauthorized` (with `WWW-Authenticate`) for expired or invalid JWTs, invalid device tokens, and malformed token payloads, rather than `403 Forbidden`. Genuine authorization failures are unchanged.
   - Frontend 401 interceptor no longer silently swallows expired-session 401s on web cookie auth: an explicit session flag tracks whether a user is currently signed in, regardless of whether the in-memory bearer token was ever populated.
+- Fix manual logout so previously-issued JWTs are actually invalidated server-side. The logout endpoint was using `AdminSessionDep` while `get_current_user_optional` used `SessionDep`, so in production the `current_user` object came from a detached session and the `token_version += 1` bump was silently dropped on commit. Previously-signed JWTs (and any still-cached HttpOnly cookie) stayed valid until natural expiry, letting users navigate back into protected pages by typing the URL after clicking "Sign out". The endpoint now uses a single `SessionDep` so FastAPI's per-request dependency cache hands both sites the same session, and the commit actually persists.
 
 ## [0.38.1] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved task status UX: each status now has a customizable color and icon, with smart defaults driven by its category (backlog, todo, in progress, done). Kanban column headers show the status icon and a colored accent bar, and every status dropdown (kanban, project table/gantt rows, My Tasks, tag task lists, task edit page) now shows the icon beside the name and mirrors the active status color on the trigger border.
 
+### Fixed
+
+- Auto-redirect to the welcome/login page when the access token expires, instead of leaving the app in a broken state until the user manually refreshes. Shows a "Your session has expired" toast before the redirect.
+  - Backend now returns `401 Unauthorized` (with `WWW-Authenticate`) for expired or invalid JWTs, invalid device tokens, and malformed token payloads, rather than `403 Forbidden`. Genuine authorization failures are unchanged.
+  - Frontend 401 interceptor no longer silently swallows expired-session 401s on web cookie auth: an explicit session flag tracks whether a user is currently signed in, regardless of whether the in-memory bearer token was ever populated.
+
 ## [0.38.1] - 2026-04-12
 
 ### Fixed

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -56,7 +56,11 @@ async def get_current_user(
         user = await _authenticate_device_token(session, device_token)
         if user:
             return user
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=AuthMessages.INVALID_DEVICE_TOKEN)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.INVALID_DEVICE_TOKEN,
+            headers={"WWW-Authenticate": "DeviceToken"},
+        )
 
     # Use the bearer token from OAuth2 scheme, fall back to HttpOnly cookie (web sessions)
     token = bearer_token or session_cookie
@@ -72,15 +76,27 @@ async def get_current_user(
     if user:
         return user
 
-    # Try JWT authentication
+    # Try JWT authentication. Any PyJWTError (expired signature, bad sig,
+    # malformed claims, …) is a credentials problem, so it should be 401
+    # "please re-authenticate", not 403 "you're not allowed". The SPA's
+    # 401 interceptor depends on this to auto-redirect to /welcome when
+    # the access token expires.
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
         token_data = TokenPayload(**payload)
     except jwt.PyJWTError as exc:  # pragma: no cover - FastAPI handles formatting
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=AuthMessages.COULD_NOT_VALIDATE_CREDENTIALS) from exc
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.COULD_NOT_VALIDATE_CREDENTIALS,
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
 
     if not token_data.sub:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=AuthMessages.INVALID_TOKEN_PAYLOAD)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.INVALID_TOKEN_PAYLOAD,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     statement = select(User).where(User.id == int(token_data.sub))
     result = await session.exec(statement)
@@ -336,7 +352,11 @@ async def get_upload_user(
             if not user.is_active:
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=AuthMessages.INACTIVE_USER)
             return user
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=AuthMessages.INVALID_DEVICE_TOKEN)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.INVALID_DEVICE_TOKEN,
+            headers={"WWW-Authenticate": "DeviceToken"},
+        )
 
     # 2. Bearer token (Authorization header), ?token= query param, or HttpOnly cookie (web sessions)
     token = bearer_token or token_param or session_cookie
@@ -354,7 +374,8 @@ async def get_upload_user(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=AuthMessages.INACTIVE_USER)
         return user
 
-    # Try JWT authentication
+    # Try JWT authentication. Expired / malformed tokens are 401 (not 403)
+    # so the SPA can auto-redirect to /welcome when the session lapses.
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
         token_data = TokenPayload(**payload)
@@ -367,10 +388,18 @@ async def get_upload_user(
                 if not user.is_active:
                     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=AuthMessages.INACTIVE_USER)
                 return user
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=AuthMessages.COULD_NOT_VALIDATE_CREDENTIALS)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.COULD_NOT_VALIDATE_CREDENTIALS,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     if not token_data.sub:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=AuthMessages.INVALID_TOKEN_PAYLOAD)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.INVALID_TOKEN_PAYLOAD,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     statement = select(User).where(User.id == int(token_data.sub))
     result = await session.exec(statement)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -84,7 +84,7 @@ async def get_current_user(
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
         token_data = TokenPayload(**payload)
-    except jwt.PyJWTError as exc:  # pragma: no cover - FastAPI handles formatting
+    except jwt.PyJWTError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=AuthMessages.COULD_NOT_VALIDATE_CREDENTIALS,

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -203,9 +203,19 @@ async def login_access_token(
 async def logout(
     request: Request,
     response: Response,
-    session: AdminSessionDep,
+    session: SessionDep,
     current_user: Annotated[User | None, Depends(get_current_user_optional)] = None,
 ) -> None:
+    # Note: `session` and `get_current_user_optional` must resolve to the
+    # SAME session. Previously this used AdminSessionDep, which in
+    # production is a different session than SessionDep — so the
+    # `current_user` object returned by the optional auth dep was attached
+    # to a detached SessionDep session, and `session.commit()` on the
+    # admin session silently dropped the token_version bump. That let
+    # previously-issued JWTs stay valid after logout, so a browser with
+    # a cached cookie could keep authenticating until natural expiry.
+    # In tests it worked by accident because conftest aliases both deps
+    # to the same fixture session.
     if current_user is not None:
         current_user.token_version += 1
         auth_header = request.headers.get("Authorization", "")

--- a/backend/app/api/v1/endpoints/auth_test.py
+++ b/backend/app/api/v1/endpoints/auth_test.py
@@ -9,12 +9,14 @@ Tests the auth API endpoints including:
 - Password reset
 """
 
+from datetime import timedelta
+
 import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
-from app.core.security import get_password_hash
+from app.core.security import create_access_token, get_password_hash
 from app.models.user import User
 from app.testing.factories import create_user, get_auth_headers, get_auth_token
 
@@ -261,6 +263,69 @@ async def test_login_email_case_insensitive(client: AsyncClient, session: AsyncS
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_malformed_jwt_returns_401(client: AsyncClient):
+    """A garbage bearer token should be rejected as 401 Unauthorized with
+    a WWW-Authenticate challenge, not 403. The SPA's 401 interceptor
+    depends on this distinction to auto-redirect expired sessions to
+    /welcome."""
+    headers = {"Authorization": "Bearer not.a.valid.jwt"}
+    response = await client.get("/api/v1/users/me", headers=headers)
+
+    assert response.status_code == 401
+    assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_expired_jwt_returns_401(
+    client: AsyncClient, session: AsyncSession
+):
+    """An expired JWT (the common case when the access token lifetime
+    elapses mid-session) must return 401, not 403. Regression guard
+    for the 403 -> 401 fix in get_current_user."""
+    user = await create_user(session)
+    expired_token = create_access_token(
+        subject=str(user.id),
+        token_version=user.token_version,
+        expires_delta=timedelta(seconds=-1),
+    )
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {expired_token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_stale_token_version_returns_401(
+    client: AsyncClient, session: AsyncSession
+):
+    """A JWT issued before a token_version bump (e.g. after logout or
+    password change) must return 401 so the SPA auto-redirects instead
+    of leaving a stale session in place."""
+    user = await create_user(session)
+    stale_token = create_access_token(
+        subject=str(user.id),
+        token_version=user.token_version,
+    )
+    # Bump the version out-of-band to simulate a logout happening in
+    # another tab.
+    user.token_version += 1
+    session.add(user)
+    await session.commit()
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {stale_token}"},
+    )
+    assert response.status_code == 401
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/endpoints/auth_test.py
+++ b/backend/app/api/v1/endpoints/auth_test.py
@@ -16,7 +16,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.security import get_password_hash
 from app.models.user import User
-from app.testing.factories import create_user
+from app.testing.factories import create_user, get_auth_headers, get_auth_token
 
 
 @pytest.mark.integration
@@ -261,3 +261,80 @@ async def test_login_email_case_insensitive(client: AsyncClient, session: AsyncS
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_logout_persists_token_version_bump(
+    client: AsyncClient, session: AsyncSession
+):
+    """The logout endpoint must actually persist the token_version bump
+    to the database. Previously the endpoint used AdminSessionDep while
+    get_current_user_optional used SessionDep, so the user object came
+    from a detached session and session.commit() silently dropped the
+    change in production. (The conftest fixture aliases both deps to the
+    same session, so this test asserts on the raw row state rather than
+    relying on a subsequent request to observe the failure.)"""
+    user = await create_user(session)
+    initial_version = user.token_version
+
+    response = await client.post(
+        "/api/v1/auth/logout", headers=get_auth_headers(user)
+    )
+    assert response.status_code == 204
+
+    # Re-read from the database to prove the bump was persisted.
+    await session.refresh(user)
+    assert user.token_version == initial_version + 1
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_logout_invalidates_existing_jwt(
+    client: AsyncClient, session: AsyncSession
+):
+    """Logging out must invalidate any previously-issued JWT by bumping
+    the user's token_version. Otherwise a browser that still has a
+    cached JWT (or cookie) can keep making authenticated requests,
+    which is how users reported "I logged out but My Tasks still
+    loads when I type the URL"."""
+    user = await create_user(session)
+    # Baseline: the token works before logout.
+    headers = get_auth_headers(user)
+    before = await client.get("/api/v1/users/me", headers=headers)
+    assert before.status_code == 200
+
+    # Capture the same token so we can replay it after logout.
+    replay_token = get_auth_token(user)
+    logout_response = await client.post(
+        "/api/v1/auth/logout",
+        headers={"Authorization": f"Bearer {replay_token}"},
+    )
+    assert logout_response.status_code == 204
+
+    # Any subsequent request using the old token must be rejected.
+    after = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {replay_token}"},
+    )
+    assert after.status_code == 401
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_logout_clears_session_cookie(
+    client: AsyncClient, session: AsyncSession
+):
+    """The logout response must set an expired session_token cookie so
+    browsers using HttpOnly cookie auth (the web default) actually
+    forget the session."""
+    user = await create_user(session)
+    response = await client.post(
+        "/api/v1/auth/logout", headers=get_auth_headers(user)
+    )
+    assert response.status_code == 204
+    set_cookie = response.headers.get("set-cookie", "")
+    assert "session_token=" in set_cookie
+    # Starlette's delete_cookie sets Max-Age=0 and an expires in the
+    # past. Accept either marker so the assertion is robust.
+    assert "Max-Age=0" in set_cookie or "1970" in set_cookie

--- a/backend/app/api/v1/endpoints/initiatives_test.py
+++ b/backend/app/api/v1/endpoints/initiatives_test.py
@@ -19,6 +19,7 @@ from app.testing.factories import (
     create_guild_membership,
     create_initiative_member,
     create_user,
+    get_auth_headers,
     get_guild_headers,
 )
 
@@ -27,13 +28,10 @@ from app.testing.factories import (
 async def test_list_initiatives_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """Test that listing initiatives requires guild context."""
+    """A user with no guild memberships should be 403 when listing initiatives."""
     user = await create_user(session, email="test@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
 
-    # Request without X-Guild-ID header
-    headers = {"Authorization": f"Bearer fake_token_{user.id}"}
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/initiatives/", headers=headers)
 
     assert response.status_code == 403

--- a/backend/app/api/v1/endpoints/projects_test.py
+++ b/backend/app/api/v1/endpoints/projects_test.py
@@ -23,6 +23,7 @@ from app.testing.factories import (
     create_guild,
     create_guild_membership,
     create_user,
+    get_auth_headers,
     get_guild_headers,
 )
 
@@ -52,13 +53,10 @@ async def _create_project(session, initiative, owner):
 async def test_list_projects_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """Test that listing projects requires guild context."""
+    """A user with no guild memberships should be 403 when listing projects."""
     user = await create_user(session)
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
 
-    # Request without X-Guild-ID header
-    headers = {"Authorization": f"Bearer fake_token_{user.id}"}
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/projects/", headers=headers)
 
     assert response.status_code == 403

--- a/backend/app/api/v1/endpoints/tasks_test.py
+++ b/backend/app/api/v1/endpoints/tasks_test.py
@@ -23,6 +23,7 @@ from app.testing.factories import (
     create_guild,
     create_guild_membership,
     create_user,
+    get_auth_headers,
     get_guild_headers,
 )
 
@@ -72,13 +73,10 @@ async def _create_task(session, project, title="Test Task"):
 async def test_list_tasks_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """Test that listing tasks requires guild context."""
+    """A user with no guild memberships should be 403 when listing tasks."""
     user = await create_user(session)
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
 
-    # Request without X-Guild-ID header
-    headers = {"Authorization": f"Bearer fake_token_{user.id}"}
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/tasks/", headers=headers)
 
     assert response.status_code == 403

--- a/frontend/public/locales/en/auth.json
+++ b/frontend/public/locales/en/auth.json
@@ -93,6 +93,9 @@
     "failedMissingToken": "OIDC login failed: missing token",
     "error": "Unable to complete OIDC login."
   },
+  "session": {
+    "expired": "Your session has expired. Please sign in again."
+  },
   "connectServer": {
     "title": "Connect to Server",
     "subtitle": "Enter the URL of your Initiative server to get started.",

--- a/frontend/public/locales/es/auth.json
+++ b/frontend/public/locales/es/auth.json
@@ -93,6 +93,9 @@
     "failedMissingToken": "Error de inicio de sesión OIDC: falta el token",
     "error": "No se pudo completar el inicio de sesión OIDC."
   },
+  "session": {
+    "expired": "Tu sesión ha expirado. Inicia sesión nuevamente."
+  },
   "connectServer": {
     "title": "Conectar al servidor",
     "subtitle": "Ingresa la URL de tu servidor Initiative para comenzar.",

--- a/frontend/public/locales/fr/auth.json
+++ b/frontend/public/locales/fr/auth.json
@@ -93,6 +93,9 @@
     "failedMissingToken": "Échec de la connexion OIDC : jeton manquant",
     "error": "Impossible de finaliser la connexion OIDC."
   },
+  "session": {
+    "expired": "Votre session a expiré. Veuillez vous reconnecter."
+  },
   "connectServer": {
     "title": "Se connecter au serveur",
     "subtitle": "Entrez l'URL de votre serveur Initiative pour commencer.",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -71,6 +71,13 @@ export const AUTH_UNAUTHORIZED_EVENT = "initiative:auth:unauthorized";
 let authToken: string | null = null;
 let isDeviceToken = false;
 let activeGuildId: number | null = null;
+// Tracks whether we currently believe a user session is active. On web the
+// in-memory authToken is never set after a page reload (cookie auth is
+// HttpOnly, so there's nothing for JS to restore). The 401 interceptor used
+// to gate on `authToken` being set, which meant expired-cookie 401s were
+// silently swallowed for reloaded tabs — the user had to manually refresh
+// again to land on /welcome. An explicit session flag closes that gap.
+let hasActiveSession = false;
 
 /**
  * Set the authentication token.
@@ -89,6 +96,10 @@ export const setCurrentGuildId = (guildId: number | null) => {
 };
 
 export const getCurrentGuildId = () => activeGuildId;
+
+export const setHasActiveSession = (value: boolean) => {
+  hasActiveSession = value;
+};
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -145,7 +156,7 @@ const emitUnauthorized = () => {
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401 && authToken) {
+    if (error.response?.status === 401 && hasActiveSession) {
       emitUnauthorized();
     }
     return Promise.reject(error);

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,7 +1,14 @@
 import { ReactNode, createContext, useContext, useEffect, useState, useCallback } from "react";
 import { Capacitor } from "@capacitor/core";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
-import { apiClient, setAuthToken, AUTH_UNAUTHORIZED_EVENT } from "@/api/client";
+import {
+  apiClient,
+  setAuthToken,
+  setHasActiveSession,
+  AUTH_UNAUTHORIZED_EVENT,
+} from "@/api/client";
 import { getItem, setItem, removeItem } from "@/lib/storage";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { queryClient } from "@/lib/queryClient";
@@ -40,10 +47,19 @@ const DEVICE_TOKEN_KEY = "initiative-is-device-token";
 const isNative = Capacitor.isNativePlatform();
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const { t } = useTranslation("auth");
   const [token, setTokenState] = useState<string | null>(null);
   const [isDeviceToken, setIsDeviceToken] = useState(false);
-  const [user, setUser] = useState<UserRead | null>(null);
+  const [user, setUserState] = useState<UserRead | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
+
+  // Keep the React user state and the api-client session flag in lockstep so
+  // the 401 interceptor always knows whether to treat a 401 as session expiry
+  // (non-null user) or as a not-logged-in visitor (null user).
+  const setUser = useCallback((nextUser: UserRead | null) => {
+    setUserState(nextUser);
+    setHasActiveSession(nextUser !== null);
+  }, []);
 
   // Load token on mount for native only (web uses HttpOnly cookie — no localStorage read needed)
   useEffect(() => {
@@ -64,7 +80,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const refreshUser = useCallback(async () => {
     const response = await apiClient.get<UserRead>("/users/me");
     setUser(response.data);
-  }, []);
+  }, [setUser]);
 
   // Bootstrap user on mount — always attempt /users/me.
   // Web: cookie is sent automatically (withCredentials). Native: token was loaded by the effect above.
@@ -89,7 +105,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
     };
     void bootstrap();
-  }, []);
+  }, [setUser]);
 
   const login = async ({ email, password, deviceName }: LoginPayload) => {
     try {
@@ -162,30 +178,38 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const logout = useCallback(async () => {
-    try {
-      await apiClient.post("/auth/logout");
-    } catch {
-      // Ignore errors — proceed with local cleanup regardless
-    }
+    // Flip local state first. setUser(null) clears the api-client session
+    // flag synchronously, so any 401s from in-flight requests (including
+    // the /auth/logout POST below if the cookie is already expired) won't
+    // re-enter the unauthorized event handler and queue a second logout.
+    setUser(null);
     setTokenState(null);
     setIsDeviceToken(false);
-    setUser(null);
     setAuthToken(null);
     removeItem(TOKEN_STORAGE_KEY);
     removeItem(DEVICE_TOKEN_KEY);
     queryClient.clear();
-  }, []);
+    try {
+      await apiClient.post("/auth/logout");
+    } catch {
+      // Ignore errors — local cleanup already happened.
+    }
+  }, [setUser]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
       return undefined;
     }
     const handleUnauthorized = () => {
+      // The api-client session flag means this only fires for users who
+      // were actually signed in, so it's safe to surface the toast here
+      // without further checks.
+      toast.error(t("session.expired"));
       void logout();
     };
     window.addEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
     return () => window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
-  }, [logout]);
+  }, [logout, t]);
 
   const value: AuthContextValue = {
     user,

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -178,10 +178,21 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const logout = useCallback(async () => {
-    // Flip local state first. setUser(null) clears the api-client session
-    // flag synchronously, so any 401s from in-flight requests (including
-    // the /auth/logout POST below if the cookie is already expired) won't
-    // re-enter the unauthorized event handler and queue a second logout.
+    // Fire the POST *first*, while the bearer token and cookie are still
+    // in place — otherwise we may log out on the client without the
+    // backend ever seeing the request, and the cached JWT/cookie can
+    // keep authenticating subsequent requests until it expires naturally.
+    //
+    // Clear hasActiveSession before the POST so the interceptor ignores
+    // any 401 that comes back from /auth/logout itself (can happen when
+    // the cookie is already expired), preventing re-entry into this
+    // same handler.
+    setHasActiveSession(false);
+    try {
+      await apiClient.post("/auth/logout");
+    } catch {
+      // Ignore errors — proceed with local cleanup regardless.
+    }
     setUser(null);
     setTokenState(null);
     setIsDeviceToken(false);
@@ -189,11 +200,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     removeItem(TOKEN_STORAGE_KEY);
     removeItem(DEVICE_TOKEN_KEY);
     queryClient.clear();
-    try {
-      await apiClient.post("/auth/logout");
-    } catch {
-      // Ignore errors — local cleanup already happened.
-    }
   }, [setUser]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes the UX bug where an expired access token left the SPA in a broken state — users had to manually refresh the page to land on `/welcome`. Now the app logs out, shows a "Your session has expired" toast, and redirects automatically the moment any API call comes back unauthorized.

There were actually **two** layers of bug that had to be fixed together:

### Backend: 403 → 401 for authentication failures

[backend/app/api/deps.py](backend/app/api/deps.py) was returning `403 Forbidden` for expired/invalid JWTs, invalid device tokens, and malformed token payloads. Per RFC 7235 those are authentication problems ("we don't know who you are / credentials are bad"), not authorization problems ("you can't do this"). Updated both `get_current_user` and `get_upload_user` to return `401 Unauthorized` with a `WWW-Authenticate` challenge header for:

- `INVALID_DEVICE_TOKEN`
- `COULD_NOT_VALIDATE_CREDENTIALS` (any `jwt.PyJWTError`, which includes `ExpiredSignatureError`)
- `INVALID_TOKEN_PAYLOAD`

Genuine authorization failures (`INSUFFICIENT_PRIVILEGES`, `GUILD_ACCESS_DENIED`, `GUILD_PERMISSION_REQUIRED`, `NO_GUILD_MEMBERSHIP`) remain 403.

### Frontend: session-flag gate in the 401 interceptor

[frontend/src/api/client.ts](frontend/src/api/client.ts)'s response interceptor used to gate on `authToken` being set:

```ts
if (error.response?.status === 401 && authToken) {
  emitUnauthorized();
}
```

On web the app uses HttpOnly cookie auth, so after a page reload `useAuth.bootstrap` hits `/users/me` via the cookie but **never populates `authToken`** — there's no JS-visible token to restore. So a reloaded tab silently swallowed every subsequent 401 and never fired the unauthorized event. (Fresh-login sessions that never reloaded worked by luck.)

Replaced the gate with an explicit `hasActiveSession` flag exposed from [client.ts](frontend/src/api/client.ts), kept in lockstep with the React user state via a `setUser` wrapper in [useAuth.tsx](frontend/src/hooks/useAuth.tsx). Whenever `user` transitions non-null, the flag flips true; logout flips it false **synchronously** before the network call, so an expired-cookie `POST /auth/logout` returning 401 can't re-enter the unauthorized event handler.

### Session-expired toast

Added `session.expired` translations to `en`/`es`/`fr` auth namespaces. The unauthorized handler in [useAuth.tsx](frontend/src/hooks/useAuth.tsx) now fires `toast.error(t("session.expired"))` before calling `logout()`. The `hasActiveSession` gate guarantees this only runs for users who were actually signed in, so there's no risk of toasting at not-logged-in visitors during initial bootstrap.

### Test fix: three `*_requires_guild_context` tests were passing by accident

Discovered while running the backend suite: three tests in [tasks_test.py](backend/app/api/v1/endpoints/tasks_test.py), [projects_test.py](backend/app/api/v1/endpoints/projects_test.py), and [initiatives_test.py](backend/app/api/v1/endpoints/initiatives_test.py) were sending `Authorization: Bearer fake_token_<id>`. That token failed JWT decode and returned 403 — which matched the assertion but never actually exercised the guild-context code path. Rewrote each to use `get_auth_headers(user)` for a user with zero guild memberships, which genuinely hits the `NO_GUILD_MEMBERSHIP` 403 branch in `get_guild_membership`.

## Test plan

- [x] `pytest app/api/v1/endpoints/auth_test.py tasks_test.py projects_test.py initiatives_test.py task_statuses_test.py` — 94/94 pass
- [x] `ruff check app/api/deps.py` — clean
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — 176/176 pass
- [ ] Manual: set `ACCESS_TOKEN_EXPIRE_MINUTES=1` in `backend/.env`, log in, wait one minute, navigate anywhere in the app → expect toast + redirect to `/welcome` (no manual refresh)
- [ ] Manual: log out the normal way — still lands on welcome with no errors
- [ ] Manual: open the app while already logged out → no spurious "session expired" toast on initial load