### PR TITLE
Editor fullscreen toggle + fix Not-tagged document filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fullscreen toggle in the document and whiteboard editors. The editor, its toolbars, action bar, and collaboration status take over the window for distraction-free writing or large-canvas diagramming. The Fullscreen button sits inline with the collaboration status badge above the editor.
+
+### Fixed
+
+- "Not tagged" filter in the Documents page tag tree view now actually filters to untagged documents. The page was computing the selection state but never sending the `untagged` query parameter to the backend, so selecting "Not tagged" returned every document instead of only the untagged ones.
+
 ## [0.39.0] - 2026-04-14
 
 ### Added

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -134,6 +134,8 @@
     "liveCollaboration": "Live collaboration",
     "collaborationDescription": "Changes sync automatically with collaborators",
     "readOnly": "You only have read access to this document.",
+    "enterFullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
     "attachedProjects": "Attached projects",
     "noAttachedProjects": "This document is not attached to any projects yet.",
     "attached": "Attached {{date}}",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -134,6 +134,8 @@
     "liveCollaboration": "Colaboración en vivo",
     "collaborationDescription": "Los cambios se sincronizan automáticamente con los colaboradores",
     "readOnly": "Solo tienes acceso de lectura a este documento.",
+    "enterFullscreen": "Pantalla completa",
+    "exitFullscreen": "Salir de pantalla completa",
     "attachedProjects": "Proyectos adjuntos",
     "noAttachedProjects": "Este documento aún no está adjunto a ningún proyecto.",
     "attached": "Adjuntado {{date}}",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -134,6 +134,8 @@
     "liveCollaboration": "Collaboration en temps réel",
     "collaborationDescription": "Les modifications se synchronisent automatiquement avec les collaborateurs",
     "readOnly": "Vous n'avez qu'un accès en lecture sur ce document.",
+    "enterFullscreen": "Plein écran",
+    "exitFullscreen": "Quitter le plein écran",
     "attachedProjects": "Projets attachés",
     "noAttachedProjects": "Ce document n'est encore attaché à aucun projet.",
     "attached": "Attaché {{date}}",

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1054,7 +1054,7 @@ export const DocumentDetailPage = () => {
           <div
             className={cn(
               isFullscreen &&
-                "bg-background fixed inset-0 z-50 flex flex-col gap-4 overflow-hidden p-4"
+                "bg-background fixed inset-0 z-50 m-0! flex flex-col gap-4 overflow-hidden p-4"
             )}
           >
             {/* Collaboration status - shown between featured image and editor.

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -14,6 +14,8 @@ import type { SerializedEditorState } from "lexical";
 import {
   ImagePlus,
   Loader2,
+  Maximize2,
+  Minimize2,
   PanelRight,
   ScrollText,
   SearchX,
@@ -59,6 +61,7 @@ import { findNewMentions } from "@/lib/mentionUtils";
 import { useGuildPath } from "@/lib/guildUrl";
 import { useCollaboration } from "@/hooks/useCollaboration";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
+import { cn } from "@/lib/utils";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -126,6 +129,7 @@ export const DocumentDetailPage = () => {
   const [whiteboardYDoc, setWhiteboardYDoc] = useState<Y.Doc | null>(null);
   const [autosaveEnabled, setAutosaveEnabled] = useState(true);
   const [collaborationEnabled, setCollaborationEnabled] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const isAutosaveRef = useRef(false);
   const featuredImageInputRef = useRef<HTMLInputElement>(null);
   // Refs for sendBeacon - need latest values in event handlers
@@ -185,6 +189,18 @@ export const DocumentDetailPage = () => {
     setWhiteboardSceneReady(false);
     setWhiteboardSceneFromCache(false);
   }, [parsedId]);
+
+  // Lock body scroll while the editor is in fullscreen so wheel events
+  // over the overlay don't bleed through to the page beneath.
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const body = window.document.body;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+    return () => {
+      body.style.overflow = previousOverflow;
+    };
+  }, [isFullscreen]);
 
   useEffect(() => {
     if (!document) {
@@ -1035,19 +1051,41 @@ export const DocumentDetailPage = () => {
             />
           </Suspense>
         ) : (
-          <>
+          <div
+            className={cn(
+              isFullscreen &&
+                "bg-background fixed inset-0 z-50 flex flex-col gap-4 overflow-hidden p-4"
+            )}
+          >
             {/* Collaboration status - shown between featured image and editor.
                 Also shown when offline even in non-collaborative mode, so the
                 user sees an explicit offline indicator at the top of the editor. */}
-            {(collaborationEnabled || !isOnline) && (
-              <CollaborationStatusBadge
-                connectionStatus={collaboration.connectionStatus}
-                collaborators={collaboration.collaborators}
-                isCollaborating={collaboration.isCollaborating}
-                isSynced={collaboration.isSynced}
-                isOnline={isOnline}
-              />
-            )}
+            <div className="flex items-center gap-2">
+              {(collaborationEnabled || !isOnline) && (
+                <CollaborationStatusBadge
+                  connectionStatus={collaboration.connectionStatus}
+                  collaborators={collaboration.collaborators}
+                  isCollaborating={collaboration.isCollaborating}
+                  isSynced={collaboration.isSynced}
+                  isOnline={isOnline}
+                />
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsFullscreen((value) => !value)}
+                aria-label={t(isFullscreen ? "detail.exitFullscreen" : "detail.enterFullscreen")}
+                className="ml-auto"
+              >
+                {isFullscreen ? (
+                  <Minimize2 className="mr-2 h-4 w-4" />
+                ) : (
+                  <Maximize2 className="mr-2 h-4 w-4" />
+                )}
+                {t(isFullscreen ? "detail.exitFullscreen" : "detail.enterFullscreen")}
+              </Button>
+            </div>
             {/*
               Key is just document.id - we don't remount when entering collaborative mode.
               The CollaborationPlugin handles syncing the existing content to Yjs.
@@ -1070,6 +1108,7 @@ export const DocumentDetailPage = () => {
                     yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}
                     isSynced={collaboration.isSynced}
                     hasOtherCollaborators={collaboration.collaborators.length > 0}
+                    className={cn(isFullscreen && "h-full min-h-0 flex-1")}
                   />
                 ) : (
                   <div className="flex h-96 items-center justify-center rounded-xl border">
@@ -1083,7 +1122,7 @@ export const DocumentDetailPage = () => {
                   onSerializedChange={handleContentChange}
                   readOnly={!canEditDocument}
                   showToolbar={canEditDocument}
-                  className="max-h-[80vh]"
+                  className={cn("max-h-[80vh]", isFullscreen && "h-full max-h-none min-h-0 flex-1")}
                   mentionableUsers={mentionableUsers}
                   documentName={title}
                   collaborative={collaborationEnabled && collaboration.isReady}
@@ -1164,7 +1203,7 @@ export const DocumentDetailPage = () => {
                 <p className="text-muted-foreground text-sm">{t("detail.readOnly")}</p>
               )}
             </div>
-          </>
+          </div>
         )}
 
         <Card>

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -285,6 +285,7 @@ export const DocumentsView = ({
       : {}),
     ...(searchQuery.trim() ? { search: searchQuery.trim() } : {}),
     ...(queryTagIds.length > 0 ? { tag_ids: queryTagIds } : {}),
+    ...(treeWantsUntagged ? { untagged: true } : {}),
     page,
     page_size: pageSize,
     ...(sortBy ? { sort_by: sortBy } : {}),
@@ -313,6 +314,7 @@ export const DocumentsView = ({
           : {}),
         ...(searchQuery.trim() ? { search: searchQuery.trim() } : {}),
         ...(queryTagIds.length > 0 ? { tag_ids: queryTagIds } : {}),
+        ...(treeWantsUntagged ? { untagged: true } : {}),
         page: targetPage,
         page_size: pageSize,
         ...(sortBy ? { sort_by: sortBy } : {}),
@@ -320,7 +322,16 @@ export const DocumentsView = ({
       };
       void prefetchDocuments(prefetchParams);
     },
-    [initiativeFilter, searchQuery, queryTagIds, pageSize, sortBy, sortDir, prefetchDocuments]
+    [
+      initiativeFilter,
+      searchQuery,
+      queryTagIds,
+      treeWantsUntagged,
+      pageSize,
+      sortBy,
+      sortDir,
+      prefetchDocuments,
+    ]
   );
 
   const initiativesQuery = useInitiatives();


### PR DESCRIPTION
## Summary

Two unrelated frontend changes bundled together since they touch the same area.

### Fullscreen toggle for the document and whiteboard editors

Both editors render inside a constrained card (`max-h-[80vh]` for Lexical, `h-[80vh]` for the Excalidraw whiteboard) surrounded by breadcrumbs, the metadata card, the page sidebar, and the global app chrome. For long-form writing or detailed diagramming, that's a lot of competing UI. The new toggle wraps the editor block in `fixed inset-0 z-50 bg-background flex flex-col` and overrides the editor's `className` (via the existing `cn(...)` merge each editor already does on its root container) with `h-full min-h-0 flex-1` so it expands to fill the wrapper.

- The toggle button sits inline with the `CollaborationStatusBadge` directly above the editor, right-aligned via `ml-auto` so it stays in the same spot whether or not the badge is visible.
- A single `useEffect` locks `body.style.overflow` while fullscreen is active so wheel events over the overlay don't bleed through to the page beneath.
- Action bar (save, autosave, collab toggle) and the collaboration status all move into the fullscreen wrapper, so users can still save and toggle settings without exiting.
- No internal changes to [editor.tsx](frontend/src/components/documents/editor/editor.tsx) or [WhiteboardDocumentEditor.tsx](frontend/src/components/documents/WhiteboardDocumentEditor.tsx) — both already accept `className` and merge it into their root container.
- New `detail.enterFullscreen` / `detail.exitFullscreen` translations for en/es/fr.

Skipped intentionally: native Fullscreen API (browser-controlled "press Esc" toast is jarring), Esc-to-exit shortcut (Excalidraw uses Esc to deselect — high risk of conflict), and reaching into the parent layout to hide the sidebar (the `z-50 bg-background` overlay covers it for free).

### Fix: "Not tagged" filter on the Documents page tag tree view

[DocumentsPage.tsx](frontend/src/pages/DocumentsPage.tsx) was computing `treeWantsUntagged` correctly when "Not tagged" was selected in the tag tree, but the documents-list query params (and the prefetch params) never forwarded the `untagged=true` flag to the backend. Result: selecting "Not tagged" returned every document in the workspace instead of only the untagged ones. Added `...(treeWantsUntagged ? { untagged: true } : {})` to both spread blocks and added `treeWantsUntagged` to the prefetch `useCallback` dep array. Backend already supports the param ([documents.py:215, 245](backend/app/api/v1/endpoints/documents.py#L215)) — purely a frontend wiring miss.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean (21.41s)
- [x] `pnpm test:run` — 176/176 pass
- [ ] Manual: open a regular document → click the Fullscreen button (top-right above the editor) → editor + action bar fill the window → save still works → click Exit fullscreen → returns to normal layout, no scroll lock leak
- [ ] Manual: open a whiteboard → same flow → Excalidraw fills the window, panning/zoom/tools work
- [ ] Manual: collab document → CollaborationStatusBadge stays visible inline with the toggle
- [ ] Manual: Documents page → switch to Tags view → click "Not tagged" → only untagged docs render → click a tag → tag filter works → click "Not tagged" again → reverts to untagged-only