### PR TITLE
Tear collaboration provider down on document unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - "Not tagged" filter in the Documents page tag tree view now actually filters to untagged documents. The page was computing the selection state but never sending the `untagged` query parameter to the backend, so selecting "Not tagged" returned every document instead of only the untagged ones.
+- Leaving a collaborative document now tears the connection down cleanly. Other collaborators no longer see the leaver's avatar flicker (disappear briefly then reappear), and the "Collaboration connection failed — Maximum reconnection attempts reached" toast no longer fires after the user has navigated away from the document. The unmount cleanup in `useCollaboration` was using a soft, debounced `disconnect()` (a React Strict Mode optimization) instead of `destroy()`, leaving the provider alive in the global pool, the reconnect loop running, and the error callback still wired to the unmounted page's toast.
 
 ## [0.39.0] - 2026-04-14
 

--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -74,9 +74,12 @@ export function useCollaboration({
   // Sync timeout to detect stuck connections
   const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Create stable callback refs
-  const onSyncedRef = useRef(onSynced);
-  const onErrorRef = useRef(onError);
+  // Create stable callback refs. Allow undefined so we can clear them in the
+  // unmount cleanup — otherwise an in-flight reconnect that resolves after
+  // unmount could still call them, and a toast would fire on a page the user
+  // has already left.
+  const onSyncedRef = useRef<UseCollaborationOptions["onSynced"]>(onSynced);
+  const onErrorRef = useRef<UseCollaborationOptions["onError"]>(onError);
   useEffect(() => {
     onSyncedRef.current = onSynced;
     onErrorRef.current = onError;
@@ -278,18 +281,25 @@ export function useCollaboration({
     }
   }, [isReady]);
 
-  // Cleanup on unmount - use disconnect (debounced) instead of destroy
-  // This allows the provider to be reused if the component remounts quickly (React Strict Mode)
-  // The provider will only be destroyed when the document ID changes (via the wsUrl change effect)
+  // Cleanup on unmount — destroy the provider so it leaves the global
+  // activeProviders map, closes the socket immediately, and stops any
+  // reconnect loop. Using a soft disconnect() here was a Strict-Mode
+  // optimization but caused two real bugs on real navigation: other users
+  // saw the avatar flicker (provider stayed alive briefly and re-stabilized),
+  // and the error callback fired toasts on pages the user had already left.
+  // The Strict-Mode cost is just one extra WS setup in dev — acceptable.
   useEffect(() => {
     return () => {
-      providerRef.current?.disconnect();
-      // Clear sync timeout
+      providerRef.current?.destroy();
+      providerRef.current = null;
+      currentWsUrlRef.current = null;
       if (syncTimeoutRef.current) {
         clearTimeout(syncTimeoutRef.current);
         syncTimeoutRef.current = null;
       }
-      // Don't null refs - provider may be reused on quick remount
+      // Null callback refs so any stray async invocation after destroy is a no-op.
+      onSyncedRef.current = undefined;
+      onErrorRef.current = undefined;
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Two related symptoms reported when leaving a collaborative document:

1. **Avatar flicker for the remaining user** — User B watches User A's presence avatar disappear briefly, then come back, when A navigates away.
2. **Stale toast** — after navigating away from a collab document, if the network later drops or the backend goes down, the toast _"Collaboration connection failed — Connection lost. Maximum reconnection attempts reached."_ appears on whatever page the user is now on.

Both trace back to the same line in [`useCollaboration.ts`](frontend/src/hooks/useCollaboration.ts): the unmount cleanup called `provider.disconnect()` (a debounced 100ms soft-close, deliberately built for React Strict Mode's mount/unmount/mount cycle) instead of `provider.destroy()`.

## Why the soft disconnect caused the bugs

- `disconnect()` schedules a 100ms timeout before closing the WS. The provider stays alive in the global `activeProviders` map ([`CollaborationProvider.ts:333`](frontend/src/lib/yjs/CollaborationProvider.ts#L333) — only `destroy()` removes it). Any path that calls `getOrCreateProvider(wsUrl, …)` during that window — Lexical's `CollaborationPlugin` re-rendering, Strict Mode quirks, etc. — gets the alive provider and calls `.connect()`, which `cancelPendingDisconnect()` ([line 315](frontend/src/lib/yjs/CollaborationProvider.ts#L315)) cancels the queued WS close. Server sees the connection re-stabilize, presence is rebroadcast, User B sees A reappear.
- The reconnect loop ([`scheduleReconnect`, line 698](frontend/src/lib/yjs/CollaborationProvider.ts#L698)) keeps running. If the WS later drops on its own (network, server stop), it cycles through `maxReconnectAttempts` and finally calls [`emitError(...)`](frontend/src/lib/yjs/CollaborationProvider.ts#L705).
- The error handler attached at [`useCollaboration.ts:236-244`](frontend/src/hooks/useCollaboration.ts#L236-L244) calls `onErrorRef.current(error)`. Nothing was ever clearing `onErrorRef` on unmount, so the captured `toast.error(...)` from `DocumentDetailPage` fires from a component that unmounted long ago.

## Fix

Switch the unmount cleanup to `destroy()` and null the refs:

- `provider.destroy()` removes it from `activeProviders`, clears `disconnectTimeout` + `reconnectTimeout`, closes the WS immediately, and calls `errorHandlers.clear()` (and the other handler-set clears) so any in-flight reconnect that fires after destruction can't reach React.
- Null `providerRef.current`, `currentWsUrlRef.current`, and the two callback refs as belt-and-braces so any straggler async path is a no-op.
- Type the callback refs as nullable (`useRef<UseCollaborationOptions["onSynced"]>(...)`) so the cleanup compiles.

The runtime `disconnect` / `connect` callbacks the hook returns to its consumer are unchanged. The debounce still helps the in-page "Live collaboration" checkbox toggle (pause/resume on the same page).

## Trade-off

In dev under Strict Mode the WebSocket now sets up twice on initial page load instead of being reused via the debounce. One extra WS setup per page load is much cheaper than the two bugs the optimization caused.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — 176/176 pass
- [ ] **Manual reproducer 1 (avatar flicker)** — open the same collab document in two browser sessions (User A and User B). Confirm both avatars appear in each other's collaborator list. Have A navigate to a non-document page. In B, A's avatar should disappear once and stay gone — no reappearance.
- [ ] **Manual reproducer 2 (stale toast)** — open a collab document in session A, then navigate away to a non-document page. With session A on the non-doc page, kill the backend (Ctrl+C uvicorn) or toggle DevTools "Offline". Wait ~30s for the reconnect backoff to exhaust. No "Collaboration connection failed" toast should appear.
- [ ] **Sanity (Strict Mode dev)** — initial page load in `pnpm dev` should connect cleanly to the collab WS. Navigate between two different docs back-to-back; the second doc should connect.
- [ ] **Sanity (in-page collab toggle)** — uncheck "Live collaboration" on a doc, recheck it. Should disconnect and reconnect smoothly within the same page (this path uses the runtime `disconnect`/`connect`, not unmount cleanup).