### PR TITLE
Add multiplayer cursors to whiteboard + unify collab colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Multiplayer cursors on whiteboards. When multiple users edit the same whiteboard document at once, each person now sees the others' pointer positions in real time, labeled with their name and tinted with their avatar color. Cursor updates piggyback on the existing Yjs awareness channel, so no new backend routes were needed.
+
+### Changed
+
+- Collaboration cursor colors are now deterministic per user and consistent across the app. The Lexical document editor caret, whiteboard cursor, and collaboration badge avatar all derive the same color from the user's id, so a given user shows up the same way everywhere. Previously the Lexical caret picked a random color per session and the avatar badge used a separate palette, so none of them agreed.
+
 ## [0.40.0] - 2026-04-20
 
 ### Added

--- a/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
+++ b/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
@@ -24,9 +24,11 @@ import type {
   OrderedExcalidrawElement,
 } from "@excalidraw/excalidraw/element/types";
 import * as Y from "yjs";
+import type { ProviderAwareness } from "@lexical/yjs";
 
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/hooks/useTheme";
+import { useWhiteboardCursors } from "@/hooks/useWhiteboardCursors";
 
 export interface WhiteboardScene {
   elements: readonly ExcalidrawElement[];
@@ -57,6 +59,10 @@ export interface WhiteboardDocumentEditorProps {
    *  stale (another user has continued editing while we were gone) and
    *  the Yjs state wins on bootstrap. */
   hasOtherCollaborators?: boolean;
+  /** Yjs awareness for peer cursor presence. Null in REST-only mode. */
+  awareness?: ProviderAwareness | null;
+  /** Current user for the cursor label + color. Null-safe. */
+  currentUser?: { id: number; name: string } | null;
 }
 
 /**
@@ -83,6 +89,8 @@ export function WhiteboardDocumentEditor({
   yDoc = null,
   isSynced = true,
   hasOtherCollaborators = false,
+  awareness = null,
+  currentUser = null,
 }: WhiteboardDocumentEditorProps) {
   const { t } = useTranslation("documents");
   const { resolvedTheme } = useTheme();
@@ -120,6 +128,41 @@ export function WhiteboardDocumentEditor({
   const writesAllowedRef = useRef(false);
 
   const collaborative = Boolean(yDoc);
+
+  // Peer cursor presence via Yjs awareness. No-op when awareness is null
+  // (REST-only mode) or when enabled is false.
+  const { collaborators: peerCollaborators, publishPointer } = useWhiteboardCursors({
+    awareness,
+    clientId: yDoc?.clientID ?? null,
+    user: currentUser,
+    enabled: collaborative,
+  });
+
+  // Excalidraw's onPointerUpdate fires with scene coords (post pan/zoom), so
+  // each viewer re-projects through their own transform — no translation needed.
+  const handlePointerUpdate = useCallback(
+    (payload: {
+      pointer: { x: number; y: number; tool: "pointer" | "laser" };
+      button: "down" | "up";
+    }) => {
+      publishPointer(payload.pointer, payload.button);
+    },
+    [publishPointer]
+  );
+
+  // Push peer cursors into Excalidraw via updateScene. `collaborators` isn't
+  // a direct prop — it lives in AppState and is updated imperatively. Passing
+  // via updateScene won't generate a history entry (CaptureUpdateAction.NEVER)
+  // and, importantly, won't mirror the peer map back into our serialized scene
+  // because handleExcalidrawChange uses the "database" serializer which strips
+  // ephemeral appState fields including collaborators.
+  useEffect(() => {
+    if (!excalidrawAPIRef.current) return;
+    excalidrawAPIRef.current.updateScene({
+      collaborators: peerCollaborators,
+      captureUpdate: CaptureUpdateAction.NEVER,
+    });
+  }, [peerCollaborators]);
 
   // Only compute initialData once per mount (the Excalidraw key in the parent
   // forces remount on document switch, so this is safe).
@@ -369,6 +412,7 @@ export function WhiteboardDocumentEditor({
         }}
         initialData={initialData}
         onChange={handleExcalidrawChange}
+        onPointerUpdate={handlePointerUpdate}
         viewModeEnabled={readOnly}
         isCollaborating={collaborative}
         theme={resolvedTheme}

--- a/frontend/src/components/documents/editor/CollaborationStatusBadge.tsx
+++ b/frontend/src/components/documents/editor/CollaborationStatusBadge.tsx
@@ -7,6 +7,7 @@ import { Circle, CloudOff, RefreshCw, Users, Wifi, WifiOff } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { getUserColorHsl } from "@/lib/userColor";
 import type { CollaboratorInfo } from "@/lib/yjs/CollaborationProvider";
 import type { ConnectionStatus } from "@/hooks/useCollaboration";
 
@@ -166,22 +167,9 @@ interface CollaboratorAvatarProps {
   index: number;
 }
 
-// Colors for collaborator avatars
-const AVATAR_COLORS = [
-  "bg-red-500",
-  "bg-orange-500",
-  "bg-amber-500",
-  "bg-lime-500",
-  "bg-emerald-500",
-  "bg-cyan-500",
-  "bg-blue-500",
-  "bg-violet-500",
-  "bg-pink-500",
-];
-
 function CollaboratorAvatar({ collaborator, index }: CollaboratorAvatarProps) {
   const { t } = useTranslation("documents");
-  const colorClass = AVATAR_COLORS[collaborator.user_id % AVATAR_COLORS.length];
+  const bgColor = getUserColorHsl(collaborator.user_id);
   const initials = collaborator.name
     .split(" ")
     .map((n) => n.charAt(0))
@@ -195,10 +183,9 @@ function CollaboratorAvatar({ collaborator, index }: CollaboratorAvatarProps) {
         <TooltipTrigger asChild>
           <div
             className={cn(
-              "flex h-7 w-7 items-center justify-center rounded-full border-2 border-white text-xs font-medium text-white dark:border-gray-800",
-              colorClass
+              "flex h-7 w-7 items-center justify-center rounded-full border-2 border-white text-xs font-medium text-gray-900 dark:border-gray-800"
             )}
-            style={{ zIndex: 10 - index }}
+            style={{ zIndex: 10 - index, backgroundColor: bgColor }}
           >
             {initials}
           </div>

--- a/frontend/src/components/documents/editor/editor.tsx
+++ b/frontend/src/components/documents/editor/editor.tsx
@@ -19,22 +19,7 @@ import { cn } from "@/lib/utils";
 import type { UserPublic } from "@/api/generated/initiativeAPI.schemas";
 import type { CollaborationProvider } from "@/lib/yjs/CollaborationProvider";
 import { useAuth } from "@/hooks/useAuth";
-
-// Generate a random color for cursor presence
-function getRandomColor(): string {
-  const colors = [
-    "#f87171", // red
-    "#fb923c", // orange
-    "#fbbf24", // amber
-    "#a3e635", // lime
-    "#34d399", // emerald
-    "#22d3ee", // cyan
-    "#60a5fa", // blue
-    "#a78bfa", // violet
-    "#f472b6", // pink
-  ];
-  return colors[Math.floor(Math.random() * colors.length)];
-}
+import { getUserColorHsl } from "@/lib/userColor";
 
 const editorConfig: InitialConfigType = {
   namespace: "Editor",
@@ -110,7 +95,9 @@ export function Editor({
   onWikilinkCreate,
 }: EditorProps) {
   const { user } = useAuth();
-  const userColor = useRef(getRandomColor());
+  // Per-user deterministic cursor color — matches the user's avatar in the
+  // collaboration status badge and their cursor on whiteboards.
+  const userColor = useRef(user ? getUserColorHsl(user.id) : "hsl(0, 0%, 70%)");
   const userName = user?.full_name || user?.email || "Anonymous";
   // Ref for the collaboration cursors container - must be inside the scrolling editor content
   const cursorsContainerRef = useRef<HTMLDivElement>(null!);

--- a/frontend/src/hooks/useWhiteboardCursors.ts
+++ b/frontend/src/hooks/useWhiteboardCursors.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ProviderAwareness } from "@lexical/yjs";
+import type { Collaborator, SocketId } from "@excalidraw/excalidraw/types";
+import { getUserColorHsl, userColorHashId } from "@/lib/userColor";
+
+interface WhiteboardUser {
+  id: number;
+  name: string;
+}
+
+interface Pointer {
+  x: number;
+  y: number;
+  tool: "pointer" | "laser";
+}
+
+interface WhiteboardAwarenessState {
+  whiteboard_user?: { id: number; name: string };
+  whiteboard_pointer?: Pointer & { button?: "up" | "down"; updatedAt: number };
+}
+
+interface UseWhiteboardCursorsArgs {
+  awareness: ProviderAwareness | null;
+  clientId: number | null;
+  user: WhiteboardUser | null;
+  enabled: boolean;
+}
+
+export function useWhiteboardCursors({
+  awareness,
+  clientId,
+  user,
+  enabled,
+}: UseWhiteboardCursorsArgs) {
+  const [collaborators, setCollaborators] = useState<Map<SocketId, Collaborator>>(() => new Map());
+  // Coalesce pointer events into at most one awareness update per paint.
+  // Excalidraw's onPointerUpdate can fire faster than 60Hz on high-refresh
+  // devices; a fixed ms throttle either drops the trailing sample (leaving
+  // peers on a stale final position) or runs below display rate. rAF aligns
+  // with the browser's paint cycle, so sends match what the user can see.
+  const pendingPointerRef = useRef<{ pointer: Pointer; button: "up" | "down" } | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !awareness || !user) return;
+    awareness.setLocalStateField("whiteboard_user", {
+      id: user.id,
+      name: user.name,
+    });
+    return () => {
+      // Clear immediately so peers drop our cursor instead of waiting for the
+      // 30s awareness timeout.
+      awareness.setLocalStateField("whiteboard_user", null);
+      awareness.setLocalStateField("whiteboard_pointer", null);
+    };
+  }, [awareness, enabled, user]);
+
+  useEffect(() => {
+    if (!enabled || !awareness || clientId == null) {
+      setCollaborators(new Map());
+      return;
+    }
+    const rebuild = () => {
+      const states = awareness.getStates() as unknown as Map<number, WhiteboardAwarenessState>;
+      const next = new Map<SocketId, Collaborator>();
+      states.forEach((state, peerClientId) => {
+        if (peerClientId === clientId) return;
+        const peerUser = state?.whiteboard_user;
+        if (!peerUser) return;
+        const pointer = state.whiteboard_pointer;
+        const peerColor = getUserColorHsl(peerUser.id);
+        next.set(String(peerClientId) as SocketId, {
+          // Excalidraw's cursor rendering runs getClientColor(socketId, collaborator)
+          // which hashes `collaborator.id` if present. Set it to the user id
+          // string so the cursor hue matches getUserColorHsl(user.id).
+          id: userColorHashId(peerUser.id),
+          username: peerUser.name,
+          color: { background: peerColor, stroke: peerColor },
+          pointer: pointer ? { x: pointer.x, y: pointer.y, tool: pointer.tool } : undefined,
+          button: pointer?.button ?? "up",
+        });
+      });
+      setCollaborators(next);
+    };
+    rebuild();
+    awareness.on("update", rebuild);
+    return () => {
+      awareness.off("update", rebuild);
+    };
+  }, [awareness, clientId, enabled]);
+
+  const publishPointer = useCallback(
+    (pointer: Pointer, button: "up" | "down") => {
+      if (!enabled || !awareness) return;
+      pendingPointerRef.current = { pointer, button };
+      if (rafIdRef.current !== null) return;
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null;
+        const next = pendingPointerRef.current;
+        pendingPointerRef.current = null;
+        if (!next) return;
+        awareness.setLocalStateField("whiteboard_pointer", {
+          x: next.pointer.x,
+          y: next.pointer.y,
+          tool: next.pointer.tool,
+          button: next.button,
+          updatedAt: Date.now(),
+        });
+      });
+    },
+    [awareness, enabled]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      pendingPointerRef.current = null;
+    };
+  }, []);
+
+  return useMemo(() => ({ collaborators, publishPointer }), [collaborators, publishPointer]);
+}

--- a/frontend/src/lib/userColor.ts
+++ b/frontend/src/lib/userColor.ts
@@ -1,0 +1,33 @@
+// Matches Excalidraw's internal getClientColor() — a djb2-style hash of a
+// string feeding into hsl(hue, 100%, 83%) via `(hash % 37) * 10`. See
+// @excalidraw/excalidraw/dist/dev/index.js → clients.ts. Excalidraw exposes
+// no hook to override the cursor color, so we feed it an id string that
+// hashes to the bucket we want, and mirror the same formula here for the
+// avatar badge.
+//
+// Small decimal user ids ("1", "2", …) cluster badly in djb2 — every char
+// is in [48, 57], so near ids all land in a tight hue band. Spread the id
+// through Knuth's multiplicative hash first so consecutive user ids produce
+// well-separated hues.
+
+const KNUTH = 2654435761;
+
+const spreadUserId = (userId: number): string => String((Math.abs(userId) * KNUTH) >>> 0);
+
+const djb2 = (id: string): number => {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash << 5) - hash + id.charCodeAt(i);
+  }
+  return hash;
+};
+
+export const getUserColorHsl = (userId: number): string => {
+  const hash = Math.abs(djb2(spreadUserId(userId)));
+  const hue = (hash % 37) * 10;
+  return `hsl(${hue}, 100%, 83%)`;
+};
+
+// The string to pass as Collaborator.id so Excalidraw's getClientColor()
+// lands on the same hue as getUserColorHsl(userId).
+export const userColorHashId = (userId: number): string => spreadUserId(userId);

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -57,6 +57,7 @@ const WhiteboardDocumentEditor = lazy(() =>
 );
 import type { WhiteboardScene } from "@/components/documents/WhiteboardDocumentEditor";
 import type * as Y from "yjs";
+import type { ProviderAwareness } from "@lexical/yjs";
 import { findNewMentions } from "@/lib/mentionUtils";
 import { useGuildPath } from "@/lib/guildUrl";
 import { useCollaboration } from "@/hooks/useCollaboration";
@@ -127,6 +128,7 @@ export const DocumentDetailPage = () => {
   // with the Yjs state (which would clobber the unsaved local work).
   const [whiteboardSceneFromCache, setWhiteboardSceneFromCache] = useState(false);
   const [whiteboardYDoc, setWhiteboardYDoc] = useState<Y.Doc | null>(null);
+  const [whiteboardAwareness, setWhiteboardAwareness] = useState<ProviderAwareness | null>(null);
   const [autosaveEnabled, setAutosaveEnabled] = useState(true);
   const [collaborationEnabled, setCollaborationEnabled] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -461,15 +463,18 @@ export const DocumentDetailPage = () => {
   useEffect(() => {
     if (document?.document_type !== "whiteboard") {
       setWhiteboardYDoc(null);
+      setWhiteboardAwareness(null);
       return;
     }
     if (!collaborationEnabled || !collaboration.providerFactory || !collaboration.isReady) {
       setWhiteboardYDoc(null);
+      setWhiteboardAwareness(null);
       return;
     }
     const yjsDocMap = new Map<string, import("yjs").Doc>();
     const provider = collaboration.providerFactory("main", yjsDocMap);
     setWhiteboardYDoc(provider.doc);
+    setWhiteboardAwareness(provider.awareness);
     // No cleanup — useCollaboration owns the provider lifecycle.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -1108,6 +1113,14 @@ export const DocumentDetailPage = () => {
                     yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}
                     isSynced={collaboration.isSynced}
                     hasOtherCollaborators={collaboration.collaborators.length > 0}
+                    awareness={
+                      collaborationEnabled && collaboration.isReady ? whiteboardAwareness : null
+                    }
+                    currentUser={
+                      user
+                        ? { id: user.id, name: user.full_name || user.email || "Anonymous" }
+                        : null
+                    }
                     className={cn(isFullscreen && "h-full min-h-0 flex-1")}
                   />
                 ) : (


### PR DESCRIPTION
## Summary

- Shows other users' pointers on Excalidraw whiteboards in real time via the existing Yjs awareness channel (backend already relays awareness binary frames unchanged — no backend changes).
- Unifies collaboration cursor coloring across the app: Lexical document caret, whiteboard cursor, and collab-badge avatar all derive the same deterministic color from the user's id via a new `getUserColorHsl()` helper.
- Pointer publishes coalesce to `requestAnimationFrame` so sends track the browser's paint cycle without dropping the trailing sample.

## Why

The whiteboard had the Yjs provider, awareness object, and a backend relay for awareness frames all already in place — it just never published a pointer or populated Excalidraw's `collaborators` map. The badge, Lexical caret, and (newly added) whiteboard cursor all used different color schemes, so a given user showed up in three different colors depending on the surface.

## Notable changes

- New `frontend/src/lib/userColor.ts` — `getUserColorHsl(userId)` mirrors Excalidraw's internal `getClientColor()` formula exactly (djb2 → `hsl(hue, 100%, 83%)`). Ids are pre-spread through Knuth's multiplicative hash first because small consecutive decimal strings cluster badly in djb2.
- New `frontend/src/hooks/useWhiteboardCursors.ts` — publishes local user identity + pointer into Yjs awareness, subscribes to peers, and returns a `Map<SocketId, Collaborator>`. Send side coalesces with rAF; cleanup clears fields on unmount so peers drop our cursor instantly instead of waiting out the 30s awareness timeout.
- `WhiteboardDocumentEditor` — new optional `awareness` / `currentUser` props; peer map pushed into Excalidraw imperatively via `updateScene({ collaborators, captureUpdate: NEVER })` (it isn't a direct prop).
- `DocumentDetailPage` — stashes `provider.awareness` alongside `provider.doc` in the same effect; passes both through.
- `CollaborationStatusBadge` — avatar uses `getUserColorHsl()` inline style (text switched to `text-gray-900` since the new HSL is lighter than the old Tailwind 500 palette).
- `Editor` (Lexical) — caret color switches from random-per-session to deterministic `getUserColorHsl(user.id)`.
- CHANGELOG updated.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm test:run` — 176/176 pass
- [x] `pnpm build` clean (~24s)
- [ ] Two-browser smoke: open the same whiteboard in Chrome + incognito as different users → each sees a labeled peer cursor moving in real time.
- [ ] Avatar color in the collaboration badge matches the whiteboard cursor color for the same user.
- [ ] Lexical doc caret color matches the same user's badge color.
- [ ] User A closes tab → user B sees their cursor vanish within ~1s (not 30s).
- [ ] Cursor motion doesn't trigger scene-state WS frames (only actual drawing does).