### PR TITLE
Fix kanban drag selection + markdown round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Drag-scrolling a kanban board no longer smears a text selection across every card the pointer passes over.
+
+- The document markdown converter now round-trips paragraph structure correctly. Toggling **Convert from markdown** previously turned a `\n\n` paragraph break into two stacked soft line breaks; converting back then re-emitted single newlines, so paragraphs steadily collapsed each time you toggled. Paragraph breaks now serialize as `\n\n` in markdown and parse back as real paragraphs, and shift+return soft breaks survive the round trip via the standard CommonMark hard-break syntax.
+
 - The guild filter on **My Tasks** and **Created Tasks** silently ignored your selection — picking one or more guilds still showed tasks from every guild you belong to. The pages now narrow correctly.
 
 - The task edit page sometimes opened with a blank status badge until you nudged the page (added a tag, changed a property, etc.), then it would suddenly show the right value. The page now uses the status that ships with the task itself instead of waiting for a second lookup, so the badge and status picker show the correct value the moment the task loads.

--- a/frontend/src/components/documents/editor/plugins.tsx
+++ b/frontend/src/components/documents/editor/plugins.tsx
@@ -351,7 +351,6 @@ export function Plugins({
               {/* <ShareContentPlugin /> */}
               <ImportExportPlugin documentName={documentName} />
               <MarkdownTogglePlugin
-                shouldPreserveNewLinesInMarkdown={true}
                 transformers={[
                   TABLE,
                   HR,

--- a/frontend/src/components/projects/ProjectTasksKanbanView.tsx
+++ b/frontend/src/components/projects/ProjectTasksKanbanView.tsx
@@ -213,6 +213,10 @@ const useHorizontalDragScroll = (ref: React.RefObject<HTMLDivElement | null>) =>
       scrollStart = container.scrollLeft;
       container.setPointerCapture(event.pointerId);
       container.style.cursor = "grabbing";
+      // Suppress the browser's native text-selection drag while we're
+      // pan-scrolling, otherwise the user smears a selection across every
+      // card their pointer moves over.
+      container.style.userSelect = "none";
     };
 
     const handlePointerMove = (event: PointerEvent) => {
@@ -237,6 +241,7 @@ const useHorizontalDragScroll = (ref: React.RefObject<HTMLDivElement | null>) =>
       }
       pointerId = null;
       container.style.cursor = "";
+      container.style.userSelect = "";
     };
 
     container.addEventListener("pointerdown", handlePointerDown);

--- a/frontend/src/components/ui/editor/plugins/actions/markdown-toggle-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/actions/markdown-toggle-plugin.tsx
@@ -11,13 +11,21 @@ import { FileTextIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
-export function MarkdownTogglePlugin({
-  shouldPreserveNewLinesInMarkdown,
-  transformers,
-}: {
-  shouldPreserveNewLinesInMarkdown: boolean;
-  transformers: Array<Transformer>;
-}) {
+// Both directions use Lexical's CommonMark default (false). This is the
+// only configuration that round-trips:
+//   Lexical Para A + Para B  →  "A\n\nB"  →  Lexical Para A + Para B
+//   Lexical LineBreakNode    →  "\\\n"     →  Lexical LineBreakNode
+// With shouldPreserveNewLines=true on export, paragraphs collapse to a
+// single `\n` — indistinguishable from a soft break — and the round trip
+// loses paragraph structure. The cost of `false` is that LineBreakNode
+// serializes as the CommonMark hard-break (`\\\n`, a literal backslash
+// before the newline) rather than a bare `\n`. A bare `\n` for soft
+// breaks isn't viable here: on re-import CommonMark treats it as
+// whitespace and the break is lost entirely.
+const PRESERVE_NEWLINES_ON_IMPORT = false;
+const PRESERVE_NEWLINES_ON_EXPORT = false;
+
+export function MarkdownTogglePlugin({ transformers }: { transformers: Array<Transformer> }) {
   const [editor] = useLexicalComposerContext();
 
   const handleMarkdownToggle = useCallback(() => {
@@ -29,13 +37,13 @@ export function MarkdownTogglePlugin({
           firstChild.getTextContent(),
           transformers,
           undefined, // node
-          shouldPreserveNewLinesInMarkdown
+          PRESERVE_NEWLINES_ON_IMPORT
         );
       } else {
         const markdown = $convertToMarkdownString(
           transformers,
           undefined, //node
-          shouldPreserveNewLinesInMarkdown
+          PRESERVE_NEWLINES_ON_EXPORT
         );
         const codeNode = $createCodeNode("markdown");
         codeNode.append($createTextNode(markdown));
@@ -45,8 +53,7 @@ export function MarkdownTogglePlugin({
         }
       }
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, shouldPreserveNewLinesInMarkdown]);
+  }, [editor, transformers]);
 
   return (
     <Button

--- a/frontend/src/components/ui/editor/plugins/actions/markdown-toggle-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/actions/markdown-toggle-plugin.tsx
@@ -53,7 +53,13 @@ export function MarkdownTogglePlugin({ transformers }: { transformers: Array<Tra
         }
       }
     });
-  }, [editor, transformers]);
+    // transformers is intentionally omitted: both call sites pass an
+    // inline array literal so a new reference would arrive every parent
+    // render, defeating the memoization. The transformer set is
+    // effectively constant for the lifetime of the editor instance, so
+    // capturing the first value is safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor]);
 
   return (
     <Button

--- a/frontend/src/components/ui/editor/plugins/plugins.tsx
+++ b/frontend/src/components/ui/editor/plugins/plugins.tsx
@@ -279,7 +279,6 @@ export function Plugins() {
             <ShareContentPlugin />
             <ImportExportPlugin />
             <MarkdownTogglePlugin
-              shouldPreserveNewLinesInMarkdown={true}
               transformers={[
                 TABLE,
                 HR,


### PR DESCRIPTION
## Summary

Two small UX fixes for the document/board surfaces.

- **Kanban drag-scroll no longer smears a text selection.** Pan-scrolling the board with the left mouse button used to highlight every card the pointer crossed. The drag-scroll handler now sets `user-select: none` on the scroll container while a drag is active and clears it on every termination path (pointerup / pointerleave / pointercancel).

- **Document markdown converter round-trips paragraph structure.** The toggle plugin was passing `shouldPreserveNewLinesInMarkdown=true` in both directions, which:
  - On import, turned every `\n` into a `LineBreakNode` so a `\n\n` paragraph break parsed as two stacked soft breaks instead of a real `ParagraphNode` split.
  - On export, joined paragraphs with a single `\n`, so the next import couldn't tell paragraph breaks apart from soft breaks.

  Both directions now use Lexical's CommonMark default (`false`). `\n\n` ⇄ paragraph; `LineBreakNode` ⇄ `\\\n` (CommonMark hard-break). The literal backslash is the cost of soft-break round-tripping under CommonMark — bare `\n` would be lost on re-import as whitespace. The redundant `shouldPreserveNewLinesInMarkdown` prop is dropped from the two call sites.

Both items added to **Unreleased / Fixed** in CHANGELOG.

## Test plan
- [x] `cd frontend && pnpm tsc --noEmit && pnpm lint` — green
- [ ] Manual: open a project's kanban view, click-and-drag a column gutter horizontally — board pans without selecting any card text. Release; selecting card text by clicking still works.
- [ ] Manual: open a Lexical document with multiple paragraphs (separated by blank lines) and one or two `shift+return` soft breaks. Click "Convert from markdown" → see `paragraphs` separated by `\n\n` and soft breaks rendered as `\\\n`. Click "Convert from markdown" again → paragraph structure and soft breaks restored. Repeat the toggle once more — content is stable (no progressive collapse).