### PR TITLE
Parallelize Docker public/infra builds in release workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,7 +107,7 @@ jobs:
           name: android-apk
           path: artifacts/*.apk
 
-  build-docker:
+  build-docker-public:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -179,8 +179,51 @@ jobs:
           cache-to: type=gha,scope=docker-build,mode=max
           platforms: linux/amd64,linux/arm64
 
-      - name: Image digest
-        run: echo "Image pushed with digest ${{ steps.build.outputs.digest }}"
+  build-docker-infra:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check for required secrets
+        run: |
+          if [ -z "${{ secrets.DOCKERHUB_USERNAME }}" ] || [ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+            echo "::error::Required secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are not set"
+            echo "::error::Please configure these secrets in your repository settings"
+            echo "::error::See .github/DOCKER_SETUP.md for instructions"
+            exit 1
+          fi
+          echo "Required secrets are configured"
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Version from input: $VERSION"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Version from tag: $VERSION"
+          else
+            VERSION=$(cat VERSION)
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Version from file: $VERSION"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract infra metadata (tags, labels) for Docker
         id: meta-infra
@@ -204,13 +247,13 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             VITE_API_URL=/api/v1
-            VITE_ENABLE_AUTOMATIONS=true
+            INSTALL_INFRA_EXTRAS=true
           cache-from: type=gha,scope=docker-build-infra
           cache-to: type=gha,scope=docker-build-infra,mode=max
           platforms: linux/amd64,linux/arm64
 
   release:
-    needs: [build-android, build-docker]
+    needs: [build-android, build-docker-public, build-docker-infra]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@
 # The infra image installs aioboto3 so the Kinesis event publisher works
 # when ENABLE_EVENT_PUBLISHING=true is set in the container environment.
 # The OSS image never installs aioboto3.
-#
-# VITE_ENABLE_AUTOMATIONS=true is accepted as a backward-compat alias for
-# INSTALL_INFRA_EXTRAS=true so the existing docker-publish.yml workflow
-# keeps producing a working infra image. Drop the alias once the workflow
-# build-arg is renamed.
 FROM node:20-alpine AS frontend-build
 WORKDIR /frontend
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
@@ -24,7 +19,6 @@ RUN pnpm run build
 FROM python:3.12-slim AS backend-runtime
 ARG VERSION=0.1.0
 ARG INSTALL_INFRA_EXTRAS=
-ARG VITE_ENABLE_AUTOMATIONS=
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.title="Initiative"
 LABEL org.opencontainers.image.description="Initiative project management application"
@@ -34,7 +28,7 @@ COPY backend/requirements.txt ./requirements.txt
 COPY backend/requirements-infra.txt ./requirements-infra.txt
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir -r requirements.txt \
-    && if [ "$INSTALL_INFRA_EXTRAS" = "true" ] || [ "$VITE_ENABLE_AUTOMATIONS" = "true" ]; then \
+    && if [ "$INSTALL_INFRA_EXTRAS" = "true" ]; then \
          pip install --no-cache-dir -r requirements-infra.txt; \
        fi
 COPY backend/ .


### PR DESCRIPTION
## Summary

- Split the release workflow's single `build-docker` job into two parallel jobs: `build-docker-public` and `build-docker-infra`. Each gets its own checkout, secrets check, Buildx setup, and Docker login. Cache scopes (`docker-build` vs `docker-build-infra`) were already separate, so the parallel jobs don't fight for cache.
- Switch the infra build-arg to `INSTALL_INFRA_EXTRAS=true` (the canonical name) and drop the `VITE_ENABLE_AUTOMATIONS=true` backward-compat alias from the `Dockerfile` — the ARG line, the install-gate clause, and the explanatory comment block. The Dockerfile already said to drop the alias once the workflow was updated.

## Test plan

- [ ] Tag a patch (or trigger via `workflow_dispatch`) and confirm both `build-docker-public` and `build-docker-infra` jobs run concurrently and succeed.
- [ ] Verify Docker Hub now has both `morelitea/initiative:<version>` and `morelitea/initiative-infra:<version>` images for the new tag.
- [ ] Pull the infra image and confirm `aioboto3` is installed (`docker run --rm morelitea/initiative-infra:<version> python -c "import aioboto3; print(aioboto3.__version__)"`).
- [ ] Pull the public image and confirm `aioboto3` is NOT installed.