### PR TITLE
Document fixes: read-only template copy + duplicate delete toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Read-only members can now create new documents from a template they have access to. Previously the copy required write access to the template, which defeated the point of templates being shared starters. Copying a non-template document still requires write access on the source.
 
+- Deleting a document from the document settings page no longer fires two success toasts.
+
 - Drag-scrolling a kanban board no longer smears a text selection across every card the pointer passes over.
 
 - The document markdown converter now round-trips paragraph structure correctly. Toggling **Convert from markdown** previously turned a `\n\n` paragraph break into two stacked soft line breaks; converting back then re-emitted single newlines, so paragraphs steadily collapsed each time you toggled. Paragraph breaks now serialize as `\n\n` in markdown and parse back as real paragraphs, and shift+return soft breaks survive the round trip via the standard CommonMark hard-break syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Read-only members can now create new documents from a template they have access to. Previously the copy required write access to the template, which defeated the point of templates being shared starters. Copying a non-template document still requires write access on the source.
+
 - Drag-scrolling a kanban board no longer smears a text selection across every card the pointer passes over.
 
 - The document markdown converter now round-trips paragraph structure correctly. Toggling **Convert from markdown** previously turned a `\n\n` paragraph break into two stacked soft line breaks; converting back then re-emitted single newlines, so paragraphs steadily collapsed each time you toggled. Paragraph breaks now serialize as `\n\n` in markdown and parse back as real paragraphs, and shift+return soft breaks survive the round trip via the standard CommonMark hard-break syntax.

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -1055,8 +1055,10 @@ async def copy_document(
     guild_context: GuildContextDep,
 ) -> DocumentRead:
     document = await _get_document_or_404(session, document_id=document_id, guild_id=guild_context.guild_id)
-    # Copy requires write permission for source document
-    _require_document_access(document, current_user, access="write")
+    # Templates are starter content meant to be copied — read on the source is enough.
+    # Non-templates still require write to prevent silent fork-and-edit of someone else's work.
+    required_access = "read" if document.is_template else "write"
+    _require_document_access(document, current_user, access=required_access)
     target_initiative = await _get_initiative_or_404(
         session,
         initiative_id=payload.target_initiative_id,

--- a/backend/app/api/v1/endpoints/documents_test.py
+++ b/backend/app/api/v1/endpoints/documents_test.py
@@ -218,6 +218,142 @@ async def test_create_document_skips_owner_level_grants(
 
 
 # ---------------------------------------------------------------------------
+# Copy / create-from-template tests
+# ---------------------------------------------------------------------------
+
+
+async def _make_native_doc(
+    session: AsyncSession,
+    *,
+    initiative,
+    creator,
+    title: str,
+    is_template: bool,
+) -> Document:
+    """Create a native document with creator as owner, optionally a template."""
+    doc = Document(
+        title=title,
+        initiative_id=initiative.id,
+        guild_id=initiative.guild_id,
+        created_by_id=creator.id,
+        updated_by_id=creator.id,
+        document_type=DocumentType.native,
+        content={"root": {"type": "root", "children": []}},
+        is_template=is_template,
+    )
+    session.add(doc)
+    await session.flush()
+    session.add(
+        DocumentPermission(
+            document_id=doc.id,
+            user_id=creator.id,
+            level=DocumentPermissionLevel.owner,
+            guild_id=initiative.guild_id,
+        )
+    )
+    await session.commit()
+    return doc
+
+
+@pytest.mark.integration
+async def test_copy_template_with_read_only_access(
+    client: AsyncClient, session: AsyncSession
+):
+    """A user with only read on a template can still copy it into a new document."""
+    template_owner = await create_user(session, email="template-owner@example.com")
+    reader = await create_user(session, email="reader@example.com")
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=template_owner, guild=guild, role=GuildRole.admin)
+    await create_guild_membership(session, user=reader, guild=guild)
+
+    initiative = await create_initiative(session, guild, template_owner, name="Templates Initiative")
+    # Reader needs create_docs in the target initiative; PM role grants it by default.
+    await create_initiative_member(session, initiative, reader, role_name="project_manager")
+
+    template = await _make_native_doc(
+        session,
+        initiative=initiative,
+        creator=template_owner,
+        title="Project Kickoff Template",
+        is_template=True,
+    )
+    # Grant reader explicit read-only access on the template.
+    session.add(
+        DocumentPermission(
+            document_id=template.id,
+            user_id=reader.id,
+            level=DocumentPermissionLevel.read,
+            guild_id=guild.id,
+        )
+    )
+    await session.commit()
+
+    headers = get_guild_headers(guild, reader)
+    response = await client.post(
+        f"/api/v1/documents/{template.id}/copy",
+        headers=headers,
+        json={"target_initiative_id": initiative.id, "title": "My Kickoff"},
+    )
+
+    assert response.status_code == 201, response.text
+    data = response.json()
+    assert data["title"] == "My Kickoff"
+    assert data["is_template"] is False
+    assert data["created_by_id"] == reader.id
+
+    # Reader is owner of the new doc.
+    new_perm_levels = {p["user_id"]: p["level"] for p in data["permissions"]}
+    assert new_perm_levels.get(reader.id) == "owner"
+
+    # Source template is unchanged.
+    await session.refresh(template)
+    assert template.is_template is True
+    assert template.title == "Project Kickoff Template"
+
+
+@pytest.mark.integration
+async def test_copy_non_template_still_requires_write_access(
+    client: AsyncClient, session: AsyncSession
+):
+    """Read-only access on a non-template document is still rejected by /copy."""
+    owner = await create_user(session, email="doc-owner@example.com")
+    reader = await create_user(session, email="reader@example.com")
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=owner, guild=guild, role=GuildRole.admin)
+    await create_guild_membership(session, user=reader, guild=guild)
+
+    initiative = await create_initiative(session, guild, owner, name="Docs Initiative")
+    await create_initiative_member(session, initiative, reader, role_name="project_manager")
+
+    doc = await _make_native_doc(
+        session,
+        initiative=initiative,
+        creator=owner,
+        title="Confidential Notes",
+        is_template=False,
+    )
+    session.add(
+        DocumentPermission(
+            document_id=doc.id,
+            user_id=reader.id,
+            level=DocumentPermissionLevel.read,
+            guild_id=guild.id,
+        )
+    )
+    await session.commit()
+
+    headers = get_guild_headers(guild, reader)
+    response = await client.post(
+        f"/api/v1/documents/{doc.id}/copy",
+        headers=headers,
+        json={"target_initiative_id": initiative.id, "title": "My Copy"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "DOCUMENT_WRITE_ACCESS_REQUIRED"
+
+
+# ---------------------------------------------------------------------------
 # Download endpoint tests
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -428,9 +428,14 @@ export const useUpdateDocument = (
   });
 };
 
-export const useDeleteDocument = (options?: MutationOpts<void, number[]>) => {
+export const useDeleteDocument = (
+  options?: MutationOpts<void, number[]> & {
+    /** If true, the default "X documents deleted" success toast is skipped so the caller can show its own. */
+    suppressSuccessToast?: boolean;
+  }
+) => {
   const { t } = useTranslation("documents");
-  const { onSuccess, onError, onSettled, ...rest } = options ?? {};
+  const { onSuccess, onError, onSettled, suppressSuccessToast, ...rest } = options ?? {};
 
   return useMutation({
     ...rest,
@@ -439,7 +444,9 @@ export const useDeleteDocument = (options?: MutationOpts<void, number[]>) => {
     },
     onSuccess: (...args) => {
       const documentIds = args[1];
-      toast.success(t("bulk.deleted", { count: documentIds.length }));
+      if (!suppressSuccessToast) {
+        toast.success(t("bulk.deleted", { count: documentIds.length }));
+      }
       void invalidateAllDocuments();
       onSuccess?.(...args);
     },

--- a/frontend/src/pages/DocumentSettingsPage.tsx
+++ b/frontend/src/pages/DocumentSettingsPage.tsx
@@ -169,6 +169,7 @@ export const DocumentSettingsPage = () => {
   });
 
   const deleteDocumentMutation = useDeleteDocument({
+    suppressSuccessToast: true,
     onSuccess: () => {
       toast.success(t("settings.documentDeleted"));
       setDeleteDialogOpen(false);


### PR DESCRIPTION
## Summary

Two small document-feature fixes bundled together since they're both ~one-line changes.

### 1. Allow read-only users to copy a template

`POST /api/v1/documents/{id}/copy` previously required **write** access on the source document. For templates (`is_template=True`) that was the wrong gate: members with only read access on a template couldn't use it as the starting point for their own document, defeating the whole purpose of templates.

The endpoint now requires **read** on the source when `is_template=True`, and continues to require **write** otherwise. The downstream check on the target initiative (`create_docs` permission) is unchanged, so the user must still be allowed to create documents in the destination.

### 2. Stop duplicate "Document deleted" toast on the settings page

`useDeleteDocument` always fired `"X documents deleted"`, but `DocumentSettingsPage` also fired `"Document deleted"` from its caller `onSuccess` — so a single delete from the settings page stacked two toasts.

Added an opt-out (`suppressSuccessToast`) on the hook, mirroring the existing `suppressErrorToast` pattern in `useUpdateDocument`. The settings page opts out and keeps its friendlier single-doc wording. The bulk-delete flow on `DocumentsPage` is unchanged.

## Test plan

- [x] New backend test: `test_copy_template_with_read_only_access` — read-only user copies a template; copy succeeds, copy is owned by them, source is unchanged.
- [x] New backend test: `test_copy_non_template_still_requires_write_access` — read-only user copying a non-template gets 403 `DOCUMENT_WRITE_ACCESS_REQUIRED`.
- [x] All existing `documents_test.py` tests still pass (25 passed).
- [x] `ruff check` clean; `pnpm tsc --noEmit && pnpm lint` clean.
- [ ] Reviewer: as a non-PM member with only read on a template, open the documents page → Create document → pick the template → submit. Confirm the new doc is created and you own it.
- [ ] Reviewer: open a document's settings page, click Delete, confirm only **one** toast appears.