### PR TITLE
Load dates namespace for table-view recurrence text

### DIFF
--- a/frontend/src/components/projects/ProjectTasksTableView.tsx
+++ b/frontend/src/components/projects/ProjectTasksTableView.tsx
@@ -619,9 +619,6 @@ type TaskCellProps = {
 };
 
 const TaskCell = ({ task, canOpenTask, onTaskClick }: TaskCellProps) => {
-  // ``dates`` is required because summarizeRecurrence() resolves keys
-  // under the ``recurrenceSummary.*`` namespace; without it the cell
-  // shows the raw key string until another view loads ``dates``.
   const { t } = useTranslation(["projects", "dates"]);
   // Memoize expensive recurrence computation
   const recurrenceText = useMemo(() => {

--- a/frontend/src/components/projects/ProjectTasksTableView.tsx
+++ b/frontend/src/components/projects/ProjectTasksTableView.tsx
@@ -619,7 +619,10 @@ type TaskCellProps = {
 };
 
 const TaskCell = ({ task, canOpenTask, onTaskClick }: TaskCellProps) => {
-  const { t } = useTranslation("projects");
+  // ``dates`` is required because summarizeRecurrence() resolves keys
+  // under the ``recurrenceSummary.*`` namespace; without it the cell
+  // shows the raw key string until another view loads ``dates``.
+  const { t } = useTranslation(["projects", "dates"]);
   // Memoize expensive recurrence computation
   const recurrenceText = useMemo(() => {
     if (!task.recurrence) return null;


### PR DESCRIPTION
## Summary

`ProjectTasksTableView`'s `TaskCell` was calling `useTranslation("projects")` but `summarizeRecurrence()` resolves keys under the `recurrenceSummary.*` group in `dates.json`. With i18next's lazy namespace loading, the cell rendered the literal key string (`recurrenceSummary.repeats`) on the table view until some other view (kanban, task detail) caused the `dates` namespace to be fetched.

Same pattern that `KanbanColumn.tsx` already uses (`useTranslation(["projects", "dates"])`) — applying it to the table view too.

## Test plan

- [ ] Open a project with a recurring task on the table view as a logged-out / fresh session. Confirm the row shows "Repeats …" instead of `recurrenceSummary.repeats`.
- [ ] Switch between table and kanban views; recurrence text stays localized in both.
- [x] `pnpm exec tsc --noEmit` clean.