### PR TITLE
Show all task filters in kanban view too

### DIFF
--- a/frontend/src/components/projects/ProjectTasksFilters.tsx
+++ b/frontend/src/components/projects/ProjectTasksFilters.tsx
@@ -22,7 +22,6 @@ import type { TagRead, TagSummary, TaskStatusRead } from "@/api/generated/initia
 export type ListStatusFilter = "all" | "incomplete" | number;
 
 type ProjectTasksFiltersProps = {
-  viewMode: "kanban" | "table" | "calendar" | "gantt";
   userOptions: UserOption[];
   taskStatuses: TaskStatusRead[];
   tags: TagRead[];
@@ -41,7 +40,6 @@ type ProjectTasksFiltersProps = {
 };
 
 export const ProjectTasksFilters = ({
-  viewMode,
   taskStatuses,
   userOptions,
   tags,
@@ -113,29 +111,28 @@ export const ProjectTasksFilters = ({
             </SelectContent>
           </Select>
         </div>
-        {viewMode === "table" || viewMode === "calendar" || viewMode === "gantt" ? (
-          <div className="w-full space-y-2 sm:w-48">
-            <Label
-              htmlFor="status-filter"
-              className="text-muted-foreground block text-xs font-medium"
-            >
-              {t("filters.filterByStatus")}
-            </Label>
-            <MultiSelect
-              selectedValues={statusFilters.map(String)}
-              options={taskStatuses.map((status) => ({
-                value: String(status.id),
-                label: status.name,
-              }))}
-              onChange={(values) => {
-                const numericValues = values.map(Number).filter(Number.isFinite);
-                onStatusFiltersChange(numericValues);
-              }}
-              placeholder={t("filters.allStatuses")}
-              emptyMessage={t("filters.noStatusesAvailable")}
-            />
-          </div>
-        ) : null}
+        <div className="w-full space-y-2 sm:w-48">
+          <Label
+            htmlFor="status-filter"
+            className="text-muted-foreground block text-xs font-medium"
+          >
+            {t("filters.filterByStatus")}
+          </Label>
+          <MultiSelect
+            selectedValues={statusFilters.map(String)}
+            options={taskStatuses.map((status) => ({
+              value: String(status.id),
+              label: status.name,
+            }))}
+            onChange={(values) => {
+              const numericValues = values.map(Number).filter(Number.isFinite);
+              onStatusFiltersChange(numericValues);
+            }}
+            placeholder={t("filters.allStatuses")}
+            emptyMessage={t("filters.noStatusesAvailable")}
+          />
+        </div>
+
         <div className="w-full space-y-2 sm:w-48">
           <Label htmlFor="tag-filter" className="text-muted-foreground block text-xs font-medium">
             {t("filters.filterByTag")}

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -926,7 +926,6 @@ export const ProjectTasksSection = ({
           </div>
           <CollapsibleContent forceMount className="mt-2 data-[state=closed]:hidden sm:mt-0">
             <ProjectTasksFilters
-              viewMode={viewMode}
               taskStatuses={sortedTaskStatuses}
               userOptions={userOptions}
               tags={tags}


### PR DESCRIPTION
## Summary

Kanban previously hid the status filter under the assumption that the kanban columns are the status filter. But the filter state is shared across views — if you hide "Done" in table view and switch to kanban, the filter still applies, and the status filter widget was hidden so you couldn't adjust it without switching back.

Now every filter renders in every view. Side benefit: the only view-dependent branch in `ProjectTasksFilters` is gone, so the `viewMode` prop is no longer threaded through.

## Changes

- `ProjectTasksFilters.tsx`: removed the `viewMode === "table" || …` ternary around the status filter. Removed the `viewMode` prop from the props type and destructuring.
- `ProjectTasksSection.tsx`: removed the `viewMode={viewMode}` prop pass.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean.
- [ ] Open a project on table view, apply status filter (e.g. exclude "Done"), switch to kanban — confirm the status filter widget is visible and reflects the current selection.
- [ ] Toggle the status filter on kanban view, switch back to table — confirm both views render the same filtered task set.