### PR TITLE
Sweep untracked documents in seed cleanup

### DIFF
--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -27,6 +27,7 @@ BACKEND_DIR = Path(__file__).resolve().parent.parent / "backend"
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
+from sqlalchemy import or_  # noqa: E402
 from sqlmodel import select  # noqa: E402
 from sqlmodel.ext.asyncio.session import AsyncSession  # noqa: E402
 
@@ -2891,6 +2892,30 @@ async def clean() -> None:
                     session.add(user)
             await session.flush()
             print("  Restored user settings")
+
+            # Sweep any untracked documents whose author is a seeded
+            # user. The script tracks documents it created in
+            # `state["documents"]`, but documents created outside that
+            # path (e.g. via the running app during dev) won't be in
+            # that list. ``documents.created_by_id`` / ``updated_by_id``
+            # have no ON DELETE CASCADE / SET NULL, so any leftover
+            # would block the user delete below with a FK violation.
+            if state.get("users"):
+                seeded_user_ids = state["users"]
+                leftover_doc_result = await session.exec(
+                    select(Document).where(
+                        or_(
+                            Document.created_by_id.in_(seeded_user_ids),
+                            Document.updated_by_id.in_(seeded_user_ids),
+                        )
+                    )
+                )
+                leftover_docs = leftover_doc_result.all()
+                for document in leftover_docs:
+                    await session.delete(document)
+                if leftover_docs:
+                    await session.flush()
+                    print(f"  Removed {len(leftover_docs)} untracked documents")
 
             # Users
             for uid in state.get("users", []):


### PR DESCRIPTION
## Summary

`bash scripts/dev-cleanup.sh` (and the `dev:cleanup` Zed task) was failing partway through with:

```
asyncpg.exceptions.ForeignKeyViolationError: update or delete on table "users" violates
foreign key constraint "documents_created_by_id_fkey" on table "documents"
DETAIL:  Key (id)=(292) is still referenced from table "documents".
```

The seed script tracks documents it creates in `state["documents"]` and deletes those, but documents created any other way (e.g. by the dev user via the running app) aren't tracked. They survived the targeted document delete, then blocked the user delete because `documents.created_by_id` / `updated_by_id` have no `ON DELETE CASCADE` / `SET NULL`.

The fix mirrors the existing untracked-projects sweep at the analogous spot for projects: right before the user delete, sweep all documents whose `created_by_id` or `updated_by_id` is one of the seeded user IDs and delete them. The Document → ProjectDocument / DocumentTag / DocumentPermission cascades take care of dependents.

## Test plan

- [x] Seed dev data, create one or more documents from the app as a seeded user, then run `bash scripts/dev-cleanup.sh`. Expected new line: `Removed N untracked documents`. Cleanup completes without the FK error.
- [x] Verified locally: cleanup picked up 3 untracked documents from previous dev work and finished cleanly with `Done! All seeded data removed.`