### PR TITLE
Accept delegation JWTs from initiative-auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Delegation auth for the advanced-tool service.** Accept short-lived RS256-signed JWTs from the embed's backend so it can call Initiative on a user's behalf. Existing RLS + role-permission checks still gate every action — delegation answers only "who is acting." Deactivated users can't be impersonated. Disabled by default; opt in with `AUTO_DELEGATION_PUBLIC_KEY_PEM`.
+
 - **Embedded advanced tool integration.** Initiative now supports plugging in an externally-deployed companion app as an iframe panel under specific initiatives or as a dedicated guild settings tab. Operators set `ADVANCED_TOOL_NAME` and `ADVANCED_TOOL_URL` on the backend; without those, the entire feature stays fully hidden — no UI surface, no per-initiative toggle, and the API endpoints return 404.
   - **Per-initiative panel** — initiative managers turn it on under Initiative settings → Details → Advanced Tools. Once enabled, the panel becomes the first item in the initiative's sidebar group for any user whose role grants the new `advanced_tool_enabled` permission.
   - **Per-guild panel** — guild admins get a dedicated tab in guild settings for cross-initiative or admin-only views. The tab only appears when the deployment has an advanced tool URL configured AND the user is a guild admin.

--- a/backend/alembic/versions/20260501_0081_create_auto_delegation_jti_blocklist.py
+++ b/backend/alembic/versions/20260501_0081_create_auto_delegation_jti_blocklist.py
@@ -1,0 +1,53 @@
+"""Create auto_delegation_jti_blocklist for one-shot delegation tokens.
+
+Delegation JWTs minted by initiative-auto carry a ``jti`` claim. The
+auth dep records every successfully-redeemed jti here and refuses any
+second presentation, so a leaked or sniffed token can be used at most
+once even though the JWT itself is valid for 15 minutes.
+
+``expires_at`` is set to the JWT's ``exp`` so a periodic cleanup (or a
+lazy delete on insert) can keep the table tiny — entries past their
+JWT exp are useless.
+
+Revision ID: 20260501_0081
+Revises: 20260501_0080
+Create Date: 2026-05-01
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260501_0081"
+down_revision: Union[str, None] = "20260501_0080"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auto_delegation_jti_blocklist",
+        sa.Column("jti", sa.String(length=64), primary_key=True),
+        sa.Column(
+            "redeemed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    # Cleanup index — periodic ``DELETE WHERE expires_at < now()``.
+    op.create_index(
+        "ix_auto_delegation_jti_blocklist_expires_at",
+        "auto_delegation_jti_blocklist",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_auto_delegation_jti_blocklist_expires_at",
+        table_name="auto_delegation_jti_blocklist",
+    )
+    op.drop_table("auto_delegation_jti_blocklist")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Annotated, Optional
 
 from fastapi import Cookie, Depends, Header, HTTPException, Query, Request, status
@@ -11,6 +12,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import settings
 from app.core.messages import AuthMessages, GuildMessages
 from app.core.security import (
+    AutoDelegationClaims,
     AutoDelegationVerificationError,
     verify_auto_delegation_token,
 )
@@ -19,6 +21,7 @@ from app.models.guild import Guild, GuildMembership, GuildRole
 from app.models.user import User, UserRole, UserStatus
 from app.schemas.token import TokenPayload
 from app.services import api_keys as api_keys_service
+from app.services import auto_delegation_blocklist
 from app.services import guilds as guilds_service
 from app.services import user_tokens
 
@@ -37,8 +40,32 @@ async def _authenticate_device_token(session: AsyncSession, token: str) -> Optio
     return result.one_or_none()
 
 
+def _delegation_guild_matches_header(
+    request: Request, claims: AutoDelegationClaims
+) -> bool:
+    """Reject delegation tokens whose ``guild_id`` claim contradicts the
+    request's ``X-Guild-ID`` header.
+
+    The header is what RLS will use to scope the query; if the token was
+    issued for guild 42 and the request asks for guild 99, that's a
+    cross-guild attempt — a user who's a member of both guilds shouldn't
+    be able to use a token issued in one to access the other. When the
+    header is absent (cross-guild endpoints like ``/users/me``) we allow,
+    relying on the endpoint itself to scope appropriately.
+    """
+    raw = request.headers.get("X-Guild-ID")
+    if not raw:
+        return True
+    try:
+        return int(raw) == claims.guild_id
+    except (TypeError, ValueError):
+        return False
+
+
 async def _authenticate_auto_delegation(
-    session: AsyncSession, token: str
+    request: Request,
+    session: AsyncSession,
+    token: str,
 ) -> Optional[User]:
     """Try to interpret ``token`` as a delegation JWT from initiative-auto.
 
@@ -51,6 +78,11 @@ async def _authenticate_auto_delegation(
     function only resolves identity. RLS, role-permission checks, and
     master switches gate the actual operation as if the user were
     calling directly.
+
+    Three security checks fire here in order:
+      1. Token verifies (signature, audience, issuer, required claims).
+      2. ``jti`` is not in the blocklist — first presentation only.
+      3. ``guild_id`` claim matches ``X-Guild-ID`` header when present.
     """
     if not settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
         return None  # delegation disabled — let other auth paths run
@@ -62,6 +94,17 @@ async def _authenticate_auto_delegation(
         # Returning None lets the caller try those instead of failing.
         return None
 
+    if not _delegation_guild_matches_header(request, claims):
+        return None
+
+    # Replay guard: a delegation JWT is one-shot. Even though the JWT is
+    # technically valid for 15 minutes, a captured token must not be
+    # usable a second time. The pre-flight ``is_jti_redeemed`` is a fast
+    # path; the ``record_jti`` insert below is the actual race-safe
+    # guarantee (unique-violation on the PK).
+    if await auto_delegation_blocklist.is_jti_redeemed(session, claims.jti):
+        return None
+
     statement = select(User).where(User.id == claims.user_id)
     result = await session.exec(statement)
     user = result.one_or_none()
@@ -70,7 +113,30 @@ async def _authenticate_auto_delegation(
         # since the token was minted. Auto can't impersonate non-active
         # accounts — workflows die when their owner leaves, by design.
         return None
+
+    # Burn the jti now. Two requests racing past the pre-flight check
+    # collide on the PK and the loser's ``record_jti`` raises
+    # ``DelegationReplayError``, which we convert to the same None
+    # signal — the request will be re-authenticated by another path or
+    # rejected by the standard 401.
+    try:
+        await auto_delegation_blocklist.record_jti(
+            session, jti=claims.jti, expires_at=_delegation_exp_from_jwt(token)
+        )
+    except auto_delegation_blocklist.DelegationReplayError:
+        return None
+
     return user
+
+
+def _delegation_exp_from_jwt(token: str) -> datetime:
+    """Pull the ``exp`` timestamp out of a delegation JWT without
+    re-verifying. Caller has already verified — we just need the value
+    for the blocklist row's ``expires_at`` column so the cleanup job
+    can prune expired entries.
+    """
+    payload = jwt.decode(token, options={"verify_signature": False})
+    return datetime.fromtimestamp(int(payload["exp"]), tz=timezone.utc)
 
 
 async def get_current_user(
@@ -112,7 +178,7 @@ async def get_current_user(
     # Returns None on shape/algorithm mismatch so a regular HS256 session
     # JWT carrying through this header gracefully falls through to the
     # next branch.
-    user = await _authenticate_auto_delegation(session, token)
+    user = await _authenticate_auto_delegation(request, session, token)
     if user:
         return user
 
@@ -327,6 +393,18 @@ async def get_upload_user(
     if user:
         if user.status != UserStatus.active:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=AuthMessages.INACTIVE_USER)
+        return user
+
+    # Try delegation JWT from initiative-auto. Same chain placement as
+    # ``get_current_user`` so /uploads/* accepts auto-driven workflow
+    # downloads without per-route changes. Falls through on shape /
+    # algorithm / audience mismatch so a regular HS256 session JWT
+    # arriving on the same header still hits the standard JWT branch
+    # below.
+    user = await _authenticate_auto_delegation(request, session, token)
+    if user:
+        # Delegation already enforces ``user.status == active``;
+        # ``_authenticate_auto_delegation`` returned None otherwise.
         return user
 
     # Try JWT authentication. Expired / malformed tokens are 401 (not 403)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -10,6 +10,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
 from app.core.messages import AuthMessages, GuildMessages
+from app.core.security import (
+    AutoDelegationVerificationError,
+    verify_auto_delegation_token,
+)
 from app.db.session import get_session, set_rls_context
 from app.models.guild import Guild, GuildMembership, GuildRole
 from app.models.user import User, UserRole, UserStatus
@@ -31,6 +35,42 @@ async def _authenticate_device_token(session: AsyncSession, token: str) -> Optio
     statement = select(User).where(User.id == device_token.user_id)
     result = await session.exec(statement)
     return result.one_or_none()
+
+
+async def _authenticate_auto_delegation(
+    session: AsyncSession, token: str
+) -> Optional[User]:
+    """Try to interpret ``token`` as a delegation JWT from initiative-auto.
+
+    Returns the named user when the token verifies; ``None`` otherwise so
+    the caller can fall through to other auth methods (regular JWT, API
+    key, etc.) without 401-ing on what's actually a session-token-shaped
+    bearer arriving at the same header.
+
+    Authorization beyond authentication still happens downstream — this
+    function only resolves identity. RLS, role-permission checks, and
+    master switches gate the actual operation as if the user were
+    calling directly.
+    """
+    if not settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
+        return None  # delegation disabled — let other auth paths run
+
+    try:
+        claims = verify_auto_delegation_token(token)
+    except AutoDelegationVerificationError:
+        # Could be a session JWT or API key arriving on the same header.
+        # Returning None lets the caller try those instead of failing.
+        return None
+
+    statement = select(User).where(User.id == claims.user_id)
+    result = await session.exec(statement)
+    user = result.one_or_none()
+    if user is None or user.status != UserStatus.active:
+        # The user the token names doesn't exist or has been deactivated
+        # since the token was minted. Auto can't impersonate non-active
+        # accounts — workflows die when their owner leaves, by design.
+        return None
+    return user
 
 
 async def get_current_user(
@@ -65,6 +105,14 @@ async def get_current_user(
 
     # Try API key authentication first
     user = await api_keys_service.authenticate_api_key(session, token)
+    if user:
+        return user
+
+    # Try delegation JWT from initiative-auto (RS256, distinct audience).
+    # Returns None on shape/algorithm mismatch so a regular HS256 session
+    # JWT carrying through this header gracefully falls through to the
+    # next branch.
+    user = await _authenticate_auto_delegation(session, token)
     if user:
         return user
 

--- a/backend/app/api/v1/endpoints/auto_delegation_test.py
+++ b/backend/app/api/v1/endpoints/auto_delegation_test.py
@@ -1,0 +1,270 @@
+"""Integration tests for auto-delegation hardening.
+
+These exercise the security properties the auth dep enforces on delegation
+JWTs minted by initiative-auto:
+
+* signature, audience, issuer (negative tests against tampered tokens)
+* one-shot replay rejection via the jti blocklist
+* guild_id JWT claim must match the X-Guild-ID request header when both
+  are present
+* deactivated users can't be impersonated even with a valid token
+
+These don't repeat the unit tests on token issuance — those live next
+to ``create_advanced_tool_handoff_token``. Here the focus is on the
+verification + blocklist + cross-claim consistency the dep enforces.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core import config as config_module
+from app.models.user import UserStatus
+from app.testing.factories import create_user
+
+
+# A fresh keypair per test session — keeps signatures from leaking between
+# tests if the same private key were reused via fixture caching.
+_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_PEM = _keypair.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+_PUBLIC_PEM = _keypair.public_key().public_bytes(
+    serialization.Encoding.PEM,
+    serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode()
+
+
+def _mint_delegation(
+    *,
+    user_id: int,
+    guild_id: int,
+    initiative_id: int | None = None,
+    jti: str | None = None,
+    aud: str = "initiative:auto-delegation",
+    iss: str = "initiative-auto",
+    private_pem: str = _PRIVATE_PEM,
+    expires_in: int = 900,
+) -> str:
+    now = datetime.now(timezone.utc)
+    payload: dict = {
+        "jti": jti or secrets.token_hex(8),
+        "sub": str(user_id),
+        "aud": aud,
+        "iss": iss,
+        "iat": int(now.timestamp()),
+        "exp": now + timedelta(seconds=expires_in),
+        "guild_id": guild_id,
+    }
+    if initiative_id is not None:
+        payload["initiative_id"] = initiative_id
+    return jwt.encode(payload, private_pem, algorithm="RS256")
+
+
+@pytest.fixture(autouse=True)
+def _enable_delegation(monkeypatch):
+    """Configure the public key for the duration of each test in this file.
+    Without it, ``_authenticate_auto_delegation`` short-circuits to None
+    and the tests fall through to standard-JWT auth, which is not what
+    we're exercising here."""
+    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _PUBLIC_PEM)
+
+
+@pytest.mark.integration
+async def test_delegation_token_is_one_shot(client: AsyncClient, session: AsyncSession):
+    """The same jti must succeed once and fail on the second presentation,
+    regardless of the JWT's remaining lifetime. Without this, a 15-minute
+    token captured in transit can be replayed indefinitely."""
+    user = await create_user(session, email="user@example.com")
+    token = _mint_delegation(user_id=user.id, guild_id=1, jti="replay-target-001")
+
+    first = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert first.status_code == 200, first.text
+
+    second = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # Replay falls through past delegation auth, then through the
+    # standard JWT path which rejects an HS256-shaped token, ending
+    # with the standard 401.
+    assert second.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegation_rejects_guild_mismatch(
+    client: AsyncClient, session: AsyncSession
+):
+    """A token issued for guild 42 must not authenticate a request that
+    sets X-Guild-ID: 99 — even if the user is a member of both. Stops
+    cross-guild lateral movement using a single delegation."""
+    user = await create_user(session, email="cross-guild@example.com")
+    token = _mint_delegation(user_id=user.id, guild_id=42)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Guild-ID": "99",
+        },
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegation_allows_matching_guild_header(
+    client: AsyncClient, session: AsyncSession
+):
+    """The header check is permissive when JWT.guild_id == X-Guild-ID —
+    the typical happy path with a guild-scoped endpoint."""
+    user = await create_user(session, email="happy-path@example.com")
+    token = _mint_delegation(user_id=user.id, guild_id=42)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Guild-ID": "42",
+        },
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.integration
+async def test_delegation_allows_missing_guild_header(
+    client: AsyncClient, session: AsyncSession
+):
+    """``/users/me`` is cross-guild; no X-Guild-ID required. The guild
+    consistency check must allow the call when the header is absent."""
+    user = await create_user(session, email="cross-guild-allowed@example.com")
+    token = _mint_delegation(user_id=user.id, guild_id=42)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.integration
+async def test_delegation_rejects_deactivated_user(
+    client: AsyncClient, session: AsyncSession
+):
+    """Workflows owned by deactivated users must stop working
+    immediately — no grace period during which their old tokens still
+    function."""
+    user = await create_user(session, email="deactivated@example.com")
+    user.status = UserStatus.deactivated
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+
+    token = _mint_delegation(user_id=user.id, guild_id=1)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegation_rejects_unknown_user(
+    client: AsyncClient, session: AsyncSession
+):
+    """A delegation for a user_id that doesn't exist in the DB must
+    fail — auto can't manufacture user identities Initiative didn't
+    issue."""
+    token = _mint_delegation(user_id=9_999_999, guild_id=1)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegation_rejects_wrong_audience(
+    client: AsyncClient, session: AsyncSession
+):
+    """A token with a different audience claim must not authenticate.
+    Stops a regular session JWT (or any other audience) from being
+    re-presented as a delegation."""
+    user = await create_user(session, email="wrong-aud@example.com")
+    token = _mint_delegation(user_id=user.id, guild_id=1, aud="initiative:something-else")
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegation_rejects_wrong_issuer(
+    client: AsyncClient, session: AsyncSession
+):
+    """Issuer must match — defense in depth alongside the audience check."""
+    user = await create_user(session, email="wrong-iss@example.com")
+    token = _mint_delegation(user_id=user.id, guild_id=1, iss="someone-else")
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegation_rejects_signature_from_other_key(
+    client: AsyncClient, session: AsyncSession
+):
+    """A token signed with a different RSA key must fail signature
+    verification — the load-bearing crypto property of the whole flow."""
+    user = await create_user(session, email="bad-sig@example.com")
+    other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    other_private = other_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    token = _mint_delegation(user_id=user.id, guild_id=1, private_pem=other_private)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegation_disabled_when_public_key_unset(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """Operator hasn't configured the public key → delegation auth is
+    fully off and the request falls through to the standard 401 from
+    the JWT path. No 500 from a half-configured state."""
+    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+
+    user = await create_user(session, email="delegation-off@example.com")
+    token = _mint_delegation(user_id=user.id, guild_id=1)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -88,6 +88,17 @@ class Settings(BaseSettings):
     # to pick the right verifying key — useful when rotating.
     HANDOFF_SIGNING_KEY_ID: str | None = None
 
+    # Inbound delegation from the advanced-tool service (initiative-auto).
+    # When auto needs to call Initiative on behalf of a user — either
+    # because the user is in the iframe right now, or because a workflow
+    # they own is firing — it presents a JWT signed with RS256 by its
+    # own private key. This is the matching public key. When unset,
+    # delegation auth is disabled and Initiative only accepts its own
+    # session tokens / API keys.
+    AUTO_DELEGATION_PUBLIC_KEY_PEM: str | None = None
+    AUTO_DELEGATION_AUDIENCE: str = "initiative:auto-delegation"
+    AUTO_DELEGATION_ISSUER: str = "initiative-auto"
+
     BEHIND_PROXY: bool = False  # Set True when behind nginx/load balancer to trust X-Forwarded-For
 
     @field_validator("AUTO_APPROVED_EMAIL_DOMAINS", mode="before")

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -122,3 +123,81 @@ def create_advanced_tool_handoff_token(
     headers: dict[str, Any] | None = {"kid": kid} if kid else None
     token = jwt.encode(payload, key, algorithm=algorithm, headers=headers)
     return token, int(expires_in.total_seconds())
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Inbound delegation from initiative-auto
+#
+# When auto calls our API on behalf of a user, it presents a JWT signed
+# with its private key (RS256). We verify here using the public half
+# configured at AUTO_DELEGATION_PUBLIC_KEY_PEM and resolve the JWT to a
+# user_id that the auth dependency then loads as a User. From that
+# point on the request runs through our normal RLS + role-permission
+# stack — the delegation just answers "who is acting", not "what can
+# they do".
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AutoDelegationClaims:
+    """Validated payload of a delegation JWT minted by initiative-auto."""
+
+    jti: str
+    user_id: int
+    guild_id: int
+    initiative_id: int | None
+    workflow_id: int | None
+
+
+class AutoDelegationVerificationError(Exception):
+    """Raised when the inbound delegation JWT fails any check."""
+
+
+def verify_auto_delegation_token(token: str) -> AutoDelegationClaims:
+    """Verify a delegation JWT minted by initiative-auto.
+
+    Disabled when ``AUTO_DELEGATION_PUBLIC_KEY_PEM`` is unset — that
+    config gap surfaces as a verification error so the auth dep can
+    fall through to its other token paths instead of 500'ing.
+    """
+    if not settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
+        raise AutoDelegationVerificationError("delegation auth not configured")
+
+    try:
+        payload = jwt.decode(
+            token,
+            settings.AUTO_DELEGATION_PUBLIC_KEY_PEM,
+            algorithms=["RS256"],
+            audience=settings.AUTO_DELEGATION_AUDIENCE,
+            issuer=settings.AUTO_DELEGATION_ISSUER,
+            options={"require": ["exp", "iat", "iss", "aud", "sub", "jti"]},
+        )
+    except jwt.PyJWTError as e:
+        raise AutoDelegationVerificationError(f"jwt verification failed: {e}") from e
+
+    try:
+        user_id = int(payload["sub"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise AutoDelegationVerificationError(
+            f"sub must be a numeric user id: {e}"
+        ) from e
+
+    guild_id = payload.get("guild_id")
+    if not isinstance(guild_id, int):
+        raise AutoDelegationVerificationError("guild_id must be an int")
+
+    initiative_id = payload.get("initiative_id")
+    if initiative_id is not None and not isinstance(initiative_id, int):
+        raise AutoDelegationVerificationError("initiative_id must be an int when present")
+
+    workflow_id = payload.get("workflow_id")
+    if workflow_id is not None and not isinstance(workflow_id, int):
+        raise AutoDelegationVerificationError("workflow_id must be an int when present")
+
+    return AutoDelegationClaims(
+        jti=str(payload["jti"]),
+        user_id=user_id,
+        guild_id=guild_id,
+        initiative_id=initiative_id,
+        workflow_id=workflow_id,
+    )

--- a/backend/app/models/auto_delegation_jti.py
+++ b/backend/app/models/auto_delegation_jti.py
@@ -1,0 +1,35 @@
+"""Blocklist of redeemed delegation JWT ids minted by initiative-auto.
+
+Each row corresponds to a one-time redemption of a delegation token.
+A second presentation of the same ``jti`` must be rejected even though
+the JWT itself is still within its 15-minute lifetime.
+
+``expires_at`` mirrors the JWT's ``exp`` so a periodic janitor can
+keep the table small.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, String
+from sqlmodel import Field, SQLModel
+
+
+class AutoDelegationJti(SQLModel, table=True):
+    __tablename__ = "auto_delegation_jti_blocklist"
+
+    # Columns are declared with explicit ``sa_column`` so the ORM emits
+    # ``TIMESTAMP WITH TIME ZONE`` casts that match the migration. With a
+    # naked ``datetime`` annotation SQLModel infers TZ-naive and asyncpg
+    # refuses to bind the TZ-aware values produced by
+    # ``datetime.now(timezone.utc)``.
+    jti: str = Field(
+        sa_column=Column(String(length=64), primary_key=True),
+    )
+    redeemed_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/app/services/auto_delegation_blocklist.py
+++ b/backend/app/services/auto_delegation_blocklist.py
@@ -1,0 +1,67 @@
+"""Persistence layer for the delegation-token jti blocklist.
+
+Two operations:
+
+* :func:`record_jti` — insert a fresh row. Surfaces the unique-violation
+  on the primary key as :class:`DelegationReplayError` so the caller can
+  return 401 cleanly.
+* :func:`is_jti_redeemed` — check before doing the work. Used as a fast
+  pre-flight so we don't waste cycles loading the user record on a
+  token we're about to reject.
+
+Both are idempotent under retry: if a connection drops mid-insert we
+either succeed or hit the unique violation, never silently allow a
+second redemption.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.auto_delegation_jti import AutoDelegationJti
+
+
+class DelegationReplayError(Exception):
+    """Raised when a delegation jti has already been redeemed."""
+
+
+async def is_jti_redeemed(session: AsyncSession, jti: str) -> bool:
+    """Return ``True`` if ``jti`` is already in the blocklist."""
+    existing = (
+        await session.exec(
+            select(AutoDelegationJti).where(AutoDelegationJti.jti == jti)
+        )
+    ).one_or_none()
+    return existing is not None
+
+
+async def record_jti(
+    session: AsyncSession,
+    *,
+    jti: str,
+    expires_at: datetime,
+) -> None:
+    """Persist ``jti`` so a second presentation can be rejected.
+
+    Raises :class:`DelegationReplayError` on a unique-violation, which
+    can fire if two requests carrying the same token race past the
+    pre-flight ``is_jti_redeemed`` check. Either is the correct refuse
+    signal — the second presentation should never succeed regardless of
+    which branch wins the race.
+    """
+    session.add(
+        AutoDelegationJti(
+            jti=jti,
+            redeemed_at=datetime.now(timezone.utc),
+            expires_at=expires_at,
+        )
+    )
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise DelegationReplayError(f"jti {jti} already redeemed") from exc


### PR DESCRIPTION
## Summary

- Adds an inbound auth path on Initiative that accepts RS256-signed delegation JWTs from `initiative-auto`. Validates the signature with a configured public key, resolves the JWT's `sub` to a `User`, then runs the request through the **existing** RLS + role-permission + master-switch stack.
- The delegation flow only answers "who is acting" — never "what can they do." Whatever the user can't do directly, they can't do via a workflow either.

## Why

`initiative-auto` needs to call Initiative's API on behalf of users — both interactively (the user is in the iframe right now) and asynchronously (a workflow they own is firing). Two non-options:

- **Shared secret / service token impersonating any user** — a leak compromises every account.
- **A new authorization layer just for auto** — duplicates the rules we already enforce per-user, drifts over time.

Delegation tokens fit between those: auto holds a private key, Initiative holds the public half. Tokens are short-lived (15min) and per-user. Initiative's existing per-user authz runs unchanged.

## What's new

### `core/security.py`

- `AutoDelegationClaims` dataclass — `jti`, `user_id`, `guild_id`, optional `initiative_id`, optional `workflow_id`.
- `verify_auto_delegation_token(token)` — RS256 verify against `AUTO_DELEGATION_PUBLIC_KEY_PEM`, audience + issuer check, required-claims check. Raises `AutoDelegationVerificationError` on any failure.

### `core/config.py`

Three new optional env vars (all None / disabled by default):

- `AUTO_DELEGATION_PUBLIC_KEY_PEM` — the public half of auto's signing keypair.
- `AUTO_DELEGATION_AUDIENCE` (default `initiative:auto-delegation`)
- `AUTO_DELEGATION_ISSUER` (default `initiative-auto`)

When `AUTO_DELEGATION_PUBLIC_KEY_PEM` is unset, the verifier short-circuits and the delegation path returns None — Initiative behaves exactly as before for OSS deployments.

### `api/deps.py`

`_authenticate_auto_delegation(session, token)` slots into `get_current_user`'s existing auth chain after API-key auth, before standard JWT decode. Returns None on:
- Public key not configured (delegation disabled)
- Token verification failure (any reason — could be a regular session JWT arriving on the same `Authorization: Bearer` header)
- The named user doesn't exist or isn't `active` (deactivated/anonymized accounts can't be impersonated, so workflows die when their owner leaves — by design)

Falls through to the next auth method on None. Real authn failure surfaces as 401 from the standard JWT path, not from delegation.

## What's not changed

- No endpoint changes — `/users/me`, `/api/v1/initiatives/...`, etc. all accept delegation tokens automatically because they go through the same `get_current_user` dep.
- No new tables / migrations.
- No regression on existing auth paths: 56 auth + users integration tests still pass.

## Smoke test

Manually verified end-to-end against a running `initiative-auto`:

1. Generated a 2048-bit RSA keypair (`openssl genrsa -out auto-delegation.pem 2048; openssl rsa -in ... -pubout`).
2. Set `AUTO_DELEGATION_PRIVATE_KEY_PEM` on auto, `AUTO_DELEGATION_PUBLIC_KEY_PEM` here.
3. Restarted both backends.
4. Opened the embed in Initiative; the iframe's HelloPage rendered:
   - Local session claims (from auto's own JWT) ✓
   - **`Full name: Admin User · Email: admin@example.com` from Initiative's `/users/me`** ✓ — proves the delegation chain works.

## Test plan

- [x] `cd backend && ruff check app` — clean
- [x] `cd backend && pytest app/api/v1/endpoints/auth_test.py app/api/v1/endpoints/users_test.py` — 56 pass
- [x] Manual end-to-end: full_name + email round-trip from Initiative through delegation JWT
- [ ] Generate a keypair: `openssl genrsa -out auto.pem 2048 && openssl rsa -in auto.pem -pubout -out auto.pub`
- [ ] Set `AUTO_DELEGATION_PUBLIC_KEY_PEM=$(cat auto.pub)` in `backend/.env`
- [ ] Set `AUTO_DELEGATION_PRIVATE_KEY_PEM=$(cat auto.pem)` in `initiative_auto/.env`
- [ ] Restart Initiative backend, restart `initiative-auto`
- [ ] Confirm the embed's HelloPage shows the user's `full_name` from Initiative

## What's next

This is PR1 of the auto ↔ Initiative integration. Follow-ons:

- **PR2**: Webhook subscriptions + dispatch — Initiative emits events on writes, auto subscribes per workflow.
- **PR3**: Workflow ownership model on auto — workflows store `owner_user_id`, runs delegate as the owner regardless of session.
- **PR4**: Audit log gets `via_workflow_id` column so writes can be traced back to specific workflow runs.

The receiving side of this contract is committed in `initiative_auto` at `544b34f`.