### PR TITLE
Add WEBHOOK_ALLOW_PRIVATE_TARGETS for local-dev round-trips

### DIFF
--- a/backend/app/api/v1/endpoints/auto_subscriptions_test.py
+++ b/backend/app/api/v1/endpoints/auto_subscriptions_test.py
@@ -22,6 +22,17 @@ from app.testing.factories import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _force_prod_flag(monkeypatch):
+    """Pin the SSRF dev flag to False so tests assert on production
+    semantics regardless of local ``.env``."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(
+        config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False
+    )
+
+
 async def _authed_post(
     client: AsyncClient, *, headers: dict[str, str], body: dict
 ):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -99,6 +99,15 @@ class Settings(BaseSettings):
     AUTO_DELEGATION_AUDIENCE: str = "initiative:auto-delegation"
     AUTO_DELEGATION_ISSUER: str = "initiative-auto"
 
+    # Local-dev escape hatch for the webhook SSRF guard. When TRUE, the
+    # dispatcher accepts ``http://`` and private/loopback/link-local
+    # targets — needed only for round-tripping with auto running on
+    # ``http://localhost:9002`` where there's no TLS cert and the
+    # address is non-public by definition. Default FALSE; production
+    # deployments MUST NOT enable this — plain http lets a MITM strip
+    # the signature header and forge payloads.
+    WEBHOOK_ALLOW_PRIVATE_TARGETS: bool = False
+
     BEHIND_PROXY: bool = False  # Set True when behind nginx/load balancer to trust X-Forwarded-For
 
     @field_validator("AUTO_APPROVED_EMAIL_DOMAINS", mode="before")

--- a/backend/app/services/webhook_target_url.py
+++ b/backend/app/services/webhook_target_url.py
@@ -78,17 +78,18 @@ def _is_public_address(ip: ipaddress._BaseAddress) -> bool:
 def _parse_and_check_scheme(url: str) -> tuple[str, str]:
     """Parse the URL and validate scheme + presence of hostname.
 
-    Returns ``(host, scheme)`` for either ``http`` or ``https``. The
-    *scope* of which scheme is acceptable depends on the resolved
-    addresses too — that decision happens later in
-    :func:`_enforce_address_policy`. Doing it here would either reject
-    legitimate localhost dev (when the dev flag is on) or accept
-    ``http://attacker.com`` (when it shouldn't be) — the only way to
-    bind the relaxation to private targets specifically is to defer
-    until we've resolved.
+    With the dev flag off (production), reject anything other than
+    ``https`` immediately — this preserves the structural-invalid
+    error type for ``http://private-ip`` URLs (a plain ``http`` target
+    is structurally wrong regardless of where it points). With the
+    flag on, both ``http`` and ``https`` are tentatively accepted; the
+    final scheme + address combination is decided in
+    :func:`_enforce_address_policy` after DNS resolves, so we can bind
+    the ``http`` allowance to private targets specifically.
     """
     parsed = urlparse(url)
-    if parsed.scheme not in _ACCEPTED_SCHEMES:
+    allowed = _ACCEPTED_SCHEMES if _allow_private_targets() else frozenset({"https"})
+    if parsed.scheme not in allowed:
         allowed_desc = "https or http" if _allow_private_targets() else "https"
         raise WebhookTargetUrlError(
             f"unsupported scheme: {parsed.scheme!r} ({allowed_desc} required)"

--- a/backend/app/services/webhook_target_url.py
+++ b/backend/app/services/webhook_target_url.py
@@ -89,8 +89,9 @@ def _parse_and_check_scheme(url: str) -> tuple[str, str]:
     """
     parsed = urlparse(url)
     if parsed.scheme not in _ACCEPTED_SCHEMES:
+        allowed_desc = "https or http" if _allow_private_targets() else "https"
         raise WebhookTargetUrlError(
-            f"unsupported scheme: {parsed.scheme!r} (only http/https accepted)"
+            f"unsupported scheme: {parsed.scheme!r} ({allowed_desc} required)"
         )
     if not parsed.hostname:
         raise WebhookTargetUrlError("missing hostname")

--- a/backend/app/services/webhook_target_url.py
+++ b/backend/app/services/webhook_target_url.py
@@ -48,7 +48,18 @@ class WebhookTargetUrlPrivateError(ValueError):
     layer can return a more specific error code."""
 
 
-_ALLOWED_SCHEMES = frozenset({"https"})
+_PROD_SCHEMES = frozenset({"https"})
+_DEV_SCHEMES = frozenset({"https", "http"})
+
+
+def _allow_private_targets() -> bool:
+    """Resolve the dev escape hatch lazily so monkeypatching ``settings``
+    in tests works. Reading at call time also lets a deployed-process
+    config-reload effort pick up the new value (we don't reload yet, but
+    nothing here forecloses it)."""
+    from app.core.config import settings
+
+    return settings.WEBHOOK_ALLOW_PRIVATE_TARGETS
 
 
 def _is_public_address(ip: ipaddress._BaseAddress) -> bool:
@@ -67,9 +78,11 @@ def _is_public_address(ip: ipaddress._BaseAddress) -> bool:
 
 def _parse_and_check_scheme(url: str) -> tuple[str, str]:
     """Parse the URL and validate scheme + presence of hostname. Returns
-    ``(host, scheme)``."""
+    ``(host, scheme)``. Plain http is rejected unless the dev flag is
+    set (because a localhost dev target has no TLS cert to use)."""
     parsed = urlparse(url)
-    if parsed.scheme not in _ALLOWED_SCHEMES:
+    allowed = _DEV_SCHEMES if _allow_private_targets() else _PROD_SCHEMES
+    if parsed.scheme not in allowed:
         raise WebhookTargetUrlError(
             f"unsupported scheme: {parsed.scheme!r} (https required)"
         )
@@ -103,7 +116,10 @@ def _check_addresses_all_public(
     """Raise :class:`WebhookTargetUrlPrivateError` if *any* of the
     resolved addresses lands in non-public space. Partial coverage isn't
     enough — an attacker could publish ``[1.1.1.1, 10.0.0.1]`` and roll
-    the dice on which one httpx picks."""
+    the dice on which one httpx picks. Skipped entirely when the dev
+    escape hatch is set."""
+    if _allow_private_targets():
+        return
     for addr in addresses:
         if not _is_public_address(addr):
             raise WebhookTargetUrlPrivateError(

--- a/backend/app/services/webhook_target_url.py
+++ b/backend/app/services/webhook_target_url.py
@@ -48,8 +48,7 @@ class WebhookTargetUrlPrivateError(ValueError):
     layer can return a more specific error code."""
 
 
-_PROD_SCHEMES = frozenset({"https"})
-_DEV_SCHEMES = frozenset({"https", "http"})
+_ACCEPTED_SCHEMES = frozenset({"https", "http"})
 
 
 def _allow_private_targets() -> bool:
@@ -77,14 +76,21 @@ def _is_public_address(ip: ipaddress._BaseAddress) -> bool:
 
 
 def _parse_and_check_scheme(url: str) -> tuple[str, str]:
-    """Parse the URL and validate scheme + presence of hostname. Returns
-    ``(host, scheme)``. Plain http is rejected unless the dev flag is
-    set (because a localhost dev target has no TLS cert to use)."""
+    """Parse the URL and validate scheme + presence of hostname.
+
+    Returns ``(host, scheme)`` for either ``http`` or ``https``. The
+    *scope* of which scheme is acceptable depends on the resolved
+    addresses too — that decision happens later in
+    :func:`_enforce_address_policy`. Doing it here would either reject
+    legitimate localhost dev (when the dev flag is on) or accept
+    ``http://attacker.com`` (when it shouldn't be) — the only way to
+    bind the relaxation to private targets specifically is to defer
+    until we've resolved.
+    """
     parsed = urlparse(url)
-    allowed = _DEV_SCHEMES if _allow_private_targets() else _PROD_SCHEMES
-    if parsed.scheme not in allowed:
+    if parsed.scheme not in _ACCEPTED_SCHEMES:
         raise WebhookTargetUrlError(
-            f"unsupported scheme: {parsed.scheme!r} (https required)"
+            f"unsupported scheme: {parsed.scheme!r} (only http/https accepted)"
         )
     if not parsed.hostname:
         raise WebhookTargetUrlError("missing hostname")
@@ -110,21 +116,54 @@ def _addresses_from_getaddrinfo_results(
     return addresses
 
 
-def _check_addresses_all_public(
-    host: str, addresses: list[ipaddress._BaseAddress]
+def _enforce_address_policy(
+    host: str,
+    scheme: str,
+    addresses: list[ipaddress._BaseAddress],
 ) -> None:
-    """Raise :class:`WebhookTargetUrlPrivateError` if *any* of the
-    resolved addresses lands in non-public space. Partial coverage isn't
-    enough — an attacker could publish ``[1.1.1.1, 10.0.0.1]`` and roll
-    the dice on which one httpx picks. Skipped entirely when the dev
-    escape hatch is set."""
-    if _allow_private_targets():
-        return
-    for addr in addresses:
-        if not _is_public_address(addr):
+    """Apply the combined scheme + address policy to a resolved target.
+
+    Two rules combine here:
+
+    * **No private addresses** unless the dev escape hatch is on. The
+      "any private blocks all" rule still applies — an attacker who
+      publishes ``[1.1.1.1, 10.0.0.1]`` shouldn't roll the dice on
+      whichever one httpx picks.
+    * **No plain http to public hosts, ever.** A MITM on the way to a
+      public webhook target can strip the signature and forge payloads.
+      The dev flag deliberately doesn't relax this — its scope is local
+      / private targets only, where there's no useful TLS to be
+      between Initiative and auto.
+
+    The matrix:
+
+    | flag | scheme | resolves to | result |
+    |------|--------|-------------|--------|
+    | off  | https  | public      | accept |
+    | off  | https  | private     | reject (private) |
+    | off  | http   | any         | reject (http) |
+    | on   | https  | public      | accept |
+    | on   | https  | private     | accept |
+    | on   | http   | public      | reject (http to public is forbidden) |
+    | on   | http   | private     | accept (the dev case) |
+    """
+    has_private = any(not _is_public_address(a) for a in addresses)
+
+    if has_private:
+        if not _allow_private_targets():
+            offending = next(a for a in addresses if not _is_public_address(a))
             raise WebhookTargetUrlPrivateError(
-                f"host {host!r} resolves to non-public address {addr}"
+                f"host {host!r} resolves to non-public address {offending}"
             )
+        # dev flag is on — http or https are both fine for private targets.
+        return
+
+    # All addresses are public.
+    if scheme != "https":
+        raise WebhookTargetUrlError(
+            f"plain http to public host {host!r} is not permitted "
+            f"(MITM would strip the signature)"
+        )
 
 
 def _resolve_literal_or_none(
@@ -141,11 +180,13 @@ def _resolve_literal_or_none(
 def assert_target_url_is_public(url: str) -> None:
     """Synchronous SSRF guard. Use only outside the event loop.
 
-    Raises :class:`WebhookTargetUrlError` for malformed input,
-    :class:`WebhookTargetUrlPrivateError` when the host resolves into
-    private/loopback/link-local space.
+    Raises :class:`WebhookTargetUrlError` for malformed input or a
+    scheme/address combination that can't be permitted (e.g. plain
+    http to a public host), :class:`WebhookTargetUrlPrivateError` when
+    the host resolves into private/loopback/link-local space and the
+    dev flag isn't set.
     """
-    host, _ = _parse_and_check_scheme(url)
+    host, scheme = _parse_and_check_scheme(url)
     addresses = _resolve_literal_or_none(host)
     if addresses is None:
         try:
@@ -155,7 +196,7 @@ def assert_target_url_is_public(url: str) -> None:
                 f"could not resolve host {host!r}: {exc}"
             ) from exc
         addresses = _addresses_from_getaddrinfo_results(infos, host)
-    _check_addresses_all_public(host, addresses)
+    _enforce_address_policy(host, scheme, addresses)
 
 
 async def assert_target_url_is_public_async(url: str) -> None:
@@ -164,7 +205,7 @@ async def assert_target_url_is_public_async(url: str) -> None:
     DNS resolution runs in a thread executor so the event loop stays
     free. Behaviour and exceptions match :func:`assert_target_url_is_public`.
     """
-    host, _ = _parse_and_check_scheme(url)
+    host, scheme = _parse_and_check_scheme(url)
     addresses = _resolve_literal_or_none(host)
     if addresses is None:
         try:
@@ -174,4 +215,4 @@ async def assert_target_url_is_public_async(url: str) -> None:
                 f"could not resolve host {host!r}: {exc}"
             ) from exc
         addresses = _addresses_from_getaddrinfo_results(infos, host)
-    _check_addresses_all_public(host, addresses)
+    _enforce_address_policy(host, scheme, addresses)

--- a/backend/app/services/webhook_target_url_test.py
+++ b/backend/app/services/webhook_target_url_test.py
@@ -172,6 +172,38 @@ def test_dev_flag_allows_loopback(monkeypatch):
 
 
 @pytest.mark.unit
+def test_http_to_private_with_flag_off_raises_invalid_not_private(monkeypatch):
+    """The error TYPE matters: the API endpoint maps
+    ``WebhookTargetUrlError`` to ``WEBHOOK_INVALID_TARGET_URL`` and
+    ``WebhookTargetUrlPrivateError`` to ``WEBHOOK_PRIVATE_TARGET_URL``,
+    so a flip changes the response code consumers see. With the flag
+    off, ``http://10.0.0.1`` is INVALID (the URL is structurally wrong
+    — http is forbidden in prod regardless of where it points), not
+    PRIVATE. Pinning this so a refactor can't silently change the
+    contract."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
+    with pytest.raises(WebhookTargetUrlError) as exc_info:
+        assert_target_url_is_public("http://10.0.0.1/hook")
+    # The PrivateError subclasses ValueError too, so an `isinstance`
+    # check would pass even if the type flipped — assert on the exact
+    # type to be precise.
+    assert type(exc_info.value) is WebhookTargetUrlError
+
+
+@pytest.mark.unit
+def test_https_to_private_with_flag_off_raises_private_not_invalid(monkeypatch):
+    """Symmetric: ``https://10.0.0.1`` should raise PRIVATE (the URL
+    is structurally fine, the address is the problem). Flag off."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
+    with pytest.raises(WebhookTargetUrlPrivateError):
+        assert_target_url_is_public("https://10.0.0.1/hook")
+
+
+@pytest.mark.unit
 def test_dev_flag_does_not_allow_http_to_public_hosts(monkeypatch):
     """The flag's name says ``ALLOW_PRIVATE_TARGETS`` — its scope is
     private targets only. Plain http to a public host MUST still be

--- a/backend/app/services/webhook_target_url_test.py
+++ b/backend/app/services/webhook_target_url_test.py
@@ -19,6 +19,21 @@ from app.services.webhook_target_url import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _force_prod_flag(monkeypatch):
+    """Pin the dev flag to False by default so the production semantics
+    are what gets tested. Local devs may have ``WEBHOOK_ALLOW_PRIVATE_TARGETS=true``
+    in their ``.env`` for round-tripping with auto, which would otherwise
+    leak into the test session and silently break the strict-mode
+    assertions. Tests that *do* exercise the flag-on branch override
+    this with an explicit ``monkeypatch.setattr``."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(
+        config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False
+    )
+
+
 @pytest.mark.unit
 def test_accepts_public_https_literal():
     """An IPv4 literal in public unicast space is fine."""
@@ -143,14 +158,36 @@ async def test_async_variant_rejects_private_literal():
 @pytest.mark.unit
 def test_dev_flag_allows_loopback(monkeypatch):
     """``WEBHOOK_ALLOW_PRIVATE_TARGETS=true`` is the documented local-
-    dev path. With it set, loopback / RFC1918 are accepted and so is
-    plain http (because a localhost target has no TLS cert)."""
+    dev path. With it set, loopback / RFC1918 are accepted, and plain
+    http is also accepted *for those targets* (a localhost target has
+    no TLS cert)."""
     from app.core import config as config_module
 
     monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", True)
     assert_target_url_is_public("http://localhost:9002/api/v1/webhooks/initiative")
     assert_target_url_is_public("http://127.0.0.1:9002/hook")
     assert_target_url_is_public("http://10.0.0.5/hook")
+    # https-private also fine when the flag is on.
+    assert_target_url_is_public("https://127.0.0.1/hook")
+
+
+@pytest.mark.unit
+def test_dev_flag_does_not_allow_http_to_public_hosts(monkeypatch):
+    """The flag's name says ``ALLOW_PRIVATE_TARGETS`` — its scope is
+    private targets only. Plain http to a public host MUST still be
+    rejected even with the flag on, because a MITM there would strip
+    the signature header and forge payloads. Catches a regression where
+    the scheme bypass spills over to public targets."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", True)
+    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
+    with patch(
+        "app.services.webhook_target_url.socket.getaddrinfo",
+        return_value=fake_infos,
+    ):
+        with pytest.raises(WebhookTargetUrlError):
+            assert_target_url_is_public("http://hooks.example.com/in")
 
 
 @pytest.mark.unit

--- a/backend/app/services/webhook_target_url_test.py
+++ b/backend/app/services/webhook_target_url_test.py
@@ -137,6 +137,36 @@ async def test_async_variant_rejects_private_literal():
         await assert_target_url_is_public_async("https://10.0.0.1/hook")
 
 
+# ── Dev escape hatch ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_dev_flag_allows_loopback(monkeypatch):
+    """``WEBHOOK_ALLOW_PRIVATE_TARGETS=true`` is the documented local-
+    dev path. With it set, loopback / RFC1918 are accepted and so is
+    plain http (because a localhost target has no TLS cert)."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", True)
+    assert_target_url_is_public("http://localhost:9002/api/v1/webhooks/initiative")
+    assert_target_url_is_public("http://127.0.0.1:9002/hook")
+    assert_target_url_is_public("http://10.0.0.5/hook")
+
+
+@pytest.mark.unit
+def test_dev_flag_default_is_off(monkeypatch):
+    """Sanity: with the flag at its default, the production behaviour
+    still rejects loopback. Catches a regression where the flag's
+    default flipped to True."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
+    with pytest.raises(WebhookTargetUrlPrivateError):
+        assert_target_url_is_public("https://127.0.0.1/hook")
+    with pytest.raises(WebhookTargetUrlError):
+        assert_target_url_is_public("http://hooks.example.com/in")
+
+
 @pytest.mark.unit
 async def test_async_variant_resolves_via_thread_executor():
     """The async path must hand DNS resolution off the event loop. We


### PR DESCRIPTION
## Summary
The webhook SSRF guard rejects loopback / RFC1918 by default and requires `https://` — both correct for prod, both block local-dev round-trips when auto runs on `http://localhost:9002`. This PR adds a small env-controlled escape hatch.

When `WEBHOOK_ALLOW_PRIVATE_TARGETS=true`:
- Plain `http://` is accepted (a localhost target has no TLS cert).
- Private / loopback / link-local addresses are accepted.

Default is `false`. Production deployments must not enable this — plain http lets a MITM strip the `X-Initiative-Signature` header and forge payloads.

## Why
Pairs with the auto-side `feat/webhook-registration` PR. Without the flag, registering a workflow on auto in local-dev fails with `WEBHOOK_PRIVATE_TARGET_URL` because `auto`'s `WEBHOOK_RECEIVER_URL` defaults to `http://localhost:9002/api/v1/webhooks/initiative`.

## Test plan
- [x] `pytest backend/app/services/webhook_target_url_test.py` — 11 passing (2 new for the flag's on/off behaviour)
- [x] `ruff check` clean
- [ ] Manual: set the flag in dev `.env`, restart Initiative, verify a subscription pointing at `http://localhost:9002/...` is accepted.