### PR TITLE
Render changelog entries as markdown in the version dialog

### DIFF
--- a/backend/app/api/v1/endpoints/version.py
+++ b/backend/app/api/v1/endpoints/version.py
@@ -74,7 +74,6 @@ def get_changelog(version: Optional[str] = None, limit: int = 1) -> dict[str, li
 
     If version is provided, returns changes for that specific version.
     If not provided, returns the most recent N versions (default 1).
-    Limit parameter controls how many recent versions to return (max 10).
     """
     try:
         # Try Docker path first: /app/app/api/v1/endpoints/version.py -> /app/CHANGELOG.md
@@ -96,8 +95,7 @@ def get_changelog(version: Optional[str] = None, limit: int = 1) -> dict[str, li
         matches = re.findall(pattern, content, re.DOTALL)
 
         entries = []
-        # Clamp limit to max 10
-        max_entries = min(limit, 10) if not version else len(matches)
+        max_entries = limit if not version else len(matches)
 
         for version_num, date, changes in matches:
             # Skip if user requested a specific version and this isn't it

--- a/frontend/src/api/generated/version/version.ts
+++ b/frontend/src/api/generated/version/version.ts
@@ -306,7 +306,6 @@ export function useGetLatestDockerhubVersionApiV1VersionLatestGet<
 
 If version is provided, returns changes for that specific version.
 If not provided, returns the most recent N versions (default 1).
-Limit parameter controls how many recent versions to return (max 10).
  * @summary Get Changelog
  */
 export const getChangelogApiV1ChangelogGet = (

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -58,7 +58,7 @@ export const Markdown = ({ content, className }: MarkdownProps) => {
   return (
     <div
       className={cn(
-        "text-muted-foreground [&_a]:text-primary wrap-break-words space-y-3 text-sm **:leading-relaxed [&_a]:break-all [&_a:hover]:underline [&_h1]:mt-4 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-3 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:text-base [&_h3]:font-semibold [&_h4]:mt-2 [&_h4]:text-sm [&_h4]:font-semibold [&_h5]:mt-2 [&_h5]:text-sm [&_h5]:font-medium [&_h6]:mt-2 [&_h6]:text-xs [&_h6]:font-semibold [&_li]:mt-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-6",
+        "text-muted-foreground [&_a]:text-primary space-y-3 text-sm wrap-break-word **:leading-relaxed [&_a]:break-all [&_a:hover]:underline [&_h1]:mt-4 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-3 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:text-base [&_h3]:font-semibold [&_h4]:mt-2 [&_h4]:text-sm [&_h4]:font-semibold [&_h5]:mt-2 [&_h5]:text-sm [&_h5]:font-medium [&_h6]:mt-2 [&_h6]:text-xs [&_h6]:font-semibold [&_li]:mt-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-6",
         className
       )}
     >

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -58,7 +58,7 @@ export const Markdown = ({ content, className }: MarkdownProps) => {
   return (
     <div
       className={cn(
-        "text-muted-foreground [&_a]:text-primary space-y-3 text-sm break-words [&_*]:leading-relaxed [&_a]:break-all [&_a:hover]:underline [&_h1]:mt-4 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-3 [&_h2]:text-lg [&_h2]:font-semibold [&_li]:mt-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-6",
+        "text-muted-foreground [&_a]:text-primary wrap-break-words space-y-3 text-sm **:leading-relaxed [&_a]:break-all [&_a:hover]:underline [&_h1]:mt-4 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-3 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:text-base [&_h3]:font-semibold [&_h4]:mt-2 [&_h4]:text-sm [&_h4]:font-semibold [&_h5]:mt-2 [&_h5]:text-sm [&_h5]:font-medium [&_h6]:mt-2 [&_h6]:text-xs [&_h6]:font-semibold [&_li]:mt-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-6",
         className
       )}
     >

--- a/frontend/src/components/VersionDialog.tsx
+++ b/frontend/src/components/VersionDialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Markdown } from "@/components/Markdown";
 import { useChangelog } from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
 
@@ -62,63 +63,6 @@ export const VersionDialog = ({
 
   const handleReload = () => {
     window.location.reload();
-  };
-
-  interface ChangelogItem {
-    text: string;
-    children: string[];
-  }
-
-  // Parse changelog markdown into sections with nested items
-  const parseChangelog = (text: string) => {
-    const sections: { title: string; items: ChangelogItem[] }[] = [];
-    const lines = text.split("\n");
-
-    let currentSection: { title: string; items: ChangelogItem[] } | null = null;
-    let currentItem: ChangelogItem | null = null;
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-
-      // Section headers like "### Added"
-      if (trimmed.startsWith("### ")) {
-        if (currentSection) {
-          if (currentItem) {
-            currentSection.items.push(currentItem);
-            currentItem = null;
-          }
-          sections.push(currentSection);
-        }
-        currentSection = {
-          title: trimmed.replace("### ", ""),
-          items: [],
-        };
-      }
-      // Nested list items (indented with spaces before "- ")
-      else if (line.match(/^\s{2,}- /) && currentItem && currentSection) {
-        currentItem.children.push(trimmed.replace("- ", ""));
-      }
-      // Top-level list items
-      else if (trimmed.startsWith("- ") && currentSection) {
-        if (currentItem) {
-          currentSection.items.push(currentItem);
-        }
-        currentItem = {
-          text: trimmed.replace("- ", ""),
-          children: [],
-        };
-      }
-    }
-
-    // Don't forget the last item and section
-    if (currentSection) {
-      if (currentItem) {
-        currentSection.items.push(currentItem);
-      }
-      sections.push(currentSection);
-    }
-
-    return sections;
   };
 
   const dialogContent = (
@@ -206,60 +150,27 @@ export const VersionDialog = ({
           ) : data?.entries && data.entries.length > 0 ? (
             <ScrollArea className="flex-1">
               <div className="space-y-6 pr-6">
-                {data.entries.map((entry, entryIdx) => {
-                  const sections = parseChangelog(entry.changes);
-                  return (
-                    <div key={entry.version} className={entryIdx > 0 ? "border-t pt-6" : ""}>
-                      <div className="mb-4 border-b pb-2">
-                        <div className="flex items-center gap-2">
-                          <h4 className="text-base font-semibold">
-                            {t("version.version", { version: entry.version })}
-                          </h4>
-                          <Badge variant="outline" className="text-xs">
-                            {entry.date}
-                          </Badge>
-                        </div>
+                {data.entries.map((entry, entryIdx) => (
+                  <div key={entry.version} className={entryIdx > 0 ? "border-t pt-6" : ""}>
+                    <div className="mb-4 border-b pb-2">
+                      <div className="flex items-center gap-2">
+                        <h4 className="text-base font-semibold">
+                          {t("version.version", { version: entry.version })}
+                        </h4>
+                        <Badge variant="outline" className="text-xs">
+                          {entry.date}
+                        </Badge>
                       </div>
-
-                      {sections.length > 0 ? (
-                        <div className="space-y-4">
-                          {sections.map((section, idx) => (
-                            <div key={idx}>
-                              <h5 className="mb-2 text-sm font-semibold">{section.title}</h5>
-                              <ul className="text-muted-foreground space-y-1 text-sm">
-                                {section.items.map((item, itemIdx) => (
-                                  <li key={itemIdx}>
-                                    <div className="flex gap-2">
-                                      <span className="text-primary shrink-0">•</span>
-                                      <span>{item.text}</span>
-                                    </div>
-                                    {item.children.length > 0 && (
-                                      <ul className="mt-1 ml-4 space-y-1">
-                                        {item.children.map((child, childIdx) => (
-                                          <li key={childIdx} className="flex gap-2">
-                                            {/* eslint-disable-next-line i18next/no-literal-string */}
-                                            <span className="text-muted-foreground shrink-0">
-                                              ◦
-                                            </span>
-                                            <span>{child}</span>
-                                          </li>
-                                        ))}
-                                      </ul>
-                                    )}
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="text-muted-foreground text-sm">
-                          {t("version.noDetailedChanges")}
-                        </p>
-                      )}
                     </div>
-                  );
-                })}
+                    {entry.changes.trim() ? (
+                      <Markdown content={entry.changes} />
+                    ) : (
+                      <p className="text-muted-foreground text-sm">
+                        {t("version.noDetailedChanges")}
+                      </p>
+                    )}
+                  </div>
+                ))}
               </div>
             </ScrollArea>
           ) : (

--- a/frontend/src/components/VersionDialog.tsx
+++ b/frontend/src/components/VersionDialog.tsx
@@ -47,7 +47,7 @@ export const VersionDialog = ({
   // In update mode, show the new version's changelog only
   // In info mode, show last 5 versions
   const versionToShow = mode === "update" && newVersion ? newVersion : undefined;
-  const limit = mode === "update" ? 1 : 5;
+  const limit = mode === "update" ? 1 : 20;
 
   const changelogParams: { version?: string; limit?: number } = {};
   if (versionToShow) {


### PR DESCRIPTION
## Summary

The version dialog had a hand-rolled parser that walked the raw markdown returned by `/api/v1/changelog`, extracted `### Section` titles and `- bullets`, then rendered each text node as a plain `<span>{item.text}</span>`. Inline markdown like `**bold**`, `[links](…)` and `` `code` `` showed the raw characters instead of formatting; anything the parser didn't recognize (tables, hard line breaks within a bullet, blockquotes) was silently dropped.

Drop the parser entirely and feed each entry's `changes` string to the existing `<Markdown>` component (`react-markdown` + `remark-gfm` + `rehype-slug`), which already handles every case and is used elsewhere in the app for the same kind of authored-by-the-team content.

Also removes the 10 entry cap on the version endpoint and pulls 20 entries in the dialog.

## Notes

- The bespoke `•` / `◦` bullet glyphs are replaced by react-markdown's standard `<ul>` / nested `<ul>` (the `Markdown` component's tailwind utilities give them disc bullets and consistent spacing). Same information, less custom CSS.
- `noDetailedChanges` fallback preserved for empty entries.
- No other consumer of `VersionDialog` changes — both `mode="info"` and `mode="update"` use the same render path.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec eslint src/components/VersionDialog.tsx` clean.
- [ ] Open Version dialog (info mode) on a recent build — confirm `**bold**` renders bold, links are clickable, nested bullets show.
- [ ] Trigger update-mode dialog (or stub it locally) — confirm the same single-version markdown render.
- [ ] Empty `changes` for a version still shows the localized "no detailed changes" fallback.