### PR TITLE
Fix: rolling recurrence anchors on user's local calendar day, not UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rolling recurrence off-by-one across the UTC date boundary.** A task set to repeat "every N days after completion" anchored its next due date on the UTC calendar day, not the user's local one. For tasks whose local time crossed midnight UTC (e.g. 5pm Los Angeles is 00:00 UTC the next day), completing the task one local day earlier than the UTC day produced a next occurrence one day too soon — `every 3 days` ended up scheduling 2 days out. The advance step now converts both `now` and the original due time into the user's stored timezone before doing the date math, so the new occurrence lands on the user-intuitive calendar day.
+
 ## [0.43.1] - 2026-05-02
 
 ### Changed
@@ -24,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Wrong password on the deactivate / delete form signed you out.** The self-deletion endpoint returned `401 UNAUTHORIZED` for a password mismatch, which the SPA's global axios interceptor treats as a session-expiry signal and force-logs-out from. The user was kicked back to the login screen instead of seeing "wrong password" inline. The endpoint now returns `400` for that specific case (the user *is* authenticated — they just typed the wrong confirmation password), so the error stays scoped to the form.
 
 - **Error toasts no longer leak raw backend codes.** A class of `toast.error(...)` call sites was passing through the raw `error.message` or `response.data.detail` string as a fallback, which surfaced backend constants like `USER_INVALID_PASSWORD` to users when there was no client-side mapping. All of those now route through the existing `getErrorMessage(error, "namespace:fallbackKey")` helper, which looks up the code in the `errors` translation namespace before falling through to a localized fallback. The `errors` namespace is also now preloaded with `common` so the lookup works on any page (previously, only pages whose `useTranslation` happened to include `errors` resolved codes correctly).
-
-- **Rolling recurrence off-by-one across the UTC date boundary.** A task set to repeat "every N days after completion" anchored its next due date on the UTC calendar day, not the user's local one. For tasks whose local time crossed midnight UTC (e.g. 5pm Los Angeles is 00:00 UTC the next day), completing the task one local day earlier than the UTC day produced a next occurrence one day too soon — `every 3 days` ended up scheduling 2 days out. The advance step now converts both `now` and the original due time into the user's stored timezone before doing the date math, so the new occurrence lands on the user-intuitive calendar day.
 
 ## [0.43.0] - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Error toasts no longer leak raw backend codes.** A class of `toast.error(...)` call sites was passing through the raw `error.message` or `response.data.detail` string as a fallback, which surfaced backend constants like `USER_INVALID_PASSWORD` to users when there was no client-side mapping. All of those now route through the existing `getErrorMessage(error, "namespace:fallbackKey")` helper, which looks up the code in the `errors` translation namespace before falling through to a localized fallback. The `errors` namespace is also now preloaded with `common` so the lookup works on any page (previously, only pages whose `useTranslation` happened to include `errors` resolved codes correctly).
 
+- **Rolling recurrence off-by-one across the UTC date boundary.** A task set to repeat "every N days after completion" anchored its next due date on the UTC calendar day, not the user's local one. For tasks whose local time crossed midnight UTC (e.g. 5pm Los Angeles is 00:00 UTC the next day), completing the task one local day earlier than the UTC day produced a next occurrence one day too soon — `every 3 days` ended up scheduling 2 days out. The advance step now converts both `now` and the original due time into the user's stored timezone before doing the date math, so the new occurrence lands on the user-intuitive calendar day.
+
 ## [0.43.0] - 2026-05-01
 
 ### Added

--- a/backend/app/api/v1/endpoints/tasks.py
+++ b/backend/app/api/v1/endpoints/tasks.py
@@ -581,12 +581,25 @@ async def _advance_recurrence_if_needed(
         zone = _resolve_user_zone(user_timezone)
         now_local = now.astimezone(zone)
         due_local = task.due_date.astimezone(zone)
+        # ``replace()`` doesn't consult the zone's transition table on
+        # its own, so a gap-time result (e.g. 2:30 AM on a spring-
+        # forward day) is left labelled with the surrounding offset.
+        # The trailing ``astimezone(zone)`` is defensive — when the
+        # source and target tzinfo are the same ZoneInfo instance
+        # CPython short-circuits to ``return self``, so this is a
+        # no-op in that case, but it documents the intent and makes
+        # the call site safe if a future change resolves ``zone``
+        # from a different cache. The downstream ``+ timedelta``
+        # advance preserves wall-clock time across DST, which is the
+        # behaviour we want for daily recurrence: an "every day at
+        # 2:30 AM" task continues to fire at 2:30 AM after DST kicks
+        # in, the same way an alarm clock would.
         base_local = now_local.replace(
             hour=due_local.hour,
             minute=due_local.minute,
             second=due_local.second,
             microsecond=due_local.microsecond,
-        )
+        ).astimezone(zone)
         # ``get_next_due_date`` is timezone-naive about its frequency
         # math (adds ``timedelta(days=...)`` directly), so keep the
         # base in local time for the duration of the calculation and

--- a/backend/app/api/v1/endpoints/tasks.py
+++ b/backend/app/api/v1/endpoints/tasks.py
@@ -3,7 +3,7 @@ from typing import Annotated, List, Optional, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import selectinload
-from zoneinfo import available_timezones
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
 
 from sqlalchemy import case, func, literal, text
 from sqlmodel import select, delete
@@ -530,12 +530,30 @@ async def _set_task_assignees(session: SessionDep, task: Task, assignee_ids: lis
     await session.refresh(task, attribute_names=["assignees"])
 
 
+def _resolve_user_zone(user_tz: str | None) -> ZoneInfo:
+    """Resolve a user's stored ``timezone`` string to a ``ZoneInfo``,
+    falling back to UTC if the value is missing or unrecognised.
+
+    The user model defaults to ``"UTC"`` so this is mostly a guard
+    against bad data — but we treat an unknown zone as UTC rather than
+    erroring, since recurrence-on-completion shouldn't fail just
+    because a profile field drifted.
+    """
+    if not user_tz:
+        return ZoneInfo("UTC")
+    try:
+        return ZoneInfo(user_tz)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("UTC")
+
+
 async def _advance_recurrence_if_needed(
     session: SessionDep,
     task: Task,
     *,
     previous_status_category: TaskStatusCategory | None,
     now: datetime,
+    user_timezone: str | None,
 ) -> bool:
     current_category = task.task_status.category if task.task_status else None
     if (
@@ -553,13 +571,28 @@ async def _advance_recurrence_if_needed(
 
     strategy = task.recurrence_strategy or "fixed"
     if strategy == "rolling":
-        # For rolling: use completion DATE but preserve original TIME
-        base_date = now.replace(
-            hour=task.due_date.hour,
-            minute=task.due_date.minute,
-            second=task.due_date.second,
-            microsecond=task.due_date.microsecond,
+        # For rolling: use the user's local *calendar day* of completion
+        # but preserve the task's original *local* time-of-day. Doing
+        # this math in UTC produced an off-by-one when the task's
+        # local time crossed UTC midnight: e.g. a 5pm LA task is
+        # midnight UTC the next day, so a UTC-anchored
+        # ``now.replace(hour=0)`` landed the new occurrence one local
+        # day earlier than the user's "complete + 3 days" intuition.
+        zone = _resolve_user_zone(user_timezone)
+        now_local = now.astimezone(zone)
+        due_local = task.due_date.astimezone(zone)
+        base_local = now_local.replace(
+            hour=due_local.hour,
+            minute=due_local.minute,
+            second=due_local.second,
+            microsecond=due_local.microsecond,
         )
+        # ``get_next_due_date`` is timezone-naive about its frequency
+        # math (adds ``timedelta(days=...)`` directly), so keep the
+        # base in local time for the duration of the calculation and
+        # let the caller convert back to UTC if needed. Storing a
+        # timezone-aware value preserves the right instant either way.
+        base_date = base_local
     else:
         base_date = task.due_date
     next_due = get_next_due_date(
@@ -1271,6 +1304,7 @@ async def update_task(
         task,
         previous_status_category=previous_status_category,
         now=now,
+        user_timezone=current_user.timezone,
     )
 
     if new_assignees and project:
@@ -1586,6 +1620,7 @@ async def reorder_tasks(
             task,
             previous_status_category=previous_status_category,
             now=now,
+            user_timezone=current_user.timezone,
         )
 
     await _touch_project(session, reorder_in.project_id, timestamp=now)

--- a/backend/app/api/v1/endpoints/tasks_test.py
+++ b/backend/app/api/v1/endpoints/tasks_test.py
@@ -965,3 +965,94 @@ async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
     assert new_due_local.month == 5
     assert new_due_local.day == 6
     assert new_due_local.hour == 17
+
+
+@pytest.mark.integration
+async def test_rolling_recurrence_spring_forward_normalises_dst(
+    session: AsyncSession,
+):
+    """When the original due time falls in the clocked-forward gap on a
+    spring-forward night, the rolling-base composition has to round-trip
+    through the zone so the resulting UTC instant matches the user's
+    next wall-clock occurrence — not the non-existent local time
+    ``replace()`` would otherwise produce.
+    """
+    from datetime import datetime, timezone
+    from app.api.v1.endpoints.tasks import _advance_recurrence_if_needed
+    from app.models.task import Task, TaskStatusCategory
+    from app.services import task_statuses as task_statuses_service
+
+    user = await create_user(
+        session, email="dst-user@example.com", timezone="America/Los_Angeles"
+    )
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=user, guild=guild)
+    initiative = await _create_initiative(session, guild, user)
+    project = await _create_project(session, initiative, user)
+
+    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    todo_status = next(s for s in statuses if s.is_default)
+    done_status = next(s for s in statuses if s.name == "Done")
+    await session.commit()
+
+    # Original due: 2:30 AM Los Angeles. On a normal day that's 09:30
+    # (PST) or 10:30 (PDT) UTC; we just pick a non-DST date so the
+    # field value is unambiguous in storage.
+    original_due = datetime(2026, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    task = Task(
+        title="DST gap task",
+        project_id=project.id,
+        task_status_id=todo_status.id,
+        guild_id=guild.id,
+        due_date=original_due,
+        recurrence={"frequency": "daily", "interval": 1, "ends": "never"},
+        recurrence_strategy="rolling",
+    )
+    session.add(task)
+    await session.commit()
+    await session.refresh(
+        task, attribute_names=["task_status", "assignees", "tag_links"]
+    )
+
+    # Complete on Sunday 2026-03-08 (US spring-forward day), late
+    # morning LA so ``now_local`` is firmly in PDT. The composed
+    # rolling base — ``now_local.replace(hour=2, minute=30)`` — lands
+    # in the clock-forward gap that doesn't exist locally (the clock
+    # jumped 2:00 → 3:00 earlier that morning). The
+    # ``.astimezone(zone)`` pass re-normalises the gap value through
+    # the transition table, so the stored UTC instant corresponds to
+    # 3:30 AM PDT on the next day rather than a stale offset.
+    completion_now = datetime(2026, 3, 8, 18, 0, 0, tzinfo=timezone.utc)
+    task.task_status_id = done_status.id
+    task.task_status = done_status
+
+    advanced = await _advance_recurrence_if_needed(
+        session,
+        task,
+        previous_status_category=TaskStatusCategory.todo,
+        now=completion_now,
+        user_timezone=user.timezone,
+    )
+    assert advanced is True
+    await session.commit()
+
+    from sqlmodel import select as _select
+
+    new_task = (
+        await session.exec(
+            _select(Task).where(Task.project_id == project.id, Task.id != task.id)
+        )
+    ).first()
+    assert new_task is not None
+    assert new_task.due_date is not None
+    new_due_la = new_task.due_date.astimezone(ZoneInfo("America/Los_Angeles"))
+    # Daily +1 from completion (Mar 8) → Mar 9, fully in PDT. The
+    # important property: the wall-clock 2:30 AM of the original task
+    # is preserved on the next valid day, so the user's "every day at
+    # 2:30 AM" intent survives the DST transition. Strict UTC pin:
+    # 2026-03-09 09:30 UTC = 2026-03-09 02:30 PDT.
+    assert new_due_la.day == 9
+    assert new_due_la.hour == 2
+    assert new_due_la.minute == 30
+    new_due_utc = new_task.due_date.astimezone(timezone.utc)
+    assert new_due_utc == datetime(2026, 3, 9, 9, 30, 0, tzinfo=timezone.utc)

--- a/backend/app/api/v1/endpoints/tasks_test.py
+++ b/backend/app/api/v1/endpoints/tasks_test.py
@@ -13,6 +13,7 @@ Tests the task API endpoints at /api/v1/tasks including:
 """
 
 import json
+from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
@@ -878,3 +879,89 @@ async def test_rolling_recurrence_with_midnight_time(
     assert new_due_date.hour == 0
     assert new_due_date.minute == 0
     assert new_due_date.second == 0
+
+
+@pytest.mark.integration
+async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
+    session: AsyncSession,
+):
+    """The completion-date anchor for rolling recurrence is the user's
+    *local* calendar day, not the UTC day.
+
+    Repro: a 5pm-LA task is stored as 00:00 UTC the next day. Anchoring
+    a "+3 days" advance off the UTC date produced one local day too
+    early — completing on Sunday May 3 (LA) gave a next due of Tuesday
+    May 5 (LA) instead of Wednesday May 6 (LA).
+    """
+    from datetime import datetime, timezone
+    from app.api.v1.endpoints.tasks import _advance_recurrence_if_needed
+    from app.models.task import Task, TaskStatusCategory
+    from app.services import task_statuses as task_statuses_service
+
+    user = await create_user(
+        session, email="la-user@example.com", timezone="America/Los_Angeles"
+    )
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=user, guild=guild)
+    initiative = await _create_initiative(session, guild, user)
+    project = await _create_project(session, initiative, user)
+
+    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    todo_status = next(s for s in statuses if s.is_default)
+    done_status = next(s for s in statuses if s.name == "Done")
+    await session.commit()
+
+    # Original due: 5pm Los Angeles on Sunday 2026-05-03 → 00:00 UTC
+    # Monday 2026-05-04. The UTC representation has already crossed
+    # midnight; this is what makes the math go wrong if anchored in UTC.
+    original_due = datetime(2026, 5, 4, 0, 0, 0, tzinfo=timezone.utc)
+    task = Task(
+        title="Feed frogs",
+        project_id=project.id,
+        task_status_id=todo_status.id,
+        guild_id=guild.id,
+        due_date=original_due,
+        recurrence={"frequency": "daily", "interval": 3, "ends": "never"},
+        recurrence_strategy="rolling",
+    )
+    session.add(task)
+    await session.commit()
+    # Eager-load every relationship the helper touches so the
+    # subsequent ``_advance_recurrence_if_needed`` call doesn't trip
+    # SQLAlchemy's async-greenlet guard on a lazy load.
+    await session.refresh(
+        task, attribute_names=["task_status", "assignees", "tag_links"]
+    )
+
+    # Simulate the user completing the task at ~9pm Los Angeles on the
+    # same Sunday (2026-05-03). In UTC that's 04:00 Monday 2026-05-04.
+    completion_now = datetime(2026, 5, 4, 4, 0, 0, tzinfo=timezone.utc)
+    task.task_status_id = done_status.id
+    task.task_status = done_status
+
+    advanced = await _advance_recurrence_if_needed(
+        session,
+        task,
+        previous_status_category=TaskStatusCategory.todo,
+        now=completion_now,
+        user_timezone=user.timezone,
+    )
+    assert advanced is True
+    await session.commit()
+
+    from sqlmodel import select as _select
+
+    new_task = (
+        await session.exec(
+            _select(Task).where(Task.project_id == project.id, Task.id != task.id)
+        )
+    ).first()
+    assert new_task is not None
+    assert new_task.due_date is not None
+    # Expected: 5pm Los Angeles on Wednesday 2026-05-06 → 00:00 UTC
+    # Thursday 2026-05-07 (DST: PDT is UTC-7 on this date).
+    new_due_local = new_task.due_date.astimezone(ZoneInfo("America/Los_Angeles"))
+    assert new_due_local.year == 2026
+    assert new_due_local.month == 5
+    assert new_due_local.day == 6
+    assert new_due_local.hour == 17

--- a/backend/app/api/v1/endpoints/tasks_test.py
+++ b/backend/app/api/v1/endpoints/tasks_test.py
@@ -968,14 +968,21 @@ async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
 
 
 @pytest.mark.integration
-async def test_rolling_recurrence_spring_forward_normalises_dst(
+async def test_rolling_recurrence_spring_forward_preserves_wall_clock_time(
     session: AsyncSession,
 ):
-    """When the original due time falls in the clocked-forward gap on a
-    spring-forward night, the rolling-base composition has to round-trip
-    through the zone so the resulting UTC instant matches the user's
-    next wall-clock occurrence — not the non-existent local time
-    ``replace()`` would otherwise produce.
+    """When the original due time would land in the clocked-forward gap
+    on a spring-forward night, rolling recurrence preserves the
+    original *wall-clock* time on the next calendar day rather than
+    normalising into the gap. This is alarm-clock semantics: "every
+    day at 2:30 AM" continues to fire at 2:30 AM after DST, even
+    though 2:30 AM does not exist on the spring-forward night itself.
+
+    Concretely: completing on 2026-03-08 (US spring-forward day) with
+    an original 2:30 AM due time produces a next occurrence of
+    2026-03-09 at 02:30 PDT = 09:30 UTC. The gap on Mar 8 is
+    irrelevant because the new occurrence lands on Mar 9, where 2:30
+    AM is a valid local time.
     """
     from datetime import datetime, timezone
     from app.api.v1.endpoints.tasks import _advance_recurrence_if_needed
@@ -1016,12 +1023,12 @@ async def test_rolling_recurrence_spring_forward_normalises_dst(
 
     # Complete on Sunday 2026-03-08 (US spring-forward day), late
     # morning LA so ``now_local`` is firmly in PDT. The composed
-    # rolling base — ``now_local.replace(hour=2, minute=30)`` — lands
-    # in the clock-forward gap that doesn't exist locally (the clock
-    # jumped 2:00 → 3:00 earlier that morning). The
-    # ``.astimezone(zone)`` pass re-normalises the gap value through
-    # the transition table, so the stored UTC instant corresponds to
-    # 3:30 AM PDT on the next day rather than a stale offset.
+    # rolling base — ``now_local.replace(hour=2, minute=30)`` —
+    # references a local time that does not exist on Mar 8 (the
+    # clock jumped 2:00 → 3:00 earlier that morning). Adding one
+    # day before the stored conversion lands the new occurrence on
+    # Mar 9 at 02:30 PDT, which is a valid local time and matches
+    # the user's "every day at 2:30 AM" intent.
     completion_now = datetime(2026, 3, 8, 18, 0, 0, tzinfo=timezone.utc)
     task.task_status_id = done_status.id
     task.task_status = done_status


### PR DESCRIPTION
## Summary

Bug report: a task set to repeat **"every 3 days after completion"** scheduled the next due date 2 days out instead of 3 when the user (Los Angeles, PDT) checked it off.

## Root cause

`_advance_recurrence_if_needed` in `backend/app/api/v1/endpoints/tasks.py` did:

```python
base_date = now.replace(
    hour=task.due_date.hour,
    minute=task.due_date.minute,
    ...
)
```

with `now = datetime.now(timezone.utc)` and `task.due_date` already in UTC. For a 5pm-LA task (= 00:00 UTC the next day), `task.due_date.hour == 0`. Replacing `now`'s hour with `0` lands on the **UTC** calendar day, which can be one local day ahead. Adding `timedelta(days=3)` then produces a next occurrence one local day too soon.

Concrete repro from the report:
- Original due: 5pm Sunday May 3 LA → 00:00 UTC Mon May 4
- User completes Sunday afternoon LA → `now` is May 3 UTC
- `now.replace(hour=0)` → 00:00 UTC May 3 (= 5pm LA May 2)
- `+ timedelta(days=3)` → 00:00 UTC May 6 (= **5pm LA May 5**)
- User expected 5pm LA May 6.

The screenshot in the report showed the next occurrence at "Tuesday, May 5, 2026 at 5:00 PM" — exactly that.

## Fix

`_advance_recurrence_if_needed` now takes `user_timezone`, converts both `now` and the original due time into that zone before composing the rolling base date, then lets the recurrence service do its math with a timezone-aware datetime. Conversion back to UTC for storage happens automatically via the `DateTime(timezone=True)` column.

`User.timezone` is already a stored field with a `"UTC"` default, so the helper falls back gracefully if the field is missing or unrecognised (`ZoneInfoNotFoundError` → UTC).

Scope: only the rolling case, since that's what the report covers. The fixed-strategy path uses `task.due_date` directly, which already round-trips correctly because `+ timedelta(days=N)` preserves local time-of-day. Weekly/monthly/yearly each have separate timezone caveats already documented in `recurrence.py`; those are a separate fix.

## Test plan
- [x] New test `test_rolling_recurrence_uses_user_timezone_for_completion_date` reproduces the LA-evening case deterministically by calling the helper directly with explicit `now` and `user_timezone`. Asserts the new occurrence lands on **2026-05-06 17:00 PDT** (the user-intuitive answer), not 2026-05-05.
- [x] Existing recurrence test suite (19 tests) still passes.
- [x] `ruff check app` clean.
- [ ] Manual smoke: complete a "every N days after completion" task in the evening (LA local), confirm the next due lands N local days out.