### PR TITLE
Allow no-guild users to reach account / platform settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Rolling recurrence off-by-one across the UTC date boundary.** A task set to repeat "every N days after completion" anchored its next due date on the UTC calendar day, not the user's local one. For tasks whose local time crossed midnight UTC (e.g. 5pm Los Angeles is 00:00 UTC the next day), completing the task one local day earlier than the UTC day produced a next occurrence one day too soon — `every 3 days` ended up scheduling 2 days out. The advance step now converts both `now` and the original due time into the user's stored timezone before doing the date math, so the new occurrence lands on the user-intuitive calendar day.
 
+- **Settings unreachable when you have no guild memberships.** A user with zero memberships used to see only the "no guild" screen with create/join/logout — no path to user settings (so no way to delete their own account) and no path to platform-admin settings either. The empty-state screen now exposes **Account settings** (always) and **Platform settings** (when `user.role === "admin"`) buttons, and the `/profile/*` and `/settings/admin/*` routes render in a minimal Back-to-start shell instead of bouncing back to the empty state.
+
 ## [0.43.1] - 2026-05-02
 
 ### Changed

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -165,6 +165,9 @@
     "create": "Create",
     "inviteCodePlaceholder": "Invite code",
     "redeem": "Redeem",
+    "accountSettings": "Account settings",
+    "platformSettings": "Platform settings",
+    "shellBackToStart": "Back to start",
     "logOut": "Log out"
   },
   "notifications": {

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -165,6 +165,9 @@
     "create": "Crear",
     "inviteCodePlaceholder": "Código de invitación",
     "redeem": "Canjear",
+    "accountSettings": "Configuración de la cuenta",
+    "platformSettings": "Configuración de la plataforma",
+    "shellBackToStart": "Volver al inicio",
     "logOut": "Cerrar sesión"
   },
   "notifications": {

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -165,6 +165,9 @@
     "create": "Créer",
     "inviteCodePlaceholder": "Code d'invitation",
     "redeem": "Utiliser",
+    "accountSettings": "Paramètres du compte",
+    "platformSettings": "Paramètres de la plateforme",
+    "shellBackToStart": "Retour à l'accueil",
     "logOut": "Se déconnecter"
   },
   "notifications": {

--- a/frontend/src/lib/noGuildLayout.test.ts
+++ b/frontend/src/lib/noGuildLayout.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import { chooseNoGuildLayout } from "./noGuildLayout";
+
+/**
+ * The route gate this helper drives is an auth boundary: a wrong
+ * answer either traps a user with zero memberships out of their own
+ * account-management surface, or admits a non-admin into the
+ * platform-admin shell. Tests here pin the truth table.
+ */
+describe("chooseNoGuildLayout", () => {
+  describe("when the user has at least one guild", () => {
+    it("falls through to the main sidebar layout regardless of path / role", () => {
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: true,
+          pathname: "/profile",
+          isPlatformAdmin: false,
+        })
+      ).toBe("main");
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: true,
+          pathname: "/settings/admin",
+          isPlatformAdmin: true,
+        })
+      ).toBe("main");
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: true,
+          pathname: "/projects/42",
+          isPlatformAdmin: false,
+        })
+      ).toBe("main");
+    });
+  });
+
+  describe("user-scoped settings routes (no guilds)", () => {
+    it("renders the chromeless settings shell on /profile (any role)", () => {
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/profile",
+          isPlatformAdmin: false,
+        })
+      ).toBe("shell");
+    });
+
+    it("matches /profile sub-paths like /profile/danger", () => {
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/profile/danger",
+          isPlatformAdmin: false,
+        })
+      ).toBe("shell");
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/profile/security",
+          isPlatformAdmin: false,
+        })
+      ).toBe("shell");
+    });
+
+    it("does not match a partial-prefix collision like /profileX", () => {
+      // ``startsWith("/profile/")`` (with the trailing slash) plus the
+      // exact-match arm prevents this from leaking. Pin it so a future
+      // refactor can't drop the slash and silently widen the gate.
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/profilex",
+          isPlatformAdmin: false,
+        })
+      ).toBe("empty");
+    });
+  });
+
+  describe("platform-admin settings routes (no guilds)", () => {
+    it("renders the shell when the user is a platform admin", () => {
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/settings/admin",
+          isPlatformAdmin: true,
+        })
+      ).toBe("shell");
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/settings/admin/auth",
+          isPlatformAdmin: true,
+        })
+      ).toBe("shell");
+    });
+
+    it("falls through to NoGuildState for non-admins", () => {
+      // Non-admins shouldn't get the shell chrome for a route they
+      // can't see content on — ``AdminSettingsLayout`` would redirect
+      // them to /settings/guild anyway.
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/settings/admin",
+          isPlatformAdmin: false,
+        })
+      ).toBe("empty");
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/settings/admin/branding",
+          isPlatformAdmin: false,
+        })
+      ).toBe("empty");
+    });
+  });
+
+  describe("any other route (no guilds)", () => {
+    it("returns empty so NoGuildState renders", () => {
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/",
+          isPlatformAdmin: false,
+        })
+      ).toBe("empty");
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/projects/1",
+          isPlatformAdmin: true,
+        })
+      ).toBe("empty");
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/settings/guild",
+          isPlatformAdmin: true,
+        })
+      ).toBe("empty");
+    });
+  });
+});

--- a/frontend/src/lib/noGuildLayout.ts
+++ b/frontend/src/lib/noGuildLayout.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure decision helper for the layout `_authenticated.tsx` should
+ * render when the current user has zero guild memberships.
+ *
+ * Extracted from the route component so the path-based exemption
+ * rules are unit-testable without a full router + provider setup —
+ * the routing gate is an auth boundary, and CLAUDE.md asks for
+ * Vitest coverage on auth.
+ *
+ * Outcomes:
+ * - ``"main"``  — user has at least one guild; render the standard
+ *                 sidebar layout.
+ * - ``"shell"`` — no guilds, but the current path is a user-scoped
+ *                 settings route (or a platform-admin settings
+ *                 route for an admin); render the chromeless
+ *                 ``NoGuildSettingsShell`` so the user can still
+ *                 reach Danger Zone / platform configuration.
+ * - ``"empty"`` — no guilds and no exempt path; show
+ *                 ``NoGuildState`` (the create / join / logout
+ *                 landing page).
+ *
+ * The ``isPlatformAdmin`` flag matches whatever predicate the
+ * actual ``AdminSettingsLayout`` uses (today: ``user.role === "admin"``).
+ * Keeping the two checks aligned guarantees that the no-guild
+ * shell never admits anyone who couldn't already reach the page in
+ * the normal sidebar layout — if `AdminSettingsLayout` later
+ * tightens to "user.id === 1" or similar, this helper inherits the
+ * change automatically.
+ */
+export type NoGuildLayoutChoice = "main" | "shell" | "empty";
+
+export interface NoGuildLayoutInputs {
+  hasGuilds: boolean;
+  pathname: string;
+  isPlatformAdmin: boolean;
+}
+
+const isUserSettingsPath = (path: string): boolean =>
+  path === "/profile" || path.startsWith("/profile/");
+
+const isAdminSettingsPath = (path: string): boolean =>
+  path === "/settings/admin" || path.startsWith("/settings/admin/");
+
+export function chooseNoGuildLayout({
+  hasGuilds,
+  pathname,
+  isPlatformAdmin,
+}: NoGuildLayoutInputs): NoGuildLayoutChoice {
+  if (hasGuilds) return "main";
+  if (isUserSettingsPath(pathname)) return "shell";
+  if (isAdminSettingsPath(pathname) && isPlatformAdmin) return "shell";
+  return "empty";
+}

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -23,6 +23,7 @@ import { ProjectActivitySidebar } from "@/components/projects/ProjectActivitySid
 import { VersionDialog } from "@/components/VersionDialog";
 import { PushPermissionPrompt } from "@/components/notifications/PushPermissionPrompt";
 import { useGuilds } from "@/hooks/useGuilds";
+import { chooseNoGuildLayout } from "@/lib/noGuildLayout";
 import { useRealtimeUpdates } from "@/hooks/useRealtimeUpdates";
 import { useVersionCheck } from "@/hooks/useVersionCheck";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
@@ -112,35 +113,35 @@ function AppLayout() {
     return <Navigate to={redirectTo} replace />;
   }
 
-  // Show no-guild empty state if user has no guild memberships.
-  //
-  // Exception: user-scoped settings (``/profile/*``) and platform-admin
-  // settings (``/settings/admin/*``) don't need guild context — the
-  // user-scoped APIs the SPA calls from those pages don't require an
-  // ``X-Guild-ID`` header — and a user with zero memberships otherwise
-  // has no path to delete their account or, for platform admins, to
-  // configure system-wide settings. In that case render the outlet
-  // inside a minimal "no-guild settings shell" (header-only chrome
-  // with a Back-to-start link + logout) instead of the standard
-  // sidebar layout.
-  if (guilds.length === 0 && user) {
-    const path = location.pathname;
-    const isUserSettingsRoute = path === "/profile" || path.startsWith("/profile/");
-    const isAdminSettingsRoute = path === "/settings/admin" || path.startsWith("/settings/admin/");
+  // No-guild empty-state branch. The user-scoped settings routes
+  // (``/profile/*``) and platform-admin settings (``/settings/admin/*``
+  // for an admin) don't need guild context — the APIs they call don't
+  // require an ``X-Guild-ID`` header — and a user with zero
+  // memberships would otherwise have no path to delete their account
+  // or, for platform admins, configure system-wide settings. The
+  // path-based decision lives in ``chooseNoGuildLayout`` so it can be
+  // unit-tested without a router; see ``noGuildLayout.test.ts``.
+  if (user) {
     const isPlatformAdmin = user.role === "admin";
-
-    if (isUserSettingsRoute || (isAdminSettingsRoute && isPlatformAdmin)) {
+    const layout = chooseNoGuildLayout({
+      hasGuilds: guilds.length > 0,
+      pathname: location.pathname,
+      isPlatformAdmin,
+    });
+    if (layout === "shell") {
       return <NoGuildSettingsShell logout={logout} />;
     }
-
-    return (
-      <NoGuildState
-        canCreateGuilds={canCreateGuilds}
-        createGuild={createGuild}
-        logout={logout}
-        isPlatformAdmin={isPlatformAdmin}
-      />
-    );
+    if (layout === "empty") {
+      return (
+        <NoGuildState
+          canCreateGuilds={canCreateGuilds}
+          createGuild={createGuild}
+          logout={logout}
+          isPlatformAdmin={isPlatformAdmin}
+        />
+      );
+    }
+    // layout === "main" → fall through to the standard sidebar layout.
   }
 
   const handleClearRecent = (projectId: number) => {

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -9,7 +9,7 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Loader2, LogOut, Menu, Plus, Search, Ticket } from "lucide-react";
+import { Loader2, LogOut, Menu, Plus, Search, Settings, Ticket, UserCog } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -112,10 +112,34 @@ function AppLayout() {
     return <Navigate to={redirectTo} replace />;
   }
 
-  // Show no-guild empty state if user has no guild memberships
+  // Show no-guild empty state if user has no guild memberships.
+  //
+  // Exception: user-scoped settings (``/profile/*``) and platform-admin
+  // settings (``/settings/admin/*``) don't need guild context — the
+  // user-scoped APIs the SPA calls from those pages don't require an
+  // ``X-Guild-ID`` header — and a user with zero memberships otherwise
+  // has no path to delete their account or, for platform admins, to
+  // configure system-wide settings. In that case render the outlet
+  // inside a minimal "no-guild settings shell" (header-only chrome
+  // with a Back-to-start link + logout) instead of the standard
+  // sidebar layout.
   if (guilds.length === 0 && user) {
+    const path = location.pathname;
+    const isUserSettingsRoute = path === "/profile" || path.startsWith("/profile/");
+    const isAdminSettingsRoute = path === "/settings/admin" || path.startsWith("/settings/admin/");
+    const isPlatformAdmin = user.role === "admin";
+
+    if (isUserSettingsRoute || (isAdminSettingsRoute && isPlatformAdmin)) {
+      return <NoGuildSettingsShell logout={logout} />;
+    }
+
     return (
-      <NoGuildState canCreateGuilds={canCreateGuilds} createGuild={createGuild} logout={logout} />
+      <NoGuildState
+        canCreateGuilds={canCreateGuilds}
+        createGuild={createGuild}
+        logout={logout}
+        isPlatformAdmin={isPlatformAdmin}
+      />
     );
   }
 
@@ -202,10 +226,12 @@ function NoGuildState({
   canCreateGuilds,
   createGuild,
   logout,
+  isPlatformAdmin,
 }: {
   canCreateGuilds: boolean;
   createGuild: (input: { name: string; description?: string }) => Promise<unknown>;
   logout: () => void;
+  isPlatformAdmin: boolean;
 }) {
   const { t } = useTranslation("guilds");
   const [guildName, setGuildName] = useState("");
@@ -264,11 +290,62 @@ function NoGuildState({
           </Button>
         </div>
 
+        {/* Direct entry points to the user/platform settings pages so a
+            user with no memberships can still manage their account
+            (e.g. delete it) or, for platform admins, system-wide
+            configuration. Without these the only paths off this screen
+            are create/join/logout. */}
+        <div className="flex flex-col gap-2">
+          <Button variant="outline" asChild>
+            <Link to="/profile">
+              <UserCog className="h-4 w-4" />
+              {t("noGuild.accountSettings")}
+            </Link>
+          </Button>
+          {isPlatformAdmin && (
+            <Button variant="outline" asChild>
+              <Link to="/settings/admin">
+                <Settings className="h-4 w-4" />
+                {t("noGuild.platformSettings")}
+              </Link>
+            </Button>
+          )}
+        </div>
+
         <Button variant="ghost" onClick={logout}>
           <LogOut className="h-4 w-4" />
           {t("noGuild.logOut")}
         </Button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Minimal layout shown when the user has zero guild memberships but
+ * is on a route that doesn't need guild context (``/profile/*``,
+ * ``/settings/admin/*``). Renders the matched outlet inside a
+ * narrow container with just enough chrome (Back-to-start + logout)
+ * to navigate away.
+ */
+function NoGuildSettingsShell({ logout }: { logout: () => void }) {
+  const { t } = useTranslation("guilds");
+  return (
+    <div className="bg-background flex min-h-screen flex-col">
+      <div className="bg-card/70 supports-backdrop-filter:bg-card/60 sticky top-0 z-50 flex h-12 items-center justify-between border-b px-4 backdrop-blur">
+        <Button variant="ghost" size="sm" asChild>
+          <Link to="/">{t("noGuild.shellBackToStart")}</Link>
+        </Button>
+        <Button variant="ghost" size="sm" onClick={logout}>
+          <LogOut className="h-4 w-4" />
+          {t("noGuild.logOut")}
+        </Button>
+      </div>
+      <main className="container mx-auto min-w-0 p-4 pb-20 md:p-8 md:pb-20">
+        <Suspense fallback={<PageLoader />}>
+          <Outlet />
+        </Suspense>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Bug: a user with zero guild memberships couldn't reach the user settings page (where Danger Zone → Delete Account lives), and platform admins couldn't reach system-wide settings either. The root layout (`_authenticated.tsx`) short-circuited to `NoGuildState` whenever `guilds.length === 0`, blocking every child route.

The user-scoped APIs (`/users/me/*`) don't need guild context — the API client (`api/client.ts:138-146`) only attaches `X-Guild-ID` when `activeGuildId !== null` — so the data path already worked. The gap was purely in the SPA's route gate.

## Changes

- **`_authenticated.tsx` gate is now route-aware.** When `guilds.length === 0`:
  - On `/profile/*` (user settings) → render the outlet in a minimal `NoGuildSettingsShell` (header-only chrome with Back-to-start + logout, no sidebar).
  - On `/settings/admin/*` AND `user.role === "admin"` → same shell.
  - Otherwise → fall through to `NoGuildState` as today.
- **`NoGuildState` adds two discoverability buttons** so users can find the bypass:
  - **Account settings** → `/profile` (always shown).
  - **Platform settings** → `/settings/admin` (only when `user.role === "admin"`).
- New locale strings under `guilds.noGuild.*` (en/es/fr).

## Out of scope
- The Trash and Import tabs under user settings still appear in the no-guild shell. Trash queries scope=mine and renders an empty state cleanly. Import would be functionally meaningless without a guild but doesn't crash; tightening that empty state is a follow-up if anyone hits it.

## Test plan
- [x] `pnpm exec tsc --noEmit && pnpm lint && pnpm test:run` all clean (265 tests).
- [ ] Manual: register a fresh account with no invite → land on `NoGuildState` → click **Account settings** → reach `/profile` → Danger Zone tab → run the Delete Account wizard end-to-end.
- [ ] Manual (platform admin): with `user.role === "admin"` and zero guilds, confirm **Platform settings** appears, click it → `/settings/admin/auth` renders with tab nav.
- [ ] Manual (non-admin): confirm the **Platform settings** button is hidden.
- [ ] Manual (regression): a user with at least one guild membership still gets the standard sidebar layout — never the no-guild shell.