### PR TITLE
Fix stored XSS in legacy document embed nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stored XSS in legacy document embed nodes.** The Lexical `EmbedNode` (kept around for backwards compatibility with documents that used the old generic embed type before `YouTubeNode` / `TweetNode` existed) rendered its stored `html` field via `dangerouslySetInnerHTML` without sanitization. A user able to write a document — i.e. any guild member with edit access — could craft a serialized JSON payload containing `{ "type": "embed", "html": "<script>…</script>" }`, save the document, and have the script run in every other viewer's session. The constructor now passes the html through DOMPurify before storing it on `__html`, so all entry paths (importJSON of legacy data, paste-conversion via `convertEmbedElement`, programmatic creation) are sanitized at the same boundary. Default DOMPurify config strips `<script>`, event handler attributes, `javascript:` URLs, and `<iframe>`; legacy YouTube embeds may render empty after the fix and should be re-added with the dedicated `YouTubeNode` insert tool.
+
 ## [0.43.2] - 2026-05-03
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,6 +92,7 @@
     "cmdk": "^1.1.1",
     "color": "^5.0.3",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.4.1",
     "embla-carousel-react": "^8.6.0",
     "emoji-picker-react": "^4.18.0",
     "fuse.js": "^7.3.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dompurify:
+        specifier: ^3.4.1
+        version: 3.4.1
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.5)

--- a/frontend/src/components/ui/editor/nodes/embed-node.test.ts
+++ b/frontend/src/components/ui/editor/nodes/embed-node.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeEmbedHtml } from "./embed-node";
+
+/**
+ * Legacy EmbedNode renders stored HTML via dangerouslySetInnerHTML, so
+ * any document loaded through importJSON could otherwise execute
+ * attacker-controlled markup. These cases pin the sanitization contract
+ * we rely on at the constructor boundary.
+ */
+describe("sanitizeEmbedHtml", () => {
+  it("strips <script> tags", () => {
+    const result = sanitizeEmbedHtml("<script>window.x=1</script><p>safe</p>");
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("window.x=1");
+    expect(result).toContain("<p>safe</p>");
+  });
+
+  it("strips inline event-handler attributes", () => {
+    const result = sanitizeEmbedHtml('<img src="x" onerror="alert(1)" />');
+    expect(result).not.toContain("onerror");
+    expect(result).not.toContain("alert(1)");
+  });
+
+  it("strips javascript: URLs from anchors", () => {
+    const result = sanitizeEmbedHtml('<a href="javascript:alert(1)">click</a>');
+    expect(result).not.toContain("javascript:");
+  });
+
+  it("preserves benign formatting markup", () => {
+    const result = sanitizeEmbedHtml("<p><b>hello</b> <i>world</i></p>");
+    expect(result).toBe("<p><b>hello</b> <i>world</i></p>");
+  });
+
+  it("handles empty input", () => {
+    expect(sanitizeEmbedHtml("")).toBe("");
+  });
+});

--- a/frontend/src/components/ui/editor/nodes/embed-node.tsx
+++ b/frontend/src/components/ui/editor/nodes/embed-node.tsx
@@ -3,6 +3,7 @@
  * New embeds should use YouTubeNode or TweetNode instead.
  */
 import type { JSX } from "react";
+import DOMPurify from "dompurify";
 import {
   DecoratorNode,
   type DOMConversionMap,
@@ -22,12 +23,18 @@ export type SerializedEmbedNode = SerializedLexicalNode & {
   html: string;
 };
 
+// Sanitize legacy embed HTML before rendering. Default DOMPurify config
+// strips <script>, on* event handlers, javascript: URLs, and other XSS
+// vectors. Stored documents containing legacy <embed> nodes are loaded
+// via importJSON and would otherwise execute attacker-controlled markup.
+export const sanitizeEmbedHtml = (html: string): string => DOMPurify.sanitize(html);
+
 export class EmbedNode extends DecoratorNode<JSX.Element> {
   __html: string;
 
   constructor(html: string, key?: NodeKey) {
     super(key);
-    this.__html = html;
+    this.__html = sanitizeEmbedHtml(html);
   }
 
   static getType(): string {


### PR DESCRIPTION
## Summary

The Lexical `EmbedNode` (kept around for backwards compatibility with documents that used the old generic embed type before `YouTubeNode` / `TweetNode` existed) rendered its stored `html` field via `dangerouslySetInnerHTML` without sanitization. A user with document edit access — i.e. any guild member of an initiative with a writable document — could craft a serialized JSON payload containing `{ "type": "embed", "html": "<script>…</script>" }`, save the document, and have the script execute in every other viewer's session (stored XSS).

The fix sanitizes through DOMPurify at the constructor, so every entry path (`importJSON` of legacy stored data, paste-conversion via `convertEmbedElement`, programmatic creation via `$createEmbedNode`) hits the same boundary. Default DOMPurify config strips `<script>`, event-handler attributes, `javascript:` URLs, and `<iframe>`.

Surfaced by scantonomous SAST finding `fnd_3a25ac0db19aca7995399775` (semgrep rule `javascript_react_rule-dangerouslysetinnerhtml`, CWE-79). Triage left it untriaged because, unlike the other ~225 findings in the scan, it was a real exploitable path rather than a SAST pattern false positive.

## Notable changes

- `frontend/src/components/ui/editor/nodes/embed-node.tsx`: import DOMPurify, sanitize html in the `EmbedNode` constructor, export the helper for tests.
- `frontend/src/components/ui/editor/nodes/embed-node.test.ts`: new — pins the sanitization contract (`<script>`, `onerror`, `javascript:`) and confirms benign markup is preserved.
- `frontend/package.json` + `pnpm-lock.yaml`: add `dompurify@^3` (3.4.1).
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Behavioral note

Default DOMPurify config strips `<iframe>`. Any legacy YouTube embeds stored under the old `EmbedNode` type will render as empty divs after this change — re-add via the dedicated `YouTubeNode` insert tool to recover them. New documents already use `YouTubeNode` / `TweetNode` and aren't affected.

## Test plan

- [x] `pnpm test:run` — all 277 tests pass, including 5 new sanitization cases
- [x] `pnpm check` — typecheck clean
- [x] `pnpm lint` — no warnings
- [x] `pnpm build` — production build succeeds
- [ ] Manually verify a document with a legitimate legacy embed still loads (degrades visually but doesn't crash)
- [ ] Manually attempt to save a document with `<script>` in an embed payload, reload, confirm script does not execute