### PR TITLE
Fix lucide-icons under vite 8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -100,7 +100,7 @@
     "i18next": "^26.0.6",
     "i18next-http-backend": "^3.0.5",
     "lexical": "^0.44.0",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.14.0",
     "papaparse": "^5.5.3",
     "react": "^19.2.5",
     "react-day-picker": "^9.14.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -246,8 +246,8 @@ importers:
         specifier: ^0.44.0
         version: 0.44.0
       lucide-react:
-        specifier: ^1.8.0
-        version: 1.8.0(react@19.2.5)
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
@@ -5198,8 +5198,8 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lucide-react@1.8.0:
-    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -12554,7 +12554,7 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react@1.8.0(react@19.2.5):
+  lucide-react@1.14.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,6 +47,16 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rolldownOptions: {
+      output: {
+        // Function form still works — Rollup-compat
+        manualChunks(id) {
+          if (id.includes("/lucide-react/")) return "lucide-react";
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     strictPort: true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -50,9 +50,13 @@ export default defineConfig({
   build: {
     rolldownOptions: {
       output: {
-        // Function form still works — Rollup-compat
-        manualChunks(id) {
-          if (id.includes("/lucide-react/")) return "lucide-react";
+        codeSplitting: {
+          groups: [
+            {
+              name: "lucide-react",
+              test: /\/lucide-react\//,
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
Vite 8 made every lucide icon it's own bundle, and that broke the build