### PR TITLE
Build linux/arm64 on native ARM runners

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -6,11 +6,31 @@ on:
       - dev
   workflow_dispatch: # Allow manual trigger
 
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/initiative
+
 jobs:
-  build-dev:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v6
+
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -21,20 +41,66 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VITE_VERSION_SUFFIX=-dev-${{ steps.sha.outputs.short }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=docker-build-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=docker-build-${{ env.PLATFORM_PAIR }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-dev-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+
       - name: Get short SHA
         id: sha
         run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      - name: Download digests
+        uses: actions/download-artifact@v8
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/initiative:dev
-            ${{ secrets.DOCKERHUB_USERNAME }}/initiative:dev-${{ steps.sha.outputs.short }}
-          build-args: |
-            VITE_VERSION_SUFFIX=-dev-${{ steps.sha.outputs.short }}
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,scope=docker-build,mode=max
+          path: ${{ runner.temp }}/digests
+          pattern: digests-dev-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_NAME }}:dev \
+            -t ${{ env.IMAGE_NAME }}:dev-${{ steps.sha.outputs.short }} \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:dev-${{ steps.sha.outputs.short }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -60,7 +60,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: digests-dev-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,12 +108,25 @@ jobs:
           path: artifacts/*.apk
 
   build-docker-public:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
 
     steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -153,7 +166,65 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            VITE_API_URL=/api/v1
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=docker-build-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=docker-build-${{ env.PLATFORM_PAIR }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-release-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-docker-public:
+    needs: build-docker-public
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-release-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags) for Docker
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -164,23 +235,19 @@ jobs:
             type=semver,pattern={{major}}${{ inputs.version && format(',value=v{0}', inputs.version) || '' }}
             type=raw,value=latest
 
-      - name: Build and push Docker image (public)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.version.outputs.version }}
-            VITE_API_URL=/api/v1
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,scope=docker-build,mode=max
-          platforms: linux/amd64,linux/arm64
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   release:
-    needs: [build-android, build-docker-public]
+    needs: [build-android, merge-docker-public]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: android-apk
           path: artifacts/*.apk
@@ -194,7 +194,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: digests-release-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -243,6 +243,7 @@ jobs:
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect image
+        if: steps.meta.outputs.version != ''
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 


### PR DESCRIPTION
## Summary

Both `dev-build.yml` and `docker-publish.yml` were doing multi-arch builds the slow way: a single `ubuntu-latest` (AMD64) runner builds `linux/amd64,linux/arm64` together, with the ARM64 half running through QEMU user-mode emulation. QEMU instruction translation adds 5–15x overhead, and it's worst on native compile steps in the Python deps (`bcrypt`, `cryptography`, `psycopg`).

This switches both workflows to a matrix that runs each platform on a native runner in parallel, then merges the per-platform digests into a single multi-arch manifest.

## Notable changes

**`dev-build.yml`**
- New `build` job runs as a matrix: `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`.
- Each matrix entry pushes a per-platform image by digest (no tag) and uploads the digest as an artifact.
- New `merge` job downloads both digests and stitches them into `:dev` and `:dev-<short-sha>` via `docker buildx imagetools create`.
- GHA cache scope is now per-platform (`docker-build-linux-amd64` / `docker-build-linux-arm64`) so an ARM-only invalidation doesn't blow away the AMD64 cache.

**`docker-publish.yml`**
- Same matrix split applied to `build-docker-public`.
- New `merge-docker-public` job applies the semver tags (`{version}`, `{major}.{minor}`, `{major}`, `latest`) to the merged manifest.
- `release` job's `needs` updated from `[build-android, build-docker-public]` to `[build-android, merge-docker-public]` so the GitHub Release / Discord notification waits for the manifest to be live.

## Behavioral notes

- `ubuntu-24.04-arm` is free for public repos, which this is. Private repos pay per-minute.
- The build matrix uses `fail-fast: false` so a fluke failure on one arch doesn't kill the other half — useful when the ARM runner pool is occasionally slow to provision.
- Per-platform images pushed by digest are not tagged; only the merged manifest gets tags. Don't pull intermediate digests directly — they'll work but defeat the multi-arch dispatch.

## Test plan

- [ ] Push to this branch triggers `dev-build.yml`; both matrix jobs run on the right runners
- [ ] Compare wall-clock time on this branch vs the previous QEMU run on `dev`
- [ ] After merge, confirm `morelitea/initiative:dev` still resolves to a multi-arch manifest (`docker buildx imagetools inspect`)
- [ ] Tag a patch release on a follow-up to validate `docker-publish.yml` end-to-end (manifest, GitHub Release, Discord notification)