### PR TITLE
Pin pnpm to 10.33.3 via packageManager field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          package_json_file: frontend/package.json
 
       - name: Install dependencies
         if: steps.filter.outputs.skip != 'true'
@@ -217,7 +217,7 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          package_json_file: frontend/package.json
 
       - name: Install frontend dependencies
         if: steps.filter.outputs.skip != 'true'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          package_json_file: frontend/package.json
 
       - name: Install frontend dependencies
         working-directory: frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump vite from v7 to v8. Decreases bundler step from 25s to 2s.
 - Migrate to typescript 7 beta. Decreases compile step from 25s to 5s.
+- Bump Dockerfile Node.js from v20 to v24.
+- Pin pnpm to 11.0.6 via the `packageManager` field in `frontend/package.json`. CI and the Dockerfile auto-detect it through corepack, so contributors no longer need to match versions manually — fresh clones with corepack enabled get the right pnpm on first invocation.
 
 ## [0.43.2] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump vite from v7 to v8. Decreases bundler step from 25s to 2s.
 - Migrate to typescript 7 beta. Decreases compile step from 25s to 5s.
 - Bump Dockerfile Node.js from v20 to v24.
-- Pin pnpm to 11.0.6 via the `packageManager` field in `frontend/package.json`. CI and the Dockerfile auto-detect it through corepack, so contributors no longer need to match versions manually — fresh clones with corepack enabled get the right pnpm on first invocation.
+- Pin pnpm to 10.33.3 via the `packageManager` field in `frontend/package.json`. CI and the Dockerfile auto-detect it through corepack, so contributors no longer need to match versions manually — fresh clones with corepack enabled get the right pnpm on first invocation.
 
 ## [0.43.2] - 2026-05-03
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:20-alpine AS frontend-build
+FROM node:24-alpine AS frontend-build
 WORKDIR /frontend
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
-RUN npm install -g pnpm && pnpm install
+RUN corepack enable && pnpm install --frozen-lockfile
 COPY frontend .
 COPY VERSION /VERSION
 ARG VITE_API_URL=/api/v1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.0.6",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsgo -b && vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.0.6",
+  "packageManager": "pnpm@10.33.3",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsgo -b && vite build",


### PR DESCRIPTION
## Summary

Single source of truth for the pnpm version. After merging #406 (pnpm/action-setup v6), the workflows still pinned `9` (CI) and `10` (docker-publish), and the Dockerfile pulled "whatever npm gives me" via `npm install -g pnpm` — three independent sources, all drifting.

This switches everything to read `packageManager: pnpm@10.33.3` from `frontend/package.json` (matches the npm `latest` dist-tag and what most contributors already have installed). Corepack handles install in the Dockerfile and on contributor machines; `pnpm/action-setup@v6` reads the same field in CI when pointed at `frontend/package.json`.

## Notable changes

- `frontend/package.json`: add `"packageManager": "pnpm@10.33.3"`. Required exact semver — corepack rejects loose ranges like `pnpm@10`.
- `.github/workflows/ci.yml`, `.github/workflows/docker-publish.yml`: drop `with: version: N` inputs from `pnpm/action-setup@v6` calls; add `with: package_json_file: frontend/package.json` so the action looks in the right place (default is repo root, where there's no package.json).
- `Dockerfile`: replace `npm install -g pnpm && pnpm install` with `corepack enable && pnpm install --frozen-lockfile` so the Docker frontend build also reads the `packageManager` field. `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` keeps corepack non-interactive in the build. Also bump the base from `node:20-alpine` to `node:24-alpine` so it aligns with the Node version CI uses (`node-version: 24` in setup-node steps).

## Behavioral notes

- **Contributors who haven't run `corepack enable`** will see a "this project requires pnpm@10.33.3" error on `pnpm install`. The fix is `corepack enable` once. Worth a note in the contributor docs as a follow-up; corepack ships with Node 16+ so almost everyone has it.
- **Future bumps now happen in one place** — change the `packageManager` field, push, done. CI, the Docker image, and `pnpm` invocations on contributor machines all converge.

## Test plan

- [x] `pnpm install --frozen-lockfile` works locally (corepack resolves 10.33.3)
- [x] `pnpm build` succeeds (`built in ~2s`)
- [ ] CI run on this PR succeeds end-to-end (pnpm/action-setup picks up the field, no version mismatch errors)
- [ ] After merge, dev-build.yml succeeds (Docker frontend stage builds with corepack-installed pnpm 10.33.3 on Node 24)