### PR TITLE
Sanitize HTML on all Pydantic schema inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Auto-sanitize HTML on all API inputs.** Every Pydantic schema now extends `SanitizedBaseModel`, which runs `nh3.clean()` on every `str` field at validation time. Dangerous markup — `<script>`, `<iframe>`, `on*` event-handler attributes, `javascript:` URLs — is stripped before reaching services or the database. Safe formatting tags (`<b>`, `<i>`, `<a>`, `<p>`) pass through unchanged, and fields that must preserve user-authored content (descriptions, comments, document content, queue notes) opt out via the explicit `RichTextStr` type. Enum-typed fields are skipped automatically.
 - Limit image attachment uploads to 10 MB to prevent memory exhaustion
 - Block OIDC new-account creation when `ENABLE_PUBLIC_REGISTRATION` is disabled
 - Return opaque error codes from import parse endpoints instead of raw exception text

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -2,7 +2,9 @@
 
 from typing import Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.guild import GuildRole
 from app.models.initiative import InitiativeRole
@@ -10,25 +12,25 @@ from app.models.user import UserRole
 from app.schemas.user import ProjectBasic, UserPublic
 
 
-class PlatformRoleUpdate(BaseModel):
+class PlatformRoleUpdate(SanitizedBaseModel):
     """Schema for updating a user's platform role."""
     role: UserRole
 
 
-class PlatformAdminCountResponse(BaseModel):
+class PlatformAdminCountResponse(SanitizedBaseModel):
     """Response schema for platform admin count."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     count: int
 
 
-class AdminUserDeleteRequest(BaseModel):
+class AdminUserDeleteRequest(SanitizedBaseModel):
     """Request to deactivate, anonymize (soft delete), or hard delete a user as platform admin."""
     action: Literal["deactivate", "soft_delete", "hard_delete"]
     project_transfers: Optional[Dict[int, int]] = None  # {project_id: new_owner_id}
 
 
-class GuildBlockerInfo(BaseModel):
+class GuildBlockerInfo(SanitizedBaseModel):
     """Info about a guild blocking user deletion."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
@@ -37,7 +39,7 @@ class GuildBlockerInfo(BaseModel):
     other_members: List[UserPublic] = Field(default_factory=list)
 
 
-class InitiativeBlockerInfo(BaseModel):
+class InitiativeBlockerInfo(SanitizedBaseModel):
     """Info about an initiative blocking user deletion."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
@@ -47,7 +49,7 @@ class InitiativeBlockerInfo(BaseModel):
     other_members: List[UserPublic] = Field(default_factory=list)
 
 
-class AdminDeletionEligibilityResponse(BaseModel):
+class AdminDeletionEligibilityResponse(SanitizedBaseModel):
     """Enhanced eligibility response with actionable blocker details."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
@@ -59,11 +61,11 @@ class AdminDeletionEligibilityResponse(BaseModel):
     initiative_blockers: List[InitiativeBlockerInfo] = Field(default_factory=list)
 
 
-class AdminGuildRoleUpdate(BaseModel):
+class AdminGuildRoleUpdate(SanitizedBaseModel):
     """Schema for updating a user's guild role via admin endpoint."""
     role: GuildRole
 
 
-class AdminInitiativeRoleUpdate(BaseModel):
+class AdminInitiativeRoleUpdate(SanitizedBaseModel):
     """Schema for updating a user's initiative role via admin endpoint."""
     role: InitiativeRole

--- a/backend/app/schemas/ai_generation.py
+++ b/backend/app/schemas/ai_generation.py
@@ -1,23 +1,25 @@
 """AI Generation request and response schemas."""
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class GenerateSubtasksResponse(BaseModel):
+class GenerateSubtasksResponse(SanitizedBaseModel):
     """Response schema for subtask generation."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     subtasks: list[str]
 
 
-class GenerateDescriptionResponse(BaseModel):
+class GenerateDescriptionResponse(SanitizedBaseModel):
     """Response schema for description generation."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     description: str
 
 
-class GenerateDocumentSummaryResponse(BaseModel):
+class GenerateDocumentSummaryResponse(SanitizedBaseModel):
     """Response schema for document summarization."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 

--- a/backend/app/schemas/ai_settings.py
+++ b/backend/app/schemas/ai_settings.py
@@ -1,7 +1,9 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
 class AIProvider(str, Enum):
@@ -12,7 +14,7 @@ class AIProvider(str, Enum):
 
 
 # Platform (AppSetting) level schemas
-class PlatformAISettingsResponse(BaseModel):
+class PlatformAISettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     enabled: bool
@@ -24,7 +26,7 @@ class PlatformAISettingsResponse(BaseModel):
     allow_user_override: bool = True
 
 
-class PlatformAISettingsUpdate(BaseModel):
+class PlatformAISettingsUpdate(SanitizedBaseModel):
     enabled: bool
     provider: Optional[AIProvider] = None
     api_key: Optional[str] = None
@@ -35,7 +37,7 @@ class PlatformAISettingsUpdate(BaseModel):
 
 
 # Guild level schemas
-class GuildAISettingsResponse(BaseModel):
+class GuildAISettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     # Guild's own settings (null = inherit)
@@ -57,7 +59,7 @@ class GuildAISettingsResponse(BaseModel):
     can_override: bool = True  # Whether guild can override platform settings
 
 
-class GuildAISettingsUpdate(BaseModel):
+class GuildAISettingsUpdate(SanitizedBaseModel):
     enabled: Optional[bool] = None
     provider: Optional[AIProvider] = None
     api_key: Optional[str] = None
@@ -71,7 +73,7 @@ class GuildAISettingsUpdate(BaseModel):
 
 
 # User level schemas
-class UserAISettingsResponse(BaseModel):
+class UserAISettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     # User's own settings (null = inherit)
@@ -92,7 +94,7 @@ class UserAISettingsResponse(BaseModel):
     settings_source: str = "platform"  # "platform", "guild", or "user"
 
 
-class UserAISettingsUpdate(BaseModel):
+class UserAISettingsUpdate(SanitizedBaseModel):
     enabled: Optional[bool] = None
     provider: Optional[AIProvider] = None
     api_key: Optional[str] = None
@@ -105,7 +107,7 @@ class UserAISettingsUpdate(BaseModel):
 
 
 # Resolved settings (final computed, used internally)
-class ResolvedAISettings(BaseModel):
+class ResolvedAISettings(SanitizedBaseModel):
     enabled: bool = False
     provider: Optional[AIProvider] = None
     api_key: Optional[str] = None
@@ -115,7 +117,7 @@ class ResolvedAISettings(BaseModel):
 
 
 # Resolved settings response (without API key for frontend)
-class ResolvedAISettingsResponse(BaseModel):
+class ResolvedAISettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     enabled: bool = False
@@ -127,14 +129,14 @@ class ResolvedAISettingsResponse(BaseModel):
 
 
 # Test connection schemas
-class AITestConnectionRequest(BaseModel):
+class AITestConnectionRequest(SanitizedBaseModel):
     provider: AIProvider
     api_key: Optional[str] = None
     base_url: Optional[str] = None
     model: Optional[str] = None
 
 
-class AITestConnectionResponse(BaseModel):
+class AITestConnectionResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     success: bool
@@ -143,13 +145,13 @@ class AITestConnectionResponse(BaseModel):
 
 
 # Fetch models schemas
-class AIModelsRequest(BaseModel):
+class AIModelsRequest(SanitizedBaseModel):
     provider: AIProvider
     api_key: Optional[str] = None
     base_url: Optional[str] = None
 
 
-class AIModelsResponse(BaseModel):
+class AIModelsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     models: list[str]

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class ApiKeyMetadata(BaseModel):
+class ApiKeyMetadata(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -16,18 +18,18 @@ class ApiKeyMetadata(BaseModel):
     expires_at: Optional[datetime] = None
 
 
-class ApiKeyListResponse(BaseModel):
+class ApiKeyListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     keys: list[ApiKeyMetadata] = Field(default_factory=list)
 
 
-class ApiKeyCreateRequest(BaseModel):
+class ApiKeyCreateRequest(SanitizedBaseModel):
     name: str = Field(min_length=1, max_length=100)
     expires_at: Optional[datetime] = None
 
 
-class ApiKeyCreateResponse(BaseModel):
+class ApiKeyCreateResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     api_key: ApiKeyMetadata

--- a/backend/app/schemas/attachment.py
+++ b/backend/app/schemas/attachment.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class AttachmentUploadResponse(BaseModel):
+class AttachmentUploadResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     filename: str

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,24 +1,26 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class VerificationSendResponse(BaseModel):
+class VerificationSendResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     status: str
 
 
-class VerificationConfirmRequest(BaseModel):
+class VerificationConfirmRequest(SanitizedBaseModel):
     token: str = Field(min_length=10)
 
 
-class PasswordResetRequest(BaseModel):
+class PasswordResetRequest(SanitizedBaseModel):
     email: EmailStr
 
 
-class PasswordResetSubmit(BaseModel):
+class PasswordResetSubmit(SanitizedBaseModel):
     token: str = Field(min_length=10)
     password: str = Field(min_length=8, max_length=256)
 
@@ -26,7 +28,7 @@ class PasswordResetSubmit(BaseModel):
 # Device token schemas for mobile app authentication
 
 
-class DeviceTokenRequest(BaseModel):
+class DeviceTokenRequest(SanitizedBaseModel):
     """Request body for creating a device token."""
 
     email: EmailStr
@@ -34,7 +36,7 @@ class DeviceTokenRequest(BaseModel):
     device_name: str = Field(min_length=1, max_length=255)
 
 
-class DeviceTokenResponse(BaseModel):
+class DeviceTokenResponse(SanitizedBaseModel):
     """Response containing the device token."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
@@ -42,7 +44,7 @@ class DeviceTokenResponse(BaseModel):
     token_type: str = "device_token"
 
 
-class DeviceTokenInfo(BaseModel):
+class DeviceTokenInfo(SanitizedBaseModel):
     """Information about a device token (for listing/management)."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 

--- a/backend/app/schemas/base.py
+++ b/backend/app/schemas/base.py
@@ -1,0 +1,54 @@
+"""Base schema with automatic HTML sanitization for str fields."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated, Any
+
+import nh3
+from pydantic import BaseModel, model_validator
+
+
+class _RichTextMarker:
+    """Marker metadata: this field opts out of HTML sanitization."""
+
+
+RichTextStr = Annotated[str, _RichTextMarker()]
+"""Type alias for str fields that must NOT be sanitized (raw input preserved)."""
+
+
+def _is_rich_text(field_info) -> bool:
+    return any(isinstance(m, _RichTextMarker) for m in field_info.metadata)
+
+
+def _is_enum_type(annotation: Any) -> bool:
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        return True
+    # Handle Optional[SomeEnum], Union[SomeEnum, None], etc.
+    args = getattr(annotation, "__args__", None)
+    if args:
+        return any(
+            isinstance(a, type) and issubclass(a, Enum) for a in args
+        )
+    return False
+
+
+class SanitizedBaseModel(BaseModel):
+    """BaseModel that runs nh3.clean() on every str field by default.
+
+    Fields typed as RichTextStr opt out. Enum-typed fields are skipped.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _sanitize_strings(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        for field_name, field_info in cls.model_fields.items():
+            if _is_rich_text(field_info):
+                continue
+            if _is_enum_type(field_info.annotation):
+                continue
+            value = data.get(field_name)
+            if isinstance(value, str):
+                data[field_name] = nh3.clean(value)
+        return data

--- a/backend/app/schemas/base_test.py
+++ b/backend/app/schemas/base_test.py
@@ -1,0 +1,86 @@
+"""Tests for SanitizedBaseModel."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+import pytest
+
+from app.schemas.base import RichTextStr, SanitizedBaseModel
+
+
+class _Color(str, Enum):
+    red = "red"
+    blue = "blue"
+
+
+class _Model(SanitizedBaseModel):
+    name: str
+    bio: Optional[str] = None
+    rich: RichTextStr = ""
+    count: int = 0
+    enabled: bool = False
+    color: _Color = _Color.red
+
+
+@pytest.mark.unit
+def test_strips_script_tags() -> None:
+    m = _Model(name="<script>alert(1)</script>hello")
+    assert "<script>" not in m.name
+    assert "alert(1)" not in m.name
+    assert m.name == "hello"
+
+
+@pytest.mark.unit
+def test_preserves_safe_html() -> None:
+    m = _Model(name="<b>bold</b>")
+    assert m.name == "<b>bold</b>"
+
+
+@pytest.mark.unit
+def test_rich_text_preserves_script() -> None:
+    raw = "<script>alert(1)</script>hello"
+    m = _Model(name="x", rich=raw)
+    assert m.rich == raw
+
+
+@pytest.mark.unit
+def test_enum_field_not_modified() -> None:
+    # Enums should never be coerced through nh3.clean.
+    m = _Model(name="x", color=_Color.blue)
+    assert m.color is _Color.blue
+
+    # Same goes for string-form enum values.
+    m2 = _Model(name="x", color="red")
+    assert m2.color is _Color.red
+
+
+@pytest.mark.unit
+def test_non_str_fields_not_modified() -> None:
+    m = _Model(name="x", count=42, enabled=True)
+    assert m.count == 42
+    assert m.enabled is True
+
+
+@pytest.mark.unit
+def test_plain_text_passes_through() -> None:
+    m = _Model(name="plain text without html")
+    assert m.name == "plain text without html"
+
+
+@pytest.mark.unit
+def test_optional_str_sanitized_when_present() -> None:
+    m = _Model(name="x", bio="<script>x</script>safe")
+    assert m.bio == "safe"
+
+
+@pytest.mark.unit
+def test_optional_str_none_passes_through() -> None:
+    m = _Model(name="x", bio=None)
+    assert m.bio is None
+
+
+@pytest.mark.unit
+def test_javascript_url_stripped() -> None:
+    m = _Model(name='<a href="javascript:bad()">link</a>')
+    assert "javascript:" not in m.name

--- a/backend/app/schemas/base_test.py
+++ b/backend/app/schemas/base_test.py
@@ -1,11 +1,15 @@
 """Tests for SanitizedBaseModel."""
 from __future__ import annotations
 
+import importlib
+import pkgutil
 from enum import Enum
 from typing import Optional
 
 import pytest
+from pydantic import BaseModel
 
+import app.schemas as schemas_pkg
 from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 
@@ -84,3 +88,36 @@ def test_optional_str_none_passes_through() -> None:
 def test_javascript_url_stripped() -> None:
     m = _Model(name='<a href="javascript:bad()">link</a>')
     assert "javascript:" not in m.name
+
+
+@pytest.mark.unit
+def test_every_schema_extends_sanitized_base() -> None:
+    """Lint: every Pydantic class in app.schemas must extend SanitizedBaseModel.
+
+    Catches the case where a new schema is added that inherits directly from
+    pydantic.BaseModel, silently bypassing HTML sanitization on its str fields.
+    """
+    offenders: list[str] = []
+    for module_info in pkgutil.iter_modules(schemas_pkg.__path__):
+        if module_info.name.endswith("_test"):
+            continue
+        module = importlib.import_module(f"app.schemas.{module_info.name}")
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            if not isinstance(attr, type):
+                continue
+            if attr is BaseModel or attr is SanitizedBaseModel:
+                continue
+            if not issubclass(attr, BaseModel):
+                continue
+            # Skip classes re-exported from elsewhere.
+            if not attr.__module__.startswith("app.schemas"):
+                continue
+            if not issubclass(attr, SanitizedBaseModel):
+                offenders.append(f"{attr.__module__}.{attr.__name__}")
+    assert not offenders, (
+        "These Pydantic classes in app.schemas do not extend SanitizedBaseModel:\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+        + "\n\nInherit from SanitizedBaseModel (app.schemas.base) instead of"
+        " BaseModel so str fields are HTML-sanitized by default."
+    )

--- a/backend/app/schemas/calendar_event.py
+++ b/backend/app/schemas/calendar_event.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.calendar_event import RSVPStatus
 from app.schemas.property import PropertySummary
@@ -19,11 +21,11 @@ if TYPE_CHECKING:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 
-class CalendarEventAttendeeCreate(BaseModel):
+class CalendarEventAttendeeCreate(SanitizedBaseModel):
     user_id: int
 
 
-class CalendarEventAttendeeRead(BaseModel):
+class CalendarEventAttendeeRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     user_id: int
@@ -32,7 +34,7 @@ class CalendarEventAttendeeRead(BaseModel):
     created_at: datetime
 
 
-class CalendarEventRSVPUpdate(BaseModel):
+class CalendarEventRSVPUpdate(SanitizedBaseModel):
     rsvp_status: RSVPStatus
 
 
@@ -41,7 +43,7 @@ class CalendarEventRSVPUpdate(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class CalendarEventDocumentRead(BaseModel):
+class CalendarEventDocumentRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     document_id: int
@@ -54,7 +56,7 @@ class CalendarEventDocumentRead(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class EventRecurrence(BaseModel):
+class EventRecurrence(SanitizedBaseModel):
     frequency: str = Field(..., pattern="^(daily|weekly|monthly|yearly)$")
     interval: int = Field(default=1, ge=1, le=365)
     weekdays: Optional[List[str]] = None
@@ -75,7 +77,7 @@ class EventRecurrence(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class CalendarEventBase(BaseModel):
+class CalendarEventBase(SanitizedBaseModel):
     title: str = Field(..., min_length=1, max_length=255)
     description: Optional[str] = None
     location: Optional[str] = Field(default=None, max_length=500)
@@ -104,7 +106,7 @@ class CalendarEventCreate(CalendarEventBase):
     document_ids: Optional[List[int]] = None
 
 
-class CalendarEventUpdate(BaseModel):
+class CalendarEventUpdate(SanitizedBaseModel):
     title: Optional[str] = Field(default=None, min_length=1, max_length=255)
     description: Optional[str] = None
     location: Optional[str] = Field(default=None, max_length=500)
@@ -115,7 +117,7 @@ class CalendarEventUpdate(BaseModel):
     recurrence: Optional[EventRecurrence] = None
 
 
-class CalendarEventAttendeePreview(BaseModel):
+class CalendarEventAttendeePreview(SanitizedBaseModel):
     """Compact per-attendee snapshot for list responses.
 
     Carries the id + avatar fields the SPA needs to render tinted,
@@ -147,7 +149,7 @@ class CalendarEventSummary(CalendarEventBase):
     updated_at: datetime
 
 
-class CalendarEventListResponse(BaseModel):
+class CalendarEventListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     items: List[CalendarEventSummary]

--- a/backend/app/schemas/comment.py
+++ b/backend/app/schemas/comment.py
@@ -4,7 +4,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 
 class MentionEntityType(str, Enum):
@@ -14,7 +16,7 @@ class MentionEntityType(str, Enum):
     project = "project"
 
 
-class CommentAuthor(BaseModel):
+class CommentAuthor(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -24,8 +26,8 @@ class CommentAuthor(BaseModel):
     avatar_base64: Optional[str] = None
 
 
-class CommentBase(BaseModel):
-    content: str
+class CommentBase(SanitizedBaseModel):
+    content: RichTextStr
 
     @field_validator("content")
     @classmethod
@@ -70,9 +72,9 @@ class CommentRead(CommentBase):
     project_id: Optional[int] = None
 
 
-class RecentActivityEntry(BaseModel):
+class RecentActivityEntry(SanitizedBaseModel):
     comment_id: int
-    content: str
+    content: RichTextStr
     created_at: datetime
     author: Optional[CommentAuthor] = None
     task_id: Optional[int] = None
@@ -83,7 +85,7 @@ class RecentActivityEntry(BaseModel):
     project_name: Optional[str] = None
 
 
-class MentionSuggestion(BaseModel):
+class MentionSuggestion(SanitizedBaseModel):
     """A suggestion for mention autocomplete."""
 
     type: MentionEntityType

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.document import DocumentPermissionLevel, DocumentType
 from app.schemas.initiative import InitiativeRead, serialize_initiative
@@ -17,14 +19,14 @@ LexicalState = Dict[str, Any]
 DocumentTypeStr = Literal["native", "file", "whiteboard", "smart_link", "spreadsheet"]
 
 
-class DocumentProjectLink(BaseModel):
+class DocumentProjectLink(SanitizedBaseModel):
     project_id: int
     project_name: Optional[str] = None
     project_icon: Optional[str] = None
     attached_at: datetime
 
 
-class DocumentBase(BaseModel):
+class DocumentBase(SanitizedBaseModel):
     title: str
     initiative_id: int
     featured_image_url: Optional[str] = None
@@ -38,32 +40,32 @@ class DocumentCreate(DocumentBase):
     user_permissions: Optional[List[DocumentPermissionCreate]] = None
 
 
-class DocumentUpdate(BaseModel):
+class DocumentUpdate(SanitizedBaseModel):
     title: Optional[str] = None
     content: Optional[LexicalState] = None
     featured_image_url: Optional[str] = None
     is_template: Optional[bool] = None
 
 
-class DocumentDuplicateRequest(BaseModel):
+class DocumentDuplicateRequest(SanitizedBaseModel):
     title: Optional[str] = None
 
 
-class DocumentCopyRequest(BaseModel):
+class DocumentCopyRequest(SanitizedBaseModel):
     target_initiative_id: int
     title: Optional[str] = None
 
 
-class DocumentRolePermissionCreate(BaseModel):
+class DocumentRolePermissionCreate(SanitizedBaseModel):
     initiative_role_id: int
     level: DocumentPermissionLevel = DocumentPermissionLevel.read
 
 
-class DocumentRolePermissionUpdate(BaseModel):
+class DocumentRolePermissionUpdate(SanitizedBaseModel):
     level: DocumentPermissionLevel
 
 
-class DocumentRolePermissionRead(BaseModel):
+class DocumentRolePermissionRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     initiative_role_id: int
@@ -73,25 +75,25 @@ class DocumentRolePermissionRead(BaseModel):
     created_at: datetime
 
 
-class DocumentPermissionCreate(BaseModel):
+class DocumentPermissionCreate(SanitizedBaseModel):
     user_id: int
     level: DocumentPermissionLevel = DocumentPermissionLevel.write
 
 
-class DocumentPermissionBulkCreate(BaseModel):
+class DocumentPermissionBulkCreate(SanitizedBaseModel):
     user_ids: List[int]
     level: DocumentPermissionLevel = DocumentPermissionLevel.read
 
 
-class DocumentPermissionBulkDelete(BaseModel):
+class DocumentPermissionBulkDelete(SanitizedBaseModel):
     user_ids: List[int]
 
 
-class DocumentPermissionUpdate(BaseModel):
+class DocumentPermissionUpdate(SanitizedBaseModel):
     level: DocumentPermissionLevel
 
 
-class DocumentPermissionRead(BaseModel):
+class DocumentPermissionRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     user_id: int
@@ -99,7 +101,7 @@ class DocumentPermissionRead(BaseModel):
     created_at: datetime
 
 
-class DocumentAutocomplete(BaseModel):
+class DocumentAutocomplete(SanitizedBaseModel):
     """Lightweight document info for autocomplete/wikilinks."""
     model_config = ConfigDict(from_attributes=True)
 
@@ -108,7 +110,7 @@ class DocumentAutocomplete(BaseModel):
     updated_at: datetime
 
 
-class DocumentBacklink(BaseModel):
+class DocumentBacklink(SanitizedBaseModel):
     """Document that links to another document."""
     model_config = ConfigDict(from_attributes=True)
 
@@ -146,7 +148,7 @@ class DocumentSummary(DocumentBase):
     yjs_updated_at: Optional[datetime] = None
 
 
-class DocumentListResponse(BaseModel):
+class DocumentListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     items: List[DocumentSummary]
@@ -158,7 +160,7 @@ class DocumentListResponse(BaseModel):
     sort_dir: Optional[str] = None
 
 
-class DocumentCountsResponse(BaseModel):
+class DocumentCountsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     total_count: int
@@ -170,7 +172,7 @@ class DocumentRead(DocumentSummary):
     content: LexicalState = Field(default_factory=dict)
 
 
-class ProjectDocumentSummary(BaseModel):
+class ProjectDocumentSummary(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     document_id: int

--- a/backend/app/schemas/guild.py
+++ b/backend/app/schemas/guild.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
+
+from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 from app.models.guild import GuildRole
 from app.schemas.user import GuildRemovalProjectInfo
 
 
-class GuildBase(BaseModel):
+class GuildBase(SanitizedBaseModel):
     name: str
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     icon_base64: Optional[str] = None
 
 
@@ -30,13 +32,13 @@ class GuildRead(GuildBase):
     retention_days: Optional[int] = None
 
 
-class GuildInviteCreate(BaseModel):
+class GuildInviteCreate(SanitizedBaseModel):
     expires_at: Optional[datetime] = None
     max_uses: Optional[int] = Field(default=1, ge=1)
     invitee_email: Optional[EmailStr] = None
 
 
-class GuildInviteRead(BaseModel):
+class GuildInviteRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -50,11 +52,11 @@ class GuildInviteRead(BaseModel):
     created_at: datetime
 
 
-class GuildInviteAcceptRequest(BaseModel):
+class GuildInviteAcceptRequest(SanitizedBaseModel):
     code: str
 
 
-class GuildInviteStatus(BaseModel):
+class GuildInviteStatus(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     code: str
@@ -67,9 +69,9 @@ class GuildInviteStatus(BaseModel):
     uses: Optional[int] = None
 
 
-class GuildUpdate(BaseModel):
+class GuildUpdate(SanitizedBaseModel):
     name: Optional[str] = None
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     icon_base64: Optional[str] = None
     # Trash retention period in days. None means "never auto-purge".
     # Sentinel "unset" semantics: explicitly omit the field to leave the
@@ -77,12 +79,12 @@ class GuildUpdate(BaseModel):
     retention_days: Optional[int] = Field(default=None, ge=1, le=3650)
 
 
-class GuildOrderUpdate(BaseModel):
+class GuildOrderUpdate(SanitizedBaseModel):
     model_config = ConfigDict(populate_by_name=True)
     guild_ids: list[int] = Field(min_length=1, alias="guildIds")
 
 
-class GuildSummary(BaseModel):
+class GuildSummary(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -90,12 +92,12 @@ class GuildSummary(BaseModel):
     icon_base64: Optional[str] = None
 
 
-class GuildMembershipUpdate(BaseModel):
+class GuildMembershipUpdate(SanitizedBaseModel):
     """Schema for updating a user's guild membership role."""
     role: GuildRole
 
 
-class LeaveGuildEligibilityResponse(BaseModel):
+class LeaveGuildEligibilityResponse(SanitizedBaseModel):
     """Response for checking if a user can leave a guild.
 
     ``owned_projects`` lists projects in this guild whose ``owner_id``
@@ -115,7 +117,7 @@ class LeaveGuildEligibilityResponse(BaseModel):
     owned_projects: list[GuildRemovalProjectInfo] = Field(default_factory=list)
 
 
-class LeaveGuildRequest(BaseModel):
+class LeaveGuildRequest(SanitizedBaseModel):
     """Body for ``DELETE /guilds/{id}/leave``.
 
     Every project the leaving user owns in this guild must appear in

--- a/backend/app/schemas/ical.py
+++ b/backend/app/schemas/ical.py
@@ -2,10 +2,12 @@
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class ICalEventPreview(BaseModel):
+class ICalEventPreview(SanitizedBaseModel):
     summary: str
     start_at: str
     end_at: Optional[str] = None
@@ -13,22 +15,22 @@ class ICalEventPreview(BaseModel):
     has_recurrence: bool
 
 
-class ICalParseResult(BaseModel):
+class ICalParseResult(SanitizedBaseModel):
     event_count: int
     events: List[ICalEventPreview]
     has_recurring: bool
 
 
-class ICalParseRequest(BaseModel):
+class ICalParseRequest(SanitizedBaseModel):
     ics_content: str = Field(..., max_length=2_000_000)
 
 
-class ICalImportRequest(BaseModel):
+class ICalImportRequest(SanitizedBaseModel):
     initiative_id: int
     ics_content: str = Field(..., max_length=2_000_000)
 
 
-class ICalImportResult(BaseModel):
+class ICalImportResult(SanitizedBaseModel):
     events_created: int = 0
     events_failed: int = 0
     errors: List[str] = Field(default_factory=list)

--- a/backend/app/schemas/import_data.py
+++ b/backend/app/schemas/import_data.py
@@ -1,9 +1,11 @@
 from typing import Dict, List
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class TodoistImportRequest(BaseModel):
+class TodoistImportRequest(SanitizedBaseModel):
     """Request body for importing tasks from Todoist CSV export."""
 
     project_id: int = Field(..., description="Target project to import tasks into")
@@ -13,7 +15,7 @@ class TodoistImportRequest(BaseModel):
     )
 
 
-class ImportResult(BaseModel):
+class ImportResult(SanitizedBaseModel):
     """Result of an import operation."""
 
     tasks_created: int = Field(default=0, description="Number of tasks successfully created")
@@ -22,14 +24,14 @@ class ImportResult(BaseModel):
     errors: List[str] = Field(default_factory=list, description="List of error messages")
 
 
-class TodoistSection(BaseModel):
+class TodoistSection(SanitizedBaseModel):
     """A section detected in the Todoist CSV."""
 
     name: str
     task_count: int
 
 
-class TodoistParseResult(BaseModel):
+class TodoistParseResult(SanitizedBaseModel):
     """Result of parsing a Todoist CSV file."""
 
     sections: List[TodoistSection] = Field(
@@ -42,7 +44,7 @@ class TodoistParseResult(BaseModel):
 # Vikunja import schemas
 
 
-class VikunjaImportRequest(BaseModel):
+class VikunjaImportRequest(SanitizedBaseModel):
     """Request body for importing tasks from Vikunja JSON export."""
 
     project_id: int = Field(..., description="Target Initiative project to import into")
@@ -53,7 +55,7 @@ class VikunjaImportRequest(BaseModel):
     )
 
 
-class VikunjaBucket(BaseModel):
+class VikunjaBucket(SanitizedBaseModel):
     """A bucket (status column) from a Vikunja project."""
 
     id: int
@@ -61,7 +63,7 @@ class VikunjaBucket(BaseModel):
     task_count: int
 
 
-class VikunjaProject(BaseModel):
+class VikunjaProject(SanitizedBaseModel):
     """A project detected in the Vikunja export."""
 
     id: int
@@ -70,7 +72,7 @@ class VikunjaProject(BaseModel):
     buckets: List[VikunjaBucket] = Field(default_factory=list)
 
 
-class VikunjaParseResult(BaseModel):
+class VikunjaParseResult(SanitizedBaseModel):
     """Result of parsing a Vikunja JSON export."""
 
     projects: List[VikunjaProject] = Field(
@@ -82,7 +84,7 @@ class VikunjaParseResult(BaseModel):
 # TickTick import schemas
 
 
-class TickTickImportRequest(BaseModel):
+class TickTickImportRequest(SanitizedBaseModel):
     """Request body for importing tasks from TickTick CSV export."""
 
     project_id: int = Field(..., description="Target Initiative project to import into")
@@ -93,14 +95,14 @@ class TickTickImportRequest(BaseModel):
     )
 
 
-class TickTickColumn(BaseModel):
+class TickTickColumn(SanitizedBaseModel):
     """A column (status) from a TickTick list."""
 
     name: str
     task_count: int
 
 
-class TickTickList(BaseModel):
+class TickTickList(SanitizedBaseModel):
     """A list detected in the TickTick export."""
 
     name: str
@@ -108,7 +110,7 @@ class TickTickList(BaseModel):
     columns: List[TickTickColumn] = Field(default_factory=list)
 
 
-class TickTickParseResult(BaseModel):
+class TickTickParseResult(SanitizedBaseModel):
     """Result of parsing a TickTick CSV export."""
 
     lists: List[TickTickList] = Field(

--- a/backend/app/schemas/initiative.py
+++ b/backend/app/schemas/initiative.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import Dict, List, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 from app.models.initiative import InitiativeRole, PermissionKey
 from app.schemas.user import UserPublic
@@ -13,9 +15,9 @@ if TYPE_CHECKING:  # pragma: no cover
 HEX_COLOR_PATTERN = r"^#(?:[0-9a-fA-F]{3}){1,2}$"
 
 
-class InitiativeBase(BaseModel):
+class InitiativeBase(SanitizedBaseModel):
     name: str
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     color: Optional[str] = Field(default=None, pattern=HEX_COLOR_PATTERN)
     queues_enabled: bool = False
     events_enabled: bool = False
@@ -26,9 +28,9 @@ class InitiativeCreate(InitiativeBase):
     pass
 
 
-class InitiativeUpdate(BaseModel):
+class InitiativeUpdate(SanitizedBaseModel):
     name: Optional[str] = None
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     color: Optional[str] = Field(default=None, pattern=HEX_COLOR_PATTERN)
     queues_enabled: Optional[bool] = None
     events_enabled: Optional[bool] = None
@@ -36,7 +38,7 @@ class InitiativeUpdate(BaseModel):
 
 
 # Role schemas
-class InitiativeRolePermissionRead(BaseModel):
+class InitiativeRolePermissionRead(SanitizedBaseModel):
     """Permission entry for a role."""
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
@@ -44,7 +46,7 @@ class InitiativeRolePermissionRead(BaseModel):
     enabled: bool
 
 
-class InitiativeRoleRead(BaseModel):
+class InitiativeRoleRead(SanitizedBaseModel):
     """Role definition with permissions."""
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
@@ -58,7 +60,7 @@ class InitiativeRoleRead(BaseModel):
     member_count: int = 0
 
 
-class InitiativeRoleCreate(BaseModel):
+class InitiativeRoleCreate(SanitizedBaseModel):
     """Create a new custom role."""
     name: str = Field(..., min_length=1, max_length=100)
     display_name: str = Field(..., min_length=1, max_length=100)
@@ -66,14 +68,14 @@ class InitiativeRoleCreate(BaseModel):
     permissions: Optional[Dict[PermissionKey, bool]] = None
 
 
-class InitiativeRoleUpdate(BaseModel):
+class InitiativeRoleUpdate(SanitizedBaseModel):
     """Update a role's display name and/or permissions."""
     display_name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     is_manager: Optional[bool] = None
     permissions: Optional[Dict[PermissionKey, bool]] = None
 
 
-class AdvancedToolHandoffResponse(BaseModel):
+class AdvancedToolHandoffResponse(SanitizedBaseModel):
     """Short-lived bootstrap token for the embedded advanced-tool iframe.
 
     The SPA passes this to the iframe via postMessage. The iframe's backend
@@ -94,7 +96,7 @@ class AdvancedToolHandoffResponse(BaseModel):
     initiative_id: Optional[int] = None
 
 
-class MyInitiativePermissions(BaseModel):
+class MyInitiativePermissions(SanitizedBaseModel):
     """Current user's permissions for an initiative."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
@@ -110,25 +112,25 @@ class MyInitiativePermissions(BaseModel):
 
 
 # Member schemas - updated to work with role_id
-class InitiativeMemberBase(BaseModel):
+class InitiativeMemberBase(SanitizedBaseModel):
     user_id: int
     role_id: Optional[int] = None
     # Keep legacy role field for backward compatibility
     role: InitiativeRole = InitiativeRole.member
 
 
-class InitiativeMemberAdd(BaseModel):
+class InitiativeMemberAdd(SanitizedBaseModel):
     """Add a member to an initiative."""
     user_id: int
     role_id: Optional[int] = None
 
 
-class InitiativeMemberUpdate(BaseModel):
+class InitiativeMemberUpdate(SanitizedBaseModel):
     """Update a member's role."""
     role_id: int
 
 
-class InitiativeMemberRead(BaseModel):
+class InitiativeMemberRead(SanitizedBaseModel):
     """Member info including their role."""
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 from typing import Any, List
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.notification import NotificationType
 
 
-class NotificationRead(BaseModel):
+class NotificationRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -16,14 +18,14 @@ class NotificationRead(BaseModel):
     read_at: datetime | None = None
 
 
-class NotificationListResponse(BaseModel):
+class NotificationListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     notifications: List[NotificationRead]
     unread_count: int
 
 
-class NotificationCountResponse(BaseModel):
+class NotificationCountResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     unread_count: int

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 from app.models.project import ProjectPermissionLevel
 from app.schemas.initiative import InitiativeRead
@@ -13,9 +15,9 @@ from app.schemas.user import UserPublic
 from app.schemas.comment import CommentAuthor
 
 
-class ProjectBase(BaseModel):
+class ProjectBase(SanitizedBaseModel):
     name: str
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     icon: Optional[str] = None
 
 
@@ -28,28 +30,28 @@ class ProjectCreate(ProjectBase):
     user_permissions: Optional[List[ProjectPermissionCreate]] = None
 
 
-class ProjectUpdate(BaseModel):
+class ProjectUpdate(SanitizedBaseModel):
     name: Optional[str] = None
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     icon: Optional[str] = None
     is_template: Optional[bool] = None
     pinned: Optional[bool] = None
 
 
-class ProjectDuplicateRequest(BaseModel):
+class ProjectDuplicateRequest(SanitizedBaseModel):
     name: Optional[str] = None
 
 
-class ProjectRolePermissionCreate(BaseModel):
+class ProjectRolePermissionCreate(SanitizedBaseModel):
     initiative_role_id: int
     level: ProjectPermissionLevel = ProjectPermissionLevel.read
 
 
-class ProjectRolePermissionUpdate(BaseModel):
+class ProjectRolePermissionUpdate(SanitizedBaseModel):
     level: ProjectPermissionLevel
 
 
-class ProjectRolePermissionRead(BaseModel):
+class ProjectRolePermissionRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     initiative_role_id: int
@@ -59,7 +61,7 @@ class ProjectRolePermissionRead(BaseModel):
     created_at: datetime
 
 
-class ProjectPermissionBase(BaseModel):
+class ProjectPermissionBase(SanitizedBaseModel):
     user_id: int
     level: ProjectPermissionLevel = ProjectPermissionLevel.write
 
@@ -68,16 +70,16 @@ class ProjectPermissionCreate(ProjectPermissionBase):
     pass
 
 
-class ProjectPermissionBulkCreate(BaseModel):
+class ProjectPermissionBulkCreate(SanitizedBaseModel):
     user_ids: List[int]
     level: ProjectPermissionLevel = ProjectPermissionLevel.read
 
 
-class ProjectPermissionBulkDelete(BaseModel):
+class ProjectPermissionBulkDelete(SanitizedBaseModel):
     user_ids: List[int]
 
 
-class ProjectPermissionUpdate(BaseModel):
+class ProjectPermissionUpdate(SanitizedBaseModel):
     level: ProjectPermissionLevel
 
 
@@ -87,7 +89,7 @@ class ProjectPermissionRead(ProjectPermissionBase):
     created_at: datetime
 
 
-class ProjectTaskSummary(BaseModel):
+class ProjectTaskSummary(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     total: int = 0
@@ -119,7 +121,7 @@ class ProjectRead(ProjectBase):
     my_permission_level: Optional[str] = None
 
 
-class ProjectListResponse(BaseModel):
+class ProjectListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     items: List[ProjectRead]
@@ -129,34 +131,34 @@ class ProjectListResponse(BaseModel):
     has_next: bool
 
 
-class ProjectReorderRequest(BaseModel):
+class ProjectReorderRequest(SanitizedBaseModel):
     project_ids: List[int] = Field(default_factory=list)
 
 
-class ProjectFavoriteStatus(BaseModel):
+class ProjectFavoriteStatus(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     project_id: int
     is_favorited: bool
 
 
-class ProjectRecentViewRead(BaseModel):
+class ProjectRecentViewRead(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     project_id: int
     last_viewed_at: datetime
 
 
-class ProjectActivityEntry(BaseModel):
+class ProjectActivityEntry(SanitizedBaseModel):
     comment_id: int
-    content: str
+    content: RichTextStr
     created_at: datetime
     author: Optional[CommentAuthor] = None
     task_id: int
     task_title: str
 
 
-class ProjectActivityResponse(BaseModel):
+class ProjectActivityResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     items: List[ProjectActivityEntry]

--- a/backend/app/schemas/project_export.py
+++ b/backend/app/schemas/project_export.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.property import PropertyType
 from app.models.task import TaskPriority, TaskStatusCategory
@@ -24,7 +26,7 @@ MIN_SUPPORTED_IMPORT_VERSION = 1
 """Imports below this version are rejected. Future migrations may bridge older versions."""
 
 
-class ProjectExportProject(BaseModel):
+class ProjectExportProject(SanitizedBaseModel):
     name: str
     icon: Optional[str] = None
     description: Optional[str] = None
@@ -32,12 +34,12 @@ class ProjectExportProject(BaseModel):
     is_archived: bool = False
 
 
-class ProjectExportTag(BaseModel):
+class ProjectExportTag(SanitizedBaseModel):
     name: str
     color: str
 
 
-class ProjectExportTaskStatus(BaseModel):
+class ProjectExportTaskStatus(SanitizedBaseModel):
     name: str
     category: TaskStatusCategory
     position: int = 0
@@ -46,7 +48,7 @@ class ProjectExportTaskStatus(BaseModel):
     is_default: bool = False
 
 
-class ProjectExportPropertyDefinition(BaseModel):
+class ProjectExportPropertyDefinition(SanitizedBaseModel):
     name: str
     type: PropertyType
     position: float = 0.0
@@ -54,7 +56,7 @@ class ProjectExportPropertyDefinition(BaseModel):
     options: Optional[List[dict]] = None
 
 
-class ProjectExportPropertyValue(BaseModel):
+class ProjectExportPropertyValue(SanitizedBaseModel):
     """Typed property value snapshot.
 
     ``property_type`` is repeated alongside the value so the importer can
@@ -81,13 +83,13 @@ class ProjectExportPropertyValue(BaseModel):
     value_json: Optional[Any] = None
 
 
-class ProjectExportSubtask(BaseModel):
+class ProjectExportSubtask(SanitizedBaseModel):
     content: str
     is_completed: bool = False
     position: int = 0
 
 
-class ProjectExportTask(BaseModel):
+class ProjectExportTask(SanitizedBaseModel):
     title: str
     description: Optional[str] = None
     priority: TaskPriority = TaskPriority.medium
@@ -110,7 +112,7 @@ class ProjectExportTask(BaseModel):
     property_values: List[ProjectExportPropertyValue]
 
 
-class ProjectExportEnvelope(BaseModel):
+class ProjectExportEnvelope(SanitizedBaseModel):
     """Top-level export document. Versioned so the importer can refuse
     or migrate older / unknown formats.
 
@@ -134,7 +136,7 @@ class ProjectExportEnvelope(BaseModel):
     tasks: List[ProjectExportTask]
 
 
-class ProjectImportRequest(BaseModel):
+class ProjectImportRequest(SanitizedBaseModel):
     """Body for ``POST /api/v1/projects/import``.
 
     The envelope is included inline rather than as multipart so the API
@@ -153,7 +155,7 @@ class ProjectImportRequest(BaseModel):
     envelope: dict
 
 
-class ProjectImportResult(BaseModel):
+class ProjectImportResult(SanitizedBaseModel):
     """Summary of what happened during an import. Surfaced in the UI so
     the user can see how many references were dropped or remapped."""
 

--- a/backend/app/schemas/property.py
+++ b/backend/app/schemas/property.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.property import PropertyType
 
@@ -12,7 +14,7 @@ _HEX_COLOR_PATTERN = r"^#[0-9A-Fa-f]{6}$"
 _SELECT_TYPES = {PropertyType.select, PropertyType.multi_select}
 
 
-class PropertyOption(BaseModel):
+class PropertyOption(SanitizedBaseModel):
     """One option entry for select / multi_select property definitions."""
 
     value: str = Field(..., min_length=1, max_length=64, pattern=_SLUG_PATTERN)
@@ -20,7 +22,7 @@ class PropertyOption(BaseModel):
     color: Optional[str] = Field(default=None, pattern=_HEX_COLOR_PATTERN)
 
 
-class PropertyDefinitionBase(BaseModel):
+class PropertyDefinitionBase(SanitizedBaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     type: PropertyType
     position: float = 0.0
@@ -53,7 +55,7 @@ class PropertyDefinitionCreate(PropertyDefinitionBase):
     initiative_id: int
 
 
-class PropertyDefinitionUpdate(BaseModel):
+class PropertyDefinitionUpdate(SanitizedBaseModel):
     """Mutable fields on a property definition.
 
     ``type`` is deliberately excluded — type changes require a dedicated
@@ -95,7 +97,7 @@ class PropertyDefinitionRead(PropertyDefinitionBase):
     updated_at: datetime
 
 
-class PropertyDefinitionUpdateResponse(BaseModel):
+class PropertyDefinitionUpdateResponse(SanitizedBaseModel):
     """Envelope for PATCH /property-definitions/{id}.
 
     Always returns ``orphaned_value_count`` so the SPA can surface a
@@ -109,7 +111,7 @@ class PropertyDefinitionUpdateResponse(BaseModel):
     orphaned_value_count: int = 0
 
 
-class PropertyValueInput(BaseModel):
+class PropertyValueInput(SanitizedBaseModel):
     """A single (property_id, value) pair submitted by the client.
 
     The value is polymorphic because the Pydantic layer can't know the
@@ -121,7 +123,7 @@ class PropertyValueInput(BaseModel):
     value: Any = None
 
 
-class PropertyValuesSetRequest(BaseModel):
+class PropertyValuesSetRequest(SanitizedBaseModel):
     """Replace-all payload for PUT /{entity}/{id}/properties.
 
     An empty list clears every property value on the entity.
@@ -130,7 +132,7 @@ class PropertyValuesSetRequest(BaseModel):
     values: List[PropertyValueInput] = Field(default_factory=list)
 
 
-class PropertySummary(BaseModel):
+class PropertySummary(SanitizedBaseModel):
     """Lightweight property value for embedding in entity reads.
 
     ``value`` is rehydrated from the correct typed column by the service

--- a/backend/app/schemas/push.py
+++ b/backend/app/schemas/push.py
@@ -1,9 +1,11 @@
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class PushTokenRegisterRequest(BaseModel):
+class PushTokenRegisterRequest(SanitizedBaseModel):
     """Request body for registering a push notification token."""
 
     push_token: str = Field(min_length=1, max_length=512)
@@ -11,20 +13,20 @@ class PushTokenRegisterRequest(BaseModel):
     device_token_id: Optional[int] = None
 
 
-class PushTokenUnregisterRequest(BaseModel):
+class PushTokenUnregisterRequest(SanitizedBaseModel):
     """Request body for unregistering a push notification token."""
 
     push_token: str = Field(min_length=1, max_length=512)
 
 
-class PushTokenResponse(BaseModel):
+class PushTokenResponse(SanitizedBaseModel):
     """Generic response for push token operations."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     status: str
 
 
-class FCMConfigResponse(BaseModel):
+class FCMConfigResponse(SanitizedBaseModel):
     """Public FCM configuration for mobile app initialization.
 
     Only exposes public fields (API key, project ID, sender ID).

--- a/backend/app/schemas/query.py
+++ b/backend/app/schemas/query.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Generic, Literal, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
 MAX_PAGE_SIZE = 100
@@ -32,7 +34,7 @@ class SortDir(str, Enum):
     desc = "desc"
 
 
-class FilterCondition(BaseModel):
+class FilterCondition(SanitizedBaseModel):
     """A single field comparison.
 
     Set ``negate=True`` to invert the result::
@@ -49,7 +51,7 @@ class FilterCondition(BaseModel):
     negate: bool = False
 
 
-class FilterGroup(BaseModel):
+class FilterGroup(SanitizedBaseModel):
     """Group of conditions combined with AND or OR logic.
 
     Set ``negate=True`` to invert the entire group::
@@ -86,12 +88,12 @@ class FilterGroup(BaseModel):
     conditions: list[FilterCondition | FilterGroup]
 
 
-class SortField(BaseModel):
+class SortField(SanitizedBaseModel):
     field: str
     dir: SortDir = SortDir.asc
 
 
-class PaginationParams(BaseModel):
+class PaginationParams(SanitizedBaseModel):
     page: int = Field(default=1, ge=1)
     page_size: int = Field(default=20, ge=0, le=MAX_PAGE_SIZE)
 
@@ -99,7 +101,7 @@ class PaginationParams(BaseModel):
 T = TypeVar("T")
 
 
-class PaginatedResponse(BaseModel, Generic[T]):
+class PaginatedResponse(SanitizedBaseModel, Generic[T]):
     items: list[T]
     total_count: int
     page: int

--- a/backend/app/schemas/queue.py
+++ b/backend/app/schemas/queue.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 from app.models.queue import QueuePermissionLevel
 from app.schemas.tag import TagSummary
@@ -18,12 +20,12 @@ if TYPE_CHECKING:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 
-class QueuePermissionCreate(BaseModel):
+class QueuePermissionCreate(SanitizedBaseModel):
     user_id: int
     level: QueuePermissionLevel = QueuePermissionLevel.write
 
 
-class QueuePermissionRead(BaseModel):
+class QueuePermissionRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     user_id: int
@@ -31,12 +33,12 @@ class QueuePermissionRead(BaseModel):
     created_at: datetime
 
 
-class QueueRolePermissionCreate(BaseModel):
+class QueueRolePermissionCreate(SanitizedBaseModel):
     initiative_role_id: int
     level: QueuePermissionLevel = QueuePermissionLevel.read
 
 
-class QueueRolePermissionRead(BaseModel):
+class QueueRolePermissionRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     initiative_role_id: int
@@ -51,7 +53,7 @@ class QueueRolePermissionRead(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class QueueItemDocumentRead(BaseModel):
+class QueueItemDocumentRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     document_id: int
@@ -59,7 +61,7 @@ class QueueItemDocumentRead(BaseModel):
     attached_at: datetime
 
 
-class QueueItemTaskRead(BaseModel):
+class QueueItemTaskRead(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     task_id: int
@@ -72,11 +74,11 @@ class QueueItemTaskRead(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class QueueItemBase(BaseModel):
+class QueueItemBase(SanitizedBaseModel):
     label: str = Field(..., min_length=1, max_length=255)
     position: int = 0
     color: Optional[str] = None
-    notes: Optional[str] = None
+    notes: Optional[RichTextStr] = None
     is_visible: bool = True
 
 
@@ -87,12 +89,12 @@ class QueueItemCreate(QueueItemBase):
     task_ids: Optional[List[int]] = None
 
 
-class QueueItemUpdate(BaseModel):
+class QueueItemUpdate(SanitizedBaseModel):
     label: Optional[str] = None
     position: Optional[int] = None
     user_id: Optional[int] = None
     color: Optional[str] = None
-    notes: Optional[str] = None
+    notes: Optional[RichTextStr] = None
     is_visible: Optional[bool] = None
 
 
@@ -109,8 +111,8 @@ class QueueItemRead(QueueItemBase):
     created_at: datetime
 
 
-class QueueItemReorderRequest(BaseModel):
-    class ReorderItem(BaseModel):
+class QueueItemReorderRequest(SanitizedBaseModel):
+    class ReorderItem(SanitizedBaseModel):
         id: int
         position: int
 
@@ -122,7 +124,7 @@ class QueueItemReorderRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class QueueBase(BaseModel):
+class QueueBase(SanitizedBaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     description: Optional[str] = None
 
@@ -133,7 +135,7 @@ class QueueCreate(QueueBase):
     user_permissions: Optional[List[QueuePermissionCreate]] = None
 
 
-class QueueUpdate(BaseModel):
+class QueueUpdate(SanitizedBaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
 
@@ -153,7 +155,7 @@ class QueueSummary(QueueBase):
     my_permission_level: Optional[str] = None
 
 
-class QueueListResponse(BaseModel):
+class QueueListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     items: List[QueueSummary]

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,8 +1,10 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
-class OIDCSettingsResponse(BaseModel):
+from app.schemas.base import SanitizedBaseModel
+
+class OIDCSettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     enabled: bool
@@ -15,7 +17,7 @@ class OIDCSettingsResponse(BaseModel):
     scopes: List[str] = Field(default_factory=list)
 
 
-class OIDCSettingsUpdate(BaseModel):
+class OIDCSettingsUpdate(SanitizedBaseModel):
     enabled: bool
     issuer: Optional[str] = None
     client_id: Optional[str] = None
@@ -26,19 +28,19 @@ class OIDCSettingsUpdate(BaseModel):
     scopes: List[str] = Field(default_factory=list)
 
 
-class InterfaceSettingsResponse(BaseModel):
+class InterfaceSettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     light_accent_color: str
     dark_accent_color: str
 
 
-class InterfaceSettingsUpdate(BaseModel):
+class InterfaceSettingsUpdate(SanitizedBaseModel):
     light_accent_color: str
     dark_accent_color: str
 
 
-class RoleLabelsResponse(BaseModel):
+class RoleLabelsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     admin: str
@@ -46,13 +48,13 @@ class RoleLabelsResponse(BaseModel):
     member: str
 
 
-class RoleLabelsUpdate(BaseModel):
+class RoleLabelsUpdate(SanitizedBaseModel):
     admin: Optional[str] = Field(default=None, min_length=1, max_length=64)
     project_manager: Optional[str] = Field(default=None, min_length=1, max_length=64)
     member: Optional[str] = Field(default=None, min_length=1, max_length=64)
 
 
-class EmailSettingsResponse(BaseModel):
+class EmailSettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     host: Optional[str] = None
@@ -65,7 +67,7 @@ class EmailSettingsResponse(BaseModel):
     test_recipient: Optional[EmailStr] = None
 
 
-class EmailSettingsUpdate(BaseModel):
+class EmailSettingsUpdate(SanitizedBaseModel):
     host: Optional[str] = None
     port: Optional[int] = Field(default=None, ge=1, le=65535)
     secure: bool = False
@@ -76,13 +78,13 @@ class EmailSettingsUpdate(BaseModel):
     test_recipient: Optional[EmailStr] = None
 
 
-class EmailTestRequest(BaseModel):
+class EmailTestRequest(SanitizedBaseModel):
     recipient: Optional[EmailStr] = None
 
 
 # --- OIDC Claim Mapping schemas ---
 
-class OIDCClaimMappingCreate(BaseModel):
+class OIDCClaimMappingCreate(SanitizedBaseModel):
     claim_value: str = Field(min_length=1, max_length=500)
     target_type: str  # "guild" or "initiative"
     guild_id: int
@@ -91,7 +93,7 @@ class OIDCClaimMappingCreate(BaseModel):
     initiative_role_id: Optional[int] = None
 
 
-class OIDCClaimMappingUpdate(BaseModel):
+class OIDCClaimMappingUpdate(SanitizedBaseModel):
     claim_value: Optional[str] = Field(default=None, min_length=1, max_length=500)
     target_type: Optional[str] = None
     guild_id: Optional[int] = None
@@ -100,7 +102,7 @@ class OIDCClaimMappingUpdate(BaseModel):
     initiative_role_id: Optional[int] = None
 
 
-class OIDCClaimMappingRead(BaseModel):
+class OIDCClaimMappingRead(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     id: int
@@ -115,11 +117,11 @@ class OIDCClaimMappingRead(BaseModel):
     initiative_role_name: Optional[str] = None
 
 
-class OIDCClaimPathUpdate(BaseModel):
+class OIDCClaimPathUpdate(SanitizedBaseModel):
     claim_path: Optional[str] = Field(default=None, max_length=500)
 
 
-class OIDCMappingsResponse(BaseModel):
+class OIDCMappingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     claim_path: Optional[str] = None

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -1,10 +1,12 @@
 from datetime import date
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class VelocityWeekData(BaseModel):
+class VelocityWeekData(SanitizedBaseModel):
     """Weekly velocity data showing tasks assigned vs completed."""
 
     week_start: date = Field(..., description="Start date of the week")
@@ -12,14 +14,14 @@ class VelocityWeekData(BaseModel):
     completed: int = Field(..., description="Number of tasks completed this week")
 
 
-class HeatmapDayData(BaseModel):
+class HeatmapDayData(SanitizedBaseModel):
     """Daily activity data for heatmap visualization."""
 
     day: date = Field(..., description="Date of activity", serialization_alias="date")
     activity_count: int = Field(..., description="Number of task activities on this date")
 
 
-class GuildTaskBreakdown(BaseModel):
+class GuildTaskBreakdown(SanitizedBaseModel):
     """Task completion breakdown by guild."""
 
     guild_id: int = Field(..., description="Guild ID")
@@ -27,7 +29,7 @@ class GuildTaskBreakdown(BaseModel):
     completed_count: int = Field(..., description="Number of completed tasks in this guild")
 
 
-class UserStatsResponse(BaseModel):
+class UserStatsResponse(SanitizedBaseModel):
     """Comprehensive user statistics response."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 

--- a/backend/app/schemas/subtask.py
+++ b/backend/app/schemas/subtask.py
@@ -1,34 +1,36 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class SubtaskBase(BaseModel):
+class SubtaskBase(SanitizedBaseModel):
     content: str = Field(min_length=1, max_length=2000)
     is_completed: bool = False
 
 
-class SubtaskCreate(BaseModel):
+class SubtaskCreate(SanitizedBaseModel):
     content: str = Field(min_length=1, max_length=2000)
 
 
-class SubtaskUpdate(BaseModel):
+class SubtaskUpdate(SanitizedBaseModel):
     content: Optional[str] = Field(default=None, min_length=1, max_length=2000)
     is_completed: Optional[bool] = None
 
 
-class SubtaskBatchCreate(BaseModel):
+class SubtaskBatchCreate(SanitizedBaseModel):
     """Create multiple subtasks at once."""
     contents: list[str] = Field(min_length=1, max_length=50)
 
 
-class SubtaskReorderItem(BaseModel):
+class SubtaskReorderItem(SanitizedBaseModel):
     id: int
     position: int
 
 
-class SubtaskReorderRequest(BaseModel):
+class SubtaskReorderRequest(SanitizedBaseModel):
     items: list[SubtaskReorderItem]
 
 
@@ -42,7 +44,7 @@ class SubtaskRead(SubtaskBase):
     updated_at: datetime
 
 
-class TaskSubtaskProgress(BaseModel):
+class TaskSubtaskProgress(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     completed: int = 0

--- a/backend/app/schemas/tag.py
+++ b/backend/app/schemas/tag.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class TagBase(BaseModel):
+class TagBase(SanitizedBaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     color: str = Field(default="#6366F1", pattern=r"^#[0-9A-Fa-f]{6}$")
 
@@ -20,7 +22,7 @@ class TagCreate(TagBase):
     pass
 
 
-class TagUpdate(BaseModel):
+class TagUpdate(SanitizedBaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     color: Optional[str] = Field(default=None, pattern=r"^#[0-9A-Fa-f]{6}$")
 
@@ -33,7 +35,7 @@ class TagUpdate(BaseModel):
         return v
 
 
-class TagSummary(BaseModel):
+class TagSummary(SanitizedBaseModel):
     """Lightweight tag representation for embedding in other schemas."""
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
@@ -51,12 +53,12 @@ class TagRead(TagBase):
     updated_at: datetime
 
 
-class TagSetRequest(BaseModel):
+class TagSetRequest(SanitizedBaseModel):
     """Request body for setting tags on an entity."""
     tag_ids: List[int] = Field(default_factory=list)
 
 
-class TaggedEntitiesResponse(BaseModel):
+class TaggedEntitiesResponse(SanitizedBaseModel):
     """Response for GET /tags/{id}/entities - all entities with a given tag."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
@@ -65,7 +67,7 @@ class TaggedEntitiesResponse(BaseModel):
     documents: List["TaggedDocumentSummary"] = Field(default_factory=list)
 
 
-class TaggedTaskSummary(BaseModel):
+class TaggedTaskSummary(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -74,7 +76,7 @@ class TaggedTaskSummary(BaseModel):
     project_name: Optional[str] = None
 
 
-class TaggedProjectSummary(BaseModel):
+class TaggedProjectSummary(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -83,7 +85,7 @@ class TaggedProjectSummary(BaseModel):
     initiative_name: Optional[str] = None
 
 
-class TaggedDocumentSummary(BaseModel):
+class TaggedDocumentSummary(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -92,7 +94,7 @@ class TaggedDocumentSummary(BaseModel):
     initiative_name: Optional[str] = None
 
 
-class TaggedEventSummary(BaseModel):
+class TaggedEventSummary(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 from app.schemas.user import UserPublic
 from app.schemas.task_status import TaskStatusRead
@@ -14,7 +16,7 @@ from app.models.task import TaskPriority
 from app.models.user import UserStatus
 
 
-class TaskAssigneeSummary(BaseModel):
+class TaskAssigneeSummary(SanitizedBaseModel):
     """Minimal assignee data for task lists.
 
     Includes ``status`` so the frontend can render the "Deleted user
@@ -35,7 +37,7 @@ WeekPositionLiteral = Literal["first", "second", "third", "fourth", "last"]
 RecurrenceEndsLiteral = Literal["never", "on_date", "after_occurrences"]
 
 
-class TaskRecurrence(BaseModel):
+class TaskRecurrence(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     frequency: Literal["daily", "weekly", "monthly", "yearly"]
@@ -106,9 +108,9 @@ class TaskRecurrence(BaseModel):
         return self
 
 
-class TaskBase(BaseModel):
+class TaskBase(SanitizedBaseModel):
     title: str
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     priority: TaskPriority = TaskPriority.medium
     start_date: Optional[datetime] = None
     due_date: Optional[datetime] = None
@@ -122,9 +124,9 @@ class TaskCreate(TaskBase):
     task_status_id: Optional[int] = None
 
 
-class TaskUpdate(BaseModel):
+class TaskUpdate(SanitizedBaseModel):
     title: Optional[str] = None
-    description: Optional[str] = None
+    description: Optional[RichTextStr] = None
     task_status_id: Optional[int] = None
     priority: Optional[TaskPriority] = None
     assignee_ids: Optional[List[int]] = None
@@ -135,11 +137,11 @@ class TaskUpdate(BaseModel):
     is_archived: Optional[bool] = None
 
 
-class TaskMoveRequest(BaseModel):
+class TaskMoveRequest(SanitizedBaseModel):
     target_project_id: int = Field(gt=0)
 
 
-class TaskProjectInitiativeSummary(BaseModel):
+class TaskProjectInitiativeSummary(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -147,7 +149,7 @@ class TaskProjectInitiativeSummary(BaseModel):
     color: Optional[str] = None
 
 
-class TaskProjectSummary(BaseModel):
+class TaskProjectSummary(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     id: int
@@ -208,7 +210,7 @@ class TaskListRead(TaskBase):
     properties: List[PropertySummary] = []
 
 
-class TaskListResponse(BaseModel):
+class TaskListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     items: List[TaskListRead]
@@ -220,12 +222,12 @@ class TaskListResponse(BaseModel):
     sorting: Optional[str] = None
 
 
-class TaskReorderItem(BaseModel):
+class TaskReorderItem(SanitizedBaseModel):
     id: int
     task_status_id: int
     sort_order: float
 
 
-class TaskReorderRequest(BaseModel):
+class TaskReorderRequest(SanitizedBaseModel):
     project_id: int
     items: list[TaskReorderItem]

--- a/backend/app/schemas/task_status.py
+++ b/backend/app/schemas/task_status.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.task import TaskStatusCategory
 
@@ -10,7 +12,7 @@ from app.models.task import TaskStatusCategory
 HEX_COLOR_PATTERN = r"^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$"
 
 
-class TaskStatusBase(BaseModel):
+class TaskStatusBase(SanitizedBaseModel):
     name: str = Field(min_length=1, max_length=100)
     category: TaskStatusCategory
     position: int = Field(ge=0)
@@ -19,7 +21,7 @@ class TaskStatusBase(BaseModel):
     icon: str = Field(min_length=1, max_length=64)
 
 
-class TaskStatusCreate(BaseModel):
+class TaskStatusCreate(SanitizedBaseModel):
     name: str = Field(min_length=1, max_length=100)
     category: TaskStatusCategory
     position: Optional[int] = Field(default=None, ge=0)
@@ -30,7 +32,7 @@ class TaskStatusCreate(BaseModel):
     icon: Optional[str] = Field(default=None, min_length=1, max_length=64)
 
 
-class TaskStatusUpdate(BaseModel):
+class TaskStatusUpdate(SanitizedBaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     category: Optional[TaskStatusCategory] = None
     position: Optional[int] = Field(default=None, ge=0)
@@ -48,14 +50,14 @@ class TaskStatusRead(TaskStatusBase):
     project_id: int
 
 
-class TaskStatusDeleteRequest(BaseModel):
+class TaskStatusDeleteRequest(SanitizedBaseModel):
     fallback_status_id: Optional[int] = None
 
 
-class TaskStatusReorderItem(BaseModel):
+class TaskStatusReorderItem(SanitizedBaseModel):
     id: int
     position: int
 
 
-class TaskStatusReorderRequest(BaseModel):
+class TaskStatusReorderRequest(SanitizedBaseModel):
     items: List[TaskStatusReorderItem]

--- a/backend/app/schemas/token.py
+++ b/backend/app/schemas/token.py
@@ -1,14 +1,14 @@
+from app.schemas.base import SanitizedBaseModel
+
 from typing import Optional
 
-from pydantic import BaseModel
 
-
-class Token(BaseModel):
+class Token(SanitizedBaseModel):
     access_token: str
     token_type: str = "bearer"
 
 
-class TokenPayload(BaseModel):
+class TokenPayload(SanitizedBaseModel):
     sub: Optional[str] = None
     exp: Optional[int] = None
     iat: Optional[int] = None

--- a/backend/app/schemas/trash.py
+++ b/backend/app/schemas/trash.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from app.schemas.base import SanitizedBaseModel
 
 
 EntityType = Literal[
@@ -19,7 +21,7 @@ EntityType = Literal[
 ]
 
 
-class TrashItem(BaseModel):
+class TrashItem(SanitizedBaseModel):
     model_config = ConfigDict(from_attributes=True, json_schema_serialization_defaults_required=True)
 
     entity_type: EntityType
@@ -31,7 +33,7 @@ class TrashItem(BaseModel):
     purge_at: Optional[datetime] = None
 
 
-class TrashListResponse(BaseModel):
+class TrashListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     items: list[TrashItem]
@@ -39,11 +41,11 @@ class TrashListResponse(BaseModel):
     retention_days: Optional[int] = None
 
 
-class RestoreRequest(BaseModel):
+class RestoreRequest(SanitizedBaseModel):
     new_owner_id: Optional[int] = None
 
 
-class RestoreNeedsReassignmentResponse(BaseModel):
+class RestoreNeedsReassignmentResponse(SanitizedBaseModel):
     """409 payload when the entity's owner is no longer an active member of
     the relevant initiative. The client opens a picker seeded with
     ``valid_owner_ids`` and resubmits with the chosen one."""

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,14 +1,16 @@
 from datetime import datetime
 from typing import Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, computed_field
+from pydantic import ConfigDict, EmailStr, Field, computed_field
+
+from app.schemas.base import SanitizedBaseModel
 
 from app.models.initiative import InitiativeRole
 from app.models.user import UserRole, UserStatus
 from app.core.config import settings
 
 
-class UserBase(BaseModel):
+class UserBase(SanitizedBaseModel):
     email: EmailStr
     full_name: Optional[str] = None
     role: UserRole = UserRole.member
@@ -28,7 +30,7 @@ class UserCreate(UserBase):
     captcha_token: Optional[str] = None
 
 
-class UserUpdate(BaseModel):
+class UserUpdate(SanitizedBaseModel):
     full_name: Optional[str] = None
     role: Optional[UserRole] = None
     password: Optional[str] = None
@@ -55,7 +57,7 @@ class UserUpdate(BaseModel):
     locale: Optional[str] = Field(default=None, pattern=r"^[a-z]{2}(-[A-Z]{2})?$")
 
 
-class UserPublic(BaseModel):
+class UserPublic(SanitizedBaseModel):
     """Public user information exposed to other users.
 
     Includes ``status`` so the frontend can render the "Deleted user #{id}"
@@ -133,13 +135,13 @@ class UserInDB(UserRead):
     hashed_password: str
 
 
-class UserInitiativeRole(BaseModel):
+class UserInitiativeRole(SanitizedBaseModel):
     initiative_id: int
     initiative_name: str
     role: InitiativeRole
 
 
-class UserSelfUpdate(BaseModel):
+class UserSelfUpdate(SanitizedBaseModel):
     full_name: Optional[str] = None
     password: Optional[str] = None
     avatar_base64: Optional[str] = None
@@ -164,7 +166,7 @@ class UserSelfUpdate(BaseModel):
     locale: Optional[str] = Field(default=None, pattern=r"^[a-z]{2}(-[A-Z]{2})?$")
 
 
-class ProjectBasic(BaseModel):
+class ProjectBasic(SanitizedBaseModel):
     """Basic project information for deletion flow"""
     model_config = ConfigDict(from_attributes=True)
 
@@ -173,7 +175,7 @@ class ProjectBasic(BaseModel):
     initiative_id: int
 
 
-class AccountDeletionRequest(BaseModel):
+class AccountDeletionRequest(SanitizedBaseModel):
     """Request from a user to deactivate or anonymize (soft-delete) their own account.
 
     `hard_delete` is intentionally not allowed from this self-service endpoint;
@@ -185,7 +187,7 @@ class AccountDeletionRequest(BaseModel):
     project_transfers: Optional[Dict[int, int]] = None  # {project_id: new_owner_id}
 
 
-class DeletionEligibilityResponse(BaseModel):
+class DeletionEligibilityResponse(SanitizedBaseModel):
     """Response indicating whether user can be deleted and any blockers"""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
@@ -196,7 +198,7 @@ class DeletionEligibilityResponse(BaseModel):
     last_admin_guilds: List[str] = Field(default_factory=list)
 
 
-class GuildRemovalProjectInfo(BaseModel):
+class GuildRemovalProjectInfo(SanitizedBaseModel):
     """Per-project payload on ``GuildRemovalEligibilityResponse``.
 
     Bundles the candidate transfer recipients next to the project so
@@ -214,7 +216,7 @@ class GuildRemovalProjectInfo(BaseModel):
     candidates: List[UserPublic] = Field(default_factory=list)
 
 
-class GuildRemovalEligibilityResponse(BaseModel):
+class GuildRemovalEligibilityResponse(SanitizedBaseModel):
     """Pre-flight info for ``DELETE /users/{user_id}`` (guild admin
     removes a member from their guild).
 
@@ -231,7 +233,7 @@ class GuildRemovalEligibilityResponse(BaseModel):
     owned_projects: List[GuildRemovalProjectInfo] = Field(default_factory=list)
 
 
-class GuildRemovalRequest(BaseModel):
+class GuildRemovalRequest(SanitizedBaseModel):
     """Body for ``DELETE /users/{user_id}``.
 
     Every project the target user owns in the active guild must
@@ -249,7 +251,7 @@ class GuildRemovalRequest(BaseModel):
     project_deletions: List[int] = Field(default_factory=list)
 
 
-class AccountDeletionResponse(BaseModel):
+class AccountDeletionResponse(SanitizedBaseModel):
     """Response after a deactivate / anonymize / hard-delete action."""
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 

--- a/backend/app/schemas/webhook_subscription.py
+++ b/backend/app/schemas/webhook_subscription.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import ConfigDict, Field, HttpUrl
+
+from app.schemas.base import SanitizedBaseModel
 
 
-class WebhookSubscriptionCreate(BaseModel):
+class WebhookSubscriptionCreate(SanitizedBaseModel):
     """Body for ``POST /api/v1/auto/subscriptions``.
 
     Initiative-id and guild-id are NOT taken from the body — they
@@ -22,13 +24,13 @@ class WebhookSubscriptionCreate(BaseModel):
     workflow_id: int | None = None
 
 
-class WebhookSubscriptionUpdate(BaseModel):
+class WebhookSubscriptionUpdate(SanitizedBaseModel):
     target_url: HttpUrl | None = None
     event_types: list[str] | None = Field(default=None, min_length=1)
     active: bool | None = None
 
 
-class WebhookSubscriptionRead(BaseModel):
+class WebhookSubscriptionRead(SanitizedBaseModel):
     """Public view. Notably ``hmac_secret`` is NOT in here — once minted
     on create it never leaves the DB again. Receivers either store the
     secret from the create response or rotate the subscription."""

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ email-validator = "^2.1.1"
 httpx = "^0.28.1"
 alembic = "^1.14.0"
 icalendar = ">=6.0.0"
+nh3 = "^0.3.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ slowapi==0.1.9
 tzdata>=2024.1  # Required on Windows for timezone support
 python-magic>=0.4.27  # MIME type detection for file uploads
 icalendar>=6.0.0  # iCal import/export
+nh3==0.3.5  # HTML sanitization for schema inputs
 
 # Collaboration (Yjs CRDT)
 pycrdt~=0.12.50

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -5,33 +5,6 @@ import HttpBackend from "i18next-http-backend";
 
 import { getItem, setItem } from "@/lib/storage";
 
-export const defaultNS = "common";
-export const namespaces = [
-  "common",
-  "auth",
-  "nav",
-  "projects",
-  "tasks",
-  "documents",
-  "initiatives",
-  "settings",
-  "tags",
-  "guilds",
-  "import",
-  "notifications",
-  "queues",
-  "events",
-  "stats",
-  "landing",
-  "errors",
-  "dates",
-  "dashboard",
-  "command",
-  "properties",
-] as const;
-
-const LANGUAGE_STORAGE_KEY = "initiative-language";
-
 /**
  * Custom language detector that uses the app's storage abstraction
  * instead of accessing localStorage directly. This ensures language
@@ -42,18 +15,17 @@ const storageLanguageDetector: LanguageDetectorModule = {
   type: "languageDetector",
   init() {},
   detect() {
-    const stored = getItem(LANGUAGE_STORAGE_KEY);
+    const stored = getItem("initiative-language");
     if (stored) {
       return stored;
     }
-    // Fall back to browser language
     if (typeof navigator !== "undefined") {
       return navigator.language;
     }
     return undefined;
   },
   cacheUserLanguage(lng: string) {
-    setItem(LANGUAGE_STORAGE_KEY, lng);
+    setItem("initiative-language", lng);
   },
 };
 
@@ -64,7 +36,9 @@ void i18n
   .init({
     load: "languageOnly",
     fallbackLng: "en",
-    defaultNS,
+    supportedLngs: ["en", "es", "fr"],
+    nonExplicitSupportedLngs: true,
+    defaultNS: "common",
     fallbackNS: "common",
     // ``errors`` is preloaded alongside ``common`` because
     // ``getErrorMessage`` (in ``@/lib/errorMessage``) is invoked from


### PR DESCRIPTION
## Summary

- Adds `nh3` and a new `SanitizedBaseModel` that auto-sanitizes every `str` field on every schema in `app/schemas/`. Dangerous markup (`<script>`, `<iframe>`, `on*` handlers, `javascript:` URLs) is stripped at validation time before reaching services or the DB. Safe formatting tags (`<b>`, `<i>`, `<a>`, `<p>`) pass through.
- Fields meant to hold user-authored markup opt out via the explicit `RichTextStr` type: `comment.content`, `project.description`/`content`, `guild.description`, `initiative.description`, `task.description`, `queue.notes`. Enum-typed fields are skipped automatically.
- Minor i18n cleanup: drops unused `namespaces` / `defaultNS` exports from `frontend/src/i18n.ts`, inlines the language storage key, adds `supportedLngs: ["en", "es", "fr"]` so unsupported browser locales fall back to `en` without 404ing on the namespace fetches.

## Notable changes

- **Dependency**: `nh3 ^0.3.5` added to `backend/pyproject.toml` and pinned in `backend/requirements.txt`.
- **All 28 schema files** in `app/schemas/` reparented from `BaseModel` → `SanitizedBaseModel`.
- **New module**: `app/schemas/base.py` (47 lines) with `SanitizedBaseModel`, `RichTextStr`, and the field-walking validator.
- **New test**: `app/schemas/base_test.py` covers strip/preserve/opt-out/enum/optional paths.

## Schema / env updates

- No DB migration required.
- No env var changes.
- New runtime dependency (`nh3`) — run `pip install -r backend/requirements.txt` (or `poetry install`) after pulling.

## Test plan

- [x] `cd backend && pytest app/schemas/base_test.py` — 9/9 passing
- [ ] Reviewer: confirm no existing endpoint relies on raw `<script>` or attribute-handler strings passing through. (None expected — RichTextStr was applied to every field with user-authored markup.)
- [ ] Reviewer: spot-check that a `POST /api/v1/tasks` with `title: "<script>alert(1)</script>x"` returns a task whose stored `title` is just `"x"`.