### PR TITLE
Restrict Ollama AI provider to platform scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Restrict Ollama AI provider to platform-level settings. Guild and user AI settings no longer offer Ollama as a provider option (it cannot reasonably be reached from outside the host's network anyway). A migration nulls out any pre-existing Ollama overrides on guild_settings and users, falling back to the inherited platform configuration.
+- Show an inline HTTP warning on the platform AI page when the Ollama base URL is configured with `http://`, reminding admins to use TLS in production.
+- Platform admins can now point Ollama / custom AI base URLs at `http://` or private addresses. The SSRF guard still applies to guild/user-supplied URLs in the test-connection and fetch-models endpoints; it is bypassed only when the caller is a platform admin (who already controls the host). AI generation paths trust ollama URLs unconditionally now that ollama is platform-only.
 - Bump vite from v7 to v8. Decreases bundler step from 25s to 2s.
 - Migrate to typescript 7 beta. Decreases compile step from 25s to 5s.
 - Bump Dockerfile Node.js from v20 to v24.

--- a/backend/alembic/versions/20260515_0084_remove_ollama_from_guild_user_ai.py
+++ b/backend/alembic/versions/20260515_0084_remove_ollama_from_guild_user_ai.py
@@ -1,0 +1,49 @@
+"""Null out Ollama AI settings at guild and user scope.
+
+Ollama is now only configurable at the platform level. Any existing
+guild_settings or users rows that selected ollama have their AI override
+fields cleared so they fall back to inherited platform settings.
+
+Revision ID: 20260515_0084
+Revises: 20260501_0083
+Create Date: 2026-05-15
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260515_0084"
+down_revision = "20260501_0083"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            """
+            UPDATE guild_settings
+            SET ai_provider = NULL,
+                ai_api_key_encrypted = NULL,
+                ai_base_url = NULL,
+                ai_model = NULL
+            WHERE ai_provider = 'ollama'
+            """
+        )
+    )
+    op.execute(
+        text(
+            """
+            UPDATE users
+            SET ai_provider = NULL,
+                ai_api_key_encrypted = NULL,
+                ai_base_url = NULL,
+                ai_model = NULL
+            WHERE ai_provider = 'ollama'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/api/v1/endpoints/ai_settings.py
+++ b/backend/app/api/v1/endpoints/ai_settings.py
@@ -20,7 +20,7 @@ from app.api.deps import (
 )
 from app.api.v1.endpoints.admin import AdminUserDep
 from app.models.guild import GuildRole
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.schemas.ai_settings import (
     AIModelsRequest,
     AIModelsResponse,
@@ -154,7 +154,10 @@ async def test_ai_connection(
         resolved = await ai_settings_service.resolve_ai_settings(session, current_user, guild_context.guild_id)
         api_key = resolved.api_key
 
-    return await ai_settings_service.test_ai_connection(payload, existing_api_key=api_key)
+    bypass_ssrf = current_user.role == UserRole.admin
+    return await ai_settings_service.test_ai_connection(
+        payload, existing_api_key=api_key, bypass_ssrf=bypass_ssrf
+    )
 
 
 # Fetch models endpoint (any authenticated user)
@@ -175,10 +178,12 @@ async def fetch_ai_models(
         resolved = await ai_settings_service.resolve_ai_settings(session, current_user, guild_context.guild_id)
         api_key = resolved.api_key
 
+    bypass_ssrf = current_user.role == UserRole.admin
     models, error = await ai_settings_service.fetch_models(
         payload.provider,
         api_key,
         payload.base_url,
+        bypass_ssrf=bypass_ssrf,
     )
 
     return AIModelsResponse(models=models, error=error)

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -331,3 +331,4 @@ class WebhookSubscriptionMessages:
 
 class AIMessages:
     INVALID_BASE_URL = "AI_INVALID_BASE_URL"
+    PROVIDER_NOT_ALLOWED = "AI_PROVIDER_NOT_ALLOWED"

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -37,7 +37,10 @@ async def _validate_generation_base_url(
     provider: AIProvider | None,
     base_url: str | None,
 ) -> None:
-    if provider not in {AIProvider.ollama, AIProvider.custom} or not base_url:
+    # Ollama is platform-admin-only (guild/user can no longer select it),
+    # so its base_url is operator-controlled and trusted. Only custom
+    # providers still flow user-supplied URLs that need the SSRF guard.
+    if provider != AIProvider.custom or not base_url:
         return
     try:
         await assert_target_url_is_public_async(base_url)

--- a/backend/app/services/ai_generation_test.py
+++ b/backend/app/services/ai_generation_test.py
@@ -20,16 +20,13 @@ async def _resolved_settings(
 
 
 @pytest.mark.unit
-async def test_generate_subtasks_blocks_existing_private_ollama_base_url(monkeypatch):
-    async def fake_resolve(*args, **kwargs):
-        return await _resolved_settings(AIProvider.ollama, "http://169.254.169.254")
-
-    monkeypatch.setattr(ai_generation, "resolve_ai_settings", fake_resolve)
-
-    with pytest.raises(ai_generation.AIGenerationError) as exc_info:
-        await ai_generation.generate_subtasks(None, object(), 1, object())
-
-    assert str(exc_info.value) == "AI_INVALID_BASE_URL"
+async def test_generate_subtasks_allows_private_ollama_base_url():
+    """Ollama is platform-only (operator-controlled), so the SSRF guard
+    no longer applies to its base_url during generation."""
+    # Should not raise — guard is bypassed for ollama.
+    await ai_generation._validate_generation_base_url(
+        AIProvider.ollama, "http://169.254.169.254"
+    )
 
 
 @pytest.mark.unit

--- a/backend/app/services/ai_settings.py
+++ b/backend/app/services/ai_settings.py
@@ -168,6 +168,9 @@ async def update_guild_ai_settings(
     if not platform_settings.ai_allow_guild_override:
         raise PermissionError("Guild AI settings override is disabled by platform administrator")
 
+    if not payload.clear_settings and payload.provider == AIProvider.ollama:
+        raise HTTPException(status_code=400, detail=AIMessages.PROVIDER_NOT_ALLOWED)
+
     if not payload.clear_settings and payload.base_url:
         try:
             await assert_target_url_is_public_async(payload.base_url)
@@ -307,6 +310,9 @@ async def update_user_ai_settings(
     if not can_override:
         raise PermissionError("User AI settings override is disabled by administrator")
 
+    if not payload.clear_settings and payload.provider == AIProvider.ollama:
+        raise HTTPException(status_code=400, detail=AIMessages.PROVIDER_NOT_ALLOWED)
+
     if not payload.clear_settings and payload.base_url:
         try:
             await assert_target_url_is_public_async(payload.base_url)
@@ -431,8 +437,15 @@ async def test_ai_connection(
     request: AITestConnectionRequest,
     *,
     existing_api_key: str | None = None,
+    bypass_ssrf: bool = False,
 ) -> AITestConnectionResponse:
-    """Test connection to an AI provider."""
+    """Test connection to an AI provider.
+
+    ``bypass_ssrf=True`` lets a platform admin point Ollama (or a custom
+    provider) at a private or http:// endpoint — they own the host, so
+    the SSRF guard is unnecessary noise for them. Non-platform callers
+    always get the guard.
+    """
     api_key = request.api_key or existing_api_key
 
     if request.provider == AIProvider.openai:
@@ -440,9 +453,13 @@ async def test_ai_connection(
     elif request.provider == AIProvider.anthropic:
         return await _test_anthropic_connection(api_key, request.model)
     elif request.provider == AIProvider.ollama:
-        return await _test_ollama_connection(request.base_url, request.model)
+        return await _test_ollama_connection(
+            request.base_url, request.model, bypass_ssrf=bypass_ssrf
+        )
     elif request.provider == AIProvider.custom:
-        return await _test_custom_connection(api_key, request.base_url, request.model)
+        return await _test_custom_connection(
+            api_key, request.base_url, request.model, bypass_ssrf=bypass_ssrf
+        )
     else:
         return AITestConnectionResponse(
             success=False,
@@ -611,9 +628,11 @@ async def _test_anthropic_connection(
 async def _test_ollama_connection(
     base_url: str | None,
     model: str | None,
+    *,
+    bypass_ssrf: bool = False,
 ) -> AITestConnectionResponse:
     """Test Ollama connection."""
-    if base_url:
+    if base_url and not bypass_ssrf:
         try:
             await assert_target_url_is_public_async(base_url)
         except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as e:
@@ -671,6 +690,8 @@ async def _test_custom_connection(
     api_key: str | None,
     base_url: str | None,
     model: str | None,
+    *,
+    bypass_ssrf: bool = False,
 ) -> AITestConnectionResponse:
     """Test custom OpenAI-compatible endpoint."""
     if not base_url:
@@ -679,10 +700,11 @@ async def _test_custom_connection(
             message="Base URL is required for custom provider",
         )
 
-    try:
-        await assert_target_url_is_public_async(base_url)
-    except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as e:
-        return AITestConnectionResponse(success=False, message=f"Invalid base URL: {e}")
+    if not bypass_ssrf:
+        try:
+            await assert_target_url_is_public_async(base_url)
+        except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as e:
+            return AITestConnectionResponse(success=False, message=f"Invalid base URL: {e}")
     url = base_url.rstrip("/")
     headers = {}
     if api_key:
@@ -750,19 +772,23 @@ async def fetch_models(
     provider: AIProvider,
     api_key: str | None,
     base_url: str | None,
+    *,
+    bypass_ssrf: bool = False,
 ) -> tuple[list[str], str | None]:
     """Fetch available models from an AI provider.
 
     Returns (models, error_message). If successful, error_message is None.
+    ``bypass_ssrf=True`` skips the public-URL guard for ollama/custom —
+    platform admins use this to point at on-host private endpoints.
     """
     if provider == AIProvider.openai:
         return await _fetch_openai_models(api_key)
     elif provider == AIProvider.anthropic:
         return await _fetch_anthropic_models(api_key)
     elif provider == AIProvider.ollama:
-        return await _fetch_ollama_models(base_url)
+        return await _fetch_ollama_models(base_url, bypass_ssrf=bypass_ssrf)
     elif provider == AIProvider.custom:
-        return await _fetch_custom_models(api_key, base_url)
+        return await _fetch_custom_models(api_key, base_url, bypass_ssrf=bypass_ssrf)
     else:
         return [], f"Unknown provider: {provider}"
 
@@ -824,9 +850,13 @@ async def _fetch_anthropic_models(api_key: str | None) -> tuple[list[str], str |
         return [], str(e)
 
 
-async def _fetch_ollama_models(base_url: str | None) -> tuple[list[str], str | None]:
+async def _fetch_ollama_models(
+    base_url: str | None,
+    *,
+    bypass_ssrf: bool = False,
+) -> tuple[list[str], str | None]:
     """Fetch available models from Ollama."""
-    if base_url:
+    if base_url and not bypass_ssrf:
         try:
             await assert_target_url_is_public_async(base_url)
         except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as e:
@@ -854,15 +884,18 @@ async def _fetch_ollama_models(base_url: str | None) -> tuple[list[str], str | N
 async def _fetch_custom_models(
     api_key: str | None,
     base_url: str | None,
+    *,
+    bypass_ssrf: bool = False,
 ) -> tuple[list[str], str | None]:
     """Fetch available models from custom OpenAI-compatible endpoint."""
     if not base_url:
         return [], "Base URL required"
 
-    try:
-        await assert_target_url_is_public_async(base_url)
-    except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as e:
-        return [], f"Invalid base URL: {e}"
+    if not bypass_ssrf:
+        try:
+            await assert_target_url_is_public_async(base_url)
+        except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as e:
+            return [], f"Invalid base URL: {e}"
     url = base_url.rstrip("/")
     headers = {}
     if api_key:

--- a/backend/app/services/ai_settings_test.py
+++ b/backend/app/services/ai_settings_test.py
@@ -1,12 +1,21 @@
 """Tests for AI settings SSRF guard on base_url."""
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import HTTPException
 
+from app.core.messages import AIMessages
+from app.schemas.ai_settings import (
+    AIProvider,
+    GuildAISettingsUpdate,
+    UserAISettingsUpdate,
+)
 from app.services.ai_settings import (
     _test_ollama_connection,
     _test_custom_connection,
     _fetch_ollama_models,
     _fetch_custom_models,
+    update_guild_ai_settings,
+    update_user_ai_settings,
 )
 
 
@@ -81,3 +90,103 @@ async def test_fetch_ollama_models_allows_no_base_url():
         models, error = await _fetch_ollama_models(None)
         assert error is None
         assert "llama3" in models
+
+
+@pytest.mark.unit
+async def test_update_guild_ai_settings_rejects_ollama():
+    """Guild AI settings cannot select Ollama; only platform admins can."""
+    platform_settings = MagicMock(ai_allow_guild_override=True)
+    payload = GuildAISettingsUpdate(provider=AIProvider.ollama)
+
+    with patch(
+        "app.services.ai_settings.get_app_settings",
+        AsyncMock(return_value=platform_settings),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await update_guild_ai_settings(MagicMock(), 1, payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == AIMessages.PROVIDER_NOT_ALLOWED
+
+
+@pytest.mark.unit
+async def test_update_user_ai_settings_rejects_ollama():
+    """User AI settings cannot select Ollama; only platform admins can."""
+    platform_settings = MagicMock(ai_allow_user_override=True)
+    user = MagicMock()
+    payload = UserAISettingsUpdate(provider=AIProvider.ollama)
+
+    with patch(
+        "app.services.ai_settings.get_app_settings",
+        AsyncMock(return_value=platform_settings),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await update_user_ai_settings(MagicMock(), user, payload, guild_id=None)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == AIMessages.PROVIDER_NOT_ALLOWED
+
+
+@pytest.mark.unit
+async def test_ollama_test_connection_bypass_allows_http_private():
+    """bypass_ssrf=True (platform admin) lets http://private through."""
+    with patch("app.services.ai_settings.httpx.AsyncClient") as mock_client:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": [{"name": "llama3"}]}
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+        mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value.get = AsyncMock(return_value=mock_response)
+
+        result = await _test_ollama_connection(
+            "http://10.0.0.1:11434", None, bypass_ssrf=True
+        )
+        assert result.success is True
+
+
+@pytest.mark.unit
+async def test_fetch_ollama_models_bypass_allows_http_private():
+    """bypass_ssrf=True lets _fetch_ollama_models hit a private endpoint."""
+    with patch("app.services.ai_settings.httpx.AsyncClient") as mock_client:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": [{"name": "llama3"}]}
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+        mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value.get = AsyncMock(return_value=mock_response)
+
+        models, error = await _fetch_ollama_models(
+            "http://192.168.1.10:11434", bypass_ssrf=True
+        )
+        assert error is None
+        assert "llama3" in models
+
+
+@pytest.mark.unit
+async def test_update_guild_ai_settings_allows_clear_settings_with_ollama_unset():
+    """clear_settings=True bypasses the provider check (settings get nulled regardless)."""
+    platform_settings = MagicMock(ai_allow_guild_override=True)
+    guild_settings = MagicMock()
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    payload = GuildAISettingsUpdate(clear_settings=True, provider=AIProvider.ollama)
+
+    with patch(
+        "app.services.ai_settings.get_app_settings",
+        AsyncMock(return_value=platform_settings),
+    ), patch(
+        "app.services.ai_settings.get_or_create_guild_settings",
+        AsyncMock(return_value=guild_settings),
+    ), patch(
+        "app.services.ai_settings.reapply_rls_context",
+        AsyncMock(),
+    ), patch(
+        "app.services.ai_settings.get_guild_ai_settings",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        await update_guild_ai_settings(session, 1, payload)
+
+    assert guild_settings.ai_provider is None

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -223,5 +223,7 @@
   "PROJECT_EXPORT_NO_TASK_STATUSES": "The project export has no task statuses, which is required for import.",
   "ADVANCED_TOOL_NOT_CONFIGURED": "The advanced tool is not configured for this deployment.",
   "ADVANCED_TOOL_NOT_ENABLED": "The advanced tool is not enabled for this initiative.",
+  "AI_INVALID_BASE_URL": "Base URL is not allowed. Use a public hostname.",
+  "AI_PROVIDER_NOT_ALLOWED": "Ollama can only be configured at the platform level.",
   "fallback": "Something went wrong. Please try again."
 }

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -154,6 +154,7 @@
     "apiKeyHelpNewShort": "Enter your API key for this provider.",
     "modelFieldLabel": "Model",
     "baseUrlLabel": "Base URL",
+    "httpWarning": "Using an unencrypted HTTP endpoint. Configure TLS / HTTPS for production deployments.",
     "saveSettings": "Save settings",
     "savingSettings": "Saving\u2026",
     "testConnection": "Test Connection",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -223,5 +223,7 @@
   "PROJECT_EXPORT_NO_TASK_STATUSES": "La exportación del proyecto no tiene estados de tarea, que son obligatorios para importar.",
   "ADVANCED_TOOL_NOT_CONFIGURED": "La herramienta avanzada no está configurada en esta instalación.",
   "ADVANCED_TOOL_NOT_ENABLED": "La herramienta avanzada no está activada para esta iniciativa.",
+  "AI_INVALID_BASE_URL": "La URL base no está permitida. Use un nombre de host público.",
+  "AI_PROVIDER_NOT_ALLOWED": "Ollama solo se puede configurar a nivel de plataforma.",
   "fallback": "Algo salió mal. Por favor intenta de nuevo."
 }

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -154,6 +154,7 @@
     "apiKeyHelpNewShort": "Ingresa tu clave API para este proveedor.",
     "modelFieldLabel": "Modelo",
     "baseUrlLabel": "URL base",
+    "httpWarning": "Usando un endpoint HTTP sin cifrar. Configure TLS / HTTPS para entornos de producción.",
     "saveSettings": "Guardar configuración",
     "savingSettings": "Guardando\u2026",
     "testConnection": "Probar conexión",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -223,5 +223,7 @@
   "PROJECT_EXPORT_NO_TASK_STATUSES": "L'exportation du projet ne contient aucun statut de tâche, qui est obligatoire pour l'importer.",
   "ADVANCED_TOOL_NOT_CONFIGURED": "L’outil avancé n’est pas configuré sur cette installation.",
   "ADVANCED_TOOL_NOT_ENABLED": "L’outil avancé n’est pas activé pour cette initiative.",
+  "AI_INVALID_BASE_URL": "L'URL de base n'est pas autorisée. Utilisez un nom d'hôte public.",
+  "AI_PROVIDER_NOT_ALLOWED": "Ollama ne peut être configuré qu'au niveau de la plateforme.",
   "fallback": "Une erreur s'est produite. Veuillez réessayer."
 }

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -154,6 +154,7 @@
     "apiKeyHelpNewShort": "Entrez votre clé API pour ce fournisseur.",
     "modelFieldLabel": "Modèle",
     "baseUrlLabel": "URL de base",
+    "httpWarning": "Utilisation d'un point de terminaison HTTP non chiffré. Configurez TLS / HTTPS pour les déploiements en production.",
     "saveSettings": "Enregistrer les paramètres",
     "savingSettings": "Enregistrement\u2026",
     "testConnection": "Tester la connexion",

--- a/frontend/src/hooks/useAIEnabled.ts
+++ b/frontend/src/hooks/useAIEnabled.ts
@@ -14,9 +14,13 @@ export const useAIEnabled = () => {
     staleTime: 5 * 60 * 1000,
   });
 
+  const data = query.data;
+  // Ollama doesn't require an API key; every other provider does.
+  const hasCredentials = data?.provider === "ollama" || Boolean(data?.has_api_key);
+
   return {
-    isEnabled: Boolean(query.data?.enabled && query.data?.has_api_key),
+    isEnabled: Boolean(data?.enabled && hasCredentials),
     isLoading: query.isLoading,
-    data: query.data,
+    data,
   };
 };

--- a/frontend/src/lib/ai-providers.ts
+++ b/frontend/src/lib/ai-providers.ts
@@ -79,3 +79,14 @@ export const getModelsForProvider = (
   }
   return PROVIDER_CONFIGS[provider]?.defaultModels ?? [];
 };
+
+export type AISettingsScope = "platform" | "guild" | "user";
+
+const PROVIDERS_BY_SCOPE: Record<AISettingsScope, AIProvider[]> = {
+  platform: ["openai", "anthropic", "ollama", "custom"],
+  guild: ["openai", "anthropic", "custom"],
+  user: ["openai", "anthropic", "custom"],
+};
+
+export const getProvidersForScope = (scope: AISettingsScope): AIProvider[] =>
+  PROVIDERS_BY_SCOPE[scope];

--- a/frontend/src/pages/SettingsAIPage.tsx
+++ b/frontend/src/pages/SettingsAIPage.tsx
@@ -22,7 +22,7 @@ import {
   useFetchAIModels,
 } from "@/hooks/useAISettings";
 import { useAuth } from "@/hooks/useAuth";
-import { getModelsForProvider, PROVIDER_CONFIGS } from "@/lib/ai-providers";
+import { getModelsForProvider, getProvidersForScope, PROVIDER_CONFIGS } from "@/lib/ai-providers";
 import type { AIProvider, PlatformAISettingsUpdate } from "@/api/generated/initiativeAPI.schemas";
 
 interface FormState {
@@ -181,6 +181,10 @@ export const SettingsAIPage = () => {
             <Select
               value={formState.provider}
               onValueChange={(value) => {
+                // Radix Select fires onValueChange("") via its hidden bubble
+                // input when the controlled value is set before SelectItems
+                // mount. None of our items have value="", so ignore that call.
+                if (!value) return;
                 const config = PROVIDER_CONFIGS[value as AIProvider];
                 setFormState((prev) => ({
                   ...prev,
@@ -194,14 +198,9 @@ export const SettingsAIPage = () => {
                 <SelectValue placeholder={t("ai.providerPlaceholder")} />
               </SelectTrigger>
               <SelectContent>
-                {(
-                  Object.entries(PROVIDER_CONFIGS) as [
-                    AIProvider,
-                    (typeof PROVIDER_CONFIGS)[AIProvider],
-                  ][]
-                ).map(([key, config]) => (
+                {getProvidersForScope("platform").map((key) => (
                   <SelectItem key={key} value={key}>
-                    {config.label}
+                    {PROVIDER_CONFIGS[key].label}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -241,6 +240,12 @@ export const SettingsAIPage = () => {
                 }
                 placeholder={providerConfig?.defaultBaseUrl ?? "https://api.example.com/v1"}
               />
+              {formState.provider === "ollama" &&
+                formState.baseUrl.trim().toLowerCase().startsWith("http://") && (
+                  <p className="text-sm text-yellow-600 dark:text-yellow-500">
+                    {t("ai.httpWarning")}
+                  </p>
+                )}
             </div>
           )}
 

--- a/frontend/src/pages/SettingsGuildAIPage.tsx
+++ b/frontend/src/pages/SettingsGuildAIPage.tsx
@@ -23,7 +23,7 @@ import {
   useFetchAIModels,
 } from "@/hooks/useAISettings";
 import { useGuilds } from "@/hooks/useGuilds";
-import { getModelsForProvider, PROVIDER_CONFIGS } from "@/lib/ai-providers";
+import { getModelsForProvider, getProvidersForScope, PROVIDER_CONFIGS } from "@/lib/ai-providers";
 import type { AIProvider, GuildAISettingsUpdate } from "@/api/generated/initiativeAPI.schemas";
 
 interface FormState {
@@ -307,6 +307,9 @@ export const SettingsGuildAIPage = () => {
                 <Select
                   value={formState.provider}
                   onValueChange={(value) => {
+                    // Ignore Radix Select's spurious "" reset (fired by the
+                    // hidden bubble input before SelectItems mount).
+                    if (!value) return;
                     const config = PROVIDER_CONFIGS[value as AIProvider];
                     setFormState((prev) => ({
                       ...prev,
@@ -320,14 +323,9 @@ export const SettingsGuildAIPage = () => {
                     <SelectValue placeholder={t("ai.providerPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    {(
-                      Object.entries(PROVIDER_CONFIGS) as [
-                        AIProvider,
-                        (typeof PROVIDER_CONFIGS)[AIProvider],
-                      ][]
-                    ).map(([key, config]) => (
+                    {getProvidersForScope("guild").map((key) => (
                       <SelectItem key={key} value={key}>
-                        {config.label}
+                        {PROVIDER_CONFIGS[key].label}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/frontend/src/pages/UserSettingsAIPage.tsx
+++ b/frontend/src/pages/UserSettingsAIPage.tsx
@@ -22,7 +22,7 @@ import {
   useTestAIConnection,
   useFetchAIModels,
 } from "@/hooks/useAISettings";
-import { getModelsForProvider, PROVIDER_CONFIGS } from "@/lib/ai-providers";
+import { getModelsForProvider, getProvidersForScope, PROVIDER_CONFIGS } from "@/lib/ai-providers";
 import type { AIProvider, UserAISettingsUpdate } from "@/api/generated/initiativeAPI.schemas";
 
 interface FormState {
@@ -309,6 +309,9 @@ export const UserSettingsAIPage = () => {
                 <Select
                   value={formState.provider}
                   onValueChange={(value) => {
+                    // Ignore Radix Select's spurious "" reset (fired by the
+                    // hidden bubble input before SelectItems mount).
+                    if (!value) return;
                     const config = PROVIDER_CONFIGS[value as AIProvider];
                     setFormState((prev) => ({
                       ...prev,
@@ -322,14 +325,9 @@ export const UserSettingsAIPage = () => {
                     <SelectValue placeholder={t("ai.providerPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    {(
-                      Object.entries(PROVIDER_CONFIGS) as [
-                        AIProvider,
-                        (typeof PROVIDER_CONFIGS)[AIProvider],
-                      ][]
-                    ).map(([key, config]) => (
+                    {getProvidersForScope("user").map((key) => (
                       <SelectItem key={key} value={key}>
-                        {config.label}
+                        {PROVIDER_CONFIGS[key].label}
                       </SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
## Summary

Follow-up to #448 — that PR added an SSRF guard on AI `base_url` writes/tests, which broke the typical Ollama deployment of `http://<private-ip>:11434`. Per the discussion there, Ollama is now only configurable at the platform level (where the operator owns the host), and it's hidden from guild/user AI settings entirely.

- Guild and user AI settings reject `provider=ollama` on write (new `AI_PROVIDER_NOT_ALLOWED` error code) and the dropdown no longer offers it.
- New Alembic migration nulls any existing Ollama overrides on `guild_settings` / `users` so they fall back to the inherited platform config.
- Platform AI page shows an inline yellow warning when an Ollama `base_url` uses `http://` (TLS recommended in production).
- Platform admins bypass the SSRF guard on `/ai/test` and `/ai/models` so they can legitimately point at on-host private endpoints. Non-admins still get the guard.
- `ai_generation` no longer SSRF-guards Ollama URLs — since Ollama is platform-only, the URL is operator-controlled.
- Frontend `useAIEnabled` treats Ollama as having credentials (no API key needed), matching the backend, so AI Generate buttons appear with Ollama selected.
- Worked around a Radix Select bug where `onValueChange("")` fires spuriously when the controlled value is set before `SelectItem`s mount (the dropdown was wiping the saved provider on page refresh).
- Translations added for `ai.httpWarning` and `AI_PROVIDER_NOT_ALLOWED` in en/es/fr.

## Test plan

- [ ] `cd backend && pytest app/services/ai_settings_test.py` — 12 cases pass
- [ ] `cd backend && alembic upgrade head` — migration runs cleanly; rows where guild_settings/users had `ai_provider='ollama'` get NULLed
- [ ] As platform admin → Settings → AI: select Ollama, enter `http://<private-ip>:11434`, save, refresh page → provider/base_url/model persist and yellow HTTP warning shows
- [ ] As platform admin → Test Connection with the above URL → connects successfully (no "unsupported scheme" error)
- [ ] As guild admin → Settings → Guild AI: Ollama is absent from the provider dropdown
- [ ] As regular user → Settings → User AI: Ollama is absent from the provider dropdown
- [ ] With Ollama configured at platform scope, open a task → AI Generate buttons render and produce subtasks