### PR TITLE
Fix backend dependency conflict (pycrdt / pycrdt-websocket)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,8 @@ icalendar>=6.0.0  # iCal import/export
 nh3==0.3.5  # HTML sanitization for schema inputs
 
 # Collaboration (Yjs CRDT)
-pycrdt~=0.12.50
+# pycrdt-websocket 0.16.1 requires pycrdt>=0.13,<0.14; keep these aligned.
+pycrdt~=0.13.0
 pycrdt-websocket~=0.16.1
 
 # Testing dependencies


### PR DESCRIPTION
## Problem

CI on `dev` (and every open PR) fails at the backend **Install dependencies** step:

```
ERROR: Cannot install -r requirements.txt and pycrdt~=0.12.50 because these
package versions have conflicting dependencies. (ResolutionImpossible)
```

Dependabot #471 bumped `pycrdt-websocket` `~=0.16.0 → ~=0.16.1`. `pycrdt-websocket==0.16.1` requires `pycrdt>=0.13.0,<0.14.0`, but `requirements.txt` still pinned `pycrdt~=0.12.50` (`>=0.12.50,<0.13`). The bump merged without carrying the matching `pycrdt` bump, so pip can no longer resolve the backend deps. This breaks "Backend Lint & Tests" and "Check Generated Types" on all PRs.

## Fix

Bump `pycrdt~=0.12.50 → ~=0.13.0` to match what `pycrdt-websocket 0.16.1` requires. `pycrdt-store` (a new transitive dep of pycrdt-websocket 0.16.1) is resolved automatically.

## Verification

- `pip install --dry-run -r backend/requirements.txt` → resolves cleanly (`pycrdt-0.13.0`, `pycrdt-store-0.1.4`, `pycrdt-websocket-0.16.1`).
- `app/services/collaboration.py` only uses `Doc()`, `apply_update()`, `get_update()` / `get_update(state_vector)` — exercised directly on pycrdt 0.13.0 with a clean update round-trip; module imports fine.
- Backend test suite (documents endpoints) passes against pycrdt 0.13.0 locally.

Single-line dependency fix; no application code changes. Should be merged first so other PRs can go green on rebase.