### PR TITLE
Allow same-origin framing of inline HTML/SVG documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **HTML and SVG documents now preview in the in-app viewer.** The `X-Frame-Options: DENY` header added in 0.44.0 also applied to the document-download endpoint, so the file viewer's iframe was blocked from displaying uploaded HTML/SVG files (`refused to display … X-Frame-Options to 'deny'`). The inline document response now sends `X-Frame-Options: SAMEORIGIN` and `Content-Security-Policy: frame-ancestors 'self'`, so the same-origin viewer can render them while cross-origin framing stays blocked. The existing `script-src 'none'` and sandboxed iframe are unchanged — uploaded HTML still cannot execute scripts, so there is no stored-XSS regression.
+
 ## [0.44.0] - 2026-05-16
 
 ### Added

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -1698,12 +1698,17 @@ async def download_document_file(
     ext = (document.original_filename or filename).rsplit(".", 1)[-1].lower()
     content_type = (document.file_content_type or "").lower()
     if ext in ("svg", "html", "htm") or "svg" in content_type or "html" in content_type:
-        # Disable scripts (stored-XSS hardening) but allow the file to be framed
-        # by the same-origin in-app document viewer. X-Frame-Options set here
-        # overrides the SecurityHeadersMiddleware global DENY (it uses
-        # setdefault); frame-ancestors 'self' is the CSP-level equivalent.
-        headers["Content-Security-Policy"] = "script-src 'none'; frame-ancestors 'self'"
-        headers["X-Frame-Options"] = "SAMEORIGIN"
+        if inline:
+            # Disable scripts (stored-XSS hardening) but allow the file to be
+            # framed by the same-origin in-app document viewer. X-Frame-Options
+            # set here overrides the SecurityHeadersMiddleware global DENY (it
+            # uses setdefault); frame-ancestors 'self' is the CSP equivalent.
+            headers["Content-Security-Policy"] = "script-src 'none'; frame-ancestors 'self'"
+            headers["X-Frame-Options"] = "SAMEORIGIN"
+        else:
+            # Non-inline downloads are sent as attachments; keep the strict
+            # script-src and let the global X-Frame-Options: DENY stand.
+            headers["Content-Security-Policy"] = "script-src 'none'"
 
     logger.info("document_download document_id=%d user=%d inline=%s", document_id, current_user.id, inline)
     if inline:

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -1698,7 +1698,12 @@ async def download_document_file(
     ext = (document.original_filename or filename).rsplit(".", 1)[-1].lower()
     content_type = (document.file_content_type or "").lower()
     if ext in ("svg", "html", "htm") or "svg" in content_type or "html" in content_type:
-        headers["Content-Security-Policy"] = "script-src 'none'"
+        # Disable scripts (stored-XSS hardening) but allow the file to be framed
+        # by the same-origin in-app document viewer. X-Frame-Options set here
+        # overrides the SecurityHeadersMiddleware global DENY (it uses
+        # setdefault); frame-ancestors 'self' is the CSP-level equivalent.
+        headers["Content-Security-Policy"] = "script-src 'none'; frame-ancestors 'self'"
+        headers["X-Frame-Options"] = "SAMEORIGIN"
 
     logger.info("document_download document_id=%d user=%d inline=%s", document_id, current_user.id, inline)
     if inline:

--- a/backend/app/api/v1/endpoints/documents_test.py
+++ b/backend/app/api/v1/endpoints/documents_test.py
@@ -490,16 +490,17 @@ async def test_download_inline_returns_no_attachment_header(
 
 
 @pytest.mark.integration
-async def test_download_inline_html_is_same_origin_framable_but_scriptless(
-    client: AsyncClient, session: AsyncSession
+@pytest.mark.parametrize("filename", ["dl_inline.html", "dl_inline.svg"])
+async def test_download_inline_html_svg_is_same_origin_framable_but_scriptless(
+    client: AsyncClient, session: AsyncSession, filename: str
 ) -> None:
-    """Inline HTML can be framed by the same-origin viewer but cannot run scripts."""
+    """Inline HTML/SVG can be framed by the same-origin viewer but cannot run scripts."""
     owner = await create_user(session)
     guild = await create_guild(session, creator=owner)
     await create_guild_membership(session, user=owner, guild=guild)
     initiative = await create_initiative(session, guild, owner)
 
-    doc = await _create_file_document(session, initiative=initiative, owner=owner, filename="dl_inline.html")
+    doc = await _create_file_document(session, initiative=initiative, owner=owner, filename=filename)
     try:
         headers = get_auth_headers(owner)
         response = await client.get(f"/api/v1/documents/{doc.id}/download?inline=1", headers=headers)
@@ -512,7 +513,33 @@ async def test_download_inline_html_is_same_origin_framable_but_scriptless(
         assert "script-src 'none'" in csp
         assert "attachment" not in response.headers.get("content-disposition", "")
     finally:
-        (_uploads_dir() / "dl_inline.html").unlink(missing_ok=True)
+        (_uploads_dir() / filename).unlink(missing_ok=True)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("filename", ["dl_attach.html", "dl_attach.svg"])
+async def test_download_non_inline_html_svg_keeps_global_deny(
+    client: AsyncClient, session: AsyncSession, filename: str
+) -> None:
+    """Non-inline HTML/SVG downloads stay attachments and do not relax framing."""
+    owner = await create_user(session)
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(session, user=owner, guild=guild)
+    initiative = await create_initiative(session, guild, owner)
+
+    doc = await _create_file_document(session, initiative=initiative, owner=owner, filename=filename)
+    try:
+        headers = get_auth_headers(owner)
+        response = await client.get(f"/api/v1/documents/{doc.id}/download", headers=headers)
+        assert response.status_code == 200
+        # Served as an attachment; the framing relaxation must not apply here
+        assert "attachment" in response.headers.get("content-disposition", "")
+        assert response.headers.get("x-frame-options") != "SAMEORIGIN"
+        csp = response.headers.get("content-security-policy", "")
+        assert "script-src 'none'" in csp
+        assert "frame-ancestors" not in csp
+    finally:
+        (_uploads_dir() / filename).unlink(missing_ok=True)
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/endpoints/documents_test.py
+++ b/backend/app/api/v1/endpoints/documents_test.py
@@ -490,6 +490,32 @@ async def test_download_inline_returns_no_attachment_header(
 
 
 @pytest.mark.integration
+async def test_download_inline_html_is_same_origin_framable_but_scriptless(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """Inline HTML can be framed by the same-origin viewer but cannot run scripts."""
+    owner = await create_user(session)
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(session, user=owner, guild=guild)
+    initiative = await create_initiative(session, guild, owner)
+
+    doc = await _create_file_document(session, initiative=initiative, owner=owner, filename="dl_inline.html")
+    try:
+        headers = get_auth_headers(owner)
+        response = await client.get(f"/api/v1/documents/{doc.id}/download?inline=1", headers=headers)
+        assert response.status_code == 200
+        # Same-origin framing allowed (overrides the global DENY middleware)
+        assert response.headers.get("x-frame-options") == "SAMEORIGIN"
+        csp = response.headers.get("content-security-policy", "")
+        assert "frame-ancestors 'self'" in csp
+        # Stored-XSS hardening preserved: scripts still disabled
+        assert "script-src 'none'" in csp
+        assert "attachment" not in response.headers.get("content-disposition", "")
+    finally:
+        (_uploads_dir() / "dl_inline.html").unlink(missing_ok=True)
+
+
+@pytest.mark.integration
 async def test_download_query_token_auth(
     client: AsyncClient, session: AsyncSession
 ) -> None:


### PR DESCRIPTION
## Problem

Uploaded HTML/SVG documents fail to render in the in-app file viewer. The viewer embeds them in an `<iframe>` pointed at the inline document-download endpoint, but `SecurityHeadersMiddleware` (added in 0.44.0) stamps `X-Frame-Options: DENY` onto **every** response — including that endpoint. The browser then refuses to display the response in a frame:

> Refused to display 'https://…' in a frame because it set 'X-Frame-Options' to 'deny'.

(reported in-app as a `(blocked:other)` document request and a blank viewer).

## Changes

- **`backend/app/api/v1/endpoints/documents.py`** — for inline HTML/SVG responses, set `X-Frame-Options: SAMEORIGIN` and `Content-Security-Policy: frame-ancestors 'self'` alongside the existing `script-src 'none'`. Because the middleware uses `setdefault`, setting the header in the endpoint takes precedence over the global `DENY`. Same-origin (the SPA) can now frame these files; cross-origin framing stays blocked.
- **No security regression:** `script-src 'none'` and the viewer's `sandbox=""` iframe are unchanged, so uploaded HTML still cannot execute scripts (stored-XSS hardening preserved).
- **Test** — `test_download_inline_html_is_same_origin_framable_but_scriptless` asserts the inline HTML response is same-origin framable *and* still script-disabled.
- **CHANGELOG** — `[Unreleased] → Fixed` entry.

## Schema / env

None.

## Testing

```
cd backend && pytest app/api/v1/endpoints/documents_test.py -k download_inline   # 2 passed
cd backend && ruff check app/api/v1/endpoints/documents.py app/api/v1/endpoints/documents_test.py   # clean
```