### PR TITLE
Fix CORS blocking Capacitor native app when CORS_ALLOWED_ORIGINS is restricted

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,8 @@ APP_URL=http://localhost:5173
 
 # CORS allowed origins (comma-separated). Defaults to * which allows all origins.
 # Set to your frontend URL(s) in production: CORS_ALLOWED_ORIGINS=https://app.example.com
+# Native mobile app origins (capacitor://localhost, https://com.morelitea.initiative) are
+# always included automatically and do not need to be listed here.
 CORS_ALLOWED_ORIGINS=
 
 # Guild creation

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,6 +3,13 @@ from functools import lru_cache
 from pydantic import EmailStr, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# Origins used by the Capacitor native mobile app (iOS and Android).
+# Must always be allowed regardless of CORS_ALLOWED_ORIGINS setting.
+CAPACITOR_NATIVE_ORIGINS = [
+    "https://com.morelitea.initiative",  # Capacitor custom hostname (iOS & Android)
+    "capacitor://localhost",              # Capacitor fallback scheme
+]
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
@@ -150,7 +157,13 @@ class Settings(BaseSettings):
             items = value.split(",")
         else:
             items = value
-        return [item.strip() for item in items if item and item.strip()] or ["*"]
+        origins = [item.strip() for item in items if item and item.strip()] or ["*"]
+        # Always include native mobile app origins when not using wildcard
+        if origins != ["*"]:
+            for origin in CAPACITOR_NATIVE_ORIGINS:
+                if origin not in origins:
+                    origins.append(origin)
+        return origins
 
     @field_validator("ADVANCED_TOOL_ALLOWED_ORIGINS", mode="before")
     @classmethod

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -43,12 +43,13 @@ def test_cors_allowed_origins_always_includes_native_origins():
 
 
 def test_cors_allowed_origins_no_duplicate_native_origins():
-    # If someone manually lists a native origin, it shouldn't be duplicated
+    # If someone manually lists native origins, they shouldn't be duplicated
     settings = Settings(
         SECRET_KEY="test-secret",
         DATABASE_URL_APP="postgresql+asyncpg://app:app@localhost/app",
         DATABASE_URL_ADMIN="postgresql+asyncpg://admin:admin@localhost/app",
-        CORS_ALLOWED_ORIGINS=f"https://prod.example.com, {CAPACITOR_NATIVE_ORIGINS[0]}",
+        CORS_ALLOWED_ORIGINS=", ".join(["https://prod.example.com"] + CAPACITOR_NATIVE_ORIGINS),
     )
 
-    assert settings.CORS_ALLOWED_ORIGINS.count(CAPACITOR_NATIVE_ORIGINS[0]) == 1
+    for origin in CAPACITOR_NATIVE_ORIGINS:
+        assert settings.CORS_ALLOWED_ORIGINS.count(origin) == 1

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -1,6 +1,6 @@
 """Tests for application settings parsing."""
 
-from app.core.config import Settings
+from app.core.config import CAPACITOR_NATIVE_ORIGINS, Settings
 
 
 def test_cors_allowed_origins_accepts_comma_separated_string():
@@ -14,10 +14,12 @@ def test_cors_allowed_origins_accepts_comma_separated_string():
     assert settings.CORS_ALLOWED_ORIGINS == [
         "https://app.example.com",
         "https://admin.example.com",
+        *CAPACITOR_NATIVE_ORIGINS,
     ]
 
 
 def test_cors_allowed_origins_blank_defaults_to_wildcard():
+    # wildcard should NOT get native origins appended
     settings = Settings(
         SECRET_KEY="test-secret",
         DATABASE_URL_APP="postgresql+asyncpg://app:app@localhost/app",
@@ -26,3 +28,27 @@ def test_cors_allowed_origins_blank_defaults_to_wildcard():
     )
 
     assert settings.CORS_ALLOWED_ORIGINS == ["*"]
+
+
+def test_cors_allowed_origins_always_includes_native_origins():
+    settings = Settings(
+        SECRET_KEY="test-secret",
+        DATABASE_URL_APP="postgresql+asyncpg://app:app@localhost/app",
+        DATABASE_URL_ADMIN="postgresql+asyncpg://admin:admin@localhost/app",
+        CORS_ALLOWED_ORIGINS="https://prod.example.com",
+    )
+
+    for origin in CAPACITOR_NATIVE_ORIGINS:
+        assert origin in settings.CORS_ALLOWED_ORIGINS
+
+
+def test_cors_allowed_origins_no_duplicate_native_origins():
+    # If someone manually lists a native origin, it shouldn't be duplicated
+    settings = Settings(
+        SECRET_KEY="test-secret",
+        DATABASE_URL_APP="postgresql+asyncpg://app:app@localhost/app",
+        DATABASE_URL_ADMIN="postgresql+asyncpg://admin:admin@localhost/app",
+        CORS_ALLOWED_ORIGINS=f"https://prod.example.com, {CAPACITOR_NATIVE_ORIGINS[0]}",
+    )
+
+    assert settings.CORS_ALLOWED_ORIGINS.count(CAPACITOR_NATIVE_ORIGINS[0]) == 1


### PR DESCRIPTION
## Summary

- When `CORS_ALLOWED_ORIGINS` is set to specific domains in production, the native iOS/Android app was unable to connect to the backend
- Capacitor native apps send requests from `https://com.morelitea.initiative` (the custom hostname set in `capacitor.config.ts`), which was not in the allowlist
- The `parse_cors_allowed_origins` validator now automatically appends `CAPACITOR_NATIVE_ORIGINS` (`https://com.morelitea.initiative` and `capacitor://localhost`) whenever a non-wildcard origin list is configured

## Changes

- `backend/app/core/config.py` — added `CAPACITOR_NATIVE_ORIGINS` constant and updated validator to inject native origins into any non-wildcard allowlist (deduplicates if already present)
- `backend/.env.example` — added comment noting native origins are included automatically
- `backend/app/core/config_test.py` — updated existing tests and added two new tests covering the native-origin injection and deduplication behaviour

## Test plan

- [x] `pytest app/core/config_test.py` — all 4 tests pass
- [ ] Deploy with `CORS_ALLOWED_ORIGINS=https://yourapp.example.com` and confirm native iOS/Android app can authenticate and make API calls
- [ ] Confirm wildcard (`CORS_ALLOWED_ORIGINS=` unset) still works as before

## Notes

No schema or endpoint changes — frontend type regeneration is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)