### PR TITLE
Fix iOS CORS: add capacitor:// scheme origin and set iosScheme=https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native iOS app could not connect when `CORS_ALLOWED_ORIGINS` was restricted (follow-up to v0.44.2).** Capacitor's iOS WebView uses `capacitor://` as the default URL scheme, producing the origin `capacitor://com.morelitea.initiative` — distinct from the `https://` origin Android sends. This origin was not included in the automatic native-origins allowlist, so iPhones were still rejected. The backend now allows `capacitor://com.morelitea.initiative` in addition to `https://com.morelitea.initiative`. The Capacitor config also adds `iosScheme: "https"` so future iOS builds use the same `https://` origin as Android, making a single origin sufficient going forward.
+
 ## [0.44.2] - 2026-05-17
 
 ### Fixed

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,8 +6,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # Origins used by the Capacitor native mobile app (iOS and Android).
 # Must always be allowed regardless of CORS_ALLOWED_ORIGINS setting.
 CAPACITOR_NATIVE_ORIGINS = [
-    "https://com.morelitea.initiative",  # Capacitor custom hostname (iOS & Android)
-    "capacitor://localhost",              # Capacitor fallback scheme
+    "https://com.morelitea.initiative",      # Capacitor custom hostname (Android + iOS with iosScheme=https)
+    "capacitor://com.morelitea.initiative",  # Capacitor default iOS scheme with custom hostname
+    "capacitor://localhost",                 # Capacitor fallback (no custom hostname)
 ]
 
 

--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -9,6 +9,7 @@ const config: CapacitorConfig = {
     // Use HTTP scheme to avoid mixed content issues with self-hosted HTTP servers (LOCAL development and LAN testing)
     // androidScheme: "http",
     hostname: "com.morelitea.initiative",
+    iosScheme: "https",
   },
   android: {
     // Allow HTTP requests (for self-hosted servers without HTTPS) (LOCAL development and LAN testing)


### PR DESCRIPTION
## Problem

After the v0.44.2 CORS fix, Android phones connected successfully but iPhones still got \"Connection failed\". 

Capacitor's iOS WebView defaults to the `capacitor://` URL scheme, so requests originate from `capacitor://com.morelitea.initiative` — not `https://com.morelitea.initiative` like Android. This origin was missing from `CAPACITOR_NATIVE_ORIGINS`, so the backend rejected it.

## Changes

- **Backend**: adds `capacitor://com.morelitea.initiative` to `CAPACITOR_NATIVE_ORIGINS` alongside the existing `https://` and `capacitor://localhost` entries
- **Frontend**: adds `iosScheme: "https"` to `capacitor.config.ts` so future iOS builds use the same `https://` origin as Android — eventually making a single origin sufficient

## Testing

- Confirmed `curl -H "Origin: capacitor://com.morelitea.initiative"` now returns `Access-Control-Allow-Origin: capacitor://com.morelitea.initiative` after deploy
- All 4 CORS config unit tests pass
- Tested on physical iPhone 11 Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)