### PR TITLE
Fix spreadsheet column/row resize on Retina displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spreadsheet column/row resize now persists on Mac (and other high-DPI/Retina devices).** Pointer events on Retina displays report fractional coordinates (e.g. `clientX = 123.5`), which the spreadsheet's `clampInt` integer validator rejected. The sanitized formatting record then came back empty, and `updateColumn` / `updateRow` interpreted that as "delete the entry" — so releasing the mouse silently reverted the column or row to its default size. The resize handler now rounds the new size to an integer before committing. Also rewrote the resize event wiring to attach `pointermove` / `pointerup` / `pointercancel` listeners synchronously inside `pointerdown` (eliminating a latent race where a fast release on a Mac trackpad could miss `pointerup` before the React effect attached).
+
 - **Pagination control now resyncs when external code resets the page.** When a filter change called `setPage(1)` on the My Tasks / My Projects / My Documents / Created Tasks / Documents / Tag Tasks tables, the underlying query refetched page 1 correctly but the DataTable's internal pagination control kept its old `pageIndex`, so the UI continued to show the previous page number and an empty/short data page. DataTable now accepts a controlled `pageIndex` prop in `manualPagination` mode and syncs to it on change. Bug existed since manual pagination was introduced; surfaced while validating filter behavior in the Biome migration.
 
 ### Changed

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -198,6 +198,10 @@ export const SpreadsheetDocumentEditor = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragRef = useRef<DragState | null>(null);
   const resizeStartRef = useRef<{ pos: number; size: number }>({ pos: 0, size: 0 });
+  // Stable ref so the resize effect can call the latest formatting mutators
+  // without listing `formatting` (a new object every render) as a dependency.
+  const formattingRef = useRef(formatting);
+  formattingRef.current = formatting; // keep current on every render
 
   // Effective per-index sizes: an in-flight resize preview wins over the
   // shared formatting value, which wins over the constant default.
@@ -711,39 +715,11 @@ export const SpreadsheetDocumentEditor = ({
   }, [pendingImport, replaceAll, formatting, docForData, t]);
 
   // --- column / row resize ----------------------------------------------
-  useEffect(() => {
-    if (!drag) return;
-    const onMove = (e: PointerEvent) => {
-      const cur = dragRef.current;
-      if (!cur) return;
-      const delta =
-        cur.kind === "col"
-          ? e.clientX - resizeStartRef.current.pos
-          : e.clientY - resizeStartRef.current.pos;
-      const lo = cur.kind === "col" ? MIN_COL_WIDTH : MIN_ROW_HEIGHT;
-      const hi = cur.kind === "col" ? MAX_COL_WIDTH : MAX_ROW_HEIGHT;
-      const size = Math.max(lo, Math.min(resizeStartRef.current.size + delta, hi));
-      const next = { ...cur, size };
-      dragRef.current = next;
-      setDrag(next);
-    };
-    const onUp = () => {
-      const cur = dragRef.current;
-      if (cur) {
-        if (cur.kind === "col") formatting.updateColumn(cur.index, { width: cur.size });
-        else formatting.updateRow(cur.index, { height: cur.size });
-      }
-      dragRef.current = null;
-      setDrag(null);
-    };
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
-    return () => {
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
-    };
-  }, [drag, formatting]);
-
+  // Listeners are attached synchronously inside startResize (the pointerdown
+  // handler) so there is never a gap between "drag started" and "pointerup
+  // is handled".  The previous useEffect approach had an inherent race: React
+  // defers effects until after paint, so a quick release (common on Mac
+  // trackpads) could fire pointerup before the effect had a chance to run.
   const startResize = useCallback(
     (kind: "col" | "row", index: number, e: ReactPointerEvent) => {
       if (readOnly) return;
@@ -757,6 +733,44 @@ export const SpreadsheetDocumentEditor = ({
       const next = { kind, index, size };
       dragRef.current = next;
       setDrag(next);
+
+      const onMove = (ev: PointerEvent) => {
+        const cur = dragRef.current;
+        if (!cur) return;
+        const delta =
+          cur.kind === "col"
+            ? ev.clientX - resizeStartRef.current.pos
+            : ev.clientY - resizeStartRef.current.pos;
+        const lo = cur.kind === "col" ? MIN_COL_WIDTH : MIN_ROW_HEIGHT;
+        const hi = cur.kind === "col" ? MAX_COL_WIDTH : MAX_ROW_HEIGHT;
+        // Round to integer: pointer coords are fractional on Retina/Mac, and
+        // sanitizeColumnFmt/RowFmt drop non-integer sizes (clampInt requires
+        // Number.isInteger), which previously caused the commit to silently
+        // delete the entry and revert to the default width/height.
+        const newSize = Math.round(Math.max(lo, Math.min(resizeStartRef.current.size + delta, hi)));
+        const updated = { ...cur, size: newSize };
+        dragRef.current = updated;
+        setDrag(updated);
+      };
+
+      const finish = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", finish);
+        window.removeEventListener("pointercancel", finish);
+        const cur = dragRef.current;
+        if (cur) {
+          const fmt = formattingRef.current;
+          if (cur.kind === "col") fmt.updateColumn(cur.index, { width: cur.size });
+          else fmt.updateRow(cur.index, { height: cur.size });
+        }
+        dragRef.current = null;
+        setDrag(null);
+      };
+
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", finish);
+      // pointercancel fires on Mac when the OS takes over a trackpad gesture.
+      window.addEventListener("pointercancel", finish);
     },
     [readOnly, colWidth, rowHeight]
   );

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -198,7 +198,11 @@ export const SpreadsheetDocumentEditor = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragRef = useRef<DragState | null>(null);
   const resizeStartRef = useRef<{ pos: number; size: number }>({ pos: 0, size: 0 });
-  // Stable ref so the resize effect can call the latest formatting mutators
+  // Owns the window listeners attached during a resize drag.  Held in a ref
+  // so the unmount cleanup (below) can abort an in-flight drag, preventing
+  // a stale formatting write after the editor has gone away.
+  const resizeAbortRef = useRef<AbortController | null>(null);
+  // Stable ref so the resize handler can call the latest formatting mutators
   // without listing `formatting` (a new object every render) as a dependency.
   const formattingRef = useRef(formatting);
   formattingRef.current = formatting; // keep current on every render
@@ -720,6 +724,12 @@ export const SpreadsheetDocumentEditor = ({
   // is handled".  The previous useEffect approach had an inherent race: React
   // defers effects until after paint, so a quick release (common on Mac
   // trackpads) could fire pointerup before the effect had a chance to run.
+  //
+  // An AbortController owns listener lifetime so:
+  //   - commit / cancel both tear down with a single ``.abort()`` call
+  //   - the unmount effect (below) aborts an in-flight drag, preventing a
+  //     stale ``formattingRef.current.updateColumn`` write into a Yjs doc
+  //     whose view has already been unmounted.
   const startResize = useCallback(
     (kind: "col" | "row", index: number, e: ReactPointerEvent) => {
       if (readOnly) return;
@@ -733,6 +743,13 @@ export const SpreadsheetDocumentEditor = ({
       const next = { kind, index, size };
       dragRef.current = next;
       setDrag(next);
+
+      // Abort any previous drag's listeners (defensive — shouldn't happen,
+      // but a missed pointerup would otherwise leak them indefinitely).
+      resizeAbortRef.current?.abort();
+      const controller = new AbortController();
+      resizeAbortRef.current = controller;
+      const { signal } = controller;
 
       const onMove = (ev: PointerEvent) => {
         const cur = dragRef.current;
@@ -753,27 +770,46 @@ export const SpreadsheetDocumentEditor = ({
         setDrag(updated);
       };
 
-      const finish = () => {
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", finish);
-        window.removeEventListener("pointercancel", finish);
+      const teardown = () => {
+        controller.abort();
+        if (resizeAbortRef.current === controller) resizeAbortRef.current = null;
+        dragRef.current = null;
+        setDrag(null);
+      };
+
+      const commit = () => {
         const cur = dragRef.current;
         if (cur) {
           const fmt = formattingRef.current;
           if (cur.kind === "col") fmt.updateColumn(cur.index, { width: cur.size });
           else fmt.updateRow(cur.index, { height: cur.size });
         }
-        dragRef.current = null;
-        setDrag(null);
+        teardown();
       };
 
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", finish);
-      // pointercancel fires on Mac when the OS takes over a trackpad gesture.
-      window.addEventListener("pointercancel", finish);
+      // pointercancel fires on Mac when the OS reclassifies a trackpad
+      // gesture as a scroll — the user wasn't trying to resize, so discard
+      // the in-flight drag instead of writing whatever intermediate size
+      // it happened to reach.
+      const cancel = () => {
+        teardown();
+      };
+
+      window.addEventListener("pointermove", onMove, { signal });
+      window.addEventListener("pointerup", commit, { signal });
+      window.addEventListener("pointercancel", cancel, { signal });
     },
     [readOnly, colWidth, rowHeight]
   );
+
+  // Abort any in-flight resize drag when the editor unmounts so the window
+  // listeners can't fire against a stale formattingRef afterwards.
+  useEffect(() => {
+    return () => {
+      resizeAbortRef.current?.abort();
+      resizeAbortRef.current = null;
+    };
+  }, []);
   const resetSize = useCallback(
     (kind: "col" | "row", index: number) => {
       if (readOnly) return;


### PR DESCRIPTION
## Problem

On Mac (both Vivaldi and Safari), resizing a column or row in the spreadsheet editor visually previewed correctly but reverted to the default size as soon as the mouse was released. Same code worked fine on Windows.

## Root cause

`PointerEvent.clientX` / `clientY` report **fractional pixel values** on Retina / high-DPI displays (e.g. `123.5`). On Windows they're integers.

The commit path runs through `sanitizeColumnFmt` / `sanitizeRowFmt`, which use `clampInt`:

```ts
if (typeof value !== "number" || !Number.isInteger(value)) return undefined;
```

A fractional width therefore became `undefined`, the sanitized record came back empty (`Object.keys(out).length === 0 → undefined`), and `updateColumn` / `updateRow` interpreted that as "delete the entry" — silently reverting the column/row to default.

## Fix

1. **Round the size to an integer** before committing in the resize handler. This is the bug.
2. **Rewrote the resize listener wiring** to attach `pointermove` / `pointerup` / `pointercancel` synchronously inside the `pointerdown` handler, rather than in a `useEffect` whose deps changed on every move event and every render. The effect approach also had a latent race: React defers effects until after paint, so a fast release on a Mac trackpad could miss `pointerup` before the listener attached.
3. **Added `pointercancel` handling** since macOS fires it when a trackpad gesture gets reclassified as a scroll.

(2) and (3) aren't strictly required to fix the reported bug, but they remove real latent issues and were uncovered during diagnosis — leaving them in.

## Testing

- Manually verified on Mac (Vivaldi + Safari): column and row resize persists after release.
- `pnpm tsc --noEmit` and `pnpm biome check` pass on the changed file.

## Notes

The original symptom ("reverts to default") looked like an event handling bug, which sent the first two diagnostic attempts down the wrong path (listener race, formatting object identity). The real cause was a silent data drop in the sanitization layer. Saved a memory note for the next time we see something similar. We could also consider adding a dev-mode `console.warn` when `sanitizeColumnFmt` / `sanitizeRowFmt` drop a known field — happy to do that in a follow-up if useful.