### PR TITLE
Fix sidebar New Counter Group button while on counters page

### DIFF
--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -102,7 +102,33 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
   }, [canCreate, effectiveInitiativeId, initiativePerms, initiatives.length]);
 
   const [createOpen, setCreateOpen] = useState(searchParams.create === "true");
+  const isClosingCreateDialog = useRef(false);
   const [search, setSearch] = useState("");
+
+  // Open the create dialog whenever ?create=true is present — including when
+  // the sidebar "+" navigates here while already on the page (the useState
+  // initializer above only runs on mount).
+  useEffect(() => {
+    const shouldCreate = searchParams.create === "true";
+    if (shouldCreate && !createOpen && !isClosingCreateDialog.current) {
+      setCreateOpen(true);
+    }
+    if (!shouldCreate) {
+      isClosingCreateDialog.current = false;
+    }
+  }, [searchParams.create, createOpen]);
+
+  const handleCreateOpenChange = (open: boolean) => {
+    setCreateOpen(open);
+    if (!open && searchParams.create) {
+      isClosingCreateDialog.current = true;
+      void router.navigate({
+        to: gp("/counter-groups"),
+        search: { initiativeId: searchParams.initiativeId },
+        replace: true,
+      });
+    }
+  };
   const getDefaultFiltersVisibility = () =>
     typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches;
   const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
@@ -199,7 +225,7 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
 
       <CreateCounterGroupDialog
         open={createOpen}
-        onOpenChange={setCreateOpen}
+        onOpenChange={handleCreateOpenChange}
         initiativeId={lockedInitiativeId ?? undefined}
         defaultInitiativeId={effectiveInitiativeId ?? undefined}
         onSuccess={handleCreated}


### PR DESCRIPTION
## Summary

The sidebar "+" for counters navigates to `/counter-groups?create=true`. The page opened the create dialog only via a `useState` initializer reading that param — which doesn't re-run when you're **already** on the counters page, so the button did nothing there (it worked fine from other pages, which mount the component fresh).

Added an effect that opens the dialog whenever `?create=true` is present (guarded by a ref so it doesn't reopen after the user closes it), plus a close handler that clears the param from the URL — mirroring the existing Queues page behavior.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint`
- [ ] Manual: on the counters list page, click the sidebar "+" → dialog opens; close it → reopens on next click; same from other pages still works.