### PR TITLE
Format regenerated API types with biome in promote.sh

### DIFF
--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -379,12 +379,17 @@ do_release() {
 
     # Regenerate frontend types so the version comment stays in sync.
     # Export OpenAPI spec from the backend (no running server needed),
-    # then run orval to regenerate TypeScript types from the spec.
+    # then run orval + biome-format to match exactly what the CI
+    # "Check Generated Types" job does (see .github/workflows/ci.yml). The
+    # project formats with biome — using `pnpm prettier` here produced
+    # subtle whitespace differences that failed the drift check.
+    # Errors are surfaced (no `2>/dev/null` suppression) so a broken regen
+    # fails the release rather than silently shipping stale types.
     if [[ -f frontend/package.json ]] && command -v pnpm &>/dev/null; then
         dim "  Exporting OpenAPI spec and regenerating frontend types..."
-        (cd backend && .venv/bin/python scripts/export_openapi.py ../frontend/openapi.json) 2>/dev/null
-        (cd frontend && pnpm orval && pnpm prettier --write src/api/generated/) 2>/dev/null
-        if ! git diff --quiet frontend/src/api/generated/ 2>/dev/null; then
+        (cd backend && .venv/bin/python scripts/export_openapi.py ../frontend/openapi.json)
+        (cd frontend && pnpm orval && pnpm format:api)
+        if ! git diff --quiet frontend/src/api/generated/; then
             git add frontend/src/api/generated/
             git commit -m "regenerate API types for v$new_version"
         fi


### PR DESCRIPTION
## Problem

Every release PR opened by \`scripts/promote.sh\` fails the **Check Generated Types** CI job (e.g. [v0.45.2 PR #530's run](https://github.com/Morelitea/initiative/actions/runs/26344953760/job/77553208509?pr=530)). CI regenerates the files and the drift check sees them as different from what the release branch committed.

## Cause

\`scripts/promote.sh\` formats the regenerated files with **prettier**:

\`\`\`bash
(cd frontend && pnpm orval && pnpm prettier --write src/api/generated/) 2>/dev/null
\`\`\`

But the project migrated from Prettier to Biome in v0.45.0 (see the changelog). CI uses **biome** via \`pnpm format:api\`:

\`\`\`yaml
- name: Regenerate types
  run: |
    cd frontend
    pnpm orval
    pnpm format:api
\`\`\`

Prettier and Biome agree on most things but not all whitespace / line-wrapping details, so the committed output diverged from CI's regen — every release PR tripped the drift check.

## Fix

- Switch \`pnpm prettier\` → \`pnpm format:api\` in [scripts/promote.sh](scripts/promote.sh#L368-L380) so the release commit matches what CI regenerates.
- Drop the \`2>/dev/null\` suppression on the export/orval/format commands so a real regen failure aborts the release instead of silently shipping stale types.

## Testing

Side-by-side check that the promote script now runs the same two commands as CI:

\`\`\`
CI:  pnpm orval && pnpm format:api
new: pnpm orval && pnpm format:api
\`\`\`

No code paths changed — just the formatter invocation. The next release PR opened by \`promote.sh\` should pass \`check-generated-types\` cleanly.