### PR TITLE
Add full-screen counter focus view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Counter focus view.** Each counter can now be opened in a full-screen, mobile-first layout via the "Open full screen" menu item on the row (URL: `/g/{guildId}/counter-groups/{groupId}/counter/{counterId}`). The view scales the value, progress bar, or segmented-clock dial to fill the viewport, exposes thumb-zone-sized `−`/`+` controls in the bottom safe area, lets you cycle through the group's counters with chevrons or a horizontal swipe, and stays in sync with other clients via the existing WebSocket. Counter view components gained a `2xl` size variant used by this layout.
+
 ## [0.46.0] - 2026-05-23
 
 ### Added

--- a/frontend/public/locales/en/counters.json
+++ b/frontend/public/locales/en/counters.json
@@ -81,8 +81,18 @@
   "noAccess": "Access Denied",
   "noAccessDescription": "You do not have permission to view this counter group.",
   "backToGroups": "Back to Counter Groups",
+  "backToGroup": "Back to group",
   "counterCount_one": "{{count}} counter",
   "counterCount_other": "{{count}} counters",
+
+  "focus": {
+    "openFocus": "Open full screen",
+    "exit": "Exit full screen",
+    "next": "Next counter",
+    "previous": "Previous counter",
+    "counterPosition": "{{current}} / {{total}}",
+    "notFound": "Counter not found in this group"
+  },
   "createFirst": "Create Your First Counter Group",
 
   "settings": "Settings",

--- a/frontend/public/locales/es/counters.json
+++ b/frontend/public/locales/es/counters.json
@@ -81,8 +81,18 @@
   "noAccess": "Acceso denegado",
   "noAccessDescription": "No tienes permiso para ver este grupo de contadores.",
   "backToGroups": "Volver a los grupos de contadores",
+  "backToGroup": "Volver al grupo",
   "counterCount_one": "{{count}} contador",
   "counterCount_other": "{{count}} contadores",
+
+  "focus": {
+    "openFocus": "Abrir pantalla completa",
+    "exit": "Salir de la pantalla completa",
+    "next": "Contador siguiente",
+    "previous": "Contador anterior",
+    "counterPosition": "{{current}} / {{total}}",
+    "notFound": "Contador no encontrado en este grupo"
+  },
   "createFirst": "Crea tu primer grupo de contadores",
 
   "settings": "Configuración",

--- a/frontend/public/locales/fr/counters.json
+++ b/frontend/public/locales/fr/counters.json
@@ -81,8 +81,18 @@
   "noAccess": "Accès refusé",
   "noAccessDescription": "Vous n’avez pas l’autorisation de voir ce groupe de compteurs.",
   "backToGroups": "Retour aux groupes de compteurs",
+  "backToGroup": "Retour au groupe",
   "counterCount_one": "{{count}} compteur",
   "counterCount_other": "{{count}} compteurs",
+
+  "focus": {
+    "openFocus": "Ouvrir en plein écran",
+    "exit": "Quitter le plein écran",
+    "next": "Compteur suivant",
+    "previous": "Compteur précédent",
+    "counterPosition": "{{current}} / {{total}}",
+    "notFound": "Compteur introuvable dans ce groupe"
+  },
   "createFirst": "Créez votre premier groupe de compteurs",
 
   "settings": "Paramètres",

--- a/frontend/src/components/initiativeTools/counters/CounterRow.tsx
+++ b/frontend/src/components/initiativeTools/counters/CounterRow.tsx
@@ -1,6 +1,16 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, Minus, MoreVertical, Pencil, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import {
+  GripVertical,
+  Maximize2,
+  Minus,
+  MoreVertical,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { CounterRead } from "@/api/generated/initiativeAPI.schemas";
@@ -24,6 +34,8 @@ interface CounterRowProps {
   counter: CounterRead;
   canWrite: boolean;
   layout?: CounterLayout;
+  /** Link to the full-screen single-counter view. Hides the button when omitted. */
+  focusHref?: string;
   onSetCount: (value: string) => void;
   onIncrement: () => void;
   onDecrement: () => void;
@@ -36,6 +48,7 @@ export const CounterRow = ({
   counter,
   canWrite,
   layout = "row",
+  focusHref,
   onSetCount,
   onIncrement,
   onDecrement,
@@ -148,12 +161,19 @@ export const CounterRow = ({
           aria-label={t("more")}
           className={cn("h-7 w-7 opacity-70 hover:opacity-100", moreHoverClass)}
           style={{ color: fg }}
-          disabled={!canWrite}
         >
           <MoreVertical className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {focusHref && (
+          <DropdownMenuItem asChild>
+            <Link to={focusHref}>
+              <Maximize2 className="h-4 w-4" />
+              {t("focus.openFocus")}
+            </Link>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onSelect={onReset} disabled={!canWrite}>
           <RotateCcw className="h-4 w-4" />
           {t("reset")}

--- a/frontend/src/components/initiativeTools/counters/CounterValueInput.tsx
+++ b/frontend/src/components/initiativeTools/counters/CounterValueInput.tsx
@@ -10,7 +10,7 @@ interface CounterValueInputProps {
   /** Called with the typed value after blur, debounce, or Enter. */
   onCommit: (value: string) => void;
   /** Visual size — affects font size only. */
-  size?: "xl" | "lg" | "md" | "sm";
+  size?: "2xl" | "xl" | "lg" | "md" | "sm";
   /** Apply this text color (e.g. contrasting against a colored card). */
   textColor?: string;
   className?: string;
@@ -87,12 +87,19 @@ export const CounterValueInput = ({
       if (valueLength <= 11) return "text-xl";
       return "text-base";
     }
-    // "xl" (grid cards)
-    if (valueLength <= 4) return "text-5xl";
-    if (valueLength <= 6) return "text-4xl";
-    if (valueLength <= 8) return "text-3xl";
-    if (valueLength <= 11) return "text-2xl";
-    return "text-xl";
+    if (size === "xl") {
+      if (valueLength <= 4) return "text-5xl";
+      if (valueLength <= 6) return "text-4xl";
+      if (valueLength <= 8) return "text-3xl";
+      if (valueLength <= 11) return "text-2xl";
+      return "text-xl";
+    }
+    // "2xl" (fullscreen focus view)
+    if (valueLength <= 3) return "text-8xl";
+    if (valueLength <= 5) return "text-7xl";
+    if (valueLength <= 7) return "text-6xl";
+    if (valueLength <= 10) return "text-5xl";
+    return "text-4xl";
   })();
 
   // Size the box to the typed content (font-mono ⇒ 1 char ≈ 1ch) so the input —

--- a/frontend/src/components/initiativeTools/counters/views/CounterNumberView.tsx
+++ b/frontend/src/components/initiativeTools/counters/views/CounterNumberView.tsx
@@ -9,8 +9,8 @@ interface CounterNumberViewProps {
   onCommit: (value: string) => void;
   ariaLabel?: string;
   className?: string;
-  /** Size hint — "xl" for grid cards where the value should dominate. */
-  size?: "xl" | "lg";
+  /** Size hint — "xl" for grid cards, "2xl" for fullscreen focus. */
+  size?: "2xl" | "xl" | "lg";
 }
 
 export const CounterNumberView = ({

--- a/frontend/src/components/initiativeTools/counters/views/CounterProgressBarView.tsx
+++ b/frontend/src/components/initiativeTools/counters/views/CounterProgressBarView.tsx
@@ -11,8 +11,8 @@ interface CounterProgressBarViewProps {
   onCommit: (value: string) => void;
   ariaLabel?: string;
   className?: string;
-  /** Size hint — "xl" enlarges the value for grid cards. */
-  size?: "xl" | "lg";
+  /** Size hint — "xl" enlarges the value for grid cards, "2xl" for fullscreen focus. */
+  size?: "2xl" | "xl" | "lg";
 }
 
 const toNum = (value: string): number => {
@@ -44,8 +44,17 @@ export const CounterProgressBarView = ({
   const value = toNum(count);
   const pct = range > 0 ? Math.max(0, Math.min(100, ((value - minN) / range) * 100)) : 0;
 
+  const slashSize =
+    size === "2xl"
+      ? "text-xl opacity-70"
+      : size === "xl"
+        ? "text-base opacity-70"
+        : "text-sm opacity-70";
+  const barHeight = size === "2xl" ? "h-4" : "h-2";
+  const gapClass = size === "2xl" ? "gap-3" : "gap-1.5";
+
   return (
-    <div className={cn("flex w-full flex-col items-center gap-1.5", className)}>
+    <div className={cn("flex w-full flex-col items-center", gapClass, className)}>
       <div
         className="flex items-baseline justify-center gap-1 font-mono tabular-nums"
         style={{ color: textColor }}
@@ -59,12 +68,10 @@ export const CounterProgressBarView = ({
           size={size}
           ariaLabel={ariaLabel}
         />
-        <span className={size === "xl" ? "text-base opacity-70" : "text-sm opacity-70"}>
-          / {max}
-        </span>
+        <span className={slashSize}>/ {max}</span>
       </div>
       <div
-        className="h-2 w-full overflow-hidden rounded-full"
+        className={cn("w-full overflow-hidden rounded-full", barHeight)}
         style={{ background: "rgba(0,0,0,0.18)" }}
       >
         <div

--- a/frontend/src/components/initiativeTools/counters/views/CounterSegmentedClockView.tsx
+++ b/frontend/src/components/initiativeTools/counters/views/CounterSegmentedClockView.tsx
@@ -11,8 +11,8 @@ interface CounterSegmentedClockViewProps {
   onCommit: (value: string) => void;
   ariaLabel?: string;
   className?: string;
-  /** Size hint — "lg" doubles the diameter for grid cards. */
-  size?: "md" | "lg";
+  /** Size hint — "lg" doubles the diameter for grid cards, "2xl" for fullscreen focus. */
+  size?: "2xl" | "lg" | "md";
 }
 
 const toNum = (value: string): number => {
@@ -53,8 +53,15 @@ export const CounterSegmentedClockView = ({
   // Grid cards ("lg") size the dial responsively: on a 2-up phone the card's
   // value area is only ~65px tall, so start small and grow with the breakpoints
   // that widen the grid. The row layout ("md") keeps a fixed dial.
-  const wrapperSize = size === "lg" ? "h-16 w-16 sm:h-20 sm:w-20 lg:h-24 lg:w-24" : "h-20 w-20";
-  const inputSize = size === "lg" ? "lg" : "md";
+  // "2xl" is the fullscreen focus dial — fills most of the focus viewport area.
+  const wrapperSize =
+    size === "2xl"
+      ? "h-64 w-64 sm:h-72 sm:w-72"
+      : size === "lg"
+        ? "h-16 w-16 sm:h-20 sm:w-20 lg:h-24 lg:w-24"
+        : "h-20 w-20";
+  const inputSize = size === "2xl" ? "2xl" : size === "lg" ? "lg" : "md";
+  const strokeWidth = size === "2xl" ? 4 : 6;
 
   return (
     <div className={cn("relative inline-flex items-center justify-center", wrapperSize, className)}>
@@ -64,7 +71,7 @@ export const CounterSegmentedClockView = ({
         aria-hidden="true"
       >
         <circle
-          strokeWidth={6}
+          strokeWidth={strokeWidth}
           fill="transparent"
           stroke="rgba(0,0,0,0.18)"
           r={RADIUS}
@@ -72,7 +79,7 @@ export const CounterSegmentedClockView = ({
           cy={CENTER}
         />
         <circle
-          strokeWidth={6}
+          strokeWidth={strokeWidth}
           strokeLinecap="round"
           fill="transparent"
           stroke={fillColor}

--- a/frontend/src/pages/initiativeTools/counters/CounterDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterDetailPage.tsx
@@ -243,13 +243,13 @@ export function CounterDetailPage() {
               aria-label={t("more")}
               className={cn("h-10 w-10", chromeButtonClass)}
               style={{ color: fg }}
-              disabled={!canWrite}
             >
               <MoreVertical className="h-5 w-5" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
+              disabled={!canWrite}
               onSelect={() => {
                 stepper.cancel(counter.id);
                 resetOne.mutate(counter.id);
@@ -258,7 +258,7 @@ export function CounterDetailPage() {
               <RotateCcw className="h-4 w-4" />
               {t("reset")}
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => setEditing(counter)}>
+            <DropdownMenuItem disabled={!canWrite} onSelect={() => setEditing(counter)}>
               <Pencil className="h-4 w-4" />
               {t("editCounter")}
             </DropdownMenuItem>

--- a/frontend/src/pages/initiativeTools/counters/CounterDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterDetailPage.tsx
@@ -1,0 +1,347 @@
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  Minus,
+  MoreVertical,
+  Pencil,
+  Plus,
+  RotateCcw,
+  X,
+} from "lucide-react";
+import { type TouchEvent, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { CounterRead } from "@/api/generated/initiativeAPI.schemas";
+import { CounterFormDialog } from "@/components/initiativeTools/counters/CounterFormDialog";
+import { CounterNumberView } from "@/components/initiativeTools/counters/views/CounterNumberView";
+import { CounterProgressBarView } from "@/components/initiativeTools/counters/views/CounterProgressBarView";
+import { CounterSegmentedClockView } from "@/components/initiativeTools/counters/views/CounterSegmentedClockView";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useCounterGroupRealtime } from "@/hooks/useCounterGroupRealtime";
+import {
+  useCounterGroup,
+  useResetCounter,
+  useSetCount,
+  useSteppedCount,
+} from "@/hooks/useCounters";
+import { getContrastingTextColor } from "@/lib/counter-color";
+import { useGuildPath } from "@/lib/guildUrl";
+import { cn } from "@/lib/utils";
+
+const SWIPE_THRESHOLD_PX = 60;
+
+export function CounterDetailPage() {
+  const { t } = useTranslation(["counters", "common"]);
+  const navigate = useNavigate();
+  const gp = useGuildPath();
+  const {
+    guildId,
+    groupId: groupIdParam,
+    counterId: counterIdParam,
+  } = useParams({
+    strict: false,
+  }) as { guildId?: string; groupId?: string; counterId?: string };
+
+  const groupId = groupIdParam ? Number(groupIdParam) : null;
+  const counterId = counterIdParam ? Number(counterIdParam) : null;
+
+  const groupQuery = useCounterGroup(groupId);
+  useCounterGroupRealtime(groupId);
+
+  const setCount = useSetCount(groupId ?? 0);
+  const stepper = useSteppedCount(groupId ?? 0);
+  const resetOne = useResetCounter(groupId ?? 0);
+
+  const [editing, setEditing] = useState<CounterRead | null>(null);
+  const [touchStartX, setTouchStartX] = useState<number | null>(null);
+  const [touchStartY, setTouchStartY] = useState<number | null>(null);
+
+  const group = groupQuery.data;
+  const counters = useMemo(() => {
+    const list = group?.counters ?? [];
+    return [...list].sort((a, b) => Number(a.position) - Number(b.position));
+  }, [group?.counters]);
+
+  const currentIndex = useMemo(
+    () => counters.findIndex((c) => c.id === counterId),
+    [counters, counterId]
+  );
+  const counter = currentIndex >= 0 ? counters[currentIndex] : null;
+
+  const canWrite = group?.my_permission_level === "owner" || group?.my_permission_level === "write";
+
+  const goToCounter = (index: number) => {
+    if (counters.length === 0 || !guildId || !groupId) return;
+    const wrapped = ((index % counters.length) + counters.length) % counters.length;
+    const next = counters[wrapped];
+    if (!next) return;
+    navigate({
+      to: "/g/$guildId/counter-groups/$groupId/counter/$counterId",
+      params: {
+        guildId,
+        groupId: String(groupId),
+        counterId: String(next.id),
+      },
+      replace: true,
+    });
+  };
+
+  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    const touch = event.touches[0];
+    if (!touch) return;
+    setTouchStartX(touch.clientX);
+    setTouchStartY(touch.clientY);
+  };
+
+  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    if (touchStartX === null || touchStartY === null) return;
+    const touch = event.changedTouches[0];
+    if (!touch) return;
+    const dx = touch.clientX - touchStartX;
+    const dy = touch.clientY - touchStartY;
+    setTouchStartX(null);
+    setTouchStartY(null);
+    if (Math.abs(dx) < SWIPE_THRESHOLD_PX || Math.abs(dx) <= Math.abs(dy)) return;
+    goToCounter(currentIndex + (dx < 0 ? 1 : -1));
+  };
+
+  if (groupId === null || counterId === null) return null;
+
+  if (groupQuery.isLoading) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {t("loadingGroup")}
+        </div>
+      </div>
+    );
+  }
+
+  if (groupQuery.isError || !group) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-background px-4 text-center">
+        <h1 className="font-semibold text-2xl">{t("notFound")}</h1>
+        <p className="text-muted-foreground text-sm">{t("notFoundDescription")}</p>
+        <Button variant="outline" asChild>
+          <Link to={gp("/counter-groups")}>{t("backToGroups")}</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (!counter) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-background px-4 text-center">
+        <h1 className="font-semibold text-2xl">{t("focus.notFound")}</h1>
+        <Button variant="outline" asChild>
+          <Link to={gp(`/counter-groups/${groupId}`)}>{t("backToGroup")}</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const bg = counter.color ?? "hsl(var(--background))";
+  const fg = getContrastingTextColor(counter.color) ?? "hsl(var(--foreground))";
+  const isLight = fg === "#0F172A";
+  const hasBounds = counter.min !== null && counter.max !== null;
+
+  const stepButtonClass = isLight
+    ? "bg-black/15 hover:bg-black/25 active:bg-black/35"
+    : "bg-white/15 hover:bg-white/25 active:bg-white/35";
+
+  const chromeButtonClass = isLight
+    ? "hover:bg-black/10 focus-visible:bg-black/10"
+    : "hover:bg-white/10 focus-visible:bg-white/10";
+
+  let viewElement: React.ReactNode;
+  if (counter.view_mode === "progress_bar" && hasBounds) {
+    viewElement = (
+      <CounterProgressBarView
+        count={counter.count}
+        min={counter.min!}
+        max={counter.max!}
+        step={counter.step}
+        disabled={!canWrite}
+        textColor={fg}
+        onCommit={(value) => {
+          stepper.cancel(counter.id);
+          setCount.mutate({ counterId: counter.id, data: { count: value } });
+        }}
+        ariaLabel={counter.name}
+        size="2xl"
+      />
+    );
+  } else if (counter.view_mode === "segmented_clock" && hasBounds) {
+    viewElement = (
+      <CounterSegmentedClockView
+        count={counter.count}
+        min={counter.min!}
+        max={counter.max!}
+        step={counter.step}
+        disabled={!canWrite}
+        textColor={fg}
+        onCommit={(value) => {
+          stepper.cancel(counter.id);
+          setCount.mutate({ counterId: counter.id, data: { count: value } });
+        }}
+        ariaLabel={counter.name}
+        size="2xl"
+      />
+    );
+  } else {
+    viewElement = (
+      <CounterNumberView
+        count={counter.count}
+        step={counter.step}
+        disabled={!canWrite}
+        textColor={fg}
+        onCommit={(value) => {
+          stepper.cancel(counter.id);
+          setCount.mutate({ counterId: counter.id, data: { count: value } });
+        }}
+        ariaLabel={counter.name}
+        size="2xl"
+      />
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col" style={{ background: bg, color: fg }}>
+      <header className="flex items-center justify-between gap-2 px-3 pt-[max(env(safe-area-inset-top),0.75rem)] pb-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          asChild
+          aria-label={t("focus.exit")}
+          className={cn("h-10 w-10", chromeButtonClass)}
+          style={{ color: fg }}
+        >
+          <Link to={gp(`/counter-groups/${groupId}`)}>
+            <X className="h-5 w-5" />
+          </Link>
+        </Button>
+        <h1
+          className="min-w-0 flex-1 truncate text-center font-semibold text-lg"
+          title={counter.name}
+        >
+          {counter.name}
+        </h1>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={t("more")}
+              className={cn("h-10 w-10", chromeButtonClass)}
+              style={{ color: fg }}
+              disabled={!canWrite}
+            >
+              <MoreVertical className="h-5 w-5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onSelect={() => {
+                stepper.cancel(counter.id);
+                resetOne.mutate(counter.id);
+              }}
+            >
+              <RotateCcw className="h-4 w-4" />
+              {t("reset")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setEditing(counter)}>
+              <Pencil className="h-4 w-4" />
+              {t("editCounter")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </header>
+
+      {counters.length > 1 && (
+        <div className="flex items-center justify-between gap-3 px-3 pb-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => goToCounter(currentIndex - 1)}
+            aria-label={t("focus.previous")}
+            className={cn("h-10 w-10", chromeButtonClass)}
+            style={{ color: fg }}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </Button>
+          <span className="font-mono text-sm tabular-nums opacity-70">
+            {t("focus.counterPosition", {
+              current: currentIndex + 1,
+              total: counters.length,
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => goToCounter(currentIndex + 1)}
+            aria-label={t("focus.next")}
+            className={cn("h-10 w-10", chromeButtonClass)}
+            style={{ color: fg }}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+        </div>
+      )}
+
+      <div
+        className="flex min-h-0 flex-1 items-center justify-center overflow-hidden px-6 py-4"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        <div className="flex w-full max-w-sm items-center justify-center sm:max-w-md">
+          {viewElement}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 px-3 pt-2 pb-[max(env(safe-area-inset-bottom),0.75rem)]">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => stepper.decrement(counter)}
+          disabled={!canWrite}
+          aria-label={t("decrement")}
+          className={cn("h-24 rounded-2xl text-current shadow-sm sm:h-28", stepButtonClass)}
+          style={{ color: fg }}
+        >
+          <Minus className="h-10 w-10" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => stepper.increment(counter)}
+          disabled={!canWrite}
+          aria-label={t("increment")}
+          className={cn("h-24 rounded-2xl text-current shadow-sm sm:h-28", stepButtonClass)}
+          style={{ color: fg }}
+        >
+          <Plus className="h-10 w-10" />
+        </Button>
+      </div>
+
+      {canWrite && editing && (
+        <CounterFormDialog
+          open={!!editing}
+          onOpenChange={(open) => {
+            if (!open) setEditing(null);
+          }}
+          groupId={groupId}
+          counter={editing}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
@@ -307,6 +307,7 @@ export function CounterGroupDetailPage() {
                   counter={counter}
                   canWrite={!!canWrite}
                   layout={layout}
+                  focusHref={gp(`/counter-groups/${group.id}/counter/${counter.id}`)}
                   onSetCount={(value) => {
                     // Direct typed entry wins over any pending stepped flush.
                     stepper.cancel(counter.id);

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -90,6 +90,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAdva
 import { Route as ServerRequiredAuthenticatedGGuildIdEventsEventIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/events_.$eventId_.settings'
 import { Route as ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/documents_.$documentId_.settings'
 import { Route as ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/counter-groups_.$groupId_.settings'
+import { Route as ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/counter-groups_.$groupId_.counter_.$counterId'
 
 const ConnectRoute = ConnectRouteImport.update({
   id: '/connect',
@@ -580,6 +581,14 @@ const ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdSettingsRoute =
       getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
     } as any,
   )
+const ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute =
+  ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRouteImport.update(
+    {
+      id: '/counter-groups_/$groupId_/counter_/$counterId',
+      path: '/counter-groups/$groupId/counter/$counterId',
+      getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
+    } as any,
+  )
 
 export interface FileRoutesByFullPath {
   '/': typeof ServerRequiredAuthenticatedIndexRoute
@@ -661,6 +670,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/initiatives/$initiativeId/settings': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdSettingsRoute
   '/g/$guildId/projects/$projectId/settings': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   '/g/$guildId/queues/$queueId/settings': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
+  '/g/$guildId/counter-groups/$groupId/counter/$counterId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof ServerRequiredAuthenticatedIndexRoute
@@ -737,6 +747,7 @@ export interface FileRoutesByTo {
   '/g/$guildId/initiatives/$initiativeId/settings': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdSettingsRoute
   '/g/$guildId/projects/$projectId/settings': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   '/g/$guildId/queues/$queueId/settings': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
+  '/g/$guildId/counter-groups/$groupId/counter/$counterId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -821,6 +832,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/settings': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdSettingsRoute
   '/_serverRequired/_authenticated/g/$guildId/projects_/$projectId_/settings': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId_/settings': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
+  '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId_/counter_/$counterId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -904,6 +916,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/initiatives/$initiativeId/settings'
     | '/g/$guildId/projects/$projectId/settings'
     | '/g/$guildId/queues/$queueId/settings'
+    | '/g/$guildId/counter-groups/$groupId/counter/$counterId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -980,6 +993,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/initiatives/$initiativeId/settings'
     | '/g/$guildId/projects/$projectId/settings'
     | '/g/$guildId/queues/$queueId/settings'
+    | '/g/$guildId/counter-groups/$groupId/counter/$counterId'
   id:
     | '__root__'
     | '/_serverRequired'
@@ -1063,6 +1077,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/settings'
     | '/_serverRequired/_authenticated/g/$guildId/projects_/$projectId_/settings'
     | '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId_/settings'
+    | '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId_/counter_/$counterId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1639,6 +1654,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdSettingsRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
     }
+    '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId_/counter_/$counterId': {
+      id: '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId_/counter_/$counterId'
+      path: '/counter-groups/$groupId/counter/$counterId'
+      fullPath: '/g/$guildId/counter-groups/$groupId/counter/$counterId'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
+    }
   }
 }
 
@@ -1801,6 +1823,7 @@ interface ServerRequiredAuthenticatedGGuildIdRouteChildren {
   ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdSettingsRoute
   ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
+  ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute: typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
 }
 
 const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthenticatedGGuildIdRouteChildren =
@@ -1851,6 +1874,8 @@ const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute,
     ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute:
       ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute,
+    ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute:
+      ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute,
   }
 
 const ServerRequiredAuthenticatedGGuildIdRouteWithChildren =

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/counter-groups_.$groupId_.counter_.$counterId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/counter-groups_.$groupId_.counter_.$counterId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+  "/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId_/counter_/$counterId"
+)({
+  component: lazyRouteComponent(() =>
+    import("@/pages/initiativeTools/counters/CounterDetailPage").then((m) => ({
+      default: m.CounterDetailPage,
+    }))
+  ),
+});


### PR DESCRIPTION
## Summary

- Adds `/g/{guildId}/counter-groups/{groupId}/counter/{counterId}` — a per-counter, full-screen layout for the mobile use case where one counter should fill the viewport with thumb-zone-sized `−`/`+` controls.
- Cycle through the group's counters with the chevron buttons under the header, by horizontal swipe on touch devices, or by deep-linking. Live updates from other clients still apply via the existing `useCounterGroupRealtime` subscription.
- Counter view components (`CounterNumberView`, `CounterProgressBarView`, `CounterSegmentedClockView`) gained a `2xl` size variant used by this layout — digit goes up to `text-8xl`, progress bar to `h-4`, dial to ~256–288 px.
- Entry point is a new "Open full screen" item at the top of the per-counter dropdown menu in the group detail page (visible to viewers too — the new view is read-only-safe).
- ES/FR locale files updated alongside EN.

## Test plan

- [ ] In a counter group with ≥2 counters, open the per-row menu → "Open full screen". Land on the new route.
- [ ] On a narrow viewport (DevTools mobile preset): header, chevron row, scaled display, and `−`/`+` buttons all fit; nothing overflows horizontally; `+`/`−` are reachable in the bottom safe area.
- [ ] Chevrons + the URL update when cycling counters; back-button returns to the prior counter; the `X` exit returns to the group detail page.
- [ ] Horizontal swipe gestures cycle counters on touch input; vertical swipes do not.
- [ ] Mash `+` rapidly: only one `set` PATCH lands after the debounce window (no per-click flood).
- [ ] Open the same counter in two windows; incrementing in one updates the other.
- [ ] Each `view_mode` (number / progress_bar / segmented_clock) renders at the larger size without overflow.
- [ ] Readers (no write permission) can still open the focus view; `−`/`+` and the menu's reset/edit items are disabled.