### PR TITLE
Show task creator and creation time on edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Password complexity requirements.** New passwords must be at least 12 characters and are checked against the HaveIBeenPwned breach corpus via the k-anonymity API (only a 5-char SHA-1 prefix leaves the server). Enforced on registration, password reset, self password change, and admin user creation/update; no character-class rules per NIST SP 800-63B guidance. Existing accounts are grandfathered — short or breached passwords keep working at login until the next change. Disable the breach check by setting `HIBP_CHECK_ENABLED=false` in the backend env (e.g. for air-gapped deployments).
+- **Task edit page shows who created the task and when.** A small avatar + "Created by {name} · {relative time}" chip sits inline with the task title (right-aligned, out of the way of the edit form). Hovering reveals the absolute creation timestamp. Follows the existing avatar conventions (deterministic colour fallback, anonymized-user handling, `User #<id>` fallback when the creator is no longer in the guild).
 
 ## [0.46.2] - 2026-05-27
 

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -64,6 +64,8 @@
     "backToProjects": "\u2190 Back to projects",
     "loadProjectError": "Unable to load project context for this task.",
     "statusBadge": "Status",
+    "createdBy": "Created by {{name}} · {{time}}",
+    "createdAt": "Created {{time}}",
     "subtitle": "Edit every detail of this task.",
     "detailsTitle": "Task details",
     "detailsDescription": "Update the fields below and save your changes.",

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -64,6 +64,8 @@
     "backToProjects": "\u2190 Volver a proyectos",
     "loadProjectError": "No se pudo cargar el contexto del proyecto para esta tarea.",
     "statusBadge": "Estado",
+    "createdBy": "Creada por {{name}} · {{time}}",
+    "createdAt": "Creada {{time}}",
     "subtitle": "Edita todos los detalles de esta tarea.",
     "detailsTitle": "Detalles de la tarea",
     "detailsDescription": "Actualiza los campos a continuación y guarda tus cambios.",

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -64,6 +64,8 @@
     "backToProjects": "← Retour aux projets",
     "loadProjectError": "Impossible de charger le contexte du projet pour cette tâche.",
     "statusBadge": "Statut",
+    "createdBy": "Créée par {{name}} · {{time}}",
+    "createdAt": "Créée {{time}}",
     "subtitle": "Modifiez chaque détail de cette tâche.",
     "detailsTitle": "Détails de la tâche",
     "detailsDescription": "Mettez à jour les champs ci-dessous et enregistrez vos modifications.",

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams, useRouter } from "@tanstack/react-router";
+import { format, formatDistanceToNow } from "date-fns";
 import {
   AlertCircle,
   Archive,
@@ -40,6 +41,7 @@ import { TagPicker } from "@/components/tags";
 import { MoveTaskDialog } from "@/components/tasks/MoveTaskDialog";
 import { TaskChecklist } from "@/components/tasks/TaskChecklist";
 import { statusTriggerStyle, TaskStatusOption } from "@/components/tasks/TaskStatusOption";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
@@ -63,9 +65,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAIEnabled } from "@/hooks/useAIEnabled";
 import { useAuth } from "@/hooks/useAuth";
 import { useComments } from "@/hooks/useComments";
+import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useProject, useProjectTaskStatuses, useWritableProjects } from "@/hooks/useProjects";
 import { useSetTaskProperties } from "@/hooks/useProperties";
@@ -84,6 +88,8 @@ import { toast } from "@/lib/chesterToast";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
 import { queryClient } from "@/lib/queryClient";
+import { resolveUploadUrl } from "@/lib/uploadUrl";
+import { getInitialsForUser, getUserDisplayName, isAnonymizedUser } from "@/lib/userDisplay";
 
 const priorityOrder: TaskPriority[] = ["low", "medium", "high", "urgent"];
 
@@ -113,6 +119,7 @@ export const TaskEditPage = () => {
   useGuilds();
   const { t } = useTranslation(["tasks", "common", "properties"]);
   const gp = useGuildPath();
+  const dateLocale = useDateLocale();
   const { data: roleLabels } = useRoleLabels();
   const memberLabel = getRoleLabel("member", roleLabels);
   const { isEnabled: aiEnabled } = useAIEnabled();
@@ -312,6 +319,38 @@ export const TaskEditPage = () => {
 
   const users = useMemo(() => usersQuery.data ?? [], [usersQuery.data]);
   const project = projectQuery.data;
+
+  // Creator metadata for the inline "Created by …" chip in the title row.
+  // ``users`` may not include the creator if they've since left the guild —
+  // fall back to ``User #<id>`` in that case so the chip still renders.
+  const creator = useMemo(() => {
+    if (task?.created_by_id == null) return null;
+    return users.find((user) => user.id === task.created_by_id) ?? null;
+  }, [users, task?.created_by_id]);
+
+  const creationMeta = useMemo(() => {
+    if (!task?.created_at) return null;
+    const createdAt = new Date(task.created_at);
+    const anonymized = isAnonymizedUser(creator);
+    const displayName = creator
+      ? getUserDisplayName(creator)
+      : task.created_by_id != null
+        ? `User #${task.created_by_id}`
+        : null;
+    const avatarSrc =
+      creator && !anonymized
+        ? resolveUploadUrl(creator.avatar_url) || creator.avatar_base64 || undefined
+        : undefined;
+    return {
+      displayName,
+      avatarSrc,
+      anonymized,
+      initials: getInitialsForUser(creator),
+      creatorId: creator?.id ?? null,
+      relative: formatDistanceToNow(createdAt, { addSuffix: true, locale: dateLocale }),
+      absolute: format(createdAt, "PPpp", { locale: dateLocale }),
+    };
+  }, [task?.created_at, task?.created_by_id, creator, dateLocale]);
   // Pure DAC: only users with write access (owner or write level) can be assigned tasks
   // Includes both explicit user permissions and role-based permissions
   const userOptions = useMemo(() => {
@@ -583,6 +622,40 @@ export const TaskEditPage = () => {
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="font-semibold text-3xl tracking-tight">{title || task?.title}</h1>
           <Badge variant="secondary">{currentStatus?.name ?? t("edit.statusBadge")}</Badge>
+          {creationMeta ? (
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="ml-auto flex items-center gap-2 text-muted-foreground text-xs">
+                    {creationMeta.displayName ? (
+                      <Avatar className="h-5 w-5 border text-[10px]">
+                        {creationMeta.avatarSrc ? (
+                          <AvatarImage
+                            src={creationMeta.avatarSrc}
+                            alt={creationMeta.displayName}
+                          />
+                        ) : null}
+                        <AvatarFallback
+                          userId={creationMeta.anonymized ? null : creationMeta.creatorId}
+                        >
+                          {creationMeta.initials}
+                        </AvatarFallback>
+                      </Avatar>
+                    ) : null}
+                    <span>
+                      {creationMeta.displayName
+                        ? t("edit.createdBy", {
+                            name: creationMeta.displayName,
+                            time: creationMeta.relative,
+                          })
+                        : t("edit.createdAt", { time: creationMeta.relative })}
+                    </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{creationMeta.absolute}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
         </div>
         <p className="text-muted-foreground text-sm">{t("edit.subtitle")}</p>
       </div>

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -328,9 +328,13 @@ export const TaskEditPage = () => {
     return users.find((user) => user.id === task.created_by_id) ?? null;
   }, [users, task?.created_by_id]);
 
-  const creationMeta = useMemo(() => {
+  // The non-time-varying part of the chip. Gated on ``usersQuery.isSuccess``
+  // when there *is* a creator id so we don't flash "User #<id>" while the
+  // users list is still loading — once users arrive, the genuine "creator
+  // has left the guild" case is the only path to that fallback.
+  const creationContext = useMemo(() => {
     if (!task?.created_at) return null;
-    const createdAt = new Date(task.created_at);
+    if (task.created_by_id != null && !usersQuery.isSuccess) return null;
     const anonymized = isAnonymizedUser(creator);
     const displayName = creator
       ? getUserDisplayName(creator)
@@ -342,15 +346,36 @@ export const TaskEditPage = () => {
         ? resolveUploadUrl(creator.avatar_url) || creator.avatar_base64 || undefined
         : undefined;
     return {
+      createdAt: new Date(task.created_at),
       displayName,
       avatarSrc,
       anonymized,
       initials: getInitialsForUser(creator),
       creatorId: creator?.id ?? null,
-      relative: formatDistanceToNow(createdAt, { addSuffix: true, locale: dateLocale }),
-      absolute: format(createdAt, "PPpp", { locale: dateLocale }),
     };
-  }, [task?.created_at, task?.created_by_id, creator, dateLocale]);
+  }, [task?.created_at, task?.created_by_id, creator, usersQuery.isSuccess]);
+
+  // Tick once a minute so the "N ago" label stays fresh while the page is
+  // open — ``formatDistanceToNow`` reads ``Date.now()`` at call time, so a
+  // bare state update is enough to re-render with a current value.
+  const [, setRelativeTick] = useState(0);
+  useEffect(() => {
+    if (!creationContext) return;
+    const id = setInterval(() => setRelativeTick((n) => n + 1), 60_000);
+    return () => clearInterval(id);
+  }, [creationContext]);
+
+  // Computed each render (cheap) so the tick above actually shows up.
+  const creationMeta = creationContext
+    ? {
+        ...creationContext,
+        relative: formatDistanceToNow(creationContext.createdAt, {
+          addSuffix: true,
+          locale: dateLocale,
+        }),
+        absolute: format(creationContext.createdAt, "PPpp", { locale: dateLocale }),
+      }
+    : null;
   // Pure DAC: only users with write access (owner or write level) can be assigned tasks
   // Includes both explicit user permissions and role-based permissions
   const userOptions = useMemo(() => {


### PR DESCRIPTION
## What

Adds a small inline meta chip in the task edit page header showing **who created the task and when**.

- Small avatar (`h-5 w-5`, matching the existing inline-avatar convention used in `mentions-plugin` and `PropertyValueCell`).
- Label: `Created by {{name}} · {{relative time}}` (e.g. *"Created by Alice · 2 hours ago"*).
- Right-aligned (`ml-auto`) so it floats to the edge of the title row and stays clear of the edit form below; wraps to its own line on narrow screens.
- Hovering reveals the absolute creation timestamp via tooltip (e.g. *"May 27, 2026 at 2:30:00 PM"*).

## Why

The task edit page didn't surface task provenance — useful context when triaging an old or unfamiliar task, especially across guild members. Requested by a user.

## How

- New \`creator\` memo in [TaskEditPage.tsx](frontend/src/pages/TaskEditPage.tsx) looks up \`task.created_by_id\` in the existing \`usersQuery\` data (already fetched on this page for the assignee selector — no extra request).
- New \`creationMeta\` memo pre-computes display name, avatar src, initials, and the relative + absolute timestamps using the existing \`useDateLocale\` hook.
- Reuses the established helpers \`getInitialsForUser\`, \`getUserDisplayName\`, \`isAnonymizedUser\`, and \`resolveUploadUrl\` — same as \`CommentThread\` and \`TaskAssigneeList\`.

### Edge cases handled

- **Anonymized creator** → no avatar image, no deterministic colour fallback, \`–\` initials (matches \`TaskAssigneeList\`).
- **Creator no longer in the guild** (not in \`usersQuery\` results) → falls back to \`User #<id>\` label with a default avatar fallback.
- **Null \`created_by_id\`** → label drops to \`Created {{time}}\` with no avatar.

## i18n

New keys in \`frontend/public/locales/en/tasks.json\`:
- \`edit.createdBy\`: \`\"Created by {{name}} · {{time}}\"\`
- \`edit.createdAt\`: \`\"Created {{time}}\"\`

## Testing

- \`pnpm tsc --noEmit\` → clean
- \`pnpm lint\` (biome) → no new findings on the modified file
- Manual: rendered the chip locally against tasks with (a) a normal creator, (b) no creator, (c) a creator not in the active guild — fallbacks behave as designed.

## Screenshots

_(none — UI change is small, localized to the title row)_