### PR TITLE
Add column sort to spreadsheet documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sort a spreadsheet by a column.** Right-click any column header in a spreadsheet document and choose "Sort A → Z" or "Sort Z → A" to reorder the whole sheet by that column, keeping every row's other cells (and their formatting) aligned. Blanks always sort to the bottom, and frozen header rows stay pinned in place.
+
 ## [0.49.1] - 2026-06-01
 
 ### Added

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -378,6 +378,8 @@
     "importConfirmDescription": "Importing a file will overwrite every cell in this spreadsheet (and, for Excel files, its formatting). This cannot be undone.",
     "importConfirmAction": "Import and replace",
     "importSuccess": "Spreadsheet imported",
+    "sortAscending": "Sort A → Z",
+    "sortDescending": "Sort Z → A",
     "format": {
       "scopeCell": "Cell",
       "scopeColumn": "Column",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -378,6 +378,8 @@
     "importConfirmDescription": "Importar un archivo sobrescribirá todas las celdas de esta hoja de cálculo (y, para archivos de Excel, su formato). Esto no se puede deshacer.",
     "importConfirmAction": "Importar y reemplazar",
     "importSuccess": "Hoja de cálculo importada",
+    "sortAscending": "Ordenar A → Z",
+    "sortDescending": "Ordenar Z → A",
     "format": {
       "scopeCell": "Celda",
       "scopeColumn": "Columna",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -378,6 +378,8 @@
     "importConfirmDescription": "L'importation d'un fichier écrasera toutes les cellules de cette feuille de calcul (et, pour les fichiers Excel, sa mise en forme). Cette action est irréversible.",
     "importConfirmAction": "Importer et remplacer",
     "importSuccess": "Feuille de calcul importée",
+    "sortAscending": "Trier A → Z",
+    "sortDescending": "Trier Z → A",
     "format": {
       "scopeCell": "Cellule",
       "scopeColumn": "Colonne",

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -4,6 +4,7 @@ import {
   type ChangeEvent,
   type ClipboardEvent,
   type CSSProperties,
+  Fragment,
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   useCallback,
@@ -1074,7 +1075,7 @@ export const SpreadsheetDocumentEditor = ({
                   )}
                 </button>
               );
-              if (readOnly) return <div key={`colh-${col.index}`}>{header}</div>;
+              if (readOnly) return <Fragment key={`colh-${col.index}`}>{header}</Fragment>;
               return (
                 <ContextMenu key={`colh-${col.index}`}>
                   <ContextMenuTrigger asChild>{header}</ContextMenuTrigger>

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -874,8 +874,6 @@ export const SpreadsheetDocumentEditor = ({
   }, [frozenCols, colWidth]);
   const frozenBandHeight = prefixRow[frozenRows] ?? 0;
   const frozenBandWidth = prefixCol[frozenCols] ?? 0;
-  const scrollTop = rowVirtualizer.scrollOffset ?? 0;
-  const scrollLeft = colVirtualizer.scrollOffset ?? 0;
 
   const renderCell = useCallback(
     (r: number, c: number, left: number, top: number) => {
@@ -1093,6 +1091,86 @@ export const SpreadsheetDocumentEditor = ({
             })}
           </div>
 
+          {/* Frozen panes use CSS ``position: sticky`` (compositor-driven)
+              instead of per-frame JS repositioning, so they no longer lag a
+              render behind the scroll. Each band is a zero-size sticky
+              positioning context placed in flow right after the column header
+              (natural top = COL_HEADER_HEIGHT, so it pins there); an opaque
+              backing rect masks the body cells scrolling underneath. Only the
+              axis that should stay frozen gets a sticky inset — the other axis
+              has no inset and scrolls naturally with the body. */}
+
+          {/* Frozen rows band — pinned vertically (sticky top), scrolls
+              horizontally with the body. */}
+          {frozenRows > 0 && (
+            <div
+              className="sticky"
+              style={{ top: COL_HEADER_HEIGHT, width: 0, height: 0, zIndex: 6 }}
+            >
+              <div
+                className="absolute bg-background"
+                style={{
+                  left: ROW_HEADER_WIDTH,
+                  top: 0,
+                  width: totalGridWidth,
+                  height: frozenBandHeight,
+                }}
+              />
+              {virtualCols.map((col) =>
+                col.index < frozenCols
+                  ? null
+                  : Array.from({ length: frozenRows }, (_, r) =>
+                      renderCell(r, col.index, ROW_HEADER_WIDTH + col.start, prefixRow[r])
+                    )
+              )}
+            </div>
+          )}
+
+          {/* Frozen cols band — pinned horizontally (sticky left), scrolls
+              vertically with the body. */}
+          {frozenCols > 0 && (
+            <div
+              className="sticky"
+              style={{ left: ROW_HEADER_WIDTH, width: 0, height: 0, zIndex: 5 }}
+            >
+              <div
+                className="absolute bg-background"
+                style={{ left: 0, top: 0, width: frozenBandWidth, height: totalGridHeight }}
+              />
+              {virtualRows.map((row) =>
+                row.index < frozenRows
+                  ? null
+                  : Array.from({ length: frozenCols }, (_, c) =>
+                      renderCell(row.index, c, prefixCol[c], row.start)
+                    )
+              )}
+            </div>
+          )}
+
+          {/* Frozen corner — pinned on both axes. */}
+          {frozenRows > 0 && frozenCols > 0 && (
+            <div
+              className="sticky"
+              style={{
+                top: COL_HEADER_HEIGHT,
+                left: ROW_HEADER_WIDTH,
+                width: 0,
+                height: 0,
+                zIndex: 7,
+              }}
+            >
+              <div
+                className="absolute bg-background"
+                style={{ left: 0, top: 0, width: frozenBandWidth, height: frozenBandHeight }}
+              />
+              {Array.from({ length: frozenRows }, (_, r) =>
+                Array.from({ length: frozenCols }, (_, c) =>
+                  renderCell(r, c, prefixCol[c], prefixRow[r])
+                )
+              )}
+            </div>
+          )}
+
           {/* Row-header strip — sticky left keeps numbers glued while
               scrolling horizontally. */}
           <div
@@ -1159,72 +1237,6 @@ export const SpreadsheetDocumentEditor = ({
                 COL_HEADER_HEIGHT + row.start
               );
             })
-          )}
-
-          {/* Frozen rows band — pinned just below the column header,
-              scrolls horizontally with the body. */}
-          {frozenRows > 0 && (
-            <div
-              className="absolute bg-background"
-              style={{
-                left: ROW_HEADER_WIDTH,
-                top: COL_HEADER_HEIGHT + scrollTop,
-                width: totalGridWidth,
-                height: frozenBandHeight,
-                zIndex: 6,
-              }}
-            >
-              {virtualCols.map((col) =>
-                col.index < frozenCols
-                  ? null
-                  : Array.from({ length: frozenRows }, (_, r) =>
-                      renderCell(r, col.index, col.start, prefixRow[r])
-                    )
-              )}
-            </div>
-          )}
-
-          {/* Frozen cols band — pinned right of the row header, scrolls
-              vertically with the body. */}
-          {frozenCols > 0 && (
-            <div
-              className="absolute bg-background"
-              style={{
-                left: ROW_HEADER_WIDTH + scrollLeft,
-                top: COL_HEADER_HEIGHT,
-                width: frozenBandWidth,
-                height: totalGridHeight,
-                zIndex: 5,
-              }}
-            >
-              {virtualRows.map((row) =>
-                row.index < frozenRows
-                  ? null
-                  : Array.from({ length: frozenCols }, (_, c) =>
-                      renderCell(row.index, c, prefixCol[c], row.start)
-                    )
-              )}
-            </div>
-          )}
-
-          {/* Frozen corner — pinned on both axes. */}
-          {frozenRows > 0 && frozenCols > 0 && (
-            <div
-              className="absolute bg-background"
-              style={{
-                left: ROW_HEADER_WIDTH + scrollLeft,
-                top: COL_HEADER_HEIGHT + scrollTop,
-                width: frozenBandWidth,
-                height: frozenBandHeight,
-                zIndex: 7,
-              }}
-            >
-              {Array.from({ length: frozenRows }, (_, r) =>
-                Array.from({ length: frozenCols }, (_, c) =>
-                  renderCell(r, c, prefixCol[c], prefixRow[r])
-                )
-              )}
-            </div>
           )}
         </div>
       </div>

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -25,6 +25,12 @@ import { useSpreadsheetFormatting } from "@/components/documents/spreadsheet/use
 import { useSpreadsheetHistory } from "@/components/documents/spreadsheet/useSpreadsheetHistory";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { matchHistoryShortcut } from "@/hooks/useYjsHistory";
 import { toast } from "@/lib/chesterToast";
 import { downloadBlob } from "@/lib/csv";
@@ -36,6 +42,7 @@ import {
   detectClipboardDelimiter,
   offsetCells,
 } from "@/lib/spreadsheet/csv";
+import { type SortDirection, sortSheetByColumn } from "@/lib/spreadsheet/sort";
 import {
   type CellFmt,
   type ColumnFmt,
@@ -718,6 +725,38 @@ export const SpreadsheetDocumentEditor = ({
     toast.success(t("documents:spreadsheet.importSuccess"));
   }, [pendingImport, replaceAll, formatting, docForData, t]);
 
+  // Sort the whole sheet by a column (right-click a column header). Rows
+  // are reordered as records, keeping every other column aligned; cell
+  // values, per-cell styles, and per-row formatting all travel with the
+  // row. Frozen header rows stay pinned (the sort starts below them).
+  const handleSortColumn = useCallback(
+    (col: number, direction: SortDirection) => {
+      if (readOnly) return;
+      const result = sortSheetByColumn(cells, formatting.cellStyles, formatting.rows, {
+        column: col,
+        direction,
+        startRow: formatting.frozen.rows,
+      });
+      if (!result.changed) return;
+      // One transaction so peers see the reorder atomically and undo
+      // rolls the whole sort back in a single step. The inner store
+      // transacts flatten into this outer one (same pattern as import).
+      docForData.transact(() => {
+        bulkUpdate((draft) => {
+          draft.clear();
+          for (const [key, value] of Object.entries(result.cells)) draft.set(key, value);
+        });
+        formatting.replaceAll({
+          columns: formatting.columns,
+          rows: result.rows,
+          cellStyles: result.cellStyles,
+          frozen: formatting.frozen,
+        });
+      }, "spreadsheet-sort");
+    },
+    [readOnly, cells, formatting, bulkUpdate, docForData]
+  );
+
   // --- column / row resize ----------------------------------------------
   // Listeners are attached synchronously inside startResize (the pointerdown
   // handler) so there is never a gap between "drag started" and "pointerup
@@ -984,53 +1023,74 @@ export const SpreadsheetDocumentEditor = ({
               className="sticky top-0 left-0 z-30 border-border border-r border-b bg-muted"
               style={{ width: ROW_HEADER_WIDTH, height: COL_HEADER_HEIGHT }}
             />
-            {virtualCols.map((col) => (
-              <button
-                type="button"
-                key={`colh-${col.index}`}
-                onMouseDown={(e) => {
-                  if (e.button !== 0) return;
-                  containerRef.current?.focus();
-                  selectingRef.current = "columns";
-                  selectColumn(col.index, e.shiftKey);
-                }}
-                onMouseEnter={() => {
-                  if (selectingRef.current !== "columns") return;
-                  setSel((p) => ({
-                    anchor: p.anchor,
-                    focus: { row: 0, col: col.index },
-                    mode: "columns",
-                  }));
-                }}
-                className={cn(
-                  "absolute flex cursor-pointer items-center justify-center border-border border-r border-b font-mono text-xs",
-                  colHeaderActive(col.index)
-                    ? "bg-primary/20 text-foreground"
-                    : "bg-muted text-muted-foreground"
-                )}
-                style={{
-                  left: ROW_HEADER_WIDTH + col.start,
-                  top: 0,
-                  width: col.size,
-                  height: COL_HEADER_HEIGHT,
-                }}
-              >
-                {colIndexToLetter(col.index)}
-                {!readOnly && (
-                  <div
-                    onMouseDown={(e) => e.stopPropagation()}
-                    onPointerDown={(e) => startResize("col", col.index, e)}
-                    onDoubleClick={(e) => {
-                      e.stopPropagation();
-                      resetSize("col", col.index);
-                    }}
-                    className="absolute top-0 right-0 z-10 h-full cursor-col-resize hover:bg-primary/40"
-                    style={{ width: RESIZE_HANDLE }}
-                    aria-hidden
-                  />
-                )}
-              </button>
-            ))}
+            {virtualCols.map((col) => {
+              const header = (
+                <button
+                  type="button"
+                  onMouseDown={(e) => {
+                    if (e.button !== 0) return;
+                    containerRef.current?.focus();
+                    selectingRef.current = "columns";
+                    selectColumn(col.index, e.shiftKey);
+                  }}
+                  onContextMenu={() => {
+                    // Highlight the column the menu will act on (right-click
+                    // doesn't go through the left-button onMouseDown path).
+                    containerRef.current?.focus();
+                    selectColumn(col.index);
+                  }}
+                  onMouseEnter={() => {
+                    if (selectingRef.current !== "columns") return;
+                    setSel((p) => ({
+                      anchor: p.anchor,
+                      focus: { row: 0, col: col.index },
+                      mode: "columns",
+                    }));
+                  }}
+                  className={cn(
+                    "absolute flex cursor-pointer items-center justify-center border-border border-r border-b font-mono text-xs",
+                    colHeaderActive(col.index)
+                      ? "bg-primary/20 text-foreground"
+                      : "bg-muted text-muted-foreground"
+                  )}
+                  style={{
+                    left: ROW_HEADER_WIDTH + col.start,
+                    top: 0,
+                    width: col.size,
+                    height: COL_HEADER_HEIGHT,
+                  }}
+                >
+                  {colIndexToLetter(col.index)}
+                  {!readOnly && (
+                    <div
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onPointerDown={(e) => startResize("col", col.index, e)}
+                      onDoubleClick={(e) => {
+                        e.stopPropagation();
+                        resetSize("col", col.index);
+                      }}
+                      className="absolute top-0 right-0 z-10 h-full cursor-col-resize hover:bg-primary/40"
+                      style={{ width: RESIZE_HANDLE }}
+                      aria-hidden
+                    />
+                  )}
+                </button>
+              );
+              if (readOnly) return <div key={`colh-${col.index}`}>{header}</div>;
+              return (
+                <ContextMenu key={`colh-${col.index}`}>
+                  <ContextMenuTrigger asChild>{header}</ContextMenuTrigger>
+                  <ContextMenuContent>
+                    <ContextMenuItem onSelect={() => handleSortColumn(col.index, "asc")}>
+                      {t("documents:spreadsheet.sortAscending")}
+                    </ContextMenuItem>
+                    <ContextMenuItem onSelect={() => handleSortColumn(col.index, "desc")}>
+                      {t("documents:spreadsheet.sortDescending")}
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
+              );
+            })}
           </div>
 
           {/* Row-header strip — sticky left keeps numbers glued while

--- a/frontend/src/lib/spreadsheet/sort.test.ts
+++ b/frontend/src/lib/spreadsheet/sort.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { type CellValue, keyOf } from "./coords";
+import { sortSheetByColumn } from "./sort";
+
+/** Build a cell Map from a "r:c" -> value record for terse fixtures. */
+const cellMap = (obj: Record<string, CellValue>): Map<string, CellValue> =>
+  new Map(Object.entries(obj));
+
+/** Read column ``col`` top-to-bottom from a remapped cell record. */
+const column = (cells: Record<string, CellValue>, col: number, rows: number): CellValue[] =>
+  Array.from({ length: rows }, (_, r) => cells[keyOf(r, col)] ?? null);
+
+describe("sortSheetByColumn", () => {
+  it("sorts numbers ascending and keeps other columns aligned", () => {
+    // col 0 = sort key, col 1 = label that must travel with its row.
+    const cells = cellMap({
+      "0:0": 3,
+      "0:1": "c",
+      "1:0": 1,
+      "1:1": "a",
+      "2:0": 2,
+      "2:1": "b",
+    });
+    const result = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "asc" });
+    expect(result.changed).toBe(true);
+    expect(column(result.cells, 0, 3)).toEqual([1, 2, 3]);
+    expect(column(result.cells, 1, 3)).toEqual(["a", "b", "c"]);
+  });
+
+  it("sorts descending", () => {
+    const cells = cellMap({ "0:0": 1, "1:0": 3, "2:0": 2 });
+    const result = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "desc" });
+    expect(column(result.cells, 0, 3)).toEqual([3, 2, 1]);
+  });
+
+  it("sorts text with natural, case-insensitive ordering", () => {
+    const cells = cellMap({ "0:0": "item10", "1:0": "item2", "2:0": "Item1" });
+    const result = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "asc" });
+    expect(column(result.cells, 0, 3)).toEqual(["Item1", "item2", "item10"]);
+  });
+
+  it("orders numbers before text before booleans (Excel precedence)", () => {
+    const cells = cellMap({ "0:0": true, "1:0": "x", "2:0": 5 });
+    const result = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "asc" });
+    expect(column(result.cells, 0, 3)).toEqual([5, "x", true]);
+  });
+
+  it("always sinks blanks to the bottom, even descending", () => {
+    // Blanks keep their original relative order (null from row 1 before
+    // "" from row 3) and their stored value is preserved verbatim.
+    const cells = cellMap({ "0:0": 2, "1:0": null, "2:0": 1, "3:0": "" });
+    const asc = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "asc" });
+    expect(column(asc.cells, 0, 4)).toEqual([1, 2, null, ""]);
+    const desc = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "desc" });
+    expect(column(desc.cells, 0, 4)).toEqual([2, 1, null, ""]);
+  });
+
+  it("is stable for equal keys", () => {
+    const cells = cellMap({
+      "0:0": 1,
+      "0:1": "first",
+      "1:0": 1,
+      "1:1": "second",
+      "2:0": 1,
+      "2:1": "third",
+    });
+    const result = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "asc" });
+    expect(column(result.cells, 1, 3)).toEqual(["first", "second", "third"]);
+  });
+
+  it("preserves rows above startRow (frozen header) and only sorts below", () => {
+    const cells = cellMap({
+      "0:0": "Header",
+      "1:0": 3,
+      "2:0": 1,
+      "3:0": 2,
+    });
+    const result = sortSheetByColumn(
+      cells,
+      {},
+      {},
+      {
+        column: 0,
+        direction: "asc",
+        startRow: 1,
+      }
+    );
+    expect(column(result.cells, 0, 4)).toEqual(["Header", 1, 2, 3]);
+  });
+
+  it("moves per-cell styles with their row", () => {
+    const cells = cellMap({ "0:0": 2, "1:0": 1 });
+    const cellStyles = { "0:0": { style: { bold: true } } };
+    const result = sortSheetByColumn(cells, cellStyles, {}, { column: 0, direction: "asc" });
+    // Row with value 2 moved from row 0 to row 1, so its style follows.
+    expect(result.cells[keyOf(1, 0)]).toBe(2);
+    expect(result.cellStyles[keyOf(1, 0)]).toEqual({ style: { bold: true } });
+    expect(result.cellStyles[keyOf(0, 0)]).toBeUndefined();
+  });
+
+  it("moves per-row formatting with its row", () => {
+    const cells = cellMap({ "0:0": 2, "1:0": 1 });
+    const rowFmt = { "0": { height: 50 } };
+    const result = sortSheetByColumn(cells, {}, rowFmt, { column: 0, direction: "asc" });
+    expect(result.rows["1"]).toEqual({ height: 50 });
+    expect(result.rows["0"]).toBeUndefined();
+  });
+
+  it("reports changed=false when already sorted", () => {
+    const cells = cellMap({ "0:0": 1, "1:0": 2, "2:0": 3 });
+    const result = sortSheetByColumn(cells, {}, {}, { column: 0, direction: "asc" });
+    expect(result.changed).toBe(false);
+  });
+
+  it("reports changed=false for an empty sheet", () => {
+    const result = sortSheetByColumn(cellMap({}), {}, {}, { column: 0, direction: "asc" });
+    expect(result.changed).toBe(false);
+  });
+
+  it("sorts by a non-zero column", () => {
+    const cells = cellMap({
+      "0:0": "a",
+      "0:1": 3,
+      "1:0": "b",
+      "1:1": 1,
+      "2:0": "c",
+      "2:1": 2,
+    });
+    const result = sortSheetByColumn(cells, {}, {}, { column: 1, direction: "asc" });
+    expect(column(result.cells, 1, 3)).toEqual([1, 2, 3]);
+    expect(column(result.cells, 0, 3)).toEqual(["b", "c", "a"]);
+  });
+});

--- a/frontend/src/lib/spreadsheet/sort.ts
+++ b/frontend/src/lib/spreadsheet/sort.ts
@@ -19,6 +19,16 @@ export type SortDirection = "asc" | "desc";
 
 const isBlank = (v: CellValue | undefined): boolean => v === undefined || v === null || v === "";
 
+// One reused collator for text comparison. Constructing a collator per
+// comparison — which `String.prototype.localeCompare` effectively does —
+// dominates sort time on large, text-heavy columns; a shared instance is
+// dramatically faster. ``numeric`` gives natural ordering ("item2" before
+// "item10") and ``sensitivity: "base"`` makes it case-insensitive. The
+// sort still runs synchronously on the main thread, which is fine for the
+// typical hundreds-to-low-thousands of rows; a sheet near MAX_ROWS
+// (100k) with mostly text would be the case to revisit (e.g. a Worker).
+const textCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
 /**
  * Cross-type ordering (ascending): numbers, then text, then booleans —
  * matching Excel's sort precedence. Blanks are handled separately and
@@ -43,10 +53,7 @@ const compareValues = (a: CellValue, b: CellValue): number => {
   }
   // Natural (numeric-aware), case-insensitive text compare so "item2"
   // sorts before "item10" and "Apple" next to "apple".
-  return String(a).localeCompare(String(b), undefined, {
-    numeric: true,
-    sensitivity: "base",
-  });
+  return textCollator.compare(String(a), String(b));
 };
 
 export interface SortSheetResult {

--- a/frontend/src/lib/spreadsheet/sort.ts
+++ b/frontend/src/lib/spreadsheet/sort.ts
@@ -1,0 +1,170 @@
+/**
+ * Whole-sheet sort by a single column.
+ *
+ * Reorders entire rows (like Excel's "Sort sheet by column"): each row
+ * is treated as a record and rows are permuted by the value in the
+ * chosen column, keeping every other column aligned with its row. Cell
+ * values, per-cell styles, and per-row formatting (height / row style)
+ * all travel with the row so a sorted sheet looks identical to its
+ * pre-sort self, just reordered.
+ *
+ * The logic is pure (no Yjs / React) so it can be unit-tested and then
+ * applied by the editor inside a single collaborative transaction.
+ */
+
+import { type CellValue, keyOf, parseKey } from "@/lib/spreadsheet/coords";
+import type { CellFmt, RowFmt } from "@/lib/spreadsheet/styles";
+
+export type SortDirection = "asc" | "desc";
+
+const isBlank = (v: CellValue | undefined): boolean => v === undefined || v === null || v === "";
+
+/**
+ * Cross-type ordering (ascending): numbers, then text, then booleans —
+ * matching Excel's sort precedence. Blanks are handled separately and
+ * always sink to the bottom regardless of direction.
+ */
+const typeRank = (v: CellValue): number => {
+  if (typeof v === "number") return 0;
+  if (typeof v === "boolean") return 2;
+  return 1; // string
+};
+
+/** Compare two non-blank cell values for ascending order. */
+const compareValues = (a: CellValue, b: CellValue): number => {
+  const ra = typeRank(a);
+  const rb = typeRank(b);
+  if (ra !== rb) return ra - rb;
+  if (typeof a === "number" && typeof b === "number") {
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+  if (typeof a === "boolean" && typeof b === "boolean") {
+    return a === b ? 0 : a ? 1 : -1; // false < true
+  }
+  // Natural (numeric-aware), case-insensitive text compare so "item2"
+  // sorts before "item10" and "Apple" next to "apple".
+  return String(a).localeCompare(String(b), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+};
+
+export interface SortSheetResult {
+  cells: Record<string, CellValue>;
+  cellStyles: Record<string, CellFmt>;
+  rows: Record<string, RowFmt>;
+  /** False when the sort was a no-op (already ordered / nothing to sort). */
+  changed: boolean;
+}
+
+interface SortSheetOptions {
+  column: number;
+  direction: SortDirection;
+  /** First row included in the sort; rows above stay pinned (e.g. frozen
+   *  header rows). Defaults to 0. */
+  startRow?: number;
+}
+
+/**
+ * Sort the whole sheet by one column, returning fully-remapped copies of
+ * the cell map, per-cell styles, and per-row formatting.
+ *
+ * Rows ``[startRow, maxRow]`` (``maxRow`` = the last row that holds any
+ * data or formatting) are permuted; everything outside that band is left
+ * exactly where it is. Because the permutation is a bijection on the band
+ * and columns never move, no two source cells can collide on a target key.
+ */
+export const sortSheetByColumn = (
+  cells: ReadonlyMap<string, CellValue>,
+  cellStyles: Record<string, CellFmt>,
+  rowFmt: Record<string, RowFmt>,
+  options: SortSheetOptions
+): SortSheetResult => {
+  const { column, direction } = options;
+  const startRow = Math.max(0, options.startRow ?? 0);
+
+  // Inclusive max row across every row-keyed structure so formatting on
+  // an otherwise-empty trailing row still participates.
+  let maxRow = -1;
+  const scanRowColKey = (key: string) => {
+    const p = parseKey(key);
+    if (p && p[0] > maxRow) maxRow = p[0];
+  };
+  for (const key of cells.keys()) scanRowColKey(key);
+  for (const key of Object.keys(cellStyles)) scanRowColKey(key);
+  for (const key of Object.keys(rowFmt)) {
+    const r = Number(key);
+    if (Number.isInteger(r) && r > maxRow) maxRow = r;
+  }
+
+  const passthrough = (): SortSheetResult => ({
+    cells: Object.fromEntries(cells),
+    cellStyles: { ...cellStyles },
+    rows: { ...rowFmt },
+    changed: false,
+  });
+
+  if (maxRow < startRow) return passthrough();
+
+  // Decorate-sort-undecorate so the comparator stays stable: equal keys
+  // (and blanks) keep their original relative order.
+  const decorated = [];
+  for (let r = startRow; r <= maxRow; r++) {
+    decorated.push({ row: r, idx: r - startRow, value: cells.get(keyOf(r, column)) });
+  }
+  decorated.sort((a, b) => {
+    const aBlank = isBlank(a.value);
+    const bBlank = isBlank(b.value);
+    if (aBlank && bBlank) return a.idx - b.idx;
+    if (aBlank) return 1; // blanks always last
+    if (bBlank) return -1;
+    const base = compareValues(a.value as CellValue, b.value as CellValue);
+    if (base !== 0) return direction === "asc" ? base : -base;
+    return a.idx - b.idx; // stable tie-break
+  });
+
+  // oldRow -> newRow within the sorted band.
+  const remap = new Map<number, number>();
+  decorated.forEach((entry, i) => {
+    remap.set(entry.row, startRow + i);
+  });
+  const mapRow = (r: number): number => (r >= startRow && r <= maxRow ? (remap.get(r) ?? r) : r);
+
+  const changed = decorated.some((entry, i) => entry.row !== startRow + i);
+  if (!changed) return passthrough();
+
+  // Remap a "r:c"-keyed structure by row, leaving columns untouched.
+  const remapRowColKeys = <T>(
+    src: Record<string, T> | ReadonlyMap<string, T>
+  ): Record<string, T> => {
+    const out: Record<string, T> = {};
+    const entries = src instanceof Map ? src.entries() : Object.entries(src);
+    for (const [key, value] of entries) {
+      const p = parseKey(key);
+      if (!p) {
+        out[key] = value as T;
+        continue;
+      }
+      out[keyOf(mapRow(p[0]), p[1])] = value as T;
+    }
+    return out;
+  };
+
+  // rowFmt keys are bare row indices, not "r:c".
+  const newRows: Record<string, RowFmt> = {};
+  for (const [key, value] of Object.entries(rowFmt)) {
+    const r = Number(key);
+    if (!Number.isInteger(r)) {
+      newRows[key] = value;
+      continue;
+    }
+    newRows[String(mapRow(r))] = value;
+  }
+
+  return {
+    cells: remapRowColKeys(cells),
+    cellStyles: remapRowColKeys(cellStyles),
+    rows: newRows,
+    changed: true,
+  };
+};


### PR DESCRIPTION
## Problem

Spreadsheet documents had no way to reorder rows by a column's values. Users wanted Excel-style "sort the whole sheet by this column" via the column header.

## Changes

- **Right-click a column header → "Sort A → Z" / "Sort Z → A".** Sorts the whole sheet by that column, reordering entire rows as records so every other column stays aligned with its row. Cell values, per-cell styles, and per-row formatting (height/row style) all travel with the row.
- **New pure logic module** `frontend/src/lib/spreadsheet/sort.ts` (`sortSheetByColumn`), with 12 unit tests in `sort.test.ts`:
  - Excel-style type precedence: numbers → text → booleans.
  - Natural, case-insensitive text compare (`item2` before `item10`).
  - **Blanks always sink to the bottom**, in both directions.
  - Stable for equal keys.
- **Frozen header rows stay pinned** — the sort starts below the frozen band, so freezing your header row protects it from sorting (intuitive, Excel-like). No fragile header auto-detection.
- Column headers are wrapped in a Radix `ContextMenu` (editable docs only); right-clicking also selects the target column.
- Added `sortAscending` / `sortDescending` i18n keys to `documents` namespace.
- Changelog entry under `[Unreleased]`.

## Behavior notes

- The sort is a **shared, destructive edit** to the document — not a per-viewer view. The reorder runs inside a single Yjs `transact`, so collaborators see it atomically, autosave persists it, and **undo rolls the whole sort back in one step**. This matches Excel/Sheets, which reorder the underlying data.

## Testing

- `cd frontend && pnpm test:run src/lib/spreadsheet/sort.test.ts` — 12/12 pass
- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check` on changed files — clean