### PR TITLE
Add spreadsheet fill handle (drag-to-fill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Drag the fill handle to fill cells in spreadsheets.** Grab the small square on the bottom-right corner of a cell or selection and drag down, up, left, or right to fill the range. Formulas adjust their relative references as they go (`=A1` filled down becomes `=A2`, `=A3`, …) while `$`-anchored parts stay put; numeric runs and `text + number` patterns extrapolate as a series (1, 2 → 3, 4, 5; `Item 1` → `Item 2`); anything else is copied. Double-click the handle to auto-fill down to the extent of the neighboring column's data. The whole fill is a single undo step and syncs to collaborators.
+
 ## [0.49.4] - 2026-06-04
 
 ### Fixed

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -480,8 +480,11 @@ export const SpreadsheetDocumentEditor = ({
           else draft.set(key, value);
         }
       });
+      // Anchor on the target's top-left (not the source's) so an up/left
+      // fill — where target.r1/c1 sit above/left of the source — keeps the
+      // whole written region selected, not just the original cells.
       setSel({
-        anchor: { row: source.r1, col: source.c1 },
+        anchor: { row: target.r1, col: target.c1 },
         focus: { row: target.r2, col: target.c2 },
         mode: "range",
       });

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -47,6 +47,7 @@ import {
   detectClipboardDelimiter,
   offsetCells,
 } from "@/lib/spreadsheet/csv";
+import { type Box, computeAutofillTarget, computeFillWrites } from "@/lib/spreadsheet/fill";
 import { createEvaluator, isFormula } from "@/lib/spreadsheet/formula";
 import { type SortDirection, sortSheetByColumn } from "@/lib/spreadsheet/sort";
 import {
@@ -212,6 +213,14 @@ export const SpreadsheetDocumentEditor = ({
   const [drag, setDrag] = useState<DragState | null>(null);
   // Which header/cell drag is in progress (null = not dragging).
   const selectingRef = useRef<null | "range" | "columns" | "rows">(null);
+  // Fill-handle drag: ``fillSourceRef`` is the rectangle captured when the
+  // drag began, ``fillTargetRef`` the latest extended rectangle. Both live in
+  // refs so the once-registered window ``mouseup`` listener reads current
+  // values (never a stale closure, the same reason ``selectingRef`` is a ref).
+  // ``fillPreview`` mirrors the target in state purely to drive the tint.
+  const fillSourceRef = useRef<Box | null>(null);
+  const fillTargetRef = useRef<Box | null>(null);
+  const [fillPreview, setFillPreview] = useState<Box | null>(null);
   const [pendingImport, setPendingImport] = useState<{
     cells: Record<string, CellValue>;
     rows: number;
@@ -456,11 +465,83 @@ export const SpreadsheetDocumentEditor = ({
     });
   }, []);
 
+  // Commit a fill (drag or double-click): tile / extrapolate the source
+  // rectangle across the new region in one transaction, then keep the filled
+  // block selected. A target identical to the source (a click with no drag)
+  // is a no-op. ``null`` writes clear their cell so the map stays sparse.
+  const commitFill = useCallback(
+    (source: Box, target: Box) => {
+      if (readOnly) return;
+      const writes = computeFillWrites((r, c) => cells.get(keyOf(r, c)) ?? null, source, target);
+      if (writes.size === 0) return;
+      bulkUpdate((draft) => {
+        for (const [key, value] of writes) {
+          if (value == null) draft.delete(key);
+          else draft.set(key, value);
+        }
+      });
+      setSel({
+        anchor: { row: source.r1, col: source.c1 },
+        focus: { row: target.r2, col: target.c2 },
+        mode: "range",
+      });
+    },
+    [readOnly, cells, bulkUpdate]
+  );
+  // The once-registered window ``mouseup`` listener calls the latest commit
+  // through this ref (its closure would otherwise capture a stale ``cells``).
+  const commitFillRef = useRef(commitFill);
+  commitFillRef.current = commitFill;
+
+  // Grab the fill handle: capture the current selection as the source and
+  // seed the preview there (a click with no drag stays a no-op).
+  const startFill = useCallback(() => {
+    if (readOnly) return;
+    fillSourceRef.current = selBox;
+    fillTargetRef.current = selBox;
+    setFillPreview(selBox);
+  }, [readOnly, selBox]);
+
+  // Extend an in-progress fill toward a hovered cell, constrained to the
+  // dominant axis (vertical vs horizontal), the way a fill handle is.
+  const extendFill = useCallback((row: number, col: number) => {
+    const source = fillSourceRef.current;
+    if (!source) return;
+    const vert = Math.max(0, row - source.r2, source.r1 - row);
+    const horiz = Math.max(0, col - source.c2, source.c1 - col);
+    let target: Box;
+    if (vert === 0 && horiz === 0) target = source;
+    else if (vert >= horiz)
+      target = { ...source, r1: Math.min(source.r1, row), r2: Math.max(source.r2, row) };
+    else target = { ...source, c1: Math.min(source.c1, col), c2: Math.max(source.c2, col) };
+    fillTargetRef.current = target;
+    setFillPreview(target);
+  }, []);
+
+  // Double-click the handle: fill down to the neighbor column's data extent.
+  const autofillDown = useCallback(() => {
+    if (readOnly) return;
+    const target = computeAutofillTarget(
+      (r, c) => cells.get(keyOf(r, c)) ?? null,
+      selBox,
+      dimensions
+    );
+    commitFill(selBox, target);
+  }, [readOnly, cells, selBox, dimensions, commitFill]);
+
   // Clear the selectingRef on any pointer release so a drag that ends
-  // off-grid still stops extending the selection.
+  // off-grid still stops extending the selection. A fill drag commits here.
   useEffect(() => {
     const onUp = () => {
       selectingRef.current = null;
+      const source = fillSourceRef.current;
+      if (source) {
+        const target = fillTargetRef.current ?? source;
+        fillSourceRef.current = null;
+        fillTargetRef.current = null;
+        setFillPreview(null);
+        commitFillRef.current(source, target);
+      }
     };
     window.addEventListener("mouseup", onUp);
     return () => window.removeEventListener("mouseup", onUp);
@@ -1185,6 +1266,13 @@ export const SpreadsheetDocumentEditor = ({
       // A formula error, or a red/redParens negative number, wins over any
       // explicit text color (Excel's numFmt color section overrides font).
       if (error || negativeRendersRed(resolved, numberFormat)) cellCss.color = "#dc2626";
+      // The fill handle sits on the bottom-right corner of a cell-range
+      // selection; the preview tint covers the live drag extent.
+      const isFillCorner =
+        !readOnly && !isEditing && sel.mode === "range" && r === selBox.r2 && c === selBox.c2;
+      const inFillPreview = fillPreview
+        ? r >= fillPreview.r1 && r <= fillPreview.r2 && c >= fillPreview.c1 && c <= fillPreview.c2
+        : false;
       return (
         <CellView
           key={keyOf(r, c)}
@@ -1193,6 +1281,8 @@ export const SpreadsheetDocumentEditor = ({
           isActive={isActive}
           inSelection={isInSel(r, c)}
           inCut={inCut}
+          inFillPreview={inFillPreview}
+          showFillHandle={isFillCorner}
           isEditing={Boolean(isEditing)}
           display={display}
           title={error ?? undefined}
@@ -1210,6 +1300,12 @@ export const SpreadsheetDocumentEditor = ({
             selectCell(r, c, e.shiftKey);
           }}
           onMouseEnter={() => {
+            // A fill drag in progress takes over hover: extend its preview
+            // instead of moving the selection focus.
+            if (fillSourceRef.current) {
+              extendFill(r, c);
+              return;
+            }
             if (selectingRef.current !== "range") return;
             setSel((p) => ({
               anchor: p.anchor,
@@ -1217,6 +1313,8 @@ export const SpreadsheetDocumentEditor = ({
               mode: "range",
             }));
           }}
+          onFillHandleMouseDown={startFill}
+          onFillHandleDoubleClick={autofillDown}
           onDoubleClick={() => beginEdit(r, c)}
           onToggleBoolean={() => {
             if (readOnly || !isBoolean) return;
@@ -1234,8 +1332,11 @@ export const SpreadsheetDocumentEditor = ({
       evaluator,
       formatting,
       sel.focus,
+      sel.mode,
+      selBox,
       isInSel,
       cut,
+      fillPreview,
       editing,
       readOnly,
       peerSelectionsByCell,
@@ -1246,6 +1347,9 @@ export const SpreadsheetDocumentEditor = ({
       setCell,
       handleEditingKeyDown,
       commitEdit,
+      startFill,
+      autofillDown,
+      extendFill,
     ]
   );
 
@@ -1697,6 +1801,10 @@ interface CellViewProps {
   inSelection: boolean;
   /** Inside the pending-cut source — draws a dashed "move" marquee. */
   inCut: boolean;
+  /** Inside the live fill-handle drag extent — draws a preview tint. */
+  inFillPreview: boolean;
+  /** This is the selection's bottom-right corner — renders the fill nub. */
+  showFillHandle: boolean;
   isEditing: boolean;
   display: string;
   /** Tooltip text — used to surface a formula error token (e.g. #DIV/0!). */
@@ -1714,6 +1822,8 @@ interface CellViewProps {
   onDraftChange: (draft: string) => void;
   onEditingKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
   onEditingBlur: () => void;
+  onFillHandleMouseDown: () => void;
+  onFillHandleDoubleClick: () => void;
 }
 
 const CellView = ({
@@ -1722,6 +1832,8 @@ const CellView = ({
   isActive,
   inSelection,
   inCut,
+  inFillPreview,
+  showFillHandle,
   isEditing,
   display,
   title,
@@ -1738,6 +1850,8 @@ const CellView = ({
   onDraftChange,
   onEditingKeyDown,
   onEditingBlur,
+  onFillHandleMouseDown,
+  onFillHandleDoubleClick,
 }: CellViewProps) => {
   const baseClass = useMemo(
     () =>
@@ -1781,6 +1895,32 @@ const CellView = ({
     <div className="pointer-events-none absolute inset-0 z-[1] border-2 border-primary border-dashed" />
   ) : null;
 
+  // Tint over the new region a fill drag will write (the source already
+  // reads through the selection tint, so only paint cells outside it).
+  const fillPreviewOverlay =
+    inFillPreview && !inSelection && !isActive ? (
+      <div className="pointer-events-none absolute inset-0 bg-primary/10" />
+    ) : null;
+
+  // The draggable fill handle on the selection's bottom-right corner. Its
+  // own mousedown starts the fill (stopping selection); double-click
+  // auto-fills down. Centered on the corner, above the ring/overlays.
+  const fillHandle = showFillHandle ? (
+    // biome-ignore lint/a11y/noStaticElementInteractions: pointer-only affordance; grid keyboard model owns navigation
+    <div
+      className="absolute right-0 bottom-0 z-[3] h-[7px] w-[7px] translate-x-1/2 translate-y-1/2 cursor-crosshair rounded-[1px] border border-background bg-primary"
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        onFillHandleMouseDown();
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        onFillHandleDoubleClick();
+      }}
+    />
+  ) : null;
+
   if (isEditing) {
     return (
       <div className={baseClass} style={containerStyle}>
@@ -1817,8 +1957,10 @@ const CellView = ({
           aria-label={booleanValue ? "true" : "false"}
         />
         {selectionOverlay}
+        {fillPreviewOverlay}
         {cutOverlay}
         {peerOverlay}
+        {fillHandle}
       </div>
     );
   }
@@ -1835,8 +1977,10 @@ const CellView = ({
     >
       <span className="w-full truncate">{display}</span>
       {selectionOverlay}
+      {fillPreviewOverlay}
       {cutOverlay}
       {peerOverlay}
+      {fillHandle}
     </div>
   );
 };

--- a/frontend/src/lib/spreadsheet/fill.test.ts
+++ b/frontend/src/lib/spreadsheet/fill.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import { type CellValue, keyOf } from "./coords";
+import { type Box, computeAutofillTarget, computeFillWrites } from "./fill";
+
+// Build a reader over a sparse "r:c" → value record.
+const reader =
+  (data: Record<string, CellValue>) =>
+  (r: number, c: number): CellValue =>
+    data[keyOf(r, c)] ?? null;
+
+// Collapse the writes Map to a plain record for easy assertions.
+const writesAt = (m: Map<string, CellValue>) => Object.fromEntries(m);
+
+const box = (r1: number, r2: number, c1: number, c2: number): Box => ({ r1, r2, c1, c2 });
+
+describe("computeFillWrites — formulas", () => {
+  it("translates relative references when filling down", () => {
+    const read = reader({ [keyOf(0, 1)]: "=A1" }); // B1 = A1
+    const w = writesAt(computeFillWrites(read, box(0, 0, 1, 1), box(0, 2, 1, 1)));
+    expect(w).toEqual({ [keyOf(1, 1)]: "=A2", [keyOf(2, 1)]: "=A3" });
+  });
+
+  it("translates references when filling right", () => {
+    const read = reader({ [keyOf(1, 0)]: "=A1" }); // A2 = A1
+    const w = writesAt(computeFillWrites(read, box(1, 1, 0, 0), box(1, 1, 0, 2)));
+    expect(w).toEqual({ [keyOf(1, 1)]: "=B1", [keyOf(1, 2)]: "=C1" });
+  });
+
+  it("emits #REF! when a relative reference is pulled off-grid", () => {
+    const read = reader({ [keyOf(2, 0)]: "=A1" }); // A3 = A1
+    // Fill up from A3: the cell just above references row -1, and the one
+    // above that row -2 — both off the top of the grid.
+    const w = writesAt(computeFillWrites(read, box(2, 2, 0, 0), box(0, 2, 0, 0)));
+    expect(w[keyOf(1, 0)]).toBe("=#REF!");
+    expect(w[keyOf(0, 0)]).toBe("=#REF!");
+  });
+});
+
+describe("computeFillWrites — numeric series", () => {
+  it("copies a single number (step 0)", () => {
+    const read = reader({ [keyOf(0, 0)]: 5 });
+    const w = writesAt(computeFillWrites(read, box(0, 0, 0, 0), box(0, 2, 0, 0)));
+    expect(w).toEqual({ [keyOf(1, 0)]: 5, [keyOf(2, 0)]: 5 });
+  });
+
+  it("extrapolates an arithmetic progression downward", () => {
+    const read = reader({ [keyOf(0, 0)]: 1, [keyOf(1, 0)]: 2 });
+    const w = writesAt(computeFillWrites(read, box(0, 1, 0, 0), box(0, 4, 0, 0)));
+    expect(w).toEqual({ [keyOf(2, 0)]: 3, [keyOf(3, 0)]: 4, [keyOf(4, 0)]: 5 });
+  });
+
+  it("extrapolates upward (continuing the progression outward)", () => {
+    const read = reader({ [keyOf(3, 0)]: 10, [keyOf(4, 0)]: 20 });
+    const w = writesAt(computeFillWrites(read, box(3, 4, 0, 0), box(1, 4, 0, 0)));
+    // n = r - source.r1 (=3): row 2 → n=-1 → 0, row 1 → n=-2 → -10.
+    expect(w).toEqual({ [keyOf(2, 0)]: 0, [keyOf(1, 0)]: -10 });
+  });
+});
+
+describe("computeFillWrites — text+integer series", () => {
+  it("increments a single text+integer cell by one", () => {
+    const read = reader({ [keyOf(0, 0)]: "Item 1" });
+    const w = writesAt(computeFillWrites(read, box(0, 0, 0, 0), box(0, 2, 0, 0)));
+    expect(w).toEqual({ [keyOf(1, 0)]: "Item 2", [keyOf(2, 0)]: "Item 3" });
+  });
+
+  it("follows an established suffix step and keeps zero-padding", () => {
+    const read = reader({ [keyOf(0, 0)]: "Q01", [keyOf(1, 0)]: "Q03" });
+    const w = writesAt(computeFillWrites(read, box(0, 1, 0, 0), box(0, 3, 0, 0)));
+    expect(w).toEqual({ [keyOf(2, 0)]: "Q05", [keyOf(3, 0)]: "Q07" });
+  });
+});
+
+describe("computeFillWrites — tiling fallback", () => {
+  it("tiles plain text verbatim", () => {
+    const read = reader({ [keyOf(0, 0)]: "abc" });
+    const w = writesAt(computeFillWrites(read, box(0, 0, 0, 0), box(0, 2, 0, 0)));
+    expect(w).toEqual({ [keyOf(1, 0)]: "abc", [keyOf(2, 0)]: "abc" });
+  });
+
+  it("tiles a mixed formula+value line, translating only the formula", () => {
+    // Source rows: A1 = "x" (text), A2 = =B2 (formula). Mixed → no series.
+    const read = reader({ [keyOf(0, 0)]: "x", [keyOf(1, 0)]: "=B2" });
+    const w = writesAt(computeFillWrites(read, box(0, 1, 0, 0), box(0, 3, 0, 0)));
+    // Tiling continues the 2-tall pattern: row2→"x", row3→=B4 (shifted +2).
+    expect(w).toEqual({ [keyOf(2, 0)]: "x", [keyOf(3, 0)]: "=B4" });
+  });
+
+  it("clears a destination cell when its source cell is empty", () => {
+    // Source column has data only in row 0; row 1 is empty.
+    const read = reader({ [keyOf(0, 0)]: "x" });
+    const w = computeFillWrites(read, box(0, 1, 0, 0), box(0, 3, 0, 0));
+    expect(w.get(keyOf(2, 0))).toBe("x"); // tiles from row 0
+    expect(w.get(keyOf(3, 0))).toBe(null); // tiles from empty row 1 → clear
+  });
+});
+
+describe("computeAutofillTarget", () => {
+  const dims = { rows: 100, cols: 26 };
+
+  it("extends down to the neighboring column's contiguous extent", () => {
+    const read = reader({
+      [keyOf(0, 0)]: "a",
+      [keyOf(1, 0)]: "b",
+      [keyOf(2, 0)]: "c", // column A has data rows 0-2
+      [keyOf(0, 1)]: "=A1", // source B1
+    });
+    expect(computeAutofillTarget(read, box(0, 0, 1, 1), dims)).toEqual(box(0, 2, 1, 1));
+  });
+
+  it("falls back to the right neighbor when the left has none", () => {
+    const read = reader({
+      [keyOf(0, 1)]: 1,
+      [keyOf(1, 1)]: 1, // column B (right of source A) has data rows 0-1
+      [keyOf(0, 0)]: 7, // source A1
+    });
+    expect(computeAutofillTarget(read, box(0, 0, 0, 0), dims)).toEqual(box(0, 1, 0, 0));
+  });
+
+  it("returns the source unchanged when no neighbor has data", () => {
+    const read = reader({ [keyOf(0, 1)]: "=A1" });
+    expect(computeAutofillTarget(read, box(0, 0, 1, 1), dims)).toEqual(box(0, 0, 1, 1));
+  });
+});

--- a/frontend/src/lib/spreadsheet/fill.ts
+++ b/frontend/src/lib/spreadsheet/fill.ts
@@ -1,0 +1,158 @@
+/**
+ * Fill-handle logic: extend a source rectangle across a dragged range,
+ * the way a spreadsheet's bottom-right fill handle does.
+ *
+ * Three behaviors, decided per source *line* (each column of a vertical
+ * fill, each row of a horizontal one):
+ *   - Formula cells translate their *relative* references by the drag
+ *     offset (``$`` stays pinned) via {@link translateFormula}.
+ *   - Numeric or ``text + trailing integer`` lines extrapolate as a series
+ *     (1,2,3 → 4,5,6; ``Item 1`` → ``Item 2``).
+ *   - Anything else (booleans, plain text, mixed lines) tiles verbatim.
+ *
+ * Pure module — no React, no I/O. The caller supplies a ``read`` accessor
+ * and applies the returned writes inside its own transaction.
+ */
+
+import { type CellKey, type CellValue, keyOf } from "@/lib/spreadsheet/coords";
+import { isFormula, translateFormula } from "@/lib/spreadsheet/formula-refs";
+
+export interface Box {
+  r1: number;
+  r2: number;
+  c1: number;
+  c2: number;
+}
+
+/** Reads a cell value, ``null`` for an empty cell. */
+type CellReader = (row: number, col: number) => CellValue;
+
+const TRAILING_INT = /^(.*?)(\d+)$/;
+
+const parseTrailingInt = (s: string): { prefix: string; num: number; pad: number } | null => {
+  const m = TRAILING_INT.exec(s);
+  if (!m) return null;
+  return { prefix: m[1], num: Number(m[2]), pad: m[2].length };
+};
+
+const formatInt = (n: number, pad: number): string => {
+  const digits = String(Math.abs(n)).padStart(pad, "0");
+  return n < 0 ? `-${digits}` : digits;
+};
+
+/**
+ * Build an extrapolator over the offset ``n`` from a source line's first
+ * cell (``n = 0`` is that first cell, ``n = length`` the cell just past the
+ * end, ``n = -1`` the cell just before it), or ``null`` when the line is not
+ * a recognized series and the caller should tile instead. Formula lines
+ * always return ``null`` — they are translated, never extrapolated.
+ */
+const detectSeries = (values: CellValue[]): ((n: number) => CellValue) | null => {
+  if (values.length === 0) return null;
+  if (values.some((v) => v == null || isFormula(v))) return null;
+  const H = values.length;
+
+  // Numeric arithmetic progression. A single number has step 0 → a plain
+  // copy, matching a spreadsheet's default single-cell drag.
+  if (values.every((v) => typeof v === "number")) {
+    const nums = values as number[];
+    const step = H >= 2 ? (nums[H - 1] - nums[0]) / (H - 1) : 0;
+    return (n) => nums[0] + step * n;
+  }
+
+  // Constant-prefix text with a trailing integer (``Item 1`` → ``Item 2``).
+  // A single such cell increments by 1 per step.
+  if (values.every((v) => typeof v === "string")) {
+    const parsed = (values as string[]).map(parseTrailingInt);
+    const first = parsed[0];
+    if (first && parsed.every((p) => p !== null && p.prefix === first.prefix)) {
+      const items = parsed as { prefix: string; num: number; pad: number }[];
+      const step = H >= 2 ? (items[H - 1].num - items[0].num) / (H - 1) : 1;
+      return (n) => `${first.prefix}${formatInt(Math.round(items[0].num + step * n), first.pad)}`;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Compute the cell writes that fill ``source`` across ``target`` (the
+ * drag-extended rectangle that shares one pair of edges with ``source`` and
+ * grew along exactly one axis). Only the *new* region is returned; source
+ * cells are left untouched. A ``null`` value means "clear this cell" — the
+ * caller deletes that key to keep the map sparse.
+ */
+export const computeFillWrites = (
+  read: CellReader,
+  source: Box,
+  target: Box
+): Map<CellKey, CellValue> => {
+  const writes = new Map<CellKey, CellValue>();
+  const H = source.r2 - source.r1 + 1;
+  const W = source.c2 - source.c1 + 1;
+  const vertical = target.r1 < source.r1 || target.r2 > source.r2;
+
+  if (vertical) {
+    for (let c = source.c1; c <= source.c2; c++) {
+      const line: CellValue[] = [];
+      for (let k = 0; k < H; k++) line.push(read(source.r1 + k, c));
+      const series = detectSeries(line);
+      for (let r = target.r1; r <= target.r2; r++) {
+        if (r >= source.r1 && r <= source.r2) continue; // never overwrite source
+        const n = r - source.r1;
+        if (series) {
+          writes.set(keyOf(r, c), series(n));
+          continue;
+        }
+        const srcR = source.r1 + (((n % H) + H) % H);
+        const v = read(srcR, c);
+        writes.set(keyOf(r, c), isFormula(v) ? translateFormula(v, r - srcR, 0) : v);
+      }
+    }
+    return writes;
+  }
+
+  for (let r = source.r1; r <= source.r2; r++) {
+    const line: CellValue[] = [];
+    for (let k = 0; k < W; k++) line.push(read(r, source.c1 + k));
+    const series = detectSeries(line);
+    for (let c = target.c1; c <= target.c2; c++) {
+      if (c >= source.c1 && c <= source.c2) continue;
+      const n = c - source.c1;
+      if (series) {
+        writes.set(keyOf(r, c), series(n));
+        continue;
+      }
+      const srcC = source.c1 + (((n % W) + W) % W);
+      const v = read(r, srcC);
+      writes.set(keyOf(r, c), isFormula(v) ? translateFormula(v, 0, c - srcC) : v);
+    }
+  }
+  return writes;
+};
+
+/**
+ * Double-click target: extend ``source`` *down* to the last contiguous
+ * non-empty row of the neighboring column (the column just left of the
+ * source, falling back to the one just right). Returns ``source`` unchanged
+ * when neither neighbor has data to follow.
+ */
+export const computeAutofillTarget = (
+  read: CellReader,
+  source: Box,
+  dims: { rows: number; cols: number }
+): Box => {
+  const below = source.r2 + 1;
+  const leftHasData = source.c1 - 1 >= 0 && below < dims.rows && read(below, source.c1 - 1) != null;
+  const rightHasData =
+    source.c2 + 1 < dims.cols && below < dims.rows && read(below, source.c2 + 1) != null;
+  const neighborCol = leftHasData ? source.c1 - 1 : rightHasData ? source.c2 + 1 : null;
+  if (neighborCol === null) return source;
+
+  let last = source.r2;
+  for (let r = below; r < dims.rows; r++) {
+    if (read(r, neighborCol) == null) break;
+    last = r;
+  }
+  return last === source.r2 ? source : { ...source, r2: last };
+};

--- a/frontend/src/lib/spreadsheet/formula-refs.test.ts
+++ b/frontend/src/lib/spreadsheet/formula-refs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isFormula, shiftFormulaReferences } from "./formula-refs";
+import { isFormula, shiftFormulaReferences, translateFormula } from "./formula-refs";
 
 // The same old-index -> new-index mappers transformSheet builds.
 const insertMap =
@@ -95,5 +95,43 @@ describe("shiftFormulaReferences — boundaries", () => {
 
   it("handles multiple references in one formula", () => {
     expect(shiftFormulaReferences("=A5+B5*C1", "row", insertMap(0, 1))).toBe("=A6+B6*C2");
+  });
+});
+
+describe("translateFormula", () => {
+  it("shifts relative references by the row/col delta", () => {
+    expect(translateFormula("=A1+B1", 2, 0)).toBe("=A3+B3");
+    expect(translateFormula("=A1+B1", 0, 2)).toBe("=C1+D1");
+    expect(translateFormula("=A1", 2, 3)).toBe("=D3");
+  });
+
+  it("pins $-absolute components in place", () => {
+    expect(translateFormula("=$A$1+B1", 2, 0)).toBe("=$A$1+B3");
+    expect(translateFormula("=A$1", 2, 3)).toBe("=D$1");
+    expect(translateFormula("=$A1", 2, 3)).toBe("=$A3");
+  });
+
+  it("turns an off-grid reference into #REF!", () => {
+    // =A1 pulled up one row → row index -1.
+    expect(translateFormula("=A1", -1, 0)).toBe("=#REF!");
+    // =A1 pulled left one col → col index -1.
+    expect(translateFormula("=A1", 0, -1)).toBe("=#REF!");
+  });
+
+  it("translates both endpoints of a range as a unit", () => {
+    expect(translateFormula("=SUM(A1:A3)", 5, 0)).toBe("=SUM(A6:A8)");
+  });
+
+  it("collapses a range to #REF! when an endpoint goes off-grid", () => {
+    expect(translateFormula("=SUM(A1:A3)", -1, 0)).toBe("=SUM(#REF!)");
+  });
+
+  it("leaves string literals and function names alone", () => {
+    expect(translateFormula('="A1 total"&A1', 1, 0)).toBe('="A1 total"&A2');
+    expect(translateFormula("=LOG10(A1)", 1, 0)).toBe("=LOG10(A2)");
+  });
+
+  it("returns non-formula input unchanged", () => {
+    expect(translateFormula("plain A1", 1, 0)).toBe("plain A1");
   });
 });

--- a/frontend/src/lib/spreadsheet/formula-refs.ts
+++ b/frontend/src/lib/spreadsheet/formula-refs.ts
@@ -34,26 +34,22 @@ const isIdentTail = (c: string | undefined): boolean => {
 };
 
 /**
- * Rewrite every A1 cell reference in a formula along ``axis`` using
- * ``mapIndex`` — the exact old-index → new-index mapper that
- * ``transformSheet`` builds for an insert/delete. References on the
- * inactive axis are left untouched; a reference whose active-axis line
- * was deleted (``mapIndex`` returns ``null``) becomes ``#REF!``.
+ * Scan a formula and rewrite every A1 cell reference through ``mapSingle``,
+ * which maps one matched reference to its replacement text (or ``null`` to
+ * mark it deleted / off-grid → ``#REF!``).
  *
- * Ranges (``A1:B10``) are handled as a unit: deleting a row *inside* a
- * range shrinks it (both endpoints shift, neither is dropped), while
- * deleting the line of *either* endpoint collapses the whole range to a
- * single ``#REF!`` (``=SUM(#REF!)``, matching Excel — never the invalid
- * ``=SUM(#REF!:A10)``). ``$`` absolute markers are preserved verbatim.
+ * Ranges (``A1:B10``) are handled as a unit: a ``null`` from *either*
+ * endpoint collapses the whole range to a single ``#REF!`` (``=SUM(#REF!)``,
+ * matching Excel — never the invalid ``=SUM(#REF!:A10)``).
  *
  * The scan skips double-quoted string literals (with ``""`` escaping) so
- * text like ``="A5 total"`` is never mistaken for a reference. Non-formula
- * input is returned unchanged.
+ * text like ``="A5 total"`` is never mistaken for a reference, and only
+ * probes at identifier boundaries so a function name (``LOG10``) or a name
+ * like ``FOO_A1`` isn't rewritten. Non-formula input is returned unchanged.
  */
-export const shiftFormulaReferences = (
+const scanReferences = (
   formula: string,
-  axis: "row" | "col",
-  mapIndex: (i: number) => number | null
+  mapSingle: (m: RegExpExecArray) => string | null
 ): string => {
   if (!isFormula(formula)) return formula;
   const body = formula.slice(1);
@@ -100,15 +96,14 @@ export const shiftFormulaReferences = (
         if (m && !isIdentTail(body[afterIdx + 1 + m[0].length])) match2 = m;
       }
       if (match2) {
-        const start = mapRef(match, axis, mapIndex);
-        const end = mapRef(match2, axis, mapIndex);
-        // A deleted endpoint collapses the whole range (Excel behavior).
+        const start = mapSingle(match);
+        const end = mapSingle(match2);
+        // A deleted/off-grid endpoint collapses the whole range (Excel).
         out += start === null || end === null ? "#REF!" : `${start}:${end}`;
         i = afterIdx + 1 + match2[0].length;
         continue;
       }
-      const single = mapRef(match, axis, mapIndex);
-      out += single ?? "#REF!";
+      out += mapSingle(match) ?? "#REF!";
       i += match[0].length;
       continue;
     }
@@ -119,6 +114,36 @@ export const shiftFormulaReferences = (
 
   return out;
 };
+
+/**
+ * Rewrite every A1 cell reference in a formula along ``axis`` using
+ * ``mapIndex`` — the exact old-index → new-index mapper that
+ * ``transformSheet`` builds for an insert/delete. References on the
+ * inactive axis are left untouched; a reference whose active-axis line
+ * was deleted (``mapIndex`` returns ``null``) becomes ``#REF!``.
+ *
+ * Ranges shrink when an interior line is deleted and collapse to ``#REF!``
+ * when an endpoint's line is deleted. ``$`` absolute markers are preserved
+ * verbatim, but the index *still moves* — an insert above ``$A$5`` pushes
+ * it to ``$A$6`` because the content it points at shifted. (Contrast
+ * {@link translateFormula}, where ``$`` pins the reference in place.)
+ */
+export const shiftFormulaReferences = (
+  formula: string,
+  axis: "row" | "col",
+  mapIndex: (i: number) => number | null
+): string => scanReferences(formula, (m) => mapRef(m, axis, mapIndex));
+
+/**
+ * Translate every *relative* A1 reference in a formula by ``rowDelta`` /
+ * ``colDelta`` — the copy/fill semantics of a spreadsheet. A ``$`` marker
+ * pins that component in place (``$A$1`` never moves; ``A$1`` moves only by
+ * column; ``$A1`` only by row). A reference pushed off the grid (negative
+ * row or column) becomes ``#REF!``, and a range collapses to ``#REF!`` if
+ * either endpoint does. Non-formula input is returned unchanged.
+ */
+export const translateFormula = (formula: string, rowDelta: number, colDelta: number): string =>
+  scanReferences(formula, (m) => mapRefTranslate(m, rowDelta, colDelta));
 
 /** Rewrite one matched reference along ``axis``; ``null`` if its line was
  *  deleted (the caller turns that into ``#REF!``). */
@@ -134,4 +159,15 @@ const mapRef = (
   }
   const mapped = mapIndex(Number(digits) - 1);
   return mapped === null ? null : `${colAbs}${letters}${rowAbs}${mapped + 1}`;
+};
+
+/** Translate one matched reference by ``rowDelta`` / ``colDelta``, leaving
+ *  ``$``-pinned components untouched; ``null`` if pushed off the grid (the
+ *  caller turns that into ``#REF!``). */
+const mapRefTranslate = (m: RegExpExecArray, rowDelta: number, colDelta: number): string | null => {
+  const [, colAbs, letters, rowAbs, digits] = m;
+  const col = letterToColIndex(letters) + (colAbs ? 0 : colDelta);
+  const row = Number(digits) - 1 + (rowAbs ? 0 : rowDelta);
+  if (row < 0 || col < 0) return null;
+  return `${colAbs}${colIndexToLetter(col)}${rowAbs}${row + 1}`;
 };


### PR DESCRIPTION
## Problem

The spreadsheet editor supported selection, editing, copy/cut/paste, and formulas, but had no **fill handle** — the small square on the bottom-right corner of a selection that you drag to copy/extend cell contents. It's one of the most-used spreadsheet gestures.

## Changes

**Pure logic (tested):**
- `lib/spreadsheet/formula-refs.ts` — extracted the shared A1-reference scanner (`scanReferences`) and added **`translateFormula(formula, rowDelta, colDelta)`**. Unlike `shiftFormulaReferences` (insert/delete: *every* reference moves because content shifted), `translateFormula` shifts only **relative** parts — `$`-anchored components stay pinned, and off-grid results become `#REF!`. This is the copy/fill semantics.
- `lib/spreadsheet/fill.ts` *(new)* — `computeFillWrites` (tiles/translates/extrapolates the source across the drag region), `detectSeries` (numeric arithmetic + `text+trailing-integer`), and `computeAutofillTarget` (double-click extent from the neighbor column).

**Editor wiring** (`SpreadsheetDocumentEditor.tsx`):
- A fill nub on the selection's bottom-right corner; drag extends a single-axis (down/up/left/right) preview; release commits via one `bulkUpdate` (one undo step, one peer sync) and keeps the filled block selected.
- Double-click the nub auto-fills down to the neighbor column's data extent.
- Mirrors the existing `selectingRef` + global-`mouseup` drag pattern and the per-cell overlay pattern.

### Behavior

| Source | Drag result |
|---|---|
| Single number | Copy (Excel default; 2+ cells define the step) |
| Two+ numbers | Extrapolate the step (1, 2 → 3, 4, 5) |
| Single `text + number` | Increment by 1 (`Item 1` → `Item 2`) |
| Two+ `text + number` | Follow the suffix step (`Q01`, `Q03` → `Q05`, `Q07`) |
| Formula | Relative refs shift, `\$` stays pinned; off-grid → `#REF!` |
| Anything else | Copy/tile verbatim |

Calendar series (dates / month names) are intentionally deferred — values here are opaque strings — and fall back to verbatim copy.

## Schema / env

None.

## Testing

- `cd frontend && pnpm test:run src/lib/spreadsheet src/components/documents` — 148 passed (new `fill.test.ts` + `translateFormula` cases; existing `formula-refs`/`transform` tests confirm the scanner refactor is non-breaking)
- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm lint` — clean
- Manual (spreadsheet doc): `=A1` in B1 dragged down → `=A2`, `=A3`; `1`/`2` selected and dragged → `3, 4, 5`; `Q1` → `Q2, Q3`; formula column double-click-filled to neighbor extent; single Ctrl+Z reverts the whole fill; collaborator sees the filled cells.