### PR TITLE
Fix guild sidebar pill and project initiative desync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Add Project from an Initiative's Projects tab now always creates the project in that initiative.** Previously the new-project dialog showed the initiative you were viewing, but — when the initiatives list was already cached — could create the project in a different initiative.
+- **The active-guild indicator pill shows again in the guild sidebar on home pages.** A corrupted CSS class (spaces replaced by special characters) had made the highlight invisible.
+
 ## [0.49.5] - 2026-06-04
 
 ### Added

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -271,7 +271,7 @@ const GrantGuildButton = ({
             washes out on the colored tooltip. */}
         <p className="text-primary-foreground/80 text-xs">
           {t("temporaryAccess")}
-          {left !== null ? `   ${t("expiresInMinutes", { minutes: left })}` : ""}
+          {left !== null ? ` · ${t("expiresInMinutes", { minutes: left })}` : ""}
         </p>
       </TooltipContent>
     </Tooltip>

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -210,7 +210,7 @@ const SortableGuildButton = ({
           >
             {isActive && isHomeMode ? (
               <span
-                className="absolute·-bottom-2·left-1/2·z-10·mt-1·h-1·w-7·-translate-x-1/2·rounded-full·bg-primary/60"
+                className="absolute -bottom-2 left-1/2 z-10 mt-1 h-1 w-7 -translate-x-1/2 rounded-full bg-primary/60"
                 aria-hidden="true"
               />
             ) : null}
@@ -271,7 +271,7 @@ const GrantGuildButton = ({
             washes out on the colored tooltip. */}
         <p className="text-primary-foreground/80 text-xs">
           {t("temporaryAccess")}
-          {left !== null ? ` · ${t("expiresInMinutes", { minutes: left })}` : ""}
+          {left !== null ? `   ${t("expiresInMinutes", { minutes: left })}` : ""}
         </p>
       </TooltipContent>
     </Tooltip>

--- a/frontend/src/components/projects/CreateProjectDialog.tsx
+++ b/frontend/src/components/projects/CreateProjectDialog.tsx
@@ -72,12 +72,19 @@ export const CreateProjectDialog = ({
 
   const templatesQuery = useTemplateProjects();
 
-  // Sync initiative ID from parent when dialog opens or default changes
+  // Sync initiative ID from parent when dialog opens or default changes.
+  // A locked initiative (e.g. from the Initiative Details page) always wins so
+  // the project is created in the initiative shown in the dialog, even when the
+  // parent's default lags behind due to effect ordering / cached query data.
   useEffect(() => {
+    if (lockedInitiativeId != null) {
+      setInitiativeId(String(lockedInitiativeId));
+      return;
+    }
     if (defaultInitiativeId) {
       setInitiativeId(defaultInitiativeId);
     }
-  }, [defaultInitiativeId]);
+  }, [lockedInitiativeId, defaultInitiativeId]);
 
   // Sync description from selected template
   useEffect(() => {

--- a/frontend/src/components/projects/CreateProjectDialog.tsx
+++ b/frontend/src/components/projects/CreateProjectDialog.tsx
@@ -136,7 +136,13 @@ export const CreateProjectDialog = ({
             setName("");
             setDescription("");
             setIcon("");
-            setInitiativeId(null);
+            // Restore the default initiative rather than clearing it: the dialog
+            // stays mounted, and the sync effect won't re-run on reopen (its deps
+            // are unchanged), so clearing would leave a subsequent create with no
+            // initiative — silently returning early — until a page refresh.
+            setInitiativeId(
+              lockedInitiativeId != null ? String(lockedInitiativeId) : defaultInitiativeId
+            );
             setSelectedTemplateId(NO_TEMPLATE_VALUE);
             setIsTemplateProject(false);
             setRoleGrants([]);

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -298,6 +298,11 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
       setInitiativeId(null);
       return;
     }
+    // A locked initiative is managed by the effect above; don't fall back to the
+    // first creatable initiative or we'd desync from the locked one.
+    if (lockedInitiativeId) {
+      return;
+    }
     // Don't override if we're opening from URL params
     const urlInitiativeId = searchParams.initiativeId;
     if (initiativeId || urlInitiativeId) {
@@ -306,7 +311,7 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
     if (creatableInitiatives.length > 0) {
       setInitiativeId(String(creatableInitiatives[0].id));
     }
-  }, [canCreateProjects, initiativeId, creatableInitiatives, searchParams]);
+  }, [canCreateProjects, initiativeId, creatableInitiatives, searchParams, lockedInitiativeId]);
 
   useEffect(() => {
     if (typeof window === "undefined") {


### PR DESCRIPTION
## Problem

Two unrelated frontend bugs:

1. **Active-guild pill missing on home pages.** The indicator pill under the active guild's avatar in `GuildSidebar` stopped rendering on home pages. A tooling pass (commit `89cb5fa4`, "Update biome and fix issues") replaced the spaces in the pill's `className` with U+00B7 middle-dot characters, producing one unparseable token blob. Tailwind matched none of the classes, so the `<span>` had no position/size/color and was invisible.

2. **Add Project from an Initiative's Projects tab created projects in the wrong initiative.** The create dialog *displayed* the locked initiative but *submitted* a separate `initiativeId` state. In `ProjectsPage`, two effects competed to set that state — one to the locked initiative, one to `creatableInitiatives[0]`. When the initiatives query was already cached at mount, the fallback effect won, so the project landed in a different initiative. Intermittent ("doesn't always") because it depended on cache timing.

## Changes

- `frontend/src/components/guilds/GuildSidebar.tsx` — restore real spaces in the pill className.
- `frontend/src/components/projects/CreateProjectDialog.tsx` — the dialog's internal initiative state now always honors `lockedInitiativeId` when present, so the displayed and submitted initiative can't desync (also fixes the access-control member list).
- `frontend/src/pages/ProjectsPage.tsx` — the `creatableInitiatives[0]` fallback effect bails out when an initiative is locked, removing the race at its source (also fixes the Import dialog default on the same page).
- `CHANGELOG.md` — entries under `[Unreleased]`.

## Testing

- `pnpm typecheck` passes.
- Manual: load a home page (`/`, `/my-tasks`) and confirm the pill appears under the active guild. Then, with the initiatives list already cached, go to an Initiative → Projects → Add Project and confirm the project is created in that initiative.