### PR TITLE
Add formula reference highlights and click-to-insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Formula reference highlights and click-to-insert in spreadsheets.** While editing a cell formula (one starting with `=`), each cell or range it references is outlined on the grid in a distinct color, and the matching reference text in the cell is colored to match. Click another cell to drop its reference into the formula, drag or shift-click to insert a range (`A1:B3`), and click again to move the just-inserted reference — so you can build formulas by pointing instead of typing.
+
 ## [0.49.6] - 2026-06-05
 
 ### Fixed

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -258,14 +258,20 @@ export const SpreadsheetDocumentEditor = ({
   // unmounts and type-to-edit on the next cell stops working. A blur
   // (click-away) leaves this false so focus stays where the user clicked.
   const refocusGridRef = useRef(false);
-  // Point-mode (click/drag a cell into the formula being edited). ``anchor``
-  // is the cell the drag started on; ``span`` is the draft range the inserted
-  // reference currently occupies, so a drag re-splices over it. Held in a ref
-  // for the same reason as the fill drag — the window ``mouseup`` reads it.
-  const pointDragRef = useRef<{
+  // Point-mode (click/drag a cell into the formula being edited). The most
+  // recently inserted reference: ``anchor`` is the cell it started on, ``span``
+  // the draft range it currently occupies (so an extend re-splices over it).
+  // Persists across the mouseup that ends a click — a later shift-click reads
+  // it to extend into a range — and is cleared when the edit ends or the user
+  // types (which invalidates the recorded span).
+  const pointRefRef = useRef<{
     anchor: { row: number; col: number };
     span: { start: number; end: number };
   } | null>(null);
+  // True only while the mouse button is held after a point-mode click, so a
+  // hover (mouseenter) extends the range during a drag but not on a stray
+  // pass-over. Cleared on mouseup (see the fill-drag listener).
+  const pointDraggingRef = useRef(false);
   // Caret offset to restore after a point-mode splice updates the draft (the
   // input is controlled, so the selection must be reapplied post-render).
   const pendingCaretRef = useRef<number | null>(null);
@@ -600,7 +606,9 @@ export const SpreadsheetDocumentEditor = ({
   useEffect(() => {
     const onUp = () => {
       selectingRef.current = null;
-      pointDragRef.current = null;
+      // End any point-mode drag, but keep the last reference so a follow-up
+      // shift-click can still extend it into a range.
+      pointDraggingRef.current = false;
       const source = fillSourceRef.current;
       if (source) {
         const target = fillTargetRef.current ?? source;
@@ -641,6 +649,7 @@ export const SpreadsheetDocumentEditor = ({
       const value = coerceScalar(editing.draft);
       setCell(editing.row, editing.col, value === "" ? null : value);
       setEditing(null);
+      pointRefRef.current = null;
       if (next) selectCell(next.row, next.col);
     },
     [editing, setCell, selectCell]
@@ -648,6 +657,7 @@ export const SpreadsheetDocumentEditor = ({
 
   const cancelEdit = useCallback(() => {
     setEditing(null);
+    pointRefRef.current = null;
   }, []);
 
   // Point mode: splice the clicked cell's reference into the formula being
@@ -666,13 +676,13 @@ export const SpreadsheetDocumentEditor = ({
       let span: { start: number; end: number };
       let refText: string;
       if (extend) {
-        const drag = pointDragRef.current;
-        if (!drag) return false;
-        span = drag.span;
-        const r1 = Math.min(drag.anchor.row, row);
-        const r2 = Math.max(drag.anchor.row, row);
-        const c1 = Math.min(drag.anchor.col, col);
-        const c2 = Math.max(drag.anchor.col, col);
+        const last = pointRefRef.current;
+        if (!last) return false;
+        span = last.span;
+        const r1 = Math.min(last.anchor.row, row);
+        const r2 = Math.max(last.anchor.row, row);
+        const c1 = Math.min(last.anchor.col, col);
+        const c2 = Math.max(last.anchor.col, col);
         refText =
           r1 === r2 && c1 === c2 ? cellRef(r1, c1) : `${cellRef(r1, c1)}:${cellRef(r2, c2)}`;
       } else {
@@ -684,11 +694,11 @@ export const SpreadsheetDocumentEditor = ({
             ? { start: target.at, end: target.at }
             : { start: target.start, end: target.end };
         refText = cellRef(row, col);
-        pointDragRef.current = { anchor: { row, col }, span };
+        pointRefRef.current = { anchor: { row, col }, span };
       }
       const next = draft.slice(0, span.start) + refText + draft.slice(span.end);
       const newEnd = span.start + refText.length;
-      if (pointDragRef.current) pointDragRef.current.span = { start: span.start, end: newEnd };
+      if (pointRefRef.current) pointRefRef.current.span = { start: span.start, end: newEnd };
       pendingCaretRef.current = newEnd;
       setEditing({ row: editing.row, col: editing.col, draft: next });
       return true;
@@ -1429,9 +1439,12 @@ export const SpreadsheetDocumentEditor = ({
             // no commit). A null return means "not a reference spot" — fall
             // through to a normal, committing click.
             if (editing && isFormula(editing.draft)) {
-              const extend = e.shiftKey && pointDragRef.current !== null;
+              // Shift-click extends the last inserted reference into a range;
+              // a plain click inserts/moves a single reference.
+              const extend = e.shiftKey && pointRefRef.current !== null;
               if (insertReference(r, c, extend)) {
                 e.preventDefault();
+                pointDraggingRef.current = true;
                 return;
               }
             }
@@ -1439,11 +1452,18 @@ export const SpreadsheetDocumentEditor = ({
             selectingRef.current = "range";
             selectCell(r, c, e.shiftKey);
           }}
-          onMouseEnter={() => {
-            // A point-mode drag extends the inserted reference into a range.
-            if (pointDragRef.current) {
-              insertReference(r, c, true);
-              return;
+          onMouseEnter={(e) => {
+            // A point-mode drag (button still held) extends the reference into
+            // a range. Gate on the live button state (``e.buttons``) rather
+            // than only the flag, so a missed mouseup (release off-window, HMR)
+            // can't leave the drag stuck following the cursor.
+            if (pointDraggingRef.current) {
+              if (e.buttons === 0) {
+                pointDraggingRef.current = false;
+              } else {
+                insertReference(r, c, true);
+                return;
+              }
             }
             // A fill drag in progress takes over hover: extend its preview
             // instead of moving the selection focus.
@@ -1466,7 +1486,12 @@ export const SpreadsheetDocumentEditor = ({
             selectCell(r, c);
             setCell(r, c, !(value as boolean));
           }}
-          onDraftChange={(draft) => setEditing({ row: r, col: c, draft })}
+          onDraftChange={(draft) => {
+            // Typing invalidates the recorded reference span, so a later
+            // shift-click starts a fresh reference rather than re-splicing.
+            pointRefRef.current = null;
+            setEditing({ row: r, col: c, draft });
+          }}
           onEditingKeyDown={handleEditingKeyDown}
           onEditingBlur={() => commitEdit()}
         />
@@ -1968,7 +1993,7 @@ interface CellViewProps {
   peerColor: string | null;
   peerName: string | null;
   onMouseDown: (e: React.MouseEvent) => void;
-  onMouseEnter: () => void;
+  onMouseEnter: (e: React.MouseEvent) => void;
   onDoubleClick: () => void;
   onToggleBoolean: () => void;
   onDraftChange: (draft: string) => void;

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -9,6 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -16,6 +17,7 @@ import {
 import { useTranslation } from "react-i18next";
 import * as Y from "yjs";
 
+import { FormulaCellInput } from "@/components/documents/spreadsheet/FormulaCellInput";
 import {
   SpreadsheetToolbar,
   type ToolbarSelection,
@@ -49,6 +51,12 @@ import {
 } from "@/lib/spreadsheet/csv";
 import { type Box, computeAutofillTarget, computeFillWrites } from "@/lib/spreadsheet/fill";
 import { createEvaluator, isFormula } from "@/lib/spreadsheet/formula";
+import {
+  extractReferences,
+  FORMULA_REF_COLORS,
+  type FormulaRefToken,
+  referenceInsertTarget,
+} from "@/lib/spreadsheet/formula-refs";
 import { type SortDirection, sortSheetByColumn } from "@/lib/spreadsheet/sort";
 import {
   type CellFmt,
@@ -144,6 +152,21 @@ interface DragState {
   size: number;
 }
 
+/** A formula-reference highlight on one cell: its color and which of its
+ *  edges sit on the boundary of the reference's box (so the four edges of a
+ *  range draw a single outline rather than a grid of boxes). */
+interface RefHighlight {
+  color: string;
+  top: boolean;
+  right: boolean;
+  bottom: boolean;
+  left: boolean;
+}
+
+/** Stable empty array for non-editing cells, so they don't get a fresh
+ *  ``refTokens`` prop identity every render. */
+const EMPTY_REF_TOKENS: FormulaRefToken[] = [];
+
 export const SpreadsheetDocumentEditor = ({
   initialContent,
   onContentChange,
@@ -235,6 +258,17 @@ export const SpreadsheetDocumentEditor = ({
   // unmounts and type-to-edit on the next cell stops working. A blur
   // (click-away) leaves this false so focus stays where the user clicked.
   const refocusGridRef = useRef(false);
+  // Point-mode (click/drag a cell into the formula being edited). ``anchor``
+  // is the cell the drag started on; ``span`` is the draft range the inserted
+  // reference currently occupies, so a drag re-splices over it. Held in a ref
+  // for the same reason as the fill drag — the window ``mouseup`` reads it.
+  const pointDragRef = useRef<{
+    anchor: { row: number; col: number };
+    span: { start: number; end: number };
+  } | null>(null);
+  // Caret offset to restore after a point-mode splice updates the draft (the
+  // input is controlled, so the selection must be reapplied post-render).
+  const pendingCaretRef = useRef<number | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragRef = useRef<DragState | null>(null);
   const resizeStartRef = useRef<{ pos: number; size: number }>({ pos: 0, size: 0 });
@@ -301,6 +335,35 @@ export const SpreadsheetDocumentEditor = ({
   // evaluated at most once per snapshot via the evaluator's internal cache,
   // and only for cells the virtualized grid actually renders.
   const evaluator = useMemo(() => createEvaluator(cells), [cells]);
+
+  // References in the formula currently being edited, used to color the
+  // editor text and outline the cells they point at. Empty unless a formula
+  // (``=...``) is being typed.
+  const editingRefs = useMemo<FormulaRefToken[]>(
+    () => (editing && isFormula(editing.draft) ? extractReferences(editing.draft) : []),
+    [editing]
+  );
+
+  // The reference highlight (color + which edges form the box boundary) for a
+  // single cell, or null. Scans the (few) tokens rather than pre-enumerating
+  // every cell of every range, so a huge ``A1:A100000`` stays cheap.
+  const refHighlightAt = useCallback(
+    (r: number, c: number): RefHighlight | null => {
+      for (const t of editingRefs) {
+        if (r >= t.r1 && r <= t.r2 && c >= t.c1 && c <= t.c2) {
+          return {
+            color: FORMULA_REF_COLORS[t.colorIndex % FORMULA_REF_COLORS.length],
+            top: r === t.r1,
+            bottom: r === t.r2,
+            left: c === t.c1,
+            right: c === t.c2,
+          };
+        }
+      }
+      return null;
+    },
+    [editingRefs]
+  );
 
   // Emit the JSON snapshot to the parent on every change so the
   // existing autosave hook can PATCH ``document.content``. Captured in
@@ -537,6 +600,7 @@ export const SpreadsheetDocumentEditor = ({
   useEffect(() => {
     const onUp = () => {
       selectingRef.current = null;
+      pointDragRef.current = null;
       const source = fillSourceRef.current;
       if (source) {
         const target = fillTargetRef.current ?? source;
@@ -585,6 +649,65 @@ export const SpreadsheetDocumentEditor = ({
   const cancelEdit = useCallback(() => {
     setEditing(null);
   }, []);
+
+  // Point mode: splice the clicked cell's reference into the formula being
+  // edited. ``extend`` builds an ``A1:B3`` range from the drag anchor and
+  // overwrites the reference inserted on mousedown; otherwise it resolves the
+  // caret position (insert vs replace-the-last-ref) and seeds the drag.
+  // Returns false when the caret isn't in a reference-accepting spot, so the
+  // caller falls back to a normal (committing) click.
+  const insertReference = useCallback(
+    (row: number, col: number, extend: boolean): boolean => {
+      if (!editing) return false;
+      const input = editingInputRef.current;
+      if (!input) return false;
+      const draft = editing.draft;
+      const cellRef = (r: number, c: number) => `${colIndexToLetter(c)}${r + 1}`;
+      let span: { start: number; end: number };
+      let refText: string;
+      if (extend) {
+        const drag = pointDragRef.current;
+        if (!drag) return false;
+        span = drag.span;
+        const r1 = Math.min(drag.anchor.row, row);
+        const r2 = Math.max(drag.anchor.row, row);
+        const c1 = Math.min(drag.anchor.col, col);
+        const c2 = Math.max(drag.anchor.col, col);
+        refText =
+          r1 === r2 && c1 === c2 ? cellRef(r1, c1) : `${cellRef(r1, c1)}:${cellRef(r2, c2)}`;
+      } else {
+        const caret = input.selectionStart ?? draft.length;
+        const target = referenceInsertTarget(draft, caret);
+        if (target.kind === "none") return false;
+        span =
+          target.kind === "insert"
+            ? { start: target.at, end: target.at }
+            : { start: target.start, end: target.end };
+        refText = cellRef(row, col);
+        pointDragRef.current = { anchor: { row, col }, span };
+      }
+      const next = draft.slice(0, span.start) + refText + draft.slice(span.end);
+      const newEnd = span.start + refText.length;
+      if (pointDragRef.current) pointDragRef.current.span = { start: span.start, end: newEnd };
+      pendingCaretRef.current = newEnd;
+      setEditing({ row: editing.row, col: editing.col, draft: next });
+      return true;
+    },
+    [editing]
+  );
+
+  // Restore the caret after a point-mode splice (the controlled input resets
+  // it on re-render). Runs before paint so there's no visible jump.
+  useLayoutEffect(() => {
+    if (pendingCaretRef.current === null) return;
+    const input = editingInputRef.current;
+    if (input) {
+      const pos = pendingCaretRef.current;
+      input.focus();
+      input.setSelectionRange(pos, pos);
+    }
+    pendingCaretRef.current = null;
+  }, [editing]);
 
   // Insert a formula from the toolbar's function menu. When an aggregate
   // (SUM/AVERAGE/…) is picked with a multi-cell range selected, drop a
@@ -1295,14 +1418,33 @@ export const SpreadsheetDocumentEditor = ({
           inputRef={isEditing ? editingInputRef : null}
           peerColor={peer?.selection.color ?? null}
           peerName={peer?.user.name ?? null}
+          refHighlight={refHighlightAt(r, c)}
+          refTokens={isEditing ? editingRefs : EMPTY_REF_TOKENS}
           onMouseDown={(e) => {
             if (isEditing) return;
             if (e.button !== 0) return;
+            // Point mode: while editing a formula, clicking another cell
+            // splices its reference into the draft instead of moving the
+            // selection. preventDefault keeps the input focused (no blur →
+            // no commit). A null return means "not a reference spot" — fall
+            // through to a normal, committing click.
+            if (editing && isFormula(editing.draft)) {
+              const extend = e.shiftKey && pointDragRef.current !== null;
+              if (insertReference(r, c, extend)) {
+                e.preventDefault();
+                return;
+              }
+            }
             containerRef.current?.focus();
             selectingRef.current = "range";
             selectCell(r, c, e.shiftKey);
           }}
           onMouseEnter={() => {
+            // A point-mode drag extends the inserted reference into a range.
+            if (pointDragRef.current) {
+              insertReference(r, c, true);
+              return;
+            }
             // A fill drag in progress takes over hover: extend its preview
             // instead of moving the selection focus.
             if (fillSourceRef.current) {
@@ -1341,6 +1483,9 @@ export const SpreadsheetDocumentEditor = ({
       cut,
       fillPreview,
       editing,
+      editingRefs,
+      refHighlightAt,
+      insertReference,
       readOnly,
       peerSelectionsByCell,
       colWidth,
@@ -1816,6 +1961,10 @@ interface CellViewProps {
   readOnly: boolean;
   draft: string;
   inputRef: React.RefObject<HTMLInputElement | null> | null;
+  /** Colors this cell as a referenced cell of the formula being edited. */
+  refHighlight: RefHighlight | null;
+  /** References in the editing draft — colors the in-cell formula text. */
+  refTokens: FormulaRefToken[];
   peerColor: string | null;
   peerName: string | null;
   onMouseDown: (e: React.MouseEvent) => void;
@@ -1844,6 +1993,8 @@ const CellView = ({
   readOnly,
   draft,
   inputRef,
+  refHighlight,
+  refTokens,
   peerColor,
   peerName,
   onMouseDown,
@@ -1905,6 +2056,23 @@ const CellView = ({
       <div className="pointer-events-none absolute inset-0 bg-primary/10" />
     ) : null;
 
+  // Colored outline marking this cell as a reference of the formula being
+  // edited. Borders only on the box-boundary edges so a range reads as one
+  // rectangle rather than a grid of boxes.
+  const refOverlay = refHighlight ? (
+    <div
+      className="pointer-events-none absolute inset-0 z-[2]"
+      style={{
+        borderColor: refHighlight.color,
+        borderStyle: "solid",
+        borderTopWidth: refHighlight.top ? 2 : 0,
+        borderBottomWidth: refHighlight.bottom ? 2 : 0,
+        borderLeftWidth: refHighlight.left ? 2 : 0,
+        borderRightWidth: refHighlight.right ? 2 : 0,
+      }}
+    />
+  ) : null;
+
   // The draggable fill handle on the selection's bottom-right corner. Its
   // own mousedown starts the fill (stopping selection); double-click
   // auto-fills down. Centered on the corner, above the ring/overlays.
@@ -1927,13 +2095,13 @@ const CellView = ({
   if (isEditing) {
     return (
       <div className={baseClass} style={containerStyle}>
-        <input
-          ref={inputRef}
+        <FormulaCellInput
+          inputRef={inputRef}
           value={draft}
-          onChange={(e) => onDraftChange(e.target.value)}
+          tokens={refTokens}
+          onChange={onDraftChange}
           onKeyDown={onEditingKeyDown}
           onBlur={onEditingBlur}
-          className="h-full w-full select-text bg-background px-1.5 outline-none"
         />
         {peerOverlay}
       </div>
@@ -1961,6 +2129,7 @@ const CellView = ({
         />
         {selectionOverlay}
         {fillPreviewOverlay}
+        {refOverlay}
         {cutOverlay}
         {peerOverlay}
         {fillHandle}
@@ -1981,6 +2150,7 @@ const CellView = ({
       <span className="w-full truncate">{display}</span>
       {selectionOverlay}
       {fillPreviewOverlay}
+      {refOverlay}
       {cutOverlay}
       {peerOverlay}
       {fillHandle}

--- a/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
+++ b/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
@@ -1,0 +1,77 @@
+import { type KeyboardEvent, type RefObject, useMemo, useRef } from "react";
+
+import { FORMULA_REF_COLORS, type FormulaRefToken } from "@/lib/spreadsheet/formula-refs";
+
+interface FormulaCellInputProps {
+  value: string;
+  /** References found in ``value`` — drive the colored text segments. */
+  tokens: FormulaRefToken[];
+  inputRef: RefObject<HTMLInputElement | null> | null;
+  onChange: (value: string) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+}
+
+/**
+ * The in-cell editor for a spreadsheet cell. A single-line ``<input>`` can't
+ * render colored runs, so the real (transparent-text) input sits on top of a
+ * mirror div that paints each reference token in its highlight color — Excel's
+ * formula-bar coloring. The caret stays visible; horizontal scroll is kept in
+ * sync so long formulas stay aligned. With no tokens (a plain value, or a
+ * non-formula draft) the mirror is just the plain text, so behavior is
+ * unchanged — and the component is rendered for every edit so typing the
+ * leading "=" never remounts the input and drops focus.
+ */
+export const FormulaCellInput = ({
+  value,
+  tokens,
+  inputRef,
+  onChange,
+  onKeyDown,
+  onBlur,
+}: FormulaCellInputProps) => {
+  const mirrorRef = useRef<HTMLDivElement>(null);
+
+  const segments = useMemo(() => {
+    const out: Array<{ text: string; color: string | null }> = [];
+    let pos = 0;
+    for (const t of tokens) {
+      if (t.start > pos) out.push({ text: value.slice(pos, t.start), color: null });
+      out.push({
+        text: value.slice(t.start, t.end),
+        color: FORMULA_REF_COLORS[t.colorIndex % FORMULA_REF_COLORS.length],
+      });
+      pos = t.end;
+    }
+    if (pos < value.length) out.push({ text: value.slice(pos), color: null });
+    return out;
+  }, [value, tokens]);
+
+  return (
+    <div className="relative h-full w-full bg-background">
+      <div
+        ref={mirrorRef}
+        aria-hidden
+        className="pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-pre px-1.5 text-sm"
+      >
+        {segments.map((s, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional text segments, no stable id
+          <span key={i} style={s.color ? { color: s.color } : undefined}>
+            {s.text}
+          </span>
+        ))}
+      </div>
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+        onScroll={(e) => {
+          if (mirrorRef.current) mirrorRef.current.scrollLeft = e.currentTarget.scrollLeft;
+        }}
+        className="relative z-[1] h-full w-full select-text bg-transparent px-1.5 text-sm text-transparent caret-foreground outline-none"
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
+++ b/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
@@ -52,7 +52,7 @@ export const FormulaCellInput = ({
       <div
         ref={mirrorRef}
         aria-hidden
-        className="pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-pre px-1.5 text-sm"
+        className="pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-pre px-1.5"
       >
         {segments.map((s, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: positional text segments, no stable id
@@ -70,7 +70,12 @@ export const FormulaCellInput = ({
         onScroll={(e) => {
           if (mirrorRef.current) mirrorRef.current.scrollLeft = e.currentTarget.scrollLeft;
         }}
-        className="relative z-[1] h-full w-full select-text bg-transparent px-1.5 text-sm text-transparent caret-foreground outline-none"
+        // ``font: inherit`` so the input matches the cell's font size/weight
+        // (inputs don't inherit font by default) — both layers then track the
+        // container's text-sm default and any per-cell font-size override,
+        // keeping the colored mirror aligned with the typed text.
+        style={{ font: "inherit" }}
+        className="relative z-[1] h-full w-full select-text bg-transparent px-1.5 text-transparent caret-foreground outline-none"
       />
     </div>
   );

--- a/frontend/src/lib/spreadsheet/formula-refs.test.ts
+++ b/frontend/src/lib/spreadsheet/formula-refs.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { isFormula, shiftFormulaReferences, translateFormula } from "./formula-refs";
+import {
+  extractReferences,
+  isFormula,
+  referenceInsertTarget,
+  shiftFormulaReferences,
+  translateFormula,
+} from "./formula-refs";
 
 // The same old-index -> new-index mappers transformSheet builds.
 const insertMap =
@@ -133,5 +139,83 @@ describe("translateFormula", () => {
 
   it("returns non-formula input unchanged", () => {
     expect(translateFormula("plain A1", 1, 0)).toBe("plain A1");
+  });
+});
+
+describe("extractReferences", () => {
+  it("returns an empty array for non-formula input", () => {
+    expect(extractReferences("hello")).toEqual([]);
+    expect(extractReferences("123")).toEqual([]);
+  });
+
+  it("locates a single cell reference with its box and span", () => {
+    // "=A1" — A1 is row 0, col 0; the token spans offsets 1..3 in "=A1".
+    expect(extractReferences("=A1")).toEqual([
+      { text: "A1", start: 1, end: 3, r1: 0, c1: 0, r2: 0, c2: 0, colorIndex: 0 },
+    ]);
+  });
+
+  it("normalizes a range to a single token / box", () => {
+    const [ref] = extractReferences("=SUM(B2:C4)");
+    expect(ref).toMatchObject({ text: "B2:C4", r1: 1, c1: 1, r2: 3, c2: 2 });
+    expect(ref.start).toBe(5);
+    expect(ref.end).toBe(10);
+  });
+
+  it("gives distinct references distinct color indices in appearance order", () => {
+    expect(extractReferences("=A1+B2").map((r) => r.colorIndex)).toEqual([0, 1]);
+  });
+
+  it("shares a color index across repeated identical references", () => {
+    expect(extractReferences("=A1+A1").map((r) => r.colorIndex)).toEqual([0, 0]);
+  });
+
+  it("ignores references inside quoted string literals", () => {
+    expect(extractReferences('="A5 total"')).toEqual([]);
+  });
+
+  it("does not treat function names or longer identifiers as references", () => {
+    expect(extractReferences("=LOG10(2)")).toEqual([]);
+    expect(extractReferences("=SUM(1,2)")).toEqual([]);
+  });
+
+  it("captures absolute ($) references with the $ markers in the text", () => {
+    const [ref] = extractReferences("=$A$1");
+    expect(ref).toMatchObject({ text: "$A$1", r1: 0, c1: 0, r2: 0, c2: 0 });
+  });
+
+  it("computes correct offsets for multiple references", () => {
+    const refs = extractReferences("=A1+B2");
+    expect(refs.map((r) => [r.start, r.end])).toEqual([
+      [1, 3],
+      [4, 6],
+    ]);
+  });
+});
+
+describe("referenceInsertTarget", () => {
+  it("inserts after the leading = ", () => {
+    expect(referenceInsertTarget("=", 1)).toEqual({ kind: "insert", at: 1 });
+  });
+
+  it("inserts after an operator, ( or ,", () => {
+    expect(referenceInsertTarget("=A1+", 4)).toEqual({ kind: "insert", at: 4 });
+    expect(referenceInsertTarget("=SUM(", 5)).toEqual({ kind: "insert", at: 5 });
+    expect(referenceInsertTarget("=SUM(A1,", 8)).toEqual({ kind: "insert", at: 8 });
+  });
+
+  it("inserts after trailing whitespace following an operator", () => {
+    expect(referenceInsertTarget("=A1+ ", 5)).toEqual({ kind: "insert", at: 5 });
+  });
+
+  it("replaces a reference that follows the = or an operator", () => {
+    expect(referenceInsertTarget("=A1", 3)).toEqual({ kind: "replace", start: 1, end: 3 });
+    expect(referenceInsertTarget("=SUM(A1", 7)).toEqual({ kind: "replace", start: 5, end: 7 });
+    expect(referenceInsertTarget("=B2+C3", 6)).toEqual({ kind: "replace", start: 4, end: 6 });
+  });
+
+  it("returns none mid-literal or for a non-formula", () => {
+    expect(referenceInsertTarget("=hello", 6)).toEqual({ kind: "none" });
+    expect(referenceInsertTarget("plain", 5)).toEqual({ kind: "none" });
   });
 });

--- a/frontend/src/lib/spreadsheet/formula-refs.ts
+++ b/frontend/src/lib/spreadsheet/formula-refs.ts
@@ -171,3 +171,184 @@ const mapRefTranslate = (m: RegExpExecArray, rowDelta: number, colDelta: number)
   if (row < 0 || col < 0) return null;
   return `${colAbs}${colIndexToLetter(col)}${rowAbs}${row + 1}`;
 };
+
+// ---------------------------------------------------------------------------
+// Reference extraction (read-only) for the formula editor's live highlights.
+// ---------------------------------------------------------------------------
+
+/**
+ * Palette for the editor's reference highlights. The same index colors a
+ * reference's outline box on the grid and its text in the formula input, and
+ * is reused for repeated identical references (Excel behavior). Index with
+ * ``colorIndex % FORMULA_REF_COLORS.length``.
+ */
+export const FORMULA_REF_COLORS = [
+  "#1a73e8",
+  "#188038",
+  "#a142f4",
+  "#e8710a",
+  "#d93025",
+  "#12a4af",
+  "#c5221f",
+  "#9334e6",
+];
+
+/** One A1 reference (or ``A1:B3`` range) located inside a formula string. */
+export interface FormulaRefToken {
+  /** The matched text, e.g. ``A1`` or ``$A$1:B3``. */
+  text: string;
+  /** Character offset of the token in the full formula (including the leading "="). */
+  start: number;
+  /** Exclusive end offset. */
+  end: number;
+  /** Normalized bounding box (0-based, top-left .. bottom-right). */
+  r1: number;
+  c1: number;
+  r2: number;
+  c2: number;
+  /** Stable index into {@link FORMULA_REF_COLORS}, shared by identical refs. */
+  colorIndex: number;
+}
+
+/** Resolve a matched A1 reference to 0-based coords, or ``null`` if off-grid. */
+const refCoords = (m: RegExpExecArray): { row: number; col: number } | null => {
+  const col = letterToColIndex(m[2]);
+  const row = Number(m[4]) - 1;
+  if (col < 0 || row < 0) return null;
+  return { row, col };
+};
+
+/**
+ * Locate every A1 reference / range in a formula and return its character
+ * span and grid box, for the editor's live highlighting. Mirrors the
+ * quote-skipping and identifier-boundary rules of {@link scanReferences} (the
+ * two walks must stay in sync); off-grid references are simply omitted rather
+ * than collapsed to ``#REF!``. Non-formula input yields an empty array.
+ *
+ * ``colorIndex`` is assigned per unique reference text in order of first
+ * appearance, so ``=A1+A1`` colors both ``A1`` tokens identically.
+ */
+export const extractReferences = (formula: string): FormulaRefToken[] => {
+  if (!isFormula(formula)) return [];
+  const body = formula.slice(1);
+  const raw: Omit<FormulaRefToken, "colorIndex">[] = [];
+  let i = 0;
+  let inQuote = false;
+
+  while (i < body.length) {
+    const ch = body[i];
+
+    if (inQuote) {
+      if (ch === '"') {
+        if (body[i + 1] === '"') {
+          i += 2;
+          continue;
+        }
+        inQuote = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuote = true;
+      i++;
+      continue;
+    }
+
+    const prev = i > 0 ? body[i - 1] : "";
+    const match = IDENT_CHAR.test(prev) ? null : REF_AT_START.exec(body.slice(i));
+    if (match && !isIdentTail(body[i + match[0].length])) {
+      const afterIdx = i + match[0].length;
+      const first = refCoords(match);
+      // Look for a ``ref:ref`` range so it's recorded as one token/box.
+      let match2: RegExpExecArray | null = null;
+      if (body[afterIdx] === ":") {
+        const m = REF_AT_START.exec(body.slice(afterIdx + 1));
+        if (m && !isIdentTail(body[afterIdx + 1 + m[0].length])) match2 = m;
+      }
+      if (match2) {
+        const end2 = afterIdx + 1 + match2[0].length;
+        const second = refCoords(match2);
+        if (first && second) {
+          raw.push({
+            text: body.slice(i, end2),
+            start: i + 1,
+            end: end2 + 1,
+            r1: Math.min(first.row, second.row),
+            c1: Math.min(first.col, second.col),
+            r2: Math.max(first.row, second.row),
+            c2: Math.max(first.col, second.col),
+          });
+        }
+        i = end2;
+        continue;
+      }
+      if (first) {
+        raw.push({
+          text: match[0],
+          start: i + 1,
+          end: afterIdx + 1,
+          r1: first.row,
+          c1: first.col,
+          r2: first.row,
+          c2: first.col,
+        });
+      }
+      i = afterIdx;
+      continue;
+    }
+
+    i++;
+  }
+
+  const colorByText = new Map<string, number>();
+  return raw.map((t) => {
+    let colorIndex = colorByText.get(t.text);
+    if (colorIndex === undefined) {
+      colorIndex = colorByText.size;
+      colorByText.set(t.text, colorIndex);
+    }
+    return { ...t, colorIndex };
+  });
+};
+
+/**
+ * Where (if anywhere) a clicked cell's reference should land in the formula
+ * draft, given the caret position — the editor's "point mode" decision.
+ *
+ * - ``insert``: the caret follows a token that expects an operand (``=``, an
+ *   operator, ``(``, ``,`` or ``:``) — splice a fresh reference there.
+ * - ``replace``: the caret sits just after a reference that itself follows an
+ *   operand-accepting token — clicking moves that reference (Excel behavior).
+ * - ``none``: the caret is mid-literal/value — the click should commit the
+ *   edit normally instead.
+ */
+export type InsertTarget =
+  | { kind: "none" }
+  | { kind: "insert"; at: number }
+  | { kind: "replace"; start: number; end: number };
+
+// Final char of the (whitespace-trimmed) text before the caret that means a
+// reference may follow.
+const REF_ACCEPTING_END = /[=(,:+\-*/^&<>%]$/;
+// A trailing A1 reference (or range) at the end of the pre-caret text.
+const TRAILING_REF = /(\$?[A-Za-z]+\$?\d+(?::\$?[A-Za-z]+\$?\d+)?)$/;
+
+export const referenceInsertTarget = (draft: string, caret: number): InsertTarget => {
+  if (!isFormula(draft)) return { kind: "none" };
+  const before = draft.slice(0, caret);
+  const trimmed = before.replace(/\s+$/, "");
+  if (REF_ACCEPTING_END.test(trimmed)) return { kind: "insert", at: caret };
+  const refMatch = TRAILING_REF.exec(trimmed);
+  if (refMatch) {
+    const start = trimmed.length - refMatch[1].length;
+    const charBefore = start > 0 ? trimmed[start - 1] : "";
+    // The leading "=" (start === 1) or any operand-accepting char before the
+    // reference means the user is still pointing — clicking moves the ref.
+    if (start === 1 || REF_ACCEPTING_END.test(charBefore)) {
+      return { kind: "replace", start, end: trimmed.length };
+    }
+  }
+  return { kind: "none" };
+};


### PR DESCRIPTION
## Problem

Editing spreadsheet formulas was entirely manual — no visual link between a reference in the formula and the cell it points at, and no way to build a formula by clicking cells.

## Changes

While editing a cell formula (one starting with `=`):

- **Reference highlights** — each referenced cell/range is outlined on the grid in a distinct color (boundary-edge borders so a range reads as one rectangle), and the matching reference text in the cell is colored to match.
- **Click / drag to insert (point mode)** — click a cell to insert its reference, drag or shift-click to insert a range (`A1:B3`), and click again to move the just-inserted reference. A non-reference click commits the edit as before.

### Notable implementation details

- `formula-refs.ts`: new read-only `extractReferences` (mirrors the existing `scanReferences` quote/identifier rules), a `FORMULA_REF_COLORS` palette, and a `referenceInsertTarget` point-mode helper.
- New `FormulaCellInput` component: transparent-text input over a colored mirror, since a plain `<input>` can't render colored runs. Always rendered so typing `=` never remounts the input.
- Highlights route through the existing `renderCell` → `CellView` path, so they cover frozen panes for free. Point-mode drag mirrors the existing fill-handle drag pattern; caret is restored after each splice via `useLayoutEffect`.

## Testing

- `pnpm test:run src/lib/spreadsheet/` — 157 pass (36 in `formula-refs.test.ts`, extended with `extractReferences` + `referenceInsertTarget` cases)
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Manual: verified `=A1+B2` colored boxes + text (incl. frozen panes); click/drag/shift-click/replace insertion; literal edits and Enter/Tab/Escape unchanged.
