### PR TITLE
Fix float drift in spreadsheet fill handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Formula bar above the spreadsheet grid.** A name box (left) shows the active cell or selected range — type a reference like `B12` or `A1:C3` and press Enter to jump there — and an editable formula bar (right) shows and edits the active cell's underlying formula or value, so you can see a formula even though the cell displays its computed result. Editing works from either the bar or the cell, and clicking cells to insert references (point mode) works while editing in the bar. The cell/range indicator that used to live in the formatting toolbar now lives in the name box.
 
+### Fixed
+
+- **Dragging the spreadsheet fill handle on decimals no longer produces values like `0.30000000000000004`.** Numeric fills now round each generated value to the decimal precision of the source cells (so `0.1`, `0.2` fills to `0.3`, `0.4`, `0.5`, …), eliminating the floating-point drift that previously surfaced in the filled cells.
+
 ## [0.49.7] - 2026-06-05
 
 ### Added

--- a/frontend/src/lib/spreadsheet/fill.test.ts
+++ b/frontend/src/lib/spreadsheet/fill.test.ts
@@ -75,6 +75,14 @@ describe("computeFillWrites — numeric series", () => {
     const w = writesAt(computeFillWrites(read, box(0, 1, 0, 0), box(0, 3, 0, 0)));
     expect(w).toEqual({ [keyOf(2, 0)]: 1.75, [keyOf(3, 0)]: 2 });
   });
+
+  it("rounds decimals when filling upward (negative offset)", () => {
+    // Seeds at rows 3-4 (0.5, 0.6); filling up exercises the negative-n path.
+    const read = reader({ [keyOf(3, 0)]: 0.5, [keyOf(4, 0)]: 0.6 });
+    const w = writesAt(computeFillWrites(read, box(3, 4, 0, 0), box(0, 4, 0, 0)));
+    // n = r - 3: row 2 → 0.4, row 1 → 0.3, row 0 → 0.2 — no float drift.
+    expect(w).toEqual({ [keyOf(2, 0)]: 0.4, [keyOf(1, 0)]: 0.3, [keyOf(0, 0)]: 0.2 });
+  });
 });
 
 describe("computeFillWrites — text+integer series", () => {

--- a/frontend/src/lib/spreadsheet/fill.test.ts
+++ b/frontend/src/lib/spreadsheet/fill.test.ts
@@ -56,6 +56,25 @@ describe("computeFillWrites — numeric series", () => {
     // n = r - source.r1 (=3): row 2 → n=-1 → 0, row 1 → n=-2 → -10.
     expect(w).toEqual({ [keyOf(2, 0)]: 0, [keyOf(1, 0)]: -10 });
   });
+
+  it("rounds to the seeds' precision instead of leaking float drift", () => {
+    const read = reader({ [keyOf(0, 0)]: 0.1, [keyOf(1, 0)]: 0.2 });
+    const w = writesAt(computeFillWrites(read, box(0, 1, 0, 0), box(0, 6, 0, 0)));
+    // Naive 0.1 + 0.1*n would give 0.30000000000000004, 0.7000000000000001, …
+    expect(w).toEqual({
+      [keyOf(2, 0)]: 0.3,
+      [keyOf(3, 0)]: 0.4,
+      [keyOf(4, 0)]: 0.5,
+      [keyOf(5, 0)]: 0.6,
+      [keyOf(6, 0)]: 0.7,
+    });
+  });
+
+  it("preserves multi-decimal precision when seeds warrant it", () => {
+    const read = reader({ [keyOf(0, 0)]: 1.25, [keyOf(1, 0)]: 1.5 });
+    const w = writesAt(computeFillWrites(read, box(0, 1, 0, 0), box(0, 3, 0, 0)));
+    expect(w).toEqual({ [keyOf(2, 0)]: 1.75, [keyOf(3, 0)]: 2 });
+  });
 });
 
 describe("computeFillWrites — text+integer series", () => {

--- a/frontend/src/lib/spreadsheet/fill.ts
+++ b/frontend/src/lib/spreadsheet/fill.ts
@@ -81,7 +81,9 @@ const detectSeries = (values: CellValue[]): ((n: number) => CellValue) | null =>
     const step = H >= 2 ? (nums[H - 1] - nums[0]) / (H - 1) : 0;
     // Round each term to the seeds' precision so accumulated float drift
     // (0.1, 0.2 → 0.30000000000000004) doesn't surface in the filled cells.
-    const dp = Math.max(...nums.map(decimalPlaces));
+    // ``reduce`` rather than ``Math.max(...spread)`` so a huge source range
+    // can't blow the argument-count / call-stack limit.
+    const dp = nums.reduce((acc, v) => Math.max(acc, decimalPlaces(v)), 0);
     return (n) => roundTo(nums[0] + step * n, dp);
   }
 

--- a/frontend/src/lib/spreadsheet/fill.ts
+++ b/frontend/src/lib/spreadsheet/fill.ts
@@ -41,6 +41,28 @@ const formatInt = (n: number, pad: number): string => {
 };
 
 /**
+ * Decimal places in a number's shortest base-10 form (``0.1`` → 1, ``2`` → 0),
+ * clamped to 12 so an already noisy seed like ``0.30000000000000004`` reports a
+ * sane precision instead of 17, letting {@link roundTo} scrub the noise rather
+ * than propagate it.
+ */
+const decimalPlaces = (n: number): number => {
+  if (!Number.isFinite(n)) return 0;
+  const s = String(n);
+  const e = s.indexOf("e");
+  if (e >= 0) {
+    const dot = s.indexOf(".");
+    const mantissa = dot >= 0 ? e - dot - 1 : 0;
+    return Math.min(12, Math.max(0, mantissa - Number(s.slice(e + 1))));
+  }
+  const dot = s.indexOf(".");
+  return dot >= 0 ? Math.min(12, s.length - dot - 1) : 0;
+};
+
+/** Round to ``dp`` decimals via decimal-string round-trip, dropping IEEE-754 drift. */
+const roundTo = (x: number, dp: number): number => Number(x.toFixed(dp));
+
+/**
  * Build an extrapolator over the offset ``n`` from a source line's first
  * cell (``n = 0`` is that first cell, ``n = length`` the cell just past the
  * end, ``n = -1`` the cell just before it), or ``null`` when the line is not
@@ -57,7 +79,10 @@ const detectSeries = (values: CellValue[]): ((n: number) => CellValue) | null =>
   if (values.every((v) => typeof v === "number")) {
     const nums = values as number[];
     const step = H >= 2 ? (nums[H - 1] - nums[0]) / (H - 1) : 0;
-    return (n) => nums[0] + step * n;
+    // Round each term to the seeds' precision so accumulated float drift
+    // (0.1, 0.2 → 0.30000000000000004) doesn't surface in the filled cells.
+    const dp = Math.max(...nums.map(decimalPlaces));
+    return (n) => roundTo(nums[0] + step * n, dp);
   }
 
   // Constant-prefix text with a trailing integer (``Item 1`` → ``Item 2``).


### PR DESCRIPTION
## Problem

Dragging the spreadsheet fill handle over a decimal series produced ugly values: filling `0.1`, `0.2` downward gave `0.30000000000000004`, `0.7000000000000001`, `1.2000000000000002`, and so on.

This is IEEE-754 floating-point drift. `detectSeries` in `frontend/src/lib/spreadsheet/fill.ts` generated each numeric term as `nums[0] + step * n` and returned the raw result. Since `0.1` isn't exactly representable in binary, accumulating the step surfaces the rounding error directly in the cells. (The `text + integer` branch was already protected by `Math.round`; only the pure-numeric branch leaked.)

## Changes

- Round each generated numeric term to the decimal precision of the source cells, matching how Excel/Sheets snap a fill to the pattern's significant digits. `0.1`, `0.2` now fills to `0.3`, `0.4`, `0.5`, …
- Added `decimalPlaces(n)` — decimals in a number's shortest base-10 form, clamped to 12 so an already-noisy seed (e.g. refilling from a previous `0.30000000000000004`) reports a sane precision and gets scrubbed rather than propagated. Handles scientific-notation strings.
- Added `roundTo(x, dp)` — rounds via a decimal-string round-trip, dropping the drift.
- Genuine precision is preserved: `1.25`, `1.5` → `1.75`, `2`.
- Changelog entry under `[Unreleased]`.

## Testing

- `pnpm test:run src/lib/spreadsheet/fill.test.ts` — 16 passed, including two new cases (the drift scenario and a multi-decimal precision case).
- `pnpm typecheck` — clean.
- Manually verified in the app.