### PR TITLE
Add formula bar to spreadsheet editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Formula bar above the spreadsheet grid.** A name box (left) shows the active cell or selected range — type a reference like `B12` or `A1:C3` and press Enter to jump there — and an editable formula bar (right) shows and edits the active cell's underlying formula or value, so you can see a formula even though the cell displays its computed result. Editing works from either the bar or the cell, and clicking cells to insert references (point mode) works while editing in the bar. The cell/range indicator that used to live in the formatting toolbar now lives in the name box.
+
 ## [0.49.7] - 2026-06-05
 
 ### Added

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -425,7 +425,8 @@
       }
     },
     "formulaBar": {
-      "nameBoxLabel": "Name box — go to a cell or range (e.g. B12 or A1:C3)"
+      "nameBoxLabel": "Name box — go to a cell or range (e.g. B12 or A1:C3)",
+      "inputLabel": "Formula bar — edit the active cell's formula or value"
     },
     "format": {
       "scopeCell": "Cell",

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -424,6 +424,9 @@
         "ABS": "Absolute (non-negative) value"
       }
     },
+    "formulaBar": {
+      "nameBoxLabel": "Name box — go to a cell or range (e.g. B12 or A1:C3)"
+    },
     "format": {
       "scopeCell": "Cell",
       "scopeColumn": "Column",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -425,7 +425,8 @@
       }
     },
     "formulaBar": {
-      "nameBoxLabel": "Cuadro de nombres: ir a una celda o rango (p. ej. B12 o A1:C3)"
+      "nameBoxLabel": "Cuadro de nombres: ir a una celda o rango (p. ej. B12 o A1:C3)",
+      "inputLabel": "Barra de fórmulas: edita la fórmula o el valor de la celda activa"
     },
     "format": {
       "scopeCell": "Celda",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -424,6 +424,9 @@
         "ABS": "Valor absoluto (no negativo)"
       }
     },
+    "formulaBar": {
+      "nameBoxLabel": "Cuadro de nombres: ir a una celda o rango (p. ej. B12 o A1:C3)"
+    },
     "format": {
       "scopeCell": "Celda",
       "scopeColumn": "Columna",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -425,7 +425,8 @@
       }
     },
     "formulaBar": {
-      "nameBoxLabel": "Zone Nom : aller à une cellule ou une plage (p. ex. B12 ou A1:C3)"
+      "nameBoxLabel": "Zone Nom : aller à une cellule ou une plage (p. ex. B12 ou A1:C3)",
+      "inputLabel": "Barre de formule : modifier la formule ou la valeur de la cellule active"
     },
     "format": {
       "scopeCell": "Cellule",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -424,6 +424,9 @@
         "ABS": "Valeur absolue (non négative)"
       }
     },
+    "formulaBar": {
+      "nameBoxLabel": "Zone Nom : aller à une cellule ou une plage (p. ex. B12 ou A1:C3)"
+    },
     "format": {
       "scopeCell": "Cellule",
       "scopeColumn": "Colonne",

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -1597,12 +1597,11 @@ export const SpreadsheetDocumentEditor = ({
 
   // The formula bar mirrors the live edit draft, else the focus cell's raw
   // value (its formula/value as stored, not the computed result).
-  const formulaBarValue = editing
-    ? editing.draft
-    : (() => {
-        const raw = cells.get(keyOf(sel.focus.row, sel.focus.col));
-        return raw == null ? "" : String(raw);
-      })();
+  const formulaBarValue = useMemo(() => {
+    if (editing) return editing.draft;
+    const raw = cells.get(keyOf(sel.focus.row, sel.focus.col));
+    return raw == null ? "" : String(raw);
+  }, [editing, cells, sel.focus.row, sel.focus.col]);
 
   // Focusing the bar begins an edit of the focus cell (unless one is already
   // live); the flag keeps focus in the bar instead of the cell input.

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import * as Y from "yjs";
 
 import { FormulaCellInput } from "@/components/documents/spreadsheet/FormulaCellInput";
+import { SpreadsheetFormulaBar } from "@/components/documents/spreadsheet/SpreadsheetFormulaBar";
 import {
   SpreadsheetToolbar,
   type ToolbarSelection,
@@ -41,7 +42,13 @@ import {
 import { matchHistoryShortcut } from "@/hooks/useYjsHistory";
 import { toast } from "@/lib/chesterToast";
 import { downloadBlob } from "@/lib/csv";
-import { type CellValue, colIndexToLetter, keyOf, parseKey } from "@/lib/spreadsheet/coords";
+import {
+  type CellValue,
+  colIndexToLetter,
+  keyOf,
+  parseA1Range,
+  parseKey,
+} from "@/lib/spreadsheet/coords";
 import {
   cellsToCsv,
   coerceScalar,
@@ -253,6 +260,14 @@ export const SpreadsheetDocumentEditor = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const editingInputRef = useRef<HTMLInputElement>(null);
+  const formulaBarInputRef = useRef<HTMLInputElement>(null);
+  // The editing surface point-mode reference insertion and caret restoration
+  // target: the in-cell input or the formula-bar input, whichever last gained
+  // focus. Both edit the same draft, so a formula can be built from either.
+  const activeEditorRef = useRef<HTMLInputElement | null>(null);
+  // Set when an edit is begun by focusing the formula bar, so the
+  // begin-edit auto-focus effect doesn't yank focus down into the cell input.
+  const focusBarOnEditRef = useRef(false);
   // Set when an edit ends via the keyboard (Enter/Tab/Escape) so focus
   // returns to the grid — otherwise it falls to <body> as the input
   // unmounts and type-to-edit on the next cell stops working. A blur
@@ -534,6 +549,27 @@ export const SpreadsheetDocumentEditor = ({
     });
   }, []);
 
+  // Name-box go-to: select the cell/range the text names (clamped to the grid)
+  // and scroll its top-left into view. Invalid input is ignored — the name box
+  // resets to the current selection on blur.
+  const navigateToRef = useCallback(
+    (text: string) => {
+      const box = parseA1Range(text);
+      if (!box) return;
+      const r1 = Math.min(box.r1, dimensions.rows - 1);
+      const c1 = Math.min(box.c1, dimensions.cols - 1);
+      const r2 = Math.min(box.r2, dimensions.rows - 1);
+      const c2 = Math.min(box.c2, dimensions.cols - 1);
+      // Anchor at the bottom-right so the active (focus) cell is the top-left,
+      // matching how a spreadsheet lands the cursor on a navigated range.
+      setSel({ anchor: { row: r2, col: c2 }, focus: { row: r1, col: c1 }, mode: "range" });
+      rowVirtualizer.scrollToIndex(r1, { align: "center" });
+      colVirtualizer.scrollToIndex(c1, { align: "center" });
+      containerRef.current?.focus();
+    },
+    [dimensions.rows, dimensions.cols, rowVirtualizer, colVirtualizer]
+  );
+
   // Commit a fill (drag or double-click): tile / extrapolate the source
   // rectangle across the new region in one transaction, then keep the filled
   // block selected. A target identical to the source (a click with no drag)
@@ -660,6 +696,18 @@ export const SpreadsheetDocumentEditor = ({
     pointRefRef.current = null;
   }, []);
 
+  // Blur handler shared by the in-cell input and the formula-bar input. A blur
+  // that hands focus to the *other* editing surface is a surface switch, not
+  // an edit end — keep the draft alive instead of committing.
+  const handleEditorBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      const next = e.relatedTarget;
+      if (next === formulaBarInputRef.current || next === editingInputRef.current) return;
+      commitEdit();
+    },
+    [commitEdit]
+  );
+
   // Point mode: splice the clicked cell's reference into the formula being
   // edited. ``extend`` builds an ``A1:B3`` range from the drag anchor and
   // overwrites the reference inserted on mousedown; otherwise it resolves the
@@ -669,7 +717,7 @@ export const SpreadsheetDocumentEditor = ({
   const insertReference = useCallback(
     (row: number, col: number, extend: boolean): boolean => {
       if (!editing) return false;
-      const input = editingInputRef.current;
+      const input = activeEditorRef.current ?? editingInputRef.current;
       if (!input) return false;
       const draft = editing.draft;
       const cellRef = (r: number, c: number) => `${colIndexToLetter(c)}${r + 1}`;
@@ -710,7 +758,7 @@ export const SpreadsheetDocumentEditor = ({
   // it on re-render). Runs before paint so there's no visible jump.
   useLayoutEffect(() => {
     if (pendingCaretRef.current === null) return;
-    const input = editingInputRef.current;
+    const input = activeEditorRef.current ?? editingInputRef.current;
     if (input) {
       const pos = pendingCaretRef.current;
       input.focus();
@@ -756,6 +804,13 @@ export const SpreadsheetDocumentEditor = ({
   const editingCellKey = editing ? `${editing.row}:${editing.col}` : null;
   useEffect(() => {
     if (editingCellKey && editingInputRef.current) {
+      // Edit begun from the formula bar: leave focus there (the cell input is
+      // still mounted as a mirror, but the user is typing in the bar).
+      if (focusBarOnEditRef.current) {
+        focusBarOnEditRef.current = false;
+        return;
+      }
+      activeEditorRef.current = editingInputRef.current;
       editingInputRef.current.focus();
     } else if (!editingCellKey && refocusGridRef.current) {
       // Edit ended via the keyboard: pull focus back to the grid (the
@@ -1493,7 +1548,10 @@ export const SpreadsheetDocumentEditor = ({
             setEditing({ row: r, col: c, draft });
           }}
           onEditingKeyDown={handleEditingKeyDown}
-          onEditingBlur={() => commitEdit()}
+          onEditingBlur={handleEditorBlur}
+          onEditingFocus={() => {
+            activeEditorRef.current = editingInputRef.current;
+          }}
         />
       );
     },
@@ -1519,11 +1577,48 @@ export const SpreadsheetDocumentEditor = ({
       beginEdit,
       setCell,
       handleEditingKeyDown,
-      commitEdit,
+      handleEditorBlur,
       startFill,
       autofillDown,
       extendFill,
     ]
+  );
+
+  // The name box label: the active cell ref, or the selection range / band.
+  const formulaBarLabel = useMemo(() => {
+    const { r1, r2, c1, c2 } = selBox;
+    if (sel.mode === "columns") {
+      return c1 === c2 ? colIndexToLetter(c1) : `${colIndexToLetter(c1)}:${colIndexToLetter(c2)}`;
+    }
+    if (sel.mode === "rows") return r1 === r2 ? `${r1 + 1}` : `${r1 + 1}:${r2 + 1}`;
+    const ref = (r: number, c: number) => `${colIndexToLetter(c)}${r + 1}`;
+    return r1 === r2 && c1 === c2 ? ref(r1, c1) : `${ref(r1, c1)}:${ref(r2, c2)}`;
+  }, [sel.mode, selBox]);
+
+  // The formula bar mirrors the live edit draft, else the focus cell's raw
+  // value (its formula/value as stored, not the computed result).
+  const formulaBarValue = editing
+    ? editing.draft
+    : (() => {
+        const raw = cells.get(keyOf(sel.focus.row, sel.focus.col));
+        return raw == null ? "" : String(raw);
+      })();
+
+  // Focusing the bar begins an edit of the focus cell (unless one is already
+  // live); the flag keeps focus in the bar instead of the cell input.
+  const handleFormulaBarFocus = useCallback(() => {
+    activeEditorRef.current = formulaBarInputRef.current;
+    if (readOnly || editing) return;
+    focusBarOnEditRef.current = true;
+    beginEdit(sel.focus.row, sel.focus.col);
+  }, [readOnly, editing, beginEdit, sel.focus.row, sel.focus.col]);
+
+  const handleFormulaBarChange = useCallback(
+    (draft: string) => {
+      pointRefRef.current = null;
+      setEditing((p) => (p ? { ...p, draft } : { row: sel.focus.row, col: sel.focus.col, draft }));
+    },
+    [sel.focus.row, sel.focus.col]
   );
 
   return (
@@ -1565,6 +1660,19 @@ export const SpreadsheetDocumentEditor = ({
           onChange={handleFileSelected}
         />
       </div>
+
+      <SpreadsheetFormulaBar
+        selectionLabel={formulaBarLabel}
+        onNavigate={navigateToRef}
+        value={formulaBarValue}
+        tokens={editingRefs}
+        inputRef={formulaBarInputRef}
+        onChange={handleFormulaBarChange}
+        onFocus={handleFormulaBarFocus}
+        onKeyDown={handleEditingKeyDown}
+        onBlur={handleEditorBlur}
+        readOnly={readOnly}
+      />
 
       {/* biome-ignore lint/a11y/useSemanticElements: virtualized absolute layout doesn't fit a <table>; ARIA grid roles convey semantics */}
       <div
@@ -1998,7 +2106,8 @@ interface CellViewProps {
   onToggleBoolean: () => void;
   onDraftChange: (draft: string) => void;
   onEditingKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
-  onEditingBlur: () => void;
+  onEditingBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
+  onEditingFocus: () => void;
   onFillHandleMouseDown: () => void;
   onFillHandleDoubleClick: () => void;
 }
@@ -2029,6 +2138,7 @@ const CellView = ({
   onDraftChange,
   onEditingKeyDown,
   onEditingBlur,
+  onEditingFocus,
   onFillHandleMouseDown,
   onFillHandleDoubleClick,
 }: CellViewProps) => {
@@ -2127,6 +2237,7 @@ const CellView = ({
           onChange={onDraftChange}
           onKeyDown={onEditingKeyDown}
           onBlur={onEditingBlur}
+          onFocus={onEditingFocus}
         />
         {peerOverlay}
       </div>

--- a/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
+++ b/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
@@ -16,6 +16,9 @@ interface FormulaCellInputProps {
   /** Fired when this input gains focus — lets the editor track which of the
    *  two editing surfaces (cell vs formula bar) point-mode should target. */
   onFocus?: () => void;
+  /** Accessible label for the input — set for the standalone formula bar; the
+   *  in-cell editor inherits the grid's labelling and leaves it undefined. */
+  ariaLabel?: string;
 }
 
 /**
@@ -36,6 +39,7 @@ export const FormulaCellInput = ({
   onKeyDown,
   onBlur,
   onFocus,
+  ariaLabel,
 }: FormulaCellInputProps) => {
   const mirrorRef = useRef<HTMLDivElement>(null);
 
@@ -70,6 +74,7 @@ export const FormulaCellInput = ({
       </div>
       <input
         ref={inputRef}
+        aria-label={ariaLabel}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={onKeyDown}

--- a/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
+++ b/frontend/src/components/documents/spreadsheet/FormulaCellInput.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, type RefObject, useMemo, useRef } from "react";
+import { type FocusEvent, type KeyboardEvent, type RefObject, useMemo, useRef } from "react";
 
 import { FORMULA_REF_COLORS, type FormulaRefToken } from "@/lib/spreadsheet/formula-refs";
 
@@ -9,7 +9,13 @@ interface FormulaCellInputProps {
   inputRef: RefObject<HTMLInputElement | null> | null;
   onChange: (value: string) => void;
   onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
-  onBlur: () => void;
+  /** Receives the blur event so the caller can inspect ``relatedTarget`` (a
+   *  focus handoff between the in-cell and formula-bar editors must not
+   *  commit the edit). */
+  onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+  /** Fired when this input gains focus — lets the editor track which of the
+   *  two editing surfaces (cell vs formula bar) point-mode should target. */
+  onFocus?: () => void;
 }
 
 /**
@@ -29,6 +35,7 @@ export const FormulaCellInput = ({
   onChange,
   onKeyDown,
   onBlur,
+  onFocus,
 }: FormulaCellInputProps) => {
   const mirrorRef = useRef<HTMLDivElement>(null);
 
@@ -67,6 +74,7 @@ export const FormulaCellInput = ({
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={onKeyDown}
         onBlur={onBlur}
+        onFocus={onFocus}
         onScroll={(e) => {
           if (mirrorRef.current) mirrorRef.current.scrollLeft = e.currentTarget.scrollLeft;
         }}

--- a/frontend/src/components/documents/spreadsheet/SpreadsheetFormulaBar.tsx
+++ b/frontend/src/components/documents/spreadsheet/SpreadsheetFormulaBar.tsx
@@ -96,6 +96,7 @@ export const SpreadsheetFormulaBar = ({
         ) : (
           <FormulaCellInput
             inputRef={inputRef}
+            ariaLabel={t("documents:spreadsheet.formulaBar.inputLabel")}
             value={value}
             tokens={tokens}
             onChange={onChange}

--- a/frontend/src/components/documents/spreadsheet/SpreadsheetFormulaBar.tsx
+++ b/frontend/src/components/documents/spreadsheet/SpreadsheetFormulaBar.tsx
@@ -1,0 +1,110 @@
+import { type FocusEvent, type KeyboardEvent, type RefObject, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { FormulaCellInput } from "@/components/documents/spreadsheet/FormulaCellInput";
+import type { FormulaRefToken } from "@/lib/spreadsheet/formula-refs";
+
+interface SpreadsheetFormulaBarProps {
+  /** A1 reference of the active cell or range (``"B4"`` / ``"A1:C3"``) — the
+   *  name box display. */
+  selectionLabel: string;
+  /** Go-to: navigate/select the cell or range the name box text names. */
+  onNavigate: (text: string) => void;
+  /** The active cell's raw text — its formula/value, or the live edit draft. */
+  value: string;
+  /** References in ``value`` while a formula is being edited (colors them). */
+  tokens: FormulaRefToken[];
+  /** Ref to the formula-bar ``<input>`` so the editor can drive point-mode
+   *  reference insertion and caret restoration against it. */
+  inputRef: RefObject<HTMLInputElement | null>;
+  onChange: (value: string) => void;
+  onFocus: () => void;
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+  readOnly: boolean;
+}
+
+/**
+ * The formula bar above the grid: a name box (active-cell reference, editable
+ * for go-to navigation) and an editable formula input that mirrors the active
+ * cell. Both the in-cell editor and this bar drive the same edit draft, so a
+ * formula can be typed or pointed-at from either surface (see the editor's
+ * shared ``activeEditorRef`` / point-mode wiring).
+ */
+export const SpreadsheetFormulaBar = ({
+  selectionLabel,
+  onNavigate,
+  value,
+  tokens,
+  inputRef,
+  onChange,
+  onFocus,
+  onKeyDown,
+  onBlur,
+  readOnly,
+}: SpreadsheetFormulaBarProps) => {
+  const { t } = useTranslation(["documents", "common"]);
+  // Local name-box draft, synced to the selection unless the user is editing it.
+  const [nameDraft, setNameDraft] = useState(selectionLabel);
+  const [nameFocused, setNameFocused] = useState(false);
+  useEffect(() => {
+    if (!nameFocused) setNameDraft(selectionLabel);
+  }, [selectionLabel, nameFocused]);
+
+  const handleNameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onNavigate(nameDraft);
+      e.currentTarget.blur();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setNameDraft(selectionLabel);
+      e.currentTarget.blur();
+    }
+  };
+
+  return (
+    <div className="flex shrink-0 items-stretch border-border border-b bg-background text-sm">
+      <input
+        aria-label={t("documents:spreadsheet.formulaBar.nameBoxLabel")}
+        title={t("documents:spreadsheet.formulaBar.nameBoxLabel")}
+        className="w-24 shrink-0 border-border border-r bg-background px-2 py-1 text-center font-mono text-xs outline-none focus:bg-muted/40"
+        value={nameDraft}
+        spellCheck={false}
+        onChange={(e) => setNameDraft(e.target.value)}
+        onFocus={(e) => {
+          setNameFocused(true);
+          e.currentTarget.select();
+        }}
+        onBlur={() => {
+          setNameFocused(false);
+          setNameDraft(selectionLabel);
+        }}
+        onKeyDown={handleNameKeyDown}
+      />
+      <div
+        aria-hidden
+        className="flex shrink-0 select-none items-center border-border border-r px-2.5 font-serif text-muted-foreground italic"
+      >
+        fx
+      </div>
+      <div className="relative h-7 min-w-0 flex-1">
+        {readOnly ? (
+          <div className="flex h-full w-full items-center overflow-hidden whitespace-pre px-1.5 text-muted-foreground">
+            {value}
+          </div>
+        ) : (
+          <FormulaCellInput
+            inputRef={inputRef}
+            value={value}
+            tokens={tokens}
+            onChange={onChange}
+            onFocus={onFocus}
+            onKeyDown={onKeyDown}
+            onBlur={onBlur}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/documents/spreadsheet/SpreadsheetToolbar.tsx
+++ b/frontend/src/components/documents/spreadsheet/SpreadsheetToolbar.tsx
@@ -57,7 +57,6 @@ import {
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { HISTORY_SHORTCUT } from "@/hooks/useYjsHistory";
-import { colIndexToLetter } from "@/lib/spreadsheet/coords";
 import type {
   BorderLineStyle,
   CellAlign,
@@ -326,21 +325,6 @@ export const SpreadsheetToolbar = ({
         return t("documents:spreadsheet.format.borderThin");
     }
   };
-
-  const ref = (r: number, c: number) => `${colIndexToLetter(c)}${r + 1}`;
-  const selectionLabel =
-    mode === "columns"
-      ? t("documents:spreadsheet.format.scopeColumnLabel", {
-          name:
-            c1 === c2 ? colIndexToLetter(c1) : `${colIndexToLetter(c1)}:${colIndexToLetter(c2)}`,
-        })
-      : isRows
-        ? t("documents:spreadsheet.format.scopeRowLabel", {
-            name: r1 === r2 ? r1 + 1 : `${r1 + 1}:${r2 + 1}`,
-          })
-        : t("documents:spreadsheet.format.scopeCellLabel", {
-            name: r1 === r2 && c1 === c2 ? ref(r1, c1) : `${ref(r1, c1)}:${ref(r2, c2)}`,
-          });
 
   const scopeStyle = focusStyle;
   const scopeFormat = focusFormat;
@@ -892,17 +876,12 @@ export const SpreadsheetToolbar = ({
     </div>
   );
 
-  const labelSpan = (
-    <span className="shrink-0 font-mono text-muted-foreground text-xs">{selectionLabel}</span>
-  );
-
   if (isMobile) {
     return (
       <div className="flex w-full items-center gap-2">
         {fileMenu}
         {historyControls}
         {functionMenu}
-        {labelSpan}
         <Popover>
           <PopoverTrigger asChild>
             <Button type="button" size="sm" variant="outline" className="ml-auto h-8 gap-1.5">
@@ -930,7 +909,6 @@ export const SpreadsheetToolbar = ({
     <div className="flex flex-wrap items-center gap-1.5">
       {fileMenu}
       {historyControls}
-      {labelSpan}
       <div className="mx-0.5 h-5 w-px bg-border" aria-hidden />
       <GroupPopover
         icon={<Type className="h-4 w-4" />}

--- a/frontend/src/lib/spreadsheet/coords.test.ts
+++ b/frontend/src/lib/spreadsheet/coords.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { boundingBox, colIndexToLetter, keyOf, letterToColIndex, parseKey } from "./coords";
+import {
+  boundingBox,
+  colIndexToLetter,
+  keyOf,
+  letterToColIndex,
+  parseA1Range,
+  parseKey,
+} from "./coords";
 
 describe("colIndexToLetter / letterToColIndex", () => {
   it("round-trips single-letter columns", () => {
@@ -79,5 +86,28 @@ describe("boundingBox", () => {
       ["3:1", 99],
     ]);
     expect(boundingBox(map)).toEqual({ rows: 4, cols: 2 });
+  });
+});
+
+describe("parseA1Range", () => {
+  it("parses a single cell to a degenerate box", () => {
+    expect(parseA1Range("B12")).toEqual({ r1: 11, c1: 1, r2: 11, c2: 1 });
+    expect(parseA1Range("A1")).toEqual({ r1: 0, c1: 0, r2: 0, c2: 0 });
+  });
+
+  it("parses a range and normalizes endpoint order", () => {
+    expect(parseA1Range("A1:C3")).toEqual({ r1: 0, c1: 0, r2: 2, c2: 2 });
+    expect(parseA1Range("C3:A1")).toEqual({ r1: 0, c1: 0, r2: 2, c2: 2 });
+  });
+
+  it("is case-insensitive, tolerates whitespace and $ anchors", () => {
+    expect(parseA1Range("  aa2  ")).toEqual({ r1: 1, c1: 26, r2: 1, c2: 26 });
+    expect(parseA1Range("$A$1:$B$2")).toEqual({ r1: 0, c1: 0, r2: 1, c2: 1 });
+  });
+
+  it("rejects non-references", () => {
+    for (const bad of ["", "1", "A", "A0", "1A", "A1:", ":A1", "foo", "A1 B2"]) {
+      expect(parseA1Range(bad)).toBeNull();
+    }
   });
 });

--- a/frontend/src/lib/spreadsheet/coords.ts
+++ b/frontend/src/lib/spreadsheet/coords.ts
@@ -50,6 +50,42 @@ export const letterToColIndex = (letters: string): number => {
   return total - 1;
 };
 
+/** A normalized 0-based cell box (top-left .. bottom-right, inclusive). */
+export interface CellRange {
+  r1: number;
+  c1: number;
+  r2: number;
+  c2: number;
+}
+
+// A1 cell ref or ``ref:ref`` range, ``$`` anchors allowed and ignored.
+const A1_RANGE = /^\s*\$?([A-Za-z]+)\$?(\d+)(?:\s*:\s*\$?([A-Za-z]+)\$?(\d+))?\s*$/;
+
+/**
+ * Parse an A1-style reference or range (``"B12"``, ``"a1:c3"``, ``"$A$1"``)
+ * into a normalized 0-based box, or ``null`` when the text isn't a valid
+ * reference. Drives the formula bar's name-box go-to navigation; ``$`` anchors
+ * are accepted but carry no meaning for navigation. Endpoints are sorted so
+ * ``C3:A1`` and ``A1:C3`` yield the same box.
+ */
+export const parseA1Range = (text: string): CellRange | null => {
+  const m = A1_RANGE.exec(text);
+  if (!m) return null;
+  const c1 = letterToColIndex(m[1]);
+  const r1 = Number(m[2]) - 1;
+  if (c1 < 0 || r1 < 0) return null;
+  if (m[3] === undefined) return { r1, c1, r2: r1, c2: c1 };
+  const c2 = letterToColIndex(m[3]);
+  const r2 = Number(m[4]) - 1;
+  if (c2 < 0 || r2 < 0) return null;
+  return {
+    r1: Math.min(r1, r2),
+    c1: Math.min(c1, c2),
+    r2: Math.max(r1, r2),
+    c2: Math.max(c1, c2),
+  };
+};
+
 /**
  * Compute the bounding box (max row + 1, max col + 1) of a sparse cell
  * map. Returns ``{ rows: 0, cols: 0 }`` for an empty map.


### PR DESCRIPTION
## Summary

Adds an Excel/Sheets-style **formula bar** above the spreadsheet grid: a **name box** (active cell / selected range, with go-to navigation) and an **editable formula bar** that shows and edits the active cell's underlying formula or value.

Motivation: since formula cells display their *computed result* (`=A1+B1` shows `42`), the raw formula was previously only visible by entering in-cell edit mode. A formula bar is the standard, expected place to see and edit it.

## Changes

- **New `SpreadsheetFormulaBar` component**
  - **Name box**: shows the active cell ref / range (`B4`, `A1:C3`, `A:C`). Type a reference and press Enter to select + scroll to it; Escape reverts. Selects-all on focus.
  - **Formula input**: reuses `FormulaCellInput` so reference coloring is identical to in-cell editing. Read-only documents get a plain, non-editable display.
- **Shared edit state** in `SpreadsheetDocumentEditor`: the in-cell editor and the bar drive the same `editing` draft. A new `activeEditorRef` tracks the focused surface so **point mode** (click/drag/shift-click cells to insert references) works from either. Focus handoffs between the two surfaces no longer commit the edit (`handleEditorBlur` inspects `relatedTarget`), and focusing the bar begins an edit without the begin-edit effect pulling focus back into the grid.
- **Name-box navigation**: `parseA1Range()` (new, in `coords.ts`) parses a cell or range (case-insensitive, tolerates `$`/whitespace, normalizes endpoint order); `navigateToRef` selects and scrolls it into view via the virtualizers.
- **Toolbar cleanup**: the cell/range indicator moved out of the formatting toolbar into the name box (removed the label + its now-dead `colIndexToLetter` import).
- **i18n**: added `documents:spreadsheet.formulaBar.nameBoxLabel` in `en`, `es`, and `fr`.
- `FormulaCellInput`: added `onFocus`; `onBlur` now forwards the event.
- CHANGELOG `[Unreleased]` entry.

## Testing

- `pnpm typecheck` — clean
- `pnpm biome check` (spreadsheet dirs) — clean
- `pnpm test:run src/lib/spreadsheet/` — **161 passed**, including 4 new `parseA1Range` cases
- Manually verified: typing a formula in the bar and clicking cells to insert refs; switching focus cell↔bar mid-edit; name-box go-to (`B12`, `A1:C3`); read-only documents.