### PR TITLE
Cover OTA update reload with native splash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native app: in-app updates now apply reliably instead of re-prompting.** When the app downloaded a new version and you tapped "Reload Now," the reload sometimes failed to take and the update dialog reappeared. The app now shows a splash screen that covers the entire reload — waiting for the new version to finish downloading and verifying before swapping it in — so the update applies the first time. (Reaches existing installs after a store/APK update.)
+
 ## [0.49.8] - 2026-06-05
 
 ### Added

--- a/frontend/android/app/capacitor.build.gradle
+++ b/frontend/android/app/capacitor.build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project(':capacitor-network')
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-push-notifications')
+    implementation project(':capacitor-splash-screen')
     implementation project(':capgo-capacitor-updater')
 
 }

--- a/frontend/android/capacitor.settings.gradle
+++ b/frontend/android/capacitor.settings.gradle
@@ -29,5 +29,8 @@ project(':capacitor-preferences').projectDir = new File('../node_modules/.pnpm/@
 include ':capacitor-push-notifications'
 project(':capacitor-push-notifications').projectDir = new File('../node_modules/.pnpm/@capacitor+push-notifications@8.1.1_@capacitor+core@8.3.4/node_modules/@capacitor/push-notifications/android')
 
+include ':capacitor-splash-screen'
+project(':capacitor-splash-screen').projectDir = new File('../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen/android')
+
 include ':capgo-capacitor-updater'
 project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.pnpm/@capgo+capacitor-updater@8.47.5_@capacitor+core@8.3.4/node_modules/@capgo/capacitor-updater/android')

--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -28,6 +28,16 @@ const config: CapacitorConfig = {
       appReadyTimeout: 10000,
       responseTimeout: 20,
     },
+    // Native splash overlay. We drive it manually (launchAutoHide off) so it can cover the
+    // OTA bundle swap: useNativeUpdate shows it before CapacitorUpdater.set() reloads the
+    // WebView, and the freshly-swapped bundle hides it in main.tsx after notifyAppReady().
+    // Keeping it up on cold launch until that same hide() also removes the white flash that
+    // would otherwise appear before React mounts.
+    SplashScreen: {
+      launchAutoHide: false,
+      backgroundColor: "#ffffff",
+      showSpinner: false,
+    },
     // Disable built-in SystemBars insets handling - safe-area plugin handles it
     SystemBars: {
       insetsHandling: "disable",

--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -31,11 +31,16 @@ const config: CapacitorConfig = {
     // Native splash overlay. We drive it manually (launchAutoHide off) so it can cover the
     // OTA bundle swap: useNativeUpdate shows it before CapacitorUpdater.set() reloads the
     // WebView, and the freshly-swapped bundle hides it in main.tsx after notifyAppReady().
-    // Keeping it up on cold launch until that same hide() also removes the white flash that
-    // would otherwise appear before React mounts.
+    // Keeping it up on cold launch until that same hide() also removes the flash that would
+    // otherwise appear before React mounts.
+    //
+    // No backgroundColor: the generated splash drawable is full-screen and theme-aware (Android
+    // resolves @drawable/splash to its drawable-night variant in dark mode), so forcing a static
+    // color here would only reintroduce a wrong-theme flash — a white one in dark mode, or a
+    // dark one in light mode. Omitting it lets the plugin skip the fill (SplashScreen.java only
+    // paints when backgroundColor is set) and the theme-correct image cover the screen.
     SplashScreen: {
       launchAutoHide: false,
-      backgroundColor: "#ffffff",
       showSpinner: false,
     },
     // Disable built-in SystemBars insets handling - safe-area plugin handles it

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		CA9211110000000000000B01 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CA9211110000000000000A01 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,7 @@
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
+		CA9211110000000000000A01 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -68,6 +70,7 @@
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
 				504EC3131FED79650016851F /* Info.plist */,
+				CA9211110000000000000A01 /* PrivacyInfo.xcprivacy */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
 			);
@@ -145,6 +148,7 @@
 				50379B232058CBB4000EE86E /* capacitor.config.json in Resources */,
 				504EC30D1FED79650016851F /* Main.storyboard in Resources */,
 				2FAD9763203C412B000D30F8 /* config.xml in Resources */,
+				CA9211110000000000000B01 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/frontend/ios/App/App/PrivacyInfo.xcprivacy
+++ b/frontend/ios/App/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <!-- Required-reason API: UserDefaults, used by @capgo/capacitor-updater and
+           @capacitor/splash-screen. CA92.1 = access info only for the app itself. -->
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/frontend/ios/App/CapApp-SPM/Package.swift
+++ b/frontend/ios/App/CapApp-SPM/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         .package(name: "CapacitorNetwork", path: "../../../node_modules/.pnpm/@capacitor+network@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/network"),
         .package(name: "CapacitorPreferences", path: "../../../node_modules/.pnpm/@capacitor+preferences@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/preferences"),
         .package(name: "CapacitorPushNotifications", path: "../../../node_modules/.pnpm/@capacitor+push-notifications@8.1.1_@capacitor+core@8.3.4/node_modules/@capacitor/push-notifications"),
+        .package(name: "CapacitorSplashScreen", path: "../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen"),
         .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.pnpm/@capgo+capacitor-updater@8.47.5_@capacitor+core@8.3.4/node_modules/@capgo/capacitor-updater")
     ],
     targets: [
@@ -38,6 +39,7 @@ let package = Package(
                 .product(name: "CapacitorNetwork", package: "CapacitorNetwork"),
                 .product(name: "CapacitorPreferences", package: "CapacitorPreferences"),
                 .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications"),
+                .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
                 .product(name: "CapgoCapacitorUpdater", package: "CapgoCapacitorUpdater")
             ]
         )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "@capacitor/network": "^8.0.1",
     "@capacitor/preferences": "^8.0.1",
     "@capacitor/push-notifications": "^8.1.1",
+    "@capacitor/splash-screen": "^8.0.1",
     "@capgo/capacitor-updater": "^8.47.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@capacitor/push-notifications':
         specifier: ^8.1.1
         version: 8.1.1(@capacitor/core@8.3.4)
+      '@capacitor/splash-screen':
+        specifier: ^8.0.1
+        version: 8.0.1(@capacitor/core@8.3.4)
       '@capgo/capacitor-updater':
         specifier: ^8.47.5
         version: 8.47.5(@capacitor/core@8.3.4)
@@ -666,6 +669,11 @@ packages:
 
   '@capacitor/push-notifications@8.1.1':
     resolution: {integrity: sha512-WqzjPKIbYbARMN+GC0XMAJcxJpUUzqgzS/Ny8RODLrro38pQhm3GXYwX2Mwd+LZlLY39rGImkCkrKyQSNfuikA==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/splash-screen@8.0.1':
+    resolution: {integrity: sha512-c/ew/Z3eA7z8l06WoRAtzVF16VwYYrExmHmfGq1Cg675pVzaC/yuucB8/1xG1vhEfnW4fZ1KhSf/kzR1RiVYgg==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
@@ -7001,6 +7009,10 @@ snapshots:
       '@capacitor/core': 8.3.4
 
   '@capacitor/push-notifications@8.1.1(@capacitor/core@8.3.4)':
+    dependencies:
+      '@capacitor/core': 8.3.4
+
+  '@capacitor/splash-screen@8.0.1(@capacitor/core@8.3.4)':
     dependencies:
       '@capacitor/core': 8.3.4
 

--- a/frontend/src/hooks/useNativeUpdate.test.ts
+++ b/frontend/src/hooks/useNativeUpdate.test.ts
@@ -1,6 +1,16 @@
+import type { BundleInfo } from "@capgo/capacitor-updater";
 import { describe, expect, it } from "vitest";
 
-import { buildBundleDownloadUrl, decideNativeUpdate } from "./useNativeUpdate";
+import { buildBundleDownloadUrl, decideNativeUpdate, findReadyBundle } from "./useNativeUpdate";
+
+const bundle = (over: Partial<BundleInfo>): BundleInfo => ({
+  id: "1",
+  version: "0.0.0",
+  status: "success",
+  downloaded: "",
+  checksum: "",
+  ...over,
+});
 
 /**
  * These pure helpers back the OTA flow in {@link useNativeUpdate}. The load-bearing details:
@@ -73,5 +83,37 @@ describe("decideNativeUpdate", () => {
         minNativeVersion: "0.99.0",
       })
     ).toBe("up-to-date");
+  });
+});
+
+/**
+ * `applyUpdate` only swaps to a bundle this gate approves. The load-bearing rule: never hand a
+ * still-downloading or errored bundle to `set()` — that throws or boots a bundle that rolls back
+ * and re-shows the reload prompt. Only a `"success"` bundle for the exact target version passes.
+ */
+describe("findReadyBundle", () => {
+  it("returns the success bundle for the requested version", () => {
+    const ready = bundle({ id: "9", version: "0.49.0", status: "success" });
+    expect(findReadyBundle([bundle({ version: "0.48.0" }), ready], "0.49.0")).toBe(ready);
+  });
+
+  it("ignores a bundle that is still downloading (set() would throw)", () => {
+    expect(
+      findReadyBundle([bundle({ version: "0.49.0", status: "downloading" })], "0.49.0")
+    ).toBeNull();
+  });
+
+  it("ignores an errored bundle for the version (would roll back and re-prompt)", () => {
+    expect(findReadyBundle([bundle({ version: "0.49.0", status: "error" })], "0.49.0")).toBeNull();
+  });
+
+  it("ignores a success bundle for a different version", () => {
+    expect(
+      findReadyBundle([bundle({ version: "0.48.0", status: "success" })], "0.49.0")
+    ).toBeNull();
+  });
+
+  it("returns null when no bundles are present", () => {
+    expect(findReadyBundle([], "0.49.0")).toBeNull();
   });
 });

--- a/frontend/src/hooks/useNativeUpdate.tsx
+++ b/frontend/src/hooks/useNativeUpdate.tsx
@@ -68,24 +68,32 @@ export const decideNativeUpdate = (args: {
 export const findReadyBundle = (bundles: BundleInfo[], version: string): BundleInfo | null =>
   bundles.find((b) => b.version === version && b.status === "success") ?? null;
 
+type BundleReadiness =
+  | { status: "ready"; bundle: BundleInfo }
+  | { status: "error" }
+  | { status: "timeout" };
+
 /**
- * Resolve once a `"success"` bundle for `version` exists, polling `list()` until then or until
- * `timeoutMs` elapses (then `null`). The eager download already `await`ed `download()`, so this
- * normally returns on the first check; it only spins if the bundle is still verifying or, in the
- * "tapped reload before the download finished" case, still downloading.
+ * Poll `list()` until a `"success"` bundle for `version` exists (`ready`), the bundle reaches a
+ * terminal `"error"` (e.g. checksum verification failed after `download()` resolved), or
+ * `timeoutMs` elapses (`timeout`). The eager download already `await`ed `download()`, so this
+ * normally returns `ready` on the first check; it only spins while the bundle is still verifying
+ * or, in the "tapped reload before the download finished" case, still downloading. Failing fast
+ * on `"error"` avoids stranding the user under a blank splash for the full timeout.
  */
-const awaitReadyBundle = async (
-  version: string,
-  timeoutMs = 60_000
-): Promise<BundleInfo | null> => {
+const awaitReadyBundle = async (version: string, timeoutMs = 60_000): Promise<BundleReadiness> => {
   const start = Date.now();
   for (;;) {
-    const ready = findReadyBundle((await CapacitorUpdater.list()).bundles, version);
+    const { bundles } = await CapacitorUpdater.list();
+    const ready = findReadyBundle(bundles, version);
     if (ready) {
-      return ready;
+      return { status: "ready", bundle: ready };
+    }
+    if (bundles.some((b) => b.version === version && b.status === "error")) {
+      return { status: "error" };
     }
     if (Date.now() - start >= timeoutMs) {
-      return null;
+      return { status: "timeout" };
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
@@ -203,7 +211,8 @@ export const useNativeUpdate = () => {
   /** Swap to the downloaded bundle and reload the WebView, under cover of the native splash. */
   const applyUpdate = useCallback(async () => {
     const version = handledVersionRef.current;
-    if (!bundleIdRef.current || !version) {
+    const bundleId = bundleIdRef.current;
+    if (!bundleId || !version) {
       return;
     }
     // Raise the native splash before anything that reloads or stalls. It survives the WebView
@@ -211,23 +220,39 @@ export const useNativeUpdate = () => {
     // download/verification) → new bundle boot — no white flash, no re-shown prompt. The
     // swapped-in bundle hides it in main.tsx after notifyAppReady().
     await SplashScreen.show({ autoHide: false }).catch(() => {});
-    try {
-      // Never swap into a half-verified bundle: download() can resolve before the bundle reaches
-      // "success", and a stale tap can land while it is still downloading. Wait (under the
-      // splash) until it is ready, else set() throws or boots a bundle that rolls back and
-      // re-prompts — the reported "reload doesn't apply, dialog pops up again".
-      const ready = await awaitReadyBundle(version);
-      if (!ready) {
-        throw new Error(`OTA bundle ${version} never reached "success"`);
+
+    // Never swap into a half-verified bundle: download() can resolve before the bundle reaches
+    // "success", and a stale tap can land while it is still downloading. Wait (under the splash)
+    // until it is ready, else set() throws or boots a bundle that rolls back and re-prompts —
+    // the reported "reload doesn't apply, dialog pops up again".
+    const readiness = await awaitReadyBundle(version);
+    if (readiness.status === "ready") {
+      try {
+        await CapacitorUpdater.set({ id: readiness.bundle.id });
+        // set() reloads the WebView into the new bundle; nothing after this runs. On success the
+        // dialog disappears with the old context, so there's no need to hide it first.
+        return;
+      } catch (error) {
+        // set() failed (e.g. the OS evicted the bundle since download) — likely transient. Drop
+        // the splash and leave the prompt open so the user can retry.
+        console.debug("Failed to apply OTA bundle:", error);
+        await SplashScreen.hide().catch(() => {});
+        return;
       }
-      await CapacitorUpdater.set({ id: ready.id });
-      // set() reloads the WebView into the new bundle; nothing after this runs. On success the
-      // dialog disappears with the old context, so there's no need to hide it first.
-    } catch (error) {
-      // Swap failed (e.g. the OS evicted the bundle, or it never finished verifying). Drop the
-      // splash and leave the prompt open so the user can retry rather than being stuck.
-      console.debug("Failed to apply OTA bundle:", error);
-      await SplashScreen.hide().catch(() => {});
+    }
+
+    // No usable bundle — drop the splash so the user is never stranded on it.
+    await SplashScreen.hide().catch(() => {});
+    if (readiness.status === "error") {
+      // The download verified-failed and will never boot. Discard it and clear the dedup guard so
+      // the next foreground check re-downloads from scratch, and close the prompt — re-tapping
+      // would only hit the same dead bundle. (On "timeout" we leave the prompt open: the download
+      // may still be finishing, so a retry can succeed.)
+      console.debug(`OTA bundle ${version} reached "error"; discarding for a clean re-download`);
+      await CapacitorUpdater.delete({ id: bundleId }).catch(() => {});
+      handledVersionRef.current = null;
+      bundleIdRef.current = null;
+      setUpdateReady(HIDDEN);
     }
   }, []);
 

--- a/frontend/src/hooks/useNativeUpdate.tsx
+++ b/frontend/src/hooks/useNativeUpdate.tsx
@@ -1,5 +1,6 @@
 import { App } from "@capacitor/app";
-import { CapacitorUpdater } from "@capgo/capacitor-updater";
+import { SplashScreen } from "@capacitor/splash-screen";
+import { type BundleInfo, CapacitorUpdater } from "@capgo/capacitor-updater";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { compareVersions } from "@/hooks/useDockerHubVersion";
@@ -55,6 +56,39 @@ export const decideNativeUpdate = (args: {
     return "native-required";
   }
   return "download";
+};
+
+/**
+ * Pick the bundle that is safe to swap to for `version`: a fully-downloaded one with status
+ * `"success"`. `download()` can resolve before the bundle reaches `"success"` (still verifying),
+ * and a retained `error`/`downloading` entry must never be handed to `set()` — that throws or
+ * boots a broken bundle that rolls back, which re-shows the reload prompt. Pure so it can be
+ * unit-tested against a `list()` snapshot.
+ */
+export const findReadyBundle = (bundles: BundleInfo[], version: string): BundleInfo | null =>
+  bundles.find((b) => b.version === version && b.status === "success") ?? null;
+
+/**
+ * Resolve once a `"success"` bundle for `version` exists, polling `list()` until then or until
+ * `timeoutMs` elapses (then `null`). The eager download already `await`ed `download()`, so this
+ * normally returns on the first check; it only spins if the bundle is still verifying or, in the
+ * "tapped reload before the download finished" case, still downloading.
+ */
+const awaitReadyBundle = async (
+  version: string,
+  timeoutMs = 60_000
+): Promise<BundleInfo | null> => {
+  const start = Date.now();
+  for (;;) {
+    const ready = findReadyBundle((await CapacitorUpdater.list()).bundles, version);
+    if (ready) {
+      return ready;
+    }
+    if (Date.now() - start >= timeoutMs) {
+      return null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
 };
 
 /**
@@ -131,9 +165,7 @@ export const useNativeUpdate = () => {
       // Only reuse a fully-downloaded bundle; a retained error/partial entry would make
       // set() throw and, since we'd keep "finding" it, never re-download — leaving the user
       // stuck on this version. Filtering to status "success" forces a fresh download instead.
-      const existing = (await CapacitorUpdater.list()).bundles.find(
-        (b) => b.version === manifest.version && b.status === "success"
-      );
+      const existing = findReadyBundle((await CapacitorUpdater.list()).bundles, manifest.version);
       const bundle =
         existing ??
         (await CapacitorUpdater.download({
@@ -168,20 +200,34 @@ export const useNativeUpdate = () => {
     };
   }, [isNativePlatform, serverUrl, checkForUpdate]);
 
-  /** Swap to the downloaded bundle and reload the WebView. */
+  /** Swap to the downloaded bundle and reload the WebView, under cover of the native splash. */
   const applyUpdate = useCallback(async () => {
-    const bundleId = bundleIdRef.current;
-    if (!bundleId) {
+    const version = handledVersionRef.current;
+    if (!bundleIdRef.current || !version) {
       return;
     }
+    // Raise the native splash before anything that reloads or stalls. It survives the WebView
+    // reload set() triggers, so the user sees continuous branding from tap → (any remaining
+    // download/verification) → new bundle boot — no white flash, no re-shown prompt. The
+    // swapped-in bundle hides it in main.tsx after notifyAppReady().
+    await SplashScreen.show({ autoHide: false }).catch(() => {});
     try {
-      await CapacitorUpdater.set({ id: bundleId });
-      // set() reloads the WebView into the new bundle; nothing after this runs. On success
-      // the dialog disappears with the old context, so there's no need to hide it first.
+      // Never swap into a half-verified bundle: download() can resolve before the bundle reaches
+      // "success", and a stale tap can land while it is still downloading. Wait (under the
+      // splash) until it is ready, else set() throws or boots a bundle that rolls back and
+      // re-prompts — the reported "reload doesn't apply, dialog pops up again".
+      const ready = await awaitReadyBundle(version);
+      if (!ready) {
+        throw new Error(`OTA bundle ${version} never reached "success"`);
+      }
+      await CapacitorUpdater.set({ id: ready.id });
+      // set() reloads the WebView into the new bundle; nothing after this runs. On success the
+      // dialog disappears with the old context, so there's no need to hide it first.
     } catch (error) {
-      // set() failed (e.g. the OS evicted the downloaded bundle between download and tap).
-      // Leave the prompt open so the user can retry rather than silently no-op.
+      // Swap failed (e.g. the OS evicted the bundle, or it never finished verifying). Drop the
+      // splash and leave the prompt open so the user can retry rather than being stuck.
       console.debug("Failed to apply OTA bundle:", error);
+      await SplashScreen.hide().catch(() => {});
     }
   }, []);
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import "./styles.css";
 import "./i18n";
 
 import { Capacitor } from "@capacitor/core";
+import { SplashScreen } from "@capacitor/splash-screen";
 import { CapacitorUpdater } from "@capgo/capacitor-updater";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
@@ -60,6 +61,16 @@ async function bootstrap() {
       await CapacitorUpdater.notifyAppReady();
     } catch (error) {
       console.debug("notifyAppReady failed (updater unavailable):", error);
+    }
+
+    // Drop the native splash now that this bundle is alive. It is kept up (launchAutoHide off)
+    // to cover both cold start and the OTA bundle swap that useNativeUpdate raises before
+    // CapacitorUpdater.set() reloads the WebView. Always hide it — even if notifyAppReady threw
+    // above — so a failure there can't strand the user on the splash. Best-effort.
+    try {
+      await SplashScreen.hide();
+    } catch (error) {
+      console.debug("SplashScreen.hide failed (plugin unavailable):", error);
     }
 
     const storedUrl = getStoredServerUrl();


### PR DESCRIPTION
## Problem

On the native (Capacitor) app, when a backend served a newer web bundle, `useNativeUpdate` downloaded it and showed the changelog **Reload Now** dialog. Tapping reload "right away" didn't always apply the update — the dialog reappeared.

`CapacitorUpdater.set()` destroys the JS context and reloads the WebView into the new bundle with **no visual cover**, and it could be handed a bundle that hadn't finished verifying (`download()` can resolve before a bundle reaches `status: "success"`). A half-ready or slow-booting bundle gets rolled back by Capgo's `appReadyTimeout` safety net, which lands back on the old bundle and re-detects the update — the re-prompt.

## Changes

- **Add `@capacitor/splash-screen`** and raise it before the swap. With `launchAutoHide: false` it survives the WebView reload, so the user sees continuous branding from tap → (any remaining download/verification) → new bundle boot. `main.tsx` hides it after `notifyAppReady()` (always, even if that throws, so a failure can't strand the user on the splash).
- **Gate the swap on a verified bundle** — `findReadyBundle()` (pure, unit-tested) only approves a `status: "success"` bundle for the target version; `awaitReadyBundle()` waits under the splash if it's still downloading/verifying. On failure the splash drops and the prompt stays open to retry.
- **iOS privacy manifest** — added `ios/App/App/PrivacyInfo.xcprivacy` declaring `NSPrivacyAccessedAPICategoryUserDefaults` (`CA92.1`), required by both `@capgo/capacitor-updater` (previously missing) and `@capacitor/splash-screen`, and wired into the Xcode target so it ships.
- `npx cap sync` registered the plugin for Android (`capacitor.*.gradle`) and iOS (`Package.swift`).

## ⚠️ Native change — requires a new APK/IPA

Adding Capacitor plugins is native code; OTA can't deliver it. Existing installs only get this fix after a store/APK update. `scripts/promote.sh` should auto-bump `MIN_NATIVE_VERSION` on the next release (new `@capacitor*` deps in `frontend/package.json`) — please confirm it does.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `pnpm test:run src/hooks/useNativeUpdate.test.ts` — 14 passing (5 new `findReadyBundle` cases)
- `npx biome check` on changed files — clean
- **Manual (device/emulator only — OTA needs `isNativePlatform()`):** build APK at version A, bump backend to version B, foreground → tap **Reload Now**. Confirm the splash covers the reload continuously (no white flash, no re-prompt) and the app comes back on B. Throttle the network and tap immediately to exercise the "still downloading" path — splash stays up through completion, then swaps.