### PR TITLE
Calendar UX: drag-reschedule, start/due, tags, view persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Drag and drop to reschedule on the calendar.** Drag an event or task to a different day in month or week view — its time of day is kept — or drag a timed item to a different hour in day view, to reschedule it without opening it. A plain click still opens the item.
+- **"Add Event" button on an initiative's calendar.** A floating Add Event button (matching the existing Add Task button) now appears on an initiative's Events page for members who can create events.
+- **Tags on the calendar list view.** Tasks and events in the calendar list now show their tags.
+
+### Changed
+
+- **The chosen calendar view now persists.** Switching between day, week, month, year, or list view is remembered across sessions and devices, and shared across the Events, My Tasks, and Created Tasks calendars.
+- **Tasks clearly distinguish start from due on the calendar.** Start and due dates are labeled "Start"/"Due" with distinct markers, and a task that both starts and is due on the same day now renders as a single block spanning its time slot instead of two all-day entries.
+
 ## [0.49.9] - 2026-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Drag and drop to reschedule on the calendar.** Drag an event or task to a different day in month or week view — its time of day is kept — or drag a timed item to a different hour in day view, to reschedule it without opening it. A plain click still opens the item.
+- **Drag and drop to reschedule on the calendar.** Drag an event or task to a different day in month view (its time of day is kept), or onto a specific day-and-time slot in week view, or to a different hour in day view — rescheduling it without opening it. A plain click still opens the item.
 - **"Add Event" button on an initiative's calendar.** A floating Add Event button (matching the existing Add Task button) now appears on an initiative's Events page for members who can create events.
 - **Tags on the calendar list view.** Tasks and events in the calendar list now show their tags.
 

--- a/backend/app/api/v1/endpoints/calendar_events.py
+++ b/backend/app/api/v1/endpoints/calendar_events.py
@@ -24,6 +24,7 @@ from app.db.session import get_admin_session, reapply_rls_context
 from app.models.calendar_event import (
     CalendarEvent,
     CalendarEventAttendee,
+    CalendarEventTag,
 )
 from app.models.guild import GuildMembership
 from app.models.initiative import Initiative, PermissionKey
@@ -188,6 +189,7 @@ async def list_global_calendar_events(
             CalendarEventAttendee.user,
         ),
         selectinload(CalendarEvent.initiative),
+        selectinload(CalendarEvent.tag_links).selectinload(CalendarEventTag.tag),
         selectinload(CalendarEvent.property_values)
         .selectinload(CalendarEventPropertyValue.property_definition),
         selectinload(CalendarEvent.property_values)
@@ -440,6 +442,7 @@ async def list_calendar_events(
         .options(
             selectinload(CalendarEvent.attendees).selectinload(CalendarEventAttendee.user),
             selectinload(CalendarEvent.initiative).selectinload(Initiative.memberships),
+            selectinload(CalendarEvent.tag_links).selectinload(CalendarEventTag.tag),
             selectinload(CalendarEvent.property_values)
             .selectinload(CalendarEventPropertyValue.property_definition),
             selectinload(CalendarEvent.property_values)

--- a/backend/app/api/v1/endpoints/calendar_events_test.py
+++ b/backend/app/api/v1/endpoints/calendar_events_test.py
@@ -1,0 +1,83 @@
+"""Integration tests for calendar-event tag serialization on the list summary.
+
+The list endpoints return ``CalendarEventSummary``; these assert that tags
+assigned to an event are eager-loaded and embedded in the summary (not just
+the full ``CalendarEventRead`` detail response).
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.guild import GuildRole
+from app.models.tag import Tag
+from app.testing import (
+    create_calendar_event,
+    create_guild,
+    create_guild_membership,
+    create_initiative,
+    create_user,
+    get_guild_headers,
+)
+
+
+async def _setup_event(session: AsyncSession, *, initiative_name: str = "Init"):
+    """admin user, guild, events-enabled initiative, event."""
+    user = await create_user(session, email=f"u-{initiative_name}@example.com")
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    initiative = await create_initiative(session, guild, user, name=initiative_name)
+    initiative.events_enabled = True
+    session.add(initiative)
+    await session.commit()
+    await session.refresh(initiative)
+    event = await create_calendar_event(session, initiative, user, title="E")
+    return user, guild, initiative, event
+
+
+@pytest.mark.integration
+async def test_list_events_summary_includes_tags(
+    client: AsyncClient, session: AsyncSession
+):
+    user, guild, initiative, event = await _setup_event(session)
+    headers = get_guild_headers(guild, user)
+
+    tag = Tag(name="Priority", guild_id=guild.id, color="#ff0000")
+    session.add(tag)
+    await session.commit()
+    await session.refresh(tag)
+
+    # Assign the tag to the event.
+    assign = await client.put(
+        f"/api/v1/calendar-events/{event.id}/tags",
+        headers=headers,
+        json=[tag.id],
+    )
+    assert assign.status_code == 200
+
+    # The list summary should embed the tag.
+    response = await client.get(
+        f"/api/v1/calendar-events/?initiative_id={initiative.id}", headers=headers
+    )
+    assert response.status_code == 200
+    items = {item["id"]: item for item in response.json()["items"]}
+    assert event.id in items
+    tags = items[event.id]["tags"]
+    assert [t["id"] for t in tags] == [tag.id]
+    assert tags[0]["name"] == "Priority"
+
+
+@pytest.mark.integration
+async def test_list_events_summary_tags_default_empty(
+    client: AsyncClient, session: AsyncSession
+):
+    """An event with no tags still serializes ``tags: []`` in the summary."""
+    user, guild, initiative, event = await _setup_event(session)
+    headers = get_guild_headers(guild, user)
+
+    response = await client.get(
+        f"/api/v1/calendar-events/?initiative_id={initiative.id}", headers=headers
+    )
+    assert response.status_code == 200
+    items = {item["id"]: item for item in response.json()["items"]}
+    assert items[event.id]["tags"] == []

--- a/backend/app/schemas/calendar_event.py
+++ b/backend/app/schemas/calendar_event.py
@@ -145,6 +145,7 @@ class CalendarEventSummary(CalendarEventBase):
     attendee_names: List[str] = Field(default_factory=list)
     attendee_previews: List[CalendarEventAttendeePreview] = Field(default_factory=list)
     property_values: List[PropertySummary] = Field(default_factory=list)
+    tags: List[TagSummary] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
@@ -161,7 +162,6 @@ class CalendarEventListResponse(SanitizedBaseModel):
 
 class CalendarEventRead(CalendarEventSummary):
     attendees: List[CalendarEventAttendeeRead] = Field(default_factory=list)
-    tags: List[TagSummary] = Field(default_factory=list)
     documents: List[CalendarEventDocumentRead] = Field(default_factory=list)
 
 
@@ -267,6 +267,7 @@ def serialize_calendar_event_summary(event: "CalendarEvent") -> CalendarEventSum
         attendee_names=names,
         attendee_previews=previews,
         property_values=_serialize_event_properties(event),
+        tags=_serialize_tags(event),
         created_at=event.created_at,
         updated_at=event.updated_at,
     )
@@ -277,6 +278,5 @@ def serialize_calendar_event(event: "CalendarEvent") -> CalendarEventRead:
     return CalendarEventRead(
         **summary.model_dump(),
         attendees=_serialize_attendees(event),
-        tags=_serialize_tags(event),
         documents=_serialize_documents(event),
     )

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -76,7 +76,9 @@
     "viewMode": "View mode",
     "noEntries": "No events",
     "allDay": "All day",
-    "more": "+{{count}} more"
+    "more": "+{{count}} more",
+    "start": "Start",
+    "due": "Due"
   },
   "createAccess": {
     "advancedOptions": "Advanced options",

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -75,7 +75,9 @@
     "viewMode": "Modo de vista",
     "noEntries": "Sin eventos",
     "allDay": "Todo el día",
-    "more": "+{{count}} más"
+    "more": "+{{count}} más",
+    "start": "Inicio",
+    "due": "Vence"
   },
   "createAccess": {
     "advancedOptions": "Opciones avanzadas",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -75,7 +75,9 @@
     "viewMode": "Mode d'affichage",
     "noEntries": "Aucun événement",
     "allDay": "Toute la journée",
-    "more": "+{{count}} de plus"
+    "more": "+{{count}} de plus",
+    "start": "Début",
+    "due": "Échéance"
   },
   "createAccess": {
     "advancedOptions": "Options avancées",

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -508,6 +508,15 @@ export interface PropertySummary {
   value: unknown;
 }
 
+/**
+ * Lightweight tag representation for embedding in other schemas.
+ */
+export interface TagSummary {
+  id: number;
+  name: string;
+  color: string;
+}
+
 export interface CalendarEventSummary {
   /**
    * @minLength 1
@@ -529,6 +538,7 @@ export interface CalendarEventSummary {
   attendee_names: string[];
   attendee_previews: CalendarEventAttendeePreview[];
   property_values: PropertySummary[];
+  tags: TagSummary[];
   created_at: string;
   updated_at: string;
 }
@@ -543,15 +553,6 @@ export interface CalendarEventListResponse {
 
 export interface CalendarEventRSVPUpdate {
   rsvp_status: RSVPStatus;
-}
-
-/**
- * Lightweight tag representation for embedding in other schemas.
- */
-export interface TagSummary {
-  id: number;
-  name: string;
-  color: string;
 }
 
 export interface CalendarEventRead {
@@ -575,10 +576,10 @@ export interface CalendarEventRead {
   attendee_names: string[];
   attendee_previews: CalendarEventAttendeePreview[];
   property_values: PropertySummary[];
+  tags: TagSummary[];
   created_at: string;
   updated_at: string;
   attendees: CalendarEventAttendeeRead[];
-  tags: TagSummary[];
   documents: CalendarEventDocumentRead[];
 }
 

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -965,19 +965,16 @@ function WeekView({
             const dayMaxLane = Math.max(laneEnds.length, 1);
 
             return (
-              <DroppableDiv
-                key={key}
-                dropId={`day:${key}`}
-                data={{ type: "day", dateKey: key }}
-                disabled={!dndEnabled}
-                className="relative border-l"
-                overClassName="bg-primary/5"
-              >
-                {/* Hour slot backgrounds */}
+              <div key={key} className="relative border-l">
+                {/* Hour slots — droppable so a timed entry dropped here moves
+                    to this column's day AND this hour. */}
                 {hours.map((hour) => (
-                  // biome-ignore lint/a11y/noStaticElementInteractions: role is set if interactive
-                  <div
+                  <DroppableDiv
                     key={hour}
+                    dropId={`week-slot:${key}:${hour}`}
+                    data={{ type: "hour", hour, dateKey: key }}
+                    disabled={!dndEnabled}
+                    overClassName="bg-primary/10"
                     className={cn("border-b", onSlotClick && "cursor-pointer hover:bg-accent/30")}
                     style={{ height: ROW_HEIGHT }}
                     role={onSlotClick ? "button" : undefined}
@@ -1037,7 +1034,7 @@ function WeekView({
                     </DraggableEntryButton>
                   );
                 })}
-              </DroppableDiv>
+              </div>
             );
           })}
         </div>
@@ -1681,17 +1678,25 @@ export const CalendarView = ({
         return;
       }
 
-      // drop.type === "hour": change the time, keep the date. Skip all-day.
-      if (entry.allDay) return;
-      const newStart = new Date(start);
-      newStart.setHours(drop.hour, 0, 0, 0);
+      // drop.type === "hour": set the date to the dropped column's day. Timed
+      // entries also move to the dropped hour; all-day markers keep their
+      // (midnight) time and only change date — so dropping a task start/due
+      // marker into a week column reschedules its date. In day view the column
+      // is always the focused day, so only the time changes.
+      const targetDay = parseISO(`${drop.dateKey}T00:00:00`);
+      const newStart = new Date(targetDay);
+      if (entry.allDay) {
+        newStart.setHours(start.getHours(), start.getMinutes(), start.getSeconds(), 0);
+      } else {
+        newStart.setHours(drop.hour, 0, 0, 0);
+      }
       if (newStart.getTime() === start.getTime()) return; // no-op
       const newEnd = new Date(newStart.getTime() + durationMs);
       onEntryReschedule?.({
         entry,
         startAt: newStart.toISOString(),
         endAt: newEnd.toISOString(),
-        mode: "time",
+        mode: entry.allDay ? "day" : "time",
       });
     },
     [onEntryReschedule]

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -1,4 +1,17 @@
 import {
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  MouseSensor,
+  pointerWithin,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
   addDays,
   addMonths,
   addWeeks,
@@ -26,12 +39,14 @@ import {
   Grid3X3,
   List,
 } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { PropertySummary } from "@/api/generated/initiativeAPI.schemas";
+import type { PropertySummary, TagSummary } from "@/api/generated/initiativeAPI.schemas";
 import { PropertyValueCell } from "@/components/properties/PropertyValueCell";
 import { nonEmptyPropertySummaries } from "@/components/properties/propertyHelpers";
+import { TagBadge } from "@/components/tags/TagBadge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -45,6 +60,10 @@ import { cn } from "@/lib/utils";
 // ---------------------------------------------------------------------------
 
 export type CalendarViewMode = "day" | "week" | "month" | "year" | "list";
+
+/** Shared `useViewPreference` scope key so every calendar (initiative events,
+ *  My Tasks, Created Tasks) persists and restores the same chosen sub-view. */
+export const CALENDAR_VIEW_MODE_KEY = "calendar:view-mode";
 
 export type CalendarEntryAttendee = {
   name: string;
@@ -60,6 +79,11 @@ export type CalendarEntryAttendee = {
   userId?: number | null;
 };
 
+/** Presentational marker for task entries: lets the calendar render a
+ *  "Start"/"Due" label and a distinct dot so the two are easy to tell apart.
+ *  Unset for events and same-day task spans. */
+export type CalendarEntryKind = "start" | "due";
+
 export type CalendarEntry = {
   id: number | string;
   title: string;
@@ -72,8 +96,28 @@ export type CalendarEntry = {
   /** Custom property values attached to the underlying entity. Rendered as
    *  compact chips on the list view; other calendar views omit them. */
   properties?: PropertySummary[];
+  /** Tags attached to the underlying entity. Rendered as badges on the list view. */
+  tags?: TagSummary[];
+  /** Presentational start/due marker (see CalendarEntryKind). */
+  kind?: CalendarEntryKind;
+  /** When false, the entry cannot be dragged to reschedule (default true). */
+  draggable?: boolean;
   /** Any extra data the consumer wants to pass through */
   meta?: Record<string, unknown>;
+};
+
+/** Payload handed to ``onEntryReschedule`` after a drag drop. CalendarView
+ *  computes the resulting absolute ISO start/end (duration preserved, and
+ *  time-of-day preserved on date-only moves); the consumer routes it to the
+ *  right mutation using ``entry.meta``/``entry.kind``. */
+export type CalendarEntryReschedule = {
+  entry: CalendarEntry;
+  /** New absolute start, ISO. */
+  startAt: string;
+  /** New absolute end, ISO. Equals ``startAt`` for instant markers. */
+  endAt: string;
+  /** Which axis changed: a date-only move (month/week) or a time move (day). */
+  mode: "day" | "time";
 };
 
 type CalendarViewProps = {
@@ -88,6 +132,9 @@ type CalendarViewProps = {
   onEntryClick?: (entry: CalendarEntry) => void;
   /** Called when user clicks an empty day/time slot to create */
   onSlotClick?: (date: Date) => void;
+  /** Called when the user drags an entry to a new day (month/week) or hour
+   *  (day). When omitted, drag-to-reschedule is disabled entirely. */
+  onEntryReschedule?: (change: CalendarEntryReschedule) => void;
   /** Week start day from user preferences */
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   /** Loading state */
@@ -161,6 +208,113 @@ function formatHourLabel(hour: number): string {
   if (hour < 12) return `${hour}am`;
   if (hour === 12) return "12pm";
   return `${hour - 12}pm`;
+}
+
+/** i18n key for a task entry's start/due marker label. */
+function kindLabelKey(kind: CalendarEntryKind): "calendar.start" | "calendar.due" {
+  return kind === "start" ? "calendar.start" : "calendar.due";
+}
+
+// ---------------------------------------------------------------------------
+// Drag-and-drop primitives
+// ---------------------------------------------------------------------------
+
+/** Identifies what a droppable target represents. ``day`` (month/week) moves
+ *  the date and keeps the time; ``hour`` (day view) moves the time. */
+type DropData = { type: "day"; dateKey: string } | { type: "hour"; hour: number; dateKey: string };
+
+/**
+ * An entry rendered as a ``<button>`` that doubles as a dnd-kit draggable.
+ * When ``enabled`` is false it behaves exactly like a plain button (click to
+ * select), so non-reschedulable calendars are unaffected.
+ */
+function DraggableEntryButton({
+  entry,
+  enabled,
+  className,
+  style,
+  title,
+  onSelect,
+  children,
+}: {
+  entry: CalendarEntry;
+  enabled: boolean;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+  onSelect?: (entry: CalendarEntry) => void;
+  children: ReactNode;
+}) {
+  const canDrag = enabled && entry.draggable !== false;
+  const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
+    id: String(entry.id),
+    data: { entry },
+    disabled: !canDrag,
+  });
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      title={title}
+      className={cn(className, canDrag && "touch-none", isDragging && "opacity-30")}
+      style={style}
+      {...(canDrag ? attributes : {})}
+      {...(canDrag ? listeners : {})}
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect?.(entry);
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * A ``<div>`` that doubles as a dnd-kit droppable while still forwarding the
+ * slot's own click/keyboard handlers (used for ``onSlotClick``). Highlights on
+ * hover-over during a drag.
+ */
+function DroppableDiv({
+  dropId,
+  data,
+  disabled,
+  className,
+  overClassName,
+  style,
+  role,
+  tabIndex,
+  onClick,
+  onKeyDown,
+  children,
+}: {
+  dropId: string;
+  data: DropData;
+  disabled: boolean;
+  className?: string;
+  overClassName?: string;
+  style?: CSSProperties;
+  role?: "button";
+  tabIndex?: number;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  children?: ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: dropId, data, disabled });
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: role is set when interactive
+    <div
+      ref={setNodeRef}
+      className={cn(className, isOver && !disabled && overClassName)}
+      style={style}
+      role={role}
+      tabIndex={tabIndex}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+    >
+      {children}
+    </div>
+  );
 }
 
 function buildEntriesByDate(entries: CalendarEntry[]): Map<string, CalendarEntry[]> {
@@ -394,12 +548,14 @@ function MonthView({
   weekStartsOn,
   onEntryClick,
   onSlotClick,
+  dndEnabled = false,
 }: {
   entries: CalendarEntry[];
   focusDate: Date;
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   onEntryClick?: (entry: CalendarEntry) => void;
   onSlotClick?: (date: Date) => void;
+  dndEnabled?: boolean;
 }) {
   const { t } = useTranslation(["common", "dates"]);
 
@@ -458,9 +614,12 @@ function MonthView({
                     const overflow = daySingles.length - MAX_VISIBLE_ENTRIES;
 
                     return (
-                      // biome-ignore lint/a11y/noStaticElementInteractions: role is set if interactive
-                      <div
+                      <DroppableDiv
                         key={key}
+                        dropId={`day:${key}`}
+                        data={{ type: "day", dateKey: key }}
+                        disabled={!dndEnabled}
+                        overClassName="ring-2 ring-primary/60 ring-inset"
                         role={onSlotClick ? "button" : undefined}
                         tabIndex={onSlotClick ? 0 : undefined}
                         className={cn(
@@ -499,29 +658,40 @@ function MonthView({
                         {visibleSingles.map((entry) => {
                           const { start } = parseEntry(entry);
                           return (
-                            <button
+                            <DraggableEntryButton
                               key={entry.id}
-                              type="button"
+                              entry={entry}
+                              enabled={dndEnabled}
+                              onSelect={onEntryClick}
                               className={cn(
                                 "flex w-full items-center gap-1 text-left text-[11px] leading-tight",
                                 onEntryClick
                                   ? "cursor-pointer rounded px-0.5 hover:bg-accent"
                                   : "cursor-default"
                               )}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onEntryClick?.(entry);
-                              }}
                             >
                               <span
-                                className="h-2 w-2 shrink-0 rounded-full"
-                                style={{ backgroundColor: entry.color || "var(--primary)" }}
+                                className={cn(
+                                  "h-2 w-2 shrink-0 rounded-full",
+                                  entry.kind === "start" && "border-2 bg-transparent"
+                                )}
+                                style={
+                                  entry.kind === "start"
+                                    ? { borderColor: entry.color || "var(--primary)" }
+                                    : { backgroundColor: entry.color || "var(--primary)" }
+                                }
                               />
-                              <span className="shrink-0 text-[10px] text-muted-foreground">
-                                {entry.allDay ? "" : formatTime(start)}
-                              </span>
+                              {entry.kind ? (
+                                <span className="shrink-0 font-semibold text-[9px] text-muted-foreground uppercase">
+                                  {t(`common:${kindLabelKey(entry.kind)}`)}
+                                </span>
+                              ) : (
+                                <span className="shrink-0 text-[10px] text-muted-foreground">
+                                  {entry.allDay ? "" : formatTime(start)}
+                                </span>
+                              )}
                               <span className="truncate">{entry.title}</span>
-                            </button>
+                            </DraggableEntryButton>
                           );
                         })}
                         {overflow > 0 && (
@@ -529,7 +699,7 @@ function MonthView({
                             {t("common:calendar.more", { count: overflow })}
                           </p>
                         )}
-                      </div>
+                      </DroppableDiv>
                     );
                   })}
                 </div>
@@ -542,9 +712,11 @@ function MonthView({
                   const top = 24 + span.lane * (SPAN_BAR_HEIGHT + SPAN_BAR_GAP);
 
                   return (
-                    <button
+                    <DraggableEntryButton
                       key={`${span.entry.id}-${dateKey(week[span.startCol])}`}
-                      type="button"
+                      entry={span.entry}
+                      enabled={dndEnabled}
+                      onSelect={onEntryClick}
                       className={cn(
                         "absolute z-10 flex items-center gap-1 overflow-hidden rounded px-2 font-medium text-[11px] text-white",
                         onEntryClick ? "cursor-pointer hover:brightness-90" : "cursor-default"
@@ -556,15 +728,11 @@ function MonthView({
                         height: SPAN_BAR_HEIGHT,
                         backgroundColor: span.entry.color || "var(--primary)",
                       }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEntryClick?.(span.entry);
-                      }}
                     >
                       <span className={cn("truncate", !span.showTitle && "opacity-70")}>
                         {span.entry.title}
                       </span>
-                    </button>
+                    </DraggableEntryButton>
                   );
                 })}
               </div>
@@ -586,12 +754,14 @@ function WeekView({
   weekStartsOn,
   onEntryClick,
   onSlotClick,
+  dndEnabled = false,
 }: {
   entries: CalendarEntry[];
   focusDate: Date;
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   onEntryClick?: (entry: CalendarEntry) => void;
   onSlotClick?: (date: Date) => void;
+  dndEnabled?: boolean;
 }) {
   const { t } = useTranslation(["common", "dates"]);
 
@@ -709,9 +879,11 @@ function WeekView({
                 const widthFrac = span.spanCols / 7;
                 const top = span.lane * (SPAN_BAR_HEIGHT + SPAN_BAR_GAP) + 2;
                 return (
-                  <button
+                  <DraggableEntryButton
                     key={`${span.entry.id}-${span.startCol}`}
-                    type="button"
+                    entry={span.entry}
+                    enabled={dndEnabled}
+                    onSelect={onEntryClick}
                     className={cn(
                       "absolute z-10 flex items-center gap-1 overflow-hidden rounded px-2 font-medium text-[11px] text-white",
                       onEntryClick ? "cursor-pointer hover:brightness-90" : "cursor-default"
@@ -723,13 +895,14 @@ function WeekView({
                       height: SPAN_BAR_HEIGHT,
                       backgroundColor: span.entry.color || "var(--primary)",
                     }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onEntryClick?.(span.entry);
-                    }}
                   >
+                    {span.entry.kind && (
+                      <span className="shrink-0 rounded-sm bg-white/25 px-1 font-semibold text-[9px] uppercase">
+                        {t(`common:${kindLabelKey(span.entry.kind)}`)}
+                      </span>
+                    )}
                     <span className="truncate">{span.entry.title}</span>
-                  </button>
+                  </DraggableEntryButton>
                 );
               })}
             </div>
@@ -792,7 +965,14 @@ function WeekView({
             const dayMaxLane = Math.max(laneEnds.length, 1);
 
             return (
-              <div key={key} className="relative border-l">
+              <DroppableDiv
+                key={key}
+                dropId={`day:${key}`}
+                data={{ type: "day", dateKey: key }}
+                disabled={!dndEnabled}
+                className="relative border-l"
+                overClassName="bg-primary/5"
+              >
                 {/* Hour slot backgrounds */}
                 {hours.map((hour) => (
                   // biome-ignore lint/a11y/noStaticElementInteractions: role is set if interactive
@@ -826,9 +1006,11 @@ function WeekView({
                   const leftPct = (block.lane / dayMaxLane) * 100;
 
                   return (
-                    <button
+                    <DraggableEntryButton
                       key={block.entry.id}
-                      type="button"
+                      entry={block.entry}
+                      enabled={dndEnabled}
+                      onSelect={onEntryClick}
                       className={cn(
                         "absolute z-10 flex overflow-hidden rounded-r border text-left text-[11px] transition-colors",
                         onEntryClick ? "cursor-pointer hover:brightness-90" : "cursor-default"
@@ -842,10 +1024,6 @@ function WeekView({
                         backgroundColor: "var(--card)",
                         boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
                       }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEntryClick?.(block.entry);
-                      }}
                     >
                       <div className="flex flex-col px-1.5 py-0.5">
                         <span className="truncate font-medium">{block.entry.title}</span>
@@ -856,10 +1034,10 @@ function WeekView({
                           </span>
                         )}
                       </div>
-                    </button>
+                    </DraggableEntryButton>
                   );
                 })}
-              </div>
+              </DroppableDiv>
             );
           })}
         </div>
@@ -877,11 +1055,13 @@ function DayView({
   focusDate,
   onEntryClick,
   onSlotClick,
+  dndEnabled = false,
 }: {
   entries: CalendarEntry[];
   focusDate: Date;
   onEntryClick?: (entry: CalendarEntry) => void;
   onSlotClick?: (date: Date) => void;
+  dndEnabled?: boolean;
 }) {
   const { t } = useTranslation(["common"]);
 
@@ -960,6 +1140,11 @@ function DayView({
               }}
               onClick={() => onEntryClick?.(entry)}
             >
+              {entry.kind && (
+                <span className="shrink-0 rounded-sm bg-white/25 px-1 font-semibold text-[9px] uppercase">
+                  {t(`common:${kindLabelKey(entry.kind)}`)}
+                </span>
+              )}
               <span className="truncate">{entry.title}</span>
             </button>
           ))}
@@ -983,11 +1168,14 @@ function DayView({
 
         {/* Content column — relative container for positioned blocks */}
         <div className="relative border-l">
-          {/* Clickable hour slot backgrounds */}
+          {/* Clickable + droppable hour slot backgrounds */}
           {hours.map((hour) => (
-            // biome-ignore lint/a11y/noStaticElementInteractions: role is set if interactive
-            <div
+            <DroppableDiv
               key={hour}
+              dropId={`hour:${key}:${hour}`}
+              data={{ type: "hour", hour, dateKey: key }}
+              disabled={!dndEnabled}
+              overClassName="bg-primary/10"
               className={cn("border-b", onSlotClick && "cursor-pointer hover:bg-accent/30")}
               style={{ height: ROW_HEIGHT }}
               role={onSlotClick ? "button" : undefined}
@@ -1016,9 +1204,11 @@ function DayView({
             const leftPct = (block.lane / maxLane) * 100;
 
             return (
-              <button
+              <DraggableEntryButton
                 key={block.entry.id}
-                type="button"
+                entry={block.entry}
+                enabled={dndEnabled}
+                onSelect={onEntryClick}
                 className={cn(
                   "absolute z-10 flex overflow-hidden rounded-r border text-left text-[11px] transition-colors",
                   onEntryClick ? "cursor-pointer hover:brightness-90" : "cursor-default"
@@ -1032,10 +1222,6 @@ function DayView({
                   backgroundColor: "var(--card)",
                   boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
                 }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEntryClick?.(block.entry);
-                }}
               >
                 <div className="flex flex-col px-2 py-1">
                   <span className="truncate font-medium">{block.entry.title}</span>
@@ -1044,7 +1230,7 @@ function DayView({
                     {formatTime(parseEntry(block.entry).end)}
                   </span>
                 </div>
-              </button>
+              </DraggableEntryButton>
             );
           })}
         </div>
@@ -1269,7 +1455,12 @@ function ListView({
 
               {/* Title + description + property chips */}
               <div className="min-w-0 flex-1">
-                <span className="truncate font-medium">{entry.title}</span>
+                {entry.kind && (
+                  <span className="mr-1.5 rounded-sm bg-muted px-1 font-semibold text-[10px] text-muted-foreground uppercase">
+                    {t(`common:${kindLabelKey(entry.kind)}`)}
+                  </span>
+                )}
+                <span className="font-medium">{entry.title}</span>
                 {entry.description && (
                   <p className="mt-0.5 line-clamp-2 text-muted-foreground text-xs">
                     {entry.description}
@@ -1290,6 +1481,18 @@ function ListView({
                     </div>
                   );
                 })()}
+                {entry.tags && entry.tags.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {entry.tags.slice(0, 3).map((tag) => (
+                      <TagBadge key={tag.id} tag={tag} size="sm" />
+                    ))}
+                    {entry.tags.length > 3 && (
+                      <span className="text-muted-foreground text-xs">
+                        +{entry.tags.length - 3}
+                      </span>
+                    )}
+                  </div>
+                )}
               </div>
 
               {/* Attendee avatars */}
@@ -1428,11 +1631,71 @@ export const CalendarView = ({
   onFocusDateChange,
   onEntryClick,
   onSlotClick,
+  onEntryReschedule,
   weekStartsOn = 0,
   isLoading = false,
   hideListView = false,
 }: CalendarViewProps) => {
   const periodLabel = usePeriodLabel(viewMode, focusDate, weekStartsOn);
+  const dndEnabled = !!onEntryReschedule;
+  const [activeEntry, setActiveEntry] = useState<CalendarEntry | null>(null);
+
+  // A small move (>5px mouse, long-press on touch) starts a drag; a plain
+  // click still selects the entry, so navigation keeps working.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } })
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveEntry((event.active.data.current?.entry as CalendarEntry | undefined) ?? null);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveEntry(null);
+      const { active, over } = event;
+      if (!over) return;
+      const entry = active.data.current?.entry as CalendarEntry | undefined;
+      const drop = over.data.current as DropData | undefined;
+      if (!entry || !drop) return;
+
+      const start = parseISO(entry.startAt);
+      if (Number.isNaN(start.getTime())) return;
+      const end = parseISO(entry.endAt);
+      const durationMs = Number.isNaN(end.getTime()) ? 0 : end.getTime() - start.getTime();
+
+      if (drop.type === "day") {
+        // Change the date, keep the time-of-day (local midnight for all-day).
+        const target = parseISO(`${drop.dateKey}T00:00:00`);
+        const newStart = new Date(target);
+        newStart.setHours(start.getHours(), start.getMinutes(), start.getSeconds(), 0);
+        if (dateKey(newStart) === dateKey(start)) return; // no-op
+        const newEnd = new Date(newStart.getTime() + durationMs);
+        onEntryReschedule?.({
+          entry,
+          startAt: newStart.toISOString(),
+          endAt: newEnd.toISOString(),
+          mode: "day",
+        });
+        return;
+      }
+
+      // drop.type === "hour": change the time, keep the date. Skip all-day.
+      if (entry.allDay) return;
+      const newStart = new Date(start);
+      newStart.setHours(drop.hour, 0, 0, 0);
+      if (newStart.getTime() === start.getTime()) return; // no-op
+      const newEnd = new Date(newStart.getTime() + durationMs);
+      onEntryReschedule?.({
+        entry,
+        startAt: newStart.toISOString(),
+        endAt: newEnd.toISOString(),
+        mode: "time",
+      });
+    },
+    [onEntryReschedule]
+  );
 
   if (isLoading) {
     return (
@@ -1442,17 +1705,8 @@ export const CalendarView = ({
     );
   }
 
-  return (
-    <div className="space-y-4 rounded-xl border bg-card p-4 shadow-sm">
-      <CalendarHeader
-        viewMode={viewMode}
-        onViewModeChange={onViewModeChange}
-        focusDate={focusDate}
-        onFocusDateChange={onFocusDateChange}
-        periodLabel={periodLabel}
-        hideListView={hideListView}
-      />
-
+  const views = (
+    <>
       {viewMode === "month" ? (
         <MonthView
           entries={entries}
@@ -1460,6 +1714,7 @@ export const CalendarView = ({
           weekStartsOn={weekStartsOn}
           onEntryClick={onEntryClick}
           onSlotClick={onSlotClick}
+          dndEnabled={dndEnabled}
         />
       ) : null}
 
@@ -1470,6 +1725,7 @@ export const CalendarView = ({
           weekStartsOn={weekStartsOn}
           onEntryClick={onEntryClick}
           onSlotClick={onSlotClick}
+          dndEnabled={dndEnabled}
         />
       ) : null}
 
@@ -1479,6 +1735,7 @@ export const CalendarView = ({
           focusDate={focusDate}
           onEntryClick={onEntryClick}
           onSlotClick={onSlotClick}
+          dndEnabled={dndEnabled}
         />
       ) : null}
 
@@ -1495,6 +1752,43 @@ export const CalendarView = ({
       {viewMode === "list" ? (
         <ListView entries={entries} focusDate={focusDate} onEntryClick={onEntryClick} />
       ) : null}
+    </>
+  );
+
+  return (
+    <div className="space-y-4 rounded-xl border bg-card p-4 shadow-sm">
+      <CalendarHeader
+        viewMode={viewMode}
+        onViewModeChange={onViewModeChange}
+        focusDate={focusDate}
+        onFocusDateChange={onFocusDateChange}
+        periodLabel={periodLabel}
+        hideListView={hideListView}
+      />
+
+      {dndEnabled ? (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={pointerWithin}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={() => setActiveEntry(null)}
+        >
+          {views}
+          <DragOverlay>
+            {activeEntry ? (
+              <div
+                className="pointer-events-none flex items-center gap-1 rounded px-2 py-1 font-medium text-[11px] text-white shadow-lg"
+                style={{ backgroundColor: activeEntry.color || "var(--primary)" }}
+              >
+                <span className="truncate">{activeEntry.title}</span>
+              </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      ) : (
+        views
+      )}
     </div>
   );
 };

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -234,6 +234,7 @@ function DraggableEntryButton({
   className,
   style,
   title,
+  dragId,
   onSelect,
   children,
 }: {
@@ -242,12 +243,17 @@ function DraggableEntryButton({
   className?: string;
   style?: CSSProperties;
   title?: string;
+  /** Override for the dnd-kit draggable id. Required where the same entry is
+   *  rendered as more than one strip (e.g. a span crossing multiple week rows
+   *  in month view) so each registration has a unique id. Defaults to the
+   *  entry id. ``data.entry`` is unchanged, so reschedule routing is identical. */
+  dragId?: string;
   onSelect?: (entry: CalendarEntry) => void;
   children: ReactNode;
 }) {
   const canDrag = enabled && entry.draggable !== false;
   const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
-    id: String(entry.id),
+    id: dragId ?? String(entry.id),
     data: { entry },
     disabled: !canDrag,
   });
@@ -711,9 +717,15 @@ function MonthView({
                   // Offset below the day number line (~24px)
                   const top = 24 + span.lane * (SPAN_BAR_HEIGHT + SPAN_BAR_GAP);
 
+                  // A span crossing multiple week rows renders one strip per
+                  // row; disambiguate the dnd-kit id by week so registrations
+                  // don't collide.
+                  const weekDragKey = `${span.entry.id}-${dateKey(week[span.startCol])}`;
+
                   return (
                     <DraggableEntryButton
-                      key={`${span.entry.id}-${dateKey(week[span.startCol])}`}
+                      key={weekDragKey}
+                      dragId={weekDragKey}
                       entry={span.entry}
                       enabled={dndEnabled}
                       onSelect={onEntryClick}
@@ -881,6 +893,7 @@ function WeekView({
                 return (
                   <DraggableEntryButton
                     key={`${span.entry.id}-${span.startCol}`}
+                    dragId={`${span.entry.id}-${span.startCol}`}
                     entry={span.entry}
                     enabled={dndEnabled}
                     onSelect={onEntryClick}

--- a/frontend/src/components/calendar/index.ts
+++ b/frontend/src/components/calendar/index.ts
@@ -1,2 +1,8 @@
-export type { CalendarEntry, CalendarEntryAttendee, CalendarViewMode } from "./CalendarView";
-export { CalendarView } from "./CalendarView";
+export type {
+  CalendarEntry,
+  CalendarEntryAttendee,
+  CalendarEntryKind,
+  CalendarEntryReschedule,
+  CalendarViewMode,
+} from "./CalendarView";
+export { CALENDAR_VIEW_MODE_KEY, CalendarView } from "./CalendarView";

--- a/frontend/src/hooks/useCalendarEvents.ts
+++ b/frontend/src/hooks/useCalendarEvents.ts
@@ -133,6 +133,37 @@ export const useUpdateCalendarEvent = (
   });
 };
 
+/**
+ * Update an event identified per-call (the event id travels in the mutation
+ * variables) rather than bound at hook construction. Used by the calendar
+ * drag-to-reschedule flow, where the target event isn't known until drop time.
+ */
+export const useRescheduleCalendarEvent = (
+  options?: MutationOpts<CalendarEventRead, { eventId: number; data: CalendarEventUpdate }>
+) => {
+  const { t } = useTranslation("events");
+  const { onSuccess, onError, onSettled, ...rest } = options ?? {};
+
+  return useMutation({
+    ...rest,
+    mutationFn: async ({ eventId, data }: { eventId: number; data: CalendarEventUpdate }) =>
+      updateCalendarEventApiV1CalendarEventsEventIdPatch(
+        eventId,
+        data
+      ) as unknown as Promise<CalendarEventRead>,
+    onSuccess: (...args) => {
+      void invalidateCalendarEvent(args[1].eventId);
+      void invalidateAllCalendarEvents();
+      onSuccess?.(...args);
+    },
+    onError: (...args) => {
+      toast.error(t("error"));
+      onError?.(...args);
+    },
+    onSettled,
+  });
+};
+
 export const useDeleteCalendarEvent = (options?: MutationOpts<void, number>) => {
   const { t } = useTranslation("events");
   const { onSuccess, onError, onSettled, ...rest } = options ?? {};

--- a/frontend/src/pages/CreatedTasksPage.tsx
+++ b/frontend/src/pages/CreatedTasksPage.tsx
@@ -5,7 +5,12 @@ import { useTranslation } from "react-i18next";
 
 import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllTasks } from "@/api/query-keys";
-import { type CalendarEntry, CalendarView, type CalendarViewMode } from "@/components/calendar";
+import {
+  CALENDAR_VIEW_MODE_KEY,
+  type CalendarEntry,
+  CalendarView,
+  type CalendarViewMode,
+} from "@/components/calendar";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { buildPropertyColumns, propertyColumnIds } from "@/components/properties/propertyColumns";
 import { getOpenCreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
@@ -18,6 +23,7 @@ import { useGlobalTasksTable } from "@/hooks/useGlobalTasksTable";
 import { useGuilds } from "@/hooks/useGuilds";
 import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
 import { useProperties } from "@/hooks/useProperties";
+import { useViewPreference } from "@/hooks/useViewPreference";
 import { useGuildPath } from "@/lib/guildUrl";
 import type { TranslateFn } from "@/types/i18n";
 
@@ -29,7 +35,10 @@ export const CreatedTasksPage = () => {
   const navigate = useNavigate();
 
   const [viewMode, setViewMode] = useState<"table" | "calendar">("table");
-  const [calendarViewMode, setCalendarViewMode] = useState<CalendarViewMode>("month");
+  const [calendarViewMode, setCalendarViewMode] = useViewPreference<CalendarViewMode>(
+    CALENDAR_VIEW_MODE_KEY,
+    "month"
+  );
   const [calendarFocusDate, setCalendarFocusDate] = useState(() => new Date());
   const weekStartsOn = (user?.week_starts_on ?? 0) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
 

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -5,7 +5,12 @@ import { useTranslation } from "react-i18next";
 
 import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllTasks } from "@/api/query-keys";
-import { type CalendarEntry, CalendarView, type CalendarViewMode } from "@/components/calendar";
+import {
+  CALENDAR_VIEW_MODE_KEY,
+  type CalendarEntry,
+  CalendarView,
+  type CalendarViewMode,
+} from "@/components/calendar";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { buildPropertyColumns, propertyColumnIds } from "@/components/properties/propertyColumns";
 import { getOpenCreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
@@ -18,6 +23,7 @@ import { useGlobalTasksTable } from "@/hooks/useGlobalTasksTable";
 import { useGuilds } from "@/hooks/useGuilds";
 import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
 import { useProperties } from "@/hooks/useProperties";
+import { useViewPreference } from "@/hooks/useViewPreference";
 import { guildPath, useGuildPath } from "@/lib/guildUrl";
 import type { TranslateFn } from "@/types/i18n";
 
@@ -29,7 +35,10 @@ export const MyTasksPage = () => {
   const navigate = useNavigate();
 
   const [viewMode, setViewMode] = useState<"table" | "calendar">("table");
-  const [calendarViewMode, setCalendarViewMode] = useState<CalendarViewMode>("month");
+  const [calendarViewMode, setCalendarViewMode] = useViewPreference<CalendarViewMode>(
+    CALENDAR_VIEW_MODE_KEY,
+    "month"
+  );
   const [calendarFocusDate, setCalendarFocusDate] = useState(() => new Date());
   const weekStartsOn = (user?.week_starts_on ?? 0) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
 

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -1,7 +1,7 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { useRouter, useSearch } from "@tanstack/react-router";
 import { addYears, endOfYear, format, startOfYear, subYears } from "date-fns";
-import { ChevronDown, Download, Filter, Loader2, Upload } from "lucide-react";
+import { ChevronDown, Download, Filter, Loader2, Plus, Upload } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -12,7 +12,13 @@ import type {
   TaskPriority,
   TaskStatusCategory,
 } from "@/api/generated/initiativeAPI.schemas";
-import { type CalendarEntry, CalendarView, type CalendarViewMode } from "@/components/calendar";
+import {
+  CALENDAR_VIEW_MODE_KEY,
+  type CalendarEntry,
+  type CalendarEntryReschedule,
+  CalendarView,
+  type CalendarViewMode,
+} from "@/components/calendar";
 import { CreateEventDialog } from "@/components/initiativeTools/events/CreateEventDialog";
 import { ICalImportDialog } from "@/components/initiativeTools/events/ICalImportDialog";
 import {
@@ -24,15 +30,18 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { useAuth } from "@/hooks/useAuth";
-import { useCalendarEventsList } from "@/hooks/useCalendarEvents";
+import { useCalendarEventsList, useRescheduleCalendarEvent } from "@/hooks/useCalendarEvents";
 import {
   canCreate as canCreatePermission,
   useMyInitiativePermissions,
 } from "@/hooks/useInitiativeRoles";
-import { useTasks } from "@/hooks/useTasks";
+import { useTasks, useUpdateTask } from "@/hooks/useTasks";
+import { useViewPreference } from "@/hooks/useViewPreference";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
 import { getItem, setItem } from "@/lib/storage";
+
+import { buildTaskCalendarEntries } from "./taskCalendarEntries";
 
 const STORAGE_KEY = "initiative-events-prefs";
 
@@ -128,8 +137,11 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   searchParamsRef.current = searchParams;
   const isClosingCreateDialog = useRef(false);
 
-  // Calendar state
-  const [viewMode, setViewMode] = useState<CalendarViewMode>("month");
+  // Calendar state — view mode persists per-user across all calendars.
+  const [viewMode, setViewMode] = useViewPreference<CalendarViewMode>(
+    CALENDAR_VIEW_MODE_KEY,
+    "month"
+  );
   const [focusDate, setFocusDate] = useState(() => new Date());
 
   // Filter state (persisted)
@@ -277,6 +289,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
             userId: att.user_id,
           })),
           properties: event.property_values,
+          tags: event.tags,
           meta: { type: "event", eventId: event.id },
         });
       });
@@ -285,42 +298,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     if (showTasks) {
       const tasks = tasksQuery.data?.items ?? [];
       tasks.forEach((task) => {
-        const taskAttendees = task.assignees
-          .filter((a) => a.full_name)
-          .map((a) => ({
-            name: a.full_name!,
-            avatarUrl: a.avatar_url,
-            avatarBase64: a.avatar_base64,
-            userId: a.id,
-          }));
-        const color = getProjectColor(task.project_id);
-
-        if (task.due_date) {
-          entries.push({
-            id: `task-${task.id}-due`,
-            title: task.title,
-            startAt: task.due_date,
-            endAt: task.due_date,
-            allDay: true,
-            color,
-            attendees: taskAttendees,
-            properties: task.properties,
-            meta: { type: "task", taskId: task.id },
-          });
-        }
-        if (task.start_date) {
-          entries.push({
-            id: `task-${task.id}-start`,
-            title: task.title,
-            startAt: task.start_date,
-            endAt: task.start_date,
-            allDay: true,
-            color,
-            attendees: taskAttendees,
-            properties: task.properties,
-            meta: { type: "task", taskId: task.id },
-          });
-        }
+        entries.push(...buildTaskCalendarEntries(task, getProjectColor(task.project_id)));
       });
     }
 
@@ -376,6 +354,41 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
       void router.navigate({ to: gp(`/tasks/${meta.taskId}`) });
     }
   };
+
+  // Drag-to-reschedule: route the computed new times to the right mutation.
+  // A start/due marker patches only that field; an event or same-day span
+  // shifts both endpoints (CalendarView already preserved the duration).
+  const updateTask = useUpdateTask();
+  const rescheduleEvent = useRescheduleCalendarEvent();
+
+  const handleEntryReschedule = useCallback(
+    ({ entry, startAt, endAt }: CalendarEntryReschedule) => {
+      const meta = entry.meta as
+        | { type?: string; taskId?: number; eventId?: number; kind?: "start" | "due" | "span" }
+        | undefined;
+      if (!meta) return;
+      if (meta.type === "event" && meta.eventId) {
+        rescheduleEvent.mutate({
+          eventId: meta.eventId,
+          data: { start_at: startAt, end_at: endAt },
+        });
+        return;
+      }
+      if (meta.type === "task" && meta.taskId) {
+        if (meta.kind === "start") {
+          updateTask.mutate({ taskId: meta.taskId, data: { start_date: startAt } });
+        } else if (meta.kind === "due") {
+          updateTask.mutate({ taskId: meta.taskId, data: { due_date: startAt } });
+        } else {
+          updateTask.mutate({
+            taskId: meta.taskId,
+            data: { start_date: startAt, due_date: endAt },
+          });
+        }
+      }
+    },
+    [updateTask, rescheduleEvent]
+  );
 
   const defaultStartDate = createDefaultDate ? format(createDefaultDate, "yyyy-MM-dd") : undefined;
 
@@ -562,6 +575,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
           onFocusDateChange={setFocusDate}
           onEntryClick={handleEntryClick}
           onSlotClick={canCreateEvents ? handleSlotClick : undefined}
+          onEntryReschedule={canCreateEvents ? handleEntryReschedule : undefined}
           weekStartsOn={weekStartsOn}
         />
       )}
@@ -581,6 +595,19 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
         onOpenChange={setImportDialogOpen}
         fixedInitiativeId={initiativeId ?? undefined}
       />
+
+      {canCreateEvents && initiativeId && (
+        <Button
+          className="fixed right-6 bottom-6 z-40 h-12 rounded-full px-6 shadow-lg shadow-primary/40"
+          onClick={() => {
+            setCreateDefaultDate(null);
+            setCreateDialogOpen(true);
+          }}
+        >
+          <Plus className="h-4 w-4" />
+          {t("createEvent")}
+        </Button>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -267,6 +267,18 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     return false;
   }, [canCreate, initiativeId, initiativePermissions]);
 
+  // Tasks belong to projects; the precise per-project edit permission is
+  // enforced by the backend on drop. Here we gate task-chip dragging on
+  // project-create permission as a proxy, so users who can't manage project
+  // content don't get draggable task chips. Decoupled from canCreateEvents so
+  // event-create and task-edit are judged independently.
+  const canEditTasks = useMemo(() => {
+    if (initiativeId && initiativePermissions) {
+      return canCreatePermission(initiativePermissions, "projects");
+    }
+    return false;
+  }, [initiativeId, initiativePermissions]);
+
   // --- Merge events + tasks into calendar entries ---
   const calendarEntries = useMemo<CalendarEntry[]>(() => {
     const entries: CalendarEntry[] = [];
@@ -290,6 +302,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
           })),
           properties: event.property_values,
           tags: event.tags,
+          draggable: canCreateEvents,
           meta: { type: "event", eventId: event.id },
         });
       });
@@ -298,12 +311,14 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     if (showTasks) {
       const tasks = tasksQuery.data?.items ?? [];
       tasks.forEach((task) => {
-        entries.push(...buildTaskCalendarEntries(task, getProjectColor(task.project_id)));
+        entries.push(
+          ...buildTaskCalendarEntries(task, getProjectColor(task.project_id), canEditTasks)
+        );
       });
     }
 
     return entries;
-  }, [showEvents, showTasks, eventsQuery.data, tasksQuery.data]);
+  }, [showEvents, showTasks, eventsQuery.data, tasksQuery.data, canCreateEvents, canEditTasks]);
 
   // Create dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -575,7 +590,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
           onFocusDateChange={setFocusDate}
           onEntryClick={handleEntryClick}
           onSlotClick={canCreateEvents ? handleSlotClick : undefined}
-          onEntryReschedule={canCreateEvents ? handleEntryReschedule : undefined}
+          onEntryReschedule={canCreateEvents || canEditTasks ? handleEntryReschedule : undefined}
           weekStartsOn={weekStartsOn}
         />
       )}

--- a/frontend/src/pages/initiativeTools/events/taskCalendarEntries.test.ts
+++ b/frontend/src/pages/initiativeTools/events/taskCalendarEntries.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTag } from "@/__tests__/factories";
+import { buildTask, buildTaskAssignee } from "@/__tests__/factories/task.factory";
+
+import { buildTaskCalendarEntries } from "./taskCalendarEntries";
+
+// Local-time ISO strings (no trailing "Z") so parseISO / isSameDay don't shift
+// the day across timezones in CI.
+const COLOR = "#3b82f6";
+
+describe("buildTaskCalendarEntries", () => {
+  it("renders one timed span for same-day start & due with real times", () => {
+    const task = buildTask({
+      id: 7,
+      start_date: "2026-01-15T09:00:00",
+      due_date: "2026-01-15T17:00:00",
+    });
+
+    const entries = buildTaskCalendarEntries(task, COLOR);
+
+    expect(entries).toHaveLength(1);
+    const [entry] = entries;
+    expect(entry.id).toBe("task-7");
+    expect(entry.allDay).toBe(false);
+    expect(entry.startAt).toBe("2026-01-15T09:00:00");
+    expect(entry.endAt).toBe("2026-01-15T17:00:00");
+    expect(entry.kind).toBeUndefined();
+    expect(entry.meta).toMatchObject({ type: "task", taskId: 7, kind: "span" });
+  });
+
+  it("renders one all-day entry when same-day start & due are both midnight", () => {
+    const task = buildTask({
+      id: 8,
+      start_date: "2026-01-15T00:00:00",
+      due_date: "2026-01-15T00:00:00",
+    });
+
+    const entries = buildTaskCalendarEntries(task, COLOR);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].allDay).toBe(true);
+    expect(entries[0].meta).toMatchObject({ kind: "span" });
+  });
+
+  it("renders two labeled markers when start & due fall on different days", () => {
+    const task = buildTask({
+      id: 9,
+      start_date: "2026-01-15T09:00:00",
+      due_date: "2026-01-18T17:00:00",
+    });
+
+    const entries = buildTaskCalendarEntries(task, COLOR);
+
+    expect(entries).toHaveLength(2);
+    const start = entries.find((e) => e.kind === "start");
+    const due = entries.find((e) => e.kind === "due");
+    expect(start?.id).toBe("task-9-start");
+    expect(start?.allDay).toBe(true);
+    expect(start?.startAt).toBe("2026-01-15T09:00:00");
+    expect(start?.meta).toMatchObject({ type: "task", taskId: 9, kind: "start" });
+    expect(due?.id).toBe("task-9-due");
+    expect(due?.startAt).toBe("2026-01-18T17:00:00");
+    expect(due?.meta).toMatchObject({ type: "task", taskId: 9, kind: "due" });
+  });
+
+  it("renders a single start marker when only start_date is set", () => {
+    const task = buildTask({ id: 10, start_date: "2026-01-15T09:00:00", due_date: undefined });
+    const entries = buildTaskCalendarEntries(task, COLOR);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe("start");
+    expect(entries[0].meta).toMatchObject({ kind: "start" });
+  });
+
+  it("renders a single due marker when only due_date is set", () => {
+    const task = buildTask({ id: 11, start_date: undefined, due_date: "2026-01-15T17:00:00" });
+    const entries = buildTaskCalendarEntries(task, COLOR);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe("due");
+    expect(entries[0].meta).toMatchObject({ kind: "due" });
+  });
+
+  it("renders nothing when the task has no dates", () => {
+    const task = buildTask({ id: 12, start_date: undefined, due_date: undefined });
+    expect(buildTaskCalendarEntries(task, COLOR)).toHaveLength(0);
+  });
+
+  it("propagates color, tags, and assignees onto entries", () => {
+    const tag = buildTag({ name: "urgent" });
+    const task = buildTask({
+      id: 13,
+      start_date: "2026-01-15T09:00:00",
+      tags: [tag],
+      assignees: [buildTaskAssignee({ id: 42, full_name: "Alice" })],
+    });
+
+    const [entry] = buildTaskCalendarEntries(task, COLOR);
+
+    expect(entry.color).toBe(COLOR);
+    expect(entry.tags).toEqual([tag]);
+    expect(entry.attendees).toEqual([
+      { name: "Alice", avatarUrl: null, avatarBase64: null, userId: 42 },
+    ]);
+  });
+});

--- a/frontend/src/pages/initiativeTools/events/taskCalendarEntries.test.ts
+++ b/frontend/src/pages/initiativeTools/events/taskCalendarEntries.test.ts
@@ -85,6 +85,18 @@ describe("buildTaskCalendarEntries", () => {
     expect(buildTaskCalendarEntries(task, COLOR)).toHaveLength(0);
   });
 
+  it("propagates the draggable flag onto entries (defaults to true)", () => {
+    const task = buildTask({
+      id: 14,
+      start_date: "2026-01-15T09:00:00",
+      due_date: "2026-01-18T17:00:00",
+    });
+    expect(buildTaskCalendarEntries(task, COLOR).every((e) => e.draggable === true)).toBe(true);
+    expect(buildTaskCalendarEntries(task, COLOR, false).every((e) => e.draggable === false)).toBe(
+      true
+    );
+  });
+
   it("propagates color, tags, and assignees onto entries", () => {
     const tag = buildTag({ name: "urgent" });
     const task = buildTask({

--- a/frontend/src/pages/initiativeTools/events/taskCalendarEntries.ts
+++ b/frontend/src/pages/initiativeTools/events/taskCalendarEntries.ts
@@ -1,0 +1,94 @@
+import { isSameDay, parseISO } from "date-fns";
+
+import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
+import type { CalendarEntry } from "@/components/calendar";
+
+/** A datetime with no meaningful time-of-day (a date-only task date). */
+const isMidnight = (d: Date) => d.getHours() === 0 && d.getMinutes() === 0 && d.getSeconds() === 0;
+
+/**
+ * Build the calendar entries for a single task.
+ *
+ * - Both start & due on the *same day* with real (different) times → ONE timed
+ *   entry spanning the slot (`allDay: false`).
+ * - Both on the same day but equal / both-midnight → ONE all-day entry (can't
+ *   meaningfully span a time slot).
+ * - Both on *different days* → TWO labeled markers (`kind: "start" | "due"`) so
+ *   the user can tell them apart and drag each independently.
+ * - Only one of start/due → a single marker.
+ *
+ * `meta.kind` (`"start" | "due" | "span"`) drives reschedule routing; the
+ * top-level `kind` drives the start/due visual treatment.
+ */
+export function buildTaskCalendarEntries(task: TaskListRead, color: string): CalendarEntry[] {
+  const attendees = task.assignees
+    .filter((a) => a.full_name)
+    .map((a) => ({
+      name: a.full_name as string,
+      avatarUrl: a.avatar_url,
+      avatarBase64: a.avatar_base64,
+      userId: a.id,
+    }));
+
+  const base = {
+    title: task.title,
+    color,
+    attendees,
+    properties: task.properties,
+    tags: task.tags,
+  };
+
+  const start = task.start_date ? parseISO(task.start_date) : null;
+  const due = task.due_date ? parseISO(task.due_date) : null;
+
+  const startMarker = (): CalendarEntry => ({
+    ...base,
+    id: `task-${task.id}-start`,
+    startAt: task.start_date as string,
+    endAt: task.start_date as string,
+    allDay: true,
+    kind: "start",
+    meta: { type: "task", taskId: task.id, kind: "start" },
+  });
+  const dueMarker = (): CalendarEntry => ({
+    ...base,
+    id: `task-${task.id}-due`,
+    startAt: task.due_date as string,
+    endAt: task.due_date as string,
+    allDay: true,
+    kind: "due",
+    meta: { type: "task", taskId: task.id, kind: "due" },
+  });
+
+  if (start && due) {
+    const degenerate = start.getTime() === due.getTime() || (isMidnight(start) && isMidnight(due));
+    if (isSameDay(start, due) && !degenerate) {
+      return [
+        {
+          ...base,
+          id: `task-${task.id}`,
+          startAt: task.start_date as string,
+          endAt: task.due_date as string,
+          allDay: false,
+          meta: { type: "task", taskId: task.id, kind: "span" },
+        },
+      ];
+    }
+    if (isSameDay(start, due)) {
+      return [
+        {
+          ...base,
+          id: `task-${task.id}`,
+          startAt: task.start_date as string,
+          endAt: task.due_date as string,
+          allDay: true,
+          meta: { type: "task", taskId: task.id, kind: "span" },
+        },
+      ];
+    }
+    return [startMarker(), dueMarker()];
+  }
+  if (start) return [startMarker()];
+  if (due) return [dueMarker()];
+  return [];
+}

--- a/frontend/src/pages/initiativeTools/events/taskCalendarEntries.ts
+++ b/frontend/src/pages/initiativeTools/events/taskCalendarEntries.ts
@@ -3,24 +3,27 @@ import { isSameDay, parseISO } from "date-fns";
 import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
 import type { CalendarEntry } from "@/components/calendar";
 
-/** A datetime with no meaningful time-of-day (a date-only task date). */
-const isMidnight = (d: Date) => d.getHours() === 0 && d.getMinutes() === 0 && d.getSeconds() === 0;
-
 /**
  * Build the calendar entries for a single task.
  *
- * - Both start & due on the *same day* with real (different) times → ONE timed
- *   entry spanning the slot (`allDay: false`).
- * - Both on the same day but equal / both-midnight → ONE all-day entry (can't
+ * - Both start & due on the *same day* with different times → ONE timed entry
+ *   spanning the slot (`allDay: false`).
+ * - Both on the same day at the same instant → ONE all-day entry (can't
  *   meaningfully span a time slot).
  * - Both on *different days* → TWO labeled markers (`kind: "start" | "due"`) so
  *   the user can tell them apart and drag each independently.
  * - Only one of start/due → a single marker.
  *
  * `meta.kind` (`"start" | "due" | "span"`) drives reschedule routing; the
- * top-level `kind` drives the start/due visual treatment.
+ * top-level `kind` drives the start/due visual treatment. `draggable` gates
+ * whether the entry can be dragged to reschedule (callers pass the relevant
+ * permission; the backend remains authoritative).
  */
-export function buildTaskCalendarEntries(task: TaskListRead, color: string): CalendarEntry[] {
+export function buildTaskCalendarEntries(
+  task: TaskListRead,
+  color: string,
+  draggable = true
+): CalendarEntry[] {
   const attendees = task.assignees
     .filter((a) => a.full_name)
     .map((a) => ({
@@ -36,6 +39,7 @@ export function buildTaskCalendarEntries(task: TaskListRead, color: string): Cal
     attendees,
     properties: task.properties,
     tags: task.tags,
+    draggable,
   };
 
   const start = task.start_date ? parseISO(task.start_date) : null;
@@ -61,7 +65,7 @@ export function buildTaskCalendarEntries(task: TaskListRead, color: string): Cal
   });
 
   if (start && due) {
-    const degenerate = start.getTime() === due.getTime() || (isMidnight(start) && isMidnight(due));
+    const degenerate = start.getTime() === due.getTime();
     if (isSameDay(start, due) && !degenerate) {
       return [
         {


### PR DESCRIPTION
## Problem

The calendar views had several rough edges: you couldn't move an event or task without opening it; a task's start and due rendered as two identical all-day chips (indistinguishable, and noisy when both land on the same day); the chosen view didn't persist; there was no quick "Add Event" affordance; and the list view dropped tags.

## What changed

**Drag & drop to reschedule** (`CalendarView.tsx`, using the dnd-kit already in the repo)
- Month view: drag an event/task to a different day — time of day is preserved.
- Week view: drag a timed entry onto a specific day-and-time slot (changes both day and hour); all-day task markers dropped into a column just change date.
- Day view: drag a timed block to a different hour.
- A 5px activation distance keeps a plain click = open; only a real drag reschedules. Optimistic via existing invalidation + error toasts.
- New `onEntryReschedule` prop on `CalendarView`; `EventsPage` routes drops to `useUpdateTask` / a new `useRescheduleCalendarEvent` (start marker → `start_date`, due marker → `due_date`, span/event → both endpoints, duration preserved).

**Distinguish task start vs due**
- Start/due markers now render labeled "Start"/"Due" chips with distinct dots across month/week/day/list.
- A task that both starts and is due on the same day renders as a single block spanning its time slot instead of two all-day entries (logic extracted to the tested `taskCalendarEntries.ts`).

**Add Event FAB** — floating button on an initiative's calendar page (matches the Add Task FAB), gated on event-create permission.

**Persisted calendar view** — `viewMode` now uses `useViewPreference` (key `calendar:view-mode`), shared across Events, My Tasks, and Created Tasks.

**Tags on the list view** — both tasks and events now show tags.

## Schema / generated-types change

- Added `tags: List[TagSummary]` to `CalendarEventSummary` and eager-loaded `tag_links` in both event-list queries (`calendar_events.py`). Regenerated Orval types (`initiativeAPI.schemas.ts`).

## i18n

- Added `calendar.start` / `calendar.due` to `en`/`es`/`fr` `common.json`.

## Testing

- Backend: `pytest app/api/v1/endpoints/calendar_events_test.py app/schemas` — 12 passed (incl. 2 new tags-in-summary tests); `ruff check app` clean.
- Frontend: `pnpm typecheck`, `pnpm lint`, production build, full suite (558 tests incl. 7 new `taskCalendarEntries` unit tests + locale parity) — all green.
- Dev server boots cleanly; the one console error on the landing page is pre-existing (confirmed by stashing these changes).

## Reviewer notes

- **Not yet driven live in an authenticated browser session** (drag interaction): the dev backend was logged-out and dnd pointer sequences are unreliable to simulate, so the drag behavior is covered by type/build/unit checks rather than a click-through. A quick manual pass on month/week/day drag is worth doing.
- `CHANGELOG.md` updated under `[Unreleased]`.