### PR TITLE
Fix OTA reload hanging on splash screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mobile app "Reload now" no longer hangs on the splash screen.** After the splash-covered OTA reload landed, tapping "Reload now" showed the splash for ~60 seconds and then re-displayed the same "New Version Available" dialog without applying the update. The reload waited for the downloaded bundle to report a `success` status that Capacitor only assigns *after* a bundle boots and confirms itself — a freshly downloaded bundle is `pending` — so the wait always timed out. The update now applies as soon as the bundle is downloaded and ready.
+
 ## [0.50.0] - 2026-06-08
 
 ### Added

--- a/frontend/src/hooks/useNativeUpdate.test.ts
+++ b/frontend/src/hooks/useNativeUpdate.test.ts
@@ -6,7 +6,7 @@ import { buildBundleDownloadUrl, decideNativeUpdate, findReadyBundle } from "./u
 const bundle = (over: Partial<BundleInfo>): BundleInfo => ({
   id: "1",
   version: "0.0.0",
-  status: "success",
+  status: "pending",
   downloaded: "",
   checksum: "",
   ...over,
@@ -87,14 +87,21 @@ describe("decideNativeUpdate", () => {
 });
 
 /**
- * `applyUpdate` only swaps to a bundle this gate approves. The load-bearing rule: never hand a
- * still-downloading or errored bundle to `set()` — that throws or boots a bundle that rolls back
- * and re-shows the reload prompt. Only a `"success"` bundle for the exact target version passes.
+ * `applyUpdate` only swaps to a bundle this gate approves. The load-bearing rule: a freshly
+ * downloaded bundle is `"pending"` (Capgo only marks it `"success"` after set() + the booted
+ * bundle calls notifyAppReady), so the gate must accept `"pending"` — gating on `"success"`
+ * would wait forever and re-show the prompt. It must still reject a still-downloading or errored
+ * bundle — handing either to `set()` throws or boots a bundle that rolls back and re-prompts.
  */
 describe("findReadyBundle", () => {
-  it("returns the success bundle for the requested version", () => {
-    const ready = bundle({ id: "9", version: "0.49.0", status: "success" });
+  it("returns the downloaded (pending) bundle for the requested version", () => {
+    const ready = bundle({ id: "9", version: "0.49.0", status: "pending" });
     expect(findReadyBundle([bundle({ version: "0.48.0" }), ready], "0.49.0")).toBe(ready);
+  });
+
+  it("also accepts an already-confirmed (success) bundle for the version (reuse/downgrade)", () => {
+    const ready = bundle({ id: "9", version: "0.49.0", status: "success" });
+    expect(findReadyBundle([ready], "0.49.0")).toBe(ready);
   });
 
   it("ignores a bundle that is still downloading (set() would throw)", () => {
@@ -107,9 +114,9 @@ describe("findReadyBundle", () => {
     expect(findReadyBundle([bundle({ version: "0.49.0", status: "error" })], "0.49.0")).toBeNull();
   });
 
-  it("ignores a success bundle for a different version", () => {
+  it("ignores a pending bundle for a different version", () => {
     expect(
-      findReadyBundle([bundle({ version: "0.48.0", status: "success" })], "0.49.0")
+      findReadyBundle([bundle({ version: "0.48.0", status: "pending" })], "0.49.0")
     ).toBeNull();
   });
 

--- a/frontend/src/hooks/useNativeUpdate.tsx
+++ b/frontend/src/hooks/useNativeUpdate.tsx
@@ -59,14 +59,20 @@ export const decideNativeUpdate = (args: {
 };
 
 /**
- * Pick the bundle that is safe to swap to for `version`: a fully-downloaded one with status
- * `"success"`. `download()` can resolve before the bundle reaches `"success"` (still verifying),
- * and a retained `error`/`downloading` entry must never be handed to `set()` — that throws or
- * boots a broken bundle that rolls back, which re-shows the reload prompt. Pure so it can be
- * unit-tested against a `list()` snapshot.
+ * Pick the bundle that is safe to swap to for `version`: a fully-downloaded one awaiting
+ * activation. In Capgo's lifecycle a bundle is `"downloading"` while in flight, becomes
+ * `"pending"` once `download()` has fully written and verified it (the state we want), and only
+ * becomes `"success"` *after* `set()` swaps to it and the booted bundle calls `notifyAppReady()`
+ * — so a not-yet-applied bundle is never `"success"`, and gating on that status would wait
+ * forever. `"success"` is still accepted for the rare reuse/downgrade case where the target is an
+ * already-confirmed bundle. A retained `error`/`downloading` entry must never be handed to
+ * `set()` — that throws or boots a broken bundle that rolls back and re-shows the reload prompt.
+ * Pure so it can be unit-tested against a `list()` snapshot.
  */
 export const findReadyBundle = (bundles: BundleInfo[], version: string): BundleInfo | null =>
-  bundles.find((b) => b.version === version && b.status === "success") ?? null;
+  bundles.find(
+    (b) => b.version === version && (b.status === "pending" || b.status === "success")
+  ) ?? null;
 
 type BundleReadiness =
   | { status: "ready"; bundle: BundleInfo }
@@ -74,12 +80,12 @@ type BundleReadiness =
   | { status: "timeout" };
 
 /**
- * Poll `list()` until a `"success"` bundle for `version` exists (`ready`), the bundle reaches a
- * terminal `"error"` (e.g. checksum verification failed after `download()` resolved), or
- * `timeoutMs` elapses (`timeout`). The eager download already `await`ed `download()`, so this
- * normally returns `ready` on the first check; it only spins while the bundle is still verifying
- * or, in the "tapped reload before the download finished" case, still downloading. Failing fast
- * on `"error"` avoids stranding the user under a blank splash for the full timeout.
+ * Poll `list()` until a downloaded-and-ready (`"pending"`) bundle for `version` exists (`ready`),
+ * the bundle reaches a terminal `"error"` (e.g. checksum verification failed), or `timeoutMs`
+ * elapses (`timeout`). The eager download already `await`ed `download()`, which leaves the bundle
+ * `"pending"`, so this normally returns `ready` on the first check; it only spins in the "tapped
+ * reload before the download finished" case, where the bundle is still `"downloading"`. Failing
+ * fast on `"error"` avoids stranding the user under a blank splash for the full timeout.
  */
 const awaitReadyBundle = async (version: string, timeoutMs = 60_000): Promise<BundleReadiness> => {
   const start = Date.now();
@@ -170,9 +176,10 @@ export const useNativeUpdate = () => {
       // Reuse a previously-downloaded bundle for this version if present (avoids a
       // "already exists" error from download() across launches); otherwise download it.
       const downloadUrl = buildBundleDownloadUrl(serverUrl, manifest.url);
-      // Only reuse a fully-downloaded bundle; a retained error/partial entry would make
-      // set() throw and, since we'd keep "finding" it, never re-download — leaving the user
-      // stuck on this version. Filtering to status "success" forces a fresh download instead.
+      // Only reuse a fully-downloaded ("pending") bundle; a retained error/partial entry would
+      // make set() throw and, since we'd keep "finding" it, never re-download — leaving the user
+      // stuck on this version. findReadyBundle excludes error/downloading, forcing a fresh
+      // download instead.
       const existing = findReadyBundle((await CapacitorUpdater.list()).bundles, manifest.version);
       const bundle =
         existing ??
@@ -221,10 +228,10 @@ export const useNativeUpdate = () => {
     // swapped-in bundle hides it in main.tsx after notifyAppReady().
     await SplashScreen.show({ autoHide: false }).catch(() => {});
 
-    // Never swap into a half-verified bundle: download() can resolve before the bundle reaches
-    // "success", and a stale tap can land while it is still downloading. Wait (under the splash)
-    // until it is ready, else set() throws or boots a bundle that rolls back and re-prompts —
-    // the reported "reload doesn't apply, dialog pops up again".
+    // Never swap into a still-downloading bundle: a stale tap can land before download() finished
+    // (status "downloading"). Wait (under the splash) until it is "pending" (downloaded + ready),
+    // else set() throws or boots a bundle that rolls back and re-prompts — the reported "reload
+    // doesn't apply, dialog pops up again".
     const readiness = await awaitReadyBundle(version);
     if (readiness.status === "ready") {
       try {


### PR DESCRIPTION
## Problem

On the native (Capacitor) app, tapping **"Reload now"** in the *New Version Available* dialog shows the splash screen for ~60 seconds, then re-displays the same dialog without ever applying the update. Re-tapping repeats the cycle. This started with the splash-covered OTA reload (#598).

## Root cause

The splash work added `findReadyBundle`, which only hands a bundle to `CapacitorUpdater.set()` once its status is `"success"`. That status is impossible before the swap.

Verified against the installed capgo source (`@capgo/capacitor-updater` 8.47.5, `CapgoUpdater.java`):

- `download()` completes → bundle status is **`PENDING`** (line 735)
- `set()` runs → status stays **`PENDING`** (line 1241)
- Status becomes **`SUCCESS`** only in `setSuccess()` (line 1336), which `notifyAppReady()` calls **after the new bundle boots and confirms itself**

So a downloaded-but-not-yet-applied bundle is always `"pending"`. `awaitReadyBundle` polled `list()` for a `"success"` bundle that never appears → hit the full 60s timeout → hid the splash and left the prompt open → re-tap repeated.

## Changes

- `findReadyBundle` now accepts a downloaded-and-ready `"pending"` bundle (still also accepts `"success"` for the rare reuse/downgrade case) and continues to reject `"downloading"`/`"error"` entries. The update now applies as soon as the bundle is downloaded.
- Corrected the now-inaccurate doc comments (the "download() can resolve before it reaches success / still verifying" premise was false — download leaves the bundle `pending`).
- Updated `useNativeUpdate.test.ts` to encode the correct lifecycle, adding a case asserting a `"pending"` bundle is accepted.
- CHANGELOG `[Unreleased]` → Fixed entry.

## Testing

- `pnpm test:run src/hooks/useNativeUpdate.test.ts` — 15/15 pass
- `pnpm typecheck` — clean
- `biome check` on changed files — clean

⚠️ This path is a no-op on web and only exercises on a real device/emulator, which requires cutting a release to verify end-to-end. The fix is backed by the capgo source and unit tests; full native verification will happen on the next release build.