### PR TITLE
Improve calendar events

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"fcdbdbd9-1865-4825-9d9a-a7ef5e0658e2","pid":53805,"procStart":"Sat May 30 05:53:44 2026","acquiredAt":1780128491137}
+{"sessionId":"d502c547-a302-4f24-94f9-a6e3e43a3ec0","pid":89915,"procStart":"162255266","acquiredAt":1780948143402}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Events can span multiple days.** A timed event's end can now fall on a later day (the 24-hour limit is gone). The create dialog and edit page gained separate end-date pickers, and the calendar draws a multi-day timed event across each day it touches — in week and day views it fills the time grid on every day (start day from its start time, full middle days, end day up to its end time) rather than sitting in the all-day bar.
+- **Edit an event's tags.** The event settings page now has a tag picker (matching tasks and documents) to add or remove tags; changes save immediately.
+
+### Changed
+
+- **Event reminder and invitation times now show in your timezone.** Event notification emails and push messages (invitations, reschedules, cancellations, and reminders) previously printed the start time in UTC. They now render in the recipient's own timezone in a more readable form (e.g. "Wed, Jul 1, 2026 at 2:30 PM PDT").
+- **Creating an event adds you as an attendee by default.** The event creation dialog now starts with you in the attendee list (you can still remove yourself).
+- **Changing an event's start time keeps its length.** Adjusting the start time shifts the end by the same amount, preserving the event's duration (including multi-day spans) instead of forcing it back to one hour.
+- **Consistent date, time, and color pickers for events.** The event edit page now uses the same calendar date pickers, half-hour time selectors, and color picker as the create dialog.
+- **Declined attendees stop getting event notifications.** If you decline an event's invitation, you no longer receive its reschedule, update, or cancellation notifications — matching reminders, which already skipped declined RSVPs.
+
 ## [0.50.1] - 2026-06-08
 
 ### Fixed

--- a/backend/app/api/v1/endpoints/calendar_events.py
+++ b/backend/app/api/v1/endpoints/calendar_events.py
@@ -25,6 +25,7 @@ from app.models.calendar_event import (
     CalendarEvent,
     CalendarEventAttendee,
     CalendarEventTag,
+    RSVPStatus,
 )
 from app.models.guild import GuildMembership
 from app.models.initiative import Initiative, PermissionKey
@@ -600,13 +601,6 @@ async def update_calendar_event(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="end_at must be after start_at",
             )
-        if not event.all_day:
-            from datetime import timedelta
-            if (event.end_at - event.start_at) > timedelta(hours=24):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Non-all-day events cannot span more than 24 hours",
-                )
         event.updated_at = datetime.now(timezone.utc)
         session.add(event)
 
@@ -620,7 +614,14 @@ async def update_calendar_event(
         )
         if meaningful_change:
             for attendee in event.attendees:
-                if attendee.user and attendee.user_id != current_user.id:
+                # Skip the editor and anyone who declined — a declined attendee
+                # isn't coming, so reschedules/edits are noise (mirrors the
+                # reminder pass, which also skips declined RSVPs).
+                if (
+                    attendee.user
+                    and attendee.user_id != current_user.id
+                    and attendee.rsvp_status != RSVPStatus.declined
+                ):
                     await notifications_service.notify_event_updated(
                         session,
                         attendee=attendee.user,
@@ -658,7 +659,13 @@ async def delete_calendar_event(
     )
     retention_days = await guilds_service.get_guild_retention_days(session, guild_context.guild_id)
     for attendee in event.attendees:
-        if attendee.user and attendee.user_id != current_user.id:
+        # A declined attendee already isn't attending, so skip the cancellation
+        # notice for them (consistent with update/reminder notifications).
+        if (
+            attendee.user
+            and attendee.user_id != current_user.id
+            and attendee.rsvp_status != RSVPStatus.declined
+        ):
             await notifications_service.notify_event_cancelled(
                 session,
                 attendee=attendee.user,

--- a/backend/app/api/v1/endpoints/calendar_events_test.py
+++ b/backend/app/api/v1/endpoints/calendar_events_test.py
@@ -144,6 +144,53 @@ async def test_create_event_notifies_attendees_not_creator(
 
 
 @pytest.mark.integration
+async def test_create_multi_day_timed_event_is_allowed(
+    client: AsyncClient, session: AsyncSession
+):
+    """A timed (non-all-day) event may now span more than 24 hours / cross days."""
+    organizer, _attendee, guild, initiative = await _setup_organizer_and_attendee(session)
+    headers = get_guild_headers(guild, organizer)
+
+    response = await client.post(
+        "/api/v1/calendar-events/",
+        headers=headers,
+        json={
+            "initiative_id": initiative.id,
+            "title": "Conference",
+            "start_at": "2026-07-01T14:00:00Z",
+            "end_at": "2026-07-03T16:00:00Z",
+            "all_day": False,
+        },
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["start_at"].startswith("2026-07-01")
+    assert body["end_at"].startswith("2026-07-03")
+
+
+@pytest.mark.integration
+async def test_create_event_rejects_end_before_start(
+    client: AsyncClient, session: AsyncSession
+):
+    """end_at before start_at is still rejected."""
+    organizer, _attendee, guild, initiative = await _setup_organizer_and_attendee(session)
+    headers = get_guild_headers(guild, organizer)
+
+    response = await client.post(
+        "/api/v1/calendar-events/",
+        headers=headers,
+        json={
+            "initiative_id": initiative.id,
+            "title": "Backwards",
+            "start_at": "2026-07-03T16:00:00Z",
+            "end_at": "2026-07-01T14:00:00Z",
+            "all_day": False,
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.integration
 async def test_update_event_time_notifies_attendees_as_rescheduled(
     client: AsyncClient, session: AsyncSession
 ):
@@ -186,6 +233,64 @@ async def test_delete_event_notifies_attendees(
 
     cancels = await _notifications_for(session, attendee.id, NotificationType.event_cancelled)
     assert len(cancels) == 1
+
+
+@pytest.mark.integration
+async def test_update_event_skips_declined_attendees(
+    client: AsyncClient, session: AsyncSession
+):
+    """An attendee who declined doesn't get reschedule/update notifications."""
+    organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(session)
+    headers = get_guild_headers(guild, organizer)
+    event = await create_calendar_event(session, initiative, organizer, title="Review")
+    await client.put(
+        f"/api/v1/calendar-events/{event.id}/attendees",
+        headers=headers,
+        json=[attendee.id],
+    )
+    declined = await client.patch(
+        f"/api/v1/calendar-events/{event.id}/rsvp",
+        headers=get_guild_headers(guild, attendee),
+        json={"rsvp_status": "declined"},
+    )
+    assert declined.status_code == 200
+
+    response = await client.patch(
+        f"/api/v1/calendar-events/{event.id}",
+        headers=headers,
+        json={"start_at": "2026-08-01T15:00:00Z", "end_at": "2026-08-01T16:00:00Z"},
+    )
+    assert response.status_code == 200
+
+    updates = await _notifications_for(session, attendee.id, NotificationType.event_updated)
+    assert updates == []
+
+
+@pytest.mark.integration
+async def test_delete_event_skips_declined_attendees(
+    client: AsyncClient, session: AsyncSession
+):
+    """An attendee who declined doesn't get the cancellation notice."""
+    organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(session)
+    headers = get_guild_headers(guild, organizer)
+    event = await create_calendar_event(session, initiative, organizer, title="Retro")
+    await client.put(
+        f"/api/v1/calendar-events/{event.id}/attendees",
+        headers=headers,
+        json=[attendee.id],
+    )
+    declined = await client.patch(
+        f"/api/v1/calendar-events/{event.id}/rsvp",
+        headers=get_guild_headers(guild, attendee),
+        json={"rsvp_status": "declined"},
+    )
+    assert declined.status_code == 200
+
+    response = await client.delete(f"/api/v1/calendar-events/{event.id}", headers=headers)
+    assert response.status_code == 204
+
+    cancels = await _notifications_for(session, attendee.id, NotificationType.event_cancelled)
+    assert cancels == []
 
 
 @pytest.mark.integration

--- a/backend/app/schemas/calendar_event.py
+++ b/backend/app/schemas/calendar_event.py
@@ -91,11 +91,6 @@ class CalendarEventBase(SanitizedBaseModel):
     def validate_dates(self) -> "CalendarEventBase":
         if self.end_at < self.start_at:
             raise ValueError("end_at must be after start_at")
-        # Non-all-day events cannot span more than 24 hours
-        if not self.all_day:
-            from datetime import timedelta
-            if (self.end_at - self.start_at) > timedelta(hours=24):
-                raise ValueError("Non-all-day events cannot span more than 24 hours")
         return self
 
 

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -728,11 +728,18 @@ async def notify_comment_reply(
 # ---------------------------------------------------------------------------
 
 
-def _format_event_when(event: CalendarEvent) -> str:
-    """Human-readable event start for email/push bodies (UTC, like overdue)."""
+def _format_event_when(event: CalendarEvent, recipient: User) -> str:
+    """Human-readable event start, localized to the recipient's timezone.
+
+    All-day events show just the date; timed events convert the stored UTC
+    instant into the recipient's IANA timezone and append the zone abbrev
+    (e.g. ``Wed, Jul 1, 2026 at 2:30 PM PDT``).
+    """
     if event.all_day:
-        return event.start_at.strftime("%Y-%m-%d")
-    return event.start_at.strftime("%Y-%m-%d %H:%M UTC")
+        return event.start_at.strftime("%a, %b %-d, %Y")
+    tz = _resolve_timezone(recipient.timezone)
+    local = event.start_at.astimezone(tz)
+    return local.strftime("%a, %b %-d, %Y at %-I:%M %p %Z")
 
 
 async def _deliver_event_notification(
@@ -821,7 +828,7 @@ async def notify_event_invitation(
     if attendee.id == organizer.id:
         return
     organizer_name = organizer.full_name or organizer.email
-    when = _format_event_when(event)
+    when = _format_event_when(event, attendee)
     await _deliver_event_notification(
         session,
         recipient=attendee,
@@ -850,7 +857,7 @@ async def notify_event_updated(
     if attendee.id == editor.id:
         return
     editor_name = editor.full_name or editor.email
-    when = _format_event_when(event)
+    when = _format_event_when(event, attendee)
     if time_changed:
         headline = "Event rescheduled"
         body = f"{editor_name} rescheduled {event.title} to {when}."
@@ -886,7 +893,7 @@ async def notify_event_cancelled(
     if attendee.id == canceller.id:
         return
     canceller_name = canceller.full_name or canceller.email
-    when = _format_event_when(event)
+    when = _format_event_when(event, attendee)
     await _deliver_event_notification(
         session,
         recipient=attendee,
@@ -944,7 +951,7 @@ async def notify_event_reminder(
     guild_id: int,
 ) -> None:
     """Send a scheduled lead-time reminder for an upcoming event."""
-    when = _format_event_when(event)
+    when = _format_event_when(event, recipient)
     await _deliver_event_notification(
         session,
         recipient=recipient,

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -11,10 +11,11 @@ import pytest
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models.calendar_event import CalendarEventAttendee, RSVPStatus
+from app.models.calendar_event import CalendarEvent, CalendarEventAttendee, RSVPStatus
 from app.models.event_reminder_dispatch import EventReminderDispatch
 from app.models.notification import Notification, NotificationType
-from app.services.notifications import _run_event_reminder_pass
+from app.models.user import User
+from app.services.notifications import _format_event_when, _run_event_reminder_pass
 from app.testing import (
     create_calendar_event,
     create_guild,
@@ -58,6 +59,48 @@ async def _reminders_for(session: AsyncSession, user_id: int) -> list[Notificati
         )
     )
     return list(result.all())
+
+
+@pytest.mark.unit
+def test_format_event_when_localizes_to_recipient_timezone():
+    """A timed event renders in the recipient's IANA timezone with its abbrev."""
+    event = CalendarEvent(
+        title="Sync",
+        start_at=datetime(2026, 7, 1, 21, 30, tzinfo=timezone.utc),
+        end_at=datetime(2026, 7, 1, 22, 30, tzinfo=timezone.utc),
+        all_day=False,
+    )
+    la = User(timezone="America/Los_Angeles")
+    assert _format_event_when(event, la) == "Wed, Jul 1, 2026 at 2:30 PM PDT"
+
+    utc_user = User(timezone="UTC")
+    assert _format_event_when(event, utc_user) == "Wed, Jul 1, 2026 at 9:30 PM UTC"
+
+
+@pytest.mark.unit
+def test_format_event_when_all_day_omits_time_and_zone():
+    """All-day events show just the date, regardless of recipient timezone."""
+    event = CalendarEvent(
+        title="Holiday",
+        start_at=datetime(2026, 7, 1, 0, 0, tzinfo=timezone.utc),
+        end_at=datetime(2026, 7, 1, 23, 59, tzinfo=timezone.utc),
+        all_day=True,
+    )
+    assert _format_event_when(event, User(timezone="Asia/Tokyo")) == "Wed, Jul 1, 2026"
+
+
+@pytest.mark.unit
+def test_format_event_when_falls_back_on_bad_timezone():
+    """An unrecognized timezone string falls back to UTC instead of raising."""
+    event = CalendarEvent(
+        title="Sync",
+        start_at=datetime(2026, 7, 1, 21, 30, tzinfo=timezone.utc),
+        end_at=datetime(2026, 7, 1, 22, 30, tzinfo=timezone.utc),
+        all_day=False,
+    )
+    assert _format_event_when(event, User(timezone="Not/AZone")) == (
+        "Wed, Jul 1, 2026 at 9:30 PM UTC"
+    )
 
 
 @pytest.mark.integration

--- a/frontend/public/locales/en/events.json
+++ b/frontend/public/locales/en/events.json
@@ -10,7 +10,6 @@
   "eventCreated": "Event created",
   "eventUpdated": "Event updated",
   "eventDeleted": "Event deleted",
-
   "eventTitle": "Title",
   "titlePlaceholder": "Event title",
   "description": "Description",
@@ -19,30 +18,28 @@
   "locationPlaceholder": "Add a location or link...",
   "startDate": "Start",
   "endDate": "End",
+  "startTime": "Start time",
+  "endTime": "End time",
   "allDay": "All day",
   "color": "Color",
-
   "attendees": "Attendees",
   "addAttendee": "Add attendee",
   "removeAttendee": "Remove attendee",
   "noAttendees": "No attendees",
   "attendeeCount_one": "{{count}} attendee",
   "attendeeCount_other": "{{count}} attendees",
-
   "rsvp": "RSVP",
   "rsvpPending": "Pending",
   "rsvpAccepted": "Accepted",
   "rsvpDeclined": "Declined",
   "rsvpTentative": "Tentative",
   "rsvpUpdated": "RSVP updated",
-
   "recurrence": "Recurrence",
   "noRecurrence": "Does not repeat",
   "daily": "Daily",
   "weekly": "Weekly",
   "monthly": "Monthly",
   "yearly": "Yearly",
-
   "permissions": "Permissions",
   "rolePermissions": "Role Permissions",
   "userPermissions": "User Permissions",
@@ -59,7 +56,6 @@
   "noRolePermissions": "No role permissions set.",
   "noUserPermissions": "No user permissions set.",
   "permissionsUpdated": "Permissions updated",
-
   "settings": "Settings",
   "details": "Details",
   "access": "Access",
@@ -70,7 +66,6 @@
   "changeAccess": "Change access",
   "removing": "Removing...",
   "addAllCount": "Add all ({{count}})",
-
   "filters": {
     "heading": "Filters",
     "show": "Show filters",
@@ -81,7 +76,6 @@
     "allInitiatives": "All initiatives",
     "noMatchingEvents": "No matching events"
   },
-
   "loading": "Loading...",
   "loadError": "Failed to load events",
   "loadingEvent": "Loading event...",
@@ -94,10 +88,8 @@
   "noAccessDescription": "You don't have permission to view this event.",
   "backToEvents": "Back to events",
   "error": "Something went wrong",
-
   "initiative": "Initiative",
   "selectInitiative": "Select initiative",
-
   "deleteEventConfirm": "The event will be sent to the trash. You can restore it from Settings → Trash before the retention period ends.",
   "dangerZoneDescription": "Destructive actions. Deleted events go to the trash and can be restored before the retention period ends.",
   "settingsDescription": "Manage event details, access, and advanced options.",
@@ -111,14 +103,12 @@
   "tags": "Tags",
   "noTags": "No tags",
   "properties": "Properties",
-
   "today": "Today",
   "upcoming": "Upcoming",
   "past": "Past",
-
   "export": {
     "exportIcs": "Export .ics",
-    "exporting": "Exporting\u2026",
+    "exporting": "Exporting…",
     "exportError": "Failed to export events"
   },
   "import": {
@@ -128,14 +118,14 @@
     "uploadFileLabel": "Choose .ics file",
     "selectInitiative": "Import to initiative",
     "parseButton": "Preview",
-    "parsing": "Parsing\u2026",
+    "parsing": "Parsing…",
     "parseFailed": "Failed to parse .ics file",
     "noEventsFound": "No events found in the file.",
     "foundEvents_one": "Found {{count}} event",
     "foundEvents_other": "Found {{count}} events",
     "hasRecurring": "Includes recurring events",
     "importButton": "Import Events",
-    "importing": "Importing\u2026",
+    "importing": "Importing…",
     "eventsCreated_one": "{{count}} event created",
     "eventsCreated_other": "{{count}} events created",
     "eventsFailed_one": "{{count}} event failed",

--- a/frontend/public/locales/es/events.json
+++ b/frontend/public/locales/es/events.json
@@ -18,6 +18,8 @@
   "locationPlaceholder": "Agregar una ubicación o enlace...",
   "startDate": "Inicio",
   "endDate": "Fin",
+  "startTime": "Hora de inicio",
+  "endTime": "Hora de fin",
   "allDay": "Todo el día",
   "color": "Color",
   "attendees": "Asistentes",
@@ -104,10 +106,9 @@
   "today": "Hoy",
   "upcoming": "Próximos",
   "past": "Pasados",
-
   "export": {
     "exportIcs": "Exportar .ics",
-    "exporting": "Exportando\u2026",
+    "exporting": "Exportando…",
     "exportError": "Error al exportar eventos"
   },
   "import": {
@@ -117,14 +118,14 @@
     "uploadFileLabel": "Elegir archivo .ics",
     "selectInitiative": "Importar a iniciativa",
     "parseButton": "Vista previa",
-    "parsing": "Analizando\u2026",
+    "parsing": "Analizando…",
     "parseFailed": "Error al analizar el archivo .ics",
     "noEventsFound": "No se encontraron eventos en el archivo.",
     "foundEvents_one": "Se encontró {{count}} evento",
     "foundEvents_other": "Se encontraron {{count}} eventos",
     "hasRecurring": "Incluye eventos recurrentes",
     "importButton": "Importar eventos",
-    "importing": "Importando\u2026",
+    "importing": "Importando…",
     "eventsCreated_one": "{{count}} evento creado",
     "eventsCreated_other": "{{count}} eventos creados",
     "eventsFailed_one": "{{count}} evento fallido",

--- a/frontend/public/locales/fr/events.json
+++ b/frontend/public/locales/fr/events.json
@@ -18,6 +18,8 @@
   "locationPlaceholder": "Ajouter un lieu ou un lien...",
   "startDate": "Début",
   "endDate": "Fin",
+  "startTime": "Heure de début",
+  "endTime": "Heure de fin",
   "allDay": "Toute la journée",
   "color": "Couleur",
   "attendees": "Participants",
@@ -104,10 +106,9 @@
   "today": "Aujourd'hui",
   "upcoming": "À venir",
   "past": "Passés",
-
   "export": {
     "exportIcs": "Exporter .ics",
-    "exporting": "Exportation\u2026",
+    "exporting": "Exportation…",
     "exportError": "Échec de l'exportation des événements"
   },
   "import": {
@@ -117,14 +118,14 @@
     "uploadFileLabel": "Choisir un fichier .ics",
     "selectInitiative": "Importer dans l'initiative",
     "parseButton": "Aperçu",
-    "parsing": "Analyse\u2026",
+    "parsing": "Analyse…",
     "parseFailed": "Échec de l'analyse du fichier .ics",
     "noEventsFound": "Aucun événement trouvé dans le fichier.",
     "foundEvents_one": "{{count}} événement trouvé",
     "foundEvents_other": "{{count}} événements trouvés",
     "hasRecurring": "Comprend des événements récurrents",
     "importButton": "Importer les événements",
-    "importing": "Importation\u2026",
+    "importing": "Importation…",
     "eventsCreated_one": "{{count}} événement créé",
     "eventsCreated_other": "{{count}} événements créés",
     "eventsFailed_one": "{{count}} événement échoué",

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -195,6 +195,31 @@ function parseEntry(entry: CalendarEntry): { start: Date; end: Date } {
   return { start: parseISO(entry.startAt), end: parseISO(entry.endAt) };
 }
 
+/**
+ * Clip a timed entry to a single day, returning the fractional start/end hours
+ * (0–24) of the portion that falls on `day`, or null when it doesn't overlap.
+ * Multi-day timed events use this so each day renders only its slice: the start
+ * day runs from its start time to midnight, any middle day fills 0–24, and the
+ * end day runs from midnight to its end time.
+ */
+function daySegmentHours(
+  day: Date,
+  entry: CalendarEntry
+): { startHour: number; endHour: number } | null {
+  const { start, end } = parseEntry(entry);
+  if (Number.isNaN(start.getTime())) return null;
+  const safeEnd = Number.isNaN(end.getTime()) ? start : end;
+  const dayStart = startOfDay(day);
+  const nextDay = addDays(dayStart, 1);
+  if (safeEnd <= dayStart || start >= nextDay) return null;
+  const segStart = start < dayStart ? dayStart : start;
+  const segEnd = safeEnd > nextDay ? nextDay : safeEnd;
+  const startHour = (segStart.getTime() - dayStart.getTime()) / 3_600_000;
+  let endHour = (segEnd.getTime() - dayStart.getTime()) / 3_600_000;
+  if (endHour <= startHour) endHour = Math.min(startHour + 1, 24);
+  return { startHour, endHour };
+}
+
 function formatTime(date: Date): string {
   const h = getHours(date);
   const m = getMinutes(date);
@@ -782,33 +807,37 @@ function WeekView({
     return eachDayOfInterval({ start, end: addDays(start, 6) });
   }, [focusDate, weekStartsOn]);
 
+  // The top span bar holds ONLY all-day entries. Timed entries — including
+  // multi-day ones — render as clipped blocks in each day's time grid below.
+  const allDayEntries = useMemo(() => entries.filter((e) => e.allDay), [entries]);
+  const timedEntries = useMemo(() => entries.filter((e) => !e.allDay), [entries]);
+
   const { spans, singleDay } = useMemo(
-    () => computeSpanPlacements(weekDays, entries),
-    [weekDays, entries]
+    () => computeSpanPlacements(weekDays, allDayEntries),
+    [weekDays, allDayEntries]
   );
 
-  // Build timed entries by date (single-day non-all-day entries only)
+  // A timed entry shows on every day it overlaps (multi-day events repeat,
+  // clipped to each day's slice via daySegmentHours).
   const timedByDate = useMemo(() => {
     const map = new Map<string, CalendarEntry[]>();
-    for (const [key, dayEntries] of singleDay) {
-      map.set(
-        key,
-        dayEntries.filter((e) => !e.allDay)
-      );
+    for (const day of weekDays) {
+      const list = timedEntries.filter((e) => daySegmentHours(day, e) !== null);
+      if (list.length) map.set(dateKey(day), list);
     }
     return map;
-  }, [singleDay]);
+  }, [weekDays, timedEntries]);
 
-  // Also collect single-day all-day entries for the span area
+  // Single-day all-day entries shown as one-column chips in the span area.
+  // (`singleDay` only holds all-day entries now, since computeSpanPlacements
+  // was given the all-day subset.)
   const allDaySingles = useMemo(() => {
     const result: SpanPlacement[] = [];
     for (const [key, dayEntries] of singleDay) {
       const col = weekDays.findIndex((d) => dateKey(d) === key);
       if (col === -1) continue;
       for (const entry of dayEntries) {
-        if (entry.allDay) {
-          result.push({ entry, startCol: col, spanCols: 1, lane: 0, showTitle: true });
-        }
+        result.push({ entry, startCol: col, spanCols: 1, lane: 0, showTitle: true });
       }
     }
     return result;
@@ -950,10 +979,9 @@ function WeekView({
               lane: number;
             }[] = [];
             for (const entry of dayEntries) {
-              const { start, end } = parseEntry(entry);
-              const sH = getHours(start) + getMinutes(start) / 60;
-              const eH = getHours(end) + getMinutes(end) / 60;
-              dayBlocks.push({ entry, startHour: sH, endHour: eH <= sH ? sH + 1 : eH, lane: 0 });
+              const seg = daySegmentHours(day, entry);
+              if (!seg) continue;
+              dayBlocks.push({ entry, startHour: seg.startHour, endHour: seg.endHour, lane: 0 });
             }
             dayBlocks.sort(
               (a, b) =>
@@ -1016,8 +1044,12 @@ function WeekView({
                   const leftPct = (block.lane / dayMaxLane) * 100;
 
                   return (
+                    // A multi-day timed event renders one block per day, so the
+                    // dnd-kit id must include the day to stay unique (data.entry
+                    // is unchanged, so reschedule routing is identical).
                     <DraggableEntryButton
-                      key={block.entry.id}
+                      key={`${block.entry.id}-${key}`}
+                      dragId={`${block.entry.id}-${key}`}
                       entry={block.entry}
                       enabled={dndEnabled}
                       onSelect={onEntryClick}
@@ -1101,10 +1133,9 @@ function DayView({
   const { blocks, maxLane } = useMemo(() => {
     const result: TimedBlock[] = [];
     for (const entry of timedEntries) {
-      const { start, end } = parseEntry(entry);
-      const sH = getHours(start) + getMinutes(start) / 60;
-      const eH = getHours(end) + getMinutes(end) / 60;
-      result.push({ entry, startHour: sH, endHour: eH <= sH ? sH + 1 : eH, lane: 0 });
+      const seg = daySegmentHours(focusDate, entry);
+      if (!seg) continue;
+      result.push({ entry, startHour: seg.startHour, endHour: seg.endHour, lane: 0 });
     }
     // Sort and assign lanes for overlapping
     result.sort(
@@ -1127,7 +1158,7 @@ function DayView({
       }
     }
     return { blocks: result, maxLane: Math.max(laneEnds.length, 1) };
-  }, [timedEntries]);
+  }, [timedEntries, focusDate]);
 
   return (
     <div className="space-y-3">

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -10,6 +10,7 @@ import type {
 import { TaskRecurrenceSelector } from "@/components/projects/TaskRecurrenceSelector";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DateTimePicker } from "@/components/ui/date-time-picker";
 import {
   Dialog,
   DialogContent,
@@ -29,18 +30,19 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/hooks/useAuth";
 import { useCreateCalendarEvent } from "@/hooks/useCalendarEvents";
 import { useInitiativeMembers } from "@/hooks/useInitiatives";
 import type { DialogProps } from "@/types/dialog";
 
-// Generate half-hour time slots
-const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
-  const hour = Math.floor(i / 2);
-  const minute = i % 2 === 0 ? "00" : "30";
-  const hh = String(hour).padStart(2, "0");
-  const label = `${hour === 0 ? 12 : hour > 12 ? hour - 12 : hour}:${minute} ${hour < 12 ? "AM" : "PM"}`;
-  return { value: `${hh}:${minute}`, label };
-});
+import {
+  datesAreValid,
+  endTimeOptionsFor,
+  offsetEndTime,
+  parseLocalDate,
+  shiftEndPreservingDuration,
+  TIME_OPTIONS,
+} from "./eventDateTime";
 
 type CreateEventDialogProps = DialogProps & {
   initiativeId: number;
@@ -58,6 +60,7 @@ export const CreateEventDialog = ({
   onSuccess,
 }: CreateEventDialogProps) => {
   const { t } = useTranslation(["events", "common"]);
+  const { user } = useAuth();
 
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -94,15 +97,15 @@ export const CreateEventDialog = ({
 
   useEffect(() => {
     if (open) {
+      // The creator attends their own event by default.
+      setAttendeeIds(user ? [user.id] : []);
       if (defaultStartDate) {
         setStartDate(defaultStartDate);
         setEndDate(defaultStartDate);
       }
       if (defaultStartTime) {
         setStartTime(defaultStartTime);
-        const [h, m] = defaultStartTime.split(":").map(Number);
-        const endH = Math.min(h + 1, 23);
-        setEndTime(`${String(endH).padStart(2, "0")}:${String(m).padStart(2, "0")}`);
+        setEndTime(offsetEndTime(defaultStartTime));
       }
     } else {
       setTitle("");
@@ -117,7 +120,40 @@ export const CreateEventDialog = ({
       setRecurrence(null);
       setRecurrenceStrategy("fixed");
     }
-  }, [open, defaultStartDate, defaultStartTime]);
+  }, [open, defaultStartDate, defaultStartTime, user]);
+
+  // Apply a new start date/time, shifting the end so the event keeps its
+  // current length (a 90-minute event stays 90 minutes; a multi-day event keeps
+  // its span). The end may land on a later day — that's how multi-day timed
+  // events are created.
+  const applyStart = (nextDate: string, nextTime: string) => {
+    setStartDate(nextDate);
+    setStartTime(nextTime);
+    const shifted = shiftEndPreservingDuration(
+      startDate,
+      startTime,
+      endDate,
+      endTime,
+      nextDate,
+      nextTime
+    );
+    if (shifted) {
+      setEndDate(shifted.endDate);
+      setEndTime(shifted.endTime);
+    }
+  };
+
+  const endTimeOptions = useMemo(
+    () => endTimeOptionsFor(startDate, endDate, startTime),
+    [startDate, endDate, startTime]
+  );
+
+  // Guard submit against an end that lands before the start (possible after the
+  // user edits the end date/time independently).
+  const datesValid = useMemo(
+    () => datesAreValid(allDay, startDate, startTime, endDate, endTime),
+    [allDay, startDate, endDate, startTime, endTime]
+  );
 
   const createEvent = useCreateCalendarEvent({
     onSuccess: (event) => {
@@ -127,11 +163,11 @@ export const CreateEventDialog = ({
   });
 
   const isCreating = createEvent.isPending;
-  const canSubmit = title.trim() && startDate && !isCreating;
+  const canSubmit = title.trim() && datesValid && !isCreating;
 
   const handleSubmit = () => {
     const trimmedTitle = title.trim();
-    if (!trimmedTitle || !startDate) return;
+    if (!trimmedTitle || !datesValid) return;
 
     let startISO: string;
     let endISO: string;
@@ -140,7 +176,7 @@ export const CreateEventDialog = ({
       endISO = new Date(`${endDate || startDate}T23:59:59`).toISOString();
     } else {
       startISO = new Date(`${startDate}T${startTime}:00`).toISOString();
-      endISO = new Date(`${startDate}T${endTime}:00`).toISOString();
+      endISO = new Date(`${endDate || startDate}T${endTime}:00`).toISOString();
     }
 
     createEvent.mutate({
@@ -227,44 +263,44 @@ export const CreateEventDialog = ({
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label>{t("startDate")}</Label>
-                <Input
-                  type="date"
+                <DateTimePicker
                   value={startDate}
-                  onChange={(e) => {
-                    setStartDate(e.target.value);
-                    if (!endDate || e.target.value > endDate) {
-                      setEndDate(e.target.value);
+                  includeTime={false}
+                  onChange={(next) => {
+                    setStartDate(next);
+                    if (!endDate || next > endDate) {
+                      setEndDate(next);
                     }
                   }}
                 />
               </div>
               <div className="space-y-2">
                 <Label>{t("endDate")}</Label>
-                <Input
-                  type="date"
+                <DateTimePicker
                   value={endDate}
-                  onChange={(e) => setEndDate(e.target.value)}
-                  min={startDate || undefined}
+                  includeTime={false}
+                  onChange={setEndDate}
+                  calendarProps={(() => {
+                    const min = parseLocalDate(startDate);
+                    return min ? { disabled: { before: min } } : undefined;
+                  })()}
                 />
               </div>
             </div>
           ) : (
             <div className="space-y-3">
-              <div className="space-y-2">
-                <Label>{t("startDate")}</Label>
-                <Input
-                  type="date"
-                  value={startDate}
-                  onChange={(e) => {
-                    setStartDate(e.target.value);
-                    setEndDate(e.target.value);
-                  }}
-                />
-              </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label>{t("startDate")}</Label>
-                  <Select value={startTime} onValueChange={setStartTime}>
+                  <DateTimePicker
+                    value={startDate}
+                    includeTime={false}
+                    onChange={(next) => applyStart(next, startTime)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>{t("startTime")}</Label>
+                  <Select value={startTime} onValueChange={(value) => applyStart(startDate, value)}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
@@ -277,14 +313,28 @@ export const CreateEventDialog = ({
                     </SelectContent>
                   </Select>
                 </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label>{t("endDate")}</Label>
+                  <DateTimePicker
+                    value={endDate}
+                    includeTime={false}
+                    onChange={setEndDate}
+                    calendarProps={(() => {
+                      const min = parseLocalDate(startDate);
+                      return min ? { disabled: { before: min } } : undefined;
+                    })()}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>{t("endTime")}</Label>
                   <Select value={endTime} onValueChange={setEndTime}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent className="max-h-60">
-                      {TIME_OPTIONS.map((opt) => (
+                      {endTimeOptions.map((opt) => (
                         <SelectItem key={opt.value} value={opt.value}>
                           {opt.label}
                         </SelectItem>

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -40,6 +40,7 @@ import {
   endTimeOptionsFor,
   offsetEndTime,
   parseLocalDate,
+  reconcileEndTime,
   shiftEndPreservingDuration,
   TIME_OPTIONS,
 } from "./eventDateTime";
@@ -320,7 +321,10 @@ export const CreateEventDialog = ({
                   <DateTimePicker
                     value={endDate}
                     includeTime={false}
-                    onChange={setEndDate}
+                    onChange={(next) => {
+                      setEndDate(next);
+                      setEndTime(reconcileEndTime(startDate, startTime, next, endTime));
+                    }}
                     calendarProps={(() => {
                       const min = parseLocalDate(startDate);
                       return min ? { disabled: { before: min } } : undefined;

--- a/frontend/src/components/initiativeTools/events/eventDateTime.test.ts
+++ b/frontend/src/components/initiativeTools/events/eventDateTime.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  datesAreValid,
+  endTimeOptionsFor,
+  offsetEndTime,
+  shiftEndPreservingDuration,
+  toTimeSlotRounded,
+} from "./eventDateTime";
+
+describe("offsetEndTime", () => {
+  it("adds one hour, clamping at the end of the day", () => {
+    expect(offsetEndTime("09:00")).toBe("10:00");
+    expect(offsetEndTime("23:00")).toBe("23:30"); // clamped to last slot
+  });
+});
+
+describe("shiftEndPreservingDuration", () => {
+  it("keeps a same-day duration when the start moves", () => {
+    // 1-hour event; move start to 16:00 → end follows to 17:00.
+    expect(
+      shiftEndPreservingDuration(
+        "2026-07-01",
+        "09:00",
+        "2026-07-01",
+        "10:00",
+        "2026-07-01",
+        "16:00"
+      )
+    ).toEqual({
+      endDate: "2026-07-01",
+      endTime: "17:00",
+    });
+  });
+
+  it("preserves a multi-day span and rolls the end onto a later day", () => {
+    // 25-hour event (Jul 1 09:00 → Jul 2 10:00); move start to Jul 5 09:00.
+    expect(
+      shiftEndPreservingDuration(
+        "2026-07-01",
+        "09:00",
+        "2026-07-02",
+        "10:00",
+        "2026-07-05",
+        "09:00"
+      )
+    ).toEqual({
+      endDate: "2026-07-06",
+      endTime: "10:00",
+    });
+  });
+
+  it("defaults to a one-hour duration when there is no prior end", () => {
+    expect(shiftEndPreservingDuration("", "09:00", "", "10:00", "2026-07-01", "14:00")).toEqual({
+      endDate: "2026-07-01",
+      endTime: "15:00",
+    });
+  });
+});
+
+describe("endTimeOptionsFor", () => {
+  it("hides slots at or before the start on the same day", () => {
+    const opts = endTimeOptionsFor("2026-07-01", "2026-07-01", "09:00");
+    expect(opts.some((o) => o.value === "09:00")).toBe(false);
+    expect(opts.some((o) => o.value === "09:30")).toBe(true);
+  });
+
+  it("allows every slot when the end is on a later day", () => {
+    const opts = endTimeOptionsFor("2026-07-01", "2026-07-03", "09:00");
+    expect(opts).toHaveLength(48);
+    expect(opts.some((o) => o.value === "00:00")).toBe(true);
+  });
+});
+
+describe("datesAreValid", () => {
+  it("accepts a multi-day timed range", () => {
+    expect(datesAreValid(false, "2026-07-01", "14:00", "2026-07-03", "16:00")).toBe(true);
+  });
+
+  it("rejects an end before the start", () => {
+    expect(datesAreValid(false, "2026-07-03", "16:00", "2026-07-01", "14:00")).toBe(false);
+  });
+
+  it("allows an all-day event ending on the same day", () => {
+    expect(datesAreValid(true, "2026-07-01", "00:00", "2026-07-01", "00:00")).toBe(true);
+  });
+});
+
+describe("toTimeSlotRounded", () => {
+  it("snaps an off-grid time to the nearest half hour", () => {
+    expect(toTimeSlotRounded(new Date("2026-07-01T14:15:00"))).toBe("14:30");
+    expect(toTimeSlotRounded(new Date("2026-07-01T14:07:00"))).toBe("14:00");
+  });
+});

--- a/frontend/src/components/initiativeTools/events/eventDateTime.test.ts
+++ b/frontend/src/components/initiativeTools/events/eventDateTime.test.ts
@@ -4,6 +4,7 @@ import {
   datesAreValid,
   endTimeOptionsFor,
   offsetEndTime,
+  reconcileEndTime,
   shiftEndPreservingDuration,
   toTimeSlotRounded,
 } from "./eventDateTime";
@@ -83,6 +84,22 @@ describe("datesAreValid", () => {
 
   it("allows an all-day event ending on the same day", () => {
     expect(datesAreValid(true, "2026-07-01", "00:00", "2026-07-01", "00:00")).toBe(true);
+  });
+});
+
+describe("reconcileEndTime", () => {
+  it("snaps a now-invalid end time forward when the end rolls back to the start day", () => {
+    // End was 12:00 on a later day; rolled back to the start day where the
+    // start is 14:00 — 12:00 is no longer selectable, so snap to 15:00.
+    expect(reconcileEndTime("2026-07-01", "14:00", "2026-07-01", "12:00")).toBe("15:00");
+  });
+
+  it("leaves a still-valid same-day end time untouched", () => {
+    expect(reconcileEndTime("2026-07-01", "09:00", "2026-07-01", "10:00")).toBe("10:00");
+  });
+
+  it("leaves the end time untouched when the end is on a later day", () => {
+    expect(reconcileEndTime("2026-07-01", "14:00", "2026-07-03", "12:00")).toBe("12:00");
   });
 });
 

--- a/frontend/src/components/initiativeTools/events/eventDateTime.ts
+++ b/frontend/src/components/initiativeTools/events/eventDateTime.ts
@@ -1,0 +1,104 @@
+// Shared date/time helpers for the event create dialog and edit page so both
+// use the identical pickers, half-hour slots, and duration-preserving logic.
+
+export const DEFAULT_DURATION_MINUTES = 60;
+const DAY_END_MINUTES = 23 * 60 + 30; // last selectable slot (23:30)
+
+// Half-hour time slots: { value: "HH:MM", label: "h:MM AM/PM" }.
+export const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
+  const hour = Math.floor(i / 2);
+  const minute = i % 2 === 0 ? "00" : "30";
+  const hh = String(hour).padStart(2, "0");
+  const label = `${hour === 0 ? 12 : hour > 12 ? hour - 12 : hour}:${minute} ${hour < 12 ? "AM" : "PM"}`;
+  return { value: `${hh}:${minute}`, label };
+});
+
+export const toMinutes = (slot: string): number => {
+  const [h, m] = slot.split(":").map(Number);
+  return h * 60 + m;
+};
+
+export const toSlot = (minutes: number): string => {
+  const clamped = Math.max(0, Math.min(minutes, DAY_END_MINUTES));
+  return `${String(Math.floor(clamped / 60)).padStart(2, "0")}:${String(clamped % 60).padStart(2, "0")}`;
+};
+
+// Slot one hour after `start`, used to seed the end time on first open.
+export const offsetEndTime = (start: string): string =>
+  toSlot(toMinutes(start) + DEFAULT_DURATION_MINUTES);
+
+// Parse a "yyyy-MM-dd" string as a local date to avoid the UTC-midnight shift
+// that `new Date("yyyy-MM-dd")` introduces in negative-offset timezones.
+export const parseLocalDate = (value: string): Date | undefined => {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  return match ? new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3])) : undefined;
+};
+
+// Combine a "yyyy-MM-dd" date and "HH:MM" slot into a local Date (null if no date).
+export const composeDateTime = (date: string, time: string): Date | null => {
+  if (!date) return null;
+  const d = new Date(`${date}T${time || "00:00"}:00`);
+  return Number.isNaN(d.getTime()) ? null : d;
+};
+
+export const toDateKey = (d: Date): string =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+export const toTimeSlot = (d: Date): string =>
+  `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+
+// Local "HH:MM" snapped to the nearest half-hour slot, so a Select bound to
+// TIME_OPTIONS can display the time of an existing (possibly off-grid) event.
+export const toTimeSlotRounded = (d: Date): string =>
+  toSlot(Math.round((d.getHours() * 60 + d.getMinutes()) / 30) * 30);
+
+/**
+ * Given the current start/end (each a date + time slot) and a new start,
+ * return the end that keeps the event's current length. A 90-minute event
+ * stays 90 minutes; a multi-day event keeps its span (the end may land on a
+ * later day). Returns null when the next start can't be parsed.
+ */
+export const shiftEndPreservingDuration = (
+  prevStartDate: string,
+  prevStartTime: string,
+  prevEndDate: string,
+  prevEndTime: string,
+  nextDate: string,
+  nextTime: string
+): { endDate: string; endTime: string } | null => {
+  const nextStart = composeDateTime(nextDate, nextTime);
+  if (!nextStart) return null;
+  const prevStart = composeDateTime(prevStartDate, prevStartTime);
+  const prevEnd = composeDateTime(prevEndDate || prevStartDate, prevEndTime);
+  const durationMs = prevStart && prevEnd ? prevEnd.getTime() - prevStart.getTime() : 0;
+  const keepMs = durationMs > 0 ? durationMs : DEFAULT_DURATION_MINUTES * 60_000;
+  const nextEnd = new Date(nextStart.getTime() + keepMs);
+  return { endDate: toDateKey(nextEnd), endTime: toTimeSlot(nextEnd) };
+};
+
+// End-time slots offered for the given range. On the same day the end must be
+// after the start, so earlier slots are hidden; across days every time is valid.
+export const endTimeOptionsFor = (startDate: string, endDate: string, startTime: string) => {
+  if (startDate && endDate && endDate !== startDate) return TIME_OPTIONS;
+  const startMinutes = toMinutes(startTime);
+  return TIME_OPTIONS.filter((opt) => toMinutes(opt.value) > startMinutes);
+};
+
+// Whether the start/end pair is a valid (non-negative-length) range.
+export const datesAreValid = (
+  allDay: boolean,
+  startDate: string,
+  startTime: string,
+  endDate: string,
+  endTime: string
+): boolean => {
+  if (!startDate) return false;
+  if (allDay) {
+    const s = parseLocalDate(startDate);
+    const e = parseLocalDate(endDate || startDate);
+    return !!s && !!e && e >= s;
+  }
+  const s = composeDateTime(startDate, startTime);
+  const e = composeDateTime(endDate || startDate, endTime);
+  return !!s && !!e && e > s;
+};

--- a/frontend/src/components/initiativeTools/events/eventDateTime.ts
+++ b/frontend/src/components/initiativeTools/events/eventDateTime.ts
@@ -76,6 +76,22 @@ export const shiftEndPreservingDuration = (
   return { endDate: toDateKey(nextEnd), endTime: toTimeSlot(nextEnd) };
 };
 
+// When the end date moves onto the start day and the current end time is no
+// longer after the start, snap it forward so the end-time Select never shows a
+// value that its filtered options exclude. Across days (or when still valid)
+// the end time is left untouched.
+export const reconcileEndTime = (
+  startDate: string,
+  startTime: string,
+  nextEndDate: string,
+  endTime: string
+): string => {
+  if (nextEndDate === startDate && toMinutes(endTime) <= toMinutes(startTime)) {
+    return offsetEndTime(startTime);
+  }
+  return endTime;
+};
+
 // End-time slots offered for the given range. On the same day the end must be
 // after the start, so earlier slots are hidden; across days every time is valid.
 export const endTimeOptionsFor = (startDate: string, endDate: string, startTime: string) => {

--- a/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
@@ -6,8 +6,19 @@ import { useTranslation } from "react-i18next";
 import type {
   PropertyDefinitionRead,
   PropertySummary,
+  TagSummary,
 } from "@/api/generated/initiativeAPI.schemas";
+import {
+  datesAreValid,
+  endTimeOptionsFor,
+  parseLocalDate,
+  shiftEndPreservingDuration,
+  TIME_OPTIONS,
+  toDateKey,
+  toTimeSlotRounded,
+} from "@/components/initiativeTools/events/eventDateTime";
 import { AddPropertyButton, PropertyList } from "@/components/properties";
+import { TagPicker } from "@/components/tags";
 import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
@@ -19,16 +30,26 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { DateTimePicker } from "@/components/ui/date-time-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import {
   useCalendarEvent,
   useDeleteCalendarEvent,
   useSetEventAttendees,
+  useSetEventTags,
   useUpdateCalendarEvent,
 } from "@/hooks/useCalendarEvents";
 import { useInitiativeMembers } from "@/hooks/useInitiatives";
@@ -47,10 +68,13 @@ export function EventSettingsPage() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [location, setLocation] = useState("");
-  const [startAt, setStartAt] = useState("");
-  const [endAt, setEndAt] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [startTime, setStartTime] = useState("09:00");
+  const [endDate, setEndDate] = useState("");
+  const [endTime, setEndTime] = useState("10:00");
   const [allDay, setAllDay] = useState(false);
   const [color, setColor] = useState("");
+  const [tags, setTags] = useState<TagSummary[]>([]);
   const [attendeeIds, setAttendeeIds] = useState<number[]>([]);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
@@ -135,13 +159,47 @@ export function EventSettingsPage() {
       setTitle(event.title);
       setDescription(event.description ?? "");
       setLocation(event.location ?? "");
-      setStartAt(toLocalDateTimeString(new Date(event.start_at)));
-      setEndAt(toLocalDateTimeString(new Date(event.end_at)));
+      const start = new Date(event.start_at);
+      const end = new Date(event.end_at);
+      setStartDate(toDateKey(start));
+      setStartTime(toTimeSlotRounded(start));
+      setEndDate(toDateKey(end));
+      setEndTime(toTimeSlotRounded(end));
       setAllDay(event.all_day);
       setColor(event.color ?? "");
+      setTags(event.tags ?? []);
       setAttendeeIds(event.attendees.map((a) => a.user_id));
     }
   }, [event]);
+
+  // Apply a new start date/time, shifting the end to keep the event's length
+  // (mirrors the create dialog; multi-day spans are preserved).
+  const applyStart = (nextDate: string, nextTime: string) => {
+    setStartDate(nextDate);
+    setStartTime(nextTime);
+    const shifted = shiftEndPreservingDuration(
+      startDate,
+      startTime,
+      endDate,
+      endTime,
+      nextDate,
+      nextTime
+    );
+    if (shifted) {
+      setEndDate(shifted.endDate);
+      setEndTime(shifted.endTime);
+    }
+  };
+
+  const endTimeOptions = useMemo(
+    () => endTimeOptionsFor(startDate, endDate, startTime),
+    [startDate, endDate, startTime]
+  );
+
+  const datesValid = useMemo(
+    () => datesAreValid(allDay, startDate, startTime, endDate, endTime),
+    [allDay, startDate, endDate, startTime, endTime]
+  );
 
   const updateEvent = useUpdateCalendarEvent(eventId, {
     onSuccess: () => toast.success(t("detailsUpdated")),
@@ -151,6 +209,14 @@ export function EventSettingsPage() {
     onSuccess: () => toast.success(t("detailsUpdated")),
   });
 
+  const setEventTags = useSetEventTags(eventId);
+
+  // Tags persist immediately on change (like tasks/documents), no Save button.
+  const handleTagsChange = (newTags: TagSummary[]) => {
+    setTags(newTags);
+    setEventTags.mutate(newTags.map((tag) => tag.id));
+  };
+
   const deleteEvent = useDeleteCalendarEvent({
     onSuccess: () => {
       toast.success(t("eventDeleted"));
@@ -159,15 +225,18 @@ export function EventSettingsPage() {
   });
 
   const handleSave = () => {
-    const startValue = allDay ? `${startAt.split("T")[0]}T00:00:00` : startAt;
-    const endValue = allDay ? `${endAt.split("T")[0]}T23:59:59` : endAt;
+    if (!datesValid) return;
+    const startValue = allDay ? `${startDate}T00:00:00` : `${startDate}T${startTime}:00`;
+    const endValue = allDay
+      ? `${endDate || startDate}T23:59:59`
+      : `${endDate || startDate}T${endTime}:00`;
 
     updateEvent.mutate({
       title: title.trim() || undefined,
       description: description.trim() || undefined,
       location: location.trim() || undefined,
-      start_at: startValue ? new Date(startValue).toISOString() : undefined,
-      end_at: endValue ? new Date(endValue).toISOString() : undefined,
+      start_at: new Date(startValue).toISOString(),
+      end_at: new Date(endValue).toISOString(),
       all_day: allDay,
       color: color || undefined,
     });
@@ -257,56 +326,101 @@ export function EventSettingsPage() {
           {allDay ? (
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label htmlFor="event-start">{t("startDate")}</Label>
-                <Input
-                  id="event-start"
-                  type="date"
-                  value={startAt.split("T")[0]}
-                  onChange={(e) => setStartAt(e.target.value)}
+                <Label>{t("startDate")}</Label>
+                <DateTimePicker
+                  value={startDate}
+                  includeTime={false}
+                  onChange={(next) => {
+                    setStartDate(next);
+                    if (!endDate || next > endDate) {
+                      setEndDate(next);
+                    }
+                  }}
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="event-end">{t("endDate")}</Label>
-                <Input
-                  id="event-end"
-                  type="date"
-                  value={endAt.split("T")[0]}
-                  onChange={(e) => setEndAt(e.target.value)}
-                  min={startAt.split("T")[0] || undefined}
+                <Label>{t("endDate")}</Label>
+                <DateTimePicker
+                  value={endDate}
+                  includeTime={false}
+                  onChange={setEndDate}
+                  calendarProps={(() => {
+                    const min = parseLocalDate(startDate);
+                    return min ? { disabled: { before: min } } : undefined;
+                  })()}
                 />
               </div>
             </div>
           ) : (
-            <div className="space-y-2">
-              <Label htmlFor="event-start">{t("startDate")}</Label>
-              <Input
-                id="event-start"
-                type="datetime-local"
-                value={startAt}
-                onChange={(e) => setStartAt(e.target.value)}
-              />
-              <Label htmlFor="event-end">{t("endDate")}</Label>
-              <Input
-                id="event-end"
-                type="datetime-local"
-                value={endAt}
-                onChange={(e) => setEndAt(e.target.value)}
-              />
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>{t("startDate")}</Label>
+                  <DateTimePicker
+                    value={startDate}
+                    includeTime={false}
+                    onChange={(next) => applyStart(next, startTime)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>{t("startTime")}</Label>
+                  <Select value={startTime} onValueChange={(value) => applyStart(startDate, value)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-60">
+                      {TIME_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>{t("endDate")}</Label>
+                  <DateTimePicker
+                    value={endDate}
+                    includeTime={false}
+                    onChange={setEndDate}
+                    calendarProps={(() => {
+                      const min = parseLocalDate(startDate);
+                      return min ? { disabled: { before: min } } : undefined;
+                    })()}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>{t("endTime")}</Label>
+                  <Select value={endTime} onValueChange={setEndTime}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-60">
+                      {endTimeOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
             </div>
           )}
 
           <div className="space-y-2">
             <Label htmlFor="event-color">{t("color")}</Label>
-            <Input
+            <ColorPickerPopover
               id="event-color"
-              type="color"
-              value={color || "#6366f1"}
-              onChange={(e) => setColor(e.target.value)}
-              className="h-10 w-20"
+              value={color || "#6366F1"}
+              onChange={setColor}
+              triggerLabel={t("color")}
             />
           </div>
 
-          <Button onClick={handleSave} disabled={updateEvent.isPending}>
+          <Button onClick={handleSave} disabled={updateEvent.isPending || !datesValid}>
             {updateEvent.isPending ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -367,6 +481,16 @@ export function EventSettingsPage() {
         </CardContent>
       </Card>
 
+      {/* Tags */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("tags")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TagPicker selectedTags={tags} onChange={handleTagsChange} />
+        </CardContent>
+      </Card>
+
       {/* Custom Properties */}
       <Card>
         <CardHeader>
@@ -412,9 +536,4 @@ export function EventSettingsPage() {
       />
     </div>
   );
-}
-
-function toLocalDateTimeString(date: Date): string {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }

--- a/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   datesAreValid,
   endTimeOptionsFor,
   parseLocalDate,
+  reconcileEndTime,
   shiftEndPreservingDuration,
   TIME_OPTIONS,
   toDateKey,
@@ -212,9 +213,15 @@ export function EventSettingsPage() {
   const setEventTags = useSetEventTags(eventId);
 
   // Tags persist immediately on change (like tasks/documents), no Save button.
+  // Optimistically update, then roll back to the prior selection if the save
+  // fails (the hook surfaces an error toast on its own).
   const handleTagsChange = (newTags: TagSummary[]) => {
+    const previous = tags;
     setTags(newTags);
-    setEventTags.mutate(newTags.map((tag) => tag.id));
+    setEventTags.mutate(
+      newTags.map((tag) => tag.id),
+      { onError: () => setTags(previous) }
+    );
   };
 
   const deleteEvent = useDeleteCalendarEvent({
@@ -384,7 +391,10 @@ export function EventSettingsPage() {
                   <DateTimePicker
                     value={endDate}
                     includeTime={false}
-                    onChange={setEndDate}
+                    onChange={(next) => {
+                      setEndDate(next);
+                      setEndTime(reconcileEndTime(startDate, startTime, next, endTime));
+                    }}
                     calendarProps={(() => {
                       const min = parseLocalDate(startDate);
                       return min ? { disabled: { before: min } } : undefined;


### PR DESCRIPTION
## Problem

A batch of calendar-event improvements: notification times were UTC-only and terse, timed events couldn't span dates, the create/edit forms were inconsistent, event tags couldn't be edited in the UI, and declined attendees still received event notifications.

## Changes

### Backend
- **Timezone-aware notification times** — event emails/push (invitation, reschedule, cancel, reminder) now render in the recipient's timezone in a readable form (e.g. `Wed, Jul 1, 2026 at 2:30 PM PDT`) instead of UTC.
- **Multi-day timed events** — dropped the 24-hour ceiling in the schema validator and update endpoint; `end >= start` still enforced.
- **RSVP-gated notifications** — declined attendees no longer get reschedule/update/cancellation notices, matching the reminder pass which already skipped them.

### Frontend
- **Create dialog** — auto-adds the creator to attendees; preserves event duration when the start changes (including multi-day spans); end-time dropdown limited to slots after the start; added an end-date picker so events can span days.
- **Calendar rendering** — multi-day *timed* events now draw across each day's time grid in week/day views (start day from its start time, full middle days, end day to its end time) rather than landing in the all-day bar; only all-day events use that bar. Per-day blocks get unique drag ids.
- **Event edit page** — now uses the same calendar date pickers, half-hour time selectors, and color picker as the create dialog, and gained a tag editor (matching tasks/documents; saves immediately).
- Shared the date/time logic between the dialog and edit page in a new `eventDateTime.ts` helper module.

### Schema / i18n
- No DB schema changes. Added `startTime`/`endTime` keys to the `events` namespace (en/es/fr).

## Testing
- Backend: `pytest app/api/v1/endpoints/calendar_events_test.py app/services/notifications_test.py` — 18 passed (new cases: multi-day create accepted, end-before-start rejected, declined attendees skipped on update/cancel, timezone formatting).
- Frontend: `pnpm test:run` — 573 passed (new `eventDateTime.test.ts` covering duration shift, end-time options, validity, snapping).
- `pnpm typecheck`, `pnpm biome check`, and `ruff check app/` all clean.

## Note for reviewers
Cancellation notices are also suppressed for declined attendees (for consistency) — easy to send those to everyone if you'd prefer.