### PR TITLE
Add guild table classification manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Internal: table classification manifest (`app/db/tenancy.py`) marking every table as shared or guild-scoped, with a test guarding completeness — the first step toward schema-per-guild tenancy.
 - **Events can span multiple days.** A timed event's end can now fall on a later day (the 24-hour limit is gone). The create dialog and edit page gained separate end-date pickers, and the calendar draws a multi-day timed event across each day it touches — in week and day views it fills the time grid on every day (start day from its start time, full middle days, end day up to its end time) rather than sitting in the all-day bar.
 - **Edit an event's tags.** The event settings page now has a tag picker (matching tasks and documents) to add or remove tags; changes save immediately.
 

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -27,6 +27,11 @@ from app.models.counter import Counter, CounterGroup, CounterGroupPermission, Co
 from app.models.upload import Upload
 from app.models.user_view_preference import UserViewPreference
 from app.models.access_grant import AccessGrant
+from app.models.user_token import UserToken
+from app.models.push_token import PushToken
+from app.models.auto_delegation_jti import AutoDelegationJti
+from app.models.task_assignment_digest import TaskAssignmentDigestItem
+from app.models.webhook_subscription import WebhookSubscription
 
 __all__ = [
     "User",
@@ -82,4 +87,9 @@ __all__ = [
     "CounterGroupRolePermission",
     "Upload",
     "UserViewPreference",
+    "UserToken",
+    "PushToken",
+    "AutoDelegationJti",
+    "TaskAssignmentDigestItem",
+    "WebhookSubscription",
 ]

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -1,0 +1,131 @@
+"""Authoritative table classification for schema-per-guild multi-tenancy.
+
+This module is the single source of truth for *where each table lives* once
+each guild becomes its own PostgreSQL schema:
+
+- **Shared tables** stay in the ``public`` schema. They are identity, the
+  tenancy roster, platform configuration, and per-user / cross-guild concerns
+  that are read *without* a guild context (login, "list my guilds", platform
+  admin, SSO auto-join, the notification inbox).
+- **Guild-scoped tables** move into a per-guild schema (``guild_<id>``). They
+  are the actual tenant content (initiatives, projects, tasks, documents,
+  calendar, queues, counters, tags, and their child/association tables).
+
+Every ``table=True`` model MUST appear in exactly one of the two sets below.
+``tenancy_test.py`` enforces this against ``SQLModel.metadata`` so that a new
+table cannot be added without an explicit placement decision — an unclassified
+guild-scoped table would silently leak across tenants.
+
+See ``history/schema-per-guild-design.md`` (§2 Table classification) for the
+rationale behind each placement, including the resolved "Bucket C" edge cases:
+``guild_invites`` / ``oidc_claim_mappings`` stay shared (read pre-routing,
+before guild membership exists); ``guild_settings`` / ``recent_views`` /
+``event_reminder_dispatches`` / ``task_assignment_digest_items`` are
+guild-scoped (always accessed with a guild context, background jobs visit each
+guild's schema in turn).
+"""
+
+from __future__ import annotations
+
+# --- Shared (stay in the ``public`` schema) ---------------------------------
+# Read without a guild context, or inherently cross-guild. Must never be
+# duplicated per schema.
+SHARED_TABLES: frozenset[str] = frozenset(
+    {
+        # Identity & per-user auth/devices (one user spans many guilds)
+        "users",
+        "user_api_keys",
+        "user_tokens",
+        "push_tokens",
+        "auto_delegation_jti_blocklist",
+        "user_view_preferences",  # personal UI state (filters/sort/view-mode)
+        # Tenancy roster — must be readable *before* a request is routed
+        "guilds",
+        "guild_memberships",
+        # Consumed pre-membership / pre-routing
+        "guild_invites",  # looked up by token before the user is a member
+        "oidc_claim_mappings",  # SSO auto-join rules, read across all guilds at login
+        # Platform-wide
+        "app_settings",  # OIDC / SMTP / branding config
+        "access_grants",  # PAM — inherently cross-guild (request -> approve -> scoped)
+        "notifications",  # per-user inbox spanning guilds (carries guild_id after split)
+    }
+)
+
+# --- Guild-scoped (move into ``guild_<id>`` schemas) ------------------------
+# The actual tenant content. Always accessed with a guild context.
+GUILD_SCOPED_TABLES: frozenset[str] = frozenset(
+    {
+        # Guild config that always reads with a guild context
+        "guild_settings",
+        "webhook_subscriptions",
+        # Initiatives + roles
+        "initiatives",
+        "initiative_members",
+        "initiative_roles",
+        "initiative_role_permissions",
+        # Projects + permissions / ordering / favorites / activity
+        "projects",
+        "project_documents",
+        "project_permissions",
+        "project_role_permissions",
+        "project_orders",
+        "project_favorites",
+        "project_tags",
+        # Tasks + children
+        "tasks",
+        "subtasks",
+        "task_assignees",
+        "task_statuses",
+        "task_tags",
+        "task_property_values",
+        "task_assignment_digest_items",
+        # Documents + versions / permissions / links
+        "documents",
+        "document_file_versions",
+        "document_permissions",
+        "document_role_permissions",
+        "document_tags",
+        "document_links",
+        "document_property_values",
+        # Comments, tags, custom properties, uploads
+        "comments",
+        "tags",
+        "property_definitions",
+        "uploads",
+        "recent_views",
+        # Calendar events + children
+        "calendar_events",
+        "calendar_event_attendees",
+        "calendar_event_documents",
+        "calendar_event_tags",
+        "calendar_event_property_values",
+        "event_reminder_dispatches",
+        # Queues + items + permissions
+        "queues",
+        "queue_items",
+        "queue_permissions",
+        "queue_role_permissions",
+        "queue_item_documents",
+        "queue_item_tags",
+        "queue_item_tasks",
+        # Counters + groups + permissions
+        "counters",
+        "counter_groups",
+        "counter_group_permissions",
+        "counter_group_role_permissions",
+    }
+)
+
+# Union of every table that has an explicit placement decision.
+ALL_CLASSIFIED_TABLES: frozenset[str] = SHARED_TABLES | GUILD_SCOPED_TABLES
+
+
+def is_guild_scoped(table_name: str) -> bool:
+    """Return True if ``table_name`` moves into per-guild schemas."""
+    return table_name in GUILD_SCOPED_TABLES
+
+
+def is_shared(table_name: str) -> bool:
+    """Return True if ``table_name`` stays in the ``public`` schema."""
+    return table_name in SHARED_TABLES

--- a/backend/app/db/tenancy_test.py
+++ b/backend/app/db/tenancy_test.py
@@ -1,0 +1,62 @@
+"""Completeness guard for the schema-per-guild table classification.
+
+These tests fail if any ``table=True`` model is missing a placement decision,
+or if the manifest names a table that does not exist. They are the safety net
+that keeps ``tenancy.py`` honest as the schema evolves: adding a new table
+without classifying it (the dangerous case — an unclassified guild-scoped
+table would leak across tenants) breaks CI here.
+
+Pure metadata checks — no database required.
+"""
+
+import pytest
+from sqlmodel import SQLModel
+
+from app.db import base  # noqa: F401  # populates SQLModel.metadata with every table
+from app.db.tenancy import (
+    ALL_CLASSIFIED_TABLES,
+    GUILD_SCOPED_TABLES,
+    SHARED_TABLES,
+    is_guild_scoped,
+    is_shared,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _metadata_tables() -> set[str]:
+    return set(SQLModel.metadata.tables.keys())
+
+
+def test_shared_and_guild_scoped_are_disjoint():
+    """A table cannot be both shared and guild-scoped."""
+    overlap = SHARED_TABLES & GUILD_SCOPED_TABLES
+    assert not overlap, f"Tables classified in BOTH buckets: {sorted(overlap)}"
+
+
+def test_every_table_is_classified():
+    """Every real table must appear in exactly one bucket (no silent gaps)."""
+    unclassified = _metadata_tables() - ALL_CLASSIFIED_TABLES
+    assert not unclassified, (
+        "These tables exist but are not placed in SHARED_TABLES or "
+        f"GUILD_SCOPED_TABLES in app/db/tenancy.py: {sorted(unclassified)}. "
+        "Add each to the correct bucket — an unclassified guild-scoped table "
+        "would leak across tenants."
+    )
+
+
+def test_manifest_has_no_phantom_tables():
+    """The manifest must not name tables that don't exist (typos / renames)."""
+    phantom = ALL_CLASSIFIED_TABLES - _metadata_tables()
+    assert not phantom, (
+        "These tables are classified in app/db/tenancy.py but do not exist in "
+        f"the model metadata: {sorted(phantom)}. Remove or fix the names."
+    )
+
+
+def test_helpers_agree_with_sets():
+    assert is_guild_scoped("tasks") and not is_shared("tasks")
+    assert is_shared("users") and not is_guild_scoped("users")
+    # Unknown tables are neither (forces an explicit decision rather than a default).
+    assert not is_guild_scoped("does_not_exist")
+    assert not is_shared("does_not_exist")


### PR DESCRIPTION
## Problem

The schema-per-guild tenancy work (moving each guild from RLS-based isolation to its own Postgres schema) needs a single, authoritative answer to *which tables stay shared vs. which move into per-guild schemas*. Without it, every later step (model routing, per-schema DDL, data migration) would be guessing, and a newly-added table could silently end up unisolated.

This is **step one**: the classification manifest + a guard. No runtime behavior changes; nothing is moved or routed yet.

## Changes

**Backend**
- `app/db/tenancy.py` — the manifest: `SHARED_TABLES` (13, stay in `public`) and `GUILD_SCOPED_TABLES` (49, move to `guild_<id>`), with `is_shared` / `is_guild_scoped` helpers and rationale comments (including the resolved edge cases: `guild_invites` / `oidc_claim_mappings` stay shared; `guild_settings` / `recent_views` / digest tables are guild-scoped).
- `app/db/tenancy_test.py` — completeness guard: fails if any table is unclassified, double-classified, or named but nonexistent. Auto-runs in CI (it's a `_test.py` under `app/`), so adding a table without placing it goes red.
- `app/db/base.py` — imported 5 previously-missing models (`user_tokens`, `push_tokens`, `auto_delegation_jti_blocklist`, `task_assignment_digest_items`, `webhook_subscriptions`) so `SQLModel.metadata` — and Alembic autogenerate — sees all **62** tables. (Latent fix: autogenerate previously couldn't see those 5.)

**Frontend infra** (separate commit)
- `frontend/.nvmrc` (`22`) + `scripts/dev-frontend.sh` now `nvm use`s it. The script sourced nvm but never selected a version, inheriting Node 20; pnpm@11 requires Node ≥22.13.

## Testing

- `pytest app/db/tenancy_test.py` → **4 passed** (confirms the manifest covers exactly all 62 tables).
- `ruff check` on the three backend files → clean.
- Verified `dev-frontend.sh` selects Node v22.22.3 and `pnpm` runs without the `node:sqlite` crash.

## Notes

- Design doc lives in `history/` (gitignored), not included here.
- No schema/data changes; no migration. Follow-up steps (model schema tagging, routing, per-guild roles, data migration) are tracked separately.