### PR TITLE
Fix quoted color defaults and widen for alpha channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Tag and custom-property colors now accept 8-digit hex (`#RRGGBBAA`) for an alpha channel, matching task statuses.
+
+### Fixed
+
+- Corrected malformed stored defaults for tag/task-status colors and the task-status icon (an extra pair of quotes had been baked into the default value).
+
 ## [0.50.2] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Tag and custom-property colors now accept 8-digit hex (`#RRGGBBAA`) for an alpha channel, matching task statuses.
+- table classification manifest (`app/db/tenancy.py`) marking every table as shared or guild-scoped, with a test guarding completeness — the first step toward schema-per-guild tenancy.
 
 ### Fixed
 
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Internal: table classification manifest (`app/db/tenancy.py`) marking every table as shared or guild-scoped, with a test guarding completeness — the first step toward schema-per-guild tenancy.
 - **Events can span multiple days.** A timed event's end can now fall on a later day (the 24-hour limit is gone). The create dialog and edit page gained separate end-date pickers, and the calendar draws a multi-day timed event across each day it touches — in week and day views it fills the time grid on every day (start day from its start time, full middle days, end day up to its end time) rather than sitting in the all-day bar.
 - **Edit an event's tags.** The event settings page now has a tag picker (matching tasks and documents) to add or remove tags; changes save immediately.
 

--- a/backend/alembic/versions/20260608_0098_color_defaults_and_alpha.py
+++ b/backend/alembic/versions/20260608_0098_color_defaults_and_alpha.py
@@ -1,0 +1,72 @@
+"""Fix quoted color/icon defaults and widen hex-color columns for alpha.
+
+Two fixes to color/icon columns:
+
+1. Double-quoted ``server_default``: three columns were defined with
+   ``server_default="'#value'"`` — the extra SQL quotes get double-escaped, so
+   the stored DEFAULT became the literal quoted string (e.g. ``'#6366F1'``,
+   quotes included) instead of ``#6366F1``. For ``tags.color`` (VARCHAR(7)) that
+   default can't even be applied. Masked because the ORM always sends an
+   explicit value. Affected: ``tags.color``, ``task_statuses.color``,
+   ``task_statuses.icon``.
+
+2. Alpha channel: hex-color columns that were VARCHAR(7) (``#RRGGBB`` only) are
+   widened to VARCHAR(9) so ``#RRGGBBAA`` fits, matching ``task_statuses.color``
+   which was already 9. Affected: ``tags.color``, ``property_definitions.color``.
+
+Revision ID: 20260608_0098
+Revises: 20260607_0097
+Create Date: 2026-06-08
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260608_0098"
+down_revision = "20260607_0097"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Widen hex-color columns to allow an alpha channel (#RRGGBBAA).
+    op.alter_column(
+        "tags", "color",
+        existing_type=sa.String(7), type_=sa.String(9), existing_nullable=False,
+    )
+    op.alter_column(
+        "property_definitions", "color",
+        existing_type=sa.String(7), type_=sa.String(9), existing_nullable=True,
+    )
+
+    # 2. Correct the double-quoted DEFAULT clauses (unquoted values).
+    op.execute("ALTER TABLE tags ALTER COLUMN color SET DEFAULT '#6366F1'")
+    op.execute("ALTER TABLE task_statuses ALTER COLUMN color SET DEFAULT '#94A3B8'")
+    op.execute("ALTER TABLE task_statuses ALTER COLUMN icon SET DEFAULT 'circle-dashed'")
+
+    # Repair any rows that captured the bad literal-quoted value (quotes included).
+    op.execute("UPDATE task_statuses SET color = '#94A3B8' WHERE color = '''#94A3B8'''")
+    op.execute(
+        "UPDATE task_statuses SET icon = 'circle-dashed' WHERE icon = '''circle-dashed'''"
+    )
+
+
+def downgrade() -> None:
+    # Restore the original (double-quoted) defaults.
+    op.execute("ALTER TABLE tags ALTER COLUMN color SET DEFAULT '''#6366F1'''")
+    op.execute("ALTER TABLE task_statuses ALTER COLUMN color SET DEFAULT '''#94A3B8'''")
+    op.execute(
+        "ALTER TABLE task_statuses ALTER COLUMN icon SET DEFAULT '''circle-dashed'''"
+    )
+
+    # Narrow the hex-color columns back to VARCHAR(7), truncating any alpha.
+    op.alter_column(
+        "property_definitions", "color",
+        existing_type=sa.String(9), type_=sa.String(7), existing_nullable=True,
+        postgresql_using="left(color, 7)",
+    )
+    op.alter_column(
+        "tags", "color",
+        existing_type=sa.String(9), type_=sa.String(7), existing_nullable=False,
+        postgresql_using="left(color, 7)",
+    )

--- a/backend/app/models/property.py
+++ b/backend/app/models/property.py
@@ -70,7 +70,7 @@ class PropertyDefinition(SQLModel, table=True):
     )
     color: Optional[str] = Field(
         default=None,
-        sa_column=Column(String(length=7), nullable=True),
+        sa_column=Column(String(length=9), nullable=True),
     )
     options: Optional[List[dict]] = Field(
         default=None,

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -33,7 +33,7 @@ class Tag(SoftDeleteMixin, table=True):
     )
     color: str = Field(
         default="#6366F1",
-        sa_column=Column(String(length=7), nullable=False, server_default="'#6366F1'"),
+        sa_column=Column(String(length=9), nullable=False, server_default="#6366F1"),
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -51,11 +51,11 @@ class TaskStatus(SQLModel, table=True):
     )
     color: str = Field(
         default="#94A3B8",
-        sa_column=Column(String(length=9), nullable=False, server_default="'#94A3B8'"),
+        sa_column=Column(String(length=9), nullable=False, server_default="#94A3B8"),
     )
     icon: str = Field(
         default="circle-dashed",
-        sa_column=Column(String(length=64), nullable=False, server_default="'circle-dashed'"),
+        sa_column=Column(String(length=64), nullable=False, server_default="circle-dashed"),
     )
 
     project: Optional["Project"] = Relationship(back_populates="task_statuses")


### PR DESCRIPTION
## Problem

Three color/icon columns were defined with `server_default="'#value'"`. SQLAlchemy treats a plain string as a value and quotes it, so the embedded quotes get **double-escaped** — the stored DEFAULT became the literal 9-char string `'#6366F1'` (quotes included) instead of `#6366F1`. For `tags.color` (`VARCHAR(7)`) that default can't even be applied (`value too long`). It stayed hidden because the ORM always sends an explicit value, so the DB default rarely fires.

Separately, two hex-color columns were `VARCHAR(7)` (`#RRGGBB` only) and couldn't hold an alpha channel.

## Changes

**Fix the malformed defaults** (models + migration `20260608_0098`):
- `tags.color`, `task_statuses.color`, `task_statuses.icon` defaults corrected to the unquoted value. Migration also repairs any row that captured the bad literal value.

**Widen hex-color columns for alpha** (`#RRGGBBAA`):
- `tags.color` and `property_definitions.color`: `VARCHAR(7)` → `VARCHAR(9)`, matching `task_statuses.color` (already 9).

A full sweep of every `*color*` column confirmed these are the only ones affected — the accent-color columns already use bare-string defaults and are `VARCHAR(20)`; the other `.color` columns are `VARCHAR(32)`.

## Testing

- Migration verified end-to-end on the test DB: upgrade corrects all three defaults and widens both columns; downgrade restores the prior state; re-upgrade is clean.
- `ruff check` on changed models + migration → clean.
- Targeted tag/property/status test selection ran green (one unrelated pre-existing failure in `auth_test.py::test_bootstrap_status_no_users`, not touched by this PR).

## Notes

- `task_statuses.icon` is an icon **name** (`circle-dashed`), not a color — only its quoted default was fixed; its width is unchanged.