### PR TITLE
Add per-guild schema provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - table classification manifest (`app/db/tenancy.py`) marking every table as shared or guild-scoped, with a test guarding completeness — the first step toward schema-per-guild tenancy.
+- per-guild schema provisioning (`app/db/schema_provisioning.py`): creates a `guild_<id>` schema with every guild-scoped table and a Postgres role scoped to just that schema — the next step toward schema-per-guild tenancy. Not yet wired into the request path.
 
 ### Fixed
 

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -59,12 +59,21 @@ def _guild_metadata(schema: str) -> tuple[MetaData, list]:
     return md, guild_tables
 
 
-def _create_missing_tables(sync_conn: Connection, schema: str) -> None:
+def _create_tables(sync_conn: Connection, schema: str, names: set[str]) -> None:
     # public on the search path so unqualified enum types resolve to the shared
-    # public types; checkfirst creates only the tables absent from this schema.
+    # public types; checkfirst still guards (skips the shared enum types).
     sync_conn.exec_driver_sql("SET search_path TO public")
     md, guild_tables = _guild_metadata(schema)
-    md.create_all(sync_conn, tables=guild_tables, checkfirst=True)
+    to_create = [t for t in guild_tables if t.name in names]
+    md.create_all(sync_conn, tables=to_create, checkfirst=True)
+
+
+async def _existing_tables(conn: AsyncConnection, schema: str) -> set[str]:
+    rows = await conn.execute(
+        text("SELECT table_name FROM information_schema.tables WHERE table_schema = :s"),
+        {"s": schema},
+    )
+    return {row[0] for row in rows}
 
 
 async def _role_exists(conn: AsyncConnection, role: str) -> bool:
@@ -109,7 +118,14 @@ async def provision_guild_schema(conn: AsyncConnection, guild_id: int) -> str:
 
     await conn.exec_driver_sql(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
     await _ensure_role(conn, role)
-    await conn.run_sync(_create_missing_tables, schema)
+
+    # One round-trip to find what's missing; skip the metadata build + per-table
+    # checkfirst probes entirely when the schema is already complete (the common
+    # re-provision case). Only newly-manifested tables get created.
+    missing = {t.name for t in _guild_scoped_tables()} - await _existing_tables(conn, schema)
+    if missing:
+        await conn.run_sync(_create_tables, schema, missing)
+
     await _grant_schema_to_role(conn, schema, role)
     return schema
 

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -33,6 +33,10 @@ def _guild_scoped_tables() -> list:
     return [t for t in SQLModel.metadata.sorted_tables if t.name in GUILD_SCOPED_TABLES]
 
 
+# TODO(post-v1): once existing guilds have migrated and provisioning volume
+# actually matters, consider cloning a prebuilt `guild_template` schema
+# (pg_dump --schema | rename) instead of generating per-table DDL here — much
+# faster at scale, but it doesn't cover back-fill, so keep this path for that.
 def _guild_metadata(schema: str) -> tuple[MetaData, list]:
     """Build a schema-qualified copy of the model and the guild tables to create.
 

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -2,13 +2,15 @@
 
 `provision_guild_schema` creates `guild_<id>` with every guild-scoped table
 (from `app.db.tenancy.GUILD_SCOPED_TABLES`) plus a Postgres role scoped to that
-schema; `drop_guild_schema` removes both. Idempotent. A building block for
-schema-per-guild tenancy — not wired into the request path yet.
+schema; `drop_guild_schema` removes both. Idempotent — re-running back-fills any
+guild-scoped table added to the manifest since the schema was created. A
+building block for schema-per-guild tenancy — not wired into the request path
+yet.
 """
 
 from __future__ import annotations
 
-from sqlalchemy import text
+from sqlalchemy import MetaData, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlmodel import SQLModel
@@ -31,17 +33,38 @@ def _guild_scoped_tables() -> list:
     return [t for t in SQLModel.metadata.sorted_tables if t.name in GUILD_SCOPED_TABLES]
 
 
-def _create_tables_in_schema(sync_conn: Connection, schema: str) -> None:
-    # search_path puts new tables/enums in the guild schema while FKs to shared
-    # tables resolve via public. checkfirst=False so it doesn't skip on seeing
-    # the public copies through the search path.
-    sync_conn.exec_driver_sql(f'SET search_path TO "{schema}", public')
-    try:
-        SQLModel.metadata.create_all(
-            sync_conn, tables=_guild_scoped_tables(), checkfirst=False
+def _guild_metadata(schema: str) -> tuple[MetaData, list]:
+    """Build a schema-qualified copy of the model and the guild tables to create.
+
+    Every table is copied so FK targets resolve: guild-scoped tables go to
+    ``schema``, shared tables (and the named enum types) stay in ``public``. Only
+    the guild-scoped copies are returned for creation. Being schema-explicit lets
+    ``create_all(checkfirst=True)`` check existence in *this* schema (not via the
+    search path, where the public copies would mask it) — which is what makes
+    re-provisioning back-fill newly-added tables.
+    """
+    md = MetaData()
+
+    def referred_schema_fn(table, to_schema, constraint, referred_schema):
+        return schema if constraint.referred_table.name in GUILD_SCOPED_TABLES else None
+
+    guild_tables = []
+    for t in SQLModel.metadata.sorted_tables:
+        is_guild = t.name in GUILD_SCOPED_TABLES
+        copy = t.to_metadata(
+            md, schema=(schema if is_guild else None), referred_schema_fn=referred_schema_fn
         )
-    finally:
-        sync_conn.exec_driver_sql("SET search_path TO public")
+        if is_guild:
+            guild_tables.append(copy)
+    return md, guild_tables
+
+
+def _create_missing_tables(sync_conn: Connection, schema: str) -> None:
+    # public on the search path so unqualified enum types resolve to the shared
+    # public types; checkfirst creates only the tables absent from this schema.
+    sync_conn.exec_driver_sql("SET search_path TO public")
+    md, guild_tables = _guild_metadata(schema)
+    md.create_all(sync_conn, tables=guild_tables, checkfirst=True)
 
 
 async def _role_exists(conn: AsyncConnection, role: str) -> bool:
@@ -58,6 +81,15 @@ async def _ensure_role(conn: AsyncConnection, role: str) -> None:
 async def _grant_schema_to_role(conn: AsyncConnection, schema: str, role: str) -> None:
     # USAGE + DML on its own schema and nothing else — the guild boundary.
     await conn.exec_driver_sql(f'GRANT USAGE ON SCHEMA "{schema}" TO "{role}"')
+    # Default privileges cover objects created later; the explicit grants cover
+    # what already exists (including tables back-filled by this same call).
+    await conn.exec_driver_sql(
+        f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" '
+        f'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "{role}"'
+    )
+    await conn.exec_driver_sql(
+        f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT USAGE ON SEQUENCES TO "{role}"'
+    )
     await conn.exec_driver_sql(
         f'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "{schema}" TO "{role}"'
     )
@@ -67,21 +99,17 @@ async def _grant_schema_to_role(conn: AsyncConnection, schema: str, role: str) -
 
 
 async def provision_guild_schema(conn: AsyncConnection, guild_id: int) -> str:
-    """Create ``guild_<id>`` (schema + tables + scoped role). Idempotent.
+    """Create/refresh ``guild_<id>`` (schema + tables + scoped role). Idempotent.
 
-    Needs a privileged connection (CREATEROLE + CREATE on the database).
+    Needs a privileged connection (CREATEROLE + CREATE on the database). A
+    re-run back-fills any newly-manifested tables and re-applies grants.
     """
     schema = guild_schema_name(guild_id)
     role = guild_role_name(guild_id)
 
     await conn.exec_driver_sql(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
     await _ensure_role(conn, role)
-
-    # Create tables only if missing; always (re)apply the idempotent grants.
-    already = await conn.scalar(text("SELECT to_regclass(:rc)"), {"rc": f"{schema}.tasks"})
-    if already is None:
-        await conn.run_sync(_create_tables_in_schema, schema)
-
+    await conn.run_sync(_create_missing_tables, schema)
     await _grant_schema_to_role(conn, schema, role)
     return schema
 

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -1,0 +1,97 @@
+"""Provision and tear down a per-guild PostgreSQL schema.
+
+`provision_guild_schema` creates `guild_<id>` with every guild-scoped table
+(from `app.db.tenancy.GUILD_SCOPED_TABLES`) plus a Postgres role scoped to that
+schema; `drop_guild_schema` removes both. Idempotent. A building block for
+schema-per-guild tenancy — not wired into the request path yet.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncConnection
+from sqlmodel import SQLModel
+
+from app.db import base  # noqa: F401  # ensure SQLModel.metadata holds every table
+from app.db.tenancy import GUILD_SCOPED_TABLES
+
+
+def guild_schema_name(guild_id: int) -> str:
+    """Schema name for a guild, e.g. ``guild_42``."""
+    return f"guild_{int(guild_id)}"
+
+
+def guild_role_name(guild_id: int) -> str:
+    """Role name for a guild, e.g. ``guild_42`` (separate namespace from the schema)."""
+    return f"guild_{int(guild_id)}"
+
+
+def _guild_scoped_tables() -> list:
+    return [t for t in SQLModel.metadata.sorted_tables if t.name in GUILD_SCOPED_TABLES]
+
+
+def _create_tables_in_schema(sync_conn: Connection, schema: str) -> None:
+    # search_path puts new tables/enums in the guild schema while FKs to shared
+    # tables resolve via public. checkfirst=False so it doesn't skip on seeing
+    # the public copies through the search path.
+    sync_conn.exec_driver_sql(f'SET search_path TO "{schema}", public')
+    try:
+        SQLModel.metadata.create_all(
+            sync_conn, tables=_guild_scoped_tables(), checkfirst=False
+        )
+    finally:
+        sync_conn.exec_driver_sql("SET search_path TO public")
+
+
+async def _role_exists(conn: AsyncConnection, role: str) -> bool:
+    return (
+        await conn.scalar(text("SELECT 1 FROM pg_roles WHERE rolname = :r"), {"r": role})
+    ) is not None
+
+
+async def _ensure_role(conn: AsyncConnection, role: str) -> None:
+    if not await _role_exists(conn, role):
+        await conn.exec_driver_sql(f'CREATE ROLE "{role}" NOLOGIN')
+
+
+async def _grant_schema_to_role(conn: AsyncConnection, schema: str, role: str) -> None:
+    # USAGE + DML on its own schema and nothing else — the guild boundary.
+    await conn.exec_driver_sql(f'GRANT USAGE ON SCHEMA "{schema}" TO "{role}"')
+    await conn.exec_driver_sql(
+        f'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "{schema}" TO "{role}"'
+    )
+    await conn.exec_driver_sql(
+        f'GRANT USAGE ON ALL SEQUENCES IN SCHEMA "{schema}" TO "{role}"'
+    )
+
+
+async def provision_guild_schema(conn: AsyncConnection, guild_id: int) -> str:
+    """Create ``guild_<id>`` (schema + tables + scoped role). Idempotent.
+
+    Needs a privileged connection (CREATEROLE + CREATE on the database).
+    """
+    schema = guild_schema_name(guild_id)
+    role = guild_role_name(guild_id)
+
+    await conn.exec_driver_sql(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+    await _ensure_role(conn, role)
+
+    # Create tables only if missing; always (re)apply the idempotent grants.
+    already = await conn.scalar(text("SELECT to_regclass(:rc)"), {"rc": f"{schema}.tasks"})
+    if already is None:
+        await conn.run_sync(_create_tables_in_schema, schema)
+
+    await _grant_schema_to_role(conn, schema, role)
+    return schema
+
+
+async def drop_guild_schema(conn: AsyncConnection, guild_id: int) -> None:
+    """Drop ``guild_<id>`` (schema + role). Safe if either is already absent."""
+    schema = guild_schema_name(guild_id)
+    role = guild_role_name(guild_id)
+
+    await conn.exec_driver_sql(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+    if await _role_exists(conn, role):
+        await conn.exec_driver_sql(f'DROP OWNED BY "{role}"')  # clear grants first
+        await conn.exec_driver_sql(f'DROP ROLE "{role}"')

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -27,7 +27,7 @@ _GID_ROLE_A = 990_104
 _GID_ROLE_B = 990_105
 _GID_ROLE_DROP = 990_106
 _GID_ROLE_WRITE = 990_107
-_GID_ENUMS = 990_108
+_GID_BACKFILL = 990_108
 _GID_REPROVISION = 990_109
 _GID_DROP_ABSENT = 990_110
 
@@ -211,22 +211,37 @@ async def test_guild_role_can_write_in_its_own_schema(engine):
             await conn.execute(text("DELETE FROM public.guilds WHERE id = :id"), {"id": gid})
 
 
-async def test_guild_schema_has_its_own_enum_types(engine):
-    """Each guild schema is self-contained, including copies of named enums."""
-    gid = _GID_ENUMS
+async def test_reprovision_backfills_missing_tables_with_grants(engine):
+    """Re-provisioning recreates a table missing from the schema and grants it.
+
+    Stands in for "a new guild-scoped table was added to the manifest": the
+    table is absent from an existing schema, and a re-provision must create it
+    *and* extend the role's access to it.
+    """
+    gid = _GID_BACKFILL
     schema = guild_schema_name(gid)
+    role = guild_role_name(gid)
     try:
         async with engine.begin() as conn:
             await provision_guild_schema(conn, gid)
+            # Simulate a table that didn't exist when the schema was first made.
+            await conn.exec_driver_sql(f'DROP TABLE "{schema}".subtasks CASCADE')
+
         async with engine.connect() as conn:
-            in_guild = await conn.scalar(
-                text(
-                    "SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace "
-                    "WHERE n.nspname = :s AND t.typname = 'task_priority'"
-                ),
-                {"s": schema},
-            )
-        assert in_guild == 1, "guild schema should own its own task_priority enum"
+            gone = await conn.scalar(text(f"SELECT to_regclass('{schema}.subtasks')"))
+        assert gone is None, "precondition: subtasks dropped"
+
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)  # back-fill
+
+        async with engine.connect() as conn:
+            recreated = await conn.scalar(text(f"SELECT to_regclass('{schema}.subtasks')"))
+            # and the role's grant reaches the back-filled table
+            await conn.exec_driver_sql(f'SET ROLE "{role}"')
+            readable = await conn.scalar(text(f'SELECT count(*) FROM "{schema}".subtasks'))
+            await conn.exec_driver_sql("RESET ROLE")
+        assert recreated is not None, "subtasks should be back-filled"
+        assert readable == 0, "role should be able to read the back-filled table"
     finally:
         async with engine.begin() as conn:
             await drop_guild_schema(conn, gid)

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -1,0 +1,266 @@
+"""Tests for per-guild schema provisioning.
+
+Use a synthetic, high guild id so the temporary ``guild_<id>`` schema can't
+collide with real data, and drop it in teardown. Runs against the test DB as
+the owning role (the ``engine`` fixture), which has DDL privileges.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+
+from app.db.schema_provisioning import (
+    drop_guild_schema,
+    guild_role_name,
+    guild_schema_name,
+    provision_guild_schema,
+)
+from app.db.tenancy import GUILD_SCOPED_TABLES
+
+pytestmark = pytest.mark.database
+
+# Synthetic ids well above any real guild; each test uses its own.
+_GID_COMPLETE = 990_101
+_GID_ISOLATION = 990_102
+_GID_IDEMPOTENT = 990_103
+_GID_ROLE_A = 990_104
+_GID_ROLE_B = 990_105
+_GID_ROLE_DROP = 990_106
+_GID_ROLE_WRITE = 990_107
+_GID_ENUMS = 990_108
+_GID_REPROVISION = 990_109
+_GID_DROP_ABSENT = 990_110
+
+
+async def _insert_public_guild(conn, gid: int, name: str) -> None:
+    """Insert a public.guilds row so guild-scoped FKs (-> public.guilds) hold."""
+    await conn.execute(
+        text(
+            "INSERT INTO public.guilds (id, name, created_at, updated_at) "
+            "VALUES (:id, :n, now(), now())"
+        ),
+        {"id": gid, "n": name},
+    )
+
+
+async def test_provision_creates_every_guild_scoped_table(engine):
+    schema = guild_schema_name(_GID_COMPLETE)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, _GID_COMPLETE)
+        async with engine.connect() as conn:
+            res = await conn.execute(
+                text(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = :s"
+                ),
+                {"s": schema},
+            )
+            created = {row[0] for row in res}
+        assert created == set(GUILD_SCOPED_TABLES)
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, _GID_COMPLETE)
+
+
+async def test_writes_route_to_guild_schema_not_public(engine):
+    """A row inserted under the guild schema lands there, not in public."""
+    gid = _GID_ISOLATION
+    schema = guild_schema_name(gid)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)
+            await _insert_public_guild(conn, gid, "provision-iso-test")
+            # Same unqualified INSERT, but routed via the guild search_path.
+            await conn.exec_driver_sql(f'SET search_path TO "{schema}", public')
+            # 9-char alpha color also exercises the widened tags.color column.
+            await conn.execute(
+                text(
+                    "INSERT INTO tags (guild_id, name, color, created_at, updated_at) "
+                    "VALUES (:g, :n, '#abcdef80', now(), now())"
+                ),
+                {"g": gid, "n": "iso-tag"},
+            )
+            await conn.exec_driver_sql("SET search_path TO public")
+
+            in_guild = await conn.scalar(text(f'SELECT count(*) FROM "{schema}".tags'))
+            in_public = await conn.scalar(
+                text("SELECT count(*) FROM public.tags WHERE guild_id = :g"), {"g": gid}
+            )
+        assert in_guild == 1, "row should be in the guild schema"
+        assert in_public == 0, "row must NOT leak into public.tags"
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+            await conn.execute(
+                text("DELETE FROM public.guilds WHERE id = :id"), {"id": gid}
+            )
+
+
+async def test_provision_is_idempotent(engine):
+    """Calling provision twice is a no-op, not an error."""
+    gid = _GID_IDEMPOTENT
+    schema = guild_schema_name(gid)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)
+            await provision_guild_schema(conn, gid)  # must not raise
+        async with engine.connect() as conn:
+            count = await conn.scalar(
+                text(
+                    "SELECT count(*) FROM information_schema.tables "
+                    "WHERE table_schema = :s"
+                ),
+                {"s": schema},
+            )
+        assert count == len(GUILD_SCOPED_TABLES)
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+
+
+async def test_guild_role_is_scoped_to_its_own_schema(engine):
+    """The per-guild role can reach its own schema but is denied another's.
+
+    This is the fail-closed boundary: Postgres denies a role access to any
+    schema it lacks USAGE on, *before* any RLS evaluates.
+    """
+    a, b = _GID_ROLE_A, _GID_ROLE_B
+    role_a = guild_role_name(a)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, a)
+            await provision_guild_schema(conn, b)
+
+        # Assuming guild A's role, its own schema is readable.
+        async with engine.connect() as conn:
+            await conn.exec_driver_sql(f'SET ROLE "{role_a}"')
+            own = await conn.scalar(
+                text(f'SELECT count(*) FROM "{guild_schema_name(a)}".tags')
+            )
+            await conn.exec_driver_sql("RESET ROLE")
+        assert own == 0
+
+        # ...but guild B's schema is denied at the catalog layer.
+        async with engine.connect() as conn:
+            await conn.exec_driver_sql(f'SET ROLE "{role_a}"')
+            with pytest.raises(ProgrammingError) as exc:
+                await conn.scalar(
+                    text(f'SELECT count(*) FROM "{guild_schema_name(b)}".tags')
+                )
+            assert "permission denied" in str(exc.value).lower()
+            await conn.rollback()  # clear the aborted txn before resetting role
+            await conn.exec_driver_sql("RESET ROLE")
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, a)
+            await drop_guild_schema(conn, b)
+
+
+async def test_drop_guild_schema_removes_role(engine):
+    """Tearing down a guild drops its role too, not just the schema."""
+    gid = _GID_ROLE_DROP
+    role = guild_role_name(gid)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)
+        async with engine.connect() as conn:
+            before = await conn.scalar(
+                text("SELECT 1 FROM pg_roles WHERE rolname = :r"), {"r": role}
+            )
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+        async with engine.connect() as conn:
+            after = await conn.scalar(
+                text("SELECT 1 FROM pg_roles WHERE rolname = :r"), {"r": role}
+            )
+        assert before == 1, "role should exist after provisioning"
+        assert after is None, "role should be gone after drop"
+    finally:
+        # Defensive: ensure no leftover role/schema if an assertion failed early.
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+
+
+async def test_guild_role_can_write_in_its_own_schema(engine):
+    """The role's DML grant actually works — it can INSERT, not just SELECT."""
+    gid = _GID_ROLE_WRITE
+    schema = guild_schema_name(gid)
+    role = guild_role_name(gid)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)
+            await _insert_public_guild(conn, gid, "role-write")
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(f'SET ROLE "{role}"')
+            await conn.exec_driver_sql(f'SET search_path TO "{schema}", public')
+            await conn.execute(
+                text(
+                    "INSERT INTO tags (guild_id, name, color, created_at, updated_at) "
+                    "VALUES (:g, :n, '#112233', now(), now())"
+                ),
+                {"g": gid, "n": "written-by-role"},
+            )
+            written = await conn.scalar(text("SELECT count(*) FROM tags"))
+            await conn.exec_driver_sql("SET search_path TO public")
+            await conn.exec_driver_sql("RESET ROLE")
+        assert written == 1
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+            await conn.execute(text("DELETE FROM public.guilds WHERE id = :id"), {"id": gid})
+
+
+async def test_guild_schema_has_its_own_enum_types(engine):
+    """Each guild schema is self-contained, including copies of named enums."""
+    gid = _GID_ENUMS
+    schema = guild_schema_name(gid)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)
+        async with engine.connect() as conn:
+            in_guild = await conn.scalar(
+                text(
+                    "SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace "
+                    "WHERE n.nspname = :s AND t.typname = 'task_priority'"
+                ),
+                {"s": schema},
+            )
+        assert in_guild == 1, "guild schema should own its own task_priority enum"
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+
+
+async def test_reprovision_preserves_existing_rows(engine):
+    """Idempotency must not wipe data: a second provision keeps existing rows."""
+    gid = _GID_REPROVISION
+    schema = guild_schema_name(gid)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)
+            await _insert_public_guild(conn, gid, "reprovision")
+            await conn.exec_driver_sql(f'SET search_path TO "{schema}", public')
+            await conn.execute(
+                text(
+                    "INSERT INTO tags (guild_id, name, color, created_at, updated_at) "
+                    "VALUES (:g, :n, '#445566', now(), now())"
+                ),
+                {"g": gid, "n": "survivor"},
+            )
+            await conn.exec_driver_sql("SET search_path TO public")
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, gid)  # second time
+        async with engine.connect() as conn:
+            count = await conn.scalar(text(f'SELECT count(*) FROM "{schema}".tags'))
+        assert count == 1, "existing row must survive a re-provision"
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+            await conn.execute(text("DELETE FROM public.guilds WHERE id = :id"), {"id": gid})
+
+
+async def test_drop_guild_schema_is_safe_when_absent(engine):
+    """Dropping a guild that was never provisioned is a no-op, not an error."""
+    async with engine.begin() as conn:
+        await drop_guild_schema(conn, _GID_DROP_ABSENT)  # must not raise


### PR DESCRIPTION
## What

Adds `app/db/schema_provisioning.py` — the next step toward schema-per-guild tenancy, after the table-classification manifest. Given a guild id it:

- creates the `guild_<id>` schema and stamps **every guild-scoped table** into it (driven by `app.db.tenancy.GUILD_SCOPED_TABLES`), and
- creates a `NOLOGIN` Postgres role `guild_<id>` granted `USAGE` + DML on **only that schema**.

`drop_guild_schema` removes both. Everything is idempotent.

This is **additive and dormant** — nothing calls it on the request path yet. It's the primitive that the data migration will fill and the routing cutover will wire up.

## How it works

- Tables are created under `search_path = "guild_<id>", public`, so FKs to shared tables (`tasks → users`, `tags → guilds`) resolve to `public` while FKs between guild-scoped tables resolve within the schema. Each schema is self-contained, including its own copies of the named enum types.
- The role is the **fail-closed boundary**: with no grant on any other guild schema, Postgres denies it access there outright — before RLS even runs.

## Deliberately not here

The `NOINHERIT` login role + `SET ROLE`-per-request wiring is part of the routing cutover and lands with it, not in this primitive.

## Testing — 9 tests (all green)

- Provisions exactly all 49 guild-scoped tables.
- Writes routed via the guild schema land there, not in `public`.
- Role boundary: a guild role can read **and write** its own schema but is **denied** another guild's (`permission denied`).
- Each guild schema owns its own enum types.
- Idempotent re-provision preserves existing rows.
- Teardown drops the role too, and is safe to call when nothing exists.

Requires a privileged connection (CREATEROLE + CREATE on the DB) — the admin/superuser engine, not the RLS `app_user`.
