### PR TITLE
Carry guild in the initiative-added notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Corrected malformed stored defaults for tag/task-status colors and the task-status icon (an extra pair of quotes had been baked into the default value).
+- The "added to initiative" notification now carries its guild (id + guild-qualified deep link), like every other guild-scoped notification — so it resolves correctly in the cross-guild inbox under schema-per-guild tenancy.
 
 ## [0.50.2] - 2026-06-08
 

--- a/backend/app/api/v1/endpoints/initiatives.py
+++ b/backend/app/api/v1/endpoints/initiatives.py
@@ -783,6 +783,7 @@ async def add_initiative_member(
             user,
             initiative_id=initiative.id,
             initiative_name=initiative.name,
+            guild_id=initiative.guild_id,
         )
     return serialize_initiative(initiative)
 

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -68,6 +68,12 @@ def _event_target_path(event_id: int | None) -> str:
     return f"/events/{event_id}"
 
 
+def _initiative_target_path(initiative_id: int | None) -> str:
+    if initiative_id is None:
+        return "/initiatives"
+    return f"/initiatives/{initiative_id}"
+
+
 async def _project_guild_map(session: AsyncSession, project_ids: set[int]) -> dict[int, int]:
     if not project_ids:
         return {}
@@ -159,13 +165,21 @@ async def notify_initiative_membership(
     user: User,
     initiative_id: int,
     initiative_name: str,
+    guild_id: int,
 ) -> None:
+    target_path = _initiative_target_path(initiative_id)
     # Always create in-app notification
     await user_notifications.create_notification(
         session,
         user_id=user.id,
         notification_type=NotificationType.initiative_added,
-        data={"initiative_id": initiative_id, "initiative_name": initiative_name},
+        data={
+            "initiative_id": initiative_id,
+            "initiative_name": initiative_name,
+            "guild_id": guild_id,
+            "target_path": target_path,
+            "smart_link": _build_smart_link(target_path=target_path, guild_id=guild_id),
+        },
     )
     # Email
     if user.email_initiative_addition is not False:
@@ -187,7 +201,8 @@ async def notify_initiative_membership(
                 data={
                     "type": "initiative_added",
                     "initiative_id": str(initiative_id),
-                    "target_path": f"/initiatives/{initiative_id}",
+                    "guild_id": str(guild_id),
+                    "target_path": target_path,
                 },
             )
         except Exception as exc:

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -15,7 +15,11 @@ from app.models.calendar_event import CalendarEvent, CalendarEventAttendee, RSVP
 from app.models.event_reminder_dispatch import EventReminderDispatch
 from app.models.notification import Notification, NotificationType
 from app.models.user import User
-from app.services.notifications import _format_event_when, _run_event_reminder_pass
+from app.services.notifications import (
+    _format_event_when,
+    _run_event_reminder_pass,
+    notify_initiative_membership,
+)
 from app.testing import (
     create_calendar_event,
     create_guild,
@@ -208,3 +212,35 @@ async def test_event_reminder_skips_declined_attendees(session: AsyncSession):
 
     await _dispatch(session)
     assert await _reminders_for(session, attendee.id) == []
+
+
+@pytest.mark.integration
+async def test_notify_initiative_membership_carries_guild_context(session: AsyncSession):
+    """The initiative_added notification must carry its guild so the merged
+    cross-guild inbox can resolve/navigate it after schema-per-guild."""
+    creator = await create_user(session, email="ini-creator@example.com")
+    guild = await create_guild(session, creator=creator)
+    initiative = await create_initiative(session, guild, creator, name="Onboarding")
+    member = await create_user(session, email="ini-member@example.com")
+
+    await notify_initiative_membership(
+        session,
+        member,
+        initiative_id=initiative.id,
+        initiative_name=initiative.name,
+        guild_id=guild.id,
+    )
+
+    notifs = (
+        await session.exec(
+            select(Notification).where(
+                Notification.user_id == member.id,
+                Notification.type == NotificationType.initiative_added,
+            )
+        )
+    ).all()
+    assert len(notifs) == 1
+    data = notifs[0].data
+    assert data["guild_id"] == guild.id
+    assert data["target_path"] == f"/initiatives/{initiative.id}"
+    assert f"guild_id={guild.id}" in data["smart_link"]


### PR DESCRIPTION
## What

`notify_initiative_membership` (the `initiative_added` notification) was the **one** guild-scoped notification type that didn't embed its guild — its `data` was `{initiative_id, initiative_name}` and its deep link a bare `/initiatives/{id}`. Every other type already carries `data["guild_id"]` + a guild-qualified `smart_link`.

After schema-per-guild, `initiative` ids become per-guild, so a bare `/initiatives/{id}` link is ambiguous in the **merged cross-guild notification inbox**. This makes that last outlier consistent.

## Why no column / migration

Audited the notification flow: the inbox is queried by `user_id` only (no guild scoping, no RLS policy on `notifications`) — it's already a per-user list merged across all of a user's guilds, and each guild-scoped notification self-describes its guild for navigation. So nothing structural is needed; only this one type was missing its guild context.

## Changes

- `notifications.py`: added `_initiative_target_path` (matching the other target-path helpers); threaded `guild_id` into `notify_initiative_membership`; the in-app `data` now includes `guild_id`, `target_path`, and a guild-qualified `smart_link`, and the push payload includes `guild_id` + the proper `target_path`.
- `initiatives.py`: the sole caller passes `guild_id=initiative.guild_id`.
- Test asserting the `initiative_added` notification carries `guild_id`, `/initiatives/{id}`, and a `guild_id=…` smart link.

## Testing

- `notifications_test.py` → **9 passed** (8 existing + the new test). ruff clean.
