### PR TITLE
Demote oidc_claim_mappings initiative FKs (documented debt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - per-guild schema provisioning (`app/db/schema_provisioning.py`): creates a `guild_<id>` schema with every guild-scoped table and a Postgres role scoped to just that schema — the next step toward schema-per-guild tenancy.
 - guild creation/deletion now provisions/drops that per-guild schema and role (via a superuser provisioning connection); creating a guild rolls back if provisioning fails.
 
+### Changed
+
+- OIDC claim mappings no longer use database foreign keys for their initiative/role references — those tables move into per-guild schemas under schema-per-guild, which a shared-table FK can't span. Validity is enforced in the app (the create endpoint already validates) and the login sync skips stale references; the trade-off is documented in the model.
+
 ### Fixed
 
 - Corrected malformed stored defaults for tag/task-status colors and the task-status icon (an extra pair of quotes had been baked into the default value).

--- a/backend/alembic/versions/20260609_0099_drop_oidc_initiative_fks.py
+++ b/backend/alembic/versions/20260609_0099_drop_oidc_initiative_fks.py
@@ -1,0 +1,50 @@
+"""Drop the initiative/role FKs on oidc_claim_mappings.
+
+Under schema-per-guild, ``initiatives`` and ``initiative_roles`` move into
+per-guild schemas, so a cross-schema foreign key from the shared (public)
+``oidc_claim_mappings`` table can no longer hold. Demote ``initiative_id`` and
+``initiative_role_id`` to plain columns; integrity is enforced in app (the
+create endpoint validates the initiative/role and guild, and oidc_sync skips
+references that no longer resolve). The ``guild_id`` FK stays (public -> public).
+
+Revision ID: 20260609_0099
+Revises: 20260608_0098
+Create Date: 2026-06-09
+"""
+
+from alembic import op
+
+revision = "20260609_0099"
+down_revision = "20260608_0098"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "oidc_claim_mappings_initiative_id_fkey", "oidc_claim_mappings", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "oidc_claim_mappings_initiative_role_id_fkey",
+        "oidc_claim_mappings",
+        type_="foreignkey",
+    )
+
+
+def downgrade() -> None:
+    op.create_foreign_key(
+        "oidc_claim_mappings_initiative_id_fkey",
+        "oidc_claim_mappings",
+        "initiatives",
+        ["initiative_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "oidc_claim_mappings_initiative_role_id_fkey",
+        "oidc_claim_mappings",
+        "initiative_roles",
+        ["initiative_role_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )

--- a/backend/app/models/oidc_claim_mapping.py
+++ b/backend/app/models/oidc_claim_mapping.py
@@ -37,21 +37,35 @@ class OIDCClaimMapping(SQLModel, table=True):
         max_length=20,
         sa_column=Column(String(20), nullable=False, server_default="member"),
     )
+    # --- ARCHITECTURE DEBT: deliberate, documented, not an oversight ---
+    # These are plain integer columns, NOT foreign keys.
+    #
+    # Why it's wrong: this is a PLATFORM table (lives in `public`, shared across
+    # all guilds), but `initiatives` / `initiative_roles` are GUILD-SCOPED — under
+    # schema-per-guild they move into per-guild schemas. So these columns reach
+    # from shared data down into per-guild data, crossing the tenancy boundary.
+    # A real FK can't span that (the target lives in a different schema per row),
+    # so there is no DB-level referential integrity here: nothing stops a stale
+    # or wrong id, and nothing cleans these up when an initiative/role is deleted.
+    #
+    # The clean fix (if this is ever worth it): move initiative-level OIDC
+    # mappings into a separate GUILD-SCOPED table that lives alongside initiatives,
+    # where the FKs are intra-schema and valid; keep this platform table
+    # guild-target only. We chose not to, because OIDC->initiative provisioning is
+    # a niche self-hoster feature and didn't justify the split.
+    #
+    # Guardrails that compensate for the missing FK:
+    #   - the create endpoint (settings.py) validates the initiative/role exists
+    #     and belongs to the mapping's guild before inserting;
+    #   - oidc_sync skips any initiative/role reference that no longer resolves,
+    #     so a dangling row can't crash a login sync.
     initiative_id: Optional[int] = Field(
         default=None,
-        sa_column=Column(
-            Integer,
-            sa.ForeignKey("initiatives.id", ondelete="CASCADE"),
-            nullable=True,
-        ),
+        sa_column=Column(Integer, nullable=True),
     )
     initiative_role_id: Optional[int] = Field(
         default=None,
-        sa_column=Column(
-            Integer,
-            sa.ForeignKey("initiative_roles.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
+        sa_column=Column(Integer, nullable=True),
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/backend/app/services/oidc_sync.py
+++ b/backend/app/services/oidc_sync.py
@@ -127,10 +127,16 @@ async def sync_oidc_assignments(
     # per-guild schemas under schema-per-guild), so a purged initiative/role can
     # leave a dangling mapping. Drop it here rather than fail a membership insert.
     if initiative_guild:
+        from sqlalchemy import tuple_ as sa_tuple
+
         existing = set(
             (
                 await session.exec(
-                    select(Initiative.id).where(Initiative.id.in_(tuple(initiative_guild)))
+                    select(Initiative.id).where(
+                        sa_tuple(Initiative.id, Initiative.guild_id).in_(
+                            tuple(initiative_guild.items())
+                        )
+                    )
                 )
             ).all()
         )

--- a/backend/app/services/oidc_sync.py
+++ b/backend/app/services/oidc_sync.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.guild import GuildMembership, GuildRole
-from app.models.initiative import InitiativeMember, InitiativeRoleModel
+from app.models.initiative import Initiative, InitiativeMember, InitiativeRoleModel
 from app.models.oidc_claim_mapping import OIDCClaimMapping, OIDCMappingTargetType
 from app.models.user import User, UserStatus
 
@@ -122,6 +122,22 @@ async def sync_oidc_assignments(
             else:
                 initiative_role_candidates.setdefault(mapping.initiative_id, [])
 
+    # Skip references that no longer resolve. oidc_claim_mappings is a shared
+    # (public) table with no FK to initiatives/initiative_roles (they move into
+    # per-guild schemas under schema-per-guild), so a purged initiative/role can
+    # leave a dangling mapping. Drop it here rather than fail a membership insert.
+    if initiative_guild:
+        existing = set(
+            (
+                await session.exec(
+                    select(Initiative.id).where(Initiative.id.in_(tuple(initiative_guild)))
+                )
+            ).all()
+        )
+        for missing in set(initiative_guild) - existing:
+            initiative_guild.pop(missing, None)
+            initiative_role_candidates.pop(missing, None)
+
     # Resolve each to a single role_id using DB metadata
     initiative_roles: dict[int, int | None] = {}  # initiative_id -> role_id
     for key, candidate_ids in initiative_role_candidates.items():
@@ -141,6 +157,24 @@ async def sync_oidc_assignments(
             continue
         roles.sort(key=lambda r: (not r.is_manager, r.position))
         initiative_roles[key] = roles[0].id
+
+    # Null out any resolved role that no longer exists (the FK was demoted), so
+    # the initiative_members.role_id FK can't fail on insert — the membership is
+    # still created, just without the stale role.
+    resolved_role_ids = {rid for rid in initiative_roles.values() if rid is not None}
+    if resolved_role_ids:
+        existing_roles = set(
+            (
+                await session.exec(
+                    select(InitiativeRoleModel.id).where(
+                        InitiativeRoleModel.id.in_(tuple(resolved_role_ids))
+                    )
+                )
+            ).all()
+        )
+        for key, rid in list(initiative_roles.items()):
+            if rid is not None and rid not in existing_roles:
+                initiative_roles[key] = None
 
     # --- Guild memberships ---
     for guild_id, role_str in guild_roles.items():

--- a/backend/app/services/oidc_sync_test.py
+++ b/backend/app/services/oidc_sync_test.py
@@ -14,11 +14,14 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.guild import GuildRole
+from app.models.initiative import InitiativeMember
+from app.models.oidc_claim_mapping import OIDCClaimMapping, OIDCMappingTargetType
 from app.models.project import Project
 from app.models.user import UserStatus
 from app.services.oidc_sync import (
     _auto_transfer_owned_projects,
     _pick_fallback_owner,
+    sync_oidc_assignments,
 )
 from app.testing.factories import (
     create_guild,
@@ -262,3 +265,68 @@ async def test_auto_transfer_handles_inactive_fallback_race(
     assert any(
         "became inactive" in rec.message for rec in caplog.records
     )
+
+
+@pytest.mark.integration
+@pytest.mark.service
+async def test_sync_skips_orphaned_initiative_mapping(session: AsyncSession):
+    """A claim mapping pointing at a now-missing initiative (the FK was demoted,
+    so dangling rows are possible) must be skipped, not crash the login sync."""
+    admin = await create_user(session, email="orphan-admin@example.com")
+    guild = await create_guild(session, creator=admin)
+    user = await create_user(session, email="orphan-user@example.com")
+    session.add(
+        OIDCClaimMapping(
+            claim_value="eng",
+            target_type=OIDCMappingTargetType.initiative,
+            guild_id=guild.id,
+            guild_role="member",
+            initiative_id=99_999_999,  # does not exist
+            initiative_role_id=None,
+        )
+    )
+    await session.commit()
+
+    result = await sync_oidc_assignments(session, user_id=user.id, claim_values={"eng"})
+
+    assert result.initiatives_added == []
+    members = (
+        await session.exec(select(InitiativeMember).where(InitiativeMember.user_id == user.id))
+    ).all()
+    assert members == []
+
+
+@pytest.mark.integration
+@pytest.mark.service
+async def test_sync_nulls_orphaned_role_on_valid_initiative(session: AsyncSession):
+    """A valid initiative with a now-missing role still provisions the member —
+    the dangling role id is dropped to NULL rather than failing the insert."""
+    admin = await create_user(session, email="role-admin@example.com")
+    guild = await create_guild(session, creator=admin)
+    initiative = await create_initiative(session, guild=guild, creator=admin)
+    user = await create_user(session, email="role-user@example.com")
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.member)
+    session.add(
+        OIDCClaimMapping(
+            claim_value="pm",
+            target_type=OIDCMappingTargetType.initiative,
+            guild_id=guild.id,
+            guild_role="member",
+            initiative_id=initiative.id,
+            initiative_role_id=99_999_999,  # does not exist
+        )
+    )
+    await session.commit()
+
+    await sync_oidc_assignments(session, user_id=user.id, claim_values={"pm"})
+
+    members = (
+        await session.exec(
+            select(InitiativeMember).where(
+                InitiativeMember.user_id == user.id,
+                InitiativeMember.initiative_id == initiative.id,
+            )
+        )
+    ).all()
+    assert len(members) == 1
+    assert members[0].role_id is None


### PR DESCRIPTION
## What

`oidc_claim_mappings` is a **platform** table (lives in `public`, shared across all guilds), but its `initiative_id` / `initiative_role_id` columns reference **guild-scoped** rows. Under schema-per-guild those tables move into per-guild schemas, and a foreign key can't span from a shared table into a per-schema target. This drops those two FK constraints so the columns survive the split. The `guild_id` FK stays (public → public).

## This is deliberate, documented architecture debt

It's a smell — a platform table reaching into per-guild data with no referential integrity — and the model says so, loudly. We discussed the clean fix (relocate initiative-level mappings into a separate **guild-scoped** table where the FKs are intra-schema valid) and chose **not** to, because OIDC→initiative provisioning is a niche self-hoster feature that doesn't justify the refactor. The model comment documents what it is, why it's wrong, the clean alternative, and why we skipped it.

## Compensating guardrails (replacing what the FK gave)

- **Write-time validity**: the create endpoint already validates the initiative/role exists and belongs to the mapping's guild (unchanged).
- **On-delete / dangling rows**: the FK's `CASCADE`/`SET NULL` is gone, so `oidc_sync` now **skips** an initiative that no longer resolves and **nulls** a missing role — a dangling mapping can't crash a login sync.

## Changes

- `app/models/oidc_claim_mapping.py` — the two columns become plain integers; prominent debt comment.
- `alembic/.../20260609_0099_drop_oidc_initiative_fks.py` — drops the two FKs (downgrade re-adds them). Verified up/down/up on the test DB.
- `app/services/oidc_sync.py` — skip-orphaned-initiative + null-orphaned-role.
- Two tests proving the tolerance (the orphan inserts only succeed because the FK is now gone).

## Testing

- `oidc_sync_test.py` → **8 passed** (6 existing + 2 new). ruff clean; migration reverses cleanly.
