### PR TITLE
Add styled scrollbars to sidebar and kanban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sidebars and the kanban board now show a slim, styled scrollbar instead of the browser default — the app sidebar uses a proper scroll area, while the guild rail and kanban (column and horizontal board) scrollers keep their native scrolling and drag behavior with just restyled scrollbars.
 - OIDC claim mappings no longer use database foreign keys for their initiative/role references — those tables move into per-guild schemas under schema-per-guild, which a shared-table FK can't span. Validity is enforced in the app (the create endpoint already validates) and the login sync skips stale references; the trade-off is documented in the model.
 
 ### Fixed

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -20,6 +20,7 @@ import { InitiativeSection } from "@/components/sidebar/InitiativeSection";
 import { SidebarUserFooter } from "@/components/sidebar/SidebarUserFooter";
 import { TagBrowser } from "@/components/sidebar/TagBrowser";
 import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sidebar,
   SidebarContent,
@@ -283,226 +284,238 @@ export const AppSidebar = () => {
                   {/* </div> */}
 
                   <TabsContent value="initiatives" className="mt-0 flex-1 overflow-hidden">
-                    <SidebarContent className="h-full overflow-y-auto overflow-x-hidden">
-                      {/* Favorites Section */}
-                      {Array.isArray(favoritesQuery?.data) && favoritesQuery.data.length > 0 && (
-                        <>
-                          <SidebarGroup>
-                            <SidebarGroupLabel className="flex items-center gap-2 py-2">
-                              <Star className="h-4 w-4" />
-                              {t("favorites")}
-                            </SidebarGroupLabel>
-                            <SidebarGroupContent>
-                              <SidebarMenu>
-                                {favoritesQuery.data.map((project) => (
-                                  <SidebarMenuItem key={project.id}>
-                                    <SidebarMenuButton
-                                      asChild
-                                      isActive={project.id === activeProjectId}
-                                    >
-                                      <Link
-                                        to={gp(`/projects/${project.id}`)}
-                                        className="flex min-w-0 items-center gap-2"
+                    <ScrollArea className="[&_[data-radix-scroll-area-viewport]>div]:block! h-full">
+                      <SidebarContent className="overflow-x-hidden overflow-y-visible">
+                        {/* Favorites Section */}
+                        {Array.isArray(favoritesQuery?.data) && favoritesQuery.data.length > 0 && (
+                          <>
+                            <SidebarGroup>
+                              <SidebarGroupLabel className="flex items-center gap-2 py-2">
+                                <Star className="h-4 w-4" />
+                                {t("favorites")}
+                              </SidebarGroupLabel>
+                              <SidebarGroupContent>
+                                <SidebarMenu>
+                                  {favoritesQuery.data.map((project) => (
+                                    <SidebarMenuItem key={project.id}>
+                                      <SidebarMenuButton
+                                        asChild
+                                        isActive={project.id === activeProjectId}
                                       >
-                                        {project.icon ? (
-                                          <span className="shrink-0 text-lg">{project.icon}</span>
-                                        ) : null}
-                                        <span className="min-w-0 flex-1 truncate">
-                                          {project.name}
-                                        </span>
+                                        <Link
+                                          to={gp(`/projects/${project.id}`)}
+                                          className="flex min-w-0 items-center gap-2"
+                                        >
+                                          {project.icon ? (
+                                            <span className="shrink-0 text-lg">{project.icon}</span>
+                                          ) : null}
+                                          <span className="min-w-0 flex-1 truncate">
+                                            {project.name}
+                                          </span>
+                                        </Link>
+                                      </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                  ))}
+                                </SidebarMenu>
+                              </SidebarGroupContent>
+                            </SidebarGroup>
+                            <SidebarSeparator />
+                          </>
+                        )}
+
+                        {/* All Projects & All Documents */}
+                        {activeGuild && (
+                          <>
+                            <SidebarGroup>
+                              <SidebarGroupContent>
+                                <SidebarMenu>
+                                  <SidebarMenuItem>
+                                    <SidebarMenuButton asChild>
+                                      <Link
+                                        to={gp("/projects")}
+                                        className="flex items-center gap-2"
+                                      >
+                                        <ListTodo className="h-4 w-4" />
+                                        <span>{t("allProjects")}</span>
                                       </Link>
                                     </SidebarMenuButton>
                                   </SidebarMenuItem>
-                                ))}
-                              </SidebarMenu>
-                            </SidebarGroupContent>
-                          </SidebarGroup>
-                          <SidebarSeparator />
-                        </>
-                      )}
+                                  <SidebarMenuItem>
+                                    <SidebarMenuButton asChild>
+                                      <Link
+                                        to={gp("/documents")}
+                                        className="flex items-center gap-2"
+                                      >
+                                        <ScrollText className="h-4 w-4" />
+                                        <span>{t("allDocuments")}</span>
+                                      </Link>
+                                    </SidebarMenuButton>
+                                  </SidebarMenuItem>
+                                </SidebarMenu>
+                              </SidebarGroupContent>
+                            </SidebarGroup>
+                            <SidebarSeparator />
+                          </>
+                        )}
 
-                      {/* All Projects & All Documents */}
-                      {activeGuild && (
-                        <>
-                          <SidebarGroup>
-                            <SidebarGroupContent>
+                        {/* Initiatives Section */}
+                        <SidebarGroup>
+                          <SidebarGroupLabel className="flex items-center gap-2 py-2">
+                            <Users className="h-4 w-4" />
+                            <span className="flex-1">{t("initiatives")}</span>
+                            {visibleInitiatives.length > 0 && (
+                              <Tooltip delayDuration={300}>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-5 w-5 shrink-0"
+                                    onClick={
+                                      allInitiativesCollapsed
+                                        ? expandAllInitiatives
+                                        : collapseAllInitiatives
+                                    }
+                                    aria-label={
+                                      allInitiativesCollapsed ? t("expandAll") : t("collapseAll")
+                                    }
+                                  >
+                                    {allInitiativesCollapsed ? (
+                                      <ChevronsUpDown className="h-3.5 w-3.5" />
+                                    ) : (
+                                      <ChevronsDownUp className="h-3.5 w-3.5" />
+                                    )}
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">
+                                  <p>
+                                    {allInitiativesCollapsed ? t("expandAll") : t("collapseAll")}
+                                  </p>
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                          </SidebarGroupLabel>
+                          <SidebarGroupContent>
+                            {initiativesQuery.isLoading ? (
+                              <div className="space-y-2 px-4">
+                                <Skeleton className="h-8 w-full" />
+                                <Skeleton className="h-8 w-full" />
+                                <Skeleton className="h-8 w-full" />
+                              </div>
+                            ) : visibleInitiatives.length === 0 ? (
+                              <div className="px-4 py-2 text-muted-foreground text-sm">
+                                {t("noInitiativesAvailable")}
+                              </div>
+                            ) : (
+                              <div className="space-y-1">
+                                {visibleInitiatives.map((initiative) => {
+                                  const permissions = getUserPermissions(initiative);
+                                  return (
+                                    <InitiativeSection
+                                      key={initiative.id}
+                                      initiative={initiative}
+                                      projects={projectsByInitiative.get(initiative.id) ?? []}
+                                      documentCount={
+                                        documentCountsByInitiative.get(initiative.id) ?? 0
+                                      }
+                                      canManageInitiative={canManageInitiative(initiative)}
+                                      activeProjectId={activeProjectId}
+                                      userId={user?.id}
+                                      canViewDocs={permissions.canViewDocs}
+                                      canViewProjects={permissions.canViewProjects}
+                                      canViewQueues={permissions.canViewQueues}
+                                      canViewEvents={permissions.canViewEvents}
+                                      canViewAdvancedTool={permissions.canViewAdvancedTool}
+                                      canViewCounters={permissions.canViewCounters}
+                                      canCreateDocs={permissions.canCreateDocs}
+                                      canCreateProjects={permissions.canCreateProjects}
+                                      canCreateQueues={permissions.canCreateQueues}
+                                      canCreateEvents={permissions.canCreateEvents}
+                                      canCreateCounters={permissions.canCreateCounters}
+                                      queueCount={queueCountsByInitiative.get(initiative.id) ?? 0}
+                                      counterGroupCount={
+                                        counterGroupCountsByInitiative.get(initiative.id) ?? 0
+                                      }
+                                      activeGuildId={activeGuildId}
+                                      collapseKey={initiativeCollapseKey}
+                                    />
+                                  );
+                                })}
+                              </div>
+                            )}
+
+                            {isGuildAdmin && (
                               <SidebarMenu>
                                 <SidebarMenuItem>
-                                  <SidebarMenuButton asChild>
-                                    <Link to={gp("/projects")} className="flex items-center gap-2">
-                                      <ListTodo className="h-4 w-4" />
-                                      <span>{t("allProjects")}</span>
-                                    </Link>
-                                  </SidebarMenuButton>
-                                </SidebarMenuItem>
-                                <SidebarMenuItem>
-                                  <SidebarMenuButton asChild>
-                                    <Link to={gp("/documents")} className="flex items-center gap-2">
-                                      <ScrollText className="h-4 w-4" />
-                                      <span>{t("allDocuments")}</span>
+                                  <SidebarMenuButton asChild size="sm">
+                                    <Link to={gp("/initiatives")} search={{ create: "true" }}>
+                                      <Plus className="h-4 w-4" />
+                                      <span>{t("addInitiative")}</span>
                                     </Link>
                                   </SidebarMenuButton>
                                 </SidebarMenuItem>
                               </SidebarMenu>
-                            </SidebarGroupContent>
-                          </SidebarGroup>
-                          <SidebarSeparator />
-                        </>
-                      )}
-
-                      {/* Initiatives Section */}
-                      <SidebarGroup>
-                        <SidebarGroupLabel className="flex items-center gap-2 py-2">
-                          <Users className="h-4 w-4" />
-                          <span className="flex-1">{t("initiatives")}</span>
-                          {visibleInitiatives.length > 0 && (
-                            <Tooltip delayDuration={300}>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-5 w-5 shrink-0"
-                                  onClick={
-                                    allInitiativesCollapsed
-                                      ? expandAllInitiatives
-                                      : collapseAllInitiatives
-                                  }
-                                  aria-label={
-                                    allInitiativesCollapsed ? t("expandAll") : t("collapseAll")
-                                  }
-                                >
-                                  {allInitiativesCollapsed ? (
-                                    <ChevronsUpDown className="h-3.5 w-3.5" />
-                                  ) : (
-                                    <ChevronsDownUp className="h-3.5 w-3.5" />
-                                  )}
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom">
-                                <p>{allInitiativesCollapsed ? t("expandAll") : t("collapseAll")}</p>
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                        </SidebarGroupLabel>
-                        <SidebarGroupContent>
-                          {initiativesQuery.isLoading ? (
-                            <div className="space-y-2 px-4">
-                              <Skeleton className="h-8 w-full" />
-                              <Skeleton className="h-8 w-full" />
-                              <Skeleton className="h-8 w-full" />
-                            </div>
-                          ) : visibleInitiatives.length === 0 ? (
-                            <div className="px-4 py-2 text-muted-foreground text-sm">
-                              {t("noInitiativesAvailable")}
-                            </div>
-                          ) : (
-                            <div className="space-y-1">
-                              {visibleInitiatives.map((initiative) => {
-                                const permissions = getUserPermissions(initiative);
-                                return (
-                                  <InitiativeSection
-                                    key={initiative.id}
-                                    initiative={initiative}
-                                    projects={projectsByInitiative.get(initiative.id) ?? []}
-                                    documentCount={
-                                      documentCountsByInitiative.get(initiative.id) ?? 0
-                                    }
-                                    canManageInitiative={canManageInitiative(initiative)}
-                                    activeProjectId={activeProjectId}
-                                    userId={user?.id}
-                                    canViewDocs={permissions.canViewDocs}
-                                    canViewProjects={permissions.canViewProjects}
-                                    canViewQueues={permissions.canViewQueues}
-                                    canViewEvents={permissions.canViewEvents}
-                                    canViewAdvancedTool={permissions.canViewAdvancedTool}
-                                    canViewCounters={permissions.canViewCounters}
-                                    canCreateDocs={permissions.canCreateDocs}
-                                    canCreateProjects={permissions.canCreateProjects}
-                                    canCreateQueues={permissions.canCreateQueues}
-                                    canCreateEvents={permissions.canCreateEvents}
-                                    canCreateCounters={permissions.canCreateCounters}
-                                    queueCount={queueCountsByInitiative.get(initiative.id) ?? 0}
-                                    counterGroupCount={
-                                      counterGroupCountsByInitiative.get(initiative.id) ?? 0
-                                    }
-                                    activeGuildId={activeGuildId}
-                                    collapseKey={initiativeCollapseKey}
-                                  />
-                                );
-                              })}
-                            </div>
-                          )}
-
-                          {isGuildAdmin && (
-                            <SidebarMenu>
-                              <SidebarMenuItem>
-                                <SidebarMenuButton asChild size="sm">
-                                  <Link to={gp("/initiatives")} search={{ create: "true" }}>
-                                    <Plus className="h-4 w-4" />
-                                    <span>{t("addInitiative")}</span>
-                                  </Link>
-                                </SidebarMenuButton>
-                              </SidebarMenuItem>
-                            </SidebarMenu>
-                          )}
-                        </SidebarGroupContent>
-                      </SidebarGroup>
-                    </SidebarContent>
+                            )}
+                          </SidebarGroupContent>
+                        </SidebarGroup>
+                      </SidebarContent>
+                    </ScrollArea>
                   </TabsContent>
 
                   <TabsContent value="tags" className="mt-0 flex-1 overflow-hidden">
-                    <SidebarContent className="h-full overflow-y-auto overflow-x-hidden">
-                      <SidebarGroup>
-                        <SidebarGroupLabel className="flex items-center gap-2 py-2">
-                          <Tag className="h-4 w-4" />
-                          <span className="flex-1">{t("tags")}</span>
-                          {(tagsQuery.data ?? []).length > 0 && (
-                            <Tooltip delayDuration={300}>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-5 w-5 shrink-0"
-                                  onClick={expandAllTags}
-                                  aria-label={t("expandAll")}
-                                >
-                                  <ChevronsUpDown className="h-3.5 w-3.5" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom">
-                                <p>{t("expandAll")}</p>
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                          {(tagsQuery.data ?? []).length > 0 && (
-                            <Tooltip delayDuration={300}>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-5 w-5 shrink-0"
-                                  onClick={collapseAllTags}
-                                  aria-label={t("collapseAll")}
-                                >
-                                  <ChevronsDownUp className="h-3.5 w-3.5" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom">
-                                <p>{t("collapseAll")}</p>
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                        </SidebarGroupLabel>
-                        <SidebarGroupContent>
-                          <TagBrowser
-                            tags={tagsQuery.data ?? []}
-                            isLoading={tagsQuery.isLoading}
-                            activeGuildId={activeGuildId}
-                            collapseKey={tagCollapseKey}
-                          />
-                        </SidebarGroupContent>
-                      </SidebarGroup>
-                    </SidebarContent>
+                    <ScrollArea className="[&_[data-radix-scroll-area-viewport]>div]:!block h-full">
+                      <SidebarContent className="overflow-x-hidden overflow-y-visible">
+                        <SidebarGroup>
+                          <SidebarGroupLabel className="flex items-center gap-2 py-2">
+                            <Tag className="h-4 w-4" />
+                            <span className="flex-1">{t("tags")}</span>
+                            {(tagsQuery.data ?? []).length > 0 && (
+                              <Tooltip delayDuration={300}>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-5 w-5 shrink-0"
+                                    onClick={expandAllTags}
+                                    aria-label={t("expandAll")}
+                                  >
+                                    <ChevronsUpDown className="h-3.5 w-3.5" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">
+                                  <p>{t("expandAll")}</p>
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                            {(tagsQuery.data ?? []).length > 0 && (
+                              <Tooltip delayDuration={300}>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-5 w-5 shrink-0"
+                                    onClick={collapseAllTags}
+                                    aria-label={t("collapseAll")}
+                                  >
+                                    <ChevronsDownUp className="h-3.5 w-3.5" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">
+                                  <p>{t("collapseAll")}</p>
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                          </SidebarGroupLabel>
+                          <SidebarGroupContent>
+                            <TagBrowser
+                              tags={tagsQuery.data ?? []}
+                              isLoading={tagsQuery.isLoading}
+                              activeGuildId={activeGuildId}
+                              collapseKey={tagCollapseKey}
+                            />
+                          </SidebarGroupContent>
+                        </SidebarGroup>
+                      </SidebarContent>
+                    </ScrollArea>
                   </TabsContent>
                 </Tabs>
               </>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -462,7 +462,7 @@ export const AppSidebar = () => {
                   </TabsContent>
 
                   <TabsContent value="tags" className="mt-0 flex-1 overflow-hidden">
-                    <ScrollArea className="[&_[data-radix-scroll-area-viewport]>div]:!block h-full">
+                    <ScrollArea className="[&_[data-radix-scroll-area-viewport]>div]:block! h-full">
                       <SidebarContent className="overflow-x-hidden overflow-y-visible">
                         <SidebarGroup>
                           <SidebarGroupLabel className="flex items-center gap-2 py-2">

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -352,7 +352,7 @@ export const GuildSidebar = ({ isHomeMode = false }: { isHomeMode?: boolean }) =
 
   return (
     <aside
-      className="sticky top-0 flex max-h-screen w-20 flex-col items-center gap-3 border-r bg-sidebar px-2 pb-4 scrollbar-thin"
+      className="sticky top-0 flex max-h-screen w-20 flex-col items-center gap-3 border-r bg-sidebar px-2 pb-4"
       style={{ paddingTop: "calc(var(--safe-area-inset-top) + 1rem)" }}
     >
       <TooltipProvider delayDuration={200}>
@@ -373,7 +373,7 @@ export const GuildSidebar = ({ isHomeMode = false }: { isHomeMode?: boolean }) =
             <p>{t("nav:home")}</p>
           </TooltipContent>
         </Tooltip>
-        <div className="flex flex-col items-center gap-3 overflow-y-auto border-t py-3">
+        <div className="scrollbar-thin flex flex-col items-center gap-3 overflow-y-auto border-t py-3">
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -352,7 +352,7 @@ export const GuildSidebar = ({ isHomeMode = false }: { isHomeMode?: boolean }) =
 
   return (
     <aside
-      className="sticky top-0 flex max-h-screen w-20 flex-col items-center gap-3 border-r bg-sidebar px-2 pb-4"
+      className="sticky top-0 flex max-h-screen w-20 flex-col items-center gap-3 border-r bg-sidebar px-2 pb-4 scrollbar-thin"
       style={{ paddingTop: "calc(var(--safe-area-inset-top) + 1rem)" }}
     >
       <TooltipProvider delayDuration={200}>

--- a/frontend/src/components/projects/KanbanColumn.tsx
+++ b/frontend/src/components/projects/KanbanColumn.tsx
@@ -123,7 +123,7 @@ export const KanbanColumn = ({
           "h-full w-full transition-colors",
           collapsed
             ? "flex flex-1 items-center justify-center px-2"
-            : "flex-1 space-y-3 overflow-y-auto p-3 pr-2",
+            : "scrollbar-thin flex-1 space-y-3 overflow-y-auto p-3 pr-2",
           isOver ? "bg-muted/40" : null
         )}
       >

--- a/frontend/src/components/projects/ProjectTasksKanbanView.tsx
+++ b/frontend/src/components/projects/ProjectTasksKanbanView.tsx
@@ -80,7 +80,7 @@ export const ProjectTasksKanbanView = ({
     >
       <div
         ref={scrollContainerRef}
-        className="cursor-grab overflow-x-auto pb-4"
+        className="scrollbar-thin cursor-grab overflow-x-auto pb-4"
         data-kanban-scroll-container
       >
         <div className="flex gap-4">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -153,6 +153,26 @@
   }
 }
 
+/* Thin, rounded scrollbar that matches the Radix ScrollArea thumb styling.
+   Use on native-overflow containers (e.g. virtualized / drag-and-drop lists)
+   where wrapping in a Radix ScrollArea would break scroll measurement. */
+@utility scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background-color: var(--color-border);
+  }
+}
+
 @keyframes aurora {
   0%,
   100% {


### PR DESCRIPTION
## Problem

The app sidebar, guild rail, and kanban board/columns relied on the browser's default scrollbar, which looks heavy and inconsistent with the app's styling.

## Changes

- **App sidebar** (`AppSidebar.tsx`): the two tab scroll regions (Initiatives, Tags) now use the Radix `ScrollArea` component for a styled scrollbar. Includes a width-constraint fix (`[&_[data-radix-scroll-area-viewport]>div]:block!`) so rows still truncate correctly inside Radix's `display:table` viewport wrapper.
- **New `scrollbar-thin` utility** (`styles.css`): a Tailwind v4 `@utility` that restyles the native scrollbar (thin, rounded, `--color-border` thumb, transparent track) to match the Radix scrollbar — for containers that can't be wrapped in a `ScrollArea`.
- **Kanban columns** (`KanbanColumn.tsx`) and **horizontal board** (`ProjectTasksKanbanView.tsx`): keep their native scroll containers (so the TanStack virtualizer, dnd-kit drag-and-drop, and drag-to-pan all keep working) and just add `scrollbar-thin`.
- **Guild rail** (`GuildSidebar.tsx`): `scrollbar-thin` on the vertical guild list.

### Why not `ScrollArea` everywhere?

Wrapping the kanban scrollers in Radix `ScrollArea` broke them: the column scroller is the virtualizer's scroll element, and the board scroller is the drag-to-pan target — Radix's separate viewport element conflicts with both (broken scroll, laggy drag). The native scroll + `scrollbar-thin` approach keeps all that behavior intact.

## Testing

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- Manually verified sidebar scrolling, kanban column scrolling, virtualized columns (>20 tasks), horizontal board drag-to-pan, and dnd auto-scroll.