### PR TITLE
Rework assignee selector to match tag picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Reworked the assignee selector to match the tag picker.** Members are now picked from a single searchable dropdown where every entry has a checkbox and avatar, and toggling it adds or removes the person. Selected members sort to the top, followed by yourself (tagged "You") ahead of everyone else, and current selections appear as removable avatar chips on the trigger.
 - Sidebars and the kanban board now show a slim, styled scrollbar instead of the browser default — the app sidebar uses a proper scroll area, while the guild rail and kanban (column and horizontal board) scrollers keep their native scrolling and drag behavior with just restyled scrollbars.
 - OIDC claim mappings no longer use database foreign keys for their initiative/role references — those tables move into per-guild schemas under schema-per-guild, which a shared-table FK can't span. Validity is enforced in the app (the create endpoint already validates) and the login sync skips stale references; the trade-off is documented in the model.
 

--- a/frontend/public/locales/en/projects.json
+++ b/frontend/public/locales/en/projects.json
@@ -199,7 +199,8 @@
     "searchPlaceholder": "Search {{memberLabel}}",
     "noAssignees": "No assignees selected.",
     "removeAssignee": "Remove {{name}}",
-    "clearAssignees": "Clear assignees"
+    "clearAssignees": "Clear assignees",
+    "you": "You"
   },
 
   "statuses": {

--- a/frontend/public/locales/es/projects.json
+++ b/frontend/public/locales/es/projects.json
@@ -186,7 +186,8 @@
     "searchPlaceholder": "Buscar {{memberLabel}}",
     "noAssignees": "No hay asignados seleccionados.",
     "removeAssignee": "Quitar a {{name}}",
-    "clearAssignees": "Limpiar asignados"
+    "clearAssignees": "Limpiar asignados",
+    "you": "Tú"
   },
   "statuses": {
     "title": "Estados de tarea",

--- a/frontend/public/locales/fr/projects.json
+++ b/frontend/public/locales/fr/projects.json
@@ -185,7 +185,8 @@
     "searchPlaceholder": "Rechercher {{memberLabel}}",
     "noAssignees": "Aucun assigné sélectionné.",
     "removeAssignee": "Retirer {{name}}",
-    "clearAssignees": "Effacer les assignés"
+    "clearAssignees": "Effacer les assignés",
+    "you": "Vous"
   },
   "statuses": {
     "title": "Statuts des tâches",

--- a/frontend/src/components/projects/AssigneeSelector.tsx
+++ b/frontend/src/components/projects/AssigneeSelector.tsx
@@ -55,10 +55,10 @@ export const AssigneeSelector = ({
 
   const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
 
-  const labelById = useMemo(() => {
-    const map = new Map<number, string>();
+  const optionById = useMemo(() => {
+    const map = new Map<number, AssigneeOption>();
     options.forEach((option) => {
-      map.set(option.id, option.label);
+      map.set(option.id, option);
     });
     return map;
   }, [options]);
@@ -81,12 +81,17 @@ export const AssigneeSelector = ({
     return [...selected, ...currentUser, ...rest];
   }, [options, selectedSet, currentUserId]);
 
-  const selectedOptions = useMemo(() => {
-    return selectedIds.map((id) => ({
-      id,
-      label: labelById.get(id) ?? `User #${id}`,
-    }));
-  }, [labelById, selectedIds]);
+  const selectedOptions = useMemo<AssigneeOption[]>(() => {
+    return selectedIds.map((id) => {
+      const option = optionById.get(id);
+      return {
+        id,
+        label: option?.label ?? `User #${id}`,
+        avatarUrl: option?.avatarUrl,
+        avatarBase64: option?.avatarBase64,
+      };
+    });
+  }, [optionById, selectedIds]);
 
   const toggleAssignee = (id: number) => {
     if (!Number.isFinite(id)) {
@@ -174,7 +179,7 @@ export const AssigneeSelector = ({
                   return (
                     <CommandItem
                       key={option.id}
-                      value={option.label}
+                      value={`${option.id}-${option.label}`}
                       onSelect={() => toggleAssignee(option.id)}
                       className="cursor-pointer"
                     >

--- a/frontend/src/components/projects/AssigneeSelector.tsx
+++ b/frontend/src/components/projects/AssigneeSelector.tsx
@@ -1,15 +1,32 @@
-import { X } from "lucide-react";
+import { Check, Users, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { SearchableCombobox } from "@/components/ui/searchable-combobox";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getRoleLabel, useRoleLabels } from "@/hooks/useRoleLabels";
+import { getInitials } from "@/lib/initials";
+import { resolveUploadUrl } from "@/lib/uploadUrl";
+import { cn } from "@/lib/utils";
 
 interface AssigneeOption {
   id: number;
   label: string;
+  avatarUrl?: string | null;
+  avatarBase64?: string | null;
 }
+
+const resolveAvatarSrc = (option: AssigneeOption): string | undefined =>
+  resolveUploadUrl(option.avatarUrl) || option.avatarBase64 || undefined;
 
 interface AssigneeSelectorProps {
   selectedIds: number[];
@@ -17,6 +34,9 @@ interface AssigneeSelectorProps {
   onChange: (ids: number[]) => void;
   disabled?: boolean;
   emptyMessage?: string;
+  /** When present and in the option list, this user floats to the top of the
+   *  unselected group so people can quickly assign themselves. */
+  currentUserId?: number;
 }
 
 export const AssigneeSelector = ({
@@ -25,12 +45,15 @@ export const AssigneeSelector = ({
   onChange,
   disabled = false,
   emptyMessage,
+  currentUserId,
 }: AssigneeSelectorProps) => {
   const { t } = useTranslation("projects");
   const { data: roleLabels } = useRoleLabels();
   const memberLabel = getRoleLabel("member", roleLabels);
   const resolvedEmptyMessage = emptyMessage ?? t("assignee.emptyMessage", { memberLabel });
-  const [searchValue, setSearchValue] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
 
   const labelById = useMemo(() => {
     const map = new Map<number, string>();
@@ -40,10 +63,23 @@ export const AssigneeSelector = ({
     return map;
   }, [options]);
 
-  const comboboxItems = useMemo(
-    () => options.map((option) => ({ value: String(option.id), label: option.label })),
-    [options]
-  );
+  // Ordering: selected assignees first, then the current user, then everyone
+  // else. Each bucket keeps the incoming option order.
+  const orderedOptions = useMemo(() => {
+    const selected: AssigneeOption[] = [];
+    const currentUser: AssigneeOption[] = [];
+    const rest: AssigneeOption[] = [];
+    options.forEach((option) => {
+      if (selectedSet.has(option.id)) {
+        selected.push(option);
+      } else if (option.id === currentUserId) {
+        currentUser.push(option);
+      } else {
+        rest.push(option);
+      }
+    });
+    return [...selected, ...currentUser, ...rest];
+  }, [options, selectedSet, currentUserId]);
 
   const selectedOptions = useMemo(() => {
     return selectedIds.map((id) => ({
@@ -52,65 +88,126 @@ export const AssigneeSelector = ({
     }));
   }, [labelById, selectedIds]);
 
-  const addAssignee = (id: number) => {
-    if (!Number.isFinite(id) || selectedIds.includes(id)) {
+  const toggleAssignee = (id: number) => {
+    if (!Number.isFinite(id)) {
       return;
     }
-    onChange([...selectedIds, id]);
+    if (selectedSet.has(id)) {
+      onChange(selectedIds.filter((value) => value !== id));
+    } else {
+      onChange([...selectedIds, id]);
+    }
   };
 
   const removeAssignee = (id: number) => {
     onChange(selectedIds.filter((value) => value !== id));
   };
 
+  if (options.length === 0) {
+    return <p className="text-muted-foreground text-sm">{resolvedEmptyMessage}</p>;
+  }
+
   return (
     <div className="space-y-3">
-      {options.length === 0 ? (
-        <p className="text-muted-foreground text-sm">{resolvedEmptyMessage}</p>
-      ) : (
-        <SearchableCombobox
-          items={comboboxItems}
-          value={searchValue}
-          onValueChange={(value) => {
-            if (!value) {
-              setSearchValue("");
-              return;
-            }
-            const id = Number(value);
-            setSearchValue("");
-            addAssignee(id);
-          }}
-          placeholder={t("assignee.searchPlaceholder", { memberLabel })}
-          emptyMessage={resolvedEmptyMessage}
-          disabled={disabled}
-        />
-      )}
-      <div className="space-y-2 rounded-md border p-3">
-        {selectedOptions.length === 0 ? (
-          <p className="text-muted-foreground text-sm">{t("assignee.noAssignees")}</p>
-        ) : (
-          <ul className="space-y-2">
-            {selectedOptions.map((option) => (
-              <li key={option.id} className="flex items-center justify-between gap-3 text-sm">
-                <span className="truncate">{option.label}</span>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={() => removeAssignee(option.id)}
-                  disabled={disabled}
-                >
-                  <span className="sr-only">
-                    {t("assignee.removeAssignee", { name: option.label })}
-                  </span>
-                  <X className="h-4 w-4" />
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <Popover open={open} onOpenChange={(next) => !disabled && setOpen(next)}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className={cn(
+              "h-auto min-h-10 w-full justify-start",
+              selectedOptions.length === 0 && "text-muted-foreground"
+            )}
+          >
+            <Users className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+            {selectedOptions.length > 0 ? (
+              <div className="flex flex-wrap gap-1">
+                {selectedOptions.map((option) => {
+                  const avatarSrc = resolveAvatarSrc(option);
+                  return (
+                    <span
+                      key={option.id}
+                      className="inline-flex max-w-full items-center gap-1 rounded-md bg-secondary py-0.5 pr-1.5 pl-1 font-medium text-secondary-foreground text-xs"
+                    >
+                      <Avatar className="h-4 w-4 border text-[8px]">
+                        {avatarSrc ? <AvatarImage src={avatarSrc} alt={option.label} /> : null}
+                        <AvatarFallback userId={option.id}>
+                          {getInitials(option.label)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="truncate">{option.label}</span>
+                      <button
+                        type="button"
+                        className="ml-0.5 rounded-sm hover:opacity-70 focus:outline-none"
+                        aria-label={t("assignee.removeAssignee", { name: option.label })}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          event.preventDefault();
+                          if (!disabled) {
+                            removeAssignee(option.id);
+                          }
+                        }}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            ) : (
+              <span>{t("assignee.searchPlaceholder", { memberLabel })}</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-72 p-0" align="start">
+          <Command>
+            <CommandInput placeholder={t("assignee.searchPlaceholder", { memberLabel })} />
+            <CommandList>
+              <CommandEmpty>{resolvedEmptyMessage}</CommandEmpty>
+              <CommandGroup>
+                {orderedOptions.map((option) => {
+                  const isSelected = selectedSet.has(option.id);
+                  const isCurrentUser = option.id === currentUserId;
+                  const avatarSrc = resolveAvatarSrc(option);
+                  return (
+                    <CommandItem
+                      key={option.id}
+                      value={option.label}
+                      onSelect={() => toggleAssignee(option.id)}
+                      className="cursor-pointer"
+                    >
+                      <div
+                        className={cn(
+                          "mr-2 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-primary",
+                          isSelected
+                            ? "bg-primary text-primary-foreground"
+                            : "opacity-50 [&_svg]:invisible"
+                        )}
+                      >
+                        <Check className="h-3 w-3" />
+                      </div>
+                      <Avatar className="mr-2 h-6 w-6 border text-[10px]">
+                        {avatarSrc ? <AvatarImage src={avatarSrc} alt={option.label} /> : null}
+                        <AvatarFallback userId={option.id}>
+                          {getInitials(option.label)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="truncate">{option.label}</span>
+                      {isCurrentUser ? (
+                        <span className="ml-2 text-muted-foreground text-xs">
+                          {t("assignee.you")}
+                        </span>
+                      ) : null}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
       {selectedIds.length > 0 ? (
         <Button
           type="button"

--- a/frontend/src/components/projects/ProjectTaskComposer.tsx
+++ b/frontend/src/components/projects/ProjectTaskComposer.tsx
@@ -32,7 +32,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/hooks/useAuth";
 import { getRoleLabel, useRoleLabels } from "@/hooks/useRoleLabels";
+
+import type { UserOption } from "./projectTasksConfig";
 
 interface ProjectTaskComposerProps {
   title: string;
@@ -47,7 +50,7 @@ interface ProjectTaskComposerProps {
   isArchived: boolean;
   isSubmitting: boolean;
   hasError: boolean;
-  users: { id: number; label: string }[];
+  users: UserOption[];
   onTitleChange: (value: string) => void;
   onDescriptionChange: (value: string) => void;
   onPriorityChange: (value: TaskPriority) => void;
@@ -90,6 +93,7 @@ export const ProjectTaskComposer = ({
   const { t } = useTranslation(["projects", "common"]);
   const { data: roleLabels } = useRoleLabels();
   const memberLabel = getRoleLabel("member", roleLabels);
+  const { user: currentUser } = useAuth();
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit();
@@ -157,6 +161,7 @@ export const ProjectTaskComposer = ({
                         onChange={onAssigneesChange}
                         disabled={isSubmitting}
                         emptyMessage={t("taskComposer.assigneesEmptyMessage", { memberLabel })}
+                        currentUserId={currentUser?.id}
                       />
                     </div>
                   </div>

--- a/frontend/src/components/projects/projectTasksConfig.ts
+++ b/frontend/src/components/projects/projectTasksConfig.ts
@@ -5,6 +5,8 @@ export type DueFilterOption = "all" | "today" | "7_days" | "30_days" | "overdue"
 export type UserOption = {
   id: number;
   label: string;
+  avatarUrl?: string | null;
+  avatarBase64?: string | null;
 };
 
 export const priorityVariant: Record<TaskPriority, "default" | "secondary" | "destructive"> = {

--- a/frontend/src/components/tasks/TaskBulkEditDialog.tsx
+++ b/frontend/src/components/tasks/TaskBulkEditDialog.tsx
@@ -35,6 +35,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useAuth } from "@/hooks/useAuth";
 
 export type TaskBulkUpdate = {
   start_date: string | null;
@@ -64,6 +65,7 @@ export const TaskBulkEditDialog = ({
   onCancel,
 }: TaskBulkEditDialogProps) => {
   const { t } = useTranslation(["tasks", "common"]);
+  const { user: currentUser } = useAuth();
   const [startDate, setStartDate] = useState<string>("");
   const [dueDate, setDueDate] = useState<string>("");
   const [assigneeIds, setAssigneeIds] = useState<number[]>([]);
@@ -153,6 +155,7 @@ export const TaskBulkEditDialog = ({
                   options={userOptions}
                   onChange={setAssigneeIds}
                   emptyMessage={t("bulkEdit.noUsersAvailable")}
+                  currentUserId={currentUser?.id}
                 />
               </div>
             </AccordionContent>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -90,6 +90,8 @@ export const ProjectDetailPage = () => {
       return allUsers.map((item) => ({
         id: item.id,
         label: item.full_name ?? item.email,
+        avatarUrl: item.avatar_url,
+        avatarBase64: item.avatar_base64,
       }));
     }
 
@@ -121,6 +123,8 @@ export const ProjectDetailPage = () => {
       .map((item) => ({
         id: item.id,
         label: item.full_name ?? item.email,
+        avatarUrl: item.avatar_url,
+        avatarBase64: item.avatar_base64,
       }));
   }, [usersQuery.data, projectQuery.data]);
 

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -115,7 +115,7 @@ export const TaskEditPage = () => {
   const { taskId } = useParams({ strict: false }) as { taskId: string };
   const parsedTaskId = Number(taskId);
   const router = useRouter();
-  useAuth();
+  const { user: currentUser } = useAuth();
   useGuilds();
   const { t } = useTranslation(["tasks", "common", "properties"]);
   const gp = useGuildPath();
@@ -383,6 +383,8 @@ export const TaskEditPage = () => {
       return users.map((user) => ({
         id: user.id,
         label: user.full_name ?? user.email,
+        avatarUrl: user.avatar_url,
+        avatarBase64: user.avatar_base64,
       }));
     }
     const allowed = new Set<number>();
@@ -413,6 +415,8 @@ export const TaskEditPage = () => {
       .map((user) => ({
         id: user.id,
         label: user.full_name ?? user.email,
+        avatarUrl: user.avatar_url,
+        avatarBase64: user.avatar_base64,
       }));
   }, [users, project]);
 
@@ -851,22 +855,6 @@ export const TaskEditPage = () => {
                 </div>
               </div>
 
-              <section className="space-y-2">
-                <Label>{t("properties:title")}</Label>
-                <PropertyList
-                  entityKind="task"
-                  entityId={parsedTaskId}
-                  properties={combinedProperties}
-                  disabled={isReadOnly}
-                />
-                <AddPropertyButton
-                  initiativeId={project?.initiative_id ?? 0}
-                  currentPropertyIds={combinedPropertyIds}
-                  onAdd={handleAddProperty}
-                  disabled={isReadOnly || !project?.initiative_id}
-                />
-              </section>
-
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <Label>{t("edit.assigneesLabel")}</Label>
@@ -876,6 +864,7 @@ export const TaskEditPage = () => {
                     onChange={setAssigneeIds}
                     disabled={isReadOnly}
                     emptyMessage={t("edit.assigneesEmptyMessage", { memberLabel })}
+                    currentUserId={currentUser?.id}
                   />
                 </div>
                 <div className="space-y-2">
@@ -897,6 +886,22 @@ export const TaskEditPage = () => {
                 disabled={isReadOnly}
                 referenceDate={dueDate || startDate || task?.due_date || task?.start_date}
               />
+
+              <section className="space-y-2">
+                <Label>{t("properties:title")}</Label>
+                <PropertyList
+                  entityKind="task"
+                  entityId={parsedTaskId}
+                  properties={combinedProperties}
+                  disabled={isReadOnly}
+                />
+                <AddPropertyButton
+                  initiativeId={project?.initiative_id ?? 0}
+                  currentPropertyIds={combinedPropertyIds}
+                  onAdd={handleAddProperty}
+                  disabled={isReadOnly || !project?.initiative_id}
+                />
+              </section>
 
               <div className="flex flex-wrap gap-3">
                 <Button type="submit" disabled={updateTask.isPending || isReadOnly}>


### PR DESCRIPTION
## Problem

The assignee selector used a search-only combobox plus a separate remove-list, which looked and behaved differently from the tag picker and didn't surface who was already assigned at a glance.

## Changes

- **Tag-picker-style dropdown.** Members are now picked from a single searchable popover where each row has a square checkbox and a user avatar; selecting toggles the assignee on/off.
- **Ordering.** Selected members sort to the top, then the current user (tagged "You"), then everyone else — each bucket preserves its incoming order.
- **Trigger.** Current selections render as removable avatar chips, led by a `Users` icon matching the calendar/tag icons on the surrounding inputs (no chevron).
- **Avatars threaded through `UserOption`.** Added optional `avatarUrl`/`avatarBase64` to the option type and populated them at every construction site (`TaskEditPage`, `ProjectDetailPage`), so avatars flow into the composer, bulk-edit dialog, and task edit page.
- Wired the current user id into all three `AssigneeSelector` consumers.

## i18n

- Added `assignee.you` to `en`/`es`/`fr` `projects.json`.

## Testing

- `pnpm typecheck` — clean
- `pnpm biome check` on changed files — clean
- `pnpm test:run` — 576 passed (locale-key parity included)