### PR TITLE
Make background jobs + membership list schema-per-guild aware

### DIFF
--- a/backend/app/services/guilds.py
+++ b/backend/app/services/guilds.py
@@ -193,22 +193,45 @@ async def list_memberships(
     user_id: int,
 ) -> list[tuple[Guild, GuildMembership, int | None]]:
     """Return (guild, membership, retention_days) for each guild the user
-    belongs to. The LEFT JOIN to guild_settings keeps this a single query
-    so the guild list (rendered in the sidebar + every Settings page) doesn't
-    fan out into N+1 lookups."""
-    stmt = (
-        select(Guild, GuildMembership, GuildSetting.retention_days)
-        .join(GuildMembership, GuildMembership.guild_id == Guild.id)
-        .join(GuildSetting, GuildSetting.guild_id == Guild.id, isouter=True)
-        .where(GuildMembership.user_id == user_id)
-        .order_by(
-            GuildMembership.position.asc(),
-            GuildMembership.joined_at.asc(),
-            Guild.id.asc(),
+    belongs to.
+
+    The guild + membership rows are shared (public). ``retention_days`` lives in
+    each guild's own schema (``guild_settings``), so it's read per guild with the
+    user's membership context — a single cross-guild join would hit the empty
+    public table and report NULL for everyone. ``guild_settings.id`` is a
+    per-schema serial that collides across schemas, so each settings row is
+    detached after reading so a cached row can't shadow the next guild's."""
+    from app.db.session import set_rls_context  # lazy: avoids a circular import
+
+    await set_rls_context(session, user_id=user_id)
+    pairs = (
+        await session.exec(
+            select(Guild, GuildMembership)
+            .join(GuildMembership, GuildMembership.guild_id == Guild.id)
+            .where(GuildMembership.user_id == user_id)
+            .order_by(
+                GuildMembership.position.asc(),
+                GuildMembership.joined_at.asc(),
+                Guild.id.asc(),
+            )
         )
-    )
-    result = await session.exec(stmt)
-    return result.all()
+    ).all()
+
+    out: list[tuple[Guild, GuildMembership, int | None]] = []
+    for guild, membership in pairs:
+        await set_rls_context(session, user_id=user_id, guild_id=guild.id)
+        row = (
+            await session.exec(select(GuildSetting).where(GuildSetting.guild_id == guild.id))
+        ).one_or_none()
+        # No row yet → the 90-day default; an explicit NULL is the user's "never".
+        retention = 90 if row is None else row.retention_days
+        if row is not None:
+            session.expunge(row)
+        out.append((guild, membership, retention))
+
+    # Restore the user-only context the caller (UserSessionDep) handed us.
+    await set_rls_context(session, user_id=user_id)
+    return out
 
 
 async def create_guild_settings(session: AsyncSession, guild_id: int) -> GuildSetting:

--- a/backend/app/services/guilds_test.py
+++ b/backend/app/services/guilds_test.py
@@ -490,3 +490,28 @@ async def test_get_guild_retention_days_distinguishes_never_from_missing(
     # Suppress unused-name warning if linters complain about the user
     # we created for symmetry with other tests in this module.
     _ = user
+
+
+async def test_list_memberships_reads_retention_per_guild(session: AsyncSession):
+    """retention_days lives in each guild's own schema. The guild list must read
+    it per guild with the user's context — a single cross-guild join hits the
+    empty public guild_settings and reports NULL for everyone."""
+    from app.models.guild_setting import GuildSetting
+
+    user = await create_user(session)
+
+    guild_30 = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild_30, role=GuildRole.admin)
+    session.add(GuildSetting(guild_id=guild_30.id, retention_days=30))
+    await session.commit()
+
+    # A guild with no settings row should fall back to the 90-day default.
+    guild_default = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild_default, role=GuildRole.admin)
+    await session.commit()
+
+    memberships = await guild_service.list_memberships(session, user_id=user.id)
+    by_guild = {guild.id: retention for guild, _membership, retention in memberships}
+
+    assert by_guild[guild_30.id] == 30  # read from the guild's own schema
+    assert by_guild[guild_default.id] == 90  # default when no settings row

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from sqlalchemy import select, delete
+from sqlalchemy import select, delete, update as sa_update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.db.session import AdminSessionLocal, set_rls_context
@@ -73,23 +73,6 @@ def _initiative_target_path(initiative_id: int | None) -> str:
     if initiative_id is None:
         return "/initiatives"
     return f"/initiatives/{initiative_id}"
-
-
-async def _project_guild_map(session: AsyncSession, project_ids: set[int]) -> dict[int, int]:
-    if not project_ids:
-        return {}
-    stmt = (
-        select(Project.id, Initiative.guild_id)
-        .join(Project.initiative)
-        .where(Project.id.in_(tuple(project_ids)))
-    )
-    result = await session.exec(stmt)
-    rows = result.all()
-    mapping: dict[int, int] = {}
-    for project_id, guild_id in rows:
-        if project_id is not None and guild_id is not None:
-            mapping[int(project_id)] = int(guild_id)
-    return mapping
 
 
 async def enqueue_task_assignment_event(
@@ -983,84 +966,91 @@ async def notify_event_reminder(
     )
 
 
-async def _pending_assignment_user_ids(session: AsyncSession) -> list[int]:
-    stmt = (
-        select(TaskAssignmentDigestItem.user_id)
-        .where(TaskAssignmentDigestItem.processed_at.is_(None))
-        .distinct()
-    )
-    result = await session.exec(stmt)
-    return result.scalars().all()
+async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -> None:
+    """Send task-assignment digests to opted-in users as of ``now``.
 
+    Split out from ``process_task_assignment_digests`` so tests can drive it with
+    the test session. Each user's pending digest items live in their own guild
+    schemas, so they're gathered with the user's membership context (no
+    superadmin) and the items are marked processed back in each schema.
+    """
+    result = await session.exec(select(User).where(User.email_task_assignment.is_not(False)))
+    users = result.scalars().all()
+    if not users:
+        logger.debug("task-digest: no opted-in users")
+        return
+    # Capture before routing — the gather expunges the identity map.
+    candidates = [(u.id, u.email, u.last_task_assignment_digest_at) for u in users]
+    for user_id, email, last_at in candidates:
+        if last_at and last_at + timedelta(hours=1) > now:
+            continue  # rate-limited to one digest per hour
+        per_guild_items: dict[int, list[int]] = {}
 
-async def _load_user(session: AsyncSession, user_id: int) -> User | None:
-    result = await session.exec(select(User).where(User.id == user_id))
-    return result.scalar_one_or_none()
+        async def _fetch(routed: AsyncSession, gid: int) -> list[dict]:
+            items = (
+                await routed.exec(
+                    select(TaskAssignmentDigestItem)
+                    .where(
+                        TaskAssignmentDigestItem.user_id == user_id,
+                        TaskAssignmentDigestItem.processed_at.is_(None),
+                    )
+                    .order_by(TaskAssignmentDigestItem.created_at.asc())
+                )
+            ).scalars().all()
+            per_guild_items[gid] = [item.id for item in items]
+            return [
+                {
+                    "task_title": item.task_title,
+                    "project_name": item.project_name,
+                    "assigned_by_name": item.assigned_by_name,
+                    "link": _build_smart_link(
+                        target_path=_task_target_path(item.task_id, item.project_id),
+                        guild_id=gid,  # the item's guild IS the routed schema
+                    ),
+                }
+                for item in items
+            ]
+
+        guild_ids = await member_guild_ids(session, user_id)
+        assignments = await gather_across_guilds(session, user_id, guild_ids, _fetch)
+        if not assignments:
+            continue
+        # Send: re-load the user (gather expunged it) in a shared-table context.
+        session.expunge_all()
+        await set_rls_context(session, user_id=user_id)
+        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one()
+        try:
+            await email_service.send_task_assignment_digest_email(session, user, assignments)
+            logger.info("task-digest: sent %d assignment(s) to user %s", len(assignments), email)
+        except email_service.EmailNotConfiguredError:
+            logger.warning("SMTP not configured; skipping task digest for %s", email)
+            continue
+        except RuntimeError as exc:  # pragma: no cover
+            logger.error("Failed to send task digest: %s", exc)
+            continue
+        # Mark the gathered items processed, back in each guild's schema.
+        for gid, item_ids in per_guild_items.items():
+            if not item_ids:
+                continue
+            session.expunge_all()
+            await set_rls_context(session, user_id=user_id, guild_id=gid)
+            await session.exec(
+                sa_update(TaskAssignmentDigestItem)
+                .where(TaskAssignmentDigestItem.id.in_(item_ids))
+                .values(processed_at=now)
+            )
+            await session.commit()
+        session.expunge_all()
+        await set_rls_context(session, user_id=user_id)
+        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one()
+        user.last_task_assignment_digest_at = now
+        session.add(user)
+        await session.commit()
 
 
 async def process_task_assignment_digests() -> None:
     async with AdminSessionLocal() as session:
-        user_ids = await _pending_assignment_user_ids(session)
-        if not user_ids:
-            logger.debug("task-digest: no pending assignment events")
-            return
-        logger.debug("task-digest: processing %d user(s)", len(user_ids))
-        now = datetime.now(timezone.utc)
-        for user_id in user_ids:
-            user = await _load_user(session, int(user_id))
-            if not user or user.email_task_assignment is False:
-                await clear_task_assignment_queue_for_user(session, user_id)
-                await session.commit()
-                continue
-            events_stmt = (
-                select(TaskAssignmentDigestItem)
-                .where(
-                    TaskAssignmentDigestItem.user_id == user_id,
-                    TaskAssignmentDigestItem.processed_at.is_(None),
-                )
-                .order_by(TaskAssignmentDigestItem.created_at.asc())
-            )
-            events_result = await session.exec(events_stmt)
-            events = events_result.scalars().all()
-            if not events:
-                continue
-            if user.last_task_assignment_digest_at and user.last_task_assignment_digest_at + timedelta(hours=1) > now:
-                continue
-            project_ids = {event.project_id for event in events if event.project_id is not None}
-            guild_map = await _project_guild_map(session, project_ids)
-            assignments = []
-            for event in events:
-                target_path = _task_target_path(event.task_id, event.project_id)
-                assignments.append(
-                    {
-                        "task_title": event.task_title,
-                        "project_name": event.project_name,
-                        "assigned_by_name": event.assigned_by_name,
-                        "link": _build_smart_link(
-                            target_path=target_path,
-                            guild_id=guild_map.get(event.project_id),
-                        ),
-                    }
-                )
-            try:
-                await email_service.send_task_assignment_digest_email(session, user, assignments)
-                logger.info(
-                    "task-digest: sent %d assignment(s) to user %s",
-                    len(assignments),
-                    user.email,
-                )
-            except email_service.EmailNotConfiguredError:
-                logger.warning("SMTP not configured; skipping task digest for %s", user.email)
-                continue
-            except RuntimeError as exc:  # pragma: no cover
-                logger.error("Failed to send task digest: %s", exc)
-                continue
-            for event in events:
-                event.processed_at = now
-                session.add(event)
-            user.last_task_assignment_digest_at = now
-            session.add(user)
-            await session.commit()
+        await _run_assignment_digest_pass(session, now=datetime.now(timezone.utc))
 
 
 def _resolve_timezone(value: str | None) -> ZoneInfo:

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -8,7 +8,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.db.session import AdminSessionLocal
+from app.db.session import AdminSessionLocal, set_rls_context
+from app.services.cross_guild import gather_across_guilds, member_guild_ids
 from app.core.config import settings as app_config
 from app.models.initiative import Initiative
 from app.models.project import Project
@@ -1070,7 +1071,12 @@ def _resolve_timezone(value: str | None) -> ZoneInfo:
         return ZoneInfo("UTC")
 
 
-async def _overdue_tasks_for_user(session: AsyncSession, user: User) -> list[dict]:
+async def _overdue_tasks_for_user(session: AsyncSession, user_id: int) -> list[dict]:
+    """Overdue tasks assigned to the user *in the currently routed guild schema*.
+
+    Run once per guild via ``gather_across_guilds`` (the session is routed into
+    each of the user's guilds in turn), so it only ever sees one guild's rows.
+    """
     stmt = (
         select(Task, Project.name, Project.id, Initiative.guild_id)
         .join(Project, Task.project_id == Project.id)
@@ -1078,7 +1084,7 @@ async def _overdue_tasks_for_user(session: AsyncSession, user: User) -> list[dic
         .join(TaskAssignee, TaskAssignee.task_id == Task.id)
         .join(TaskStatus, Task.task_status_id == TaskStatus.id)
         .where(
-            TaskAssignee.user_id == user.id,
+            TaskAssignee.user_id == user_id,
             Task.due_date.is_not(None),
             Task.due_date < datetime.now(timezone.utc),
             TaskStatus.category != TaskStatusCategory.done,
@@ -1102,44 +1108,68 @@ async def _overdue_tasks_for_user(session: AsyncSession, user: User) -> list[dic
     return tasks
 
 
+async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
+    """Send overdue-task digests to opted-in users as of ``now``.
+
+    Split out from ``process_overdue_notifications`` so tests can drive it with
+    the test session (the worker opens its own ``AdminSessionLocal``). Each
+    user's overdue tasks are gathered from their own guild schemas with their
+    membership context — no superadmin / all-guild access.
+    """
+    result = await session.exec(select(User).where(User.email_overdue_tasks.is_(True)))
+    users = result.scalars().all()
+    if not users:
+        logger.debug("overdue-digest: no users opted in")
+        return
+    # Capture plain fields up front: gathering routes per guild and expunges the
+    # identity map, which would detach these ORM rows.
+    candidates = [
+        (u.id, u.email, u.timezone, u.overdue_notification_time, u.last_overdue_notification_at)
+        for u in users
+    ]
+    for user_id, email, user_tz, notify_time, last_at in candidates:
+        tz = _resolve_timezone(user_tz)
+        now_local = now.astimezone(tz)
+        try:
+            hour, minute = map(int, notify_time.split(":"))
+        except Exception:
+            hour, minute = 21, 0
+        target_local = now_local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if now_local < target_local:
+            continue
+        if last_at and last_at.astimezone(tz).date() == now_local.date():
+            continue
+        # User-scoped: visit each of the user's guild schemas with their own
+        # membership context (no superadmin) and collect their overdue tasks.
+        guild_ids = await member_guild_ids(session, user_id)
+        tasks = await gather_across_guilds(
+            session, user_id, guild_ids,
+            lambda routed, _gid: _overdue_tasks_for_user(routed, user_id),
+        )
+        if not tasks:
+            continue
+        # Re-load the user (the gather expunged it) to send + stamp it. The
+        # email/stamp touch only shared tables, so the user-only context is fine.
+        session.expunge_all()
+        await set_rls_context(session, user_id=user_id)
+        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one()
+        try:
+            await email_service.send_overdue_tasks_email(session, user, tasks)
+            logger.info("overdue-digest: sent %d overdue task(s) to user %s", len(tasks), email)
+        except email_service.EmailNotConfiguredError:
+            logger.warning("SMTP not configured; skipping overdue digest for %s", email)
+            continue
+        except RuntimeError as exc:  # pragma: no cover
+            logger.error("Failed to send overdue digest: %s", exc)
+            continue
+        user.last_overdue_notification_at = now
+        session.add(user)
+        await session.commit()
+
+
 async def process_overdue_notifications() -> None:
     async with AdminSessionLocal() as session:
-        stmt = select(User).where(User.email_overdue_tasks.is_(True))
-        result = await session.exec(stmt)
-        users = result.scalars().all()
-        if not users:
-            logger.debug("overdue-digest: no users opted in")
-            return
-        now_utc = datetime.now(timezone.utc)
-        for user in users:
-            tz = _resolve_timezone(user.timezone)
-            now_local = now_utc.astimezone(tz)
-            try:
-                hour, minute = map(int, user.overdue_notification_time.split(":"))
-            except Exception:
-                hour, minute = 21, 0
-            target_local = now_local.replace(hour=hour, minute=minute, second=0, microsecond=0)
-            if now_local < target_local:
-                continue
-            if user.last_overdue_notification_at:
-                last_local = user.last_overdue_notification_at.astimezone(tz)
-                if last_local.date() == now_local.date():
-                    continue
-            tasks = await _overdue_tasks_for_user(session, user)
-            if not tasks:
-                continue
-            try:
-                await email_service.send_overdue_tasks_email(session, user, tasks)
-                logger.info("overdue-digest: sent %d overdue task(s) to user %s", len(tasks), user.email)
-            except email_service.EmailNotConfiguredError:
-                logger.warning("SMTP not configured; skipping overdue digest for %s", user.email)
-                continue
-            except RuntimeError as exc:  # pragma: no cover
-                logger.error("Failed to send overdue digest: %s", exc)
-                continue
-            user.last_overdue_notification_at = now_utc
-            session.add(user)
-            await session.commit()
+        await _run_overdue_pass(session, now=datetime.now(timezone.utc))
 
 
 async def _run_event_reminder_pass(session: AsyncSession, *, now: datetime) -> None:

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy import select, delete, update as sa_update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.db.session import AdminSessionLocal, set_rls_context
+from app.db.session import AdminSessionLocal, reapply_rls_context, set_rls_context
 from app.services.cross_guild import gather_across_guilds, member_guild_ids
 from app.core.config import settings as app_config
 from app.models.initiative import Initiative
@@ -1163,66 +1163,79 @@ async def process_overdue_notifications() -> None:
 
 
 async def _run_event_reminder_pass(session: AsyncSession, *, now: datetime) -> None:
-    """Dispatch any reminders due as of ``now`` using the given session.
+    """Dispatch any reminders due as of ``now``.
 
-    Split out from ``process_event_reminders`` so tests can drive it with the
-    test session (the worker opens its own ``AdminSessionLocal``).
+    User-scoped: for each user who enabled reminders, visit their own guild
+    schemas with their membership context (no superadmin) and dispatch reminders
+    for the events they attend there. Split out from ``process_event_reminders``
+    so tests can drive it with the test session.
     """
     horizon = now + timedelta(days=1)
     # Allow events that started within the grace window so a 0-minute
-    # ("at the time of the event") reminder still fires on the next poll
-    # instead of being skipped the instant the event begins.
+    # ("at the time of the event") reminder still fires on the next poll.
     lower = now - EVENT_REMINDER_GRACE
-    stmt = (
-        select(CalendarEvent, User)
-        .join(
-            CalendarEventAttendee,
-            CalendarEventAttendee.calendar_event_id == CalendarEvent.id,
-        )
-        .join(User, User.id == CalendarEventAttendee.user_id)
-        .where(
-            CalendarEvent.deleted_at.is_(None),
-            CalendarEvent.start_at > lower,
-            CalendarEvent.start_at <= horizon,
-            CalendarEventAttendee.rsvp_status != RSVPStatus.declined,
-            User.event_reminder_minutes_before.is_not(None),
-        )
-    )
-    result = await session.exec(stmt)
-    rows = result.all()
-    for event, user in rows:
-        minutes = user.event_reminder_minutes_before
+    users = (
+        await session.exec(select(User).where(User.event_reminder_minutes_before.is_not(None)))
+    ).scalars().all()
+    candidates = [(u.id, u.event_reminder_minutes_before) for u in users]
+    for user_id, minutes in candidates:
         if minutes is None:
             continue
-        remind_at = event.start_at - timedelta(minutes=minutes)
-        if remind_at > now:
-            continue
-        existing = await session.exec(
-            select(EventReminderDispatch.id).where(
-                EventReminderDispatch.event_id == event.id,
-                EventReminderDispatch.user_id == user.id,
-                EventReminderDispatch.event_start_at == event.start_at,
-            )
-        )
-        if existing.first() is not None:
-            continue
-        # Reserve the dedup row and commit it *before* dispatching the external
-        # channels. This loop polls every 60s, so if email/push went out first
-        # and the ledger commit then failed, the next poll would resend. Writing
-        # the ledger first means a commit failure here simply retries cleanly,
-        # and a success guarantees at most one send.
-        session.add(
-            EventReminderDispatch(
-                event_id=event.id,
-                user_id=user.id,
-                event_start_at=event.start_at,
-            )
-        )
-        await session.commit()
-        await notify_event_reminder(
-            session, recipient=user, event=event, guild_id=event.guild_id
-        )
-        await session.commit()
+        for guild_id in await member_guild_ids(session, user_id):
+            session.expunge_all()
+            await set_rls_context(session, user_id=user_id, guild_id=guild_id)
+            events = (
+                await session.exec(
+                    select(CalendarEvent)
+                    .join(
+                        CalendarEventAttendee,
+                        CalendarEventAttendee.calendar_event_id == CalendarEvent.id,
+                    )
+                    .where(
+                        CalendarEventAttendee.user_id == user_id,
+                        CalendarEventAttendee.rsvp_status != RSVPStatus.declined,
+                        CalendarEvent.deleted_at.is_(None),
+                        CalendarEvent.start_at > lower,
+                        CalendarEvent.start_at <= horizon,
+                    )
+                )
+            ).scalars().all()
+            # Capture before the per-reminder commits expire/detach the rows.
+            due = [
+                (e.id, e.start_at, e.guild_id)
+                for e in events
+                if e.start_at - timedelta(minutes=minutes) <= now
+            ]
+            for event_id, start_at, ev_guild_id in due:
+                existing = await session.exec(
+                    select(EventReminderDispatch.id).where(
+                        EventReminderDispatch.event_id == event_id,
+                        EventReminderDispatch.user_id == user_id,
+                        EventReminderDispatch.event_start_at == start_at,
+                    )
+                )
+                if existing.first() is not None:
+                    continue
+                # Reserve the dedup row before dispatching (reserve-then-send), so
+                # a send that outlives a failed ledger commit can't double-fire.
+                session.add(
+                    EventReminderDispatch(
+                        event_id=event_id, user_id=user_id, event_start_at=start_at
+                    )
+                )
+                await session.commit()
+                await reapply_rls_context(session)
+                recipient = (
+                    await session.exec(select(User).where(User.id == user_id))
+                ).scalar_one()
+                event = (
+                    await session.exec(select(CalendarEvent).where(CalendarEvent.id == event_id))
+                ).scalar_one()
+                await notify_event_reminder(
+                    session, recipient=recipient, event=event, guild_id=ev_guild_id
+                )
+                await session.commit()
+                await reapply_rls_context(session)
 
 
 async def process_event_reminders() -> None:

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -986,18 +986,21 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
             continue  # rate-limited to one digest per hour
         per_guild_items: dict[int, list[int]] = {}
 
-        async def _fetch(routed: AsyncSession, gid: int) -> list[dict]:
+        # Capture user_id / per_guild_items as defaults so this closure doesn't
+        # bind the loop variables by reference (B023) — safe even if the call
+        # site is ever refactored to defer the closures.
+        async def _fetch(routed: AsyncSession, gid: int, *, _uid=user_id, _items=per_guild_items) -> list[dict]:
             items = (
                 await routed.exec(
                     select(TaskAssignmentDigestItem)
                     .where(
-                        TaskAssignmentDigestItem.user_id == user_id,
+                        TaskAssignmentDigestItem.user_id == _uid,
                         TaskAssignmentDigestItem.processed_at.is_(None),
                     )
                     .order_by(TaskAssignmentDigestItem.created_at.asc())
                 )
             ).scalars().all()
-            per_guild_items[gid] = [item.id for item in items]
+            _items[gid] = [item.id for item in items]
             return [
                 {
                     "task_title": item.task_title,
@@ -1018,7 +1021,9 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
         # Send: re-load the user (gather expunged it) in a shared-table context.
         session.expunge_all()
         await set_rls_context(session, user_id=user_id)
-        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one()
+        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one_or_none()
+        if user is None:  # deleted between the snapshot and now — skip, don't abort the pass
+            continue
         try:
             await email_service.send_task_assignment_digest_email(session, user, assignments)
             logger.info("task-digest: sent %d assignment(s) to user %s", len(assignments), email)
@@ -1040,9 +1045,12 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
                 .values(processed_at=now)
             )
             await session.commit()
+            await reapply_rls_context(session)  # commit may have dropped the connection's context
         session.expunge_all()
         await set_rls_context(session, user_id=user_id)
-        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one()
+        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one_or_none()
+        if user is None:
+            continue
         user.last_task_assignment_digest_at = now
         session.add(user)
         await session.commit()
@@ -1134,7 +1142,9 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
         guild_ids = await member_guild_ids(session, user_id)
         tasks = await gather_across_guilds(
             session, user_id, guild_ids,
-            lambda routed, _gid: _overdue_tasks_for_user(routed, user_id),
+            # _uid default-binds user_id so the closure doesn't capture the loop
+            # variable by reference (B023).
+            lambda routed, _gid, _uid=user_id: _overdue_tasks_for_user(routed, _uid),
         )
         if not tasks:
             continue
@@ -1142,7 +1152,9 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
         # email/stamp touch only shared tables, so the user-only context is fine.
         session.expunge_all()
         await set_rls_context(session, user_id=user_id)
-        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one()
+        user = (await session.exec(select(User).where(User.id == user_id))).scalar_one_or_none()
+        if user is None:  # deleted between the snapshot and now — skip, don't abort the pass
+            continue
         try:
             await email_service.send_overdue_tasks_email(session, user, tasks)
             logger.info("overdue-digest: sent %d overdue task(s) to user %s", len(tasks), email)
@@ -1227,10 +1239,12 @@ async def _run_event_reminder_pass(session: AsyncSession, *, now: datetime) -> N
                 await reapply_rls_context(session)
                 recipient = (
                     await session.exec(select(User).where(User.id == user_id))
-                ).scalar_one()
+                ).scalar_one_or_none()
                 event = (
                     await session.exec(select(CalendarEvent).where(CalendarEvent.id == event_id))
-                ).scalar_one()
+                ).scalar_one_or_none()
+                if recipient is None or event is None:
+                    continue  # deleted mid-run; dedup row stays so we don't retry
                 await notify_event_reminder(
                     session, recipient=recipient, event=event, guild_id=ev_guild_id
                 )

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -26,20 +26,23 @@ from app.services.notifications import (
     _run_overdue_pass,
     notify_initiative_membership,
 )
-from app.models.guild import GuildRole
+from app.models.guild import Guild, GuildRole
 from app.testing import (
     create_calendar_event,
     create_guild,
     create_guild_membership,
     create_initiative,
+    create_initiative_member,
     create_project,
     create_user,
 )
 
 
 async def _dispatch(session: AsyncSession) -> None:
-    """Drive the reminder pass with the test session (the worker opens its
-    own AdminSessionLocal pointed at the dev DB)."""
+    """Drive the reminder pass with the test session. The worker's
+    AdminSessionLocal (app_admin) sees the shared users table; mirror that so the
+    user-list read isn't RLS-filtered (the gather inside is still member-scoped)."""
+    await set_rls_context(session, is_superadmin=True)
     await _run_event_reminder_pass(session, now=datetime.now(timezone.utc))
 
 
@@ -53,7 +56,7 @@ async def _events_initiative(session: AsyncSession, creator):
     return guild, initiative
 
 
-async def _add_attendee(session, event, user, *, rsvp=RSVPStatus.pending):
+async def _add_attendee(session, initiative, event, user, *, rsvp=RSVPStatus.pending):
     attendee = CalendarEventAttendee(
         calendar_event_id=event.id,
         user_id=user.id,
@@ -62,6 +65,12 @@ async def _add_attendee(session, event, user, *, rsvp=RSVPStatus.pending):
     )
     session.add(attendee)
     await session.commit()
+    # Reminders are gathered in the attendee's own context, so they must be a
+    # guild + initiative member to see the event under RLS (as the real app
+    # enforces — you can only attend events in initiatives you belong to).
+    guild = await session.get(Guild, event.guild_id)
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.member)
+    await create_initiative_member(session, initiative, user, role_name="member")
 
 
 async def _reminders_for(session: AsyncSession, user_id: int) -> list[Notification]:
@@ -124,14 +133,14 @@ async def test_event_reminder_fires_once_within_lead_window(
     attendee = await create_user(
         session, email="attendee@example.com", event_reminder_minutes_before=15
     )
-    _, initiative = await _events_initiative(session, creator)
+    guild, initiative = await _events_initiative(session, creator)
     # Starts in 10 min; with a 15-min lead the reminder is already due.
     start_at = datetime.now(timezone.utc) + timedelta(minutes=10)
     event = await create_calendar_event(
         session, initiative, creator, title="Standup", start_at=start_at,
         end_at=start_at + timedelta(minutes=30),
     )
-    await _add_attendee(session, event, attendee)
+    await _add_attendee(session, initiative, event, attendee)
 
     await _dispatch(session)
     assert len(await _reminders_for(session, attendee.id)) == 1
@@ -140,6 +149,8 @@ async def test_event_reminder_fires_once_within_lead_window(
     await _dispatch(session)
     assert len(await _reminders_for(session, attendee.id)) == 1
 
+    # The dispatch ledger is guild-scoped; read it under the guild's context.
+    await set_rls_context(session, user_id=attendee.id, guild_id=guild.id)
     dispatches = await session.exec(
         select(EventReminderDispatch).where(EventReminderDispatch.user_id == attendee.id)
     )
@@ -161,7 +172,7 @@ async def test_event_reminder_skipped_when_lead_time_off(session: AsyncSession):
         session, initiative, creator, title="Sync", start_at=start_at,
         end_at=start_at + timedelta(minutes=30),
     )
-    await _add_attendee(session, event, attendee)
+    await _add_attendee(session, initiative, event, attendee)
 
     await _dispatch(session)
     assert await _reminders_for(session, attendee.id) == []
@@ -180,7 +191,7 @@ async def test_event_reminder_not_due_when_outside_lead_window(session: AsyncSes
         session, initiative, creator, title="Later", start_at=start_at,
         end_at=start_at + timedelta(minutes=30),
     )
-    await _add_attendee(session, event, attendee)
+    await _add_attendee(session, initiative, event, attendee)
 
     await _dispatch(session)
     assert await _reminders_for(session, attendee.id) == []
@@ -199,7 +210,7 @@ async def test_event_reminder_at_time_of_event_fires_at_start(session: AsyncSess
         session, initiative, creator, title="Now", start_at=start_at,
         end_at=start_at + timedelta(minutes=30),
     )
-    await _add_attendee(session, event, attendee)
+    await _add_attendee(session, initiative, event, attendee)
 
     await _dispatch(session)
     assert len(await _reminders_for(session, attendee.id)) == 1
@@ -217,7 +228,7 @@ async def test_event_reminder_skips_declined_attendees(session: AsyncSession):
         session, initiative, creator, title="Optional", start_at=start_at,
         end_at=start_at + timedelta(minutes=30),
     )
-    await _add_attendee(session, event, attendee, rsvp=RSVPStatus.declined)
+    await _add_attendee(session, initiative, event, attendee, rsvp=RSVPStatus.declined)
 
     await _dispatch(session)
     assert await _reminders_for(session, attendee.id) == []
@@ -386,3 +397,36 @@ async def test_assignment_digest_gathers_items_across_user_guilds(
             )
         ).all()
         assert pending == [], f"guild {guild_id} items not marked processed"
+
+
+@pytest.mark.integration
+async def test_event_reminders_fire_across_a_users_guilds(session: AsyncSession):
+    """A user attending due events in several guilds must get a reminder in each.
+    Under schema-per-guild the events live in different schemas, so the old
+    single public-scoped scan would only ever see the routed guild."""
+    attendee = await create_user(
+        session, email="multi-reminder@example.com", event_reminder_minutes_before=15
+    )
+    for label in ("Alpha", "Beta"):
+        await set_rls_context(session, is_superadmin=True)  # permissive for the guild INSERT
+        creator = await create_user(session, email=f"organizer-{label}@example.com")
+        guild = await create_guild(session, creator=creator)
+        initiative = await create_initiative(session, guild, creator, name=label)
+        initiative.events_enabled = True
+        session.add(initiative)
+        await session.commit()
+        await session.refresh(initiative)
+        # Starts in 10 min; with the attendee's 15-min lead the reminder is due.
+        start_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+        event = await create_calendar_event(
+            session, initiative, creator, title=f"{label} Standup",
+            start_at=start_at, end_at=start_at + timedelta(minutes=30),
+        )
+        await _add_attendee(session, initiative, event, attendee)
+
+    await _dispatch(session)
+
+    # Count across guilds: notifications are shared, so view them as superadmin.
+    await set_rls_context(session, is_superadmin=True)
+    reminders = await _reminders_for(session, attendee.id)
+    assert len(reminders) == 2

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -16,10 +16,12 @@ from app.models.calendar_event import CalendarEvent, CalendarEventAttendee, RSVP
 from app.models.event_reminder_dispatch import EventReminderDispatch
 from app.models.notification import Notification, NotificationType
 from app.models.task import Task, TaskAssignee, TaskPriority, TaskStatus, TaskStatusCategory
+from app.models.task_assignment_digest import TaskAssignmentDigestItem
 from app.models.user import User
 from app.services import email as email_service
 from app.services.notifications import (
     _format_event_when,
+    _run_assignment_digest_pass,
     _run_event_reminder_pass,
     _run_overdue_pass,
     notify_initiative_membership,
@@ -311,3 +313,76 @@ async def test_overdue_digest_gathers_tasks_across_user_guilds(session: AsyncSes
 
     assert captured.get("user_id") == user.id
     assert captured.get("titles") == {"Alpha overdue", "Beta overdue"}
+
+
+async def _assignment_item_in_new_guild(session: AsyncSession, user: User, *, label: str):
+    """Queue a task-assignment digest item for ``user`` in a brand-new guild."""
+    # A prior call left the session in a guild-member context; reset so the new
+    # guild INSERT into public.guilds isn't RLS-denied.
+    await set_rls_context(session, is_superadmin=True)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    initiative = await create_initiative(session, guild, user, name=label)
+    project = await create_project(session, initiative, user, name=f"{label} Project")
+    status = TaskStatus(
+        guild_id=guild.id, project_id=project.id, name="Todo",
+        category=TaskStatusCategory.todo, position=0, is_default=True,
+    )
+    session.add(status)
+    await session.commit()
+    await session.refresh(status)
+    task = Task(
+        guild_id=guild.id, project_id=project.id, task_status_id=status.id,
+        title=f"{label} task", priority=TaskPriority.medium,
+    )
+    session.add(task)
+    await session.commit()
+    await session.refresh(task)
+    # digest items have no guild_id column, so route by search_path before insert.
+    await set_rls_context(session, user_id=user.id, guild_id=guild.id)
+    session.add(
+        TaskAssignmentDigestItem(
+            user_id=user.id, task_id=task.id, project_id=project.id,
+            task_title=task.title, project_name=project.name, assigned_by_name="Assigner",
+        )
+    )
+    await session.commit()
+    return guild
+
+
+@pytest.mark.integration
+async def test_assignment_digest_gathers_items_across_user_guilds(
+    session: AsyncSession, monkeypatch
+):
+    """The task-assignment digest must collect a user's pending items from every
+    guild they belong to and mark them processed in each schema — a single
+    public-scoped scan (the old behaviour) would see none of them."""
+    user = await create_user(session, email="multi-digest@example.com")  # opted in by default
+    guild_a = await _assignment_item_in_new_guild(session, user, label="Alpha")
+    guild_b = await _assignment_item_in_new_guild(session, user, label="Beta")
+
+    captured: dict = {}
+
+    async def _capture_email(sess, recipient, assignments):
+        captured["user_id"] = recipient.id
+        captured["titles"] = {a["task_title"] for a in assignments}
+
+    monkeypatch.setattr(email_service, "send_task_assignment_digest_email", _capture_email)
+
+    await set_rls_context(session, is_superadmin=True)
+    await _run_assignment_digest_pass(session, now=datetime.now(timezone.utc))
+
+    assert captured.get("user_id") == user.id
+    assert captured.get("titles") == {"Alpha task", "Beta task"}
+
+    # Items were marked processed in each guild's own schema.
+    for guild_id in (guild_a.id, guild_b.id):
+        await set_rls_context(session, user_id=user.id, guild_id=guild_id)
+        pending = (
+            await session.exec(
+                select(TaskAssignmentDigestItem).where(
+                    TaskAssignmentDigestItem.processed_at.is_(None)
+                )
+            )
+        ).all()
+        assert pending == [], f"guild {guild_id} items not marked processed"

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -11,19 +11,26 @@ import pytest
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.db.session import set_rls_context
 from app.models.calendar_event import CalendarEvent, CalendarEventAttendee, RSVPStatus
 from app.models.event_reminder_dispatch import EventReminderDispatch
 from app.models.notification import Notification, NotificationType
+from app.models.task import Task, TaskAssignee, TaskPriority, TaskStatus, TaskStatusCategory
 from app.models.user import User
+from app.services import email as email_service
 from app.services.notifications import (
     _format_event_when,
     _run_event_reminder_pass,
+    _run_overdue_pass,
     notify_initiative_membership,
 )
+from app.models.guild import GuildRole
 from app.testing import (
     create_calendar_event,
     create_guild,
+    create_guild_membership,
     create_initiative,
+    create_project,
     create_user,
 )
 
@@ -244,3 +251,63 @@ async def test_notify_initiative_membership_carries_guild_context(session: Async
     assert data["guild_id"] == guild.id
     assert data["target_path"] == f"/initiatives/{initiative.id}"
     assert f"guild_id={guild.id}" in data["smart_link"]
+
+
+async def _overdue_task_in_new_guild(session: AsyncSession, user: User, *, label: str):
+    """Give ``user`` an overdue task assigned to them in a brand-new guild, so a
+    user in several guilds has overdue work spread across guild schemas."""
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    initiative = await create_initiative(session, guild, user, name=label)
+    project = await create_project(session, initiative, user, name=f"{label} Project")
+    status = TaskStatus(
+        guild_id=guild.id, project_id=project.id, name="Todo",
+        category=TaskStatusCategory.todo, position=0, is_default=True,
+    )
+    session.add(status)
+    await session.commit()
+    await session.refresh(status)
+    task = Task(
+        guild_id=guild.id, project_id=project.id, task_status_id=status.id,
+        title=f"{label} overdue", priority=TaskPriority.medium,
+        due_date=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    session.add(task)
+    await session.commit()
+    await session.refresh(task)
+    session.add(TaskAssignee(task_id=task.id, user_id=user.id, guild_id=guild.id))
+    await session.commit()
+    return guild
+
+
+@pytest.mark.integration
+async def test_overdue_digest_gathers_tasks_across_user_guilds(session: AsyncSession, monkeypatch):
+    """The overdue digest must collect a user's overdue tasks from EVERY guild
+    they belong to. Under schema-per-guild each guild's tasks live in its own
+    schema, so a single public-scoped scan (the old behaviour) would miss all
+    but the routed guild — this asserts both guilds' tasks reach the email."""
+    user = await create_user(
+        session,
+        email="multi-overdue@example.com",
+        email_overdue_tasks=True,
+        overdue_notification_time="00:00",  # always past, so the digest fires
+        timezone="UTC",
+    )
+    await _overdue_task_in_new_guild(session, user, label="Alpha")
+    await _overdue_task_in_new_guild(session, user, label="Beta")
+
+    captured: dict = {}
+
+    async def _capture_email(sess, recipient, tasks):
+        captured["user_id"] = recipient.id
+        captured["titles"] = {t["title"] for t in tasks}
+
+    monkeypatch.setattr(email_service, "send_overdue_tasks_email", _capture_email)
+
+    # Mirror the worker's starting context: its AdminSessionLocal (app_admin) sees
+    # the shared users table; the gather inside still scopes guild data per member.
+    await set_rls_context(session, is_superadmin=True)
+    await _run_overdue_pass(session, now=datetime.now(timezone.utc))
+
+    assert captured.get("user_id") == user.id
+    assert captured.get("titles") == {"Alpha overdue", "Beta overdue"}

--- a/backend/app/services/trash_purge.py
+++ b/backend/app/services/trash_purge.py
@@ -21,12 +21,14 @@ import logging
 from datetime import datetime, timezone
 
 from sqlalchemy import inspect as sa_inspect
+from sqlmodel import select
 
-from app.db.session import AdminSessionLocal
+from app.db.session import AdminSessionLocal, set_rls_context
 from app.db.soft_delete_filter import select_including_deleted
 from app.models.calendar_event import CalendarEvent
 from app.models.comment import Comment
 from app.models.document import Document
+from app.models.guild import Guild
 from app.models.initiative import Initiative
 from app.models.project import Project
 from app.models.queue import Queue, QueueItem
@@ -82,9 +84,30 @@ async def _run_purge_pass(session, *, now: datetime) -> None:
             await hard_purge_entity(session, row)
 
 
+async def _purge_all_guilds(session, *, now: datetime) -> None:
+    """Run the purge pass once in every guild's schema.
+
+    Each guild's trashed rows live in its own schema, so the worker has to visit
+    them all. Trash purge is system maintenance with no owning user, so (unlike
+    the user-scoped notification jobs) it routes in as superadmin — which also
+    bypasses the RESTRICTIVE FOR DELETE policy, mirroring the old BYPASSRLS
+    worker. Guilds are enumerated on the admin context first; each schema gets
+    its own committed pass. Split out so tests can drive it with the test
+    session.
+    """
+    await set_rls_context(session, is_superadmin=True)
+    guild_ids = list(await session.exec(select(Guild.id).order_by(Guild.id.asc())))
+    for guild_id in guild_ids:
+        # ids collide across schemas, so clear the identity map between guilds.
+        session.expunge_all()
+        await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+        await _run_purge_pass(session, now=now)
+        await session.commit()
+
+
 async def process_trash_purges() -> None:
-    """One pass of the auto-purge loop. Idempotent and safe to run on a
-    schedule even when nothing is due.
+    """One pass of the auto-purge loop across every guild schema. Idempotent and
+    safe to run on a schedule even when nothing is due.
 
     Uses ``hard_purge_entity`` per row so that:
     1. ``Document`` upload cleanup (blobs + Upload rows) runs before each
@@ -96,5 +119,4 @@ async def process_trash_purges() -> None:
     """
     now = datetime.now(timezone.utc)
     async with AdminSessionLocal() as session:
-        await _run_purge_pass(session, now=now)
-        await session.commit()
+        await _purge_all_guilds(session, now=now)

--- a/backend/app/services/trash_purge_test.py
+++ b/backend/app/services/trash_purge_test.py
@@ -95,3 +95,42 @@ async def test_auto_purge_does_not_double_purge_cascaded_descendants(
     ).scalar_one()
     assert initiative_count == 0
     assert project_count == 0
+
+
+async def test_auto_purge_sweeps_every_guild_schema(session: AsyncSession):
+    """Expired trash lives in each guild's own schema, so the purge worker must
+    visit every guild — the old single public-scoped pass would purge nothing.
+    Stage expired trash in two guilds and assert _purge_all_guilds clears both."""
+    from app.db.session import set_rls_context
+    from app.services.trash_purge import _purge_all_guilds
+
+    user = await create_user(session)
+    past = datetime.now(timezone.utc) - timedelta(days=2)
+    targets: list[tuple[int, int]] = []  # (guild_id, initiative_id)
+
+    for label in ("Gamma", "Delta"):
+        guild = await create_guild(session, creator=user)
+        initiative = await create_initiative(session, guild, user, name=label)
+        await soft_delete_entity(session, initiative, deleted_by_user_id=user.id, retention_days=1)
+        await session.commit()
+        # Backdate purge_at so this initiative is due (same guild context).
+        refreshed = (
+            await session.exec(
+                select_including_deleted(Initiative).where(Initiative.id == initiative.id)
+            )
+        ).one()
+        refreshed.purge_at = past
+        session.add(refreshed)
+        await session.commit()
+        targets.append((guild.id, initiative.id))
+
+    await _purge_all_guilds(session, now=datetime.now(timezone.utc))
+
+    for guild_id, initiative_id in targets:
+        await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+        count = (
+            await session.execute(
+                text("SELECT COUNT(*) FROM initiatives WHERE id = :id"), {"id": initiative_id}
+            )
+        ).scalar_one()
+        assert count == 0, f"guild {guild_id} initiative {initiative_id} not purged"


### PR DESCRIPTION
## Problem

After the schema-per-guild cutover (#630), several cross-guild reads still ran on the admin (`app_admin`) session with the `public` search_path. Guild-scoped data now lives in per-guild schemas, so these scanned the empty/legacy `public.*` tables and silently did nothing — and the test suite stayed green because nothing exercised the **multi-guild** path.

## Changes

Each background job is reframed **user-scoped** — it acts with the same access as the user it's notifying (reusing `member_guild_ids` + `gather_across_guilds`, **no `is_superadmin` / all-guild access**):

- **Overdue-task digest** — gather each opted-in user's overdue tasks across *their* guild schemas with their membership context.
- **Task-assignment digest** — gather pending digest items across the user's guilds, send one combined digest, mark items processed back in each schema.
- **Event reminders** — dispatch per user across the guilds they belong to (attendees must be guild + initiative members to see the event under RLS, as the app enforces); reserve-then-send dedup preserved, re-applying RLS context across per-reminder commits.
- **`list_memberships`** — read `retention_days` per guild schema (the single cross-guild `LEFT JOIN` hit the empty public `guild_settings` and reported NULL retention for every guild in the sidebar); detaches each settings row since `guild_settings.id` is a per-schema serial that collides across schemas.

The one exception is **trash purge** — it deletes *everyone's* expired trash on a schedule, so there's no user to scope it to. It already runs BYPASSRLS by design; it now iterates every guild schema as superadmin (system maintenance). 

## Tests

Every job gets a **multi-guild test that fails on the old public-only scan**: tasks/items/events/reminders spread across two guild schemas must all be gathered. Each background pass was split into a `_run_*_pass(session, now)` so tests can drive it with the test session. Dead public-scan helpers removed (`_pending_assignment_user_ids`, `_project_guild_map`, `_load_user`).

### Test commands run
```
pytest app/services/notifications_test.py        # 12 passed
pytest app/services/guilds_test.py app/api/v1/endpoints/guilds_test.py   # 66 passed
pytest app/services/trash_purge_test.py          # 2 passed
pytest app/api/v1/endpoints/calendar_events_test.py app/services/soft_delete_test.py  # 19 passed
```

## Notes

- No schema/env changes.
- Reviewers: the user-scoped context juggling (capture-before-gather, expunge between guilds, re-apply RLS after commits) is the subtle part — see the inline comments.