### PR TITLE
Add the forward guild-scoped migration helper

### DIFF
--- a/backend/app/db/guild_migrations.py
+++ b/backend/app/db/guild_migrations.py
@@ -74,20 +74,27 @@ def apply_to_all_guild_schemas(
     conversion drops it; pass ``False`` once those copies are gone (and a
     ``guild_template`` exists, add it to the targets).
 
+    Must run inside a transaction (migrations always do): the per-schema
+    ``search_path`` is set with ``is_local=true`` so it's scoped to that
+    transaction. If a statement fails, the error propagates uncaught and the
+    transaction rollback reverts the search_path — there is deliberately no
+    ``finally`` reset, which on an aborted transaction would itself raise and
+    mask the original error (and could strand a stale search_path on the
+    connection). On success we reset to ``public`` for any later statements in
+    the same transaction, since Alembic may batch migrations into one.
+
     Reminder: after using this in a migration, regenerate
     ``alembic/guild/guild_schema.sql`` so newly provisioned guilds get the change.
     """
     targets = (["public"] if include_public else []) + guild_schema_names(connection)
-    try:
-        for schema in targets:
-            # set_config (not SET) so it lands on this exact connection, matching
-            # how set_rls_context routes; schema name comes from pg_namespace so
-            # it's already a safe identifier.
-            connection.execute(
-                text("SELECT set_config('search_path', :sp, false)"),
-                {"sp": f"{schema}, public"},
-            )
-            for statement in statements:
-                connection.execute(text(statement))
-    finally:
-        connection.execute(text("SELECT set_config('search_path', 'public', false)"))
+    for schema in targets:
+        # set_config (not SET) so it lands on this exact connection, matching how
+        # set_rls_context routes; is_local=true scopes it to the transaction.
+        # Schema names come from pg_namespace, so they're already safe identifiers.
+        connection.execute(
+            text("SELECT set_config('search_path', :sp, true)"),
+            {"sp": f"{schema}, public"},
+        )
+        for statement in statements:
+            connection.execute(text(statement))
+    connection.execute(text("SELECT set_config('search_path', 'public', true)"))

--- a/backend/app/db/guild_migrations.py
+++ b/backend/app/db/guild_migrations.py
@@ -1,0 +1,93 @@
+"""Apply a guild-scoped schema change to every guild schema, from a migration.
+
+Under schema-per-guild a guild-scoped table (tasks, projects, documents, …)
+exists once per guild schema — ``guild_1.tasks``, ``guild_2.tasks``, … — plus the
+legacy ``public.tasks`` (until the data conversion drops it). A normal Alembic
+migration runs once against ``public``, so it would only change one of them.
+
+The forward pattern has two halves, kept in sync:
+
+1. **Existing guilds** — a guild-scoped migration calls
+   :func:`apply_to_all_guild_schemas` in its ``upgrade()`` (and the reverse in
+   ``downgrade()``). The migration owns the DDL (so the migration stays a
+   self-contained, immutable record of *what* changed); this helper only owns the
+   stable mechanism of *where* it runs.
+
+2. **New guilds** — provisioning builds a fresh guild schema by running
+   ``alembic/guild/guild_schema.sql`` (see ``app.db.schema_provisioning``). After
+   landing a guild-scoped migration, regenerate that artifact
+   (``python scripts/gen_guild_schema.py`` → commit) so guilds created later
+   include the change.
+
+The **drift-guard test** (``schema_provisioning_test.test_guild_schema_matches_alembic_public``)
+provisions a fresh schema and diffs it against ``public``: if you applied a delta
+to existing schemas but forgot to regenerate the artifact (or vice-versa), a new
+guild won't match and CI fails. The two halves can't silently diverge.
+
+Example migration::
+
+    from alembic import op
+    from app.db.guild_migrations import apply_to_all_guild_schemas
+
+    def upgrade() -> None:
+        apply_to_all_guild_schemas(
+            op.get_bind(),
+            "ALTER TABLE tasks ADD COLUMN archived boolean NOT NULL DEFAULT false",
+        )
+
+    def downgrade() -> None:
+        apply_to_all_guild_schemas(op.get_bind(), "ALTER TABLE tasks DROP COLUMN archived")
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+# Guild schemas are named ``guild_<id>`` (see schema_provisioning.guild_schema_name).
+_GUILD_SCHEMA_REGEX = "^guild_[0-9]+$"
+
+
+def guild_schema_names(connection: Connection) -> list[str]:
+    """Every provisioned guild schema, sorted. For guild-scoped migrations."""
+    rows = connection.execute(
+        text("SELECT nspname FROM pg_namespace WHERE nspname ~ :pat ORDER BY nspname"),
+        {"pat": _GUILD_SCHEMA_REGEX},
+    )
+    return [row[0] for row in rows]
+
+
+def apply_to_all_guild_schemas(
+    connection: Connection,
+    *statements: str,
+    include_public: bool = True,
+) -> None:
+    """Run schema-relative DDL in every guild schema (and ``public`` by default).
+
+    Each statement must be written WITHOUT a schema qualifier — e.g.
+    ``ALTER TABLE tasks ADD COLUMN …`` — because it is run once per target schema
+    with ``search_path`` pointed there (unqualified table/enum names resolve in
+    that schema, falling through to ``public`` for shared types). Pass several
+    statements to apply them as an ordered group per schema.
+
+    ``include_public`` keeps the legacy ``public`` copy in step until the data
+    conversion drops it; pass ``False`` once those copies are gone (and a
+    ``guild_template`` exists, add it to the targets).
+
+    Reminder: after using this in a migration, regenerate
+    ``alembic/guild/guild_schema.sql`` so newly provisioned guilds get the change.
+    """
+    targets = (["public"] if include_public else []) + guild_schema_names(connection)
+    try:
+        for schema in targets:
+            # set_config (not SET) so it lands on this exact connection, matching
+            # how set_rls_context routes; schema name comes from pg_namespace so
+            # it's already a safe identifier.
+            connection.execute(
+                text("SELECT set_config('search_path', :sp, false)"),
+                {"sp": f"{schema}, public"},
+            )
+            for statement in statements:
+                connection.execute(text(statement))
+    finally:
+        connection.execute(text("SELECT set_config('search_path', 'public', false)"))

--- a/backend/app/db/guild_migrations_test.py
+++ b/backend/app/db/guild_migrations_test.py
@@ -19,6 +19,8 @@ pytestmark = pytest.mark.database
 
 _GID_A = 990_201
 _GID_B = 990_202
+_GID_C = 990_203
+_GID_D = 990_204
 _COLUMN = "_mig_helper_test"
 
 
@@ -86,3 +88,54 @@ async def test_apply_to_all_guild_schemas_hits_every_guild(engine):
             )
             await drop_guild_schema(conn, _GID_A)
             await drop_guild_schema(conn, _GID_B)
+
+
+async def test_apply_to_all_guild_schemas_includes_public_by_default(engine):
+    """The default include_public=True also changes the legacy public copy — the
+    path every guild-scoped migration takes until public's copies are retired."""
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, _GID_C)
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda c: apply_to_all_guild_schemas(
+                    c, f"ALTER TABLE tags ADD COLUMN IF NOT EXISTS {_COLUMN} boolean"
+                )  # include_public defaults to True
+            )
+        async with engine.connect() as conn:
+            assert await _tags_has_column(conn, "public")  # the default path hit public
+            assert await _tags_has_column(conn, guild_schema_name(_GID_C))
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda c: apply_to_all_guild_schemas(
+                    c, f"ALTER TABLE tags DROP COLUMN IF EXISTS {_COLUMN}"
+                )  # remove from public + every guild schema
+            )
+            await drop_guild_schema(conn, _GID_C)
+
+
+async def test_apply_to_all_guild_schemas_failure_propagates_and_reverts(engine):
+    """A failing DDL must surface its OWN error (not a masking cleanup error) and
+    leave no stale search_path on the connection after rollback."""
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, _GID_D)
+
+        async with engine.connect() as conn:
+            trans = await conn.begin()
+            with pytest.raises(Exception) as exc_info:
+                await conn.run_sync(
+                    lambda c: apply_to_all_guild_schemas(
+                        c, "ALTER TABLE tags ADD COLUMN _boom bogus_type_xyz", include_public=False
+                    )
+                )
+            # The original DDL error, not a 'current transaction is aborted' mask.
+            assert "current transaction is aborted" not in str(exc_info.value).lower()
+            await trans.rollback()
+            # is_local search_path reverts on rollback — no stale guild schema.
+            search_path = (await conn.exec_driver_sql("SHOW search_path")).scalar()
+            assert "guild_" not in search_path
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, _GID_D)

--- a/backend/app/db/guild_migrations_test.py
+++ b/backend/app/db/guild_migrations_test.py
@@ -1,0 +1,88 @@
+"""Tests for the guild-scoped migration helper (the forward migration pattern).
+
+Synthetic, high guild ids so the temporary ``guild_<id>`` schemas can't collide
+with real data; dropped in teardown. Runs against the test DB as the owning role
+(the ``engine`` fixture), which has DDL privileges.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.db.guild_migrations import apply_to_all_guild_schemas, guild_schema_names
+from app.db.schema_provisioning import (
+    drop_guild_schema,
+    guild_schema_name,
+    provision_guild_schema,
+)
+
+pytestmark = pytest.mark.database
+
+_GID_A = 990_201
+_GID_B = 990_202
+_COLUMN = "_mig_helper_test"
+
+
+async def _tags_has_column(conn, schema: str) -> bool:
+    return bool(
+        await conn.scalar(
+            text(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :s AND table_name = 'tags' AND column_name = :c)"
+            ),
+            {"s": schema, "c": _COLUMN},
+        )
+    )
+
+
+async def test_apply_to_all_guild_schemas_hits_every_guild(engine):
+    """A guild-scoped DDL change applied via the helper lands in every provisioned
+    guild schema — the core of the forward migration pattern (a normal migration
+    would only touch one schema)."""
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, _GID_A)
+            await provision_guild_schema(conn, _GID_B)
+
+        # The provisioned schemas are enumerated.
+        async with engine.connect() as conn:
+            names = await conn.run_sync(guild_schema_names)
+        assert guild_schema_name(_GID_A) in names
+        assert guild_schema_name(_GID_B) in names
+
+        # Apply an idempotent, schema-relative ALTER to every guild schema.
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda c: apply_to_all_guild_schemas(
+                    c, f"ALTER TABLE tags ADD COLUMN IF NOT EXISTS {_COLUMN} boolean",
+                    include_public=False,
+                )
+            )
+
+        async with engine.connect() as conn:
+            assert await _tags_has_column(conn, guild_schema_name(_GID_A))
+            assert await _tags_has_column(conn, guild_schema_name(_GID_B))
+            # public was excluded (include_public=False).
+            assert not await _tags_has_column(conn, "public")
+
+        # The reverse (a downgrade) removes it everywhere.
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda c: apply_to_all_guild_schemas(
+                    c, f"ALTER TABLE tags DROP COLUMN IF EXISTS {_COLUMN}",
+                    include_public=False,
+                )
+            )
+        async with engine.connect() as conn:
+            assert not await _tags_has_column(conn, guild_schema_name(_GID_A))
+            assert not await _tags_has_column(conn, guild_schema_name(_GID_B))
+    finally:
+        # Best-effort: ensure no other guild schema keeps the throwaway column.
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda c: apply_to_all_guild_schemas(
+                    c, f"ALTER TABLE tags DROP COLUMN IF EXISTS {_COLUMN}",
+                    include_public=False,
+                )
+            )
+            await drop_guild_schema(conn, _GID_A)
+            await drop_guild_schema(conn, _GID_B)


### PR DESCRIPTION
## Why

This is the *forward migration pattern* for schema-per-guild. A guild-scoped table (`tasks`, `projects`, …) now lives once per guild schema — `guild_1.tasks`, `guild_2.tasks`, … — plus the legacy `public.tasks`. A normal Alembic migration runs once against `public`, so on its own it would only change one of them.

## The pattern (two halves, kept in sync)

1. **Existing guilds** — a guild-scoped migration calls `apply_to_all_guild_schemas(op.get_bind(), <ddl>)` in `upgrade()` (reverse in `downgrade()`). The **migration owns the DDL** so it stays a self-contained, immutable record of *what* changed; this helper owns only the stable mechanism of *where* it runs (enumerate `guild_<id>` schemas via `pg_namespace`, set search_path, apply).
2. **New guilds** — provisioning builds a fresh schema from `alembic/guild/guild_schema.sql`. After a guild-scoped migration, regenerate that artifact (`python scripts/gen_guild_schema.py` → commit) so guilds created later include the change.

The **drift-guard test** (`test_guild_schema_matches_alembic_public`) provisions a fresh schema and diffs it against `public`. If you apply a delta to existing schemas but forget to regenerate the artifact (or vice-versa), a new guild won't match and CI fails — the two halves can't silently diverge.

## Example

```python
from alembic import op
from app.db.guild_migrations import apply_to_all_guild_schemas

def upgrade() -> None:
    apply_to_all_guild_schemas(
        op.get_bind(),
        "ALTER TABLE tasks ADD COLUMN archived boolean NOT NULL DEFAULT false",
    )

def downgrade() -> None:
    apply_to_all_guild_schemas(op.get_bind(), "ALTER TABLE tasks DROP COLUMN archived")
```

Statements are schema-relative (no schema qualifier) — they run with `search_path` pointed at each target so unqualified table/enum names resolve in-schema, falling through to `public` for shared types. `include_public=True` keeps the legacy copy in step until the data conversion drops it; once `guild_template` exists it's added to the targets.

## Changes

- `app/db/guild_migrations.py` — `apply_to_all_guild_schemas` + `guild_schema_names`, with the full pattern in the module docstring.
- `app/db/guild_migrations_test.py` — provisions two guild schemas, asserts a DDL change reaches both and the reverse removes it (and `public` is excluded when asked).

Only new files; nothing existing touched.

## Test
```
pytest app/db/guild_migrations_test.py   # 1 passed
```

## Notes
- No guild-scoped migration has needed this yet — it's the infrastructure so the first one is a one-liner and nobody forgets the per-schema loop.
- Depends on nothing from the per-guild-background-jobs PR (#633); both branch off `dev`.