### PR TITLE
Run guild conversion in init() (fixes dev-migrate on a pre-cutover DB)

### DIFF
--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -154,6 +154,12 @@ async def check_pre_baseline_db() -> None:
 async def init() -> None:
     await check_pre_baseline_db()
     await run_migrations()
+    # Provision + migrate any pre-cutover guilds from public into their schemas
+    # BEFORE anything below routes into a guild's role/schema — an existing guild
+    # has no guild_<id> role until it's provisioned, so set_rls_context would fail.
+    from app.db.guild_conversion import convert_public_to_guild_schemas
+
+    await convert_public_to_guild_schemas()
     await init_superuser()
     async with AdminSessionLocal() as session:
         # guild_settings is guild-scoped; route into the primary guild's schema so


### PR DESCRIPTION
## Problem

Found while testing the data conversion (#635) against a real pre-cutover (older, populated) database via `scripts/dev-migrate.sh`:

```
asyncpg.exceptions.InvalidParameterValueError: role "guild_1" does not exist
  ...
  File ".../app/db/init_db.py", line 163, in init
    await set_rls_context(session, guild_id=primary_id)
```

The conversion was wired into `main.on_startup` (the uvicorn boot path) but **not** into `init_db.init()`, which `dev-migrate.sh` / `python -m app.db.init_db` run. So on an existing DB, `init()` reached `set_rls_context(guild_id=primary_id)` for an old guild that was never provisioned — and `SET ROLE guild_<id>` fails because that role doesn't exist yet.

## Fix

Run `convert_public_to_guild_schemas()` right after `run_migrations()` in `init()`, before anything routes into a guild role/schema. The conversion provisions every existing guild (creating its `guild_<id>` role + schema) and migrates its data, so `set_rls_context(primary)` then succeeds.

Both entry points now run the (idempotent) conversion after migrations: `main.on_startup` for the packaged/uvicorn boot, and `init_db.init()` for the CLI / `dev-migrate.sh` path.

## Notes
- Depends on #635 (the conversion module), which is already merged to `dev`.
- One-line change; `init_db` imports clean and the conversion suite stays green (2 passed). The real validation is re-running `dev-migrate.sh` on the old DB.