### PR TITLE
Add scoped pyright gate and fix return types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           cd backend
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov ruff
+          pip install pytest pytest-asyncio pytest-cov ruff pyright
 
       - name: Run Alembic migrations
         # conftest.py auto-applies migrations before tests run, so this
@@ -125,6 +125,15 @@ jobs:
         run: |
           cd backend
           ruff check app
+
+      - name: Type-check with Pyright
+        # Scoped gate: pyrightconfig.json enforces only reportReturnType
+        # (the SQLModel-noisy rules are off), so this fails on return-type
+        # regressions without drowning in ORM-expression false positives.
+        if: steps.changes.outputs.skip != 'true'
+        run: |
+          cd backend
+          pyright app
 
       - name: Run tests
         if: steps.changes.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           cd backend
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov ruff pyright
+          pip install pytest pytest-asyncio pytest-cov ruff "pyright>=1.1.410,<2"
 
       - name: Run Alembic migrations
         # conftest.py auto-applies migrations before tests run, so this

--- a/backend/app/api/v1/endpoints/admin.py
+++ b/backend/app/api/v1/endpoints/admin.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List
+from typing import Annotated, List, Sequence
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Response
@@ -55,7 +55,7 @@ AdminSessionDep = Annotated[AsyncSession, Depends(get_admin_session)]
 async def list_all_users(
     session: AdminSessionDep,
     _current_user: UsersReadDep,
-) -> List[User]:
+) -> Sequence[User]:
     """List all users in the platform (admin only)."""
     from app.services.users import SYSTEM_USER_EMAIL
 
@@ -630,7 +630,7 @@ async def admin_get_initiative_members(
     initiative_id: int,
     session: AdminSessionDep,
     _current_user: GuildsManageDep,
-) -> List[User]:
+) -> Sequence[User]:
     """List members of any initiative (platform admin only).
 
     Bypasses RLS so admins can see members across guilds,

--- a/backend/app/api/v1/endpoints/initiatives.py
+++ b/backend/app/api/v1/endpoints/initiatives.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List
+from typing import Annotated, List, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
@@ -675,7 +675,7 @@ async def get_initiative_members(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
-) -> List[User]:
+) -> Sequence[User]:
     """Get all members of an initiative."""
     await _get_initiative_or_404(initiative_id, session, guild_context.guild_id)
 

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -49,7 +49,7 @@ async def mark_notification_read(
     )
     if not notification:
         raise HTTPException(status_code=404, detail=NotificationMessages.NOT_FOUND)
-    return notification
+    return NotificationRead.model_validate(notification)
 
 
 @router.post("/read-all", response_model=NotificationCountResponse)

--- a/backend/app/api/v1/endpoints/property_definitions.py
+++ b/backend/app/api/v1/endpoints/property_definitions.py
@@ -1,7 +1,7 @@
 """CRUD endpoints for initiative-scoped custom property definitions."""
 
 from datetime import datetime, timezone
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Optional, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
@@ -164,7 +164,7 @@ async def list_property_definitions(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     initiative_id: Optional[int] = Query(default=None),
-) -> List[PropertyDefinition]:
+) -> Sequence[PropertyDefinition]:
     """List property definitions.
 
     With ``initiative_id``, returns definitions for that initiative only

--- a/backend/app/api/v1/endpoints/tags.py
+++ b/backend/app/api/v1/endpoints/tags.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Annotated, List
+from typing import Annotated, List, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
@@ -68,7 +68,7 @@ async def list_tags(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> List[Tag]:
+) -> Sequence[Tag]:
     """List all tags in the current guild."""
     stmt = (
         select(Tag)

--- a/backend/app/api/v1/endpoints/task_statuses.py
+++ b/backend/app/api/v1/endpoints/task_statuses.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List
+from typing import Annotated, List, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
@@ -80,7 +80,7 @@ async def list_task_statuses(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> List[TaskStatus]:
+) -> Sequence[TaskStatus]:
     await _get_project_with_access(
         session,
         project_id,
@@ -192,7 +192,7 @@ async def reorder_task_statuses(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> List[TaskStatus]:
+) -> Sequence[TaskStatus]:
     project = await _ensure_can_manage(
         session,
         project_id,

--- a/backend/app/api/v1/endpoints/tasks.py
+++ b/backend/app/api/v1/endpoints/tasks.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Annotated, List, Optional, Literal
+from typing import Annotated, List, Optional, Literal, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import selectinload
@@ -473,7 +473,7 @@ def _task_to_list_read(task: Task) -> TaskListRead:
     )
 
 
-async def _list_subtasks_for_task(session: SessionDep, task_id: int) -> list[Subtask]:
+async def _list_subtasks_for_task(session: SessionDep, task_id: int) -> Sequence[Subtask]:
     stmt = (
         select(Subtask)
         .where(Subtask.task_id == task_id)
@@ -1652,7 +1652,7 @@ async def reorder_tasks(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> List[Task]:
+) -> Sequence[Task]:
     if not reorder_in.items:
         return []
 
@@ -1810,7 +1810,7 @@ async def list_subtasks(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> List[Subtask]:
+) -> Sequence[Subtask]:
     task = await _fetch_task(session, task_id, guild_context.guild_id)
     if not task:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=TaskMessages.NOT_FOUND)
@@ -1929,7 +1929,7 @@ async def reorder_subtasks(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> List[Subtask]:
+) -> Sequence[Subtask]:
     task = await _fetch_task(session, task_id, guild_context.guild_id)
     if not task:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=TaskMessages.NOT_FOUND)

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Optional, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlmodel import select, update as sql_update
@@ -518,7 +518,7 @@ async def get_my_initiative_members(
     initiative_id: int,
     session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
-) -> List[User]:
+) -> Sequence[User]:
     """List members of an initiative the current user belongs to.
 
     Uses AdminSession to bypass RLS so users can see members across guilds

--- a/backend/app/services/api_keys.py
+++ b/backend/app/services/api_keys.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from hashlib import sha256
 from secrets import token_urlsafe
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 from sqlmodel import select
 from app.db.session import reapply_rls_context
@@ -24,7 +24,7 @@ def _generate_secret() -> str:
     return f"{API_KEY_PREFIX}{token_urlsafe(32)}"
 
 
-async def list_api_keys(session: AsyncSession, *, user: User) -> list[UserApiKey]:
+async def list_api_keys(session: AsyncSession, *, user: User) -> Sequence[UserApiKey]:
     statement = select(UserApiKey).where(UserApiKey.user_id == user.id).order_by(UserApiKey.created_at.desc())
     result = await session.exec(statement)
     return result.all()

--- a/backend/app/services/guilds.py
+++ b/backend/app/services/guilds.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 import secrets
 
@@ -380,7 +381,7 @@ async def _generate_unique_invite_code(session: AsyncSession) -> str:
     raise RuntimeError("Unable to generate unique invite code")
 
 
-async def list_guild_invites(session: AsyncSession, *, guild_id: int) -> list[GuildInvite]:
+async def list_guild_invites(session: AsyncSession, *, guild_id: int) -> Sequence[GuildInvite]:
     stmt = select(GuildInvite).where(GuildInvite.guild_id == guild_id).order_by(GuildInvite.created_at.desc())
     result = await session.exec(stmt)
     return result.all()

--- a/backend/app/services/oidc_sync.py
+++ b/backend/app/services/oidc_sync.py
@@ -37,7 +37,7 @@ def extract_claim_values(
 ) -> set[str]:
     """Extract claim values from userinfo or id_token using dot-notation path."""
 
-    def _traverse(data: dict, path_parts: list[str]) -> list | str | None:
+    def _traverse(data: dict, path_parts: list[str]) -> list | str | dict | None:
         current = data
         for part in path_parts:
             if not isinstance(current, dict):

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -16,7 +16,7 @@ initiative membership, initiative RBAC) lives in ``rls.py``.
 """
 
 from enum import Enum
-from typing import Any
+from typing import Any, TypeVar
 
 from fastapi import HTTPException, status
 from sqlalchemy import inspect
@@ -45,6 +45,12 @@ from app.core.messages import ProjectMessages, DocumentMessages
 # Generic helpers (work with both project and document permission enums)
 # ---------------------------------------------------------------------------
 
+# Permission-level enum the generic helpers operate on. Bound to Enum so each
+# caller's concrete level type (ProjectPermissionLevel, DocumentPermissionLevel,
+# QueuePermissionLevel) flows through to the return type.
+PermLevel = TypeVar("PermLevel", bound=Enum)
+
+
 def _get_user_role_ids(
     memberships: list[Any] | None,
     user_id: int,
@@ -63,8 +69,8 @@ def role_permission_level(
     role_permissions: list[Any] | None,
     memberships: list[Any] | None,
     user_id: int,
-    level_order: dict[Enum, int],
-) -> Enum | None:
+    level_order: dict[PermLevel, int],
+) -> PermLevel | None:
     """Get the highest role-based permission level for a user.
 
     Works with both ProjectPermissionLevel and DocumentPermissionLevel enums.
@@ -86,7 +92,7 @@ def role_permission_level(
     if not user_role_ids:
         return None
 
-    best: Enum | None = None
+    best: PermLevel | None = None
     for rp in role_permissions:
         if rp.initiative_role_id in user_role_ids:
             if best is None or level_order.get(rp.level, 0) > level_order.get(best, 0):
@@ -95,10 +101,10 @@ def role_permission_level(
 
 
 def effective_permission_level(
-    user_level: Enum | None,
-    role_level: Enum | None,
-    level_order: dict[Enum, int],
-) -> Enum | None:
+    user_level: PermLevel | None,
+    role_level: PermLevel | None,
+    level_order: dict[PermLevel, int],
+) -> PermLevel | None:
     """Return the higher of two permission levels (MAX behaviour).
 
     Args:

--- a/backend/app/services/properties.py
+++ b/backend/app/services/properties.py
@@ -320,7 +320,7 @@ async def _load_definitions(
         return {}
     stmt = select(PropertyDefinition).where(PropertyDefinition.id.in_(ids))
     result = await session.exec(stmt)
-    return {defn.id: defn for defn in result.all()}
+    return {defn.id: defn for defn in result.all() if defn.id is not None}
 
 
 async def _set_property_values(
@@ -973,4 +973,4 @@ async def load_definitions_by_ids(
         return {}
     stmt = select(PropertyDefinition).where(PropertyDefinition.id.in_(ids))
     result = await session.exec(stmt)
-    return {defn.id: defn for defn in result.all()}
+    return {defn.id: defn for defn in result.all() if defn.id is not None}

--- a/backend/app/services/soft_delete.py
+++ b/backend/app/services/soft_delete.py
@@ -179,7 +179,7 @@ async def _initiative_member_ids(
         .where(User.status == UserStatus.active)
     )
     result = await session.exec(stmt)
-    return list(result.all())
+    return [uid for uid in result.all() if uid is not None]
 
 
 async def _resolve_initiative_scope(

--- a/backend/app/services/task_statuses.py
+++ b/backend/app/services/task_statuses.py
@@ -43,7 +43,7 @@ def _sorted(statuses: Iterable[TaskStatus]) -> list[TaskStatus]:
     return sorted(statuses, key=lambda status: (status.position, status.id or 0))
 
 
-async def list_statuses(session: AsyncSession, project_id: int) -> list[TaskStatus]:
+async def list_statuses(session: AsyncSession, project_id: int) -> Sequence[TaskStatus]:
     stmt = (
         select(TaskStatus)
         .where(TaskStatus.project_id == project_id)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ pytest-asyncio = "^1.3.0"
 pytest-cov = "^7.1.0"
 httpx = "^0.28.1"
 ruff = ">=0.4.7,<0.16.0"
+pyright = "^1.1.410"
 
 [build-system]
 requires = ["poetry-core>=1.8.0"]

--- a/backend/pyrightconfig.json
+++ b/backend/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "include": ["app"],
+  "exclude": ["**/__pycache__", "**/.venv", "**/migrations"],
+  "typeCheckingMode": "off",
+  "reportReturnType": "error",
+  "reportUndefinedVariable": "none"
+}

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -343,7 +343,10 @@ def _expunge_guild_scoped(session: AsyncSession) -> None:
     """
     sync = session.sync_session
     for obj in list(sync.identity_map.values()):
-        if getattr(obj, "__tablename__", None) in GUILD_SCOPED_TABLES:
+        # expunge cascades along relationships, so a guild-scoped object from the
+        # snapshot may already be detached (e.g. an Initiative's members went with
+        # it) — skip anything no longer in the session.
+        if obj in sync and getattr(obj, "__tablename__", None) in GUILD_SCOPED_TABLES:
             sync.expunge(obj)
 
 


### PR DESCRIPTION
## Problem

DeepSource flagged 7 pre-existing TYP-005 (incompatible return value type) errors in three service files. Investigating with pyright surfaced the same *class* of issue more broadly: **28 return-type mismatches across 15 files**, all annotation-precision gaps from SQLModel / SQLAlchemy 2.x typing — **none are runtime bugs**. The repo had no type-checker gate to catch this class going forward.

## Changes

**Type fixes (no behavior change):**
- **Generic permission helpers** (`services/permissions.py`) — `role_permission_level` / `effective_permission_level` are now generic over a `TypeVar` bound to `Enum`, so each caller's concrete level (`Project` / `Document` / `Queue` / `Counter`PermissionLevel) flows through instead of the base `Enum`. Fixes the original TYP-005.
- **`Sequence` returns** — `Result.all()` genuinely returns `Sequence[T]`, so 17 functions now annotate `Sequence[X]` instead of `list[X]` (idiomatic SQLAlchemy 2.x). Includes the cascade onto endpoints that return those results directly.
- **PK-optional narrowing** (`soft_delete.py`, `properties.py`) — filter `None` out of `select(Model.id)` results so `list[int]` / `Dict[int, …]` are honest.
- **ORM→schema** (`endpoints/notifications.py`) — `NotificationRead.model_validate(...)` in `mark_notification_read`.
- **oidc_sync** — widened `_traverse` return type to include `dict`.

**Pyright scoped gate:**
- `backend/pyrightconfig.json` — `typeCheckingMode: "off"` with only `reportReturnType: "error"` re-enabled. This dodges the ~1750 SQLModel ORM-expression false positives that make a full gate impractical, while still catching return-type regressions. Clean baseline (0/0/0), verified to catch a deliberate-bug probe.
- `pyproject.toml` — `pyright` added to the dev group; ad-hoc mypy not introduced.
- `ci.yml` — "Type-check with Pyright" step after Ruff, behind the same backend-changes guard.

**Dev seed fix:**
- Guard `_expunge_guild_scoped` against already-detached instances (`obj in sync`) — expunge cascades along relationships, so an Initiative's members may already be gone from the session by the time the loop reaches them.

## Testing

- `cd backend && pyright app` → `0 errors, 0 warnings`
- `cd backend && ruff check app` → passes
- Enforcement verified with a temporary return-type-bug probe (caught, then removed)

No changelog entry — dev tooling / internal types only.