### PR TITLE
Add read-only token permissions to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   backend-tests:
     name: Backend Lint & Tests

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -6,6 +6,9 @@ on:
       - dev
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/initiative
 


### PR DESCRIPTION
## Problem

The **CI** (`ci.yml`) and **Dev Build** (`dev-build.yml`) workflows had no `permissions:` block, so their jobs ran with the repository-default `GITHUB_TOKEN` scopes. Restricting the token to the minimum needed is a GitHub security best practice and brings these two in line with `docker-publish.yml` and `tag-release.yml`, which already scope their tokens.

## Changes

- `ci.yml` — added top-level `permissions: contents: read` (applies to `backend-tests`, `frontend-lint-and-test`, `check-generated-types`).
- `dev-build.yml` — added top-level `permissions: contents: read` (applies to `build` and `merge`).

A top-level block sets the baseline for every job. All jobs are read-only — checkout + run tests/linters/build. The Dev Build push to Docker Hub uses separate `DOCKERHUB_*` secrets, not the `GITHUB_TOKEN`, so no write scope is required.

## Testing

No functional code changed; this only restricts CI token scopes. CI will run on this PR and exercise the updated workflows.