### PR TITLE
Don't expose exception detail in sync-content response

### DIFF
--- a/backend/app/api/v1/endpoints/collaboration.py
+++ b/backend/app/api/v1/endpoints/collaboration.py
@@ -449,6 +449,8 @@ async def sync_document_content(
         logger.info(f"Sync content: Updated content for document {document_id} by {user.email}")
         return {"status": "ok"}
     except Exception as e:
+        # Log the full error server-side; return a generic message so internal
+        # detail (e.g. DB error text) isn't exposed to the caller.
         logger.error(f"Sync content: Failed to update document {document_id}: {e}")
         await session.rollback()
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": "Failed to sync content"}


### PR DESCRIPTION
## Problem

CodeQL flagged `py/stack-trace-exposure` (Information exposure through an exception) in the `sync-content` endpoint. The handler returned the raw exception text to the caller:

```python
return {"status": "error", "message": str(e)}
```

The `try` block wraps `documents_service.sync_document_links` plus a `session.commit()`, so the most likely exception is a SQLAlchemy/asyncpg database error — and `str(e)` on those can contain internal detail (SQL fragments, table/column/constraint names). Returning that in a response body reachable by an external caller is the leak the rule targets.

Low real-world risk (the only caller is a page-unload `sendBeacon`/`keepalive` fetch whose response the browser discards, and the detail is already logged server-side), but the fix is free and removes the exposure.

## Changes

- `collaboration.py` — return a generic `"Failed to sync content"` message; keep the full error in the existing `logger.error(...)` server-side log.

No functional impact: no client reads the `message` field for this beacon endpoint.

## Testing

No behavioral change to the success path; error path now returns a static string. Backend CI (lint + scoped tests) runs on this PR.