### PR TITLE
Validate OIDC authorization endpoint before redirect

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -528,10 +528,16 @@ async def oidc_login(
     # The authorization endpoint comes from the IdP's remote discovery
     # document. Require an absolute https URL before redirecting the user
     # there, so a malformed or tampered discovery doc can't send them to a
-    # non-TLS or non-http(s) location (CodeQL py/url-redirection).
+    # non-TLS or non-http(s) location (CodeQL py/url-redirection). Guard the
+    # value type too: a non-string (e.g. null) endpoint must surface the clean
+    # OIDC_METADATA_INCOMPLETE error rather than a urlsplit TypeError.
     authorization_endpoint = metadata["authorization_endpoint"]
-    parsed_endpoint = urlsplit(authorization_endpoint)
-    if parsed_endpoint.scheme != "https" or not parsed_endpoint.hostname:
+    parsed_endpoint = (
+        urlsplit(authorization_endpoint)
+        if isinstance(authorization_endpoint, str)
+        else None
+    )
+    if parsed_endpoint is None or parsed_endpoint.scheme != "https" or not parsed_endpoint.hostname:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=OidcMessages.OIDC_METADATA_INCOMPLETE,

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -6,7 +6,7 @@ import logging
 import secrets
 import time
 from typing import Any, Annotated
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
@@ -525,7 +525,18 @@ async def oidc_login(
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
     }
-    authorize_url = f"{metadata['authorization_endpoint']}?{urlencode(params)}"
+    # The authorization endpoint comes from the IdP's remote discovery
+    # document. Require an absolute https URL before redirecting the user
+    # there, so a malformed or tampered discovery doc can't send them to a
+    # non-TLS or non-http(s) location (CodeQL py/url-redirection).
+    authorization_endpoint = metadata["authorization_endpoint"]
+    parsed_endpoint = urlsplit(authorization_endpoint)
+    if parsed_endpoint.scheme != "https" or not parsed_endpoint.hostname:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=OidcMessages.OIDC_METADATA_INCOMPLETE,
+        )
+    authorize_url = f"{authorization_endpoint}?{urlencode(params)}"
     return RedirectResponse(authorize_url)
 
 

--- a/backend/app/api/v1/endpoints/auth_test.py
+++ b/backend/app/api/v1/endpoints/auth_test.py
@@ -741,6 +741,36 @@ async def test_oidc_login_rejects_non_https_authorization_endpoint(
 
 @pytest.mark.integration
 @pytest.mark.auth
+async def test_oidc_login_rejects_null_authorization_endpoint(
+    client: AsyncClient,
+    monkeypatch,
+):
+    """A non-string (e.g. null) authorization_endpoint must surface the clean
+    OIDC_METADATA_INCOMPLETE error, not an uncaught urlsplit TypeError."""
+    import app.api.v1.endpoints.auth as auth_module
+
+    async def _fake_runtime_config(s):
+        settings_obj = type("S", (), {
+            "oidc_enabled": True, "oidc_issuer": "https://id.example.com",
+            "oidc_client_id": "cid", "oidc_client_secret_encrypted": None,
+            "oidc_scopes": ["openid"], "oidc_provider_name": "Test",
+        })()
+        metadata = {
+            "authorization_endpoint": None,
+            "token_endpoint": "https://id.example.com/token",
+        }
+        return settings_obj, metadata
+
+    monkeypatch.setattr(auth_module, "_get_oidc_runtime_config", _fake_runtime_config)
+
+    response = await client.get("/api/v1/auth/oidc/login", follow_redirects=False)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "OIDC_METADATA_INCOMPLETE"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
 async def test_oidc_login_redirects_to_https_authorization_endpoint(
     client: AsyncClient,
     monkeypatch,

--- a/backend/app/api/v1/endpoints/auth_test.py
+++ b/backend/app/api/v1/endpoints/auth_test.py
@@ -709,6 +709,65 @@ async def test_oidc_callback_blocks_new_user_when_registration_disabled(
     assert "session_token" not in response.cookies
 
 
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_oidc_login_rejects_non_https_authorization_endpoint(
+    client: AsyncClient,
+    monkeypatch,
+):
+    """A discovery doc whose authorization_endpoint isn't an absolute https
+    URL must not be used as a redirect target (CodeQL py/url-redirection)."""
+    import app.api.v1.endpoints.auth as auth_module
+
+    async def _fake_runtime_config(s):
+        settings_obj = type("S", (), {
+            "oidc_enabled": True, "oidc_issuer": "https://id.example.com",
+            "oidc_client_id": "cid", "oidc_client_secret_encrypted": None,
+            "oidc_scopes": ["openid"], "oidc_provider_name": "Test",
+        })()
+        metadata = {
+            "authorization_endpoint": "http://evil.example.com/auth",
+            "token_endpoint": "https://id.example.com/token",
+        }
+        return settings_obj, metadata
+
+    monkeypatch.setattr(auth_module, "_get_oidc_runtime_config", _fake_runtime_config)
+
+    response = await client.get("/api/v1/auth/oidc/login", follow_redirects=False)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "OIDC_METADATA_INCOMPLETE"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_oidc_login_redirects_to_https_authorization_endpoint(
+    client: AsyncClient,
+    monkeypatch,
+):
+    """Happy path: an https authorization_endpoint is used as the redirect."""
+    import app.api.v1.endpoints.auth as auth_module
+
+    async def _fake_runtime_config(s):
+        settings_obj = type("S", (), {
+            "oidc_enabled": True, "oidc_issuer": "https://id.example.com",
+            "oidc_client_id": "cid", "oidc_client_secret_encrypted": None,
+            "oidc_scopes": ["openid"], "oidc_provider_name": "Test",
+        })()
+        metadata = {
+            "authorization_endpoint": "https://id.example.com/auth",
+            "token_endpoint": "https://id.example.com/token",
+        }
+        return settings_obj, metadata
+
+    monkeypatch.setattr(auth_module, "_get_oidc_runtime_config", _fake_runtime_config)
+
+    response = await client.get("/api/v1/auth/oidc/login", follow_redirects=False)
+
+    assert response.status_code in (302, 307)
+    assert response.headers["location"].startswith("https://id.example.com/auth?")
+
+
 # --- Password policy -------------------------------------------------
 
 


### PR DESCRIPTION
## Problem

CodeQL flagged `py/url-redirection` (URL redirection from remote source) in the OIDC login flow:

```python
authorize_url = f"{metadata['authorization_endpoint']}?{urlencode(params)}"
return RedirectResponse(authorize_url)
```

`metadata['authorization_endpoint']` comes from the IdP's remote `/.well-known/openid-configuration` discovery document. The redirect host is determined entirely by the (owner-only, admin-configured) issuer — not by the request — so this is largely by-design and low real-world risk. But nothing currently verifies the endpoint is even an absolute **https** URL before sending a user there.

## Changes

- `auth.py` — before redirecting, parse `authorization_endpoint` and require `scheme == "https"` with a hostname; otherwise raise `OIDC_METADATA_INCOMPLETE` (500), matching how other malformed-metadata cases are handled. A malformed or tampered discovery doc can no longer redirect users to a non-TLS or non-http(s) location.
- `auth_test.py` — adds two tests: non-https endpoint is rejected (500), https endpoint redirects (302/307).

### Why not host-allowlist against the issuer?

That's what would fully "sanitize" the flow for CodeQL, but it breaks legitimate multi-host IdPs — e.g. AWS Cognito's issuer (`cognito-idp.*.amazonaws.com`) and authorization endpoint (`*.auth.*.amazoncognito.com`) are different registrable domains. The https check is the strongest validation that stays compatible with arbitrary IdPs. If CodeQL still reports the path after this, it's a by-design dismissal rather than a code defect.

## Testing

```
pytest app/api/v1/endpoints/auth_test.py -k oidc   # 4 passed
```