### PR TITLE
Drop unused context param from fetchAndStoreConfig

### DIFF
--- a/frontend/android/app/src/main/java/com/morelitea/initiative/FirebaseInitializer.java
+++ b/frontend/android/app/src/main/java/com/morelitea/initiative/FirebaseInitializer.java
@@ -44,7 +44,7 @@ public class FirebaseInitializer {
         String storedServerUrl = prefs.getString(KEY_SERVER_URL, "");
         if (!serverUrl.equals(storedServerUrl) || !prefs.contains(KEY_PROJECT_ID)) {
             Log.d(TAG, "Fetching FCM config from backend: " + serverUrl);
-            if (!fetchAndStoreConfig(context, serverUrl, prefs)) {
+            if (!fetchAndStoreConfig(serverUrl, prefs)) {
                 Log.w(TAG, "Failed to fetch FCM config, push notifications disabled");
                 return false;
             }
@@ -89,12 +89,11 @@ public class FirebaseInitializer {
     /**
      * Fetch FCM configuration from backend API and store in SharedPreferences.
      *
-     * @param context Application context
      * @param serverUrl Backend server URL
      * @param prefs SharedPreferences to store config
      * @return true if config was fetched successfully, false otherwise
      */
-    private static boolean fetchAndStoreConfig(Context context, String serverUrl, SharedPreferences prefs) {
+    private static boolean fetchAndStoreConfig(String serverUrl, SharedPreferences prefs) {
         final CountDownLatch latch = new CountDownLatch(1);
         final boolean[] success = {false};
 


### PR DESCRIPTION
## Problem

CodeQL (useless parameter) flagged `FirebaseInitializer.fetchAndStoreConfig(Context context, ...)` — the `context` parameter is passed at the call site but never read in the method body, which does all its work via `serverUrl` and `prefs`.

## Changes

- Remove `Context context` from the `fetchAndStoreConfig` signature.
- Drop the argument at the single call site in `initializeFirebase`.
- Remove the now-stale `@param context` javadoc line.

`Context` is still used by `initializeFirebase` and `clearConfig`, so the import is unchanged. No behavior change — purely interface cleanup.

## Testing

Mechanical parameter removal; no logic affected. Android build/CI exercises the file.