### PR TITLE
Exempt guild icon + iCal content from the sanitizer cap

### DIFF
--- a/backend/app/schemas/guild.py
+++ b/backend/app/schemas/guild.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from pydantic import ConfigDict, EmailStr, Field
 
-from app.schemas.base import RichTextStr, SanitizedBaseModel
+from app.schemas.base import RawTextStr, RichTextStr, SanitizedBaseModel
 
 from app.models.guild import GuildRole
 from app.schemas.user import GuildRemovalProjectInfo
@@ -14,7 +14,7 @@ from app.schemas.user import GuildRemovalProjectInfo
 class GuildBase(SanitizedBaseModel):
     name: str
     description: Optional[RichTextStr] = None
-    icon_base64: Optional[str] = None
+    icon_base64: Optional[RawTextStr] = None
 
 
 class GuildCreate(GuildBase):
@@ -72,7 +72,7 @@ class GuildInviteStatus(SanitizedBaseModel):
 class GuildUpdate(SanitizedBaseModel):
     name: Optional[str] = None
     description: Optional[RichTextStr] = None
-    icon_base64: Optional[str] = None
+    icon_base64: Optional[RawTextStr] = None
     # Trash retention period in days. None means "never auto-purge".
     # Sentinel "unset" semantics: explicitly omit the field to leave the
     # current setting untouched; set null to switch to never-purge.
@@ -106,7 +106,7 @@ class GuildSummary(SanitizedBaseModel):
 
     id: int
     name: str
-    icon_base64: Optional[str] = None
+    icon_base64: Optional[RawTextStr] = None
 
 
 class GuildMembershipUpdate(SanitizedBaseModel):

--- a/backend/app/schemas/ical.py
+++ b/backend/app/schemas/ical.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from pydantic import Field
 
-from app.schemas.base import SanitizedBaseModel
+from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 
 class ICalEventPreview(SanitizedBaseModel):
@@ -22,12 +22,12 @@ class ICalParseResult(SanitizedBaseModel):
 
 
 class ICalParseRequest(SanitizedBaseModel):
-    ics_content: str = Field(..., max_length=2_000_000)
+    ics_content: RawTextStr = Field(..., max_length=2_000_000)
 
 
 class ICalImportRequest(SanitizedBaseModel):
     initiative_id: int
-    ics_content: str = Field(..., max_length=2_000_000)
+    ics_content: RawTextStr = Field(..., max_length=2_000_000)
 
 
 class ICalImportResult(SanitizedBaseModel):


### PR DESCRIPTION
Follow-up to #642.

## Problem
The 8 KiB plain-text length cap added in #642 runs in a `before` validator on **every** `str` field — during response construction as well as request parsing. Two large/raw fields weren't exempted:

- **`GuildRead.icon_base64`** — a base64 guild icon (same class as `avatar_base64`). Real icons exceed 8 KiB, so building the response **500'd `GET /api/v1/guilds/`**:
  ```
  Value error, icon_base64 exceeds the maximum length of 8192 characters
  ```
- **`ICalParseRequest` / `ICalImportRequest.ics_content`** — raw `.ics` upload (`max_length=2_000_000`). The cap would reject any real calendar import, and the sanitizer would HTML-mangle the file.

## Fix
Mark both `RawTextStr`, matching `avatar_base64` and the CSV/JSON import fields — they're large/opaque data that must bypass both sanitization and the cap.

## Verification
Swept every `SanitizedBaseModel` subclass: **no other non-exempt `str` field** declares `max_length > 8 KiB` or is a `*base64` field, so this completes the exemption set. `ruff` clean.

## Note (separate, not in this PR)
While sweeping I noticed `password` fields are run through the plain-text sanitizer (pre-existing — `nh3.clean` did it before #642 too). Sanitizing a credential is wrong in principle; passing it verbatim (`RawTextStr`) would also make registration consistent with the form-based login path. Flagging for a separate decision since it touches auth.