### PR TITLE
Store credentials verbatim (never HTML-sanitize passwords/secrets)

### DIFF
--- a/backend/app/schemas/ai_settings.py
+++ b/backend/app/schemas/ai_settings.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import ConfigDict, Field
 
-from app.schemas.base import SanitizedBaseModel
+from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 
 class AIProvider(str, Enum):
@@ -29,7 +29,7 @@ class PlatformAISettingsResponse(SanitizedBaseModel):
 class PlatformAISettingsUpdate(SanitizedBaseModel):
     enabled: bool
     provider: Optional[AIProvider] = None
-    api_key: Optional[str] = None
+    api_key: Optional[RawTextStr] = None
     base_url: Optional[str] = None
     model: Optional[str] = None
     allow_guild_override: bool = True
@@ -62,7 +62,7 @@ class GuildAISettingsResponse(SanitizedBaseModel):
 class GuildAISettingsUpdate(SanitizedBaseModel):
     enabled: Optional[bool] = None
     provider: Optional[AIProvider] = None
-    api_key: Optional[str] = None
+    api_key: Optional[RawTextStr] = None
     base_url: Optional[str] = None
     model: Optional[str] = None
     allow_user_override: Optional[bool] = None
@@ -97,7 +97,7 @@ class UserAISettingsResponse(SanitizedBaseModel):
 class UserAISettingsUpdate(SanitizedBaseModel):
     enabled: Optional[bool] = None
     provider: Optional[AIProvider] = None
-    api_key: Optional[str] = None
+    api_key: Optional[RawTextStr] = None
     base_url: Optional[str] = None
     model: Optional[str] = None
     clear_settings: bool = Field(
@@ -110,7 +110,7 @@ class UserAISettingsUpdate(SanitizedBaseModel):
 class ResolvedAISettings(SanitizedBaseModel):
     enabled: bool = False
     provider: Optional[AIProvider] = None
-    api_key: Optional[str] = None
+    api_key: Optional[RawTextStr] = None
     base_url: Optional[str] = None
     model: Optional[str] = None
     source: str = "platform"  # Where the settings came from
@@ -131,7 +131,7 @@ class ResolvedAISettingsResponse(SanitizedBaseModel):
 # Test connection schemas
 class AITestConnectionRequest(SanitizedBaseModel):
     provider: AIProvider
-    api_key: Optional[str] = None
+    api_key: Optional[RawTextStr] = None
     base_url: Optional[str] = None
     model: Optional[str] = None
 
@@ -147,7 +147,7 @@ class AITestConnectionResponse(SanitizedBaseModel):
 # Fetch models schemas
 class AIModelsRequest(SanitizedBaseModel):
     provider: AIProvider
-    api_key: Optional[str] = None
+    api_key: Optional[RawTextStr] = None
     base_url: Optional[str] = None
 
 

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import ConfigDict, Field
 
-from app.schemas.base import SanitizedBaseModel
+from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 
 class ApiKeyMetadata(SanitizedBaseModel):
@@ -33,4 +33,4 @@ class ApiKeyCreateResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     api_key: ApiKeyMetadata
-    secret: str
+    secret: RawTextStr

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import ConfigDict, EmailStr, Field
 
-from app.schemas.base import SanitizedBaseModel
+from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 
 class VerificationSendResponse(SanitizedBaseModel):
@@ -27,7 +27,7 @@ class PasswordResetSubmit(SanitizedBaseModel):
     # ``app.core.password_policy`` and are invoked from the endpoint,
     # so all policy failures surface with a flat error code from
     # ``PasswordMessages`` that ``errors.json`` can map.
-    password: str = Field(max_length=256)
+    password: RawTextStr = Field(max_length=256)
 
 
 # Device token schemas for mobile app authentication
@@ -37,7 +37,7 @@ class DeviceTokenRequest(SanitizedBaseModel):
     """Request body for creating a device token."""
 
     email: EmailStr
-    password: str = Field(min_length=1)
+    password: RawTextStr = Field(min_length=1)
     device_name: str = Field(min_length=1, max_length=255)
 
 

--- a/backend/app/schemas/guild.py
+++ b/backend/app/schemas/guild.py
@@ -92,7 +92,7 @@ class GuildDeletionRequest(SanitizedBaseModel):
       OIDC-only users (who have no usable password), mirroring the
       account-deletion endpoint, which is why it defaults to empty.
     """
-    password: str = ""
+    password: RawTextStr = ""
     confirmation_text: str
 
 

--- a/backend/app/schemas/push.py
+++ b/backend/app/schemas/push.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import ConfigDict, Field
 
-from app.schemas.base import SanitizedBaseModel
+from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 
 class PushTokenRegisterRequest(SanitizedBaseModel):
@@ -37,5 +37,5 @@ class FCMConfigResponse(SanitizedBaseModel):
     enabled: bool
     project_id: Optional[str] = None
     application_id: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[RawTextStr] = None
     sender_id: Optional[str] = None

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from pydantic import ConfigDict, EmailStr, Field
 
-from app.schemas.base import SanitizedBaseModel
+from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 class OIDCSettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
@@ -21,7 +21,7 @@ class OIDCSettingsUpdate(SanitizedBaseModel):
     enabled: bool
     issuer: Optional[str] = None
     client_id: Optional[str] = None
-    client_secret: Optional[str] = None
+    client_secret: Optional[RawTextStr] = None
     redirect_uri: Optional[str] = None
     post_login_redirect: Optional[str] = None
     provider_name: Optional[str] = None
@@ -73,7 +73,7 @@ class EmailSettingsUpdate(SanitizedBaseModel):
     secure: bool = False
     reject_unauthorized: bool = True
     username: Optional[str] = None
-    password: Optional[str] = None
+    password: Optional[RawTextStr] = None
     from_address: Optional[str] = None
     test_recipient: Optional[EmailStr] = None
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -23,7 +23,7 @@ class UserCreate(UserBase):
     # ``app.core.password_policy`` and are invoked from the endpoint,
     # so all policy failures surface with a flat error code from
     # ``PasswordMessages`` that ``errors.json`` can map.
-    password: str = Field(max_length=256)
+    password: RawTextStr = Field(max_length=256)
     # Optional IANA timezone forwarded by the SPA on registration so a
     # new account starts at the user's wall clock instead of the model
     # default ``"UTC"``. Validated server-side by ``_normalize_timezone``;
@@ -39,7 +39,7 @@ class UserCreate(UserBase):
 class UserUpdate(SanitizedBaseModel):
     full_name: Optional[str] = None
     role: Optional[UserRole] = None
-    password: Optional[str] = Field(default=None, max_length=256)
+    password: Optional[RawTextStr] = Field(default=None, max_length=256)
     status: Optional[UserStatus] = None
     avatar_base64: Optional[RawTextStr] = None
     avatar_url: Optional[str] = None
@@ -169,7 +169,7 @@ class UserInitiativeRole(SanitizedBaseModel):
 
 class UserSelfUpdate(SanitizedBaseModel):
     full_name: Optional[str] = None
-    password: Optional[str] = Field(default=None, max_length=256)
+    password: Optional[RawTextStr] = Field(default=None, max_length=256)
     avatar_base64: Optional[RawTextStr] = None
     avatar_url: Optional[str] = None
     week_starts_on: Optional[int] = None
@@ -213,7 +213,7 @@ class AccountDeletionRequest(SanitizedBaseModel):
     only platform admins can purge a row, and they do so via the admin endpoint.
     """
     action: Literal["deactivate", "soft_delete"]
-    password: str
+    password: RawTextStr
     confirmation_text: str
     project_transfers: Optional[Dict[int, int]] = None  # {project_id: new_owner_id}
 


### PR DESCRIPTION
Follow-up to the sanitizer work in #642.

## Problem
Passwords and secrets are carried on schemas that extend `SanitizedBaseModel`, so they were run through the plain-text HTML stripper (`_strip_to_plain_text`). A password or secret containing `<` (or a `<tag>` sequence) was **silently mangled** before being hashed/stored.

For passwords this is auth-breaking: the **login** path reads the password raw via `OAuth2PasswordRequestForm` (no sanitization), while **register/reset** sanitize it. So a user who registers `pa<b>ss` gets `pass` hashed, then can never log in (login sends `pa<b>ss` raw → mismatch).

For service secrets (SMTP password, OIDC `client_secret`, AI `api_key`) the mangled value is what's stored and sent to the external provider — breaking the integration.

## Fix
Mark every credential field `RawTextStr` so it's stored/compared exactly as entered:
- **Passwords (7):** `UserCreate`, `UserUpdate`, `UserSelfUpdate`, `AccountDeletionRequest`, `PasswordResetSubmit`, `DeviceTokenRequest`, `GuildDeletionRequest`.
- **Secrets (10):** OIDC `client_secret`, SMTP `password`, the 6 AI `api_key` fields, `ApiKeyCreateResponse.secret`, `FCMConfigResponse.api_key`.

Existing `Field(max_length=...)` DoS gates are kept. Pure `str → RawTextStr` — verified the exported OpenAPI is **byte-identical** to the dev baseline, so no generated-types regen.

## No lockout risk
Anyone who can log in **today** has a password where sanitization was a no-op (no `<tag>`), so their stored hash already equals the verbatim hash — and login is untouched by this change. The only users affected by sanitization are ones who *already* can't log in (special-char password + sanitizing register); they're unchanged and still need a reset. Going forward, registration stores the password exactly as typed.

## Verification
- Confirmed all 17 fields are exempt from sanitization and a value like `p@ss<b>w&ord"<script>!` round-trips verbatim through the password and SMTP-password schemas.
- `ruff` clean. OpenAPI byte-identical to baseline (no Orval regen).

## Minor follow-up (not here)
`DeviceTokenRequest` / `AccountDeletionRequest` / `GuildDeletionRequest` passwords now have no length bound (same as the OAuth2 login form, which is also unbounded). Bounding all password inputs — including the login form — is a separate small hardening.