### PR TITLE
Fail closed when serving uploads with no DB row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Validation errors no longer echo the submitted value (LOW-001).** FastAPI's default 422 response includes the offending `input`, which on a failed `register`/`token`/password-reset or an SMTP/OIDC settings update would have leaked the submitted password or secret. The 422 handler now strips `input` (and the pydantic docs `url`) while keeping field locations and messages, which are already public via the OpenAPI schema.
 - **Plain-text fields are length-capped (CRIT-002 DoS).** String fields are rejected past 8 KiB, bounding stored size and the entity-decode work. Fields that legitimately hold large data (base64 avatars, CSV/JSON import payloads, AI-generated text) opt out via a new `RawTextStr` marker — which also stops import payloads from being HTML-mangled on the way in.
 - **Rich-text opt-out now works through `Optional[...]`.** A field typed `Optional[RichTextStr]` (every task/project/initiative/guild `description` and queue `notes`) was silently still being stripped, because the opt-out marker was nested inside the `Optional` union and invisible to the field metadata. The detector now walks the annotation, so these fields are preserved as intended (matching non-optional rich-text like comment content).
+- Uploaded files with no matching database record now return 404 instead of being served to any authenticated user, closing a fail-open cross-guild access path.
 
 ## [0.50.2] - 2026-06-08
 

--- a/backend/app/api/uploads_test.py
+++ b/backend/app/api/uploads_test.py
@@ -40,12 +40,26 @@ async def test_upload_accessible_with_auth_header(
     client: AsyncClient, session: AsyncSession
 ) -> None:
     """GET /uploads/<file> with Authorization Bearer header returns 200."""
+    from app.models.upload import Upload
+
     uploads_dir = _uploads_dir()
     test_file = uploads_dir / "test_auth_header.txt"
     test_file.write_text("hello")
     try:
         user = await create_user(session)
-        headers = get_auth_headers(user)
+        guild = await create_guild(session, creator=user)
+        await create_guild_membership(session, user=user, guild=guild)
+        session.add(
+            Upload(
+                filename="test_auth_header.txt",
+                guild_id=guild.id,
+                uploader_user_id=user.id,
+                size_bytes=5,
+            )
+        )
+        await session.commit()
+
+        headers = {**get_auth_headers(user), "X-Guild-ID": str(guild.id)}
         response = await client.get("/uploads/test_auth_header.txt", headers=headers)
         assert response.status_code == 200
     finally:
@@ -57,13 +71,30 @@ async def test_upload_accessible_with_query_token(
     client: AsyncClient, session: AsyncSession
 ) -> None:
     """GET /uploads/<file>?token=<jwt> returns 200."""
+    from app.models.upload import Upload
+
     uploads_dir = _uploads_dir()
     test_file = uploads_dir / "test_query_token.txt"
     test_file.write_text("hello")
     try:
         user = await create_user(session)
+        guild = await create_guild(session, creator=user)
+        await create_guild_membership(session, user=user, guild=guild)
+        session.add(
+            Upload(
+                filename="test_query_token.txt",
+                guild_id=guild.id,
+                uploader_user_id=user.id,
+                size_bytes=5,
+            )
+        )
+        await session.commit()
+
         token = get_auth_token(user)
-        response = await client.get(f"/uploads/test_query_token.txt?token={token}")
+        response = await client.get(
+            f"/uploads/test_query_token.txt?token={token}",
+            headers={"X-Guild-ID": str(guild.id)},
+        )
         assert response.status_code == 200
     finally:
         test_file.unlink(missing_ok=True)
@@ -158,18 +189,23 @@ async def test_upload_non_member_cannot_access_file(
 
 
 @pytest.mark.integration
-async def test_upload_legacy_file_accessible_to_any_authenticated_user(
+async def test_upload_without_db_record_returns_404(
     client: AsyncClient, session: AsyncSession
 ) -> None:
-    """A file with no DB record (legacy) is accessible to any authenticated user."""
+    """A blob on disk with no Upload row fails closed (404), not the bytes.
+
+    Without an Upload row there is no owning guild to authorize against, so
+    serving the file would leak it to any authenticated user cross-guild.
+    """
     uploads_dir = _uploads_dir()
-    test_file = uploads_dir / "test_legacy_file.txt"
-    test_file.write_text("legacy content")
+    test_file = uploads_dir / "test_orphan_file.txt"
+    test_file.write_text("orphan content")
     try:
         user = await create_user(session)
         headers = get_auth_headers(user)
-        response = await client.get("/uploads/test_legacy_file.txt", headers=headers)
-        assert response.status_code == 200
+        response = await client.get("/uploads/test_orphan_file.txt", headers=headers)
+        assert response.status_code == 404
+        assert b"orphan content" not in response.content
     finally:
         test_file.unlink(missing_ok=True)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -129,20 +129,25 @@ async def serve_upload_file(
     if not file_path.is_file():
         raise HTTPException(status_code=404)
 
-    # Guild authorization: look up upload record and verify membership
+    # Guild authorization: look up upload record and verify membership.
+    # Fail closed: a blob on disk without a matching Upload row has no owning
+    # guild to authorize against, so we 404 (don't confirm existence) rather
+    # than serve it to any authenticated user cross-guild. Every legitimate
+    # write path inserts an Upload row, so a row-less blob is never expected.
     record_result = await session.exec(
         select(Upload).where(Upload.filename == FilePath(filename).name)
     )
     record = record_result.one_or_none()
-    if record is not None:
-        membership_result = await session.exec(
-            select(GuildMembership).where(
-                GuildMembership.guild_id == record.guild_id,
-                GuildMembership.user_id == current_user.id,
-            )
+    if record is None:
+        raise HTTPException(status_code=404)
+    membership_result = await session.exec(
+        select(GuildMembership).where(
+            GuildMembership.guild_id == record.guild_id,
+            GuildMembership.user_id == current_user.id,
         )
-        if membership_result.one_or_none() is None:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    )
+    if membership_result.one_or_none() is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
     headers: dict[str, str] = {}
     if filename.lower().endswith((".svg", ".html", ".htm")):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -954,7 +954,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
     { name = "ruff", specifier = ">=0.4.7,<0.16" },
-    { name = "ty", specifier = ">=0.0.48" },
+    { name = "ty", specifier = ">=0.0.48,<0.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem (SEC-6, 2026-06-11 security audit)

`serve_upload_file` ran the guild-membership check only when an `Upload` row existed. Any blob on disk without a matching row was served to **any authenticated user, cross-guild** — fail-open tenant isolation. Latent today (every write path inserts a row; filenames are 128-bit UUIDs), but structurally unsafe.

## Changes

- `backend/app/main.py`: when no `Upload` row matches, return **404** (not the bytes; bare 404 so existence isn't confirmed). The membership check is now unconditional once a record exists.
- Verified no legitimate flow serves row-less files: all write paths (`attachments.py`, `documents.py`, document duplication) insert `Upload` rows; avatars use base64/external URLs; branding/SPA assets are served from `STATIC_DIR` by a separate handler.
- Tests: flipped `test_upload_legacy_file_accessible_to_any_authenticated_user` (which codified the fail-open behavior) to `test_upload_without_db_record_returns_404`; the two auth-mechanics tests now create a proper guild + `Upload` row.
- Also includes a 1-line `uv.lock` refresh (re-lock after the pyright→ty swap's `<0.1` bound) so the lockfile stops dirtying on every `uv sync`.

## Schema/env updates

None. No migration.

## Testing

```
cd backend && uv run pytest app/api/uploads_test.py   # 9 passed ×3 runs
cd backend && uv run ruff check app                   # passed
```

Note: the CHANGELOG line may trivially conflict with sibling security PRs.