### PR TITLE
Force platform member on admin user create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Validation errors no longer echo the submitted value (LOW-001).** FastAPI's default 422 response includes the offending `input`, which on a failed `register`/`token`/password-reset or an SMTP/OIDC settings update would have leaked the submitted password or secret. The 422 handler now strips `input` (and the pydantic docs `url`) while keeping field locations and messages, which are already public via the OpenAPI schema.
 - **Plain-text fields are length-capped (CRIT-002 DoS).** String fields are rejected past 8 KiB, bounding stored size and the entity-decode work. Fields that legitimately hold large data (base64 avatars, CSV/JSON import payloads, AI-generated text) opt out via a new `RawTextStr` marker — which also stops import payloads from being HTML-mangled on the way in.
 - **Rich-text opt-out now works through `Optional[...]`.** A field typed `Optional[RichTextStr]` (every task/project/initiative/guild `description` and queue `notes`) was silently still being stripped, because the opt-out marker was nested inside the `Optional` union and invisible to the field metadata. The detector now walks the annotation, so these fields are preserved as intended (matching non-optional rich-text like comment content).
+- Guild admins can no longer assign a platform role when creating a user; admin-created accounts are always platform members, closing a privilege-escalation path to `owner`.
 
 ## [0.50.2] - 2026-06-08
 

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -27,7 +27,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.guild import GuildRole, GuildMembership
 from app.models.initiative import InitiativeMember
 from app.core.capabilities import Capability, user_has_capability
-from app.models.user import User, UserStatus
+from app.models.user import User, UserRole, UserStatus
 from app.models.user_token import UserToken, UserTokenPurpose
 from app.schemas.user import (
     UserCreate,
@@ -246,7 +246,13 @@ async def create_user(
         email_encrypted=encrypt_field(normalized_email, SALT_EMAIL),
         full_name=user_in.full_name,
         hashed_password=get_password_hash(user_in.password),
-        role=user_in.role,
+        # Always a plain platform ``member`` — a guild admin must never be
+        # able to mint an elevated platform role (owner/admin/...) from this
+        # endpoint. Platform roles are changed only via the capability-gated,
+        # bounded-delegation flow at ``/admin/users/{id}/platform-role``.
+        # ``UserCreate`` no longer carries a ``role`` field, so there is
+        # nothing in the request body to honour here. See SEC-1.
+        role=UserRole.member,
         email_verified=True,
     )
     session.add(user)

--- a/backend/app/api/v1/endpoints/users_test.py
+++ b/backend/app/api/v1/endpoints/users_test.py
@@ -15,6 +15,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.models.guild import GuildRole
+from app.models.user import User, UserRole
 
 from app.testing.factories import (
     create_guild,
@@ -953,3 +954,78 @@ async def test_self_delete_rejects_anonymized_transfer_target(
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "USER_INVALID_TRANSFER_RECIPIENT"
+
+
+@pytest.mark.integration
+async def test_create_user_ignores_requested_platform_role(
+    client: AsyncClient, session: AsyncSession
+):
+    """A guild admin cannot escalate a new account to a platform role.
+
+    Regression for SEC-1: ``POST /users/`` previously trusted the request
+    body's ``role`` field, letting a guild admin mint a platform ``owner``
+    (config.manage + data.bypass) with a chosen password. The created user
+    must always be a plain platform ``member`` regardless of what the body
+    asks for.
+    """
+    guild = await create_guild(session)
+    admin = await create_user(session, email="admin@example.com")
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+
+    headers = get_guild_headers(guild, admin)
+
+    for requested_role in ("owner", "admin", "moderator", "support"):
+        new_email = f"escalate-{requested_role}@example.com"
+        response = await client.post(
+            "/api/v1/users/",
+            headers=headers,
+            json={
+                "email": new_email,
+                "full_name": "Should Be Member",
+                "password": "testpassword123",
+                "role": requested_role,
+            },
+        )
+
+        # The smuggled ``role`` field is ignored, not rejected: creation
+        # still succeeds, but the resulting platform role is always member.
+        assert response.status_code == 201, response.text
+        assert response.json()["role"] == UserRole.member.value
+
+        created = (
+            await session.exec(
+                select(User).where(User.email_hash == hash_email(new_email))
+            )
+        ).one()
+        assert created.role == UserRole.member
+
+
+@pytest.mark.integration
+async def test_create_user_happy_path_creates_member(
+    client: AsyncClient, session: AsyncSession
+):
+    """Default admin-created account succeeds and is a platform member."""
+    guild = await create_guild(session)
+    admin = await create_user(session, email="happy-admin@example.com")
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+
+    headers = get_guild_headers(guild, admin)
+
+    response = await client.post(
+        "/api/v1/users/",
+        headers=headers,
+        json={
+            "email": "newmember@example.com",
+            "full_name": "New Member",
+            "password": "testpassword123",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["full_name"] == "New Member"
+    assert body["role"] == UserRole.member.value

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -17,7 +17,18 @@ class UserBase(SanitizedBaseModel):
     role: UserRole = UserRole.member
 
 
-class UserCreate(UserBase):
+class UserCreate(SanitizedBaseModel):
+    # Deliberately does NOT inherit ``UserBase.role``. Platform role must
+    # never be settable from a create payload: this schema backs both
+    # self-registration (``/auth/register``) and guild-admin user creation
+    # (``POST /users/``), and neither caller is authorized to grant a
+    # platform role from the request body. Registration computes the role
+    # itself (first user = owner, everyone else = member) and the admin
+    # endpoint forces ``member``; standing platform roles change only via
+    # ``/admin/users/{id}/platform-role`` (capability-gated, bounded
+    # delegation). See SEC-1.
+    email: EmailStr
+    full_name: Optional[str] = None
     # ``max_length`` is a cheap DoS gate so we don't argon2-hash a
     # multi-megabyte payload. The min length and breach checks live in
     # ``app.core.password_policy`` and are invoked from the endpoint,

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3153,7 +3153,6 @@ export interface UserAISettingsUpdate {
 export interface UserCreate {
   email: string;
   full_name?: string | null;
-  role?: UserRole;
   /** @maxLength 256 */
   password: string;
   timezone?: string | null;


### PR DESCRIPTION
## Problem (SEC-1, 2026-06-11 security audit — Critical)

`POST /api/v1/users/` is gated only by guild-admin role but set the new user's **platform** role straight from the request body (`role=user_in.role`). `UserCreate` inherited `role: UserRole = UserRole.member` from `UserBase`, which accepts `owner`. A guild admin could mint an account holding `config.manage` + `data.bypass` (all-guild RLS bypass) with a password they choose — privilege escalation to platform owner.

## Changes

- `UserCreate` no longer carries `role` (now extends `SanitizedBaseModel` directly, declaring `email`/`full_name` explicitly; field parity with the old shape otherwise). A smuggled `role` in the body is ignored by Pydantic.
- `create_user` hard-codes `role=UserRole.member`, with a comment pointing platform-role changes at the capability-gated `/admin/users/{id}/platform-role` flow.
- Verified all `UserCreate` consumers: `register_user` already computes its own role (first user = owner, else member) and ignores the field; the admin **update** path already strips `role` (`users.py` "Platform role changes are not allowed via this endpoint"). No other consumers.
- Regression tests: admin POSTing `role=owner/admin/moderator/support` → 201 with platform role `member` (asserted in response and DB); happy path still works.
- Regenerated Orval types (`UserCreate.role` dropped from `initiativeAPI.schemas.ts`); no hand-written frontend code referenced it.

## Schema/env updates

Backend schema `UserCreate` changed → generated API types regenerated. No env changes, no migration.

## Testing

```
cd backend && uv run pytest app/api/v1/endpoints/users_test.py   # 38 passed
cd backend && uv run ruff check app                              # passed
cd backend && uv run python scripts/export_openapi.py ../frontend/openapi.json && cd ../frontend && pnpm orval
```

Note: the CHANGELOG line may trivially conflict with sibling security PRs.