### PR TITLE
Revoke sessions on admin password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CSV exports are no longer vulnerable to formula injection (SEC-11).** User-controlled fields (names, emails, initiative names) in the guild and platform user CSV exports were written verbatim, so a cell beginning with `=`, `+`, `-`, `@`, tab, or carriage return could execute as a spreadsheet formula (e.g. `=HYPERLINK(...)`, `=cmd|...`) when opened in Excel or Google Sheets. Every exported cell is now prefixed with a single quote when it starts with one of those characters, so spreadsheets treat it as text; benign values are unchanged.
 - Guild admins can no longer assign a platform role when creating a user; admin-created accounts are always platform members, closing a privilege-escalation path to `owner`.
 - Uploaded files with no matching database record now return 404 instead of being served to any authenticated user, closing a fail-open cross-guild access path.
+- **Resetting a member's password now ends their other sessions.** When a guild admin resets a user's password, that user's existing logins and device tokens are now invalidated, matching the self-service and forgot-password flows — so resetting a compromised account actually locks the attacker out.
 
 ## [0.50.2] - 2026-06-08
 

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -14,7 +14,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import delete as sql_delete, select, update as sql_update
+from sqlmodel import delete as sql_delete, select
 
 from app.api.deps import SessionDep, get_current_active_user, get_current_user_optional
 from app.db.session import get_admin_session
@@ -58,7 +58,7 @@ from app.services import user_tokens
 from app.services import initiatives as initiatives_service
 from app.services import guilds as guilds_service
 from app.services.oidc_sync import extract_claim_values, sync_oidc_assignments
-from app.models.user_token import UserToken, UserTokenPurpose
+from app.models.user_token import UserTokenPurpose
 
 router = APIRouter()
 AdminSessionDep = Annotated[AsyncSession, Depends(get_admin_session)]
@@ -974,21 +974,13 @@ async def reset_password(
             status_code=status.HTTP_404_NOT_FOUND, detail=AuthMessages.USER_NOT_FOUND
         )
     user.hashed_password = get_password_hash(payload.password)
-    user.token_version += 1
+    # Bump token_version and revoke active device tokens so a stale
+    # JWT/device token can't survive the reset.
+    await user_tokens.revoke_user_sessions(session, user=user)
     if not user.email_verified:
         user.email_verified = True
     user.updated_at = datetime.now(timezone.utc)
     session.add(user)
-    # Bulk-revoke all active device tokens
-    await session.exec(
-        sql_update(UserToken)
-        .where(
-            UserToken.user_id == user.id,
-            UserToken.purpose == UserTokenPurpose.device_auth,
-            UserToken.consumed_at.is_(None),
-        )
-        .values(consumed_at=datetime.now(timezone.utc))
-    )
     await session.commit()
     await session.refresh(user)
     return VerificationSendResponse(status="reset")

--- a/backend/app/api/v1/endpoints/auth_test.py
+++ b/backend/app/api/v1/endpoints/auth_test.py
@@ -972,6 +972,61 @@ async def test_password_reset_rejects_short_password(
 
 @pytest.mark.integration
 @pytest.mark.auth
+async def test_password_reset_revokes_sessions_and_device_tokens(
+    client: AsyncClient, session: AsyncSession
+):
+    """A successful forgot-password reset must invalidate the user's
+    outstanding JWT (token_version bump) and active device tokens, so a
+    stolen-but-unexpired credential can't survive the reset."""
+    from sqlmodel import select
+
+    from app.models.user_token import UserToken, UserTokenPurpose
+    from app.services import user_tokens
+
+    user = await create_user(session, email="reset-revoke@example.com")
+    old_jwt = get_auth_token(user)
+    device_token = await user_tokens.create_device_token(
+        session, user_id=user.id, device_name="Reset phone"
+    )
+    reset_token = await user_tokens.create_token(
+        session,
+        user_id=user.id,
+        purpose=UserTokenPurpose.password_reset,
+    )
+
+    response = await client.post(
+        "/api/v1/auth/password/reset",
+        json={"token": reset_token, "password": "brand-new-secret-123"},
+    )
+    assert response.status_code == 200
+
+    # Old JWT rejected (token_version bumped).
+    post_jwt = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {old_jwt}"},
+    )
+    assert post_jwt.status_code == 401
+
+    # Device token rejected (consumed).
+    post_device = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"DeviceToken {device_token}"},
+    )
+    assert post_device.status_code == 401
+
+    token_row = (
+        await session.exec(
+            select(UserToken).where(
+                UserToken.user_id == user.id,
+                UserToken.purpose == UserTokenPurpose.device_auth,
+            )
+        )
+    ).one()
+    assert token_row.consumed_at is not None
+
+
+@pytest.mark.integration
+@pytest.mark.auth
 async def test_register_rolls_back_when_guild_seed_fails(
     client: AsyncClient, session: AsyncSession, monkeypatch
 ):

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Annotated, List, Optional, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from sqlmodel import select, update as sql_update
+from sqlmodel import select
 
 from app.api.deps import (
     RLSSessionDep,
@@ -28,7 +28,6 @@ from app.models.guild import GuildRole, GuildMembership
 from app.models.initiative import InitiativeMember
 from app.core.capabilities import Capability, user_has_capability
 from app.models.user import User, UserRole, UserStatus
-from app.models.user_token import UserToken, UserTokenPurpose
 from app.schemas.user import (
     UserCreate,
     UserGuildMember,
@@ -58,6 +57,7 @@ from app.services import users as users_service
 from app.services import api_keys as api_keys_service
 from app.services import csv_export
 from app.services import stats_service
+from app.services import user_tokens as user_tokens_service
 
 # Allowed values for the optional "task completion visual feedback" effect.
 # Mirrored on the frontend in src/lib/taskCompletionVisualFeedback.ts; keep
@@ -289,17 +289,9 @@ async def update_users_me(
     if password:
         await enforce_password_policy(password)
         current_user.hashed_password = get_password_hash(password)
-        current_user.token_version += 1
-        # Bulk-revoke all active device tokens
-        await session.exec(
-            sql_update(UserToken)
-            .where(
-                UserToken.user_id == current_user.id,
-                UserToken.purpose == UserTokenPurpose.device_auth,
-                UserToken.consumed_at.is_(None),
-            )
-            .values(consumed_at=datetime.now(timezone.utc))
-        )
+        # Bump token_version and revoke active device tokens so a stale
+        # JWT/device token can't survive the password change.
+        await user_tokens_service.revoke_user_sessions(session, user=current_user)
 
     if "avatar_base64" in update_data:
         avatar_value = update_data["avatar_base64"]
@@ -429,6 +421,11 @@ async def update_user(
     if password := update_data.pop("password", None):
         await enforce_password_policy(password)
         user.hashed_password = get_password_hash(password)
+        # Resetting a compromised account must invalidate the attacker's
+        # outstanding sessions: bump token_version (kills unexpired JWTs)
+        # and revoke active device tokens, mirroring the self-service and
+        # forgot-password reset paths.
+        await user_tokens_service.revoke_user_sessions(session, user=user)
     if "avatar_base64" in update_data:
         user.avatar_base64 = update_data.pop("avatar_base64")
         if user.avatar_base64:

--- a/backend/app/api/v1/endpoints/users_test.py
+++ b/backend/app/api/v1/endpoints/users_test.py
@@ -22,6 +22,7 @@ from app.testing.factories import (
     create_guild_membership,
     create_user,
     get_auth_headers,
+    get_auth_token,
     get_guild_headers,
 )
 
@@ -171,7 +172,6 @@ async def test_admin_password_reset_revokes_sessions_and_device_tokens(
     the admin's "fix"."""
     from app.models.user_token import UserToken, UserTokenPurpose
     from app.services import user_tokens
-    from app.testing.factories import get_auth_token
 
     guild = await create_guild(session)
     admin = await create_user(session, email="admin@example.com")
@@ -230,6 +230,54 @@ async def test_admin_password_reset_revokes_sessions_and_device_tokens(
         await session.exec(
             select(UserToken).where(
                 UserToken.user_id == member.id,
+                UserToken.purpose == UserTokenPurpose.device_auth,
+            )
+        )
+    ).one()
+    assert token_row.consumed_at is not None
+
+
+@pytest.mark.integration
+async def test_self_service_password_change_revokes_sessions_and_device_tokens(
+    client: AsyncClient, session: AsyncSession
+):
+    """Changing your own password via PATCH /users/me must invalidate other
+    outstanding JWTs and active device tokens — completing the three-path
+    symmetry with the admin-reset and forgot-password flows (all share
+    ``revoke_user_sessions`` / ``revoke_active_device_tokens``)."""
+    from app.models.user_token import UserToken, UserTokenPurpose
+    from app.services import user_tokens
+
+    user = await create_user(session, email="self-change@example.com")
+    old_jwt = get_auth_token(user)
+    device_token = await user_tokens.create_device_token(
+        session, user_id=user.id, device_name="Old phone"
+    )
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        json={"password": "brand-new-secret-123"},
+        headers={"Authorization": f"Bearer {old_jwt}"},
+    )
+    assert response.status_code == 200
+
+    # The pre-change JWT is rejected (token_version bumped).
+    stale = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {old_jwt}"},
+    )
+    assert stale.status_code == 401
+
+    # The device token was revoked (consumed).
+    stale_device = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"DeviceToken {device_token}"},
+    )
+    assert stale_device.status_code == 401
+    token_row = (
+        await session.exec(
+            select(UserToken).where(
+                UserToken.user_id == user.id,
                 UserToken.purpose == UserTokenPurpose.device_auth,
             )
         )

--- a/backend/app/api/v1/endpoints/users_test.py
+++ b/backend/app/api/v1/endpoints/users_test.py
@@ -162,6 +162,82 @@ async def test_update_user_by_id_as_admin(client: AsyncClient, session: AsyncSes
 
 
 @pytest.mark.integration
+async def test_admin_password_reset_revokes_sessions_and_device_tokens(
+    client: AsyncClient, session: AsyncSession
+):
+    """A guild admin resetting a member's password must invalidate the
+    member's outstanding JWT and active device tokens. Otherwise an
+    attacker who compromised the account keeps a working session after
+    the admin's "fix"."""
+    from app.models.user_token import UserToken, UserTokenPurpose
+    from app.services import user_tokens
+    from app.testing.factories import get_auth_token
+
+    guild = await create_guild(session)
+    admin = await create_user(session, email="admin@example.com")
+    member = await create_user(session, email="member@example.com")
+
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await create_guild_membership(
+        session, user=member, guild=guild, role=GuildRole.member
+    )
+
+    # The member's pre-reset session: a JWT bound to the current
+    # token_version and a long-lived device token.
+    member_jwt = get_auth_token(member)
+    device_token = await user_tokens.create_device_token(
+        session, user_id=member.id, device_name="Member's phone"
+    )
+
+    # Sanity check: both credentials work before the reset.
+    pre_jwt = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {member_jwt}"},
+    )
+    assert pre_jwt.status_code == 200
+    pre_device = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"DeviceToken {device_token}"},
+    )
+    assert pre_device.status_code == 200
+
+    # Admin resets the member's password.
+    reset = await client.patch(
+        f"/api/v1/users/{member.id}",
+        headers=get_guild_headers(guild, admin),
+        json={"password": "brand-new-secret-123"},
+    )
+    assert reset.status_code == 200
+
+    # The member's old JWT is now rejected (token_version bumped).
+    post_jwt = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {member_jwt}"},
+    )
+    assert post_jwt.status_code == 401
+
+    # The member's device token is now rejected (consumed).
+    post_device = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"DeviceToken {device_token}"},
+    )
+    assert post_device.status_code == 401
+
+    # The device token row is marked consumed in the DB.
+    token_row = (
+        await session.exec(
+            select(UserToken).where(
+                UserToken.user_id == member.id,
+                UserToken.purpose == UserTokenPurpose.device_auth,
+            )
+        )
+    ).one()
+    assert token_row.consumed_at is not None
+
+
+@pytest.mark.integration
 async def test_update_user_as_member_forbidden(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/services/user_tokens.py
+++ b/backend/app/services/user_tokens.py
@@ -3,10 +3,11 @@ from hashlib import sha256
 import secrets
 from typing import Optional, List
 
-from sqlmodel import select, delete
+from sqlmodel import select, delete, update as sql_update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.db.session import reapply_rls_context
+from app.models.user import User
 from app.models.user_token import UserToken, UserTokenPurpose
 
 
@@ -210,3 +211,44 @@ async def revoke_device_token(
     session.add(token)
     await session.commit()
     return True
+
+
+async def revoke_active_device_tokens(
+    session: AsyncSession,
+    *,
+    user_id: int,
+) -> None:
+    """Mark every active device token for a user as consumed.
+
+    Used after a password change/reset so previously-issued long-lived
+    device tokens can no longer authenticate. Does not commit — the caller
+    owns the surrounding transaction.
+    """
+    await session.exec(
+        sql_update(UserToken)
+        .where(
+            UserToken.user_id == user_id,
+            UserToken.purpose == UserTokenPurpose.device_auth,
+            UserToken.consumed_at.is_(None),
+        )
+        .values(consumed_at=datetime.now(timezone.utc))
+    )
+
+
+async def revoke_user_sessions(
+    session: AsyncSession,
+    *,
+    user: User,
+) -> None:
+    """Invalidate every outstanding session for ``user`` after a credential
+    change.
+
+    Bumps ``token_version`` (which the JWT/WS authenticators compare against,
+    invalidating any still-unexpired access token) and bulk-revokes the
+    user's active ``device_auth`` tokens. Shared by the self-service password
+    change, the forgot-password reset, and the admin password reset so the
+    three paths can't drift. Does not commit — the caller owns the transaction
+    and is responsible for ``session.add(user)``/``commit``.
+    """
+    user.token_version += 1
+    await revoke_active_device_tokens(session, user_id=user.id)


### PR DESCRIPTION
## Problem (SEC-8, 2026-06-11 security audit — Medium)

The admin `update_user` password branch updated `hashed_password` only. Unlike the self-update and forgot-reset paths it didn't bump `token_version` or revoke device tokens — so after an admin resets a compromised account's password, the attacker's JWT and device token kept working. False assurance exactly when revocation matters most.

## Changes

- New shared service helpers in `app/services/user_tokens.py`: `revoke_user_sessions` (token_version bump) and `revoke_active_device_tokens` (marks active `device_auth` tokens consumed) — the revoke block previously existed as three inline copies.
- The **admin password branch** now calls both helpers; the **self-update** and **forgot-reset** paths were refactored onto the same helpers (behavior unchanged) so the four sites can't drift again.
- Regression tests: admin resets a user's password → the user's prior JWT is rejected (401) and their device token is consumed; equivalent coverage for the forgot-reset path.

## Schema/env updates

None. No migration.

## Testing

```
cd backend && uv run ruff check app   # clean
cd backend && uv run pytest app/api/v1/endpoints/users_test.py app/api/v1/endpoints/auth_test.py app/services/user_tokens_test.py
```

Ported onto current dev from the audit worktree; conflicts with the merged SEC-1/SEC-9/SEC-13 changes were resolved (imports kept where dev gained new usages; both sides of test-insertion collisions kept). CI runs the full suite. CHANGELOG line may conflict trivially with sibling security PRs.