### PR TITLE
Reinstate initiative-scope permission layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Reinstated the initiative permission layer dropped by the schema-per-guild cutover.** The old database-level "must be a member of the owning initiative" check (`is_initiative_member` RESTRICTIVE policies) didn't carry over into per-guild schemas, so a document/project permission row left behind after someone was removed from an initiative quietly became a live grant. Access checks and the visibility queries now require initiative scope (member, guild admin, or platform `data.bypass`) on top of an explicit permission row, removing a member from an initiative also deletes their document permission rows (project permissions already were), and a live PAM grant still acts as membership of every initiative it covers. New shared helpers in `app/services/membership.py` provide batch-efficient guild/initiative membership checks for future use.
+
 ### Added
 
 - **Expandable guild sidebar.** The icon-only guild rail can now expand into a "Guilds" flyout that shows each guild's full name and member count. Open it with the chevron toggle (or swipe in from the rail), collapse it with the header button, click-away (desktop), or by swiping it closed. On mobile the flyout fills the drawer; on desktop it floats over the sidebar. Member counts are exposed via a new `member_count` field on the guild list response. Drag-to-reorder still works (press-and-hold on touch so it doesn't fight the swipe gestures).

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -12,6 +12,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.capabilities import Capability, user_has_capability
 from app.core.config import settings
 from app.core.pam_context import set_active_grant
+from app.core.role_context import set_active_role
 from app.core.messages import AuthMessages, GuildMessages
 from app.core.security import (
     AutoDelegationClaims,
@@ -415,6 +416,10 @@ async def get_guild_session(
         # resource access checks (require_*_access) honor it consistently with
         # RLS — what the grantee can list, they can also open/edit per level.
         set_active_grant(guild_context.guild_id, access_level)
+        # No real membership — leave the role context clear so role-gated
+        # paths (initiative-scope guild-admin bypass) don't treat the grantee
+        # as a member.
+        set_active_role(None, None)
         # Leave current_guild_id unset — the existing write policies treat a
         # matching current_guild_id as proof of membership. Scope the grant via
         # pam_guild_id instead.
@@ -431,6 +436,9 @@ async def get_guild_session(
         return session
 
     set_active_grant(None, None)
+    # Record the membership role for this request's active guild so the sync
+    # access checks can apply the guild-admin leg of the initiative-scope gate.
+    set_active_role(guild_context.guild_id, guild_context.role.value)
     await set_rls_context(
         session,
         user_id=current_user.id,

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -88,6 +88,7 @@ from app.schemas.tag import TagSetRequest
 from app.services import attachments as attachments_service
 from app.services import documents as documents_service
 from app.services import initiatives as initiatives_service
+from app.services import membership as membership_service
 from app.services import notifications as notifications_service
 from app.services import permissions as permissions_service
 from app.services import properties as properties_service
@@ -243,6 +244,7 @@ def _require_document_access(
     access: str = "read",
     require_owner: bool = False,
     manage_access: bool = False,
+    guild_role: GuildRole | str | None = None,
 ) -> None:
     """Check if user has required access to a document.
 
@@ -262,6 +264,7 @@ def _require_document_access(
         user,
         access=access,
         require_owner=require_owner,
+        guild_role=guild_role,
     )
 
 
@@ -2342,7 +2345,17 @@ async def download_document_file(
             status_code=status.HTTP_404_NOT_FOUND, detail=DocumentMessages.NOT_FOUND
         )
 
-    _require_document_access(document, current_user, access="read")
+    # Iframe downloads carry no X-Guild-ID, so the request role context is
+    # unset — resolve the user's role in the document's guild explicitly for
+    # the initiative-scope gate's guild-admin leg.
+    guild_role = (
+        await membership_service.guild_role_map(
+            session, document.guild_id, (current_user.id,)
+        )
+    ).get(current_user.id)
+    _require_document_access(
+        document, current_user, access="read", guild_role=guild_role
+    )
 
     logger.info(
         "document_download document_id=%d user=%d inline=%s",
@@ -2378,7 +2391,15 @@ async def download_document_file_version(
             status_code=status.HTTP_404_NOT_FOUND, detail=DocumentMessages.NOT_FOUND
         )
 
-    _require_document_access(document, current_user, access="read")
+    # Same rationale as download_document_file: no request role context here.
+    guild_role = (
+        await membership_service.guild_role_map(
+            session, document.guild_id, (current_user.id,)
+        )
+    ).get(current_user.id)
+    _require_document_access(
+        document, current_user, access="read", guild_role=guild_role
+    )
 
     version_result = await session.exec(
         select(DocumentFileVersion).where(

--- a/backend/app/api/v1/endpoints/documents_scope_test.py
+++ b/backend/app/api/v1/endpoints/documents_scope_test.py
@@ -1,0 +1,91 @@
+"""Initiative-scope enforcement for document access.
+
+The schema-per-guild cutover removed the DB-level RESTRICTIVE
+``is_initiative_member`` policies; these tests pin the app-level replacement:
+removal from an initiative must end document access — the permission rows are
+cleaned up, and a stale row alone would not grant access anyway
+(``initiative_scope_ok`` gate, unit-tested in ``services/permissions_test``).
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.guild import GuildRole
+from app.testing.factories import (
+    create_guild,
+    create_guild_membership,
+    create_initiative,
+    create_initiative_member,
+    create_user,
+    get_guild_headers,
+)
+
+
+async def _setup(session: AsyncSession):
+    admin = await create_user(session, email="admin@example.com")
+    member = await create_user(session, email="member@example.com")
+    guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await create_guild_membership(
+        session, user=member, guild=guild, role=GuildRole.member
+    )
+    initiative = await create_initiative(session, guild, admin)
+    await create_initiative_member(session, initiative, member)
+    return admin, member, guild, initiative
+
+
+@pytest.mark.integration
+async def test_initiative_removal_ends_document_access(
+    client: AsyncClient, session: AsyncSession
+):
+    admin, member, guild, initiative = await _setup(session)
+    admin_headers = get_guild_headers(guild, admin)
+    member_headers = get_guild_headers(guild, member)
+
+    # Admin creates a document and shares it with the member.
+    response = await client.post(
+        "/api/v1/documents/",
+        headers=admin_headers,
+        json={"title": "Shared Doc", "initiative_id": initiative.id},
+    )
+    assert response.status_code == 201
+    doc_id = response.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/documents/{doc_id}/members",
+        headers=admin_headers,
+        json={"user_id": member.id, "level": "write"},
+    )
+    assert response.status_code == 201
+
+    # Member can open and list the document while in the initiative.
+    response = await client.get(
+        f"/api/v1/documents/{doc_id}", headers=member_headers
+    )
+    assert response.status_code == 200
+    response = await client.get("/api/v1/documents/", headers=member_headers)
+    assert doc_id in {d["id"] for d in response.json()["items"]}
+
+    # Remove the member from the initiative.
+    response = await client.delete(
+        f"/api/v1/initiatives/{initiative.id}/members/{member.id}",
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+
+    # Access is gone: open is 403, the list no longer contains the doc.
+    response = await client.get(
+        f"/api/v1/documents/{doc_id}", headers=member_headers
+    )
+    assert response.status_code == 403
+    response = await client.get("/api/v1/documents/", headers=member_headers)
+    assert doc_id not in {d["id"] for d in response.json()["items"]}
+
+    # The admin (initiative PM here) is unaffected.
+    response = await client.get(
+        f"/api/v1/documents/{doc_id}", headers=admin_headers
+    )
+    assert response.status_code == 200

--- a/backend/app/api/v1/endpoints/documents_scope_test.py
+++ b/backend/app/api/v1/endpoints/documents_scope_test.py
@@ -62,9 +62,7 @@ async def test_initiative_removal_ends_document_access(
     assert response.status_code == 201
 
     # Member can open and list the document while in the initiative.
-    response = await client.get(
-        f"/api/v1/documents/{doc_id}", headers=member_headers
-    )
+    response = await client.get(f"/api/v1/documents/{doc_id}", headers=member_headers)
     assert response.status_code == 200
     response = await client.get("/api/v1/documents/", headers=member_headers)
     assert doc_id in {d["id"] for d in response.json()["items"]}
@@ -77,15 +75,11 @@ async def test_initiative_removal_ends_document_access(
     assert response.status_code == 200
 
     # Access is gone: open is 403, the list no longer contains the doc.
-    response = await client.get(
-        f"/api/v1/documents/{doc_id}", headers=member_headers
-    )
+    response = await client.get(f"/api/v1/documents/{doc_id}", headers=member_headers)
     assert response.status_code == 403
     response = await client.get("/api/v1/documents/", headers=member_headers)
     assert doc_id not in {d["id"] for d in response.json()["items"]}
 
     # The admin (initiative PM here) is unaffected.
-    response = await client.get(
-        f"/api/v1/documents/{doc_id}", headers=admin_headers
-    )
+    response = await client.get(f"/api/v1/documents/{doc_id}", headers=admin_headers)
     assert response.status_code == 200

--- a/backend/app/api/v1/endpoints/initiatives.py
+++ b/backend/app/api/v1/endpoints/initiatives.py
@@ -18,6 +18,7 @@ from app.core.security import create_advanced_tool_handoff_token
 from app.core.config import settings
 from app.db.session import reapply_rls_context
 from app.models.access_grant import AccessLevel
+from app.models.document import Document, DocumentPermission
 from app.models.project import Project, ProjectPermission, ProjectPermissionLevel
 from app.models.initiative import (
     Initiative,
@@ -1054,6 +1055,20 @@ async def remove_initiative_member(
                     .where(TaskAssignee.task_id.in_(tuple(task_ids)))
                 )
                 await session.exec(delete_stmt)
+
+        # Remove the user's document permissions in this initiative. With the
+        # DB-level initiative-scope policies gone (schema-per-guild), a stale
+        # row would otherwise remain a live grant after removal.
+        await session.exec(
+            delete(DocumentPermission).where(
+                DocumentPermission.user_id == user_id,
+                DocumentPermission.document_id.in_(
+                    select(Document.id).where(
+                        Document.initiative_id == initiative_id
+                    )
+                ),
+            )
+        )
 
         await session.commit()
         await reapply_rls_context(session)

--- a/backend/app/api/v1/endpoints/initiatives.py
+++ b/backend/app/api/v1/endpoints/initiatives.py
@@ -1063,9 +1063,7 @@ async def remove_initiative_member(
             delete(DocumentPermission).where(
                 DocumentPermission.user_id == user_id,
                 DocumentPermission.document_id.in_(
-                    select(Document.id).where(
-                        Document.initiative_id == initiative_id
-                    )
+                    select(Document.id).where(Document.initiative_id == initiative_id)
                 ),
             )
         )

--- a/backend/app/core/pam_context.py
+++ b/backend/app/core/pam_context.py
@@ -32,6 +32,17 @@ def set_active_grant(guild_id: Optional[int], access_level: Optional[str]) -> No
         _active_grant.set((guild_id, access_level))
 
 
+def active_grant_guild() -> Optional[int]:
+    """The guild covered by this request's live grant, or None.
+
+    Lets request-time SQL builders (e.g. ``initiative_scope_clause``) embed
+    the granted guild as a literal predicate, mirroring how the old
+    ``is_initiative_member()`` SQL function honored ``app.pam_*`` GUCs.
+    """
+    current = _active_grant.get()
+    return current[0] if current is not None else None
+
+
 def active_grant_level(guild_id: int) -> Optional[str]:
     """The grant access level covering ``guild_id`` this request, or None."""
     current = _active_grant.get()

--- a/backend/app/core/role_context.py
+++ b/backend/app/core/role_context.py
@@ -1,0 +1,42 @@
+"""Request-scoped active-guild role context.
+
+The deps layer records the authenticated user's role in the request's active
+guild here (mirroring ``pam_context``). The sync app-layer access checks
+(``require_project_access`` / ``require_document_access``) consult it for the
+guild-admin leg of the initiative-scope gate — the leg the old RESTRICTIVE RLS
+policies expressed as ``current_setting('app.current_guild_role') = 'admin'`` —
+without the session being threaded through them.
+
+Keyed by guild id so a context recorded for the request's active guild never
+bleeds into another guild's entities during cross-guild gathers. PAM requests
+deliberately leave this unset — grant semantics flow through ``pam_context``.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Optional, Tuple
+
+# (guild_id, role) for the request's active guild membership, or None.
+_active_role: contextvars.ContextVar[Optional[Tuple[int, str]]] = (
+    contextvars.ContextVar("active_guild_role", default=None)
+)
+
+
+def set_active_role(guild_id: Optional[int], role: Optional[str]) -> None:
+    """Record (or clear) the active guild membership role for this request."""
+    if guild_id is None or role is None:
+        _active_role.set(None)
+    else:
+        _active_role.set((guild_id, role))
+
+
+def active_guild_role(guild_id: Optional[int]) -> Optional[str]:
+    """The recorded role if it covers ``guild_id`` this request, else None."""
+    if guild_id is None:
+        return None
+    current = _active_role.get()
+    if current is None:
+        return None
+    recorded_guild, role = current
+    return role if recorded_guild == guild_id else None

--- a/backend/app/services/initiatives.py
+++ b/backend/app/services/initiatives.py
@@ -454,6 +454,24 @@ async def remove_user_from_guild_initiatives(
             user_id=user_id,
         )
 
+    # Remove the user's remaining document permissions in those initiatives
+    # (one statement for the whole batch). With the DB-level initiative-scope
+    # policies gone (schema-per-guild), a stale row would otherwise remain a
+    # live grant after removal.
+    if initiative_ids:
+        from app.models.document import Document, DocumentPermission
+
+        await session.exec(
+            delete(DocumentPermission).where(
+                DocumentPermission.user_id == user_id,
+                DocumentPermission.document_id.in_(
+                    select(Document.id).where(
+                        Document.initiative_id.in_(tuple(initiative_ids))
+                    )
+                ),
+            )
+        )
+
     # Remove initiative memberships
     stmt = delete(InitiativeMember).where(
         InitiativeMember.user_id == user_id,

--- a/backend/app/services/membership.py
+++ b/backend/app/services/membership.py
@@ -100,9 +100,7 @@ def initiative_scope_clause(
     bypass_roles = tuple(roles_with_capability(Capability.DATA_BYPASS))
     return or_(
         initiative_access_clause(user_id, initiative_id_col, guild_id_col),
-        exists(
-            select(1).where(User.id == user_id, User.role.in_(bypass_roles))
-        ),
+        exists(select(1).where(User.id == user_id, User.role.in_(bypass_roles))),
     )
 
 
@@ -159,9 +157,7 @@ async def is_initiative_member(
     session: AsyncSession, initiative_id: int, user_id: int
 ) -> bool:
     """Single-user convenience over :func:`initiative_member_user_ids`."""
-    return bool(
-        await initiative_member_user_ids(session, initiative_id, (user_id,))
-    )
+    return bool(await initiative_member_user_ids(session, initiative_id, (user_id,)))
 
 
 async def guild_member_user_ids(
@@ -171,9 +167,7 @@ async def guild_member_user_ids(
 ) -> set[int]:
     """The subset of ``user_ids`` that belong to the guild (every member when
     ``user_ids`` is None). Shared table — no guild routing required."""
-    stmt = select(GuildMembership.user_id).where(
-        GuildMembership.guild_id == guild_id
-    )
+    stmt = select(GuildMembership.user_id).where(GuildMembership.guild_id == guild_id)
     if user_ids is not None:
         if not user_ids:
             return set()
@@ -200,9 +194,7 @@ async def guild_role_map(
     return {user_id: role for user_id, role in rows.all()}
 
 
-async def is_guild_admin(
-    session: AsyncSession, guild_id: int, user_id: int
-) -> bool:
+async def is_guild_admin(session: AsyncSession, guild_id: int, user_id: int) -> bool:
     """Whether the user is an admin of the guild. Shared table — works on any
     session."""
     role = (await guild_role_map(session, guild_id, (user_id,))).get(user_id)

--- a/backend/app/services/membership.py
+++ b/backend/app/services/membership.py
@@ -1,0 +1,209 @@
+"""Shared guild- and initiative-membership checks.
+
+The schema-per-guild cutover removed the DB-level initiative-membership
+RESTRICTIVE policy layer (``is_initiative_member()``), so initiative scoping
+is now enforced entirely in application code. This module is the single
+source of truth for those checks: clause builders for embedding membership
+predicates in any SELECT, and batch lookups that resolve membership for many
+users (or many initiatives) in one round trip instead of a per-user loop.
+
+Routing contract:
+  - ``guild_memberships`` is a shared/public table — the guild helpers work on
+    any session, routed or not.
+  - ``initiative_members`` lives in each guild's schema — callers must already
+    be routed into the right guild (``RLSSessionDep`` or ``set_rls_context``)
+    before using the initiative helpers, exactly like any other guild-scoped
+    query.
+"""
+
+from typing import Collection, Iterable, Optional
+
+from sqlalchemy import ColumnElement, exists, or_, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.capabilities import Capability, roles_with_capability
+from app.models.guild import GuildMembership, GuildRole
+from app.models.initiative import InitiativeMember
+from app.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# Clause builders — compose into WHERE conditions of any statement
+# ---------------------------------------------------------------------------
+
+
+def initiative_member_clause(
+    user_id: int, initiative_id_col: ColumnElement[int] | int
+) -> ColumnElement[bool]:
+    """EXISTS predicate: ``user_id`` is a member of the referenced initiative.
+
+    ``initiative_id_col`` is typically a column on the outer statement
+    (e.g. ``Document.initiative_id``) but a literal id also works.
+    """
+    return exists(
+        select(1).where(
+            InitiativeMember.initiative_id == initiative_id_col,
+            InitiativeMember.user_id == user_id,
+        )
+    )
+
+
+def guild_member_clause(
+    user_id: int,
+    guild_id_col: ColumnElement[int] | int,
+    *,
+    role: Optional[GuildRole] = None,
+) -> ColumnElement[bool]:
+    """EXISTS predicate: ``user_id`` belongs to the referenced guild.
+
+    Pass ``role=GuildRole.admin`` to require a specific guild role.
+    """
+    conditions = [
+        GuildMembership.guild_id == guild_id_col,
+        GuildMembership.user_id == user_id,
+    ]
+    if role is not None:
+        conditions.append(GuildMembership.role == role)
+    return exists(select(1).where(*conditions))
+
+
+def initiative_access_clause(
+    user_id: int,
+    initiative_id_col: ColumnElement[int] | int,
+    guild_id_col: ColumnElement[int] | int,
+) -> ColumnElement[bool]:
+    """The app-level replacement for the old RESTRICTIVE RLS expression
+    ``is_initiative_member(...) OR guild-admin OR superadmin``: member of the
+    initiative, or admin of the guild that owns it.
+
+    The superadmin leg is intentionally not encoded in SQL — callers that
+    serve ``data.bypass`` holders skip the gate instead (they can see the
+    user object; the query cannot).
+    """
+    return or_(
+        initiative_member_clause(user_id, initiative_id_col),
+        guild_member_clause(user_id, guild_id_col, role=GuildRole.admin),
+    )
+
+
+def initiative_scope_clause(
+    user_id: int,
+    initiative_id_col: ColumnElement[int] | int,
+    guild_id_col: ColumnElement[int] | int,
+) -> ColumnElement[bool]:
+    """Full app-level replacement for the old RESTRICTIVE RLS expression
+    ``is_initiative_member(...) OR IS_ADMIN OR IS_SUPER``, evaluated per row in
+    SQL so it stays correct inside cross-guild gathers and arbitrary batch
+    sizes: initiative member, OR admin of the row's guild, OR a platform role
+    holding ``data.bypass``.
+    """
+    bypass_roles = tuple(roles_with_capability(Capability.DATA_BYPASS))
+    return or_(
+        initiative_access_clause(user_id, initiative_id_col, guild_id_col),
+        exists(
+            select(1).where(User.id == user_id, User.role.in_(bypass_roles))
+        ),
+    )
+
+
+def member_initiative_ids_select(user_id: int):
+    """SELECT of initiative ids the user belongs to, for use as a subquery
+    (``Entity.initiative_id.in_(member_initiative_ids_select(uid))``)."""
+    return select(InitiativeMember.initiative_id).where(
+        InitiativeMember.user_id == user_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch lookups — one query regardless of how many users/initiatives
+# ---------------------------------------------------------------------------
+
+
+async def initiative_member_user_ids(
+    session: AsyncSession,
+    initiative_id: int,
+    user_ids: Optional[Collection[int]] = None,
+) -> set[int]:
+    """The subset of ``user_ids`` that are members of the initiative
+    (every member when ``user_ids`` is None). One query for any batch size."""
+    stmt = select(InitiativeMember.user_id).where(
+        InitiativeMember.initiative_id == initiative_id
+    )
+    if user_ids is not None:
+        if not user_ids:
+            return set()
+        stmt = stmt.where(InitiativeMember.user_id.in_(tuple(set(user_ids))))
+    return set((await session.execute(stmt)).scalars().all())
+
+
+async def user_member_initiative_ids(
+    session: AsyncSession,
+    user_id: int,
+    initiative_ids: Optional[Collection[int]] = None,
+) -> set[int]:
+    """The subset of ``initiative_ids`` the user is a member of (all of the
+    user's initiatives in the routed guild when ``initiative_ids`` is None)."""
+    stmt = select(InitiativeMember.initiative_id).where(
+        InitiativeMember.user_id == user_id
+    )
+    if initiative_ids is not None:
+        if not initiative_ids:
+            return set()
+        stmt = stmt.where(
+            InitiativeMember.initiative_id.in_(tuple(set(initiative_ids)))
+        )
+    return set((await session.execute(stmt)).scalars().all())
+
+
+async def is_initiative_member(
+    session: AsyncSession, initiative_id: int, user_id: int
+) -> bool:
+    """Single-user convenience over :func:`initiative_member_user_ids`."""
+    return bool(
+        await initiative_member_user_ids(session, initiative_id, (user_id,))
+    )
+
+
+async def guild_member_user_ids(
+    session: AsyncSession,
+    guild_id: int,
+    user_ids: Optional[Collection[int]] = None,
+) -> set[int]:
+    """The subset of ``user_ids`` that belong to the guild (every member when
+    ``user_ids`` is None). Shared table — no guild routing required."""
+    stmt = select(GuildMembership.user_id).where(
+        GuildMembership.guild_id == guild_id
+    )
+    if user_ids is not None:
+        if not user_ids:
+            return set()
+        stmt = stmt.where(GuildMembership.user_id.in_(tuple(set(user_ids))))
+    return set((await session.execute(stmt)).scalars().all())
+
+
+async def guild_role_map(
+    session: AsyncSession,
+    guild_id: int,
+    user_ids: Iterable[int],
+) -> dict[int, GuildRole]:
+    """Guild role per user for a batch of users in one query. Users without a
+    membership are absent from the result."""
+    ids = tuple(set(user_ids))
+    if not ids:
+        return {}
+    rows = await session.execute(
+        select(GuildMembership.user_id, GuildMembership.role).where(
+            GuildMembership.guild_id == guild_id,
+            GuildMembership.user_id.in_(ids),
+        )
+    )
+    return {user_id: role for user_id, role in rows.all()}
+
+
+async def is_guild_admin(
+    session: AsyncSession, guild_id: int, user_id: int
+) -> bool:
+    """Whether the user is an admin of the guild. Shared table — works on any
+    session."""
+    role = (await guild_role_map(session, guild_id, (user_id,))).get(user_id)
+    return role == GuildRole.admin

--- a/backend/app/services/membership.py
+++ b/backend/app/services/membership.py
@@ -22,6 +22,7 @@ from sqlalchemy import ColumnElement, exists, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.capabilities import Capability, roles_with_capability
+from app.core.pam_context import active_grant_guild
 from app.models.guild import GuildMembership, GuildRole
 from app.models.initiative import InitiativeMember
 from app.models.user import User
@@ -95,13 +96,23 @@ def initiative_scope_clause(
     ``is_initiative_member(...) OR IS_ADMIN OR IS_SUPER``, evaluated per row in
     SQL so it stays correct inside cross-guild gathers and arbitrary batch
     sizes: initiative member, OR admin of the row's guild, OR a platform role
-    holding ``data.bypass``.
+    holding ``data.bypass``, OR a live PAM grant covering the row's guild.
+
+    The PAM leg mirrors the old ``is_initiative_member()`` SQL function (which
+    honored the ``app.pam_*`` GUCs): the request's active grant — if any — is
+    embedded as a literal guild predicate at build time, keeping this clause
+    consistent with the loaded-data gate (``initiative_scope_ok``). Build the
+    clause per request, inside the request's context.
     """
     bypass_roles = tuple(roles_with_capability(Capability.DATA_BYPASS))
-    return or_(
+    legs = [
         initiative_access_clause(user_id, initiative_id_col, guild_id_col),
         exists(select(1).where(User.id == user_id, User.role.in_(bypass_roles))),
-    )
+    ]
+    granted_guild = active_grant_guild()
+    if granted_guild is not None:
+        legs.append(guild_id_col == granted_guild)
+    return or_(*legs)
 
 
 def member_initiative_ids_select(user_id: int):

--- a/backend/app/services/membership_test.py
+++ b/backend/app/services/membership_test.py
@@ -1,0 +1,135 @@
+"""Tests for the shared guild/initiative membership helpers."""
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.guild import GuildRole
+from app.models.initiative import Initiative
+from app.services import membership as membership_service
+from app.testing.factories import (
+    create_guild,
+    create_guild_membership,
+    create_initiative,
+    create_initiative_member,
+    create_user,
+)
+
+
+async def _setup(session: AsyncSession):
+    admin = await create_user(session, email="admin@example.com")
+    member = await create_user(session, email="member@example.com")
+    outsider = await create_user(session, email="outsider@example.com")
+    guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await create_guild_membership(
+        session, user=member, guild=guild, role=GuildRole.member
+    )
+    initiative = await create_initiative(session, guild, admin)
+    await create_initiative_member(session, initiative, member)
+    return admin, member, outsider, guild, initiative
+
+
+@pytest.mark.integration
+async def test_initiative_member_user_ids_batch(session: AsyncSession):
+    admin, member, outsider, _guild, initiative = await _setup(session)
+
+    found = await membership_service.initiative_member_user_ids(
+        session, initiative.id, (admin.id, member.id, outsider.id)
+    )
+    assert found == {admin.id, member.id}
+
+    # Unrestricted: every member, still one query.
+    assert await membership_service.initiative_member_user_ids(
+        session, initiative.id
+    ) == {admin.id, member.id}
+
+    # Empty batch short-circuits without a query.
+    assert (
+        await membership_service.initiative_member_user_ids(
+            session, initiative.id, ()
+        )
+        == set()
+    )
+
+
+@pytest.mark.integration
+async def test_user_member_initiative_ids(session: AsyncSession):
+    admin, member, outsider, _guild, initiative = await _setup(session)
+
+    assert await membership_service.user_member_initiative_ids(
+        session, member.id, (initiative.id,)
+    ) == {initiative.id}
+    assert (
+        await membership_service.user_member_initiative_ids(
+            session, outsider.id, (initiative.id,)
+        )
+        == set()
+    )
+    assert await membership_service.is_initiative_member(
+        session, initiative.id, member.id
+    )
+    assert not await membership_service.is_initiative_member(
+        session, initiative.id, outsider.id
+    )
+
+
+@pytest.mark.integration
+async def test_guild_role_map_batch(session: AsyncSession):
+    admin, member, outsider, guild, _initiative = await _setup(session)
+
+    roles = await membership_service.guild_role_map(
+        session, guild.id, (admin.id, member.id, outsider.id)
+    )
+    assert roles == {admin.id: GuildRole.admin, member.id: GuildRole.member}
+
+    assert await membership_service.is_guild_admin(session, guild.id, admin.id)
+    assert not await membership_service.is_guild_admin(
+        session, guild.id, member.id
+    )
+    assert not await membership_service.is_guild_admin(
+        session, guild.id, outsider.id
+    )
+
+    found = await membership_service.guild_member_user_ids(
+        session, guild.id, (admin.id, outsider.id)
+    )
+    assert found == {admin.id}
+
+
+@pytest.mark.integration
+async def test_initiative_member_clause_filters_rows(session: AsyncSession):
+    """The clause builders compose into real statements."""
+    admin, member, outsider, _guild, initiative = await _setup(session)
+
+    for user, expected in ((member, [initiative.id]), (outsider, [])):
+        stmt = select(Initiative.id).where(
+            membership_service.initiative_member_clause(user.id, Initiative.id)
+        )
+        assert list((await session.execute(stmt)).scalars().all()) == expected
+
+
+@pytest.mark.integration
+async def test_initiative_scope_clause_legs(session: AsyncSession):
+    """member / guild-admin / platform-bypass legs of the scope clause."""
+    from app.models.user import UserRole
+
+    admin, member, outsider, _guild, initiative = await _setup(session)
+    platform_admin = await create_user(
+        session, email="platform@example.com", role=UserRole.admin
+    )
+
+    async def scoped_ids(user) -> list[int]:
+        stmt = select(Initiative.id).where(
+            membership_service.initiative_scope_clause(
+                user.id, Initiative.id, Initiative.guild_id
+            )
+        )
+        return list((await session.execute(stmt)).scalars().all())
+
+    assert await scoped_ids(member) == [initiative.id]  # member leg
+    assert await scoped_ids(admin) == [initiative.id]  # guild-admin leg
+    assert await scoped_ids(outsider) == []  # no leg
+    assert await scoped_ids(platform_admin) == [initiative.id]  # data.bypass leg

--- a/backend/app/services/membership_test.py
+++ b/backend/app/services/membership_test.py
@@ -48,9 +48,7 @@ async def test_initiative_member_user_ids_batch(session: AsyncSession):
 
     # Empty batch short-circuits without a query.
     assert (
-        await membership_service.initiative_member_user_ids(
-            session, initiative.id, ()
-        )
+        await membership_service.initiative_member_user_ids(session, initiative.id, ())
         == set()
     )
 
@@ -86,12 +84,8 @@ async def test_guild_role_map_batch(session: AsyncSession):
     assert roles == {admin.id: GuildRole.admin, member.id: GuildRole.member}
 
     assert await membership_service.is_guild_admin(session, guild.id, admin.id)
-    assert not await membership_service.is_guild_admin(
-        session, guild.id, member.id
-    )
-    assert not await membership_service.is_guild_admin(
-        session, guild.id, outsider.id
-    )
+    assert not await membership_service.is_guild_admin(session, guild.id, member.id)
+    assert not await membership_service.is_guild_admin(session, guild.id, outsider.id)
 
     found = await membership_service.guild_member_user_ids(
         session, guild.id, (admin.id, outsider.id)

--- a/backend/app/services/membership_test.py
+++ b/backend/app/services/membership_test.py
@@ -127,3 +127,28 @@ async def test_initiative_scope_clause_legs(session: AsyncSession):
     assert await scoped_ids(admin) == [initiative.id]  # guild-admin leg
     assert await scoped_ids(outsider) == []  # no leg
     assert await scoped_ids(platform_admin) == [initiative.id]  # data.bypass leg
+
+
+@pytest.mark.integration
+async def test_initiative_scope_clause_pam_leg(session: AsyncSession):
+    """A live PAM grant covering the row's guild satisfies the scope clause
+    (and a grant for a different guild does not)."""
+    from app.core.pam_context import set_active_grant
+
+    _admin, _member, outsider, guild, initiative = await _setup(session)
+
+    def stmt():
+        return select(Initiative.id).where(
+            membership_service.initiative_scope_clause(
+                outsider.id, Initiative.id, Initiative.guild_id
+            )
+        )
+
+    try:
+        set_active_grant(guild.id, "read")
+        assert list((await session.execute(stmt())).scalars().all()) == [initiative.id]
+
+        set_active_grant(guild.id + 999, "read")  # other guild's grant
+        assert list((await session.execute(stmt())).scalars().all()) == []
+    finally:
+        set_active_grant(None, None)

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -22,8 +22,12 @@ from fastapi import HTTPException, status
 from sqlalchemy import inspect
 from sqlmodel import select
 
-from app.core.pam_context import active_grant_level, grant_satisfies
+from app.core.capabilities import Capability, user_has_capability
+from app.core.pam_context import active_grant_level, grant_satisfies, has_active_grant
+from app.core.role_context import active_guild_role
+from app.services.membership import initiative_scope_clause
 
+from app.models.guild import GuildRole
 from app.models.project import (
     Project,
     ProjectPermission,
@@ -176,9 +180,20 @@ def visible_project_ids_subquery(user_id: int):
 
     Combines user-specific ``ProjectPermission`` rows with role-based
     ``ProjectRolePermission`` rows matched via ``InitiativeMember``.
+
+    The explicit-permission branch is additionally gated on initiative scope
+    (member / guild admin / platform bypass): a permission row left behind
+    after the user was removed from the initiative must not grant access.
+    The DB-level RESTRICTIVE policies used to enforce this; under
+    schema-per-guild this subquery is the enforcement point.
     """
-    user_perm_subq = select(ProjectPermission.project_id).where(
-        ProjectPermission.user_id == user_id
+    user_perm_subq = (
+        select(ProjectPermission.project_id)
+        .join(Project, Project.id == ProjectPermission.project_id)
+        .where(
+            ProjectPermission.user_id == user_id,
+            initiative_scope_clause(user_id, Project.initiative_id, Project.guild_id),
+        )
     )
     role_perm_subq = select(ProjectRolePermission.project_id).join(
         InitiativeMember,
@@ -193,9 +208,18 @@ def visible_document_ids_subquery(user_id: int):
 
     Combines user-specific ``DocumentPermission`` rows with role-based
     ``DocumentRolePermission`` rows matched via ``InitiativeMember``.
+
+    The explicit-permission branch is additionally gated on initiative scope
+    (member / guild admin / platform bypass) — see
+    ``visible_project_ids_subquery`` for why.
     """
-    user_perm_subq = select(DocumentPermission.document_id).where(
-        DocumentPermission.user_id == user_id
+    user_perm_subq = (
+        select(DocumentPermission.document_id)
+        .join(Document, Document.id == DocumentPermission.document_id)
+        .where(
+            DocumentPermission.user_id == user_id,
+            initiative_scope_clause(user_id, Document.initiative_id, Document.guild_id),
+        )
     )
     role_perm_subq = select(DocumentRolePermission.document_id).join(
         InitiativeMember,
@@ -203,6 +227,40 @@ def visible_document_ids_subquery(user_id: int):
         & (InitiativeMember.user_id == user_id),
     )
     return user_perm_subq.union(role_perm_subq)
+
+
+# ── Initiative-scope gate (loaded-data variant) ──────────────────
+
+
+def initiative_scope_ok(
+    entity: Any,
+    user: User,
+    *,
+    guild_role: GuildRole | str | None = None,
+) -> bool:
+    """Sync counterpart of ``initiative_scope_clause`` for single entities
+    whose ``initiative.memberships`` are already eagerly loaded.
+
+    Mirrors the old RESTRICTIVE policy expression: initiative member, OR
+    admin of the entity's guild (from ``guild_role`` if the caller has it,
+    else the request's role context), OR ``data.bypass`` holder, OR a live
+    PAM grant covering the guild (a grantee acts as a member of every
+    initiative in scope).
+    """
+    initiative = getattr(entity, "initiative", None)
+    memberships = (
+        getattr(initiative, "memberships", None) if initiative is not None else None
+    ) or []
+    if any(m.user_id == user.id for m in memberships):
+        return True
+    if user_has_capability(user, Capability.DATA_BYPASS):
+        return True
+    guild_id = getattr(entity, "guild_id", None)
+    if guild_id is not None and has_active_grant(guild_id):
+        return True
+    role = guild_role if guild_role is not None else active_guild_role(guild_id)
+    role_value = role.value if isinstance(role, GuildRole) else role
+    return role_value == GuildRole.admin.value
 
 
 # ── High-level helpers for projects ─────────────────────────────
@@ -281,15 +339,24 @@ def require_project_access(
     *,
     access: str = "read",
     require_owner: bool = False,
+    guild_role: GuildRole | str | None = None,
 ) -> None:
     """Raise HTTPException if user lacks required project access.
 
     DAC: Access granted through explicit ProjectPermission or role-based
     permission.  Effective level = MAX(user-specific, role-based).
     A live PAM grant covering the project's guild also satisfies read/write.
+
+    Access additionally requires initiative scope (member / guild admin /
+    platform bypass) — a stale permission row alone never grants access.
     """
     if grant_satisfies(project.guild_id, access=access, require_owner=require_owner):
         return
+    if not initiative_scope_ok(project, user, guild_role=guild_role):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ProjectMessages.NO_ACCESS,
+        )
     effective = _effective_project_level(project, user.id)
 
     if require_owner:
@@ -407,15 +474,24 @@ def require_document_access(
     *,
     access: str = "read",
     require_owner: bool = False,
+    guild_role: GuildRole | str | None = None,
 ) -> None:
     """Raise HTTPException if user lacks required document access.
 
     DAC: Access granted through explicit DocumentPermission or role-based
     permission.  Effective level = MAX(user-specific, role-based).
     A live PAM grant covering the document's guild also satisfies read/write.
+
+    Access additionally requires initiative scope (member / guild admin /
+    platform bypass) — a stale permission row alone never grants access.
     """
     if grant_satisfies(document.guild_id, access=access, require_owner=require_owner):
         return
+    if not initiative_scope_ok(document, user, guild_role=guild_role):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=DocumentMessages.NO_ACCESS,
+        )
     effective = _effective_document_level(document, user)
 
     if require_owner:

--- a/backend/app/services/permissions_test.py
+++ b/backend/app/services/permissions_test.py
@@ -45,16 +45,25 @@ def _make_project(
     role_permissions: list | None = None,
     memberships: list | None = None,
     guild_id: int = 1,
+    member: bool = True,
 ) -> SimpleNamespace:
-    """Build a mock project with eagerly-loaded relationships."""
+    """Build a mock project with eagerly-loaded relationships.
+
+    By default the permission-holding user is also an initiative member
+    (the normal production state); pass ``member=False`` to model a stale
+    permission row left behind after removal from the initiative.
+    """
     permissions = []
+    all_memberships = list(memberships or [])
     if user_id is not None and user_level is not None:
         permissions.append(SimpleNamespace(user_id=user_id, level=user_level))
+        if member:
+            all_memberships.append(SimpleNamespace(user_id=user_id, role_id=None))
     return SimpleNamespace(
         guild_id=guild_id,
         permissions=permissions,
         role_permissions=role_permissions or [],
-        initiative=SimpleNamespace(memberships=memberships or []),
+        initiative=SimpleNamespace(memberships=all_memberships),
     )
 
 
@@ -65,16 +74,25 @@ def _make_document(
     role_permissions: list | None = None,
     memberships: list | None = None,
     guild_id: int = 1,
+    member: bool = True,
 ) -> SimpleNamespace:
-    """Build a mock document with eagerly-loaded relationships."""
+    """Build a mock document with eagerly-loaded relationships.
+
+    By default the permission-holding user is also an initiative member
+    (the normal production state); pass ``member=False`` to model a stale
+    permission row left behind after removal from the initiative.
+    """
     permissions = []
+    all_memberships = list(memberships or [])
     if user_id is not None and user_level is not None:
         permissions.append(SimpleNamespace(user_id=user_id, level=user_level))
+        if member:
+            all_memberships.append(SimpleNamespace(user_id=user_id, role_id=None))
     return SimpleNamespace(
         guild_id=guild_id,
         permissions=permissions,
         role_permissions=role_permissions or [],
-        initiative=SimpleNamespace(memberships=memberships or []),
+        initiative=SimpleNamespace(memberships=all_memberships),
     )
 
 
@@ -398,3 +416,118 @@ def test_compute_project_permission_grant_does_not_downgrade_dac():
         assert compute_project_permission(project, 99) == "owner"
     finally:
         set_active_grant(None, None)
+
+
+# ---------------------------------------------------------------------------
+# Initiative-scope gate (replacement for the dropped RESTRICTIVE RLS layer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_stale_document_permission_denied_without_membership():
+    """An explicit permission row left behind after initiative removal must
+    not grant access (the old DB RESTRICTIVE policy enforced this)."""
+    doc = _make_document(
+        user_id=1, user_level=DocumentPermissionLevel.write, member=False
+    )
+    user = _make_user(user_id=1)
+    with pytest.raises(HTTPException) as exc_info:
+        require_document_access(doc, user, access="read")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == DocumentMessages.NO_ACCESS
+
+
+@pytest.mark.unit
+def test_stale_project_permission_denied_without_membership():
+    project = _make_project(
+        user_id=1, user_level=ProjectPermissionLevel.owner, member=False
+    )
+    user = _make_user(user_id=1)
+    with pytest.raises(HTTPException) as exc_info:
+        require_project_access(project, user, access="read")
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.unit
+def test_guild_admin_bypasses_initiative_scope_via_param():
+    """A guild admin holding an explicit permission keeps access without
+    membership (mirrors the old policy's IS_ADMIN leg)."""
+    doc = _make_document(
+        user_id=1, user_level=DocumentPermissionLevel.read, member=False
+    )
+    user = _make_user(user_id=1)
+    with patch(_PATCH_TARGET, return_value=doc.permissions):
+        require_document_access(
+            doc, user, access="read", guild_role="admin"
+        )  # should not raise
+
+
+@pytest.mark.unit
+def test_guild_admin_bypasses_initiative_scope_via_role_context():
+    from app.core.role_context import set_active_role
+
+    doc = _make_document(
+        user_id=1, user_level=DocumentPermissionLevel.read, member=False, guild_id=7
+    )
+    user = _make_user(user_id=1)
+    try:
+        set_active_role(7, "admin")
+        with patch(_PATCH_TARGET, return_value=doc.permissions):
+            require_document_access(doc, user, access="read")  # should not raise
+    finally:
+        set_active_role(None, None)
+
+
+@pytest.mark.unit
+def test_role_context_for_other_guild_does_not_bypass():
+    """An admin role recorded for guild A must not unlock guild B's entities
+    (cross-guild gathers)."""
+    from app.core.role_context import set_active_role
+
+    doc = _make_document(
+        user_id=1, user_level=DocumentPermissionLevel.read, member=False, guild_id=8
+    )
+    user = _make_user(user_id=1)
+    try:
+        set_active_role(7, "admin")
+        with pytest.raises(HTTPException):
+            require_document_access(doc, user, access="read")
+    finally:
+        set_active_role(None, None)
+
+
+@pytest.mark.unit
+def test_superadmin_bypasses_initiative_scope():
+    doc = _make_document(
+        user_id=1, user_level=DocumentPermissionLevel.read, member=False
+    )
+    user = _make_user(user_id=1, role=UserRole.owner)
+    with patch(_PATCH_TARGET, return_value=doc.permissions):
+        require_document_access(doc, user, access="read")  # should not raise
+
+
+@pytest.mark.unit
+def test_pam_grant_bypasses_initiative_scope():
+    """A live grant acts as membership of every initiative in the guild."""
+    from app.core.pam_context import set_active_grant
+
+    doc = _make_document(guild_id=7)
+    user = _make_user(user_id=99)
+    try:
+        set_active_grant(7, "read")
+        require_document_access(doc, user, access="read")  # should not raise
+    finally:
+        set_active_grant(None, None)
+
+
+@pytest.mark.unit
+def test_membership_without_permission_row_still_denied():
+    """The gate is an AND-layer: membership alone grants nothing."""
+    doc = _make_document(
+        memberships=[SimpleNamespace(user_id=1, role_id=None)]
+    )
+    user = _make_user(user_id=1)
+    with patch(_PATCH_TARGET, return_value=doc.permissions):
+        with pytest.raises(HTTPException) as exc_info:
+            require_document_access(doc, user, access="read")
+    assert exc_info.value.status_code == 403

--- a/backend/app/services/permissions_test.py
+++ b/backend/app/services/permissions_test.py
@@ -523,9 +523,7 @@ def test_pam_grant_bypasses_initiative_scope():
 @pytest.mark.unit
 def test_membership_without_permission_row_still_denied():
     """The gate is an AND-layer: membership alone grants nothing."""
-    doc = _make_document(
-        memberships=[SimpleNamespace(user_id=1, role_id=None)]
-    )
+    doc = _make_document(memberships=[SimpleNamespace(user_id=1, role_id=None)])
     user = _make_user(user_id=1)
     with patch(_PATCH_TARGET, return_value=doc.permissions):
         with pytest.raises(HTTPException) as exc_info:


### PR DESCRIPTION
## Problem

The schema-per-guild cutover (#630) replaced **guild** isolation with schemas + fail-closed roles, but the separate **initiative** permission layer — the `AS RESTRICTIVE` `is_initiative_member()` RLS policies that gated documents, projects, tasks, queues, events, etc. on top of DAC — was never ported into the guild schemas (`guild_schema.sql` has no policies and no `is_initiative_member` function). Concrete live hole: removing a user from an initiative deletes their `ProjectPermission` rows but **not** their non-owner `DocumentPermission` rows; those stale rows used to be inert under the restrictive policy and are now live grants — the ex-member kept read/write on shared documents (lists, open, downloads, edits) as long as they stayed in the guild.

## Changes

**New shared helpers — `app/services/membership.py`** (SQLAlchemy 2.0, batch-efficient; intended for use across the app):
- Clause builders: `initiative_member_clause`, `guild_member_clause`, `initiative_access_clause`, and `initiative_scope_clause` — the full app-level mirror of the old policy expression (initiative member OR guild admin OR platform `data.bypass`), evaluated per row in SQL so it stays correct in cross-guild gathers.
- Batch lookups (one query for any batch size): `initiative_member_user_ids`, `user_member_initiative_ids`, `guild_member_user_ids`, `guild_role_map`, plus single-user conveniences.

**Enforcement (documents + projects):**
- `visible_document_ids_subquery` / `visible_project_ids_subquery`: the explicit-permission branch is now gated on `initiative_scope_clause` (role-based branch was already membership-gated by construction). All eight call sites (documents, projects, comments, tags, property definitions) inherit the gate with no changes.
- `require_document_access` / `require_project_access`: same gate on loaded data via new `initiative_scope_ok`, with the old policy's bypasses preserved — guild admin (via a new request-scoped `role_context`, mirroring `pam_context`, or an explicit `guild_role` param on the X-Guild-ID-less iframe download endpoints), platform `data.bypass`, and live PAM grants (a grantee still acts as a member of every initiative the grant covers).
- Removing an initiative member now also deletes their `DocumentPermission` rows (single-member endpoint + the bulk `remove_user_from_guild_initiatives` path), in parity with the existing `ProjectPermission` cleanup.

## Tests
- `app/services/permissions_test.py`: mock builders now model the production state (permission holder is a member); 8 new gate tests (stale-row denial, admin/superadmin/PAM bypasses, cross-guild role-context isolation, AND-layer semantics).
- `app/services/membership_test.py` (new): batch helpers + every leg of the scope clause against a real DB.
- `app/api/v1/endpoints/documents_scope_test.py` (new): end-to-end — share doc, remove member from initiative, member loses open+list access, admin unaffected.

```
pytest app/services/permissions_test.py app/services/membership_test.py \
       app/api/v1/endpoints/documents_scope_test.py            # 42 passed
pytest app/api/v1/endpoints/documents_test.py documents_global_test.py \
       projects_test.py projects_global_test.py initiatives_test.py   # 103 passed
pytest app/services/comments_test.py users_test.py app/api/uploads_test.py \
       app/api/v1/endpoints/property_definitions_test.py        # 85 passed
ruff check app                                                  # clean
```

## Notes
- Tasks/queues/events/counters had the same DB layer; their app-level checks are separate services — follow-up audit tracked in `history/SCHEMA_PER_GUILD_AUDIT.md` (finding #2).
- No data migration needed: stale rows are inert again under the gate; the cleanup prevents new buildup. A hygiene migration to purge existing stale rows can follow separately.