### PR TITLE
Run propdef membership check on routed session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Property definitions can be created again by initiative members: the membership check ran on an unrouted admin session and read the frozen pre-migration `public` tables under schema-per-guild, falsely rejecting members of any initiative created (or joined) since the cutover — and conversely still honoring memberships that had been removed. The check now runs on the request's guild-routed session.
 - Corrected malformed stored defaults for tag/task-status colors and the task-status icon (an extra pair of quotes had been baked into the default value).
 - The "added to initiative" notification now carries its guild (id + guild-qualified deep link), like every other guild-scoped notification — so it resolves correctly in the cross-guild inbox under schema-per-guild tenancy.
 - **The Initiative logo now appears in emails.** It was an inline SVG, which Gmail, Outlook, and Yahoo strip from email bodies; it's now shipped as a raster PNG embedded inline (via a Content-ID reference) so it renders without an external image fetch. Also removed a stray period that trailed the "Update notification settings" footer link.

--- a/backend/app/api/v1/endpoints/property_definitions.py
+++ b/backend/app/api/v1/endpoints/property_definitions.py
@@ -11,12 +11,17 @@ from sqlmodel import select
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.api.deps import RLSSessionDep, SessionDep, get_current_active_user
+from app.api.deps import (
+    GuildContext,
+    RLSSessionDep,
+    get_current_active_user,
+    get_guild_membership,
+)
 from app.core.messages import PropertyMessages
-from app.db.session import get_admin_session, reapply_rls_context
+from app.db.session import reapply_rls_context
 from app.models.calendar_event import CalendarEvent
 from app.models.document import Document
-from app.models.guild import GuildMembership, GuildRole
+from app.models.guild import GuildRole
 from app.models.initiative import Initiative, InitiativeMember
 from app.models.property import (
     CalendarEventPropertyValue,
@@ -44,6 +49,8 @@ from app.services import properties as properties_service
 
 router = APIRouter()
 
+GuildContextDep = Annotated[GuildContext, Depends(get_guild_membership)]
+
 
 class PropertyEntitiesResult(BaseModel):
     """Response for GET /property-definitions/{id}/entities."""
@@ -56,10 +63,17 @@ class PropertyEntitiesResult(BaseModel):
 
 
 async def _get_definition_or_404(
-    session: SessionDep,
+    session: AsyncSession,
     definition_id: int,
 ) -> PropertyDefinition:
-    """Fetch a definition by id, relying on RLS for scope enforcement."""
+    """Fetch a definition by id, relying on RLS for scope enforcement.
+
+    MUST be called with a routed session (``RLSSessionDep``). Under
+    schema-per-guild, ``property_definitions`` lives only in the active
+    guild's schema, and definition ids are unique per-guild — looking the
+    id up on an unrouted session would hit the frozen ``public`` backup
+    and resolve the wrong (or no) row.
+    """
     stmt = select(PropertyDefinition).where(PropertyDefinition.id == definition_id)
     result = await session.exec(stmt)
     defn = result.one_or_none()
@@ -72,7 +86,7 @@ async def _get_definition_or_404(
 
 
 async def _check_duplicate_name(
-    session: SessionDep,
+    session: AsyncSession,
     initiative_id: int,
     name: str,
     exclude_id: Optional[int] = None,
@@ -92,53 +106,59 @@ async def _check_duplicate_name(
 
 
 async def _ensure_initiative_member(
-    admin_session: AsyncSession,
+    session: AsyncSession,
+    guild_context: GuildContext,
     initiative_id: int,
     user: User,
 ) -> None:
-    """Explicit membership check before insert, bypassing RLS.
+    """Explicit membership check before insert, run in the active guild's schema.
 
-    Runs on an admin session so the check isn't filtered by the caller's
-    active ``X-Guild-ID`` header. ``initiative_members`` is guild-scoped
-    under RLS — if the user's active guild differs from the target
-    initiative's guild, their own membership row would otherwise be
-    invisible, producing a false "not a member" result. The admin
-    session sees the row regardless of active guild.
+    Under schema-per-guild, ``property_definitions`` and
+    ``initiative_members`` live only in the request's active guild schema,
+    and ``initiative_id`` is meaningful only within that schema. The check
+    therefore runs on the request's routed session (``RLSSessionDep``) so it
+    resolves against live data for the active guild — not the frozen
+    ``public`` backup an unrouted admin session would read.
 
-    Mirrors the RLS policy bypasses: superadmins and guild admins of
-    the initiative's guild pass without an explicit ``InitiativeMember``
-    row (same semantics as the restrictive RLS policy's
-    ``OR IS_ADMIN OR IS_SUPER`` clause).
+    Mirrors the RLS policy bypasses: superadmins and guild admins of the
+    active guild pass without an explicit ``InitiativeMember`` row (same
+    semantics as the restrictive RLS policy's ``OR IS_ADMIN OR IS_SUPER``
+    clause). The guild-admin check reads ``guild_context.role`` — already
+    resolved from the shared ``guild_memberships`` table — so no extra
+    query is needed.
 
-    Surfaces a clean ``NOT_INITIATIVE_MEMBER`` 403 so the client can
-    distinguish "you're not in this initiative" from "the definition id
-    is gone" (the original misleading ``DEFINITION_NOT_FOUND`` code).
+    A definition can only be created in the caller's active guild, so we
+    also confirm the initiative exists in this schema; an id from another
+    guild (or a deleted one) is treated as "not a member" and surfaces a
+    clean ``NOT_INITIATIVE_MEMBER`` 403 rather than the misleading
+    ``DEFINITION_NOT_FOUND`` code (or a downstream FK error on insert).
     """
-    # Superadmin bypass.
+    # Superadmin bypass — sees every guild's schema, skip the existence check.
     if user_has_capability(user, Capability.DATA_BYPASS):
         return
 
-    # Direct initiative membership.
+    # The initiative id must resolve in the active guild's schema. Ids are
+    # unique per-guild, so a foreign or deleted id has no row here.
+    init_stmt = select(Initiative.id).where(Initiative.id == initiative_id)
+    if (await session.exec(init_stmt)).one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=PropertyMessages.NOT_INITIATIVE_MEMBER,
+        )
+
+    # Guild-admin bypass: admins of the active guild may manage any
+    # initiative in that guild. GuildContext already resolved the role.
+    if guild_context.role == GuildRole.admin:
+        return
+
+    # Direct initiative membership, resolved in the active guild's schema.
     stmt = select(InitiativeMember).where(
         InitiativeMember.initiative_id == initiative_id,
         InitiativeMember.user_id == user.id,
     )
-    result = await admin_session.exec(stmt)
+    result = await session.exec(stmt)
     if result.one_or_none() is not None:
         return
-
-    # Guild-admin bypass: look up the initiative's guild and check if the
-    # user is an admin there.
-    init_stmt = select(Initiative.guild_id).where(Initiative.id == initiative_id)
-    guild_id = (await admin_session.exec(init_stmt)).one_or_none()
-    if guild_id is not None:
-        admin_stmt = select(GuildMembership).where(
-            GuildMembership.guild_id == guild_id,
-            GuildMembership.user_id == user.id,
-            GuildMembership.role == GuildRole.admin,
-        )
-        if (await admin_session.exec(admin_stmt)).one_or_none() is not None:
-            return
 
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
@@ -188,18 +208,20 @@ async def list_property_definitions(
 async def create_property_definition(
     payload: PropertyDefinitionCreate,
     session: RLSSessionDep,
-    admin_session: Annotated[AsyncSession, Depends(get_admin_session)],
+    guild_context: GuildContextDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> PropertyDefinition:
     """Create a new property definition on an initiative.
 
-    Requires the caller to be a member of the target initiative. The
-    membership check runs on the admin session so it isn't affected by
-    the active-guild RLS context — users can add properties to any
-    initiative they belong to, not just ones in their currently-active
-    guild.
+    Requires the caller to be a member of the target initiative (or a
+    guild admin / superadmin). The membership check runs on the routed
+    request session, so it resolves against the active guild's schema —
+    the only place the target initiative and its definitions live under
+    schema-per-guild.
     """
-    await _ensure_initiative_member(admin_session, payload.initiative_id, current_user)
+    await _ensure_initiative_member(
+        session, guild_context, payload.initiative_id, current_user
+    )
     await _check_duplicate_name(session, payload.initiative_id, payload.name)
 
     defn = PropertyDefinition(

--- a/backend/app/api/v1/endpoints/property_definitions.py
+++ b/backend/app/api/v1/endpoints/property_definitions.py
@@ -138,7 +138,12 @@ async def _ensure_initiative_member(
         return
 
     # The initiative id must resolve in the active guild's schema. Ids are
-    # unique per-guild, so a foreign or deleted id has no row here.
+    # unique per-guild, so a foreign or deleted id has no row here. This runs
+    # before the guild-admin bypass on purpose — admins need the FK guard too.
+    # Constraint: it assumes the routed session can see every initiative row in
+    # the schema; if per-schema initiative-scoped RLS policies are ever
+    # reintroduced, this lookup must use a policy-exempt path or guild admins
+    # outside the initiative will false-403 here.
     init_stmt = select(Initiative.id).where(Initiative.id == initiative_id)
     if (await session.exec(init_stmt)).one_or_none() is None:
         raise HTTPException(

--- a/backend/app/api/v1/endpoints/property_definitions_test.py
+++ b/backend/app/api/v1/endpoints/property_definitions_test.py
@@ -35,6 +35,7 @@ from app.testing import (
     create_guild,
     create_guild_membership,
     create_initiative,
+    create_initiative_member,
     create_project,
     create_property_definition,
     create_task_property_value,
@@ -254,6 +255,115 @@ async def test_create_rejected_when_not_initiative_member(
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "PROPERTY_NOT_INITIATIVE_MEMBER"
+
+
+@pytest.mark.integration
+async def test_create_allowed_for_initiative_member(
+    client: AsyncClient, session: AsyncSession
+):
+    """A plain (non-admin) guild member who belongs to the initiative can
+    create a definition on it.
+
+    This is the schema-per-guild regression case: the membership check now
+    runs on the routed request session against the active guild's schema,
+    so a legitimate member is no longer false-403'd by a lookup against the
+    frozen ``public`` backup.
+    """
+    admin = await create_user(session, email="admin@example.com")
+    member = await create_user(session, email="member@example.com")
+    guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await create_guild_membership(
+        session, user=member, guild=guild, role=GuildRole.member
+    )
+
+    initiative = await create_initiative(session, guild, admin, name="Init")
+    await create_initiative_member(session, initiative, member)
+
+    headers = get_guild_headers(guild, member)
+    payload = {
+        "name": "Owner Tag",
+        "type": "text",
+        "initiative_id": initiative.id,
+    }
+    response = await client.post(
+        "/api/v1/property-definitions/", headers=headers, json=payload
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Owner Tag"
+    assert data["initiative_id"] == initiative.id
+
+
+@pytest.mark.integration
+async def test_create_rejected_for_guild_member_not_in_initiative(
+    client: AsyncClient, session: AsyncSession
+):
+    """A guild member who is NOT in the target initiative is rejected with
+    the canonical NOT_INITIATIVE_MEMBER code."""
+    admin = await create_user(session, email="admin@example.com")
+    outsider = await create_user(session, email="outsider@example.com")
+    guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await create_guild_membership(
+        session, user=outsider, guild=guild, role=GuildRole.member
+    )
+
+    # Admin's initiative; outsider is a guild member but not an initiative member.
+    initiative = await create_initiative(session, guild, admin, name="Init")
+
+    headers = get_guild_headers(guild, outsider)
+    payload = {
+        "name": "Foo",
+        "type": "text",
+        "initiative_id": initiative.id,
+    }
+    response = await client.post(
+        "/api/v1/property-definitions/", headers=headers, json=payload
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "PROPERTY_NOT_INITIATIVE_MEMBER"
+
+
+@pytest.mark.integration
+async def test_create_allowed_for_guild_admin_not_in_initiative(
+    client: AsyncClient, session: AsyncSession
+):
+    """A guild admin can create a definition on any initiative in their
+    guild even without an explicit initiative-member row — mirroring the
+    restrictive RLS policy's admin bypass, now resolved off
+    ``GuildContext.role``."""
+    creator = await create_user(session, email="creator@example.com")
+    guild_admin = await create_user(session, email="gadmin@example.com")
+    guild = await create_guild(session, creator=creator)
+    await create_guild_membership(
+        session, user=creator, guild=guild, role=GuildRole.member
+    )
+    await create_guild_membership(
+        session, user=guild_admin, guild=guild, role=GuildRole.admin
+    )
+
+    # The creator owns the initiative; the guild admin is not a member of it.
+    initiative = await create_initiative(session, guild, creator, name="Init")
+
+    headers = get_guild_headers(guild, guild_admin)
+    payload = {
+        "name": "Admin Field",
+        "type": "text",
+        "initiative_id": initiative.id,
+    }
+    response = await client.post(
+        "/api/v1/property-definitions/", headers=headers, json=payload
+    )
+
+    assert response.status_code == 201
+    assert response.json()["initiative_id"] == initiative.id
 
 
 @pytest.mark.integration

--- a/frontend/src/api/generated/property-definitions/property-definitions.ts
+++ b/frontend/src/api/generated/property-definitions/property-definitions.ts
@@ -203,11 +203,11 @@ export function useListPropertyDefinitionsApiV1PropertyDefinitionsGet<
 /**
  * Create a new property definition on an initiative.
  *
- * Requires the caller to be a member of the target initiative. The
- * membership check runs on the admin session so it isn't affected by
- * the active-guild RLS context — users can add properties to any
- * initiative they belong to, not just ones in their currently-active
- * guild.
+ * Requires the caller to be a member of the target initiative (or a
+ * guild admin / superadmin). The membership check runs on the routed
+ * request session, so it resolves against the active guild's schema —
+ * the only place the target initiative and its definitions live under
+ * schema-per-guild.
  * @summary Create Property Definition
  */
 export const createPropertyDefinitionApiV1PropertyDefinitionsPost = (


### PR DESCRIPTION
## Problem

`_ensure_initiative_member` in `property_definitions.py` ran its authorization queries (`InitiativeMember`, `Initiative.guild_id`) on the **unrouted admin session** (`search_path=public`). Under schema-per-guild those queries hit the frozen `public` backups (finding #1 in `history/SCHEMA_PER_GUILD_AUDIT.md`):

- members of any initiative created since the cutover were **falsely 403'd** (`PROPERTY_NOT_INITIATIVE_MEMBER`) when creating property definitions — the membership rows don't exist in the frozen copy;
- memberships **removed** since the cutover still passed the check (stale authorization);
- the guild-admin bypass also failed, since `Initiative.guild_id` resolved to `None` for post-cutover initiatives.

The function's docstring still described the old RLS world ("bypasses RLS so the check isn't filtered by the active guild") — a rationale that's obsolete now that initiative ids are per-guild and only meaningful inside the active guild's schema.

## Changes

- `_ensure_initiative_member` now takes the request's **routed session + GuildContext**: membership and initiative-existence checks resolve in the active guild's live schema; the guild-admin bypass reads `guild_context.role` (already resolved from shared `guild_memberships` — no extra query); the superadmin (`data.bypass`) bypass is unchanged.
- `create_property_definition` dropped its `AdminSessionDep` dependency entirely.
- `_get_definition_or_404` / `_check_duplicate_name` retyped from `SessionDep` to `AsyncSession` with a routed-session requirement documented (behavior unchanged; closes the audit's footgun note for this file).

## Tests

3 new integration tests in `property_definitions_test.py`: initiative member (non-admin) can create — the previously false-403 regression case; guild member outside the initiative gets 403 on the message constant; guild admin outside the initiative can create.

```
pytest app/api/v1/endpoints/property_definitions_test.py   # 19 passed
ruff check / ruff format --check                           # clean
```