### PR TITLE
Backfill guild schemas at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Guild schemas are now re-provisioned (idempotently) on every boot: when a release adds tables to the per-guild schema layout, existing guilds pick them up automatically instead of silently falling through to the frozen pre-migration `public` copies — and a guild whose schema provisioning was interrupted mid-creation is healed at the next startup.
+
 - **Expandable guild sidebar.** The icon-only guild rail can now expand into a "Guilds" flyout that shows each guild's full name and member count. Open it with the chevron toggle (or swipe in from the rail), collapse it with the header button, click-away (desktop), or by swiping it closed. On mobile the flyout fills the drawer; on desktop it floats over the sidebar. Member counts are exposed via a new `member_count` field on the guild list response. Drag-to-reorder still works (press-and-hold on touch so it doesn't fight the swipe gestures).
 - **German (Deutsch) interface language.** Added a full German translation across all 24 i18n namespaces, registered `de` as a supported language, wired up the German date-fns locale for date formatting, and added "Deutsch" to the language picker in user interface settings.
 - Table classification manifest (`app/db/tenancy.py`) marking every table as shared or guild-scoped, with a test guarding completeness — the first step toward schema-per-guild tenancy.

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -7,10 +7,21 @@ re-running back-fills any guild-scoped table a later migration added. The model
 is never used to build the DB: Alembic is the single source, applied per schema.
 Per-request routing (search_path + SET ROLE in `set_rls_context`) sends
 guild-scoped queries into the schema.
+
+`backfill_guild_schemas` re-runs that idempotent provisioning for *every*
+existing guild on every boot (`main.on_startup`, after the legacy conversion).
+This closes two drift gaps the one-time conversion leaves open: a guild
+provisioned before `guild_schema.sql` gained a table/column/index never receives
+it (and `search_path = guild_<id>, public` silently falls through to the frozen
+public backup rather than erroring), and a crash mid-provision can leave a guild
+row whose schema doesn't exist. Provisioning is ~0.2s/guild and idempotent, so a
+plain sequential loop heals both with no extra bookkeeping.
 """
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from sqlalchemy import text
@@ -19,6 +30,8 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 from app.core.config import settings
 from app.db import session as db_session
+
+logger = logging.getLogger(__name__)
 
 # The roles the app connects as must reach the guild schema, since per-request
 # routing (search_path) sends guild-scoped queries there: app_user for the RLS
@@ -187,3 +200,49 @@ async def deprovision_guild(guild_id: int) -> None:
     """Drop a guild's schema + role on the superuser engine."""
     async with db_session.provisioning_engine.begin() as conn:
         await drop_guild_schema(conn, guild_id)
+
+
+@dataclass
+class BackfillSummary:
+    """Outcome of a `backfill_guild_schemas` sweep, for a one-line boot log."""
+
+    total: int
+    provisioned: int
+    failed: int
+
+
+async def backfill_guild_schemas() -> BackfillSummary:
+    """Re-provision every existing guild's schema + roles on boot. Idempotent.
+
+    Enumerates guild ids from the shared ``public.guilds`` table on the
+    provisioning (superuser) engine, then runs the idempotent
+    ``provision_guild`` for each. Because provisioning re-runs the canonical
+    ``guild_schema.sql`` DDL (``CREATE ... IF NOT EXISTS``) and re-applies grants,
+    this back-fills any table/column/index/grant added since a guild was first
+    provisioned and (re-)creates a schema that is missing entirely — healing both
+    the silent-drift gap and a crash that left a guild row without its schema.
+
+    Per-guild failures are logged with the guild id and skipped so one broken
+    guild can't take down boot for the rest; ``provision_guild`` runs each guild
+    in its own transaction, so a failure rolls back only that guild. Returns a
+    summary for the caller to log.
+    """
+    engine = db_session.provisioning_engine  # superuser
+    async with engine.connect() as conn:
+        guild_ids = (
+            (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
+            .scalars()
+            .all()
+        )
+
+    provisioned = 0
+    failed = 0
+    for gid in guild_ids:
+        try:
+            await provision_guild(gid)
+            provisioned += 1
+        except Exception:  # noqa: BLE001 — one broken guild must not block boot
+            failed += 1
+            logger.exception("guild schema back-fill failed for guild %s", gid)
+
+    return BackfillSummary(total=len(guild_ids), provisioned=provisioned, failed=failed)

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -21,7 +21,7 @@ plain sequential loop heals both with no extra bookkeeping.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from sqlalchemy import text
@@ -209,6 +209,7 @@ class BackfillSummary:
     total: int
     provisioned: int
     failed: int
+    failed_guild_ids: list[int] = field(default_factory=list)
 
 
 async def backfill_guild_schemas() -> BackfillSummary:
@@ -236,13 +237,18 @@ async def backfill_guild_schemas() -> BackfillSummary:
         )
 
     provisioned = 0
-    failed = 0
+    failed_guild_ids: list[int] = []
     for gid in guild_ids:
         try:
             await provision_guild(gid)
             provisioned += 1
         except Exception:  # noqa: BLE001 — one broken guild must not block boot
-            failed += 1
+            failed_guild_ids.append(gid)
             logger.exception("guild schema back-fill failed for guild %s", gid)
 
-    return BackfillSummary(total=len(guild_ids), provisioned=provisioned, failed=failed)
+    return BackfillSummary(
+        total=len(guild_ids),
+        provisioned=provisioned,
+        failed=len(failed_guild_ids),
+        failed_guild_ids=failed_guild_ids,
+    )

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -11,7 +11,9 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
+import app.db.schema_provisioning as schema_provisioning
 from app.db.schema_provisioning import (
+    backfill_guild_schemas,
     drop_guild_schema,
     guild_role_name,
     guild_schema_name,
@@ -32,6 +34,13 @@ _GID_ROLE_WRITE = 990_107
 _GID_BACKFILL = 990_108
 _GID_REPROVISION = 990_109
 _GID_DROP_ABSENT = 990_110
+# Back-fill sweep (each pair: one provisioned, one only a public row).
+_GID_BACKFILL_DONE = 990_111
+_GID_BACKFILL_MISSING = 990_112
+_GID_BACKFILL_DRIFT = 990_113
+_GID_BACKFILL_OK_A = 990_114
+_GID_BACKFILL_OK_B = 990_115
+_GID_BACKFILL_FAIL = 990_116
 
 
 async def _insert_public_guild(conn, gid: int, name: str) -> None:
@@ -397,3 +406,144 @@ async def test_guild_schema_matches_alembic_public(engine):
     finally:
         async with engine.begin() as conn:
             await drop_guild_schema(conn, _GID_DRIFT)
+
+
+# --- back-fill sweep: heal half-states and drift for existing guilds -----------
+
+
+async def test_backfill_provisions_a_guild_missing_its_schema(engine):
+    """A guild row whose schema was never created (e.g. a crash mid-provision)
+    gets its schema + tables on the next back-fill sweep."""
+    done, missing = _GID_BACKFILL_DONE, _GID_BACKFILL_MISSING
+    missing_schema = guild_schema_name(missing)
+    try:
+        async with engine.begin() as conn:
+            await _insert_public_guild(conn, done, "backfill-done")
+            await _insert_public_guild(conn, missing, "backfill-missing")
+            await provision_guild_schema(conn, done)  # only `done` is provisioned
+
+        async with engine.connect() as conn:
+            before = await conn.scalar(
+                text(
+                    "SELECT 1 FROM information_schema.schemata WHERE schema_name = :s"
+                ),
+                {"s": missing_schema},
+            )
+        assert before is None, "precondition: missing guild has no schema yet"
+
+        summary = await backfill_guild_schemas()
+        assert summary.failed == 0
+
+        async with engine.connect() as conn:
+            tables = await conn.scalar(
+                text(
+                    "SELECT count(*) FROM information_schema.tables "
+                    "WHERE table_schema = :s"
+                ),
+                {"s": missing_schema},
+            )
+        assert tables == len(GUILD_SCOPED_TABLES), "schema should be fully back-filled"
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, done)
+            await drop_guild_schema(conn, missing)
+            await conn.execute(
+                text("DELETE FROM public.guilds WHERE id = ANY(:ids)"),
+                {"ids": [done, missing]},
+            )
+
+
+async def test_backfill_repairs_a_dropped_table(engine):
+    """A table missing from an already-provisioned schema (drift: a table added to
+    guild_schema.sql after the guild was made) is recreated by the back-fill."""
+    gid = _GID_BACKFILL_DRIFT
+    schema = guild_schema_name(gid)
+    try:
+        async with engine.begin() as conn:
+            await _insert_public_guild(conn, gid, "backfill-drift")
+            await provision_guild_schema(conn, gid)
+            # Simulate a table that didn't exist when the schema was provisioned.
+            await conn.exec_driver_sql(f'DROP TABLE "{schema}".subtasks CASCADE')
+
+        async with engine.connect() as conn:
+            gone = await conn.scalar(text(f"SELECT to_regclass('{schema}.subtasks')"))
+        assert gone is None, "precondition: subtasks dropped"
+
+        summary = await backfill_guild_schemas()
+        assert summary.failed == 0
+
+        async with engine.connect() as conn:
+            recreated = await conn.scalar(
+                text(f"SELECT to_regclass('{schema}.subtasks')")
+            )
+        assert recreated is not None, "back-fill should recreate the dropped table"
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, gid)
+            await conn.execute(
+                text("DELETE FROM public.guilds WHERE id = :id"), {"id": gid}
+            )
+
+
+async def test_backfill_continues_past_a_failing_guild(engine, monkeypatch):
+    """One guild that fails to provision is logged and skipped — the others in the
+    same sweep are still processed."""
+    ok_a, ok_b, bad = _GID_BACKFILL_OK_A, _GID_BACKFILL_OK_B, _GID_BACKFILL_FAIL
+    try:
+        async with engine.begin() as conn:
+            for gid, name in (
+                (ok_a, "backfill-ok-a"),
+                (ok_b, "backfill-ok-b"),
+                (bad, "backfill-bad"),
+            ):
+                await _insert_public_guild(conn, gid, name)
+
+        # Force exactly one guild's provisioning to blow up; the real function
+        # handles every other id. backfill_guild_schemas calls provision_guild as
+        # a module-level name, so patching it here is enough.
+        real_provision_guild = schema_provisioning.provision_guild
+
+        async def _flaky_provision_guild(guild_id: int) -> str:
+            if guild_id == bad:
+                raise RuntimeError("forced provisioning failure")
+            return await real_provision_guild(guild_id)
+
+        monkeypatch.setattr(
+            schema_provisioning, "provision_guild", _flaky_provision_guild
+        )
+
+        summary = await backfill_guild_schemas()
+
+        # The bad guild is counted as failed but doesn't abort the sweep; both
+        # healthy guilds (plus any other real guild rows) still get provisioned.
+        assert summary.failed >= 1
+        assert summary.provisioned >= 2
+
+        async with engine.connect() as conn:
+            for gid in (ok_a, ok_b):
+                tables = await conn.scalar(
+                    text(
+                        "SELECT count(*) FROM information_schema.tables "
+                        "WHERE table_schema = :s"
+                    ),
+                    {"s": guild_schema_name(gid)},
+                )
+                assert tables == len(GUILD_SCOPED_TABLES), (
+                    f"healthy guild {gid} should be provisioned despite a sibling failure"
+                )
+            bad_exists = await conn.scalar(
+                text(
+                    "SELECT 1 FROM information_schema.schemata WHERE schema_name = :s"
+                ),
+                {"s": guild_schema_name(bad)},
+            )
+        assert bad_exists is None, "the forced-failure guild's schema must not exist"
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, ok_a)
+            await drop_guild_schema(conn, ok_b)
+            await drop_guild_schema(conn, bad)
+            await conn.execute(
+                text("DELETE FROM public.guilds WHERE id = ANY(:ids)"),
+                {"ids": [ok_a, ok_b, bad]},
+            )

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -432,7 +432,11 @@ async def test_backfill_provisions_a_guild_missing_its_schema(engine):
         assert before is None, "precondition: missing guild has no schema yet"
 
         summary = await backfill_guild_schemas()
-        assert summary.failed == 0
+        # Assert about OUR guilds only — the sweep covers every guild row in the
+        # shared test DB, and an unrelated broken guild must not fail this test.
+        assert done not in summary.failed_guild_ids
+        assert missing not in summary.failed_guild_ids
+        assert summary.provisioned >= 2
 
         async with engine.connect() as conn:
             tables = await conn.scalar(
@@ -470,7 +474,10 @@ async def test_backfill_repairs_a_dropped_table(engine):
         assert gone is None, "precondition: subtasks dropped"
 
         summary = await backfill_guild_schemas()
-        assert summary.failed == 0
+        # Scoped to our guild — unrelated broken guilds in the shared test DB
+        # must not fail this test.
+        assert gid not in summary.failed_guild_ids
+        assert summary.provisioned >= 1
 
         async with engine.connect() as conn:
             recreated = await conn.scalar(
@@ -516,7 +523,9 @@ async def test_backfill_continues_past_a_failing_guild(engine, monkeypatch):
 
         # The bad guild is counted as failed but doesn't abort the sweep; both
         # healthy guilds (plus any other real guild rows) still get provisioned.
-        assert summary.failed >= 1
+        assert bad in summary.failed_guild_ids
+        assert ok_a not in summary.failed_guild_ids
+        assert ok_b not in summary.failed_guild_ids
         assert summary.provisioned >= 2
 
         async with engine.connect() as conn:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -395,6 +395,19 @@ async def on_startup() -> None:
     from app.db.guild_conversion import convert_public_to_guild_schemas
 
     await convert_public_to_guild_schemas()
+    # Re-run the idempotent per-guild provisioning for every guild so any
+    # table/column/index/grant added to guild_schema.sql since a guild was
+    # provisioned is back-filled, and any guild left without a schema (e.g. a
+    # crash mid-provision) is healed. One broken guild is logged and skipped.
+    from app.db.schema_provisioning import backfill_guild_schemas
+
+    backfill = await backfill_guild_schemas()
+    logger.info(
+        "guild schema back-fill: %d provisioned, %d failed (of %d)",
+        backfill.provisioned,
+        backfill.failed,
+        backfill.total,
+    )
     async with AdminSessionLocal() as session:
         await app_settings_service.ensure_defaults(session)
     app.state.notification_tasks = background_tasks_service.start_background_tasks()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -402,12 +402,22 @@ async def on_startup() -> None:
     from app.db.schema_provisioning import backfill_guild_schemas
 
     backfill = await backfill_guild_schemas()
-    logger.info(
-        "guild schema back-fill: %d provisioned, %d failed (of %d)",
-        backfill.provisioned,
-        backfill.failed,
-        backfill.total,
-    )
+    if backfill.failed:
+        # WARNING so partial failure survives INFO-filtered logs (per-guild
+        # tracebacks were already logged inside the back-fill).
+        logger.warning(
+            "guild schema back-fill: %d provisioned, %d FAILED (of %d) — guilds %s",
+            backfill.provisioned,
+            backfill.failed,
+            backfill.total,
+            backfill.failed_guild_ids,
+        )
+    else:
+        logger.info(
+            "guild schema back-fill: %d provisioned (of %d)",
+            backfill.provisioned,
+            backfill.total,
+        )
     async with AdminSessionLocal() as session:
         await app_settings_service.ensure_defaults(session)
     app.state.notification_tasks = background_tasks_service.start_background_tasks()


### PR DESCRIPTION
## Problem

Findings #4 and #5 in `history/SCHEMA_PER_GUILD_AUDIT.md`:

- **Schema drift is silent.** Once a guild is provisioned/converted, nothing ever re-runs provisioning. When `guild_schema.sql` gains a table in a later release, existing guilds never receive it — and because `search_path = guild_<id>, public`, queries against the missing table don't error: they silently fall through to the frozen `public` backup (zeros/stale data, or cross-guild rows on tables that predate the cutover).
- **Provisioning half-states never heal.** `get_primary_guild` commits the guild row before `provision_guild()` with no compensation — a crash in between leaves a guild whose schema doesn't exist, permanently.

## Changes

- `app/db/schema_provisioning.py`: new `backfill_guild_schemas()` — enumerates `public.guilds` on the provisioning (superuser) engine and re-runs the existing idempotent `provision_guild` per guild (`CREATE ... IF NOT EXISTS` + role/grant re-application, ~0.2s/guild). Per-guild failures are logged with the guild id and skipped — one broken guild can't take down boot for the rest. Returns a typed `BackfillSummary(total, provisioned, failed)`.
- `app/main.py`: wired into `on_startup` right after `convert_public_to_guild_schemas()`, with a summary log line. (`ASGITransport` doesn't run lifespan events, so it never fires in the test suite.)

This also closes the fall-through leg of the download/uploads probes: with schemas guaranteed current at boot, a probed guild schema can't be missing a table.

## Tests

3 new tests in `schema_provisioning_test.py` using the existing provisioning harness:
- heals a guild row whose schema was never created (the crash-mid-provision half-state);
- repairs a dropped table in an existing schema;
- continues past a guild whose provisioning fails (monkeypatched single-guild failure), still provisioning the others.

```
pytest app/db/schema_provisioning_test.py app/db/guild_conversion_test.py   # 15 passed
ruff check + ruff format                                                    # clean
```