### PR TITLE
Fix cross-guild tabs + post-cutover test fallout

### DIFF
--- a/backend/app/api/v1/endpoints/collaboration.py
+++ b/backend/app/api/v1/endpoints/collaboration.py
@@ -434,13 +434,14 @@ async def sync_document_content(
     request: Request,
     session: SessionDep,
     token: str = Query(...),
-    guild_id: int = Query(...),
 ):
     """
     Sync Lexical content from the frontend to the database.
 
     This endpoint is called via navigator.sendBeacon when the page unloads
-    to ensure the content column stays in sync with yjs_state.
+    to ensure the content column stays in sync with yjs_state. The guild
+    comes from the user's server-held context (``users.active_guild_id``) —
+    the document being synced was open inside its guild.
 
     The request body should contain the Lexical serialized state as JSON.
     """
@@ -456,6 +457,14 @@ async def sync_document_content(
     if not user:
         logger.warning(f"Sync content: Auth failed for document {document_id}")
         return {"status": "error", "message": "Authentication failed"}
+
+    guild_id = user.active_guild_id
+    if guild_id is None:
+        logger.warning(
+            f"Sync content: user {user.id} has no guild context "
+            f"for document {document_id}"
+        )
+        return {"status": "error", "message": "No guild context"}
 
     # Set RLS context so queries against guild-scoped tables work
     await set_rls_context(session, user_id=user.id, guild_id=guild_id)

--- a/backend/app/api/v1/endpoints/documents_test.py
+++ b/backend/app/api/v1/endpoints/documents_test.py
@@ -398,7 +398,7 @@ async def test_download_owner_can_download(
         session, initiative=initiative, owner=owner, filename="dl_owner.pdf"
     )
     try:
-        headers = get_auth_headers(owner)
+        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
             f"/api/v1/documents/{doc.id}/download", headers=headers
         )
@@ -446,7 +446,7 @@ async def test_download_guild_member_without_permission_returns_403(
         session, initiative=initiative, owner=owner, filename="dl_no_perm.pdf"
     )
     try:
-        headers = get_auth_headers(other)
+        headers = await get_guild_headers(session, guild, other)
         response = await client.get(
             f"/api/v1/documents/{doc.id}/download", headers=headers
         )
@@ -505,7 +505,7 @@ async def test_download_read_permission_grants_access(
     await session.commit()
 
     try:
-        headers = get_auth_headers(reader)
+        headers = await get_guild_headers(session, guild, reader)
         response = await client.get(
             f"/api/v1/documents/{doc.id}/download", headers=headers
         )
@@ -528,7 +528,7 @@ async def test_download_inline_returns_no_attachment_header(
         session, initiative=initiative, owner=owner, filename="dl_inline.pdf"
     )
     try:
-        headers = get_auth_headers(owner)
+        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
             f"/api/v1/documents/{doc.id}/download?inline=1", headers=headers
         )
@@ -553,7 +553,7 @@ async def test_download_inline_html_svg_is_same_origin_framable_but_scriptless(
         session, initiative=initiative, owner=owner, filename=filename
     )
     try:
-        headers = get_auth_headers(owner)
+        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
             f"/api/v1/documents/{doc.id}/download?inline=1", headers=headers
         )
@@ -584,7 +584,7 @@ async def test_download_non_inline_html_svg_keeps_global_deny(
         session, initiative=initiative, owner=owner, filename=filename
     )
     try:
-        headers = get_auth_headers(owner)
+        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
             f"/api/v1/documents/{doc.id}/download", headers=headers
         )
@@ -614,6 +614,9 @@ async def test_download_scoped_upload_token_auth(
         session, initiative=initiative, owner=owner, filename="dl_token.pdf"
     )
     try:
+        # Download URLs carry no guild context — the server resolves it from
+        # the owner's flag, so enter the guild first.
+        await get_guild_headers(session, guild, owner)
         token, _ = create_upload_token(user_id=owner.id)
         response = await client.get(
             f"/api/v1/documents/{doc.id}/download?token={token}"

--- a/backend/app/api/v1/endpoints/initiatives_test.py
+++ b/backend/app/api/v1/endpoints/initiatives_test.py
@@ -28,13 +28,15 @@ from app.testing.factories import (
 async def test_list_initiatives_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """A user with no guild memberships should be 403 when listing initiatives."""
+    """A user with no guild context (no flag set — e.g. zero memberships)
+    gets a clean 409 when listing initiatives."""
     user = await create_user(session, email="test@example.com")
 
     headers = get_auth_headers(user)
     response = await client.get("/api/v1/initiatives/", headers=headers)
 
-    assert response.status_code == 403
+    assert response.status_code == 409
+    assert response.json()["detail"] == "NO_GUILD_MEMBERSHIP"
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/endpoints/projects_test.py
+++ b/backend/app/api/v1/endpoints/projects_test.py
@@ -53,13 +53,15 @@ async def _create_project(session, initiative, owner):
 async def test_list_projects_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """A user with no guild memberships should be 403 when listing projects."""
+    """A user with no guild context (no flag set — e.g. zero memberships)
+    gets a clean 409 when listing projects."""
     user = await create_user(session)
 
     headers = get_auth_headers(user)
     response = await client.get("/api/v1/projects/", headers=headers)
 
-    assert response.status_code == 403
+    assert response.status_code == 409
+    assert response.json()["detail"] == "NO_GUILD_MEMBERSHIP"
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/endpoints/tasks_test.py
+++ b/backend/app/api/v1/endpoints/tasks_test.py
@@ -74,13 +74,15 @@ async def _create_task(session, project, title="Test Task"):
 async def test_list_tasks_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """A user with no guild memberships should be 403 when listing tasks."""
+    """A user with no guild context (no flag set — e.g. zero memberships)
+    gets a clean 409 when listing tasks."""
     user = await create_user(session)
 
     headers = get_auth_headers(user)
     response = await client.get("/api/v1/tasks/", headers=headers)
 
-    assert response.status_code == 403
+    assert response.status_code == 409
+    assert response.json()["detail"] == "NO_GUILD_MEMBERSHIP"
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -959,7 +959,6 @@ async def delete_user(
             # to discard rather than transfer — the escape hatch for
             # the "no eligible project manager left" case.
             from app.services import soft_delete as soft_delete_service
-            from app.services import guilds as guilds_service
 
             retention_days = await guilds_service.get_guild_retention_days(
                 session, guild_context.guild_id

--- a/backend/app/api/v1/endpoints/users_test.py
+++ b/backend/app/api/v1/endpoints/users_test.py
@@ -121,14 +121,15 @@ async def test_list_users_in_guild(client: AsyncClient, session: AsyncSession):
 async def test_list_users_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """Test that listing users requires guild context."""
+    """Listing users with no guild context (no flag set) is a clean 409."""
     user = await create_user(session)
     headers = get_auth_headers(user)
 
     response = await client.get("/api/v1/users/", headers=headers)
 
-    # Should fail without guild membership
-    assert response.status_code == 403
+    # Fails without a guild context (the server-held flag is unset)
+    assert response.status_code == 409
+    assert response.json()["detail"] == "NO_GUILD_MEMBERSHIP"
 
 
 @pytest.mark.integration
@@ -792,12 +793,12 @@ async def test_export_users_csv_forbidden_for_member(
 async def test_export_users_csv_requires_guild_context(
     client: AsyncClient, session: AsyncSession
 ):
-    """Without the guild header the export is rejected."""
+    """Without a guild context the export is rejected (409)."""
     user = await create_user(session)
     headers = get_auth_headers(user)
 
     response = await client.get("/api/v1/users/export.csv", headers=headers)
-    assert response.status_code == 403
+    assert response.status_code == 409
 
 
 @pytest.mark.integration

--- a/frontend/src/api/generated/collaboration/collaboration.ts
+++ b/frontend/src/api/generated/collaboration/collaboration.ts
@@ -271,7 +271,9 @@ export function useGetDocumentCollaboratorsApiV1CollaborationDocumentsDocumentId
  * Sync Lexical content from the frontend to the database.
  *
  * This endpoint is called via navigator.sendBeacon when the page unloads
- * to ensure the content column stays in sync with yjs_state.
+ * to ensure the content column stays in sync with yjs_state. The guild
+ * comes from the user's server-held context (``users.active_guild_id``) —
+ * the document being synced was open inside its guild.
  *
  * The request body should contain the Lexical serialized state as JSON.
  * @summary Sync Document Content

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3903,7 +3903,6 @@ export type GetDocumentCollaboratorsApiV1CollaborationDocumentsDocumentIdCollabo
 
 export type SyncDocumentContentApiV1CollaborationDocumentsDocumentIdSyncContentPostParams = {
   token: string;
-  guild_id: number;
 };
 
 export type ListQueuesApiV1QueuesGetParams = {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -89,19 +89,26 @@ export const AppSidebar = () => {
   // Helper to create guild-scoped paths
   const gp = (path: string) => (activeGuildId ? guildPath(activeGuildId, path) : path);
 
-  const initiativesQuery = useInitiatives({ enabled: Boolean(activeGuild), staleTime: 60_000 });
+  // The guild tree (initiatives/projects/documents/queues/counters/tags) is
+  // only rendered on /g/ routes, and only there does the server-held guild
+  // context line up with it — on personal pages these guild-scoped queries
+  // would 409 (no context) and cache errors that linger as zeroed counts.
+  // Gate them all on actually being in the guild UI.
+  const guildTreeEnabled = Boolean(activeGuild) && isGuildRoute;
+
+  const initiativesQuery = useInitiatives({ enabled: guildTreeEnabled, staleTime: 60_000 });
 
   const projectsQuery = useProjects(undefined, {
-    enabled: Boolean(activeGuild),
+    enabled: guildTreeEnabled,
     staleTime: 60_000,
   });
 
   const favoritesQuery = useFavoriteProjects({
-    enabled: activeGuildId !== null,
+    enabled: guildTreeEnabled,
     staleTime: 60_000,
   });
 
-  const documentsQuery = useAllDocumentIds({ enabled: Boolean(activeGuild), staleTime: 60_000 });
+  const documentsQuery = useAllDocumentIds({ enabled: guildTreeEnabled, staleTime: 60_000 });
 
   const projectsByInitiative = useMemo(() => {
     const map = new Map<number, ProjectRead[]>();
@@ -128,7 +135,7 @@ export const AppSidebar = () => {
   // Fetch queues for counts (lightweight list query)
   const queuesQuery = useQueuesList(
     { page: 1, page_size: 100 },
-    { enabled: Boolean(activeGuild), staleTime: 60_000 }
+    { enabled: guildTreeEnabled, staleTime: 60_000 }
   );
 
   const queueCountsByInitiative = useMemo(() => {
@@ -144,7 +151,7 @@ export const AppSidebar = () => {
   // Fetch counter groups for counts
   const counterGroupsQuery = useCounterGroupsList(
     { page: 1, page_size: 100 },
-    { enabled: Boolean(activeGuild), staleTime: 60_000 }
+    { enabled: guildTreeEnabled, staleTime: 60_000 }
   );
   const counterGroupCountsByInitiative = useMemo(() => {
     const map = new Map<number, number>();
@@ -174,7 +181,7 @@ export const AppSidebar = () => {
   const avatarSrc = resolveUploadUrl(user?.avatar_url) || user?.avatar_base64 || null;
 
   // Fetch tags for the tag browser
-  const tagsQuery = useTags();
+  const tagsQuery = useTags({ enabled: guildTreeEnabled });
 
   // Collapse/expand all for initiatives
   const [initiativeCollapseKey, setInitiativeCollapseKey] = useState(0);

--- a/frontend/src/components/CommandCenter.tsx
+++ b/frontend/src/components/CommandCenter.tsx
@@ -268,7 +268,7 @@ export function CommandCenter() {
                 key={`suggested-${item.entity_type}-${item.entity_id}`}
                 value={`suggested-${item.entity_type}-${item.entity_id}-${item.name}`}
                 keywords={[item.name]}
-                onSelect={() => handleSelect(recentRoute(item, activeGuildId))}
+                onSelect={() => handleSelect(recentRoute(item))}
               >
                 {renderRecentIcon(item) ?? <ListTodo className="text-muted-foreground" />}
                 <span>{item.name}</span>

--- a/frontend/src/components/CommandCenter.tsx
+++ b/frontend/src/components/CommandCenter.tsx
@@ -265,8 +265,8 @@ export function CommandCenter() {
           <CommandGroup heading={t("groups.suggested")}>
             {recentItems.slice(0, 5).map((item) => (
               <CommandItem
-                key={`suggested-${item.entity_type}-${item.entity_id}`}
-                value={`suggested-${item.entity_type}-${item.entity_id}-${item.name}`}
+                key={`suggested-${item.guild_id}-${item.entity_type}-${item.entity_id}`}
+                value={`suggested-${item.guild_id}-${item.entity_type}-${item.entity_id}-${item.name}`}
                 keywords={[item.name]}
                 onSelect={() => handleSelect(recentRoute(item))}
               >

--- a/frontend/src/components/recents/RecentTabsBar.tsx
+++ b/frontend/src/components/recents/RecentTabsBar.tsx
@@ -5,9 +5,8 @@ import { useTranslation } from "react-i18next";
 import type { RecentItemRead } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
-import { useGuilds } from "@/hooks/useGuilds";
 import { renderRecentIcon } from "@/lib/recentIcon";
-import { type RecentKey, recentRoute } from "@/lib/recentRoute";
+import { type RecentKey, recentKeyMatches, recentRoute } from "@/lib/recentRoute";
 import { cn } from "@/lib/utils";
 
 interface RecentTabsBarProps {
@@ -24,7 +23,6 @@ interface RecentTabsBarProps {
  */
 export const RecentTabsBar = ({ items, activeKey, loading, onClose }: RecentTabsBarProps) => {
   const { t } = useTranslation("projects");
-  const { activeGuildId } = useGuilds();
 
   if (!loading && (!items || items.length === 0)) {
     return null;
@@ -37,12 +35,14 @@ export const RecentTabsBar = ({ items, activeKey, loading, onClose }: RecentTabs
           <p className="py-3 text-muted-foreground text-xs">{t("tabsBar.loadingRecent")}</p>
         ) : (
           items?.map((item) => {
-            const isActive =
-              activeKey?.entityType === item.entity_type && activeKey?.entityId === item.entity_id;
+            const isActive = recentKeyMatches(activeKey ?? null, item);
             return (
-              <div key={`${item.entity_type}-${item.entity_id}`} className="flex items-center">
+              <div
+                key={`${item.guild_id}-${item.entity_type}-${item.entity_id}`}
+                className="flex items-center"
+              >
                 <Link
-                  to={recentRoute(item, activeGuildId)}
+                  to={recentRoute(item)}
                   className={cn(
                     "group inline-flex items-center gap-2 rounded-t-md border border-transparent px-3 py-2 text-sm transition",
                     isActive

--- a/frontend/src/hooks/useGuilds.tsx
+++ b/frontend/src/hooks/useGuilds.tsx
@@ -33,6 +33,11 @@ export type GuildEntry = GuildRead & {
 interface GuildContextValue {
   guilds: GuildEntry[];
   activeGuildId: number | null;
+  /** The guild the SERVER currently holds for this user (users.active_guild_id
+   * mirror); null = personal mode. Unlike activeGuildId (the local "last
+   * guild" preference), this is what actually scopes requests — long-lived
+   * consumers like the events websocket must key off it. */
+  serverGuildId: number | null;
   activeGuild: GuildEntry | null;
   /** True when the active guild is reached via a read-only grant — writes are
    * blocked server-side, so the UI should hide write affordances. */
@@ -136,25 +141,33 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
   // The guild context the server currently holds for this user
   // (users.active_guild_id; null = personal mode). Seeded from the loaded
   // user so a fresh tab doesn't re-PUT a context the server already has.
+  // The ref is the synchronous source of truth for the idempotence check;
+  // the state mirror lets reactive consumers (events websocket) follow it.
   const serverContextRef = useRef<number | null | undefined>(undefined);
+  const [serverGuildId, setServerGuildId] = useState<number | null>(null);
   useEffect(() => {
     if (user && serverContextRef.current === undefined) {
       serverContextRef.current = user.active_guild_id ?? null;
+      setServerGuildId(user.active_guild_id ?? null);
     }
     if (!user) {
       serverContextRef.current = undefined;
+      setServerGuildId(null);
     }
   }, [user]);
 
   /** Push the server-held guild context (idempotent). All guild-scoped
    * requests resolve their guild from this flag, so it must land before the
-   * new context's fetches fire. Throws if the PUT fails. */
+   * new context's fetches fire. Returns true when the server context actually
+   * changed (a PUT was sent). Throws if the PUT fails. */
   const pushServerContext = useCallback(async (guildId: number | null) => {
     if (serverContextRef.current === guildId) {
-      return;
+      return false;
     }
     await setGuildContextApiV1UsersMeGuildContextPut({ guild_id: guildId });
     serverContextRef.current = guildId;
+    setServerGuildId(guildId);
+    return true;
   }, []);
 
   const applyGuildState = useCallback((guildList: GuildEntry[]) => {
@@ -295,9 +308,12 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
       // Don't switch if we are already there
       if (!user || guildId === activeGuildIdRef.current) {
         // Still make sure the server context matches (e.g. coming back from
-        // personal mode to the already-highlighted guild).
+        // personal mode to the already-highlighted guild) — and if it moved,
+        // refetch the guild-scoped queries that errored without it.
         try {
-          await pushServerContext(guildId);
+          if (await pushServerContext(guildId)) {
+            await resetGuildScopedQueries();
+          }
         } catch (err) {
           console.error("Failed to set guild context", err);
         }
@@ -336,13 +352,22 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
       // Always converge the server-held context first — the local id can
       // already match while the server flag points elsewhere (fresh tab,
       // return from personal mode). pushServerContext is idempotent.
+      let contextChanged = false;
       try {
-        await pushServerContext(guildId);
+        contextChanged = await pushServerContext(guildId);
       } catch (err) {
         console.error("Failed to set guild context", err);
       }
 
       if (guildId === activeGuildIdRef.current) {
+        // The local guild didn't change but the SERVER context did (e.g.
+        // returning to the guild from personal mode, where guild-scoped
+        // queries 409ed): those cached errors/empties won't refetch on their
+        // own — sidebar counts would stay zeroed — so reset them now that
+        // requests resolve in this guild again.
+        if (contextChanged) {
+          await resetGuildScopedQueries();
+        }
         return;
       }
 
@@ -377,6 +402,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
    */
   const adoptExternalGuildSwitch = useCallback(async (guildId: number | null) => {
     serverContextRef.current = guildId;
+    setServerGuildId(guildId);
     if (guildId === null || guildId === activeGuildIdRef.current) {
       return;
     }
@@ -503,6 +529,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
   const value: GuildContextValue = {
     guilds,
     activeGuildId,
+    serverGuildId,
     activeGuild,
     activeGuildReadOnly,
     loading,

--- a/frontend/src/hooks/useGuilds.tsx
+++ b/frontend/src/hooks/useGuilds.tsx
@@ -356,7 +356,13 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
       try {
         contextChanged = await pushServerContext(guildId);
       } catch (err) {
+        // Abort: flipping the local UI into a guild the server context never
+        // reached would have every guild-scoped request resolving under the
+        // OLD context — wrong guild, no error indication. Leave local state
+        // alone so UI and server stay consistent; the user can retry.
         console.error("Failed to set guild context", err);
+        toast.error("Unable to enter guild. Please try again.");
+        return;
       }
 
       if (guildId === activeGuildIdRef.current) {

--- a/frontend/src/hooks/useRealtimeUpdates.tsx
+++ b/frontend/src/hooks/useRealtimeUpdates.tsx
@@ -95,15 +95,20 @@ const handleCommentEvent = (data?: Record<string, unknown>) => {
 
 export const useRealtimeUpdates = () => {
   const { token, user, logout } = useAuth();
-  const { activeGuildId } = useGuilds();
+  // Key the socket off the SERVER-held context, not the local "last guild"
+  // preference: the backend scopes the stream to users.active_guild_id and
+  // policy-closes the socket when it's NULL (personal mode). Connecting off
+  // the local preference while in personal mode would auth-fail repeatedly
+  // and eventually force a logout.
+  const { serverGuildId } = useGuilds();
   const websocketRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<number | null>(null);
   const authFailureCountRef = useRef<number>(0);
 
   useEffect(() => {
-    // The socket is scoped to a single guild — without an active guild there's
+    // The socket is scoped to a single guild — in personal mode there's
     // nothing to subscribe to, and the backend would reject the auth payload.
-    if (!user || !activeGuildId) {
+    if (!user || serverGuildId === null) {
       if (websocketRef.current) {
         websocketRef.current.close();
         websocketRef.current = null;
@@ -211,5 +216,5 @@ export const useRealtimeUpdates = () => {
         websocketRef.current = null;
       }
     };
-  }, [token, user, activeGuildId, logout]);
+  }, [token, user, serverGuildId, logout]);
 };

--- a/frontend/src/hooks/useTags.ts
+++ b/frontend/src/hooks/useTags.ts
@@ -34,11 +34,12 @@ import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import type { MutationOpts } from "@/types/mutation";
 
-export const useTags = () => {
+export const useTags = (options?: { enabled?: boolean }) => {
   return useQuery<TagRead[]>({
     queryKey: getListTagsApiV1TagsGetQueryKey(),
     queryFn: () => listTagsApiV1TagsGet() as unknown as Promise<TagRead[]>,
     staleTime: 60 * 1000,
+    enabled: options?.enabled ?? true,
   });
 };
 

--- a/frontend/src/lib/recentRoute.ts
+++ b/frontend/src/lib/recentRoute.ts
@@ -4,6 +4,8 @@ import { guildPath } from "@/lib/guildUrl";
 export type RecentKey = {
   entityType: RecentItemRead["entity_type"];
   entityId: number;
+  /** Guild parsed from the URL; null on legacy un-prefixed paths. */
+  guildId: number | null;
 };
 
 const SEGMENT_BY_TYPE: Record<RecentItemRead["entity_type"], string> = {
@@ -16,14 +18,15 @@ const SEGMENT_BY_TYPE: Record<RecentItemRead["entity_type"], string> = {
 /**
  * Return the guild-scoped detail-page route for a recent item.
  *
- * If ``activeGuildId`` is null we fall back to the legacy un-prefixed path so
- * the bar still works for users who reach a detail page outside a guild
- * context (e.g. cross-guild user pages).
+ * The tabs bar is cross-guild: each tab links into the entity's OWN guild
+ * (``item.guild_id``), never the guild the viewer happens to be in —
+ * per-guild entity ids collide across guilds, so a tab opened under the
+ * wrong guild prefix would resolve to a different (or inaccessible) entity.
+ * Navigating the link enters that guild via the /g/$guildId layout.
  */
-export function recentRoute(item: RecentItemRead, activeGuildId: number | null): string {
+export function recentRoute(item: RecentItemRead): string {
   const segment = SEGMENT_BY_TYPE[item.entity_type];
-  const path = `/${segment}/${item.entity_id}`;
-  return activeGuildId ? guildPath(activeGuildId, path) : path;
+  return guildPath(item.guild_id, `/${segment}/${item.entity_id}`);
 }
 
 /**
@@ -37,21 +40,45 @@ export function getActiveRecentKey(pathname: string): RecentKey | null {
     entityType: RecentItemRead["entity_type"];
     re: RegExp;
   }> = [
-    { entityType: "project", re: /^\/g\/\d+\/projects\/(\d+)/ },
+    { entityType: "project", re: /^\/g\/(\d+)\/projects\/(\d+)/ },
     { entityType: "project", re: /^\/projects\/(\d+)/ },
-    { entityType: "document", re: /^\/g\/\d+\/documents\/(\d+)/ },
+    { entityType: "document", re: /^\/g\/(\d+)\/documents\/(\d+)/ },
     { entityType: "document", re: /^\/documents\/(\d+)/ },
-    { entityType: "queue", re: /^\/g\/\d+\/queues\/(\d+)/ },
+    { entityType: "queue", re: /^\/g\/(\d+)\/queues\/(\d+)/ },
     { entityType: "queue", re: /^\/queues\/(\d+)/ },
-    { entityType: "counter_group", re: /^\/g\/\d+\/counter-groups\/(\d+)/ },
+    { entityType: "counter_group", re: /^\/g\/(\d+)\/counter-groups\/(\d+)/ },
     { entityType: "counter_group", re: /^\/counter-groups\/(\d+)/ },
   ];
 
   for (const { entityType, re } of patterns) {
     const m = pathname.match(re);
     if (m) {
-      return { entityType, entityId: Number(m[1]) };
+      // Guild-prefixed patterns capture (guildId, entityId); legacy ones
+      // capture only (entityId).
+      if (m.length === 3) {
+        return { entityType, entityId: Number(m[2]), guildId: Number(m[1]) };
+      }
+      return { entityType, entityId: Number(m[1]), guildId: null };
     }
   }
   return null;
+}
+
+/**
+ * True when ``activeKey`` (parsed from the URL) refers to ``item``.
+ *
+ * Entity ids are only unique within a guild, so the guild must match too —
+ * otherwise a guild-A document tab would light up while viewing guild B's
+ * document that happens to share the id. A legacy un-prefixed URL (no guild
+ * in the path) matches on type+id alone.
+ */
+export function recentKeyMatches(activeKey: RecentKey | null, item: RecentItemRead): boolean {
+  if (!activeKey) {
+    return false;
+  }
+  return (
+    activeKey.entityType === item.entity_type &&
+    activeKey.entityId === item.entity_id &&
+    (activeKey.guildId === null || activeKey.guildId === item.guild_id)
+  );
 }

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -466,7 +466,7 @@ export const DocumentDetailPage = () => {
           const isAbsolute =
             API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://");
           const baseUrl = isAbsolute ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
-          const syncUrl = `${baseUrl}/collaboration/documents/${sourceDocumentId}/sync-content?token=${encodeURIComponent(token)}&guild_id=${activeGuildId}`;
+          const syncUrl = `${baseUrl}/collaboration/documents/${sourceDocumentId}/sync-content?token=${encodeURIComponent(token)}`;
           fetch(syncUrl, {
             method: "POST",
             body: JSON.stringify(stored.content),
@@ -849,7 +849,7 @@ export const DocumentDetailPage = () => {
       // Build the sync URL
       const isAbsolute = API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://");
       const baseUrl = isAbsolute ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
-      const syncUrl = `${baseUrl}/collaboration/documents/${parsedId}/sync-content?token=${encodeURIComponent(token)}&guild_id=${activeGuildId}`;
+      const syncUrl = `${baseUrl}/collaboration/documents/${parsedId}/sync-content?token=${encodeURIComponent(token)}`;
 
       // Send content via fetch with keepalive (more reliable than sendBeacon, less likely to be blocked)
       fetch(syncUrl, {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -31,6 +31,10 @@ export interface GuildContextValue {
   error: string | null;
   refreshGuilds: () => Promise<void>;
   switchGuild: (guildId: number) => Promise<void>;
+  /** Push the server-held guild context + local state for a guild URL.
+   * Awaited in the /g/$guildId beforeLoad so child routes can't fetch
+   * before the context lands. Idempotent. */
+  syncGuildFromUrl: (guildId: number) => Promise<void>;
   createGuild: (input: { name: string; description?: string }) => Promise<unknown>;
   updateGuildInState: (guild: GuildRead) => void;
   reorderGuilds: (guildIds: number[]) => void;

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId.tsx
@@ -8,7 +8,7 @@ import { StatusMessage } from "@/components/StatusMessage";
 import { useGuilds } from "@/hooks/useGuilds";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId")({
-  beforeLoad: ({ context, params }) => {
+  beforeLoad: async ({ context, params }) => {
     const guildId = Number(params.guildId);
     const { guilds } = context;
 
@@ -33,9 +33,16 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId
       return { urlGuildId: guildId, urlGuild: null };
     }
 
-    // Sync the SPA's local guild state; the layout effect below pushes the
-    // server-held context (which is what actually scopes requests).
     setCurrentGuildId(guildId);
+
+    // Push the server-held guild context BEFORE child routes render and
+    // fetch. The backend resolves every request's guild from this flag, so
+    // a query fired before the PUT lands would resolve in whatever guild
+    // the user was in previously — with per-guild entity ids that means
+    // the WRONG entity, surfacing as no-access/not-found errors when
+    // opening cross-guild links (e.g. recent tabs). Idempotent and instant
+    // when the server already holds this guild.
+    await guilds?.syncGuildFromUrl(guildId);
 
     // Provide validated guild info to child routes via route context
     return { urlGuildId: guildId, urlGuild: guild };

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId.tsx
@@ -8,7 +8,7 @@ import { StatusMessage } from "@/components/StatusMessage";
 import { useGuilds } from "@/hooks/useGuilds";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId")({
-  beforeLoad: async ({ context, params }) => {
+  beforeLoad: async ({ context, params, cause }) => {
     const guildId = Number(params.guildId);
     const { guilds } = context;
 
@@ -31,6 +31,15 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId
     if (!guild) {
       // Let the component render a "not a member" message
       return { urlGuildId: guildId, urlGuild: null };
+    }
+
+    // beforeLoad ALSO runs for link PRELOADS (defaultPreload: "intent" —
+    // hovering any cross-guild link, e.g. a recents tab). A preload must be
+    // side-effect free: switching the server-held context + resetting caches
+    // on hover ping-pongs the whole app between guilds. Only a real
+    // navigation may move the context.
+    if (cause === "preload") {
+      return { urlGuildId: guildId, urlGuild: guild };
     }
 
     setCurrentGuildId(guildId);


### PR DESCRIPTION
## Problem

After #680, opening a recent tab from another guild often showed **"you don't have access"**, and tab state behaved oddly.

Two real bugs:

1. **Tabs linked into the wrong guild.** `recentRoute(item, activeGuildId)` built every tab's link with the *viewer's current guild*, not the item's own `guild_id`. Under the old header model the bar only ever held active-guild items so this was equivalent — but the bar is now cross-guild, and per-guild entity ids collide, so clicking a guild-B tab while in guild A opened `/g/A/documents/<B's id>`: a different (or inaccessible) entity → 403/404.
2. **Context race on guild entry.** The context PUT ran in a component effect *after* child routes had already mounted and fired queries, so the first fetches could resolve under the previous guild's flag — same wrong-entity failure mode for deep links and tab clicks.

## Fix

- `recentRoute(item)` links into `item.guild_id`; active-tab highlight (`recentKeyMatches`) and React keys now match on guild as well as type+id (CommandCenter's suggested items too).
- `/g/$guildId` `beforeLoad` is async and **awaits** `syncGuildFromUrl` (idempotent — instant when the server already holds the guild), so nothing under the guild layout can fetch before the server-held context lands. The component-effect sync stays as the fallback for the guilds-still-loading case.

## Also: backend test fallout from #680

- `users.py`: removed a function-local `guilds_service` re-import that shadowed the module-level import — Python treats the name as local for the whole function, so `clear_active_guild_context` raised `UnboundLocalError` on member removal (real runtime bug, not just tests).
- Download tests now enter the guild first (downloads resolve from the server-held flag).
- The no-guild-context list/export tests assert `409 NO_GUILD_MEMBERSHIP` (was `403`).

## Testing

```
cd frontend && pnpm tsc --noEmit && pnpm biome check src && pnpm test:run   # 716 passed
cd backend && pytest app/api/v1/endpoints/documents_test.py app/api/v1/endpoints/users_test.py \
  app/api/v1/endpoints/initiatives_test.py app/api/v1/endpoints/projects_test.py \
  app/api/v1/endpoints/tasks_test.py   # all previously-failing tests green
ruff check app && ruff format app
```