### PR TITLE
Harden sync-content auth; fix unload-save path

### DIFF
--- a/backend/app/api/v1/guild_endpoints/collaboration.py
+++ b/backend/app/api/v1/guild_endpoints/collaboration.py
@@ -17,7 +17,6 @@ from typing import Annotated
 from fastapi import (
     APIRouter,
     Depends,
-    Query,
     Request,
     WebSocket,
     WebSocketDisconnect,
@@ -29,6 +28,7 @@ from sqlmodel import select
 from app.api.deps import (
     RLSSessionDep,
     SessionDep,
+    UploadUserDep,
     get_current_active_user,
     get_guild_membership,
     GuildContext,
@@ -423,30 +423,27 @@ async def sync_document_content(
     guild_id: int,
     request: Request,
     session: SessionDep,
-    token: str = Query(...),
+    user: UploadUserDep,
 ):
     """
     Sync Lexical content from the frontend to the database.
 
-    Called via navigator.sendBeacon on page unload to keep the content column
-    in sync with yjs_state. sendBeacon can't set headers, so this authenticates
-    with a ``?token=`` query param and takes the guild from the ``/g/{guild_id}``
-    path — the document being synced was open inside that guild.
+    Called via a ``keepalive`` fetch on page unload to keep the content column
+    in sync with yjs_state. Authenticates with the same header-less scheme as
+    ``/uploads/*`` and document downloads (``UploadUserDep``): the HttpOnly
+    session cookie on web, a short-lived uploads-scoped ``?token=`` on native —
+    so the long-lived session JWT never rides in a URL (SEC-12), unlike the
+    earlier ``?token=<session jwt>`` version. The guild comes from the
+    ``/g/{guild_id}`` path — the document being synced was open inside it.
 
     The request body should contain the Lexical serialized state as JSON.
     """
-    # Parse the JSON body (sendBeacon sends raw body)
+    # Parse the JSON body (the keepalive fetch sends a raw body)
     try:
         content = await request.json()
     except Exception as e:
         logger.warning(f"Sync content: Failed to parse JSON body: {e}")
         return {"status": "error", "message": "Invalid JSON body"}
-
-    # Authenticate
-    user = await _get_user_from_token(token, session)
-    if not user:
-        logger.warning(f"Sync content: Auth failed for document {document_id}")
-        return {"status": "error", "message": "Authentication failed"}
 
     # The guild comes from the path; validate membership before scoping RLS to
     # it (the path is only a selector, never a trust boundary).

--- a/backend/app/api/v1/guild_endpoints/collaboration_test.py
+++ b/backend/app/api/v1/guild_endpoints/collaboration_test.py
@@ -1,0 +1,134 @@
+"""Integration tests for the document collaboration HTTP endpoints.
+
+Focused on ``POST /g/{guild_id}/collaboration/documents/{id}/sync-content``,
+which the editor fires via a ``keepalive`` fetch on page unload. It shares the
+header-less auth of ``/uploads/*`` and downloads (``UploadUserDep``): the
+HttpOnly session cookie on web, a short-lived uploads-scoped ``?token=`` on
+native. The long-lived session JWT must never authenticate via the URL (SEC-12).
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.security import create_upload_token
+from app.models.document import (
+    Document,
+    DocumentPermission,
+    DocumentPermissionLevel,
+    DocumentType,
+)
+from app.testing.factories import (
+    create_guild,
+    create_guild_membership,
+    create_initiative,
+    create_user,
+    get_auth_token,
+)
+
+
+async def _create_native_document(
+    session: AsyncSession,
+    *,
+    initiative,
+    owner,
+) -> Document:
+    """Create a native (Lexical) document with owner write permission."""
+    doc = Document(
+        title="Sync Target",
+        initiative_id=initiative.id,
+        guild_id=initiative.guild_id,
+        created_by_id=owner.id,
+        updated_by_id=owner.id,
+        document_type=DocumentType.native,
+        content={"root": {"children": []}},
+    )
+    session.add(doc)
+    await session.flush()
+
+    perm = DocumentPermission(
+        document_id=doc.id,
+        user_id=owner.id,
+        level=DocumentPermissionLevel.owner,
+        guild_id=initiative.guild_id,
+    )
+    session.add(perm)
+    await session.commit()
+    return doc
+
+
+def _sync_url(guild_id: int, document_id: int) -> str:
+    return f"/api/v1/g/{guild_id}/collaboration/documents/{document_id}/sync-content"
+
+
+@pytest.mark.integration
+async def test_sync_content_scoped_upload_token_persists(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """A short-lived, uploads-scoped ?token= authenticates the sync (the
+    credential native WebViews carry in the URL) and the content is written."""
+    owner = await create_user(session)
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(session, user=owner, guild=guild)
+    initiative = await create_initiative(session, guild, owner)
+    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+
+    token, _ = create_upload_token(user_id=owner.id)
+    new_content = {"root": {"children": [{"type": "paragraph"}]}}
+    response = await client.post(
+        f"{_sync_url(guild.id, doc.id)}?token={token}",
+        json=new_content,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+    refreshed = (
+        await session.exec(select(Document).where(Document.id == doc.id))
+    ).one()
+    assert refreshed.content == new_content
+
+
+@pytest.mark.integration
+async def test_sync_content_session_jwt_rejected_in_query_param(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """The long-lived session JWT must NOT authenticate the sync via ?token=
+    (it would leak a full-API credential through the URL). SEC-12."""
+    owner = await create_user(session)
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(session, user=owner, guild=guild)
+    initiative = await create_initiative(session, guild, owner)
+    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+
+    session_jwt = get_auth_token(owner)
+    response = await client.post(
+        f"{_sync_url(guild.id, doc.id)}?token={session_jwt}",
+        json={"root": {"children": []}},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_sync_content_rejects_non_member(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """A validly-authenticated user who is not a member of the path guild can't
+    sync into it — the guild boundary holds independent of how auth arrived."""
+    owner = await create_user(session)
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(session, user=owner, guild=guild)
+    initiative = await create_initiative(session, guild, owner)
+    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+
+    outsider = await create_user(session)
+    token, _ = create_upload_token(user_id=outsider.id)
+    response = await client.post(
+        f"{_sync_url(guild.id, doc.id)}?token={token}",
+        json={"root": {"children": []}},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "error", "message": "No guild access"}

--- a/backend/app/api/v1/guild_endpoints/collaboration_test.py
+++ b/backend/app/api/v1/guild_endpoints/collaboration_test.py
@@ -19,7 +19,7 @@ from app.models.document import (
     DocumentPermissionLevel,
     DocumentType,
 )
-from app.testing.factories import (
+from app.testing import (
     create_guild,
     create_guild_membership,
     create_initiative,
@@ -116,7 +116,16 @@ async def test_sync_content_rejects_non_member(
     client: AsyncClient, session: AsyncSession
 ) -> None:
     """A validly-authenticated user who is not a member of the path guild can't
-    sync into it — the guild boundary holds independent of how auth arrived."""
+    sync into it — the guild boundary holds independent of how auth arrived.
+
+    Note the 200-with-error-body (not a 403): this endpoint fires from a
+    page-unload ``keepalive`` fetch whose response the client never reads, so
+    every app-level failure (bad JSON, no guild access, not found, no write
+    access) reports a soft ``{"status": "error"}`` rather than an HTTP error.
+    That contract predates this change and is deliberately preserved. Only
+    *authentication* now hard-fails (401), because that is enforced by the
+    ``UploadUserDep`` dependency before the handler runs.
+    """
     owner = await create_user(session)
     guild = await create_guild(session, creator=owner)
     await create_guild_membership(session, user=owner, guild=guild)

--- a/frontend/src/api/generated/collaboration/collaboration.ts
+++ b/frontend/src/api/generated/collaboration/collaboration.ts
@@ -296,10 +296,13 @@ export function useGetDocumentCollaboratorsApiV1GGuildIdCollaborationDocumentsDo
 /**
  * Sync Lexical content from the frontend to the database.
  *
- * Called via navigator.sendBeacon on page unload to keep the content column
- * in sync with yjs_state. sendBeacon can't set headers, so this authenticates
- * with a ``?token=`` query param and takes the guild from the ``/g/{guild_id}``
- * path — the document being synced was open inside that guild.
+ * Called via a ``keepalive`` fetch on page unload to keep the content column
+ * in sync with yjs_state. Authenticates with the same header-less scheme as
+ * ``/uploads/*`` and document downloads (``UploadUserDep``): the HttpOnly
+ * session cookie on web, a short-lived uploads-scoped ``?token=`` on native —
+ * so the long-lived session JWT never rides in a URL (SEC-12), unlike the
+ * earlier ``?token=<session jwt>`` version. The guild comes from the
+ * ``/g/{guild_id}`` path — the document being synced was open inside it.
  *
  * The request body should contain the Lexical serialized state as JSON.
  * @summary Sync Document Content
@@ -307,7 +310,7 @@ export function useGetDocumentCollaboratorsApiV1GGuildIdCollaborationDocumentsDo
 export const syncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPost = (
   guildId: number,
   documentId: number,
-  params: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams,
+  params?: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
@@ -334,7 +337,7 @@ export const getSyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentId
       {
         guildId: number;
         documentId: number;
-        params: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
+        params?: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
       },
       TContext
     >;
@@ -349,7 +352,7 @@ export const getSyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentId
     {
       guildId: number;
       documentId: number;
-      params: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
+      params?: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
     },
     TContext
   > => {
@@ -371,7 +374,7 @@ export const getSyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentId
       {
         guildId: number;
         documentId: number;
-        params: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
+        params?: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
       }
     > = (props) => {
       const { guildId, documentId, params } = props ?? {};
@@ -417,7 +420,7 @@ export const useSyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentId
       {
         guildId: number;
         documentId: number;
-        params: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
+        params?: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
       },
       TContext
     >;
@@ -434,7 +437,7 @@ export const useSyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentId
   {
     guildId: number;
     documentId: number;
-    params: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
+    params?: SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams;
   },
   TContext
 > => {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3892,7 +3892,7 @@ export type GetDocumentCollaboratorsApiV1GGuildIdCollaborationDocumentsDocumentI
 
 export type SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSyncContentPostParams =
   {
-    token: string;
+    token?: string | null;
   };
 
 export type ListMyTasksApiV1MeTasksGetParams = {

--- a/frontend/src/lib/uploadUrl.ts
+++ b/frontend/src/lib/uploadUrl.ts
@@ -4,14 +4,16 @@ import { apiClient } from "@/api/client";
 import { getUploadToken } from "@/lib/uploadToken";
 
 /**
- * Resolve an `/api/v1/...` path for a download served via iframe/window.open.
- * On native platforms, prepends the API server origin and appends a SHORT-LIVED,
- * uploads-scoped ?token= for auth (native WebViews can't send Authorization
- * headers or HttpOnly cookies). The long-lived session JWT is never put in a URL
- * — see {@link getUploadToken}. On web, returns the API path as-is (same-origin,
- * session cookie handles auth).
+ * Resolve an `/api/v1/...` path for a request that can't carry an Authorization
+ * header — a download served via iframe/window.open, or a `keepalive`/sendBeacon
+ * POST fired on page unload. On native platforms, prepends the API server origin
+ * and appends a SHORT-LIVED, uploads-scoped ?token= for auth (native WebViews
+ * can't send Authorization headers or HttpOnly cookies). The long-lived session
+ * JWT is never put in a URL — see {@link getUploadToken}. On web, returns the API
+ * path as-is (same-origin, the HttpOnly session cookie handles auth — send the
+ * request with `credentials: "include"`).
  */
-function resolveDownloadApiPath(apiPath: string): string {
+export function resolveHeaderlessApiUrl(apiPath: string): string {
   if (!Capacitor.isNativePlatform()) {
     return apiPath;
   }
@@ -49,7 +51,7 @@ export function resolveDocumentDownloadUrl(
     return null;
   }
   const base = `/api/v1/g/${guildId}/documents/${documentId}/download`;
-  return resolveDownloadApiPath(inline ? `${base}?inline=1` : base);
+  return resolveHeaderlessApiUrl(inline ? `${base}?inline=1` : base);
 }
 
 /**
@@ -67,7 +69,7 @@ export function resolveDocumentVersionDownloadUrl(
     return null;
   }
   const base = `/api/v1/g/${guildId}/documents/${documentId}/versions/${versionId}/download`;
-  return resolveDownloadApiPath(inline ? `${base}?inline=1` : base);
+  return resolveHeaderlessApiUrl(inline ? `${base}?inline=1` : base);
 }
 
 /**

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -114,7 +114,7 @@ import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
 import { findNewMentions } from "@/lib/mentionUtils";
 import { getItem, removeItem, setItem } from "@/lib/storage";
-import { resolveUploadUrl } from "@/lib/uploadUrl";
+import { resolveHeaderlessApiUrl, resolveUploadUrl } from "@/lib/uploadUrl";
 import { cn } from "@/lib/utils";
 
 export const DocumentDetailPage = () => {
@@ -467,15 +467,18 @@ export const DocumentDetailPage = () => {
           stored &&
           stored.documentId === sourceDocumentId
         ) {
-          const isAbsolute =
-            API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://");
-          const baseUrl = isAbsolute ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
-          const syncUrl = `${baseUrl}/collaboration/documents/${sourceDocumentId}/sync-content?token=${encodeURIComponent(token)}`;
+          // Header-less auth (cookie on web, scoped upload token on native) —
+          // the long-lived session JWT must never ride in a URL. The guild
+          // rides in the path (`/g/{guildId}/`), like every other guild call.
+          const syncUrl = resolveHeaderlessApiUrl(
+            `/api/v1/g/${activeGuildId}/collaboration/documents/${sourceDocumentId}/sync-content`
+          );
           fetch(syncUrl, {
             method: "POST",
             body: JSON.stringify(stored.content),
             headers: { "Content-Type": "application/json" },
             keepalive: true,
+            credentials: "include",
           }).catch(() => {});
         }
         void navigate({
@@ -768,10 +771,9 @@ export const DocumentDetailPage = () => {
       if (!pending || !tokenRef.current || !activeGuildIdRef.current) return;
       const isAbsolute = API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://");
       const baseUrl = isAbsolute ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
-      const url = `${baseUrl}/documents/${pending.documentId}`;
-      // No guild context travels with the request — the server resolves it
-      // from the user's server-held flag, which is this document's guild
-      // (the page required entering it).
+      // The guild rides in the path (`/g/{guildId}/`) — guild context is per-tab
+      // from the URL; the page required entering this document's guild.
+      const url = `${baseUrl}/g/${activeGuildIdRef.current}/documents/${pending.documentId}`;
       fetch(url, {
         method: "PATCH",
         headers: {
@@ -850,10 +852,12 @@ export const DocumentDetailPage = () => {
         return;
       }
 
-      // Build the sync URL
-      const isAbsolute = API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://");
-      const baseUrl = isAbsolute ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
-      const syncUrl = `${baseUrl}/collaboration/documents/${parsedId}/sync-content?token=${encodeURIComponent(token)}`;
+      // Build the sync URL. Header-less auth (cookie on web, scoped upload
+      // token on native) — the long-lived session JWT must never ride in a URL.
+      // The guild rides in the path (`/g/{guildId}/`).
+      const syncUrl = resolveHeaderlessApiUrl(
+        `/api/v1/g/${activeGuildId}/collaboration/documents/${parsedId}/sync-content`
+      );
 
       // Send content via fetch with keepalive (more reliable than sendBeacon, less likely to be blocked)
       fetch(syncUrl, {
@@ -861,6 +865,7 @@ export const DocumentDetailPage = () => {
         body: JSON.stringify(stored.content),
         headers: { "Content-Type": "application/json" },
         keepalive: true, // Ensures request completes even if page unloads
+        credentials: "include", // Web auth is the HttpOnly session cookie
       }).catch(() => {}); // Silently ignore errors on page unload
     };
 

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -30,6 +30,7 @@ import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
+import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useAuth } from "@/hooks/useAuth";
 import { useCalendarEventsList, useRescheduleCalendarEvent } from "@/hooks/useCalendarEvents";
 import {
@@ -104,6 +105,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   const router = useRouter();
   const { user } = useAuth();
   const gp = useGuildPath();
+  const guildId = useActiveGuildId();
   const searchParams = useSearch({ strict: false }) as {
     initiativeId?: string;
     create?: string;
@@ -397,7 +399,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
       if (initiativeId) {
         params.initiative_id = String(initiativeId);
       }
-      const response = await apiClient.get("/api/v1/calendar-events/export.ics", {
+      const response = await apiClient.get(`/g/${guildId}/calendar-events/export.ics`, {
         params,
         responseType: "blob",
       });
@@ -410,7 +412,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     } catch {
       toast.error(t("export.exportError"));
     }
-  }, [initiativeId, t]);
+  }, [guildId, initiativeId, t]);
 
   const statusOptions = useMemo(
     () =>

--- a/frontend/src/pages/user/MyCalendarPage.tsx
+++ b/frontend/src/pages/user/MyCalendarPage.tsx
@@ -209,7 +209,7 @@ export const MyCalendarPage = () => {
       if (table.guildFilters.length > 0) {
         params.guild_ids = table.guildFilters;
       }
-      const response = await apiClient.get("/api/v1/me/calendar-events/export.ics", {
+      const response = await apiClient.get("/me/calendar-events/export.ics", {
         params,
         responseType: "blob",
       });


### PR DESCRIPTION
## Problem

`POST /g/{guild_id}/collaboration/documents/{id}/sync-content` (fired by the editor via a `keepalive` fetch on page unload) authenticated with `?token=<full session JWT>`. That puts a long-lived, full-API credential in the URL, where it lands in server access logs, proxy logs, and `Referer` — exactly the leak the uploads/downloads flow was hardened against in SEC-12.

Two related URLs in `DocumentDetailPage` were also left stale by the `/g/{guild_id}` routing cutover (#686): both the sync-content URL and the unload-save `flush` PATCH omitted the `/g/{guildId}/` path segment, so they were 404ing on `dev`.

## Changes

**Backend**
- `sync_document_content` now uses the shared `UploadUserDep` (same dep as `/uploads/*` and document downloads) instead of a bespoke `?token=` + `_get_user_from_token`. Web authenticates via the HttpOnly session cookie (no credential in the URL); native uses a short-lived, uploads-scoped `?token=`. A full session JWT in `?token=` is now rejected. Guild-membership and write-permission checks are unchanged.
- Dropped the now-unused `Query` import. The WebSocket path keeps `_get_user_from_token`/`authenticate_ws_token`.

**Frontend**
- Both sync-content fetches build through `resolveHeaderlessApiUrl(...)` (the generalized, exported form of the old private `resolveDownloadApiPath`) and send `credentials: "include"` — no session JWT in the URL, correct `/g/{guildId}/` path.
- Fixed the `flush` document PATCH to target `/g/{guildId}/documents/{id}` and refreshed its stale comment (the server-held guild flag was removed in #686). Its auth (`Authorization: Bearer`) is a header, not a URL leak, so it's unchanged.

**Tests**
- New `collaboration_test.py`: scoped upload token persists content; **session JWT in `?token=` → 401** (regression lock); non-member → "No guild access".

## Testing
- Backend: `ruff check` + `ruff format` clean; `pytest app/api/v1/guild_endpoints/collaboration_test.py` → 3 passed.
- Frontend: `biome check` clean, `tsc --noEmit` clean, `vitest run src/lib/uploadUrl.test.ts` → 8 passed.

No changelog entry (covered under security updates).

---

## Follow-up: calendar `.ics` export URLs (2nd commit)

Audited every other hand-built (non-Orval) API URL for the same missing-guild-segment issue. The 4 realtime WS hooks, download helpers, and `/me/*` aggregates are all correct. Two calendar export calls were not:

- **`EventsPage.tsx`** `handleExport` hit `/api/v1/calendar-events/export.ics` — no top-level route exists (only `/g/{guild_id}/calendar-events/export.ics` and `/me/...`). Now targets the guild route via `useActiveGuildId()`, passing `initiative_id` as before.
- Both export calls also hard-prefixed `/api/v1/` on top of the axios `baseURL` (already `/api/v1`), producing a doubled `/api/v1/api/v1/...` path — they were the only `apiClient` calls in the repo doing this. Dropped the prefix from both `EventsPage` and `MyCalendarPage` (the latter's `/me/` route was already correct, just double-prefixed).
