### PR TITLE
Serve Swagger docs under a scoped CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A batch of schema-per-guild fixes: property definitions, uploads and document downloads, account deletion/deactivation cleanup, OIDC role sync, cross-guild calendars, and the "added to initiative" notification all read and write the correct guild's data again.
 - The Initiative logo now displays in emails.
 - Corrected malformed stored defaults for tag and task-status colors and icons.
-- Spell-check dictionaries and Excalidraw whiteboard fonts are no longer blocked by the Content-Security-Policy.
+- Spell-check dictionaries, Excalidraw whiteboard fonts, and the Swagger API docs page are no longer blocked by the Content-Security-Policy.
 
 ### Security
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,24 @@ CSP_FONT_ORIGINS = [
     "https://esm.sh",  # Do not promote esm.sh to script-src
 ]
 
+# Swagger UI (/docs) pulls its bundle + stylesheet from jsDelivr and, behind a
+# Cloudflare proxy, a Web Analytics beacon. These get a relaxed, docs-ONLY CSP
+# (Settings.docs_content_security_policy) applied per-route so the app-wide
+# script-src can stay 'self' (pentest MED-001) — never add these to the main CSP.
+CSP_SWAGGER_SCRIPT_ORIGINS = [
+    "https://cdn.jsdelivr.net",
+    "https://static.cloudflareinsights.com",
+]
+CSP_SWAGGER_STYLE_ORIGINS = ["https://cdn.jsdelivr.net"]
+
+
+def _format_csp(directives: dict[str, list[str]]) -> str:
+    """Render a directive map to a CSP header string, de-duplicating sources."""
+    return "; ".join(
+        f"{name} {' '.join(dict.fromkeys(values))}"
+        for name, values in directives.items()
+    )
+
 
 def _origin_of(url: str) -> str | None:
     """Return the ``scheme://host[:port]`` origin of a URL, or None if unparseable."""
@@ -213,9 +231,32 @@ class Settings(BaseSettings):
             "form-action": ["'self'"],
             "frame-ancestors": ["'none'"],
         }
-        return "; ".join(
-            f"{name} {' '.join(dict.fromkeys(values))}"
-            for name, values in directives.items()
+        return _format_csp(directives)
+
+    @property
+    def docs_content_security_policy(self) -> str:
+        """Relaxed CSP for the Swagger ``/docs`` page ONLY (applied per-route).
+
+        Swagger UI loads its bundle/stylesheet from jsDelivr and a Cloudflare
+        beacon, which the app-wide ``script-src 'self'`` (pentest MED-001)
+        rightly blocks. Rather than weaken the global policy, this scoped policy
+        whitelists just those origins for the docs HTML response. Everything else
+        stays locked down: ``object-src 'none'``, ``frame-ancestors 'none'``,
+        and ``connect-src 'self'`` (Try-It-Out hits the same-origin API).
+        """
+        return _format_csp(
+            {
+                "default-src": ["'self'"],
+                "script-src": ["'self'", *CSP_SWAGGER_SCRIPT_ORIGINS],
+                "style-src": ["'self'", "'unsafe-inline'", *CSP_SWAGGER_STYLE_ORIGINS],
+                "img-src": ["'self'", "data:", "https:"],
+                "font-src": ["'self'", "data:"],
+                "connect-src": ["'self'"],
+                "worker-src": ["'self'", "blob:"],
+                "object-src": ["'none'"],
+                "base-uri": ["'self'"],
+                "frame-ancestors": ["'none'"],
+            }
         )
 
     OIDC_ENABLED: bool = False

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -240,18 +240,29 @@ class Settings(BaseSettings):
         Swagger UI loads its bundle/stylesheet from jsDelivr and a Cloudflare
         beacon, which the app-wide ``script-src 'self'`` (pentest MED-001)
         rightly blocks. Rather than weaken the global policy, this scoped policy
-        whitelists just those origins for the docs HTML response. Everything else
-        stays locked down: ``object-src 'none'``, ``frame-ancestors 'none'``,
-        and ``connect-src 'self'`` (Try-It-Out hits the same-origin API).
+        whitelists just those origins for the docs HTML response.
+
+        ``script-src`` also needs ``'unsafe-inline'``: ``get_swagger_ui_html``
+        boots the UI from an inline ``<script>`` (FastAPI provides no nonce, and
+        a hash would break whenever the title/openapi_url change). ``connect-src``
+        allows jsDelivr so the bundle's ``.map`` sourcemap fetch doesn't error;
+        Try-It-Out still reaches the same-origin API via ``'self'``. This is
+        confined to the dev-only, ``ENABLE_API_DOCS``-gated docs page — the rest
+        of the app keeps ``script-src 'self'``, ``object-src 'none'``, and
+        ``frame-ancestors 'none'``.
         """
         return _format_csp(
             {
                 "default-src": ["'self'"],
-                "script-src": ["'self'", *CSP_SWAGGER_SCRIPT_ORIGINS],
+                "script-src": [
+                    "'self'",
+                    "'unsafe-inline'",
+                    *CSP_SWAGGER_SCRIPT_ORIGINS,
+                ],
                 "style-src": ["'self'", "'unsafe-inline'", *CSP_SWAGGER_STYLE_ORIGINS],
                 "img-src": ["'self'", "data:", "https:"],
                 "font-src": ["'self'", "data:"],
-                "connect-src": ["'self'"],
+                "connect-src": ["'self'", *CSP_SWAGGER_STYLE_ORIGINS],
                 "worker-src": ["'self'", "blob:"],
                 "object-src": ["'none'"],
                 "base-uri": ["'self'"],

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -266,6 +266,9 @@ class Settings(BaseSettings):
                 "worker-src": ["'self'", "blob:"],
                 "object-src": ["'none'"],
                 "base-uri": ["'self'"],
+                # form-action does not fall back to default-src (CSP L2+), so set
+                # it explicitly to match the global policy's lockdown.
+                "form-action": ["'self'"],
                 "frame-ancestors": ["'none'"],
             }
         )

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -209,6 +209,25 @@ def test_csp_advanced_tool_origin_only_when_configured():
     assert "https://tool.example.com" in _directive(csp, "connect-src")
 
 
+def test_docs_csp_allows_swagger_cdn_but_main_csp_does_not():
+    # Swagger's jsDelivr + Cloudflare beacon scripts are permitted ONLY on the
+    # docs-scoped policy; the app-wide script-src stays 'self' (pentest MED-001).
+    settings = _settings()
+    docs = settings.docs_content_security_policy
+    main = settings.content_security_policy
+
+    assert "https://cdn.jsdelivr.net" in _directive(docs, "script-src")
+    assert "https://static.cloudflareinsights.com" in _directive(docs, "script-src")
+    assert "https://cdn.jsdelivr.net" in _directive(docs, "style-src")
+
+    # The relaxation must not leak into the global policy.
+    assert "cdn.jsdelivr.net" not in _directive(main, "script-src")
+    assert "cloudflareinsights.com" not in main
+    # Docs page keeps the high-value vectors locked down.
+    assert "object-src 'none'" in docs
+    assert "frame-ancestors 'none'" in docs
+
+
 def test_app_url_is_https_true_for_https():
     # Drives both the Secure cookie flag and the HSTS header (pentest SEC-16).
     assert _settings(APP_URL="https://app.example.com").app_url_is_https is True

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -230,6 +230,7 @@ def test_docs_csp_allows_swagger_cdn_but_main_csp_does_not():
     # Docs page keeps the high-value vectors locked down.
     assert "object-src 'none'" in docs
     assert "frame-ancestors 'none'" in docs
+    assert "form-action 'self'" in docs
 
 
 def test_app_url_is_https_true_for_https():

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -219,10 +219,14 @@ def test_docs_csp_allows_swagger_cdn_but_main_csp_does_not():
     assert "https://cdn.jsdelivr.net" in _directive(docs, "script-src")
     assert "https://static.cloudflareinsights.com" in _directive(docs, "script-src")
     assert "https://cdn.jsdelivr.net" in _directive(docs, "style-src")
+    # Swagger boots from an inline <script>, and its bundle fetches a .map.
+    assert "'unsafe-inline'" in _directive(docs, "script-src")
+    assert "https://cdn.jsdelivr.net" in _directive(docs, "connect-src")
 
     # The relaxation must not leak into the global policy.
     assert "cdn.jsdelivr.net" not in _directive(main, "script-src")
     assert "cloudflareinsights.com" not in main
+    assert "'unsafe-inline'" not in _directive(main, "script-src")
     # Docs page keeps the high-value vectors locked down.
     assert "object-src 'none'" in docs
     assert "frame-ancestors 'none'" in docs

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,15 +46,36 @@ reserved_prefixes = [
 # SEC-16). When disabled, FastAPI serves no /docs and no /openapi.json, so the
 # full route/parameter/error map isn't handed out. Defaults to on for dev
 # ergonomics; recommend ENABLE_API_DOCS=False in production.
+# docs_url is left None even when docs are enabled: the default route would
+# inherit the app-wide CSP and the jsDelivr-hosted Swagger assets get blocked.
+# A custom route below serves the same UI with a docs-scoped CSP instead.
 app = FastAPI(
     title=settings.PROJECT_NAME,
     version=__version__,
-    docs_url=f"{settings.API_V1_STR}/docs" if settings.ENABLE_API_DOCS else None,
+    docs_url=None,
     openapi_url=(
         f"{settings.API_V1_STR}/openapi.json" if settings.ENABLE_API_DOCS else None
     ),
     redoc_url=None,
 )
+
+if settings.ENABLE_API_DOCS:
+    from fastapi.openapi.docs import get_swagger_ui_html
+
+    _DOCS_CSP = settings.docs_content_security_policy
+
+    @app.get(f"{settings.API_V1_STR}/docs", include_in_schema=False)
+    async def swagger_ui_html() -> Response:
+        # get_swagger_ui_html returns the Swagger HTML that loads its JS/CSS from
+        # jsDelivr; attach the docs-scoped CSP so only this response permits them.
+        # The middleware uses setdefault, so this explicit header wins.
+        response = get_swagger_ui_html(
+            openapi_url=f"{settings.API_V1_STR}/openapi.json",
+            title=f"{settings.PROJECT_NAME} - Swagger UI",
+        )
+        response.headers["Content-Security-Policy"] = _DOCS_CSP
+        return response
+
 
 # Initialize rate limiter (uses shared limiter from app.core.rate_limit)
 app.state.limiter = limiter

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -142,6 +142,22 @@ async def test_docs_and_openapi_served_when_enabled(client: AsyncClient) -> None
     assert schema.json()["info"]["title"]
 
 
+@pytest.mark.integration
+async def test_docs_page_serves_scoped_csp(client: AsyncClient) -> None:
+    # The custom /docs route relaxes CSP so Swagger's jsDelivr assets load, but
+    # the relaxation must stay scoped to that page — /config keeps script-src 'self'.
+    docs_csp = (await client.get("/api/v1/docs")).headers.get(
+        "content-security-policy", ""
+    )
+    assert "https://cdn.jsdelivr.net" in docs_csp
+    assert "https://static.cloudflareinsights.com" in docs_csp
+
+    other_csp = (await client.get("/api/v1/config")).headers.get(
+        "content-security-policy", ""
+    )
+    assert "cdn.jsdelivr.net" not in other_csp.split("script-src")[1].split(";")[0]
+
+
 @pytest.mark.unit
 def test_docs_routes_return_404_when_disabled() -> None:
     """HTTP-level check for the disabled path.
@@ -167,6 +183,10 @@ def test_docs_routes_return_404_when_disabled() -> None:
 @pytest.mark.unit
 def test_real_app_serves_docs_only_when_enabled() -> None:
     # The deployed app object reflects the (default-on) setting — guards
-    # against the wiring in app.main drifting from ENABLE_API_DOCS.
-    assert main_module.app.docs_url == "/api/v1/docs"
+    # against the wiring in app.main drifting from ENABLE_API_DOCS. docs_url is
+    # None because docs are served by a custom route (with a scoped CSP), so we
+    # assert that route is registered rather than the built-in attribute.
+    assert main_module.app.docs_url is None
     assert main_module.app.openapi_url == "/api/v1/openapi.json"
+    docs_routes = {getattr(r, "path", None) for r in main_module.app.routes}
+    assert "/api/v1/docs" in docs_routes

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -152,9 +152,10 @@ async def test_docs_page_serves_scoped_csp(client: AsyncClient) -> None:
     assert "https://cdn.jsdelivr.net" in docs_csp
     assert "https://static.cloudflareinsights.com" in docs_csp
 
-    other_csp = (await client.get("/api/v1/config")).headers.get(
-        "content-security-policy", ""
-    )
+    config_resp = await client.get("/api/v1/config")
+    assert config_resp.status_code == 200
+    other_csp = config_resp.headers.get("content-security-policy", "")
+    assert "script-src" in other_csp
     assert "cdn.jsdelivr.net" not in other_csp.split("script-src")[1].split(";")[0]
 
 
@@ -168,10 +169,14 @@ def test_docs_routes_return_404_when_disabled() -> None:
     HTTP that the docs/openapi routes don't exist (404), not merely that the
     attributes are ``None``. The enabled path is covered against the real app
     by ``test_docs_and_openapi_served_when_enabled``.
+
+    Mirrors the real wiring: ``docs_url`` is always ``None`` (docs are served by
+    a custom route, registered only when enabled), and with docs disabled that
+    route is never added, so ``openapi_url`` is ``None`` too.
     """
     cfg = Settings(ENABLE_API_DOCS=False)
     disabled = FastAPI(
-        docs_url=f"{cfg.API_V1_STR}/docs" if cfg.ENABLE_API_DOCS else None,
+        docs_url=None,
         openapi_url=(f"{cfg.API_V1_STR}/openapi.json" if cfg.ENABLE_API_DOCS else None),
         redoc_url=None,
     )


### PR DESCRIPTION
## Problem

Follow-up to #688. The Swagger `/docs` page is still blocked by the CSP: FastAPI's default docs route loads its UI bundle and stylesheet from `cdn.jsdelivr.net` (plus, behind a Cloudflare proxy, a Web Analytics beacon from `static.cloudflareinsights.com`). The app-wide `script-src 'self'` (pentest MED-001) correctly blocks those, so the docs page renders broken.

Adding `cdn.jsdelivr.net` to the **global** `script-src` would re-open the exact hole MED-001 closed, for every page in the app.

## Approach

Keep the global policy locked down; relax CSP **only on the docs HTML response**:

- `backend/app/main.py`: set `docs_url=None` and register a custom `/docs` route (gated on `ENABLE_API_DOCS`) that serves `get_swagger_ui_html(...)` with an explicit, docs-scoped `Content-Security-Policy` header. The `SecurityHeadersMiddleware` uses `setdefault`, so the per-route header wins.
- `backend/app/core/config.py`: add `Settings.docs_content_security_policy` — same hardened baseline (`object-src 'none'`, `frame-ancestors 'none'`, `connect-src 'self'` for Try-It-Out) but whitelisting the Swagger CDN/beacon origins for `script-src`/`style-src` only. Extracted a shared `_format_csp()` helper.

Every other route keeps `script-src 'self'`.

## Tests

- `test_docs_csp_allows_swagger_cdn_but_main_csp_does_not` — docs policy allows the CDN origins; the global policy does not.
- `test_docs_page_serves_scoped_csp` — the live `/docs` response carries the relaxed CSP while `/config` stays strict.
- Updated `test_real_app_serves_docs_only_when_enabled` — `app.docs_url` is now `None`; asserts the custom route is registered instead.

```
cd backend && pytest app/core/config_test.py app/main_test.py
```

## Note

This is the backend-served CSP. If a deploy also enforces the `<meta>` CSP in `frontend/index.html`, the `/docs` page is served by the backend (not the SPA), so it isn't affected by that meta tag.