### PR TITLE
Stop footer dropdowns from closing the mobile sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Initiative logo now displays in emails.
 - Corrected malformed stored defaults for tag and task-status colors and icons.
 - Spell-check dictionaries, Excalidraw whiteboard fonts, and the Swagger API docs page are no longer blocked by the Content-Security-Policy.
+- Opening the user or theme menu from the sidebar footer on mobile no longer collapses the sidebar.
 
 ### Security
 

--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -20,7 +20,9 @@ export const ModeToggle = () => {
   const { t } = useTranslation("nav");
 
   return (
-    <DropdownMenu>
+    // modal={false}: a modal dropdown nested in the non-modal mobile sidebar
+    // drawer dismisses the drawer on open (see SidebarUserFooter).
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"

--- a/frontend/src/components/sidebar/SidebarUserFooter.tsx
+++ b/frontend/src/components/sidebar/SidebarUserFooter.tsx
@@ -61,7 +61,10 @@ export const SidebarUserFooter = ({
     <SidebarFooter className="border-t border-r">
       <div className="flex flex-col">
         <div className="flex items-center gap-2 p-2">
-          <DropdownMenu>
+          {/* modal={false}: a modal dropdown nested in the non-modal mobile
+              sidebar drawer dismisses the drawer on open. Matches the
+              notification-bell popover, which is non-modal and doesn't. */}
+          <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -464,6 +464,12 @@ const MobileSidebar = ({
           // first control (the guild expand toggle), and its focus-triggered
           // tooltip would then stay stuck open until the user taps elsewhere.
           onOpenAutoFocus={(e) => e.preventDefault()}
+          // Don't let the Sheet dismiss itself on outside interaction. Nested
+          // poppers (the user-footer dropdown, tooltips, selects) portal to the
+          // body, so opening one reads as a focus/pointer event "outside" the
+          // drawer and would otherwise collapse it. Tap-outside-to-close is
+          // already handled by the custom overlay below, plus swipe and the X.
+          onInteractOutside={(e) => e.preventDefault()}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}


### PR DESCRIPTION
## Problem

On mobile, opening the **user-account menu** or the **theme menu** from the sidebar footer collapsed the whole sidebar drawer. The notification bell did *not* — which was the giveaway.

## Cause

Radix component defaults differ:
- `Popover` (the notification bell) defaults to `modal={false}`.
- `DropdownMenu` (the user-account and theme menus) defaults to `modal={true}`.

A **modal** popper opening inside the **non-modal** mobile sidebar drawer dismisses the drawer. The non-modal bell didn't, which is why it behaved correctly.

## Fix

- `ModeToggle.tsx` and `SidebarUserFooter.tsx`: set `modal={false}` on both `DropdownMenu`s so they match the bell's popover.
- Kept the `onInteractOutside` guard on the mobile `SheetContent` — that's what lets a non-modal popper stay open without collapsing the drawer (the bell relies on it, and so do the now-non-modal dropdowns).

## Notes

- Any *other* `DropdownMenu` rendered inside the mobile drawer (e.g. kebab/context menus in the initiatives/projects tree) would hit the same issue and need the same `modal={false}`. Left as a follow-up rather than broadening the change here; making it the shared-primitive default is an option if we'd prefer.

## Testing

- `pnpm typecheck` and `pnpm biome check` clean.
- Manual (mobile): open the user menu and the theme menu from the footer — the drawer stays open; selecting an item still works; the notification bell is unchanged.