### PR TITLE
Add SECRET_KEY rotation and JWT_SECRET_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`SECRET_KEY` rotation.** `SECRET_KEY` encrypts stored data (emails, OIDC/SMTP/AI secrets) and roots the email-lookup hash, so it can't be swapped in place — a bare change would lock out every user and orphan those secrets. To rotate it, set `PREVIOUS_SECRET_KEY` to the old value, set `SECRET_KEY` to a new one, and redeploy: the app re-encrypts everything on startup (idempotent), or run `python -m app.db.secret_key_rotation` manually. Unset `PREVIOUS_SECRET_KEY` once the logs report 0 failures. A failed `SECRET_KEY` validation now spells out this path in the error.
+- **`JWT_SECRET_KEY` for independent session-token rotation.** Optional dedicated key for signing session/login JWTs; when set it decouples token signing from `SECRET_KEY`, so it can be rotated freely — the only effect is logging everyone out, with no impact on encrypted-at-rest data. Falls back to `SECRET_KEY` when unset, so existing deployments are unaffected.
 - Expandable guild sidebar — the guild rail opens into a flyout showing each guild's full name and member count.
 - German (Deutsch) interface language.
 - Guild schemas are re-checked on every boot, so upgrades automatically add new tables to existing guilds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`SECRET_KEY` rotation.** `SECRET_KEY` encrypts stored data (emails, OIDC/SMTP/AI secrets) and roots the email-lookup hash, so it can't be swapped in place — a bare change would lock out every user and orphan those secrets. To rotate it, set `PREVIOUS_SECRET_KEY` to the old value, set `SECRET_KEY` to a new one, and redeploy: the app re-encrypts everything on startup (idempotent), or run `python -m app.db.secret_key_rotation` manually. Unset `PREVIOUS_SECRET_KEY` once the logs report 0 failures. A failed `SECRET_KEY` validation now spells out this path in the error.
-- **`JWT_SECRET_KEY` for independent session-token rotation.** Optional dedicated key for signing session/login JWTs; when set it decouples token signing from `SECRET_KEY`, so it can be rotated freely — the only effect is logging everyone out, with no impact on encrypted-at-rest data. Falls back to `SECRET_KEY` when unset, so existing deployments are unaffected.
+- **`JWT_SIGNING_KEY` for independent session-token rotation.** Optional dedicated key for signing session/login JWTs; when set it decouples token signing from `SECRET_KEY`, so it can be rotated freely — the only effect is logging everyone out, with no impact on encrypted-at-rest data. Falls back to `SECRET_KEY` when unset, so existing deployments are unaffected.
 - Expandable guild sidebar — the guild rail opens into a flyout showing each guild's full name and member count.
 - German (Deutsch) interface language.
 - Guild schemas are re-checked on every boot, so upgrades automatically add new tables to existing guilds.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,20 @@ PROJECT_NAME=Initiative API
 API_V1_STR=/api/v1
 # REQUIRED: generate with: openssl rand -hex 32
 # The app refuses to start when SECRET_KEY is unset, a known placeholder, or shorter than 32 chars.
+# SECRET_KEY roots all encrypted-at-rest data (emails, OIDC/SMTP/AI secrets) and the
+# email-lookup hash — do NOT swap it in place. To change it, set PREVIOUS_SECRET_KEY to
+# the old value, set SECRET_KEY to the new one, and redeploy: the app re-encrypts
+# everything on startup (or run `python -m app.db.secret_key_rotation`). Unset
+# PREVIOUS_SECRET_KEY once the logs report 0 failures.
 SECRET_KEY=
+# OPTIONAL: the previous SECRET_KEY, set only while rotating it (see above). Taken
+# verbatim — leave unset in normal operation.
+PREVIOUS_SECRET_KEY=
+# OPTIONAL: dedicated JWT signing key. When set, session tokens are signed with this
+# instead of SECRET_KEY, so it can be rotated freely — the only effect is forcing every
+# user to log in again, with no impact on stored data. Same strength rules as SECRET_KEY.
+# Falls back to SECRET_KEY when unset. Generate with: openssl rand -hex 32
+JWT_SECRET_KEY=
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 ALGORITHM=HS256
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,7 +16,7 @@ PREVIOUS_SECRET_KEY=
 # instead of SECRET_KEY, so it can be rotated freely — the only effect is forcing every
 # user to log in again, with no impact on stored data. Same strength rules as SECRET_KEY.
 # Falls back to SECRET_KEY when unset. Generate with: openssl rand -hex 32
-JWT_SECRET_KEY=
+JWT_SIGNING_KEY=
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 ALGORITHM=HS256
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -185,7 +185,7 @@ async def get_current_user(
     # the access token expires.
     try:
         payload = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
         )
         token_data = TokenPayload(**payload)
     except jwt.PyJWTError as exc:
@@ -637,7 +637,7 @@ async def get_upload_user(
     # so the SPA can auto-redirect to /welcome when the session lapses.
     try:
         payload = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
         )
         token_data = TokenPayload(**payload)
     except jwt.PyJWTError:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -90,7 +90,7 @@ _SECRET_KEY_ROTATION_HINT = (
 
 
 def _validate_strong_key(value: str, var_name: str, *, rotation_hint: bool) -> str:
-    """Enforce the shared strength rules for SECRET_KEY / JWT_SECRET_KEY: non-empty,
+    """Enforce the shared strength rules for SECRET_KEY / JWT_SIGNING_KEY: non-empty,
     not a known placeholder, no surrounding whitespace, >= 32 chars. ``rotation_hint``
     appends the safe-change instructions for keys that encrypt stored data."""
     hint = _SECRET_KEY_ROTATION_HINT if rotation_hint else ""
@@ -146,7 +146,7 @@ class Settings(BaseSettings):
     # signed and verified with this instead of SECRET_KEY (see ``jwt_signing_key``),
     # so it can be rotated freely — the only cost is forcing every user to re-login,
     # with no impact on encrypted-at-rest data. Falls back to SECRET_KEY when unset.
-    JWT_SECRET_KEY: str | None = None
+    JWT_SIGNING_KEY: str | None = None
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     ALGORITHM: str = "HS256"
     COOKIE_NAME: str = "session_token"
@@ -162,22 +162,22 @@ class Settings(BaseSettings):
         # fix — "just set a new key" — silently orphans all encrypted data.
         return _validate_strong_key(value, "SECRET_KEY", rotation_hint=True)
 
-    @field_validator("JWT_SECRET_KEY")
+    @field_validator("JWT_SIGNING_KEY")
     @classmethod
-    def _validate_jwt_secret_key(cls, value: str | None) -> str | None:
+    def _validate_jwt_signing_key(cls, value: str | None) -> str | None:
         # Optional, but when present it signs JWTs, so hold it to the same strength
         # bar as SECRET_KEY. No rotation hint: rotating it only forces re-login, so a
         # bare swap is the correct fix.
         if value is None:
             return None
-        return _validate_strong_key(value, "JWT_SECRET_KEY", rotation_hint=False)
+        return _validate_strong_key(value, "JWT_SIGNING_KEY", rotation_hint=False)
 
     @property
     def jwt_signing_key(self) -> str:
-        """Key used to sign/verify JWTs. Prefers the dedicated JWT_SECRET_KEY so it
+        """Key used to sign/verify JWTs. Prefers the dedicated JWT_SIGNING_KEY so it
         can be rotated without touching encrypted-at-rest data; falls back to
         SECRET_KEY for deployments that haven't set one."""
-        return self.JWT_SECRET_KEY or self.SECRET_KEY
+        return self.JWT_SIGNING_KEY or self.SECRET_KEY
 
     @property
     def app_url_is_https(self) -> bool:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -75,6 +75,48 @@ def _origin_of(url: str) -> str | None:
     return None
 
 
+# How an operator safely changes the encryption root. Appended to SECRET_KEY
+# validation failures (rotation_hint=True) so the boot-crash message points at the
+# rotation path instead of inviting the destructive "just generate a new one" fix.
+# It must travel in the ValueError text itself: pydantic validators run at settings
+# load, before logging is configured, so there's nowhere else for it to surface.
+_SECRET_KEY_ROTATION_HINT = (
+    " To CHANGE SECRET_KEY on an existing deployment, do NOT swap it directly — it "
+    "encrypts stored data (emails, OIDC/SMTP/AI secrets) and roots email lookup, so a "
+    "bare swap locks out every user and orphans those secrets. Instead set the old "
+    "value as PREVIOUS_SECRET_KEY, set SECRET_KEY to the new key, and run "
+    "`python -m app.db.secret_key_rotation`."
+)
+
+
+def _validate_strong_key(value: str, var_name: str, *, rotation_hint: bool) -> str:
+    """Enforce the shared strength rules for SECRET_KEY / JWT_SECRET_KEY: non-empty,
+    not a known placeholder, no surrounding whitespace, >= 32 chars. ``rotation_hint``
+    appends the safe-change instructions for keys that encrypt stored data."""
+    hint = _SECRET_KEY_ROTATION_HINT if rotation_hint else ""
+    known_placeholders = {"change-me", "changeme", "super-secret-key", "secret"}
+    normalized = value.strip()
+    if not normalized or normalized.lower() in known_placeholders:
+        raise ValueError(
+            f"{var_name} is unset or a known placeholder. Generate a real key "
+            f"with: openssl rand -hex 32{hint}"
+        )
+    # Reject (rather than silently strip) surrounding whitespace: every byte of this
+    # value feeds HMAC/Fernet key derivation, so quietly normalizing it would rotate
+    # the effective key out from under a deployment whose env var carried whitespace.
+    if normalized != value:
+        raise ValueError(
+            f"{var_name} has leading or trailing whitespace. Remove it — the exact "
+            f"value is used for key derivation.{hint}"
+        )
+    if len(normalized) < 32:
+        raise ValueError(
+            f"{var_name} must be at least 32 characters. Generate one with: "
+            f"openssl rand -hex 32{hint}"
+        )
+    return value
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -94,6 +136,17 @@ class Settings(BaseSettings):
     DATABASE_URL_ADMIN: str  # Admin connection with BYPASSRLS for migrations (required)
 
     SECRET_KEY: str
+    # Optional: the *previous* SECRET_KEY, set only while rotating the encryption
+    # root. Read verbatim (NO validation/normalization) so it reproduces the old
+    # effective key exactly — it may be the weak/whitespaced key being escaped, and
+    # the legacy code never stripped it. Consumed by app.db.secret_key_rotation;
+    # remove it once the rotation has run.
+    PREVIOUS_SECRET_KEY: str | None = None
+    # Optional: dedicated JWT signing key. When set, session/upload/handoff JWTs are
+    # signed and verified with this instead of SECRET_KEY (see ``jwt_signing_key``),
+    # so it can be rotated freely — the only cost is forcing every user to re-login,
+    # with no impact on encrypted-at-rest data. Falls back to SECRET_KEY when unset.
+    JWT_SECRET_KEY: str | None = None
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     ALGORITHM: str = "HS256"
     COOKIE_NAME: str = "session_token"
@@ -101,33 +154,30 @@ class Settings(BaseSettings):
     @field_validator("SECRET_KEY")
     @classmethod
     def _validate_secret_key(cls, value: str) -> str:
-        # SECRET_KEY signs session JWTs and the OIDC state HMAC, and roots all
-        # Fernet field encryption (SMTP password, OIDC client secret, AI keys,
-        # refresh tokens) plus the email_hash HMAC. A known placeholder or
-        # short key makes every one of those forgeable/decryptable, so fail
-        # closed at startup rather than booting with a guessable key.
-        known_placeholders = {"change-me", "changeme", "super-secret-key", "secret"}
-        normalized = value.strip()
-        if not normalized or normalized.lower() in known_placeholders:
-            raise ValueError(
-                "SECRET_KEY is unset or a known placeholder. Generate a real "
-                "key with: openssl rand -hex 32"
-            )
-        # Reject (rather than silently strip) surrounding whitespace: every
-        # byte of this value feeds HMAC/Fernet key derivation, so quietly
-        # normalizing it would rotate the effective key out from under a
-        # deployment whose env var carried stray whitespace.
-        if normalized != value:
-            raise ValueError(
-                "SECRET_KEY has leading or trailing whitespace. Remove it — "
-                "the exact value is used for key derivation."
-            )
-        if len(normalized) < 32:
-            raise ValueError(
-                "SECRET_KEY must be at least 32 characters. Generate one "
-                "with: openssl rand -hex 32"
-            )
-        return value
+        # SECRET_KEY signs the OIDC state HMAC and roots all Fernet field encryption
+        # (SMTP password, OIDC client secret, AI keys, refresh tokens) plus the
+        # email_hash HMAC. A known placeholder or short key makes every one of those
+        # forgeable/decryptable, so fail closed at startup rather than booting with a
+        # guessable key. The hint points at the safe rotation path because the naive
+        # fix — "just set a new key" — silently orphans all encrypted data.
+        return _validate_strong_key(value, "SECRET_KEY", rotation_hint=True)
+
+    @field_validator("JWT_SECRET_KEY")
+    @classmethod
+    def _validate_jwt_secret_key(cls, value: str | None) -> str | None:
+        # Optional, but when present it signs JWTs, so hold it to the same strength
+        # bar as SECRET_KEY. No rotation hint: rotating it only forces re-login, so a
+        # bare swap is the correct fix.
+        if value is None:
+            return None
+        return _validate_strong_key(value, "JWT_SECRET_KEY", rotation_hint=False)
+
+    @property
+    def jwt_signing_key(self) -> str:
+        """Key used to sign/verify JWTs. Prefers the dedicated JWT_SECRET_KEY so it
+        can be rotated without touching encrypted-at-rest data; falls back to
+        SECRET_KEY for deployments that haven't set one."""
+        return self.JWT_SECRET_KEY or self.SECRET_KEY
 
     @property
     def app_url_is_https(self) -> bool:

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -58,7 +58,7 @@ def test_secret_key_failure_points_at_safe_rotation_path():
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# PREVIOUS_SECRET_KEY / JWT_SECRET_KEY / jwt_signing_key
+# PREVIOUS_SECRET_KEY / JWT_SIGNING_KEY / jwt_signing_key
 # ──────────────────────────────────────────────────────────────────────────
 
 
@@ -74,23 +74,23 @@ def test_previous_secret_key_taken_verbatim_without_validation():
 
 def test_jwt_signing_key_falls_back_to_secret_key_when_unset():
     settings = _settings()
-    assert settings.JWT_SECRET_KEY is None
+    assert settings.JWT_SIGNING_KEY is None
     assert settings.jwt_signing_key == settings.SECRET_KEY
 
 
 def test_jwt_signing_key_prefers_dedicated_key_when_set():
     other = "c" * 48
-    settings = _settings(JWT_SECRET_KEY=other)
+    settings = _settings(JWT_SIGNING_KEY=other)
     assert settings.jwt_signing_key == other
     assert settings.jwt_signing_key != settings.SECRET_KEY
 
 
-def test_jwt_secret_key_enforces_strong_rules_when_set():
+def test_jwt_signing_key_enforces_strong_rules_when_set():
     # Same bar as SECRET_KEY, but only when present.
-    with pytest.raises(ValidationError, match="JWT_SECRET_KEY"):
-        _settings(JWT_SECRET_KEY="tooshort")
-    with pytest.raises(ValidationError, match="JWT_SECRET_KEY"):
-        _settings(JWT_SECRET_KEY="change-me")
+    with pytest.raises(ValidationError, match="JWT_SIGNING_KEY"):
+        _settings(JWT_SIGNING_KEY="tooshort")
+    with pytest.raises(ValidationError, match="JWT_SIGNING_KEY"):
+        _settings(JWT_SIGNING_KEY="change-me")
 
 
 def test_cors_allowed_origins_accepts_comma_separated_string():

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -47,6 +47,52 @@ def test_secret_key_accepts_strong_value():
     assert _settings().SECRET_KEY == TEST_SECRET_KEY
 
 
+def test_secret_key_failure_points_at_safe_rotation_path():
+    """The boot-crash message must steer operators to the rotation path, not the
+    destructive 'just generate a new one' fix — SECRET_KEY encrypts stored data."""
+    with pytest.raises(ValidationError) as exc:
+        _settings(SECRET_KEY="tooshort")
+    msg = str(exc.value)
+    assert "PREVIOUS_SECRET_KEY" in msg
+    assert "app.db.secret_key_rotation" in msg
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PREVIOUS_SECRET_KEY / JWT_SECRET_KEY / jwt_signing_key
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_previous_secret_key_taken_verbatim_without_validation():
+    """The OLD key must be reproduced exactly — it may be the weak/whitespaced key
+    being escaped, so the strong-key rules must NOT apply to it."""
+    weak_old = "  short-old-key  "  # would fail SECRET_KEY validation
+    settings = _settings(PREVIOUS_SECRET_KEY=weak_old)
+    assert settings.PREVIOUS_SECRET_KEY == weak_old
+    # Default when unset.
+    assert _settings().PREVIOUS_SECRET_KEY is None
+
+
+def test_jwt_signing_key_falls_back_to_secret_key_when_unset():
+    settings = _settings()
+    assert settings.JWT_SECRET_KEY is None
+    assert settings.jwt_signing_key == settings.SECRET_KEY
+
+
+def test_jwt_signing_key_prefers_dedicated_key_when_set():
+    other = "c" * 48
+    settings = _settings(JWT_SECRET_KEY=other)
+    assert settings.jwt_signing_key == other
+    assert settings.jwt_signing_key != settings.SECRET_KEY
+
+
+def test_jwt_secret_key_enforces_strong_rules_when_set():
+    # Same bar as SECRET_KEY, but only when present.
+    with pytest.raises(ValidationError, match="JWT_SECRET_KEY"):
+        _settings(JWT_SECRET_KEY="tooshort")
+    with pytest.raises(ValidationError, match="JWT_SECRET_KEY"):
+        _settings(JWT_SECRET_KEY="change-me")
+
+
 def test_cors_allowed_origins_accepts_comma_separated_string():
     settings = _settings(
         CORS_ALLOWED_ORIGINS="https://a.example.com, https://b.example.com",

--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -23,44 +23,66 @@ SALT_EMAIL = b"email"
 SALT_EVENT_PUBLISHER_PAYLOAD = b"event-publisher-payload"
 
 
-def _derive_fernet_key(salt: bytes) -> bytes:
+def _resolve_secret_key(secret_key: str | None) -> str:
+    """The explicit key when given, else the live SECRET_KEY. Lets the rotation
+    sweep (app.db.secret_key_rotation) decrypt under the old key and re-encrypt
+    under the new one without mutating global settings; default callers are
+    unaffected."""
+    return secret_key if secret_key is not None else settings.SECRET_KEY
+
+
+def _derive_fernet_key(salt: bytes, secret_key: str) -> bytes:
     hkdf = HKDF(
         algorithm=hashes.SHA256(),
         length=32,
         salt=salt,
         info=b"fernet-key",
     )
-    raw = hkdf.derive(settings.SECRET_KEY.encode())
+    raw = hkdf.derive(secret_key.encode())
     return base64.urlsafe_b64encode(raw)
 
 
-_fernets: dict[bytes, Fernet] = {}
+# Cached per (secret_key, salt): rotation derives Fernets for two distinct keys, so
+# the cache key must include the secret or the second key would collide with the first.
+_fernets: dict[tuple[str, bytes], Fernet] = {}
 
 
-def _get_fernet(salt: bytes) -> Fernet:
-    if salt not in _fernets:
-        _fernets[salt] = Fernet(_derive_fernet_key(salt))
-    return _fernets[salt]
+def _get_fernet(salt: bytes, secret_key: str) -> Fernet:
+    cache_key = (secret_key, salt)
+    if cache_key not in _fernets:
+        _fernets[cache_key] = Fernet(_derive_fernet_key(salt, secret_key))
+    return _fernets[cache_key]
 
 
-def hash_email(email: str) -> str:
+def hash_email(email: str, *, secret_key: str | None = None) -> str:
     """Deterministic HMAC-SHA256 of normalized email, keyed with SECRET_KEY.
 
-    Used for equality lookups (WHERE email_hash = ?) and unique constraints.
-    Never changes the derived key — adding a new salt would invalidate all hashes.
+    Used for equality lookups (WHERE email_hash = ?) and unique constraints. Pass
+    ``secret_key`` to hash under a specific key (the rotation sweep recomputes hashes
+    under the new key); default uses the live SECRET_KEY.
     """
     normalized = email.lower().strip()
     return _hmac.new(
-        settings.SECRET_KEY.encode(), normalized.encode(), _hashlib.sha256
+        _resolve_secret_key(secret_key).encode(), normalized.encode(), _hashlib.sha256
     ).hexdigest()
 
 
-def encrypt_field(plaintext: str, salt: bytes) -> str:
-    return _get_fernet(salt).encrypt(plaintext.encode()).decode()
+def encrypt_field(plaintext: str, salt: bytes, *, secret_key: str | None = None) -> str:
+    return (
+        _get_fernet(salt, _resolve_secret_key(secret_key))
+        .encrypt(plaintext.encode())
+        .decode()
+    )
 
 
-def decrypt_field(ciphertext: str, salt: bytes) -> str:
-    return _get_fernet(salt).decrypt(ciphertext.encode()).decode()
+def decrypt_field(
+    ciphertext: str, salt: bytes, *, secret_key: str | None = None
+) -> str:
+    return (
+        _get_fernet(salt, _resolve_secret_key(secret_key))
+        .decrypt(ciphertext.encode())
+        .decode()
+    )
 
 
 # Kept for backward compatibility — used by oidc_refresh.py and auth.py

--- a/backend/app/core/encryption_test.py
+++ b/backend/app/core/encryption_test.py
@@ -1,5 +1,7 @@
 """Unit tests for the encryption module."""
 
+import pytest
+
 from app.core.encryption import (
     SALT_EMAIL,
     decrypt_field,
@@ -60,3 +62,52 @@ def test_hash_email_salt_isolation() -> None:
     assert ct_email != ct_ai
     assert decrypt_field(ct_email, SALT_EMAIL) == "secret"
     assert decrypt_field(ct_ai, SALT_AI_API_KEY) == "secret"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Explicit-key support (used by the SECRET_KEY rotation sweep to decrypt under
+# the old key and re-encrypt under the new one without mutating global settings).
+# ──────────────────────────────────────────────────────────────────────────
+
+# Two distinct test-only keys (each ≥32 chars). Not secrets.
+_KEY_A = "a" * 48
+_KEY_B = "b" * 48
+
+
+def test_encrypt_decrypt_roundtrip_with_explicit_key() -> None:
+    """A value encrypted under an explicit key round-trips with that same key."""
+    ct = encrypt_field("hunter2", SALT_EMAIL, secret_key=_KEY_A)
+    assert decrypt_field(ct, SALT_EMAIL, secret_key=_KEY_A) == "hunter2"
+
+
+def test_ciphertext_from_one_key_fails_under_another() -> None:
+    """Ciphertext from key A must NOT decrypt under key B — this is what lets the
+    rotation sweep tell rotated rows from un-rotated ones."""
+    from cryptography.fernet import InvalidToken
+
+    ct = encrypt_field("hunter2", SALT_EMAIL, secret_key=_KEY_A)
+    with pytest.raises(InvalidToken):
+        decrypt_field(ct, SALT_EMAIL, secret_key=_KEY_B)
+
+
+def test_explicit_old_to_new_reencrypt() -> None:
+    """The rotation primitive: decrypt under old key, re-encrypt under new key."""
+    old_ct = encrypt_field("smtp-pw", SALT_EMAIL, secret_key=_KEY_A)
+    plain = decrypt_field(old_ct, SALT_EMAIL, secret_key=_KEY_A)
+    new_ct = encrypt_field(plain, SALT_EMAIL, secret_key=_KEY_B)
+    assert decrypt_field(new_ct, SALT_EMAIL, secret_key=_KEY_B) == "smtp-pw"
+
+
+def test_hash_email_explicit_key_differs_per_key() -> None:
+    """The email HMAC under different keys differs — so a rotation must recompute it,
+    and lookups must use candidates matching the active key."""
+    h_a = hash_email("alice@example.com", secret_key=_KEY_A)
+    h_b = hash_email("alice@example.com", secret_key=_KEY_B)
+    assert h_a != h_b
+    assert len(h_a) == len(h_b) == 64
+    # Explicit key matching the live default is consistent with the no-arg form.
+    from app.core.config import settings
+
+    assert hash_email(
+        "alice@example.com", secret_key=settings.SECRET_KEY
+    ) == hash_email("alice@example.com")

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -65,7 +65,7 @@ def create_access_token(
         expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode: dict[str, Any] = {"sub": subject, "exp": expire, "ver": token_version}
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    return jwt.encode(to_encode, settings.jwt_signing_key, algorithm=settings.ALGORITHM)
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -105,9 +105,9 @@ def create_upload_token(
     """Mint a short-lived, uploads-scoped JWT for ``user_id``.
 
     Returns ``(token, expires_in_seconds)`` so the SPA can schedule a refresh
-    before the token lapses. Signed with the same HS256 ``SECRET_KEY`` as the
-    session JWT but distinguished by its ``aud``/``scope`` claims and the
-    absence of ``ver`` — the general auth path will not accept it.
+    before the token lapses. Signed with the same HS256 JWT key as the session
+    JWT but distinguished by its ``aud``/``scope`` claims and the absence of
+    ``ver`` — the general auth path will not accept it.
     """
     now = datetime.now(timezone.utc)
     payload: dict[str, Any] = {
@@ -117,7 +117,7 @@ def create_upload_token(
         "iat": int(now.timestamp()),
         "exp": now + expires_in,
     }
-    token = jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    token = jwt.encode(payload, settings.jwt_signing_key, algorithm=settings.ALGORITHM)
     return token, int(expires_in.total_seconds())
 
 
@@ -132,7 +132,7 @@ def verify_upload_token(token: str) -> int:
     try:
         payload = jwt.decode(
             token,
-            settings.SECRET_KEY,
+            settings.jwt_signing_key,
             algorithms=[settings.ALGORITHM],
             audience=UPLOAD_TOKEN_AUDIENCE,
             options={"require": ["exp", "iat", "sub", "aud"]},
@@ -166,8 +166,8 @@ ADVANCED_TOOL_HANDOFF_LIFETIME = timedelta(seconds=60)
 def _resolve_handoff_signing_material() -> tuple[str, str, str | None]:
     """Pick (key, algorithm, kid) for signing advanced-tool handoff JWTs.
 
-    Default: HS256 with SECRET_KEY — works out of the box for OSS but
-    requires sharing the secret with the embed backend (single point of
+    Default: HS256 with the JWT signing key — works out of the box for OSS
+    but requires sharing the secret with the embed backend (single point of
     compromise).
 
     Preferred: RS256 with HANDOFF_SIGNING_PRIVATE_KEY_PEM — FOSS holds
@@ -179,7 +179,7 @@ def _resolve_handoff_signing_material() -> tuple[str, str, str | None]:
     private_pem = settings.HANDOFF_SIGNING_PRIVATE_KEY_PEM
     if private_pem:
         return private_pem, "RS256", settings.HANDOFF_SIGNING_KEY_ID
-    return settings.SECRET_KEY, "HS256", None
+    return settings.jwt_signing_key, "HS256", None
 
 
 def create_advanced_tool_handoff_token(

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -258,6 +258,44 @@ def test_verify_upload_token_rejects_expired_token():
 
 
 @pytest.mark.unit
+def test_session_jwt_signed_with_dedicated_jwt_secret_key(monkeypatch):
+    """When JWT_SECRET_KEY is set, session JWTs are signed/verified with it — so it
+    can be rotated independently of the encryption-rooting SECRET_KEY."""
+    jwt_key = "j" * 48
+    monkeypatch.setattr(security.settings, "JWT_SECRET_KEY", jwt_key)
+
+    token = security.create_access_token(subject="7", token_version=1)
+    # Verifies under the dedicated key...
+    payload = jwt.decode(token, jwt_key, algorithms=[security.settings.ALGORITHM])
+    assert payload["sub"] == "7"
+    # ...and NOT under SECRET_KEY (proving the keys are actually decoupled).
+    with pytest.raises(jwt.InvalidSignatureError):
+        jwt.decode(
+            token,
+            security.settings.SECRET_KEY,
+            algorithms=[security.settings.ALGORITHM],
+        )
+
+
+@pytest.mark.unit
+def test_jwt_secret_key_does_not_affect_encryption(monkeypatch):
+    """Setting/rotating JWT_SECRET_KEY must not change encryption or the email HMAC —
+    those are rooted in SECRET_KEY alone, so a JWT rotation can't orphan data."""
+    from app.core.encryption import SALT_EMAIL, encrypt_field, hash_email
+
+    before_ct = encrypt_field("alice@example.com", SALT_EMAIL)
+    before_hash = hash_email("alice@example.com")
+
+    monkeypatch.setattr(security.settings, "JWT_SECRET_KEY", "j" * 48)
+
+    # Same email hash, and the pre-rotation ciphertext still decrypts.
+    from app.core.encryption import decrypt_field
+
+    assert hash_email("alice@example.com") == before_hash
+    assert decrypt_field(before_ct, SALT_EMAIL) == "alice@example.com"
+
+
+@pytest.mark.unit
 def test_verify_upload_token_rejects_wrong_audience():
     """A token signed with our secret but carrying a foreign audience (e.g. the
     advanced-tool handoff) must not be honored as an upload token."""

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -258,11 +258,11 @@ def test_verify_upload_token_rejects_expired_token():
 
 
 @pytest.mark.unit
-def test_session_jwt_signed_with_dedicated_jwt_secret_key(monkeypatch):
-    """When JWT_SECRET_KEY is set, session JWTs are signed/verified with it — so it
+def test_session_jwt_signed_with_dedicated_jwt_signing_key(monkeypatch):
+    """When JWT_SIGNING_KEY is set, session JWTs are signed/verified with it — so it
     can be rotated independently of the encryption-rooting SECRET_KEY."""
     jwt_key = "j" * 48
-    monkeypatch.setattr(security.settings, "JWT_SECRET_KEY", jwt_key)
+    monkeypatch.setattr(security.settings, "JWT_SIGNING_KEY", jwt_key)
 
     token = security.create_access_token(subject="7", token_version=1)
     # Verifies under the dedicated key...
@@ -278,15 +278,15 @@ def test_session_jwt_signed_with_dedicated_jwt_secret_key(monkeypatch):
 
 
 @pytest.mark.unit
-def test_jwt_secret_key_does_not_affect_encryption(monkeypatch):
-    """Setting/rotating JWT_SECRET_KEY must not change encryption or the email HMAC —
+def test_jwt_signing_key_does_not_affect_encryption(monkeypatch):
+    """Setting/rotating JWT_SIGNING_KEY must not change encryption or the email HMAC —
     those are rooted in SECRET_KEY alone, so a JWT rotation can't orphan data."""
     from app.core.encryption import SALT_EMAIL, encrypt_field, hash_email
 
     before_ct = encrypt_field("alice@example.com", SALT_EMAIL)
     before_hash = hash_email("alice@example.com")
 
-    monkeypatch.setattr(security.settings, "JWT_SECRET_KEY", "j" * 48)
+    monkeypatch.setattr(security.settings, "JWT_SIGNING_KEY", "j" * 48)
 
     # Same email hash, and the pre-rotation ciphertext still decrypts.
     from app.core.encryption import decrypt_field

--- a/backend/app/db/secret_key_rotation.py
+++ b/backend/app/db/secret_key_rotation.py
@@ -1,0 +1,332 @@
+"""One-shot, re-runnable SECRET_KEY rotation.
+
+``SECRET_KEY`` roots every Fernet-encrypted field (emails, OIDC client secret +
+refresh tokens, SMTP password, AI API keys) and the ``users.email_hash`` HMAC. It
+is NOT a JWT signing key (that's the separately-rotatable ``JWT_SECRET_KEY``), so
+rotating it means re-encrypting at-rest data — it cannot be swapped in place.
+
+This module re-encrypts every such value from the OLD key (``PREVIOUS_SECRET_KEY``)
+to the NEW key (``SECRET_KEY``), and recomputes each ``email_hash`` from the new key.
+
+Idempotent + resumable: each value is tried under the NEW key first (already rotated
+→ skipped), so a second run is a no-op and an interrupted run resumes cleanly. A
+value that decrypts under NEITHER key was already unreadable before rotation, so it
+is counted and skipped (loud WARNING) rather than aborting — one corrupt legacy row
+can't block the sweep (or, at startup, the whole deploy).
+
+Runs two ways:
+  * **Automatically at startup** when ``PREVIOUS_SECRET_KEY`` is set (see
+    ``app.main.on_startup``), after guild schemas are provisioned and before traffic
+    is served — so a packaged deploy rotates itself: set the two env vars, redeploy,
+    then UNSET ``PREVIOUS_SECRET_KEY`` once the logs report 0 failures.
+  * **Manually** for an explicit/preview run::
+
+        # 1. stop the app
+        # 2. set PREVIOUS_SECRET_KEY=<old>, SECRET_KEY=<new>  (new: openssl rand -hex 32)
+        python -m app.db.secret_key_rotation --dry-run   # preview counts, no writes
+        python -m app.db.secret_key_rotation             # rotate
+        # 3. restart, confirm login / SMTP / AI keys work, then UNSET PREVIOUS_SECRET_KEY
+
+Schema-per-guild: ``guild_settings`` is guild-scoped, so its live rows live in every
+``guild_<id>`` schema (plus a retained ``public`` backup copy from the conversion);
+the sweep visits both. Runs on the provisioning (superuser) engine so it reaches
+every guild schema and bypasses RLS.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from dataclasses import dataclass, field
+
+from cryptography.fernet import InvalidToken
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from app.core.config import settings
+from app.core.encryption import (
+    SALT_AI_API_KEY,
+    SALT_EMAIL,
+    SALT_OIDC_CLIENT_SECRET,
+    SALT_OIDC_REFRESH_TOKEN,
+    SALT_SMTP_PASSWORD,
+    decrypt_field,
+    encrypt_field,
+    hash_email,
+)
+from app.db import session as db_session
+from app.db.schema_provisioning import guild_schema_name
+
+logger = logging.getLogger(__name__)
+
+# Every Fernet column EXCEPT users.email_encrypted, which is handled specially
+# because its plaintext also feeds the email_hash HMAC (the two must move together).
+# (table, column, salt). All live in ``public``; guild_settings additionally lives in
+# each guild schema (see _GUILD_SCHEMA_COLUMNS).
+_PUBLIC_FERNET_COLUMNS: list[tuple[str, str, bytes]] = [
+    ("users", "ai_api_key_encrypted", SALT_AI_API_KEY),
+    ("users", "oidc_refresh_token_encrypted", SALT_OIDC_REFRESH_TOKEN),
+    ("app_settings", "oidc_client_secret_encrypted", SALT_OIDC_CLIENT_SECRET),
+    ("app_settings", "smtp_password_encrypted", SALT_SMTP_PASSWORD),
+    ("app_settings", "ai_api_key_encrypted", SALT_AI_API_KEY),
+    ("guild_invites", "invitee_email_encrypted", SALT_EMAIL),
+    # Retained public backup copy of the (now guild-scoped) guild_settings rows.
+    ("guild_settings", "ai_api_key_encrypted", SALT_AI_API_KEY),
+]
+
+# Columns rotated once per ``guild_<id>`` schema (the live copies).
+_GUILD_SCHEMA_COLUMNS: list[tuple[str, str, bytes]] = [
+    ("guild_settings", "ai_api_key_encrypted", SALT_AI_API_KEY),
+]
+
+
+@dataclass
+class ColumnResult:
+    schema: str
+    table: str
+    column: str
+    rotated: int = 0
+    skipped: int = 0  # already under the new key (idempotent re-run)
+    failed: int = 0  # decryptable under neither key — already unreadable
+
+
+@dataclass
+class RotationSummary:
+    columns: list[ColumnResult] = field(default_factory=list)
+    dry_run: bool = False
+
+    @property
+    def rotated(self) -> int:
+        return sum(c.rotated for c in self.columns)
+
+    @property
+    def skipped(self) -> int:
+        return sum(c.skipped for c in self.columns)
+
+    @property
+    def failed(self) -> int:
+        return sum(c.failed for c in self.columns)
+
+    def render(self) -> str:
+        head = (
+            f"secret-key rotation {'(dry run) ' if self.dry_run else ''}"
+            f"— {self.rotated} rotated, {self.skipped} already-current, "
+            f"{self.failed} unreadable"
+        )
+        lines = [
+            f"  {c.schema}.{c.table}.{c.column}: "
+            f"{c.rotated} rotated, {c.skipped} skipped, {c.failed} failed"
+            for c in self.columns
+            if c.rotated or c.failed  # keep the report focused on what moved/broke
+        ]
+        return "\n".join([head, *lines])
+
+
+def _rotate_value(
+    value: str, salt: bytes, old_key: str, new_key: str
+) -> tuple[str, str | None]:
+    """Classify one ciphertext: ('skipped', value) if it already decrypts under the
+    new key, ('rotated', new_ciphertext) after re-encrypting from the old key, or
+    ('failed', None) if neither key decrypts it (already-corrupt data)."""
+    try:
+        decrypt_field(value, salt, secret_key=new_key)
+        return ("skipped", value)
+    except InvalidToken:
+        pass
+    try:
+        plaintext = decrypt_field(value, salt, secret_key=old_key)
+    except InvalidToken:
+        return ("failed", None)
+    return ("rotated", encrypt_field(plaintext, salt, secret_key=new_key))
+
+
+async def _rotate_fernet_column(
+    conn: AsyncConnection,
+    schema: str,
+    table: str,
+    column: str,
+    salt: bytes,
+    old_key: str,
+    new_key: str,
+    dry_run: bool,
+) -> ColumnResult:
+    """Re-encrypt every non-null value of one Fernet column. The ciphertext itself is
+    the UPDATE key (Fernet's random IV makes each value unique), so this needs no
+    knowledge of the table's primary key."""
+    result = ColumnResult(schema, table, column)
+    rows = await conn.execute(
+        text(
+            f'SELECT "{column}" FROM "{schema}"."{table}" WHERE "{column}" IS NOT NULL'
+        )
+    )
+    for (value,) in rows.all():
+        status, new_value = _rotate_value(value, salt, old_key, new_key)
+        if status == "skipped":
+            result.skipped += 1
+        elif status == "failed":
+            result.failed += 1
+            logger.warning(
+                "secret-key rotation: %s.%s.%s holds a value decryptable under "
+                "neither key — skipping (already unreadable)",
+                schema,
+                table,
+                column,
+            )
+        else:
+            result.rotated += 1
+            if not dry_run:
+                await conn.execute(
+                    text(
+                        f'UPDATE "{schema}"."{table}" SET "{column}" = :new '
+                        f'WHERE "{column}" = :old'
+                    ),
+                    {"new": new_value, "old": value},
+                )
+    return result
+
+
+async def _rotate_user_emails(
+    conn: AsyncConnection, old_key: str, new_key: str, dry_run: bool
+) -> ColumnResult:
+    """Re-encrypt users.email_encrypted AND recompute users.email_hash from the same
+    plaintext, in one UPDATE so the two never disagree. email_hash is a deterministic
+    HMAC, so the new hashes stay unique (one per unique email) and disjoint from the
+    old ones — no unique-constraint conflict."""
+    result = ColumnResult("public", "users", "email_encrypted+email_hash")
+    rows = await conn.execute(
+        text(
+            "SELECT email_encrypted FROM public.users WHERE email_encrypted IS NOT NULL"
+        )
+    )
+    for (enc,) in rows.all():
+        try:
+            decrypt_field(enc, SALT_EMAIL, secret_key=new_key)
+            result.skipped += 1
+            continue
+        except InvalidToken:
+            pass
+        try:
+            email = decrypt_field(enc, SALT_EMAIL, secret_key=old_key)
+        except InvalidToken:
+            result.failed += 1
+            logger.warning(
+                "secret-key rotation: a users.email_encrypted value decrypts under "
+                "neither key — skipping (already unreadable)"
+            )
+            continue
+        result.rotated += 1
+        if not dry_run:
+            await conn.execute(
+                text(
+                    "UPDATE public.users "
+                    "SET email_encrypted = :new_enc, email_hash = :new_hash "
+                    "WHERE email_encrypted = :old_enc"
+                ),
+                {
+                    "new_enc": encrypt_field(email, SALT_EMAIL, secret_key=new_key),
+                    "new_hash": hash_email(email, secret_key=new_key),
+                    "old_enc": enc,
+                },
+            )
+    return result
+
+
+async def rotate_secret_key(*, dry_run: bool = False) -> RotationSummary:
+    """Re-encrypt all SECRET_KEY-derived data from PREVIOUS_SECRET_KEY to SECRET_KEY.
+
+    Raises RuntimeError if there is nothing to rotate from (PREVIOUS_SECRET_KEY unset
+    or equal to SECRET_KEY) — callers that may hit those states benignly (startup)
+    should guard before calling.
+    """
+    old_key = settings.PREVIOUS_SECRET_KEY
+    new_key = settings.SECRET_KEY
+    if not old_key:
+        raise RuntimeError(
+            "PREVIOUS_SECRET_KEY is not set — set it to the old key to rotate from."
+        )
+    if old_key == new_key:
+        raise RuntimeError(
+            "PREVIOUS_SECRET_KEY equals SECRET_KEY — nothing to rotate; unset it."
+        )
+
+    summary = RotationSummary(dry_run=dry_run)
+    engine = db_session.provisioning_engine  # superuser: all schemas, bypasses RLS
+
+    # Platform tables (public) — one transaction; commits together, resumable on re-run.
+    async with engine.begin() as conn:
+        summary.columns.append(
+            await _rotate_user_emails(conn, old_key, new_key, dry_run)
+        )
+        for table, column, salt in _PUBLIC_FERNET_COLUMNS:
+            summary.columns.append(
+                await _rotate_fernet_column(
+                    conn, "public", table, column, salt, old_key, new_key, dry_run
+                )
+            )
+
+    # Guild-scoped live copies — one transaction per guild schema (independently
+    # resumable). A guild whose schema is missing/broken is logged and skipped.
+    async with engine.connect() as conn:
+        guild_ids = (
+            (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
+            .scalars()
+            .all()
+        )
+    for gid in guild_ids:
+        schema = guild_schema_name(gid)
+        try:
+            async with engine.begin() as conn:
+                for table, column, salt in _GUILD_SCHEMA_COLUMNS:
+                    summary.columns.append(
+                        await _rotate_fernet_column(
+                            conn, schema, table, column, salt, old_key, new_key, dry_run
+                        )
+                    )
+        except Exception:
+            logger.exception(
+                "secret-key rotation: failed to rotate schema %s — skipping", schema
+            )
+
+    log = logger.warning if summary.failed else logger.info
+    log("%s", summary.render())
+    return summary
+
+
+async def maybe_rotate_at_startup() -> None:
+    """Startup hook: rotate when PREVIOUS_SECRET_KEY names a different key, else no-op.
+    Runs the real (non-dry) sweep before the app serves traffic. Never raises for the
+    benign 'nothing to rotate' states — those are expected when PREVIOUS_SECRET_KEY is
+    unset or left equal to SECRET_KEY."""
+    old_key = settings.PREVIOUS_SECRET_KEY
+    if not old_key or old_key == settings.SECRET_KEY:
+        return
+    summary = await rotate_secret_key(dry_run=False)
+    if summary.failed:
+        logger.warning(
+            "secret-key rotation left %d unreadable value(s) — these were already "
+            "undecryptable; review the warnings above before unsetting "
+            "PREVIOUS_SECRET_KEY",
+            summary.failed,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Rotate SECRET_KEY-derived data from PREVIOUS_SECRET_KEY to SECRET_KEY."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would rotate without writing anything.",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    summary = asyncio.run(rotate_secret_key(dry_run=args.dry_run))
+    print(summary.render())
+    if summary.failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/db/secret_key_rotation.py
+++ b/backend/app/db/secret_key_rotation.py
@@ -2,7 +2,7 @@
 
 ``SECRET_KEY`` roots every Fernet-encrypted field (emails, OIDC client secret +
 refresh tokens, SMTP password, AI API keys) and the ``users.email_hash`` HMAC. It
-is NOT a JWT signing key (that's the separately-rotatable ``JWT_SECRET_KEY``), so
+is NOT a JWT signing key (that's the separately-rotatable ``JWT_SIGNING_KEY``), so
 rotating it means re-encrypting at-rest data — it cannot be swapped in place.
 
 This module re-encrypts every such value from the OLD key (``PREVIOUS_SECRET_KEY``)
@@ -142,7 +142,8 @@ def _rotate_value(
 
 
 async def _rotate_fernet_column(
-    conn: AsyncConnection,
+    read_conn: AsyncConnection,
+    write_conn: AsyncConnection,
     schema: str,
     table: str,
     column: str,
@@ -151,16 +152,19 @@ async def _rotate_fernet_column(
     new_key: str,
     dry_run: bool,
 ) -> ColumnResult:
-    """Re-encrypt every non-null value of one Fernet column. The ciphertext itself is
-    the UPDATE key (Fernet's random IV makes each value unique), so this needs no
+    """Re-encrypt every non-null value of one Fernet column. Reads are streamed (a
+    server-side cursor on ``read_conn``) so a large table isn't pulled into memory at
+    once; writes go to a separate ``write_conn`` because asyncpg can't interleave an
+    UPDATE on the same connection as an open cursor. The ciphertext itself is the
+    UPDATE key (Fernet's random IV makes each value unique), so this needs no
     knowledge of the table's primary key."""
     result = ColumnResult(schema, table, column)
-    rows = await conn.execute(
+    stream = await read_conn.stream(
         text(
             f'SELECT "{column}" FROM "{schema}"."{table}" WHERE "{column}" IS NOT NULL'
         )
     )
-    for (value,) in rows.all():
+    async for (value,) in stream:
         status, new_value = _rotate_value(value, salt, old_key, new_key)
         if status == "skipped":
             result.skipped += 1
@@ -173,33 +177,41 @@ async def _rotate_fernet_column(
                 table,
                 column,
             )
-        else:
+        elif dry_run:
             result.rotated += 1
-            if not dry_run:
-                await conn.execute(
-                    text(
-                        f'UPDATE "{schema}"."{table}" SET "{column}" = :new '
-                        f'WHERE "{column}" = :old'
-                    ),
-                    {"new": new_value, "old": value},
-                )
+        else:
+            # Count actual writes: a concurrent rotation may have already re-keyed
+            # this value (WHERE no longer matches → rowcount 0), so don't overcount.
+            res = await write_conn.execute(
+                text(
+                    f'UPDATE "{schema}"."{table}" SET "{column}" = :new '
+                    f'WHERE "{column}" = :old'
+                ),
+                {"new": new_value, "old": value},
+            )
+            result.rotated += res.rowcount or 0
     return result
 
 
 async def _rotate_user_emails(
-    conn: AsyncConnection, old_key: str, new_key: str, dry_run: bool
+    read_conn: AsyncConnection,
+    write_conn: AsyncConnection,
+    old_key: str,
+    new_key: str,
+    dry_run: bool,
 ) -> ColumnResult:
     """Re-encrypt users.email_encrypted AND recompute users.email_hash from the same
     plaintext, in one UPDATE so the two never disagree. email_hash is a deterministic
     HMAC, so the new hashes stay unique (one per unique email) and disjoint from the
-    old ones — no unique-constraint conflict."""
+    old ones — no unique-constraint conflict. Streamed read / separate write like
+    ``_rotate_fernet_column``."""
     result = ColumnResult("public", "users", "email_encrypted+email_hash")
-    rows = await conn.execute(
+    stream = await read_conn.stream(
         text(
             "SELECT email_encrypted FROM public.users WHERE email_encrypted IS NOT NULL"
         )
     )
-    for (enc,) in rows.all():
+    async for (enc,) in stream:
         try:
             decrypt_field(enc, SALT_EMAIL, secret_key=new_key)
             result.skipped += 1
@@ -215,20 +227,22 @@ async def _rotate_user_emails(
                 "neither key — skipping (already unreadable)"
             )
             continue
-        result.rotated += 1
-        if not dry_run:
-            await conn.execute(
-                text(
-                    "UPDATE public.users "
-                    "SET email_encrypted = :new_enc, email_hash = :new_hash "
-                    "WHERE email_encrypted = :old_enc"
-                ),
-                {
-                    "new_enc": encrypt_field(email, SALT_EMAIL, secret_key=new_key),
-                    "new_hash": hash_email(email, secret_key=new_key),
-                    "old_enc": enc,
-                },
-            )
+        if dry_run:
+            result.rotated += 1
+            continue
+        res = await write_conn.execute(
+            text(
+                "UPDATE public.users "
+                "SET email_encrypted = :new_enc, email_hash = :new_hash "
+                "WHERE email_encrypted = :old_enc"
+            ),
+            {
+                "new_enc": encrypt_field(email, SALT_EMAIL, secret_key=new_key),
+                "new_hash": hash_email(email, secret_key=new_key),
+                "old_enc": enc,
+            },
+        )
+        result.rotated += res.rowcount or 0
     return result
 
 
@@ -253,19 +267,29 @@ async def rotate_secret_key(*, dry_run: bool = False) -> RotationSummary:
     summary = RotationSummary(dry_run=dry_run)
     engine = db_session.provisioning_engine  # superuser: all schemas, bypasses RLS
 
-    # Platform tables (public) — one transaction; commits together, resumable on re-run.
-    async with engine.begin() as conn:
+    # Platform tables (public). Reads stream on one connection; writes commit on a
+    # second (engine.begin()) — separate connections so an open read cursor and the
+    # UPDATEs don't collide on asyncpg. The write txn commits together, resumable.
+    async with engine.connect() as read_conn, engine.begin() as write_conn:
         summary.columns.append(
-            await _rotate_user_emails(conn, old_key, new_key, dry_run)
+            await _rotate_user_emails(read_conn, write_conn, old_key, new_key, dry_run)
         )
         for table, column, salt in _PUBLIC_FERNET_COLUMNS:
             summary.columns.append(
                 await _rotate_fernet_column(
-                    conn, "public", table, column, salt, old_key, new_key, dry_run
+                    read_conn,
+                    write_conn,
+                    "public",
+                    table,
+                    column,
+                    salt,
+                    old_key,
+                    new_key,
+                    dry_run,
                 )
             )
 
-    # Guild-scoped live copies — one transaction per guild schema (independently
+    # Guild-scoped live copies — one write transaction per guild schema (independently
     # resumable). A guild whose schema is missing/broken is logged and skipped.
     async with engine.connect() as conn:
         guild_ids = (
@@ -276,11 +300,22 @@ async def rotate_secret_key(*, dry_run: bool = False) -> RotationSummary:
     for gid in guild_ids:
         schema = guild_schema_name(gid)
         try:
-            async with engine.begin() as conn:
+            async with (
+                engine.connect() as read_conn,
+                engine.begin() as write_conn,
+            ):
                 for table, column, salt in _GUILD_SCHEMA_COLUMNS:
                     summary.columns.append(
                         await _rotate_fernet_column(
-                            conn, schema, table, column, salt, old_key, new_key, dry_run
+                            read_conn,
+                            write_conn,
+                            schema,
+                            table,
+                            column,
+                            salt,
+                            old_key,
+                            new_key,
+                            dry_run,
                         )
                     )
         except Exception:
@@ -302,12 +337,21 @@ async def maybe_rotate_at_startup() -> None:
     if not old_key or old_key == settings.SECRET_KEY:
         return
     summary = await rotate_secret_key(dry_run=False)
+    # Post-run nudge (WARNING so it survives INFO-filtered logs). Phrased for the
+    # auto-rotation that JUST ran — never "go run the CLI", which would have an
+    # operator kick off a redundant concurrent sweep.
     if summary.failed:
         logger.warning(
-            "secret-key rotation left %d unreadable value(s) — these were already "
-            "undecryptable; review the warnings above before unsetting "
-            "PREVIOUS_SECRET_KEY",
+            "secret-key rotation left %d value(s) decryptable under neither key — "
+            "they were already unreadable; review the warnings above and keep "
+            "PREVIOUS_SECRET_KEY set until resolved.",
             summary.failed,
+        )
+    else:
+        logger.warning(
+            "secret-key rotation complete (%d re-encrypted this boot). UNSET "
+            "PREVIOUS_SECRET_KEY to finish retiring the old key.",
+            summary.rotated,
         )
 
 

--- a/backend/app/db/secret_key_rotation_test.py
+++ b/backend/app/db/secret_key_rotation_test.py
@@ -1,0 +1,254 @@
+"""Tests for one-shot SECRET_KEY rotation.
+
+The DB-backed tests follow the guild_conversion_test pattern: seed committed rows
+via the (superuser) ``engine`` fixture, run the rotation — which reads
+``db_session.provisioning_engine`` (pointed at the test engine by the autouse
+``_schema_test_harness`` fixture) — then clean up in ``finally``.
+
+Rotation scans ALL rows globally, so assertions target the specific seeded rows.
+Rows encrypted under some *other* key are classified ``failed`` and left untouched
+(no UPDATE), so they can't be corrupted by these tests.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.core import config
+from app.core.encryption import (
+    SALT_AI_API_KEY,
+    SALT_EMAIL,
+    decrypt_field,
+    encrypt_field,
+    hash_email,
+)
+from app.db.schema_provisioning import (
+    drop_guild_schema,
+    guild_schema_name,
+    provision_guild,
+)
+from app.db.secret_key_rotation import (
+    _rotate_value,
+    maybe_rotate_at_startup,
+    rotate_secret_key,
+)
+
+# Distinct test-only keys (≥32 chars). Deliberately different from the ambient
+# test SECRET_KEY so unrelated rows fall into the (untouched) "failed" bucket.
+OLD = "o" * 48
+NEW = "n" * 48
+
+
+def _use_keys(monkeypatch, *, old, new) -> None:
+    """Point the live settings at NEW (current) + OLD (previous). validate_assignment
+    is off, so these assignments don't re-run the strong-key validator."""
+    monkeypatch.setattr(config.settings, "SECRET_KEY", new)
+    monkeypatch.setattr(config.settings, "PREVIOUS_SECRET_KEY", old)
+
+
+# ── pure classification (no DB) ──────────────────────────────────────────────
+
+
+def test_rotate_value_skips_when_already_under_new_key():
+    already_new = encrypt_field("x", SALT_EMAIL, secret_key=NEW)
+    status, value = _rotate_value(already_new, SALT_EMAIL, OLD, NEW)
+    assert status == "skipped"
+    assert value == already_new
+
+
+def test_rotate_value_reencrypts_from_old_key():
+    old_ct = encrypt_field("x", SALT_EMAIL, secret_key=OLD)
+    status, new_ct = _rotate_value(old_ct, SALT_EMAIL, OLD, NEW)
+    assert status == "rotated"
+    assert decrypt_field(new_ct, SALT_EMAIL, secret_key=NEW) == "x"
+
+
+def test_rotate_value_reports_failed_when_neither_key_works():
+    foreign = encrypt_field("x", SALT_EMAIL, secret_key="z" * 48)
+    status, value = _rotate_value(foreign, SALT_EMAIL, OLD, NEW)
+    assert status == "failed"
+    assert value is None
+
+
+# ── guards (no DB) ───────────────────────────────────────────────────────────
+
+
+async def test_rotate_raises_without_previous_key(monkeypatch):
+    monkeypatch.setattr(config.settings, "SECRET_KEY", NEW)
+    monkeypatch.setattr(config.settings, "PREVIOUS_SECRET_KEY", None)
+    with pytest.raises(RuntimeError, match="PREVIOUS_SECRET_KEY is not set"):
+        await rotate_secret_key()
+
+
+async def test_rotate_raises_when_keys_equal(monkeypatch):
+    monkeypatch.setattr(config.settings, "SECRET_KEY", NEW)
+    monkeypatch.setattr(config.settings, "PREVIOUS_SECRET_KEY", NEW)
+    with pytest.raises(RuntimeError, match="equals SECRET_KEY"):
+        await rotate_secret_key()
+
+
+async def test_maybe_rotate_at_startup_is_noop_when_unset(monkeypatch):
+    monkeypatch.setattr(config.settings, "SECRET_KEY", NEW)
+    monkeypatch.setattr(config.settings, "PREVIOUS_SECRET_KEY", None)
+    # Must NOT raise and must not touch the DB.
+    await maybe_rotate_at_startup()
+
+
+# ── end-to-end against real tables ───────────────────────────────────────────
+
+pytestmark = pytest.mark.database
+
+
+async def _insert_user(conn, email: str, *, key: str) -> int:
+    return await conn.scalar(
+        text(
+            "INSERT INTO public.users "
+            "(email_hash, email_encrypted, ai_api_key_encrypted, hashed_password, "
+            " created_at, updated_at) "
+            "VALUES (:h, :e, :a, 'x', now(), now()) RETURNING id"
+        ),
+        {
+            "h": hash_email(email, secret_key=key),
+            "e": encrypt_field(email, SALT_EMAIL, secret_key=key),
+            "a": encrypt_field("user-ai-key", SALT_AI_API_KEY, secret_key=key),
+        },
+    )
+
+
+async def test_rotate_user_email_hash_and_fernet_columns(engine, monkeypatch):
+    """A user seeded under OLD has its email pair AND ai key re-keyed to NEW; the
+    recomputed email_hash matches a NEW-key lookup. Second run is idempotent."""
+    email = "rot-user@example.com"
+    old_hash = hash_email(email, secret_key=OLD)
+    user_id = None
+    try:
+        async with engine.begin() as conn:
+            user_id = await _insert_user(conn, email, key=OLD)
+
+        _use_keys(monkeypatch, old=OLD, new=NEW)
+        summary = await rotate_secret_key()
+        assert summary.rotated >= 2  # email pair (counts once) + ai key
+
+        async with engine.connect() as conn:
+            h, e, a = (
+                await conn.execute(
+                    text(
+                        "SELECT email_hash, email_encrypted, ai_api_key_encrypted "
+                        "FROM public.users WHERE id = :i"
+                    ),
+                    {"i": user_id},
+                )
+            ).one()
+
+        # email_hash recomputed under NEW → a NEW-key lookup now finds this user.
+        assert h == hash_email(email, secret_key=NEW)
+        assert h != old_hash
+        assert decrypt_field(e, SALT_EMAIL, secret_key=NEW) == email
+        assert decrypt_field(a, SALT_AI_API_KEY, secret_key=NEW) == "user-ai-key"
+
+        # Idempotent: a second run re-keys nothing (this row is already under NEW).
+        again = await rotate_secret_key()
+        async with engine.connect() as conn:
+            h2 = await conn.scalar(
+                text("SELECT email_hash FROM public.users WHERE id = :i"),
+                {"i": user_id},
+            )
+        assert h2 == h  # unchanged
+        # Nothing of *ours* rotated again (other rows under foreign keys are ignored).
+        assert again.rotated == 0
+    finally:
+        if user_id is not None:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text("DELETE FROM public.users WHERE id = :i"), {"i": user_id}
+                )
+
+
+async def test_dry_run_reports_but_does_not_write(engine, monkeypatch):
+    email = "rot-dry@example.com"
+    old_hash = hash_email(email, secret_key=OLD)
+    old_email_ct = encrypt_field(email, SALT_EMAIL, secret_key=OLD)
+    user_id = None
+    try:
+        async with engine.begin() as conn:
+            user_id = await conn.scalar(
+                text(
+                    "INSERT INTO public.users "
+                    "(email_hash, email_encrypted, hashed_password, created_at, updated_at) "
+                    "VALUES (:h, :e, 'x', now(), now()) RETURNING id"
+                ),
+                {"h": old_hash, "e": old_email_ct},
+            )
+
+        _use_keys(monkeypatch, old=OLD, new=NEW)
+        summary = await rotate_secret_key(dry_run=True)
+        assert summary.rotated >= 1  # would rotate
+
+        async with engine.connect() as conn:
+            h, e = (
+                await conn.execute(
+                    text(
+                        "SELECT email_hash, email_encrypted FROM public.users WHERE id = :i"
+                    ),
+                    {"i": user_id},
+                )
+            ).one()
+        # Untouched: still the OLD hash/ciphertext.
+        assert h == old_hash
+        assert e == old_email_ct
+    finally:
+        if user_id is not None:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text("DELETE FROM public.users WHERE id = :i"), {"i": user_id}
+                )
+
+
+async def test_rotate_visits_per_guild_schema_settings(engine, monkeypatch):
+    """guild_settings is guild-scoped, so its live rows live in guild_<id> schemas —
+    the sweep must re-key those, not just the public copy."""
+    gid = None
+    try:
+        async with engine.begin() as conn:
+            gid = await conn.scalar(
+                text(
+                    "INSERT INTO public.guilds (name) VALUES ('Rot Guild') RETURNING id"
+                )
+            )
+        await provision_guild(gid)  # creates the guild_<id> schema (own transaction)
+        schema = guild_schema_name(gid)
+        async with engine.begin() as conn:
+            # FK checks off so we can seed without a schema-local guild row.
+            await conn.execute(
+                text("SELECT set_config('session_replication_role', 'replica', true)")
+            )
+            await conn.execute(
+                text(
+                    f'INSERT INTO "{schema}".guild_settings '
+                    "(guild_id, created_at, updated_at, ai_api_key_encrypted) "
+                    "VALUES (:g, now(), now(), :a)"
+                ),
+                {
+                    "g": gid,
+                    "a": encrypt_field("guild-ai", SALT_AI_API_KEY, secret_key=OLD),
+                },
+            )
+
+        _use_keys(monkeypatch, old=OLD, new=NEW)
+        await rotate_secret_key()
+
+        async with engine.connect() as conn:
+            ct = await conn.scalar(
+                text(
+                    f'SELECT ai_api_key_encrypted FROM "{schema}".guild_settings '
+                    "WHERE guild_id = :g"
+                ),
+                {"g": gid},
+            )
+        assert decrypt_field(ct, SALT_AI_API_KEY, secret_key=NEW) == "guild-ai"
+    finally:
+        if gid is not None:
+            async with engine.begin() as conn:
+                await drop_guild_schema(conn, gid)
+                await conn.execute(
+                    text("DELETE FROM public.guilds WHERE id = :g"), {"g": gid}
+                )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -392,6 +392,16 @@ async def on_startup() -> None:
     # deployment (SPA served from a host other than APP_URL) is self-diagnosing.
     logger.info("CORS allowed origins: %s", settings.cors_origins)
 
+    # Nudge operators mid-rotation: PREVIOUS_SECRET_KEY lingering after the sweep
+    # keeps the old encryption key loadable indefinitely. WARNING so it survives
+    # INFO-filtered logs.
+    if settings.PREVIOUS_SECRET_KEY:
+        logger.warning(
+            "PREVIOUS_SECRET_KEY is set — a SECRET_KEY rotation is in progress. Run "
+            "`python -m app.db.secret_key_rotation`, then UNSET PREVIOUS_SECRET_KEY "
+            "to finish retiring the old key."
+        )
+
     install_soft_delete_filter()
     await check_pre_baseline_db()
     await run_migrations()
@@ -423,6 +433,13 @@ async def on_startup() -> None:
             backfill.provisioned,
             backfill.total,
         )
+    # Rotate SECRET_KEY-derived data (encrypted fields + email_hash) when
+    # PREVIOUS_SECRET_KEY names a prior key. Runs after guild schemas exist and
+    # before traffic is served, so a packaged deploy rotates itself on boot.
+    # Idempotent — a no-op once rotated (then unset PREVIOUS_SECRET_KEY).
+    from app.db.secret_key_rotation import maybe_rotate_at_startup
+
+    await maybe_rotate_at_startup()
     async with AdminSessionLocal() as session:
         await app_settings_service.ensure_defaults(session)
     app.state.notification_tasks = background_tasks_service.start_background_tasks()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -392,16 +392,6 @@ async def on_startup() -> None:
     # deployment (SPA served from a host other than APP_URL) is self-diagnosing.
     logger.info("CORS allowed origins: %s", settings.cors_origins)
 
-    # Nudge operators mid-rotation: PREVIOUS_SECRET_KEY lingering after the sweep
-    # keeps the old encryption key loadable indefinitely. WARNING so it survives
-    # INFO-filtered logs.
-    if settings.PREVIOUS_SECRET_KEY:
-        logger.warning(
-            "PREVIOUS_SECRET_KEY is set — a SECRET_KEY rotation is in progress. Run "
-            "`python -m app.db.secret_key_rotation`, then UNSET PREVIOUS_SECRET_KEY "
-            "to finish retiring the old key."
-        )
-
     install_soft_delete_filter()
     await check_pre_baseline_db()
     await run_migrations()

--- a/backend/app/services/ws_auth.py
+++ b/backend/app/services/ws_auth.py
@@ -46,7 +46,7 @@ async def authenticate_ws_token(token: str, session: AsyncSession) -> Optional[U
     # First try JWT validation.
     try:
         payload = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
         )
         token_data = TokenPayload(**payload)
         if token_data.sub:


### PR DESCRIPTION
## Problem

`SECRET_KEY` is overloaded: it signs JWTs **and** roots all Fernet field encryption (emails, OIDC client secret + refresh tokens, SMTP password, AI API keys) **and** the `users.email_hash` HMAC. So a deployment can't change it — a bare swap locks out every user (email lookups fail) and orphans every encrypted secret. With this release adding strict `SECRET_KEY` validation, deployments with a weak key would be forced into exactly that destructive swap.

## Changes

**`JWT_SECRET_KEY` — decoupled, freely-rotatable signing key**
- New optional `JWT_SECRET_KEY` + `jwt_signing_key` property (falls back to `SECRET_KEY` when unset, so existing deployments are unaffected). Validated to the same strength bar only when set.
- Every genuine JWT sign/verify site now uses it (`security.py` session/upload/handoff, `deps.py` ×2, `ws_auth.py`). The OIDC-state HMAC and all encryption stay on `SECRET_KEY`. Rotating `JWT_SECRET_KEY` only forces re-login — no data touched.

**`SECRET_KEY` rotation — one-shot, re-runnable, auto-at-startup**
- New `app/db/secret_key_rotation.py`: re-encrypts every Fernet field and recomputes every `email_hash` from `PREVIOUS_SECRET_KEY` → `SECRET_KEY`, across `public` **and** every `guild_<id>.guild_settings` (schema-per-guild aware). Idempotent (tries the new key first), resumable, and **skip-and-counts** values decryptable under neither key so one corrupt legacy row can't brick the sweep.
- **Auto-runs at startup** when `PREVIOUS_SECRET_KEY` is set (after guild schemas exist, before serving), so a packaged deploy rotates itself. Also a CLI: `python -m app.db.secret_key_rotation [--dry-run]`.
- Encryption helpers gained an optional `secret_key` arg (cache keyed by `(key, salt)`); default callers unchanged.
- `SECRET_KEY` validation failures now spell out the safe rotation path instead of inviting the destructive "just generate a new one".

## Env / config

New optional vars (documented in `backend/.env.example`):
- `PREVIOUS_SECRET_KEY` — set only while rotating; taken verbatim. Unset once logs report 0 failures.
- `JWT_SECRET_KEY` — optional dedicated JWT signing key.

No schema migration (data-only).

## Testing

```
cd backend && source .venv/bin/activate
ruff check app                                   # clean
pytest app/core/config_test.py app/core/encryption_test.py app/core/security_test.py   # 60 passed*
pytest app/db/secret_key_rotation_test.py        # 9 passed
pytest app/api/v1/public_endpoints/auth_test.py app/db/   # 179 passed
```

\* One pre-existing CSP test (`test_csp_confines_scripts_and_locks_down_vectors`) fails only because the local `backend/.env` sets `CAPTCHA_PROVIDER=turnstile`, which leaks into `Settings()`; it passes with that cleared. Unrelated to this PR.