### PR TITLE
Fix pre-0.51.0 uploads missing guild path segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Uploaded media (document files, featured images, and embedded rich-text images) that existed before v0.51.0 now resolves again. The v0.51.0 URL rewrite to `/uploads/{guild_id}/{filename}` ran before the per-guild schemas were created on first boot, so it migrated nothing and the old prefix-less URLs were copied into the guild schemas as-is (and 404'd). A new migration re-applies the rewrite in both `public` (per row) and every guild schema.
+
 ## [0.51.0] - 2026-06-15
 
 ### Added

--- a/backend/alembic/versions/20260615_0105_fix_uploads_guild_path_rewrite.py
+++ b/backend/alembic/versions/20260615_0105_fix_uploads_guild_path_rewrite.py
@@ -1,0 +1,146 @@
+"""Re-apply the /uploads/{guild_id}/ rewrite that 20260613_0103 missed
+
+20260613_0103 rewrote stored ``/uploads/{filename}`` URLs to
+``/uploads/{guild_id}/{filename}`` but ONLY in ``guild_<id>`` schemas. On an
+upgrade from a pre-schema-per-guild release those schemas do not yet exist when
+migrations run — they are created later in ``main.on_startup`` by
+``convert_public_to_guild_schemas`` / ``backfill_guild_schemas``, which run
+AFTER ``alembic upgrade head``. So 0103 saw zero guild schemas and was a no-op,
+and the conversion then copied the still-old-format URLs out of ``public`` into
+the guild schemas. Result: every stored ``/uploads/`` URL (document
+``file_url``, ``featured_image_url``, embedded rich-text/JSONB images, and
+task/project/initiative/comment/calendar descriptions) kept the prefix-less form
+and now 404s, because media is served at ``/uploads/{guild_id}/{filename}``.
+
+This migration fixes both populations and is safe regardless of conversion state
+(it also runs before conversion on every boot):
+
+* ``public.*`` — rewrite per-row using each row's own ``guild_id`` column, so a
+  guild NOT yet converted (e.g. a v0.50 -> this-version direct upgrade) is copied
+  into its schema already in the new format.
+* ``guild_<id>.*`` — rewrite in place using the gid parsed from the schema name,
+  so a deployment already converted under v0.51.0 (old-format rows sitting in its
+  guild schemas) is healed.
+
+Idempotent: matches only the OLD form — ``/uploads/`` immediately followed by the
+32-hex upload filename, with NO guild segment in between — so already-migrated
+rows and re-runs are no-ops.
+
+Revision ID: 20260615_0105
+Revises: 20260613_0104
+Create Date: 2026-06-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260615_0105"
+down_revision = "20260613_0104"
+branch_labels = None
+depends_on = None
+
+# /uploads/ followed by the 32-hex upload filename (uuid4().hex), with NO
+# {guild_id}/ segment in front of it. Capturing the hex lets us re-emit it after
+# the injected guild path. Plain (non-f) strings so the ``{32}`` quantifier
+# survives string interpolation into the SQL.
+_OLD = "/uploads/([0-9a-fA-F]{32})"
+_DOWN = "/uploads/[0-9]+/([0-9a-fA-F]{32})"
+
+# Per-guild-scoped columns that may hold direct or embedded /uploads URLs. Mirror
+# of 20260613_0103's maps. Every one of these tables also carries a ``guild_id``
+# column in ``public`` (the pre-cutover RLS model), which the public rewrite uses.
+_TEXT_COLS = {
+    "documents": ["file_url", "featured_image_url"],
+    "document_file_versions": ["file_url"],
+    "comments": ["content"],
+    "tasks": ["description"],
+    "calendar_events": ["description"],
+    "initiatives": ["description"],
+    "projects": ["description"],
+}
+_JSONB_COLS = {
+    "documents": ["content"],
+}
+_ALL_TABLES = sorted(set(_TEXT_COLS) | set(_JSONB_COLS))
+
+
+def _guild_schemas(conn):
+    return (
+        conn.execute(
+            sa.text("SELECT nspname FROM pg_namespace WHERE nspname ~ '^guild_[0-9]+$'")
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _table_exists(conn, schema, table):
+    return (
+        conn.execute(
+            sa.text("SELECT to_regclass(:q)"), {"q": f'"{schema}".{table}'}
+        ).scalar()
+        is not None
+    )
+
+
+def _rewrite_table(conn, schema, table, *, pattern, repl_expr):
+    """``UPDATE schema.table`` applying ``regexp_replace(col, pattern, repl_expr,
+    'g')`` to every targeted column. ``repl_expr`` is the SQL *replacement
+    expression* (already quoted): a literal ``'/uploads/7/\\1'`` for a guild
+    schema, or the per-row ``'/uploads/' || guild_id || '/\\1'`` for public."""
+    text_cols = _TEXT_COLS.get(table, [])
+    jsonb_cols = _JSONB_COLS.get(table, [])
+    sets = [
+        f"{c} = regexp_replace({c}, '{pattern}', {repl_expr}, 'g')" for c in text_cols
+    ]
+    sets += [
+        f"{c} = regexp_replace({c}::text, '{pattern}', {repl_expr}, 'g')::jsonb"
+        for c in jsonb_cols
+    ]
+    wheres = [f"{c} ~ '{pattern}'" for c in text_cols]
+    wheres += [f"{c}::text ~ '{pattern}'" for c in jsonb_cols]
+    if not sets:
+        return
+    conn.execute(
+        sa.text(
+            f'UPDATE "{schema}".{table} '
+            f"SET {', '.join(sets)} WHERE {' OR '.join(wheres)}"
+        )
+    )
+
+
+def _rewrite_public(conn, *, pattern, repl_expr):
+    # Public copies may already be gone in a later phase (see guild_conversion):
+    # guard each table so a dropped backup is a skip, not an error.
+    for table in _ALL_TABLES:
+        if _table_exists(conn, "public", table):
+            _rewrite_table(conn, "public", table, pattern=pattern, repl_expr=repl_expr)
+
+
+def _rewrite_guild_schemas(conn, *, pattern, repl_expr_for):
+    for schema in _guild_schemas(conn):
+        gid = int(schema.split("_", 1)[1])
+        for table in _ALL_TABLES:
+            if _table_exists(conn, schema, table):
+                _rewrite_table(
+                    conn, schema, table, pattern=pattern, repl_expr=repl_expr_for(gid)
+                )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # public: per-row gid from the row's own guild_id column.
+    _rewrite_public(conn, pattern=_OLD, repl_expr="'/uploads/' || guild_id || '/\\1'")
+    # guild schemas: gid is a constant parsed from the schema name.
+    _rewrite_guild_schemas(
+        conn, pattern=_OLD, repl_expr_for=lambda gid: f"'/uploads/{gid}/\\1'"
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    # Strip the {guild_id}/ segment back out (constant replacement either way).
+    _rewrite_public(conn, pattern=_DOWN, repl_expr="'/uploads/\\1'")
+    _rewrite_guild_schemas(
+        conn, pattern=_DOWN, repl_expr_for=lambda _gid: "'/uploads/\\1'"
+    )

--- a/backend/alembic/versions/20260615_0105_fix_uploads_guild_path_rewrite.py
+++ b/backend/alembic/versions/20260615_0105_fix_uploads_guild_path_rewrite.py
@@ -83,11 +83,13 @@ def _table_exists(conn, schema, table):
     )
 
 
-def _rewrite_table(conn, schema, table, *, pattern, repl_expr):
+def _rewrite_table(conn, schema, table, *, pattern, repl_expr, extra_where=None):
     """``UPDATE schema.table`` applying ``regexp_replace(col, pattern, repl_expr,
     'g')`` to every targeted column. ``repl_expr`` is the SQL *replacement
     expression* (already quoted): a literal ``'/uploads/7/\\1'`` for a guild
-    schema, or the per-row ``'/uploads/' || guild_id || '/\\1'`` for public."""
+    schema, or the per-row ``'/uploads/' || guild_id::text || '/\\1'`` for public.
+    ``extra_where`` AND-guards the URL-match predicate (e.g. ``guild_id IS NOT
+    NULL`` so a NULL guild_id can't ``||``-propagate the column to NULL)."""
     text_cols = _TEXT_COLS.get(table, [])
     jsonb_cols = _JSONB_COLS.get(table, [])
     sets = [
@@ -101,20 +103,27 @@ def _rewrite_table(conn, schema, table, *, pattern, repl_expr):
     wheres += [f"{c}::text ~ '{pattern}'" for c in jsonb_cols]
     if not sets:
         return
+    where = f"({' OR '.join(wheres)})"
+    if extra_where:
+        where += f" AND {extra_where}"
     conn.execute(
-        sa.text(
-            f'UPDATE "{schema}".{table} '
-            f"SET {', '.join(sets)} WHERE {' OR '.join(wheres)}"
-        )
+        sa.text(f'UPDATE "{schema}".{table} SET {", ".join(sets)} WHERE {where}')
     )
 
 
-def _rewrite_public(conn, *, pattern, repl_expr):
+def _rewrite_public(conn, *, pattern, repl_expr, extra_where=None):
     # Public copies may already be gone in a later phase (see guild_conversion):
     # guard each table so a dropped backup is a skip, not an error.
     for table in _ALL_TABLES:
         if _table_exists(conn, "public", table):
-            _rewrite_table(conn, "public", table, pattern=pattern, repl_expr=repl_expr)
+            _rewrite_table(
+                conn,
+                "public",
+                table,
+                pattern=pattern,
+                repl_expr=repl_expr,
+                extra_where=extra_where,
+            )
 
 
 def _rewrite_guild_schemas(conn, *, pattern, repl_expr_for):
@@ -129,8 +138,16 @@ def _rewrite_guild_schemas(conn, *, pattern, repl_expr_for):
 
 def upgrade() -> None:
     conn = op.get_bind()
-    # public: per-row gid from the row's own guild_id column.
-    _rewrite_public(conn, pattern=_OLD, repl_expr="'/uploads/' || guild_id || '/\\1'")
+    # public: per-row gid from the row's own guild_id column. ``::text`` makes the
+    # concat explicit, and ``guild_id IS NOT NULL`` keeps a NULL gid (nullable on
+    # comments/document_file_versions) from ``||``-nulling an otherwise-matching
+    # URL — such a row is never copied into a guild schema anyway.
+    _rewrite_public(
+        conn,
+        pattern=_OLD,
+        repl_expr="'/uploads/' || guild_id::text || '/\\1'",
+        extra_where="guild_id IS NOT NULL",
+    )
     # guild schemas: gid is a constant parsed from the schema name.
     _rewrite_guild_schemas(
         conn, pattern=_OLD, repl_expr_for=lambda gid: f"'/uploads/{gid}/\\1'"


### PR DESCRIPTION
## Problem

After upgrading to v0.51.0, media uploaded before the release (document files, **featured images**, and embedded rich-text images) 404s. The browser requests `/uploads/{filename}`, which no longer matches the new `/uploads/{guild_id}/{filename}` route.

### Root cause — a startup-ordering bug

v0.51.0 introduced schema-per-guild **and** migration `20260613_0103` (the `/uploads/{filename}` → `/uploads/{guild_id}/{filename}` rewrite) in the same release. On boot (`main.on_startup`):

1. `run_migrations()` runs **0103**, which only targets `guild_<id>` schemas and deliberately skips `public`. On the v0.50→v0.51.0 upgrade **no guild schemas exist yet** (nothing creates them during migrations), so `_guild_schemas()` returns `[]` and 0103 is a **no-op**.
2. `convert_public_to_guild_schemas()` then copies `public.documents` — still holding the old prefix-less URLs — into the freshly-created guild schemas.

Result: every stored `/uploads/` URL keeps the old form, and 0103 is stamped applied so it never re-runs. Not featured-specific — embedded body images and `file_url` are equally affected; featured images are just the most visible (every document card). Downloads still work because they resolve the blob by filename through the API. Physical files on disk and the `uploads` lookup table are unaffected — only the stored URL strings are stale.

## Fix

New migration `20260615_0105` re-applies the rewrite where the data now lives, safe regardless of conversion state:

- **`public.*`** — per row, using each row's own `guild_id` column, so a guild not yet converted (e.g. a v0.50→this-version *direct* upgrade) is copied into its schema already in the new format.
- **`guild_<id>.*`** — using the gid parsed from the schema name, so a deployment already converted under v0.51.0 is healed in place.

Idempotent: matches only the old form (`/uploads/` + 32-hex filename, no guild segment), so re-runs and already-migrated rows are no-ops. Downgrade strips the segment back out.

## Testing

- `alembic upgrade head` / `downgrade -1` against a scratch `guild_999` schema: `file_url`, `featured_image_url`, and JSONB `content` all gain `/{gid}/`; already-new-form rows untouched; downgrade reverses cleanly.
- Public per-row expression validated on a scratch table: rows with `guild_id` 7 and 42 rewrite to `/uploads/7/…` and `/uploads/42/…`; a non-`/uploads/` URL is left untouched.
- `ruff check` + `ruff format --check` pass; single alembic head.

## Notes

Production stays broken until this ships and `alembic upgrade head` runs on it. If an immediate prod fix is needed before the patch release, the equivalent one-off SQL can be run by hand.