### PR TITLE
Self-host the PDF.js worker for embedded PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Uploaded media (document files, featured images, and embedded rich-text images) that existed before v0.51.0 now resolves again. The v0.51.0 URL rewrite to `/uploads/{guild_id}/{filename}` ran before the per-guild schemas were created on first boot, so it migrated nothing and the old prefix-less URLs were copied into the guild schemas as-is (and 404'd). A new migration re-applies the rewrite in both `public` (per row) and every guild schema.
+- Embedded PDFs now render. The PDF.js worker is bundled and served same-origin instead of loaded from a CDN, so the app's `script-src 'self'` Content-Security-Policy no longer blocks it (and it works offline in the native app).
 
 ## [0.51.0] - 2026-06-15
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,7 @@
     "lexical": "^0.45.0",
     "lucide-react": "^1.17.0",
     "papaparse": "^5.5.3",
+    "pdfjs-dist": "5.4.296",
     "react": "^19.2.6",
     "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
+      pdfjs-dist:
+        specifier: 5.4.296
+        version: 5.4.296
       react:
         specifier: ^19.2.6
         version: 19.2.6

--- a/frontend/src/components/documents/FileDocumentViewer.tsx
+++ b/frontend/src/components/documents/FileDocumentViewer.tsx
@@ -37,8 +37,14 @@ import { cn } from "@/lib/utils";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 
-// Configure PDF.js worker from CDN (most reliable for Vite)
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+// Self-host the PDF.js worker as a same-origin Vite asset rather than loading it
+// from a CDN. A cross-origin worker URL forces pdf.js to import() it from inside a
+// blob worker, which the app's `script-src 'self'` CSP (pentest MED-001) blocks;
+// bundling it keeps the worker same-origin (no CSP relaxation), guarantees the
+// version matches pdfjs-dist, and works offline in the native app.
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+
+pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerSrc;
 
 // Accepted file types for uploading a new version (mirrors CreateDocumentDialog).
 const VERSION_UPLOAD_ACCEPT =


### PR DESCRIPTION
## Problem

Embedded PDFs failed to render — the PDF.js worker was blocked by the app's `script-src 'self'` CSP (pentest MED-001).

`FileDocumentViewer` pointed `pdfjs.GlobalWorkerOptions.workerSrc` at a CDN URL (`//unpkg.com/pdfjs-dist@…/build/pdf.worker.min.mjs`). For a **cross-origin** worker URL, pdf.js (5.4.296) doesn't load it directly: it wraps it in a blob worker that runs `await import("https://unpkg.com/…")`. That dynamic module `import()` is governed by `script-src`, which is locked to `'self'` — so the worker never loads.

Allowlisting `unpkg.com` in the global `script-src` would have re-opened the exact XSS hole MED-001 closed, for every page.

## Fix

Self-host the worker so it's same-origin — no CSP change:

- `frontend/src/components/documents/FileDocumentViewer.tsx`: load the worker via a Vite asset import (`import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.min.mjs?url"`) instead of the CDN URL. Vite emits it as a hashed same-origin asset, so pdf.js takes the same-origin path (`worker-src 'self'`, no blob wrapper).
- `frontend/package.json`: add `pdfjs-dist` as a direct dependency, pinned to **5.4.296** to match the version react-pdf bundles (the API and worker versions must match exactly, or pdf.js throws a version-mismatch error). It was previously only a transitive dep, so the bare import didn't resolve.

Bonus: embedded PDFs now also work offline in the native (Capacitor) app, since the worker ships in the bundle.

## Testing

- `pnpm vitest run src/components/documents/FileDocumentViewer.test.tsx` — 5 passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — succeeds; confirmed `dist/assets/pdf.worker.min-*.mjs` is emitted and referenced same-origin by the viewer chunk.

Manual verification of an embedded PDF rendering in a deployed build still recommended before merge.