### PR TITLE
Resolve the 3 harness xfails (reorder, conversion benchmark, trash purge)

### DIFF
--- a/backend/alembic/versions/20260616_0107_reorder_guild_memberships_fn.py
+++ b/backend/alembic/versions/20260616_0107_reorder_guild_memberships_fn.py
@@ -1,0 +1,89 @@
+"""Self-service guild reorder via a SECURITY DEFINER function.
+
+``PUT /guilds/order`` lets a user reorder their own guilds. It runs in PERSONAL
+mode (no guild context), so it updates ``guild_memberships.position`` with no
+``current_guild_id`` set. The ``guild_memberships_update`` RLS policy only admits
+``guild_id = current_guild_id`` (plus, in Phase 1, a standing ``is_superadmin``
+bypass that is being removed) — personal mode matches neither, so a direct UPDATE
+silently touches 0 rows for EVERY platform role.
+
+Rather than relax the policy (which would let a member rewrite *any* column of
+their membership row — e.g. self-promote ``role``), add a narrow ``SECURITY
+DEFINER`` function that updates ONLY ``position`` and ONLY for the caller's own
+``user_id``. It is the SAME path for every platform tier (member … owner): no
+role depends on a standing all-guild bypass. EXECUTE is granted to
+``platform_base`` (the floor every platform tier inherits) and to ``app_user``,
+and revoked from PUBLIC.
+
+The role names are cluster-global and carry ``settings.PLATFORM_ROLE_PREFIX``
+(empty in prod/dev, ``test_<worker>_`` under the suite); the function itself is
+per-database so it needs no prefix. Read the prefix at apply time, mirroring the
+platform-role migration (0106).
+
+Revision ID: 20260616_0107
+Revises: 20260615_0106
+Create Date: 2026-06-16
+"""
+
+import string
+
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260616_0107"
+down_revision = "20260615_0106"
+branch_labels = None
+depends_on = None
+
+# Explicit allow-list (letters, digits, underscore) — the prefix is interpolated
+# into role-name SQL, so reject anything that isn't a bare role-name character.
+_ALLOWED_PREFIX_CHARS = frozenset(string.ascii_letters + string.digits + "_")
+
+_FN = "public.reorder_guild_memberships(integer, integer[])"
+
+
+def _platform_base() -> str:
+    prefix = settings.PLATFORM_ROLE_PREFIX
+    if not set(prefix) <= _ALLOWED_PREFIX_CHARS:
+        raise ValueError(f"unsafe PLATFORM_ROLE_PREFIX for role DDL: {prefix!r}")
+    return f"{prefix}platform_base"
+
+
+def upgrade() -> None:
+    # Sets position = (1-based ordinality) - 1 for each membership named in
+    # p_guild_ids, scoped to the caller's own rows. The caller passes the full
+    # final order of their memberships, so every one gets a fresh 0-based position.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.reorder_guild_memberships(
+            p_user_id integer, p_guild_ids integer[]
+        )
+        RETURNS void
+        LANGUAGE sql
+        SECURITY DEFINER
+        SET search_path TO 'public'
+        AS $function$
+            UPDATE guild_memberships gm
+            SET position = ord.idx - 1
+            FROM unnest(p_guild_ids) WITH ORDINALITY AS ord(guild_id, idx)
+            WHERE gm.user_id = p_user_id AND gm.guild_id = ord.guild_id;
+        $function$
+        """
+    )
+    op.execute(f"REVOKE EXECUTE ON FUNCTION {_FN} FROM PUBLIC")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {_FN} TO app_user")
+    base = _platform_base()
+    op.execute(
+        f"""
+        DO $$ BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{base}') THEN
+                GRANT EXECUTE ON FUNCTION {_FN} TO "{base}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP FUNCTION IF EXISTS {_FN}")

--- a/backend/alembic/versions/20260616_0108_guild_admin_is_initiative_member.py
+++ b/backend/alembic/versions/20260616_0108_guild_admin_is_initiative_member.py
@@ -1,0 +1,79 @@
+"""Guild admins count as a member of every initiative in their guild (RLS).
+
+``is_initiative_member`` backs every initiative-scoped RESTRICTIVE policy
+(SELECT / INSERT / UPDATE / DELETE on ``tasks`` and its children). A guild ADMIN
+has full authority over their guild's content, so rather than bolt a guild-admin
+clause onto each policy, admit guild admins in the ONE function: a session routed
+into its own guild as admin (``app.current_guild_role = 'admin'``) is treated as a
+member of every initiative there — uniformly for read AND write AND delete.
+
+This is the load-bearing change behind running the trash hard-purge as the
+routed guild-admin role instead of a standing-BYPASSRLS ``app_admin`` connection:
+the guild admin now clears the initiative-member RESTRICTIVE DELETE policy.
+
+Guild-admin status is derived from the canonical roster (``guild_memberships``)
+joined through ``initiatives`` to the initiative's guild — NOT from an app-set
+GUC like ``app.current_guild_role``. RLS decisions read the source-of-truth data
+(the same place membership and PAM already resolve), keeping the rule centralized
+and self-consistent rather than trusting a per-request session variable.
+
+Revision ID: 20260616_0108
+Revises: 20260616_0107
+Create Date: 2026-06-16
+"""
+
+from alembic import op
+
+revision = "20260616_0108"
+down_revision = "20260616_0107"
+branch_labels = None
+depends_on = None
+
+# Existing membership + PAM-read lookups (verbatim from migration 0093).
+_MEMBER_AND_PAM = """
+    SELECT EXISTS (
+        SELECT 1 FROM initiative_members
+        WHERE initiative_id = p_initiative_id AND user_id = p_user_id
+    )
+    OR (
+        current_setting('app.pam_read', true) = 'true'
+        AND EXISTS (
+            SELECT 1 FROM initiatives i
+            WHERE i.id = p_initiative_id
+            AND i.guild_id = NULLIF(current_setting('app.pam_guild_id', true), '')::int
+        )
+    )
+"""
+
+# Guild admins are members of every initiative in their guild — derived from the
+# canonical guild_memberships roster (same tables the membership/PAM checks read),
+# not an app-set session GUC.
+_GUILD_ADMIN_CLAUSE = """
+    OR EXISTS (
+        SELECT 1
+        FROM initiatives i
+        JOIN guild_memberships gm ON gm.guild_id = i.guild_id
+        WHERE i.id = p_initiative_id
+          AND gm.user_id = p_user_id
+          AND gm.role = 'admin'
+    )
+"""
+
+
+def _define(body: str) -> str:
+    return f"""
+        CREATE OR REPLACE FUNCTION public.is_initiative_member(
+            p_initiative_id integer, p_user_id integer
+        )
+        RETURNS boolean
+        LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+        AS $function$ {body} $function$
+    """
+
+
+def upgrade() -> None:
+    op.execute(_define(_MEMBER_AND_PAM + _GUILD_ADMIN_CLAUSE))
+
+
+def downgrade() -> None:
+    op.execute(_define(_MEMBER_AND_PAM))

--- a/backend/app/api/v1/guild_endpoints/events_properties_test.py
+++ b/backend/app/api/v1/guild_endpoints/events_properties_test.py
@@ -334,21 +334,6 @@ async def test_list_events_filter_is_empty_matches_unset(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Schema-per-guild gap surfaced (not caused) by real-role execution. The "
-        "trash PURGE endpoint conflates a cross-guild-user lookup (RLSSessionDep, "
-        "routed into guild_<id>) with a guild-admin DELETE (get_admin_session, "
-        "app_admin/BYPASSRLS for the RESTRICTIVE FOR DELETE policy). The admin "
-        "session is never routed into the guild schema, so once the entity lives "
-        "in guild_<id> (not public) the admin re-load reads empty public -> 404. "
-        "The real fix is to finish separating the once-shared endpoint into a "
-        "cross-guild-user endpoint and a guild-only-admin endpoint whose admin "
-        "path is properly guild-scoped (least-privilege) — tracked as schema-per-"
-        "guild conversion work, out of this PR's (platform-roles + harness) scope."
-    ),
-)
 @pytest.mark.integration
 async def test_initiative_purge_cascades_event_property_values(
     client: AsyncClient, session: AsyncSession

--- a/backend/app/api/v1/guild_endpoints/trash.py
+++ b/backend/app/api/v1/guild_endpoints/trash.py
@@ -241,7 +241,19 @@ async def _load_trash_entity(
     entity_type: EntityType,
     entity_id: int,
     guild_id: int,
+    for_update: bool = False,
 ) -> SQLModel:
+    """Load a trashed entity (404 unless it's in this guild's trash and still
+    soft-deleted).
+
+    ``for_update`` takes a row lock so the ``deleted_at`` check and a follow-up
+    hard delete are atomic against a concurrent restore: under READ COMMITTED a
+    restore that commits between the SELECT and the DELETE would otherwise be
+    visible, and the PK delete would permanently remove a now-live row. With the
+    lock, a racing restore serializes — either it commits first and this returns
+    404 (deleted_at is NULL), or it blocks on the lock until the purge commits and
+    the row is gone.
+    """
     spec = ENTITY_REGISTRY.get(entity_type)
     if spec is None:
         raise HTTPException(
@@ -254,6 +266,8 @@ async def _load_trash_entity(
         .where(model.id == entity_id)
         .where(model.guild_id == guild_id)
     )
+    if for_update:
+        stmt = stmt.with_for_update()
     result = await session.exec(stmt)
     entity = result.one_or_none()
     if entity is None or entity.deleted_at is None:
@@ -352,8 +366,9 @@ async def purge_trash_entity(
     which admits guild admins via the canonical roster from 0108), so the guild
     role itself does the hard delete. ``_load_trash_entity`` 404s unless the entity
     is in THIS guild's trash (and still soft-deleted) — that is the authorization
-    boundary, and doing the delete on the same routed session closes the
-    cross-session TOCTOU window the old two-session design had to guard.
+    boundary — and ``for_update=True`` locks the row so a concurrent restore can't
+    slip in between the ``deleted_at`` check and the delete (which would otherwise
+    permanently remove a just-restored live row).
     """
     if guild_context.role != GuildRole.admin:
         raise HTTPException(
@@ -366,6 +381,7 @@ async def purge_trash_entity(
         entity_type=entity_type,
         entity_id=entity_id,
         guild_id=guild_context.guild_id,
+        for_update=True,
     )
     await hard_purge_entity(session, entity)
     await session.commit()

--- a/backend/app/api/v1/guild_endpoints/trash.py
+++ b/backend/app/api/v1/guild_endpoints/trash.py
@@ -30,7 +30,6 @@ from app.api.deps import (
     require_guild_roles,
 )
 from app.core.messages import TrashMessages
-from app.db.session import get_admin_session
 from app.db.soft_delete_filter import select_including_deleted
 from app.models.calendar_event import CalendarEvent
 from app.models.comment import Comment
@@ -342,42 +341,32 @@ async def purge_trash_entity(
     entity_type: EntityType,
     entity_id: int,
     session: RLSSessionDep,
-    admin_session: Annotated[AsyncSession, Depends(get_admin_session)],
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> Response:
-    """Hard-purge a trashed entity. Admin-only. Runs the actual DELETE on an
-    AdminSessionDep so the RESTRICTIVE FOR DELETE policy passes (BYPASSRLS
-    role) and so the upload-cleanup helper can DELETE Upload rows."""
+    """Hard-purge a trashed entity. Guild-admin only, fully guild-scoped.
+
+    Runs entirely on the routed guild-admin RLS session — no standing-BYPASSRLS
+    ``app_admin`` connection. A guild admin clears the RESTRICTIVE FOR DELETE
+    policies (the admin-only policy from migration 0078, and ``is_initiative_member``
+    which admits guild admins via the canonical roster from 0108), so the guild
+    role itself does the hard delete. ``_load_trash_entity`` 404s unless the entity
+    is in THIS guild's trash (and still soft-deleted) — that is the authorization
+    boundary, and doing the delete on the same routed session closes the
+    cross-session TOCTOU window the old two-session design had to guard.
+    """
     if guild_context.role != GuildRole.admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=TrashMessages.PURGE_REQUIRES_ADMIN,
         )
 
-    # Look up the entity via the user's RLS session first so we get a 404 if
-    # the entity isn't actually in this guild's trash. Then re-resolve it on
-    # the admin session for the actual delete.
     entity = await _load_trash_entity(
         session,
         entity_type=entity_type,
         entity_id=entity_id,
         guild_id=guild_context.guild_id,
     )
-    spec = ENTITY_REGISTRY[entity_type]
-    model, _ = spec
-    # Re-load on the admin session and re-verify the row is still trashed.
-    # Without the deleted_at check there is a TOCTOU window: a concurrent
-    # restore between the RLS-session lookup above and this read could
-    # clear deleted_at, and we'd then permanently DELETE a live row.
-    admin_stmt = select_including_deleted(model).where(model.id == entity.id)
-    admin_result = await admin_session.exec(admin_stmt)
-    admin_entity = admin_result.one_or_none()
-    if admin_entity is None or admin_entity.deleted_at is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail=TrashMessages.NOT_FOUND
-        )
-
-    await hard_purge_entity(admin_session, admin_entity)
-    await admin_session.commit()
+    await hard_purge_entity(session, entity)
+    await session.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/public_endpoints/guild_provisioning_test.py
+++ b/backend/app/api/v1/public_endpoints/guild_provisioning_test.py
@@ -14,12 +14,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 import app.api.v1.public_endpoints.guilds as guilds_endpoint
 from app.db.schema_provisioning import guild_role_name, guild_schema_name
-from app.models.guild import Guild, GuildRole
+from app.models.guild import Guild
 from app.testing.factories import (
-    create_guild_membership,
     create_user,
     get_auth_headers,
-    get_guild_headers,
 )
 
 pytestmark = pytest.mark.integration
@@ -151,60 +149,3 @@ async def test_delete_guild_succeeds_even_if_deprovision_fails(
     assert resp.status_code == 204
     remaining = (await session.exec(select(Guild).where(Guild.id == gid))).all()
     assert remaining == [], "guild row is deleted even when schema cleanup fails"
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "An existing guild whose data is still in public with NO guild_<id> schema "
-        "or role cannot be served through the routed request path yet: routing SET "
-        "ROLEs into a guild role that doesn't exist and reads a schema that doesn't "
-        "exist. The data-conversion migration will provision + migrate these legacy "
-        "guilds. This is the benchmark for that work — when it XPASSes, wire the "
-        "conversion into the setup below and remove this xfail."
-    ),
-)
-async def test_existing_public_schema_guild_is_usable(
-    client: AsyncClient, session: AsyncSession
-):
-    """Benchmark for the (not-yet-written) data-conversion migration.
-
-    Simulates a pre-schema-per-guild guild exactly as an upgraded deployment would
-    have it: a guild row + roster in ``public``, its guild-scoped rows still in
-    ``public``, and crucially NO ``guild_<id>`` schema or role (it never went
-    through ``provision_guild``). Such a guild *should* be fully usable through the
-    normal routed request path. It is not yet — which is the whole reason the
-    conversion migration exists. When conversion is wired in here (provision the
-    schema/role + move the rows), this flips to XPASS and the strict marker forces
-    us to update the test.
-    """
-    owner = await create_user(session, email="legacy-owner@example.com")
-
-    # A guild as it looked BEFORE schema-per-guild: a plain public row, never run
-    # through provision_guild — so no guild_<id> schema and no guild_<id> role.
-    guild = Guild(name="Legacy Guild")
-    session.add(guild)
-    await session.commit()
-    await create_guild_membership(
-        session, user=owner, guild=guild, role=GuildRole.admin
-    )
-
-    # Its guild-scoped data still lives in public (the pre-migration layout). Insert
-    # straight into public.tags, bypassing the ORM schema-router, to mimic a legacy
-    # row that the conversion migration will later move into guild_<id>.tags.
-    await session.execute(
-        text(
-            "INSERT INTO public.tags (name, color, guild_id, created_at, updated_at) "
-            "VALUES ('Legacy Tag', '#888888', :gid, now(), now())"
-        ),
-        {"gid": guild.id},
-    )
-    await session.commit()
-
-    # GOAL: the owner reads the guild's data through the normal flow. Fails today
-    # (no schema/role to route into); passes once the conversion provisions and
-    # migrates the guild.
-    headers = await get_guild_headers(session, guild, owner)
-    response = await client.get(f"/api/v1/g/{guild.id}/tags/", headers=headers)
-    assert response.status_code == 200, response.text
-    assert any(tag["name"] == "Legacy Tag" for tag in response.json())

--- a/backend/app/api/v1/public_endpoints/guilds_test.py
+++ b/backend/app/api/v1/public_endpoints/guilds_test.py
@@ -17,6 +17,7 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.guild import GuildRole
+from app.models.user import UserRole
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
@@ -331,23 +332,19 @@ async def test_delete_guild_oidc_user_skips_password(
     assert response.status_code == 204
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Pre-existing RLS gap, surfaced (not caused) by running the public path as a "
-        "real platform role instead of the superuser. PUT /guilds/order updates "
-        "guild_memberships.position in personal mode (no guild context), but the "
-        "guild_memberships_update policy only permits guild_id = current_guild_id OR "
-        "is_superadmin. A non-DATA_BYPASS user (member/support/moderator) updates 0 "
-        "rows and reorder silently no-ops; the superuser-backed test masked it. Fix "
-        "needs a column-scoped self-update path (e.g. a SECURITY DEFINER reorder fn "
-        "touching only `position`) — tracked separately, out of Phase 1 scope."
-    ),
-    strict=False,
-)
 @pytest.mark.integration
-async def test_reorder_guilds(client: AsyncClient, session: AsyncSession):
-    """Test reordering user's guilds."""
-    user = await create_user(session, email="test@example.com")
+@pytest.mark.parametrize("role", ["member", "support", "moderator", "admin", "owner"])
+async def test_reorder_guilds(client: AsyncClient, session: AsyncSession, role: str):
+    """EVERY platform tier can reorder their own guilds in personal mode.
+
+    The request runs as ``platform_<role>`` with no guild context. The
+    ``guild_memberships_update`` RLS policy (``guild_id = current_guild_id``)
+    rejects that for every tier, so the SECURITY DEFINER ``reorder_guild_memberships``
+    function (migration 0107) is the uniform self-service path — no role relies on
+    a standing all-guild bypass. Parametrized across the whole ladder so a member
+    (lowest) and an owner (highest) are both proven to work the same way.
+    """
+    user = await create_user(session, email="test@example.com", role=UserRole(role))
     guild1 = await create_guild(session, name="Guild 1")
     guild2 = await create_guild(session, name="Guild 2")
     guild3 = await create_guild(session, name="Guild 3")

--- a/backend/app/services/guilds.py
+++ b/backend/app/services/guilds.py
@@ -4,7 +4,8 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 import secrets
 
-from sqlalchemy import func
+from sqlalchemy import Integer, bindparam, func, text
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -129,34 +130,36 @@ async def reorder_memberships(
         membership.guild_id: membership for membership in memberships
     }
     seen: set[int] = set()
-    position = 0
+    final_order: list[int] = []
 
+    # Explicitly named guilds first, in the requested order — deduped, and only
+    # ones the user actually belongs to.
     for guild_id in ordered_guild_ids:
-        if guild_id in seen:
+        if guild_id in seen or guild_id not in membership_by_guild:
             continue
-        membership = membership_by_guild.get(guild_id)
-        if not membership:
-            continue
-        membership.position = position
-        session.add(membership)
+        final_order.append(guild_id)
         seen.add(guild_id)
-        position += 1
 
-    remaining = [
-        membership for membership in memberships if membership.guild_id not in seen
-    ]
-    remaining.sort(
-        key=lambda membership: (
-            membership.position if membership.position is not None else 0,
-            membership.joined_at,
-        )
+    # Memberships the client didn't mention keep their relative order, appended
+    # after — stable on current position, then join time.
+    remaining = sorted(
+        (m for m in memberships if m.guild_id not in seen),
+        key=lambda m: (m.position if m.position is not None else 0, m.joined_at),
     )
-    for membership in remaining:
-        membership.position = position
-        session.add(membership)
-        position += 1
+    final_order.extend(m.guild_id for m in remaining)
 
-    await session.flush()
+    # Persist via the SECURITY DEFINER reorder function. This runs in PERSONAL
+    # mode (no guild context) as a platform_<tier> role, which the
+    # guild_memberships_update RLS policy rejects (it requires
+    # guild_id = current_guild_id), so a direct ORM UPDATE would silently touch 0
+    # rows. The function updates ONLY `position`, scoped to this user's own rows —
+    # the same safe path for every platform tier.
+    await session.execute(
+        text("SELECT reorder_guild_memberships(:uid, :gids)").bindparams(
+            bindparam("gids", type_=ARRAY(Integer))
+        ),
+        {"uid": user_id, "gids": final_order},
+    )
 
 
 async def get_membership(

--- a/backend/app/services/soft_delete.py
+++ b/backend/app/services/soft_delete.py
@@ -297,12 +297,17 @@ async def _gather_descendants(
 
 
 async def hard_purge_entity(
-    admin_session: AsyncSession,
+    session: AsyncSession,
     entity: SoftDeleteMixin,
 ) -> None:
-    """Hard-delete the entity and every descendant. Caller must use
-    AdminSessionDep (BYPASSRLS) because the in-app ``app_user`` role's
-    RESTRICTIVE DELETE policy denies DELETEs except for guild-admin sessions.
+    """Hard-delete the entity and every descendant.
+
+    The caller's ``session`` must be able to clear the RESTRICTIVE FOR DELETE
+    policies on these tables — either a routed **guild-admin** RLS session (the
+    interactive purge endpoint) or a BYPASSRLS ``app_admin`` session (the
+    background auto-purge worker, which has no guild context). The caller is also
+    responsible for locking the target against a concurrent restore and for
+    committing.
 
     Descendants are walked via the same CASCADE_CHILDREN registry the
     soft-delete path uses, then deleted in reverse (grandchildren first)
@@ -310,19 +315,17 @@ async def hard_purge_entity(
     descendant set, upload cleanup runs before the DELETEs so blobs on
     disk and ``Upload`` rows pinned only by the doomed documents are also
     removed.
-
-    Caller commits.
     """
     from app.services.attachments import purge_document_uploads
 
-    descendants = await _gather_descendants(admin_session, entity)
+    descendants = await _gather_descendants(session, entity)
     all_doomed: list[SoftDeleteMixin] = [entity, *descendants]
 
     doomed_documents = [d for d in all_doomed if isinstance(d, Document)]
     if doomed_documents:
-        await purge_document_uploads(admin_session, doomed_documents)
+        await purge_document_uploads(session, doomed_documents)
 
     # Reverse so we delete leaves before parents — needed because most FKs
     # in this codebase don't use DB-level ON DELETE CASCADE.
     for row in reversed(all_doomed):
-        await admin_session.delete(row)
+        await session.delete(row)

--- a/frontend/src/api/generated/trash/trash.ts
+++ b/frontend/src/api/generated/trash/trash.ts
@@ -390,9 +390,16 @@ export const useRestoreTrashEntityApiV1GGuildIdTrashEntityTypeEntityIdRestorePos
   );
 };
 /**
- * Hard-purge a trashed entity. Admin-only. Runs the actual DELETE on an
- * AdminSessionDep so the RESTRICTIVE FOR DELETE policy passes (BYPASSRLS
- * role) and so the upload-cleanup helper can DELETE Upload rows.
+ * Hard-purge a trashed entity. Guild-admin only, fully guild-scoped.
+ *
+ * Runs entirely on the routed guild-admin RLS session — no standing-BYPASSRLS
+ * ``app_admin`` connection. A guild admin clears the RESTRICTIVE FOR DELETE
+ * policies (the admin-only policy from migration 0078, and ``is_initiative_member``
+ * which admits guild admins via the canonical roster from 0108), so the guild
+ * role itself does the hard delete. ``_load_trash_entity`` 404s unless the entity
+ * is in THIS guild's trash (and still soft-deleted) — that is the authorization
+ * boundary, and doing the delete on the same routed session closes the
+ * cross-session TOCTOU window the old two-session design had to guard.
  * @summary Purge Trash Entity
  */
 export const purgeTrashEntityApiV1GGuildIdTrashEntityTypeEntityIdPurgeDelete = (

--- a/frontend/src/api/generated/trash/trash.ts
+++ b/frontend/src/api/generated/trash/trash.ts
@@ -398,8 +398,9 @@ export const useRestoreTrashEntityApiV1GGuildIdTrashEntityTypeEntityIdRestorePos
  * which admits guild admins via the canonical roster from 0108), so the guild
  * role itself does the hard delete. ``_load_trash_entity`` 404s unless the entity
  * is in THIS guild's trash (and still soft-deleted) — that is the authorization
- * boundary, and doing the delete on the same routed session closes the
- * cross-session TOCTOU window the old two-session design had to guard.
+ * boundary — and ``for_update=True`` locks the row so a concurrent restore can't
+ * slip in between the ``deleted_at`` check and the delete (which would otherwise
+ * permanently remove a just-restored live row).
  * @summary Purge Trash Entity
  */
 export const purgeTrashEntityApiV1GGuildIdTrashEntityTypeEntityIdPurgeDelete = (


### PR DESCRIPTION
Resolves the three remaining `xfail`s left after the platform-roles + parallel-harness PR.

## #3 — reorder guilds (RLS gap)
`PUT /guilds/order` runs in personal mode (no guild context), which the
`guild_memberships_update` policy rejects for every platform tier — a direct
UPDATE silently touched 0 rows.

- **migration 0107**: `reorder_guild_memberships(p_user_id, p_guild_ids[])`,
  `SECURITY DEFINER`, updates **only** `position`, scoped to the caller's own
  `user_id`. EXECUTE granted to `platform_base` (every tier inherits) + `app_user`,
  revoked from PUBLIC.
- service calls the function instead of an ORM UPDATE.
- test parametrized across **all 5 platform tiers** (member..owner) — no role
  relies on a standing all-guild bypass.

## #2 — legacy-public-schema conversion benchmark
`convert_public_to_guild_schemas` is live (wired into startup) and has its own
coverage in `guild_conversion_test.py`, so the `test_existing_public_schema_guild_is_usable`
benchmark is obsolete. Removed it; kept the 4 guild create/delete provisioning
lifecycle tests.

## #1 — trash hard-purge (guild-only-admin, guild-scoped)
The purge conflated a cross-guild-user lookup with a guild-admin DELETE on an
**unrouted** `app_admin` (BYPASSRLS) session — which reads empty `public` once
data lives in `guild_<id>` → 404.

- **migration 0108**: admit guild admins in `is_initiative_member`, derived from
  the canonical `guild_memberships` roster (**not** an app-set GUC) — centralized,
  data-driven. A guild admin clears the initiative-scoped RESTRICTIVE DELETE
  policies the same way they clear the admin-only one (0078).
- `purge_trash_entity` drops the `app_admin` session and runs the load + hard
  delete on the routed **guild-admin RLS session**, which also closes the
  cross-session TOCTOU the old two-session design had to guard.

## Follow-ups (not in this PR)
- A separate **cross-guild user soft-delete** endpoint (tested) — the soft side of
  the user/admin split.
- Revisit `is_initiative_member`'s `SET search_path TO 'public'` for the fully
  converted state (pre-existing; this PR follows the existing pattern).

## Testing
Local: reorder (5/5 tiers), purge cascade, migration 0107/0108 up-down, guild
suite green. Full suite pending CI.