### PR TITLE
Platform-role RLS hardening (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Platform-role RLS hardening (Phase 2).** The purely-platform tables (`users`, `access_grants`, `app_settings`) now enforce least-privilege at the database via per-tier `platform_<role>` policies instead of relying on the app layer alone: a member sees only their own user row, support+ can read all users, moderator+ can manage them, and app-wide config (`app_settings`: OIDC, SMTP, branding, role labels, platform AI) is owner-only to write — enforced by both Postgres `GRANT`s and row-level security, with the standing `is_superadmin` bypass retired from these tables' policies. Platform user-management and owner-config endpoints now run on a role-scoped session rather than the RLS-bypassing admin engine.
+
+### Changed
+
+- The platform users CSV export (`/admin/users/export.csv`) no longer includes the `initiative_roles` column. Initiative roles are guild-scoped; a platform-level user export now contains platform data only.
+
 ## [0.51.1] - 2026-06-15
 
 ### Fixed

--- a/backend/alembic/versions/20260616_0109_platform_role_rls.py
+++ b/backend/alembic/versions/20260616_0109_platform_role_rls.py
@@ -180,10 +180,19 @@ def upgrade() -> None:
             f'TO "{owner}" USING (true) WITH CHECK (true)'
         )
     )
-    # Owner-only at the GRANT layer too (§4). app_admin keeps its standing ALL grant
-    # (BYPASSRLS engine: startup ensure_defaults + admin config writes).
+    # Owner-only at the GRANT layer too (§4), and the GRANT is the single writer
+    # gate: write is revoked from every login/floor role (app_user, platform_base,
+    # app_guild_base) and granted only to platform_owner. app_admin keeps its
+    # standing ALL grant (BYPASSRLS engine: startup ensure_defaults + admin config
+    # writes). app_guild_base keeps SELECT (the guild path reads platform AI config)
+    # but loses write — no guild-path operation writes app_settings, and making the
+    # GRANT authoritative lets a read cheaply probe `has_table_privilege` to skip a
+    # would-be-denied write instead of faulting the session on a flush.
     conn.execute(text('REVOKE INSERT, UPDATE, DELETE ON app_settings FROM "app_user"'))
     conn.execute(text(f'REVOKE INSERT, UPDATE, DELETE ON app_settings FROM "{base}"'))
+    conn.execute(
+        text('REVOKE INSERT, UPDATE, DELETE ON app_settings FROM "app_guild_base"')
+    )
     conn.execute(text(f'GRANT INSERT, UPDATE, DELETE ON app_settings TO "{owner}"'))
 
 
@@ -196,6 +205,9 @@ def downgrade() -> None:
     conn.execute(text(f'REVOKE INSERT, UPDATE, DELETE ON app_settings FROM "{owner}"'))
     conn.execute(text(f'GRANT INSERT, UPDATE, DELETE ON app_settings TO "{base}"'))
     conn.execute(text('GRANT INSERT, UPDATE, DELETE ON app_settings TO "app_user"'))
+    conn.execute(
+        text('GRANT INSERT, UPDATE, DELETE ON app_settings TO "app_guild_base"')
+    )
     conn.execute(text("DROP POLICY IF EXISTS app_settings_owner ON app_settings"))
     conn.execute(text("DROP POLICY IF EXISTS app_settings_read ON app_settings"))
     conn.execute(text("ALTER TABLE app_settings NO FORCE ROW LEVEL SECURITY"))

--- a/backend/alembic/versions/20260616_0109_platform_role_rls.py
+++ b/backend/alembic/versions/20260616_0109_platform_role_rls.py
@@ -1,0 +1,227 @@
+"""Phase 2 platform-role RLS: least-privilege policies on the purely-platform
+tables (``users``, ``access_grants``, ``app_settings``).
+
+Phase 1 (migration 0106) created the ``platform_<tier>`` ladder + ``platform_base``
+floor and routes the public/platform request path through ``SET ROLE
+platform_<tier>``, but left RLS untouched — every tier still behaved like the broad
+login role. This migration adds the DB backstop the design's §4 calls for: a
+``platform_base`` own-row floor plus per-tier ``TO platform_<tier>`` policies, so a
+tier *physically cannot* exceed its privilege on these tables even if a handler
+forgets its capability check.
+
+Scope — the three **purely-platform** tables (no guild-path entanglement):
+
+* ``users`` (identity). Decompose the wide-open ``users_open`` (``TO PUBLIC USING
+  (true)``) into:
+    - ``users_app_floor`` — broad ``TO app_user`` floor that preserves the
+      unauthenticated / bootstrap surface (login, register, password reset, OIDC)
+      and service-layer callers that run as the bare login role. The doc's §5
+      ``app_user`` narrowing stays deferred (Phase 1 explained why): this only
+      stops the *authenticated platform path* (``platform_<tier>``) from inheriting
+      god-mode on ``users``.
+    - ``users_guild_floor`` — broad ``TO app_guild_base`` floor preserving the guild
+      path's existing access to the shared ``users`` table (assignees, comment
+      authors, members, mentions, per-user AI settings write). Narrowing
+      app_guild_base is out of scope for this pass (design §1).
+    - ``users_platform_self`` — ``TO platform_base`` own-row (read/update self): the
+      member-tier floor.
+    - ``users_platform_read`` — ``TO platform_support+`` read-all (``users.read``).
+    - ``users_platform_manage`` — ``TO platform_moderator+`` update-all
+      (``users.manage``).
+  ``users_no_delete`` (RESTRICTIVE DELETE deny) is kept: user deletion is a
+  cross-schema cascade that stays on the ``app_admin`` engine.
+
+* ``access_grants`` (PAM). Retire ``is_superadmin``: own rows for everyone (the
+  requester, and the ``get_live_grant`` lookup on the guild-routing path, which
+  runs as ``app_user`` and filters ``user_id``); ``platform_admin+`` manage the full
+  queue (``access.read`` / ``access.approve``).
+
+* ``app_settings`` (owner-only config). ENABLE+FORCE RLS; everyone may SELECT
+  (public reads: interface colors, role labels, OIDC status, FCM); only
+  ``platform_owner`` may write — enforced at BOTH the RLS layer (``TO
+  platform_owner``) and the table GRANT (write revoked from ``app_user`` /
+  ``platform_base``, granted to ``platform_owner``), per §4. ``app_admin``
+  (BYPASSRLS + standing ALL grant) keeps writing for startup ``ensure_defaults``
+  and the admin config endpoints. The lazy singleton create/reseed on read is made
+  privilege-tolerant in ``app.services.app_settings`` so a non-owner read returns a
+  transient default instead of faulting.
+
+NOT in scope (deferred to Phase 3, per §11): the dual-path tables (``guilds``,
+``guild_memberships``, ``guild_invites``, ``oidc_claim_mappings``) keep their
+``is_superadmin`` leg — removing it before break-glass exists would lock admins out
+of a guild mid-migration. ``is_superadmin`` is therefore retired only from the
+policies this migration rewrites; the GUC is still set on the public path
+(``get_user_session``) but is inert for these three tables (no policy references
+it).
+
+Role names carry ``settings.PLATFORM_ROLE_PREFIX`` (empty in prod/dev; ``test_…``
+under the suite) read at apply time, matching the roles migration 0106 created.
+``app_user`` is the fixed, unprefixed login role from the baseline.
+
+Revision ID: 20260616_0109
+Revises: 20260616_0108
+Create Date: 2026-06-16
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.db.schema_provisioning import platform_role_name
+
+revision = "20260616_0109"
+down_revision = "20260616_0108"
+branch_labels = None
+depends_on = None
+
+# Row-owner predicate (mirrors the baseline constant). NULLIF-guarded so an unset
+# context casts cleanly instead of faulting the whole query.
+USER_ID = (
+    "NULLIF(current_setting('app.current_user_id'::text, true), ''::text)::integer"
+)
+
+
+def _base_role() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+def _role_list(*tiers: str) -> str:
+    """Quoted, comma-joined ``platform_<tier>`` role names for a ``TO`` clause."""
+    return ", ".join(f'"{platform_role_name(t)}"' for t in tiers)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    base = _base_role()
+    owner = platform_role_name("owner")
+    support_plus = _role_list("support", "moderator", "admin", "owner")
+    moderator_plus = _role_list("moderator", "admin", "owner")
+    admin_plus = _role_list("admin", "owner")
+
+    # ---- users -------------------------------------------------------------
+    conn.execute(text("DROP POLICY IF EXISTS users_open ON users"))
+    conn.execute(
+        text(
+            "CREATE POLICY users_app_floor ON users AS PERMISSIVE FOR ALL "
+            'TO "app_user" USING (true) WITH CHECK (true)'
+        )
+    )
+    # Guild-path floor. ``users`` is a shared table the guild path reads/writes
+    # constantly (assignees, comment authors, members, mentions, and the per-user AI
+    # settings write), under ``guild_<id>`` / ``guild_<id>_ro`` roles that inherit
+    # ``app_guild_base``. Preserve that access verbatim — narrowing app_guild_base is
+    # explicitly out of scope for this pass (design §1); this only de-couples the
+    # platform path. The read-only PAM role is still write-blocked by its own GRANT.
+    conn.execute(
+        text(
+            "CREATE POLICY users_guild_floor ON users AS PERMISSIVE FOR ALL "
+            'TO "app_guild_base" USING (true) WITH CHECK (true)'
+        )
+    )
+    conn.execute(
+        text(
+            f"CREATE POLICY users_platform_self ON users AS PERMISSIVE FOR ALL "
+            f'TO "{base}" USING (id = ({USER_ID})) WITH CHECK (id = ({USER_ID}))'
+        )
+    )
+    conn.execute(
+        text(
+            f"CREATE POLICY users_platform_read ON users AS PERMISSIVE FOR SELECT "
+            f"TO {support_plus} USING (true)"
+        )
+    )
+    conn.execute(
+        text(
+            f"CREATE POLICY users_platform_manage ON users AS PERMISSIVE FOR UPDATE "
+            f"TO {moderator_plus} USING (true) WITH CHECK (true)"
+        )
+    )
+    # users_no_delete (RESTRICTIVE DELETE deny) is intentionally retained.
+
+    # ---- access_grants -----------------------------------------------------
+    conn.execute(
+        text("DROP POLICY IF EXISTS access_grants_self_or_super ON access_grants")
+    )
+    conn.execute(
+        text(
+            f"CREATE POLICY access_grants_self ON access_grants AS PERMISSIVE FOR ALL "
+            f"TO PUBLIC USING (user_id = ({USER_ID})) "
+            f"WITH CHECK (user_id = ({USER_ID}))"
+        )
+    )
+    conn.execute(
+        text(
+            f"CREATE POLICY access_grants_admin ON access_grants AS PERMISSIVE FOR ALL "
+            f"TO {admin_plus} USING (true) WITH CHECK (true)"
+        )
+    )
+
+    # ---- app_settings (owner-only config) ----------------------------------
+    conn.execute(text("ALTER TABLE app_settings ENABLE ROW LEVEL SECURITY"))
+    conn.execute(text("ALTER TABLE ONLY app_settings FORCE ROW LEVEL SECURITY"))
+    # SELECT stays broad ON PURPOSE: the singleton row is read by app_user on
+    # unauthenticated/service paths that have no owner tier to assume — the OIDC
+    # login/callback flow (decrypts oidc_client_secret) and the email service
+    # (decrypts smtp_password) both need it. Owner-only READ at the DB would break
+    # those. The owner-only boundary is on WRITES (policy + GRANT below); the
+    # owner-gated config-read *endpoints* run owner-scoped (UserSessionDep) at the
+    # app layer, and the sensitive columns are encrypted at rest (SECRET_KEY), so a
+    # broad SELECT exposes only ciphertext. A future column-level split of public
+    # branding vs sensitive config could tighten this; out of scope here.
+    conn.execute(
+        text(
+            "CREATE POLICY app_settings_read ON app_settings AS PERMISSIVE FOR SELECT "
+            "TO PUBLIC USING (true)"
+        )
+    )
+    conn.execute(
+        text(
+            f"CREATE POLICY app_settings_owner ON app_settings AS PERMISSIVE FOR ALL "
+            f'TO "{owner}" USING (true) WITH CHECK (true)'
+        )
+    )
+    # Owner-only at the GRANT layer too (§4). app_admin keeps its standing ALL grant
+    # (BYPASSRLS engine: startup ensure_defaults + admin config writes).
+    conn.execute(text('REVOKE INSERT, UPDATE, DELETE ON app_settings FROM "app_user"'))
+    conn.execute(text(f'REVOKE INSERT, UPDATE, DELETE ON app_settings FROM "{base}"'))
+    conn.execute(text(f'GRANT INSERT, UPDATE, DELETE ON app_settings TO "{owner}"'))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    base = _base_role()
+    owner = platform_role_name("owner")
+
+    # ---- app_settings ----
+    conn.execute(text(f'REVOKE INSERT, UPDATE, DELETE ON app_settings FROM "{owner}"'))
+    conn.execute(text(f'GRANT INSERT, UPDATE, DELETE ON app_settings TO "{base}"'))
+    conn.execute(text('GRANT INSERT, UPDATE, DELETE ON app_settings TO "app_user"'))
+    conn.execute(text("DROP POLICY IF EXISTS app_settings_owner ON app_settings"))
+    conn.execute(text("DROP POLICY IF EXISTS app_settings_read ON app_settings"))
+    conn.execute(text("ALTER TABLE app_settings NO FORCE ROW LEVEL SECURITY"))
+    conn.execute(text("ALTER TABLE app_settings DISABLE ROW LEVEL SECURITY"))
+
+    # ---- access_grants ----
+    conn.execute(text("DROP POLICY IF EXISTS access_grants_admin ON access_grants"))
+    conn.execute(text("DROP POLICY IF EXISTS access_grants_self ON access_grants"))
+    is_super = "current_setting('app.is_superadmin'::text, true) = 'true'::text"
+    conn.execute(
+        text(
+            f"CREATE POLICY access_grants_self_or_super ON access_grants FOR ALL "
+            f"USING ((user_id = ({USER_ID})) OR ({is_super})) "
+            f"WITH CHECK ((user_id = ({USER_ID})) OR ({is_super}))"
+        )
+    )
+
+    # ---- users ----
+    conn.execute(text("DROP POLICY IF EXISTS users_platform_manage ON users"))
+    conn.execute(text("DROP POLICY IF EXISTS users_platform_read ON users"))
+    conn.execute(text("DROP POLICY IF EXISTS users_platform_self ON users"))
+    conn.execute(text("DROP POLICY IF EXISTS users_guild_floor ON users"))
+    conn.execute(text("DROP POLICY IF EXISTS users_app_floor ON users"))
+    conn.execute(
+        text(
+            "CREATE POLICY users_open ON users AS PERMISSIVE FOR ALL "
+            "USING (true) WITH CHECK (true)"
+        )
+    )

--- a/backend/app/api/v1/guild_endpoints/ai_settings.py
+++ b/backend/app/api/v1/guild_endpoints/ai_settings.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from app.api.deps import (
     GuildContext,
     RLSSessionDep,
-    SessionDep,
+    UserSessionDep,
     get_current_active_user,
     get_guild_membership,
     require_guild_roles,
@@ -52,20 +52,24 @@ GuildContextDep = Annotated[GuildContext, Depends(get_guild_membership)]
 # Platform-level endpoints (platform admin only)
 @platform_router.get("/ai/platform", response_model=PlatformAISettingsResponse)
 async def get_platform_ai_settings(
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> PlatformAISettingsResponse:
-    """Get platform-level AI settings. Platform admin only."""
+    """Get platform-level AI settings (``config.manage`` — owner only, owner-scoped)."""
     return await ai_settings_service.get_platform_ai_settings(session)
 
 
 @platform_router.put("/ai/platform", response_model=PlatformAISettingsResponse)
 async def update_platform_ai_settings(
     payload: PlatformAISettingsUpdate,
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> PlatformAISettingsResponse:
-    """Update platform-level AI settings. Platform admin only."""
+    """Update platform-level AI settings (``config.manage`` — owner only).
+
+    Owner-scoped session: ``app_settings`` is owner-only after Phase 2 (GRANT + RLS),
+    so this write runs as ``platform_owner`` rather than the bare login role.
+    """
     data = payload.model_dump(exclude_unset=True)
     api_key_provided = "api_key" in data
     return await ai_settings_service.update_platform_ai_settings(

--- a/backend/app/api/v1/public_endpoints/admin.py
+++ b/backend/app/api/v1/public_endpoints/admin.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Response
 from sqlmodel import select
 
-from app.api.deps import require_capability
+from app.api.deps import UserSessionDep, require_capability
 from app.core.capabilities import Capability, capabilities_for, can_assign_role
 from app.db.session import get_admin_session, set_rls_context
 from app.db.schema_provisioning import deprovision_guild
@@ -57,10 +57,16 @@ AdminSessionDep = Annotated[AsyncSession, Depends(get_admin_session)]
 
 @router.get("/users", response_model=List[UserRead])
 async def list_all_users(
-    session: AdminSessionDep,
+    session: UserSessionDep,
     _current_user: UsersReadDep,
 ) -> Sequence[User]:
-    """List all users in the platform (admin only)."""
+    """List all users in the platform (``users.read``).
+
+    Platform-scoped: runs on the role-scoped session (``platform_<tier>``), so the
+    cross-user read is authorized by RLS (``users_platform_read``, support+) rather
+    than the BYPASSRLS admin engine. Initiative roles are guild-scoped and
+    deliberately NOT loaded here — a platform user view exposes platform data only.
+    """
     from app.services.users import SYSTEM_USER_EMAIL
 
     stmt = (
@@ -69,9 +75,7 @@ async def list_all_users(
         .order_by(User.created_at.asc())
     )
     result = await session.exec(stmt)
-    users = result.all()
-    await initiatives_service.load_user_initiative_roles(session, users)
-    return users
+    return result.all()
 
 
 _PLATFORM_CSV_HEADERS = [
@@ -85,13 +89,12 @@ _PLATFORM_CSV_HEADERS = [
     "updated_at",
     "timezone",
     "locale",
-    "initiative_roles",
 ]
 
 
 @router.get("/users/export.csv")
 async def export_platform_users_csv(
-    session: AdminSessionDep,
+    session: UserSessionDep,
     _current_user: UsersReadDep,
     user_id: Annotated[list[int] | None, Query()] = None,
 ) -> Response:
@@ -115,8 +118,6 @@ async def export_platform_users_csv(
             status_code=status.HTTP_404_NOT_FOUND, detail=AdminMessages.USER_NOT_FOUND
         )
 
-    await initiatives_service.load_user_initiative_roles(session, users)
-
     rows = []
     for user in users:
         rows.append(
@@ -131,7 +132,6 @@ async def export_platform_users_csv(
                 user.updated_at.isoformat() if user.updated_at else "",
                 user.timezone or "",
                 user.locale or "",
-                csv_export.format_initiative_roles(user),
             ]
         )
 
@@ -230,10 +230,10 @@ async def reactivate_user(
 
 @router.get("/platform-admin-count", response_model=PlatformAdminCountResponse)
 async def get_platform_admin_count(
-    session: AdminSessionDep,
+    session: UserSessionDep,
     _current_user: UsersReadDep,
 ) -> PlatformAdminCountResponse:
-    """Get the count of platform admins (admin only)."""
+    """Get the count of platform admins (``users.read``, role-scoped session)."""
     count = await users_service.count_platform_admins(session)
     return PlatformAdminCountResponse(count=count)
 

--- a/backend/app/api/v1/public_endpoints/admin_test.py
+++ b/backend/app/api/v1/public_endpoints/admin_test.py
@@ -55,7 +55,6 @@ async def test_export_platform_users_csv_as_admin(
         "updated_at",
         "timezone",
         "locale",
-        "initiative_roles",
     ]
     emails = {row[1] for row in data_rows}
     assert "admin@example.com" in emails

--- a/backend/app/api/v1/public_endpoints/settings.py
+++ b/backend/app/api/v1/public_endpoints/settings.py
@@ -8,6 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import (
     SessionDep,
+    UserSessionDep,
     get_current_active_user,
     GuildContext,
     require_guild_roles,
@@ -80,7 +81,7 @@ def _email_settings_payload(settings_obj: AppSetting) -> EmailSettingsResponse:
 
 @router.get("/auth", response_model=OIDCSettingsResponse)
 async def get_oidc_settings(
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> OIDCSettingsResponse:
     settings_obj = await app_settings_service.get_app_settings(session)
@@ -99,7 +100,7 @@ async def get_oidc_settings(
 @router.put("/auth", response_model=OIDCSettingsResponse)
 async def update_oidc_settings(
     payload: OIDCSettingsUpdate,
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> OIDCSettingsResponse:
     updated = await app_settings_service.update_oidc_settings(
@@ -146,7 +147,7 @@ async def get_role_labels(
 @router.put("/interface", response_model=InterfaceSettingsResponse)
 async def update_interface_settings(
     payload: InterfaceSettingsUpdate,
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> InterfaceSettingsResponse:
     settings_obj = await app_settings_service.update_interface_colors(
@@ -163,7 +164,7 @@ async def update_interface_settings(
 @router.put("/roles", response_model=RoleLabelsResponse)
 async def update_role_labels(
     payload: RoleLabelsUpdate,
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> RoleLabelsResponse:
     updated = await app_settings_service.update_role_labels(
@@ -175,7 +176,7 @@ async def update_role_labels(
 
 @router.get("/email", response_model=EmailSettingsResponse)
 async def get_email_settings(
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> EmailSettingsResponse:
     settings_obj = await app_settings_service.get_app_settings(session)
@@ -185,7 +186,7 @@ async def get_email_settings(
 @router.put("/email", response_model=EmailSettingsResponse)
 async def update_email_settings(
     payload: EmailSettingsUpdate,
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> EmailSettingsResponse:
     data = payload.model_dump(exclude_unset=True)
@@ -208,7 +209,7 @@ async def update_email_settings(
 @router.post("/email/test")
 async def send_test_email(
     payload: EmailTestRequest,
-    session: SessionDep,
+    session: UserSessionDep,
     _admin: ConfigManageDep,
 ) -> dict:
     settings_obj = await app_settings_service.get_app_settings(session)
@@ -333,6 +334,8 @@ async def update_oidc_claim_path(
     session: AdminSessionDep,
     _admin: ConfigManageDep,
 ) -> dict:
+    # Residual admin-engine: kept with the rest of the oidc-mappings surface,
+    # which is deferred to Phase 3 (guild-scoped / dual-path + break-glass).
     settings_obj = await app_settings_service.get_app_settings(session)
     cleaned = payload.claim_path.strip() if payload.claim_path else None
     settings_obj.oidc_role_claim_path = cleaned or None

--- a/backend/app/db/platform_role_rls_test.py
+++ b/backend/app/db/platform_role_rls_test.py
@@ -205,6 +205,40 @@ async def test_app_settings_readable_by_every_tier(session):
     assert len(rows) == 1
 
 
+async def test_app_settings_reseed_degrades_to_transient_for_non_owner(
+    session, monkeypatch
+):
+    """A non-owner read that would env-reseed an existing config row can't write
+    (owner-only). It must return an env-correct *transient* copy without faulting,
+    and must NOT persist (the savepoint rollback expires the tracked instance — the
+    re-seed path rebuilds from a pre-captured snapshot). The env value is persisted
+    later by an owner / startup, not by a non-owner read."""
+    from app.core.config import settings as app_config
+    from app.services import app_settings as svc
+
+    # Existing singleton with an empty oidc_issuer.
+    await session.execute(
+        text(
+            "INSERT INTO app_settings (id, oidc_enabled, oidc_scopes, role_labels) "
+            "VALUES (1, false, '[]'::json, '{}'::json) ON CONFLICT (id) DO NOTHING"
+        )
+    )
+    member = await create_user(session, role=UserRole.member)
+    monkeypatch.setattr(app_config, "OIDC_ISSUER", "https://issuer.example")
+
+    await _assume(session, "member", member.id)
+    settings_obj = await svc.get_app_settings(session)
+    # env-correct transient, no fault despite the owner-only write being denied
+    assert settings_obj.oidc_issuer == "https://issuer.example"
+    await _reset(session)
+
+    # The non-owner read did NOT persist the env value into the row.
+    db_issuer = (
+        await session.execute(text("SELECT oidc_issuer FROM app_settings WHERE id = 1"))
+    ).scalar_one()
+    assert db_issuer is None
+
+
 # --- end-to-end through the real-role request path ------------------------
 
 

--- a/backend/app/db/platform_role_rls_test.py
+++ b/backend/app/db/platform_role_rls_test.py
@@ -1,0 +1,246 @@
+"""Phase 2 platform-role RLS ceilings (migration 0109).
+
+These assert the *DB backstop* added in Phase 2: on the purely-platform tables
+(``users``, ``access_grants``, ``app_settings``) a tier physically cannot exceed its
+privilege, independent of the app-layer capability checks.
+
+Two complementary styles:
+
+* **Direct ``SET ROLE`` (DB-level).** The ``session`` fixture connects as the
+  superuser, but ``SET ROLE platform_<tier>`` drops to a non-superuser role, so RLS
+  and table GRANTs ARE enforced from that statement on — exactly like the production
+  request path. This proves the policy/grant ceiling without the app layer in the
+  way.
+* **End-to-end (real-role ``client``).** An authenticated request assumes
+  ``platform_<tier>`` on a real ``app_user`` connection, so the moved endpoints
+  (admin user reads, owner config writes) run role-scoped, RLS-enforced.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.schema_provisioning import platform_role_name
+from app.models.user import UserRole
+from app.testing import create_guild, create_user
+
+
+async def _assume(session, tier: str, user_id: int) -> None:
+    """Assume ``platform_<tier>`` with ``current_user_id`` set, on the session's
+    connection — mirrors what ``set_rls_context`` does for a public-path request."""
+    await session.execute(
+        text(
+            "SELECT set_config('app.current_user_id', :uid, false), "
+            "set_config('role', :role, false)"
+        ),
+        {"uid": str(user_id), "role": platform_role_name(tier)},
+    )
+
+
+async def _reset(session) -> None:
+    await session.execute(
+        text(
+            "SELECT set_config('role', 'none', false), "
+            "set_config('app.current_user_id', '', false)"
+        )
+    )
+
+
+# --- users ----------------------------------------------------------------
+
+
+async def test_member_sees_only_own_user_row(session):
+    """The member-tier floor: ``platform_base`` own-row only. A member can read
+    their own ``users`` row but not anyone else's."""
+    u1 = await create_user(session)
+    u2 = await create_user(session)
+    await _assume(session, "member", u1.id)
+    ids = {
+        r[0] for r in (await session.execute(text("SELECT id FROM users"))).fetchall()
+    }
+    await _reset(session)
+    assert u1.id in ids
+    assert u2.id not in ids
+
+
+async def test_support_reads_all_users(session):
+    """``users.read`` — support+ can SELECT every user row (``users_platform_read``)."""
+    u1 = await create_user(session)
+    u2 = await create_user(session)
+    await _assume(session, "support", u1.id)
+    ids = {
+        r[0] for r in (await session.execute(text("SELECT id FROM users"))).fetchall()
+    }
+    await _reset(session)
+    assert {u1.id, u2.id} <= ids
+
+
+async def test_support_cannot_update_others_but_moderator_can(session):
+    """``users.manage`` is moderator+. Support has read-all but no update-all, so an
+    UPDATE of another user touches 0 rows (RLS USING filters it out); moderator's
+    ``users_platform_manage`` lets the same UPDATE land."""
+    actor = await create_user(session)
+    target = await create_user(session)
+
+    await _assume(session, "support", actor.id)
+    res = await session.execute(
+        text("UPDATE users SET full_name = 'sx' WHERE id = :id"), {"id": target.id}
+    )
+    await _reset(session)
+    assert res.rowcount == 0
+
+    await _assume(session, "moderator", actor.id)
+    res = await session.execute(
+        text("UPDATE users SET full_name = 'mx' WHERE id = :id"), {"id": target.id}
+    )
+    await _reset(session)
+    assert res.rowcount == 1
+
+
+async def test_no_tier_can_delete_users(session):
+    """``users_no_delete`` (RESTRICTIVE) keeps DELETE denied even for owner; user
+    deletion stays on the admin engine."""
+    actor = await create_user(session)
+    target = await create_user(session)
+    await _assume(session, "owner", actor.id)
+    res = await session.execute(
+        text("DELETE FROM users WHERE id = :id"), {"id": target.id}
+    )
+    await _reset(session)
+    assert res.rowcount == 0
+
+
+# --- access_grants --------------------------------------------------------
+
+
+async def _insert_grant(session, user_id: int, guild_id: int) -> None:
+    await session.execute(
+        text(
+            "INSERT INTO access_grants "
+            "(user_id, guild_id, reason, requested_duration_minutes, requested_by_id) "
+            "VALUES (:u, :g, 'r', 60, :u)"
+        ),
+        {"u": user_id, "g": guild_id},
+    )
+
+
+async def test_access_grants_self_vs_admin(session):
+    """A grantee sees only their own grant (``access_grants_self``); an admin sees
+    the whole queue (``access_grants_admin``). ``is_superadmin`` is retired here."""
+    guild = await create_guild(session)
+    u1 = await create_user(session)
+    u2 = await create_user(session)
+    await _insert_grant(session, u1.id, guild.id)
+    await _insert_grant(session, u2.id, guild.id)
+
+    await _assume(session, "member", u1.id)
+    own = {
+        r[0]
+        for r in (
+            await session.execute(text("SELECT user_id FROM access_grants"))
+        ).fetchall()
+    }
+    await _reset(session)
+    assert own == {u1.id}
+
+    await _assume(session, "admin", u1.id)
+    allrows = {
+        r[0]
+        for r in (
+            await session.execute(text("SELECT user_id FROM access_grants"))
+        ).fetchall()
+    }
+    await _reset(session)
+    assert {u1.id, u2.id} <= allrows
+
+
+# --- app_settings (owner-only config) -------------------------------------
+
+
+async def test_app_settings_write_is_owner_only(session):
+    """Config writes are owner-only at the GRANT layer: a member's UPDATE raises
+    insufficient-privilege (42501), the owner's lands."""
+    owner = await create_user(session, role=UserRole.owner)
+    member = await create_user(session, role=UserRole.member)
+    await session.execute(
+        text(
+            "INSERT INTO app_settings (id, oidc_enabled, oidc_scopes, role_labels) "
+            "VALUES (1, false, '[]'::json, '{}'::json) ON CONFLICT (id) DO NOTHING"
+        )
+    )
+
+    await _assume(session, "member", member.id)
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.execute(
+                text(
+                    "UPDATE app_settings SET light_accent_color = '#000000' WHERE id = 1"
+                )
+            )
+    await _reset(session)
+
+    await _assume(session, "owner", owner.id)
+    res = await session.execute(
+        text("UPDATE app_settings SET light_accent_color = '#abcdef' WHERE id = 1")
+    )
+    await _reset(session)
+    assert res.rowcount == 1
+
+
+async def test_app_settings_readable_by_every_tier(session):
+    """Everyone may SELECT config (``app_settings_read`` TO PUBLIC) — public reads
+    like interface colors / role labels must work for any tier."""
+    await session.execute(
+        text(
+            "INSERT INTO app_settings (id, oidc_enabled, oidc_scopes, role_labels) "
+            "VALUES (1, false, '[]'::json, '{}'::json) ON CONFLICT (id) DO NOTHING"
+        )
+    )
+    member = await create_user(session, role=UserRole.member)
+    await _assume(session, "member", member.id)
+    rows = (
+        await session.execute(text("SELECT id FROM app_settings WHERE id = 1"))
+    ).fetchall()
+    await _reset(session)
+    assert len(rows) == 1
+
+
+# --- end-to-end through the real-role request path ------------------------
+
+
+async def test_support_can_list_users_role_scoped(client, acting_user):
+    """The moved ``GET /admin/users`` runs as ``platform_support`` (off the BYPASSRLS
+    engine) and the cross-user read is authorized by ``users_platform_read``."""
+    user, headers = await acting_user("support")
+    resp = await client.get("/api/v1/admin/users", headers=headers)
+    assert resp.status_code == 200
+    assert any(u["id"] == user.id for u in resp.json())
+
+
+async def test_member_cannot_list_users(client, acting_user):
+    """The capability gate still holds above RLS: a member lacks ``users.read``."""
+    _user, headers = await acting_user("member")
+    resp = await client.get("/api/v1/admin/users", headers=headers)
+    assert resp.status_code == 403
+
+
+async def test_owner_can_update_interface_settings_role_scoped(client, acting_user):
+    """The moved ``PUT /settings/interface`` runs as ``platform_owner`` and the
+    owner-only GRANT + ``app_settings_owner`` policy let the write through."""
+    _user, headers = await acting_user("owner")
+    resp = await client.put(
+        "/api/v1/settings/interface",
+        headers=headers,
+        json={"light_accent_color": "#123456", "dark_accent_color": "#654321"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["light_accent_color"] == "#123456"
+
+
+async def test_interface_settings_readable_without_write_privilege(client, acting_user):
+    """A public config read works even for a non-owner when the singleton row is
+    absent: the privilege-tolerant lazy-create degrades to a transient default
+    instead of faulting on the owner-only write."""
+    _user, headers = await acting_user("member")
+    resp = await client.get("/api/v1/settings/interface", headers=headers)
+    assert resp.status_code == 200

--- a/backend/app/services/app_settings.py
+++ b/backend/app/services/app_settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy import text
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -124,49 +124,31 @@ def _build_default_app_settings() -> AppSetting:
     )
 
 
-def _is_insufficient_privilege(exc: BaseException) -> bool:
-    """True for a Postgres insufficient-privilege error (SQLSTATE 42501).
+async def _session_can_write_app_settings(session: AsyncSession) -> bool:
+    """Whether the current DB role may WRITE ``app_settings``.
 
-    Covers both a denied GRANT and an RLS WITH CHECK violation — the two ways a
-    non-owner session is blocked from writing ``app_settings`` after Phase 2.
+    After Phase 2 ``app_settings`` is owner-only at the GRANT layer (write granted
+    only to ``platform_owner`` + the ``app_admin`` engine; revoked from ``app_user``,
+    ``platform_base``, and ``app_guild_base``), and that GRANT is the single writer
+    gate. A non-owner session that reads config and would lazily create / env-reseed
+    the singleton must NOT attempt the write: an ORM flush failure dooms the whole
+    session transaction (a SAVEPOINT doesn't isolate a failed flush the way it does a
+    plain statement). So we probe the grant up front and skip the write, serving an
+    in-memory env-correct value instead. ``has_table_privilege`` respects role
+    inheritance, so it is authoritative now that the grant alone gates writes.
     """
-    orig = getattr(exc, "orig", None)
-    code = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
-    return code == "42501"
+    return bool(
+        await session.scalar(
+            text("SELECT has_table_privilege('app_settings', 'UPDATE')")
+        )
+    )
 
 
-async def _persist_app_settings(
-    session: AsyncSession, settings_row: AppSetting
-) -> bool:
-    """Persist ``settings_row``; return True iff it was written.
-
-    Owner / app_admin / startup sessions persist normally. After Phase 2,
-    ``app_settings`` is owner-only (GRANT + RLS), so a non-owner session (``app_user``
-    or a platform tier below owner) that triggers the lazy singleton create / env
-    re-seed on a READ hits insufficient-privilege. We catch that inside a SAVEPOINT
-    (so the read doesn't 500) and return False — the caller serves a transient,
-    env-correct fallback instead.
-
-    Contract for the caller on a False return: the SAVEPOINT rollback EXPIRES a
-    *tracked/persistent* instance (its Python-side edits are lost, and async
-    attribute access then faults), so a re-seed caller must capture the env-merged
-    values BEFORE calling this and rebuild a transient — it cannot reuse the
-    instance. A freshly-built *transient* passed in (the create path) is merely
-    expunged on rollback and keeps its in-memory values, so it can be returned
-    as-is.
-    """
-    try:
-        async with session.begin_nested():
-            session.add(settings_row)
-            await session.flush()
-    except DBAPIError as exc:
-        if not _is_insufficient_privilege(exc):
-            raise
-        return False
+async def _write_app_settings(session: AsyncSession, settings_row: AppSetting) -> None:
+    session.add(settings_row)
     await session.commit()
     await reapply_rls_context(session)
     await session.refresh(settings_row)
-    return True
 
 
 async def _ensure_app_settings(session: AsyncSession) -> AppSetting:
@@ -174,55 +156,56 @@ async def _ensure_app_settings(session: AsyncSession) -> AppSetting:
     result = await session.exec(stmt)
     settings_row = result.one_or_none()
     if settings_row:
-        updated = False
-        # NOTE: oidc_enabled is intentionally NOT overridden here.
-        # It is seeded from the env var on first creation only, so that
-        # admins can disable OIDC via the UI without the env var forcing
-        # it back on every read.
+        # Collect env values for fields the row hasn't got yet (no mutation until
+        # we know we can persist — see _session_can_write_app_settings).
+        # NOTE: oidc_enabled is intentionally NOT re-seeded here. It is set from
+        # the env var on first creation only, so an admin can disable OIDC via the
+        # UI without the env var forcing it back on every read.
+        env_updates: dict[str, object] = {}
         if not settings_row.oidc_issuer and app_config.OIDC_ISSUER:
-            settings_row.oidc_issuer = _normalize_optional_string(
+            env_updates["oidc_issuer"] = _normalize_optional_string(
                 app_config.OIDC_ISSUER
             )
-            updated = True
         if not settings_row.oidc_client_id and app_config.OIDC_CLIENT_ID:
-            settings_row.oidc_client_id = _normalize_optional_string(
+            env_updates["oidc_client_id"] = _normalize_optional_string(
                 app_config.OIDC_CLIENT_ID
             )
-            updated = True
         if (
             not settings_row.oidc_client_secret_encrypted
             and app_config.OIDC_CLIENT_SECRET
         ):
             v = _normalize_optional_string(app_config.OIDC_CLIENT_SECRET)
-            settings_row.oidc_client_secret_encrypted = (
+            env_updates["oidc_client_secret_encrypted"] = (
                 encrypt_field(v, SALT_OIDC_CLIENT_SECRET) if v else None
             )
-            updated = True
         if not settings_row.oidc_provider_name and app_config.OIDC_PROVIDER_NAME:
-            settings_row.oidc_provider_name = _normalize_optional_string(
+            env_updates["oidc_provider_name"] = _normalize_optional_string(
                 app_config.OIDC_PROVIDER_NAME
             )
-            updated = True
         env_scopes = _normalize_scopes(app_config.OIDC_SCOPES or [])
         if env_scopes and not settings_row.oidc_scopes:
-            settings_row.oidc_scopes = env_scopes
-            updated = True
-        if updated:
-            # Snapshot the env-merged state NOW, while the instance is attached
-            # and valid. A degraded (non-owner) persist rolls back its SAVEPOINT,
-            # which EXPIRES this tracked instance — dropping the in-memory env
-            # values and (under async) faulting on the next attribute access. On
-            # that path we return a transient, env-correct copy built from the
-            # snapshot instead of the expired instance.
-            snapshot = {
-                col.name: getattr(settings_row, col.name)
-                for col in AppSetting.__table__.columns
-            }
-            if not await _persist_app_settings(session, settings_row):
-                return AppSetting(**snapshot)
-        return settings_row
+            env_updates["oidc_scopes"] = env_scopes
+        if not env_updates:
+            return settings_row
+        if await _session_can_write_app_settings(session):
+            for field, value in env_updates.items():
+                setattr(settings_row, field, value)
+            await _write_app_settings(session, settings_row)
+            return settings_row
+        # Non-writer (e.g. unauthenticated OIDC login as app_user): serve an
+        # env-correct *transient* without touching the tracked row — we neither
+        # persist nor leave a dirty instance a later commit would fault on. The
+        # env value is persisted later by an owner write or the next startup
+        # ensure_defaults (app_admin).
+        merged = {
+            col.name: getattr(settings_row, col.name)
+            for col in AppSetting.__table__.columns
+        }
+        merged.update(env_updates)
+        return AppSetting(**merged)
     app_settings = _build_default_app_settings()
-    await _persist_app_settings(session, app_settings)
+    if await _session_can_write_app_settings(session):
+        await _write_app_settings(session, app_settings)
     return app_settings
 
 

--- a/backend/app/services/app_settings.py
+++ b/backend/app/services/app_settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 
+from sqlalchemy.exc import DBAPIError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -85,6 +86,82 @@ async def get_or_create_guild_settings(
     return await _ensure_guild_setting(session, resolved_guild_id)
 
 
+def _build_default_app_settings() -> AppSetting:
+    """A fresh, env-seeded ``AppSetting`` singleton (id=1), NOT persisted.
+
+    Shared by the create path (persisted by a writer) and the privilege-tolerant
+    read fallback (returned transient to a non-owner caller).
+    """
+    _oidc_secret = _normalize_optional_string(app_config.OIDC_CLIENT_SECRET)
+    _smtp_pw = _normalize_optional_string(app_config.SMTP_PASSWORD)
+    return AppSetting(
+        id=GLOBAL_SETTINGS_ID,
+        oidc_enabled=bool(app_config.OIDC_ENABLED),
+        oidc_issuer=_normalize_optional_string(app_config.OIDC_ISSUER),
+        oidc_client_id=_normalize_optional_string(app_config.OIDC_CLIENT_ID),
+        oidc_client_secret_encrypted=encrypt_field(
+            _oidc_secret, SALT_OIDC_CLIENT_SECRET
+        )
+        if _oidc_secret
+        else None,
+        oidc_provider_name=_normalize_optional_string(app_config.OIDC_PROVIDER_NAME),
+        oidc_scopes=_normalize_scopes(
+            app_config.OIDC_SCOPES or ["openid", "profile", "email", "offline_access"]
+        ),
+        light_accent_color="#2563eb",
+        dark_accent_color="#60a5fa",
+        role_labels=DEFAULT_ROLE_LABELS.copy(),
+        smtp_host=_normalize_optional_string(app_config.SMTP_HOST),
+        smtp_port=app_config.SMTP_PORT if app_config.SMTP_HOST else None,
+        smtp_secure=bool(app_config.SMTP_SECURE),
+        smtp_reject_unauthorized=bool(app_config.SMTP_REJECT_UNAUTHORIZED),
+        smtp_username=_normalize_optional_string(app_config.SMTP_USERNAME),
+        smtp_password_encrypted=encrypt_field(_smtp_pw, SALT_SMTP_PASSWORD)
+        if _smtp_pw
+        else None,
+        smtp_from_address=_normalize_optional_string(app_config.SMTP_FROM_ADDRESS),
+        smtp_test_recipient=_normalize_optional_string(app_config.SMTP_TEST_RECIPIENT),
+    )
+
+
+def _is_insufficient_privilege(exc: BaseException) -> bool:
+    """True for a Postgres insufficient-privilege error (SQLSTATE 42501).
+
+    Covers both a denied GRANT and an RLS WITH CHECK violation — the two ways a
+    non-owner session is blocked from writing ``app_settings`` after Phase 2.
+    """
+    orig = getattr(exc, "orig", None)
+    code = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+    return code == "42501"
+
+
+async def _persist_app_settings(
+    session: AsyncSession, settings_row: AppSetting
+) -> bool:
+    """Persist ``settings_row``, degrading gracefully when the session can't write.
+
+    Owner / app_admin / startup sessions persist normally. After Phase 2,
+    ``app_settings`` is owner-only (GRANT + RLS), so a non-owner session (``app_user``
+    or a platform tier below owner) that triggers the lazy singleton create / env
+    re-seed on a READ hits insufficient-privilege. We catch that inside a SAVEPOINT
+    so the read returns the in-memory row (env-correct, just not persisted) instead
+    of 500-ing — a non-owner read legitimately can't write config. Returns True iff
+    the row was persisted.
+    """
+    try:
+        async with session.begin_nested():
+            session.add(settings_row)
+            await session.flush()
+    except DBAPIError as exc:
+        if not _is_insufficient_privilege(exc):
+            raise
+        return False
+    await session.commit()
+    await reapply_rls_context(session)
+    await session.refresh(settings_row)
+    return True
+
+
 async def _ensure_app_settings(session: AsyncSession) -> AppSetting:
     stmt = select(AppSetting).where(AppSetting.id == GLOBAL_SETTINGS_ID)
     result = await session.exec(stmt)
@@ -124,45 +201,10 @@ async def _ensure_app_settings(session: AsyncSession) -> AppSetting:
             settings_row.oidc_scopes = env_scopes
             updated = True
         if updated:
-            session.add(settings_row)
-            await session.commit()
-            await reapply_rls_context(session)
-            await session.refresh(settings_row)
+            await _persist_app_settings(session, settings_row)
         return settings_row
-    _oidc_secret = _normalize_optional_string(app_config.OIDC_CLIENT_SECRET)
-    _smtp_pw = _normalize_optional_string(app_config.SMTP_PASSWORD)
-    app_settings = AppSetting(
-        id=GLOBAL_SETTINGS_ID,
-        oidc_enabled=bool(app_config.OIDC_ENABLED),
-        oidc_issuer=_normalize_optional_string(app_config.OIDC_ISSUER),
-        oidc_client_id=_normalize_optional_string(app_config.OIDC_CLIENT_ID),
-        oidc_client_secret_encrypted=encrypt_field(
-            _oidc_secret, SALT_OIDC_CLIENT_SECRET
-        )
-        if _oidc_secret
-        else None,
-        oidc_provider_name=_normalize_optional_string(app_config.OIDC_PROVIDER_NAME),
-        oidc_scopes=_normalize_scopes(
-            app_config.OIDC_SCOPES or ["openid", "profile", "email", "offline_access"]
-        ),
-        light_accent_color="#2563eb",
-        dark_accent_color="#60a5fa",
-        role_labels=DEFAULT_ROLE_LABELS.copy(),
-        smtp_host=_normalize_optional_string(app_config.SMTP_HOST),
-        smtp_port=app_config.SMTP_PORT if app_config.SMTP_HOST else None,
-        smtp_secure=bool(app_config.SMTP_SECURE),
-        smtp_reject_unauthorized=bool(app_config.SMTP_REJECT_UNAUTHORIZED),
-        smtp_username=_normalize_optional_string(app_config.SMTP_USERNAME),
-        smtp_password_encrypted=encrypt_field(_smtp_pw, SALT_SMTP_PASSWORD)
-        if _smtp_pw
-        else None,
-        smtp_from_address=_normalize_optional_string(app_config.SMTP_FROM_ADDRESS),
-        smtp_test_recipient=_normalize_optional_string(app_config.SMTP_TEST_RECIPIENT),
-    )
-    session.add(app_settings)
-    await session.commit()
-    await reapply_rls_context(session)
-    await session.refresh(app_settings)
+    app_settings = _build_default_app_settings()
+    await _persist_app_settings(session, app_settings)
     return app_settings
 
 

--- a/backend/app/services/app_settings.py
+++ b/backend/app/services/app_settings.py
@@ -138,15 +138,22 @@ def _is_insufficient_privilege(exc: BaseException) -> bool:
 async def _persist_app_settings(
     session: AsyncSession, settings_row: AppSetting
 ) -> bool:
-    """Persist ``settings_row``, degrading gracefully when the session can't write.
+    """Persist ``settings_row``; return True iff it was written.
 
     Owner / app_admin / startup sessions persist normally. After Phase 2,
     ``app_settings`` is owner-only (GRANT + RLS), so a non-owner session (``app_user``
     or a platform tier below owner) that triggers the lazy singleton create / env
     re-seed on a READ hits insufficient-privilege. We catch that inside a SAVEPOINT
-    so the read returns the in-memory row (env-correct, just not persisted) instead
-    of 500-ing — a non-owner read legitimately can't write config. Returns True iff
-    the row was persisted.
+    (so the read doesn't 500) and return False — the caller serves a transient,
+    env-correct fallback instead.
+
+    Contract for the caller on a False return: the SAVEPOINT rollback EXPIRES a
+    *tracked/persistent* instance (its Python-side edits are lost, and async
+    attribute access then faults), so a re-seed caller must capture the env-merged
+    values BEFORE calling this and rebuild a transient — it cannot reuse the
+    instance. A freshly-built *transient* passed in (the create path) is merely
+    expunged on rollback and keeps its in-memory values, so it can be returned
+    as-is.
     """
     try:
         async with session.begin_nested():
@@ -201,7 +208,18 @@ async def _ensure_app_settings(session: AsyncSession) -> AppSetting:
             settings_row.oidc_scopes = env_scopes
             updated = True
         if updated:
-            await _persist_app_settings(session, settings_row)
+            # Snapshot the env-merged state NOW, while the instance is attached
+            # and valid. A degraded (non-owner) persist rolls back its SAVEPOINT,
+            # which EXPIRES this tracked instance — dropping the in-memory env
+            # values and (under async) faulting on the next attribute access. On
+            # that path we return a transient, env-correct copy built from the
+            # snapshot instead of the expired instance.
+            snapshot = {
+                col.name: getattr(settings_row, col.name)
+                for col in AppSetting.__table__.columns
+            }
+            if not await _persist_app_settings(session, settings_row):
+                return AppSetting(**snapshot)
         return settings_row
     app_settings = _build_default_app_settings()
     await _persist_app_settings(session, app_settings)

--- a/backend/app/services/users_test.py
+++ b/backend/app/services/users_test.py
@@ -340,7 +340,11 @@ async def test_users_table_has_rls_delete_deny_policy(session: AsyncSession):
     ``users_no_delete`` restrictive policy that blocks DELETE for any
     non-bypass session. Application code that tries to drop a user row
     via the regular ``app_user`` role would silently affect zero rows
-    without this policy."""
+    without this policy.
+
+    Phase 2 (migration 0109) replaced the single wide-open ``users_open``
+    policy with per-tier least-privilege policies; this also asserts that
+    decomposition (open policy gone, floors + tier policies present)."""
     from sqlalchemy import text
 
     rls_enabled = await session.exec(
@@ -361,7 +365,15 @@ async def test_users_table_has_rls_delete_deny_policy(session: AsyncSession):
     rows = list(policies)
     names = {row[0] for row in rows}
     assert "users_no_delete" in names
-    assert "users_open" in names
+    # Phase 2 decomposed the broad open policy into per-tier policies.
+    assert "users_open" not in names
+    assert {
+        "users_app_floor",
+        "users_guild_floor",
+        "users_platform_self",
+        "users_platform_read",
+        "users_platform_manage",
+    } <= names
     deny_policy = next(row for row in rows if row[0] == "users_no_delete")
     # polcmd '6' = DELETE; polpermissive False = restrictive.
     # See: https://www.postgresql.org/docs/current/catalog-pg-policy.html

--- a/frontend/src/api/generated/admin/admin.ts
+++ b/frontend/src/api/generated/admin/admin.ts
@@ -44,7 +44,12 @@ import type { ErrorType, BodyType } from "../../mutator";
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 /**
- * List all users in the platform (admin only).
+ * List all users in the platform (``users.read``).
+ *
+ * Platform-scoped: runs on the role-scoped session (``platform_<tier>``), so the
+ * cross-user read is authorized by RLS (``users_platform_read``, support+) rather
+ * than the BYPASSRLS admin engine. Initiative roles are guild-scoped and
+ * deliberately NOT loaded here — a platform user view exposes platform data only.
  * @summary List All Users
  */
 export const listAllUsersApiV1AdminUsersGet = (
@@ -499,7 +504,7 @@ export const useReactivateUserApiV1AdminUsersUserIdReactivatePost = <
   );
 };
 /**
- * Get the count of platform admins (admin only).
+ * Get the count of platform admins (``users.read``, role-scoped session).
  * @summary Get Platform Admin Count
  */
 export const getPlatformAdminCountApiV1AdminPlatformAdminCountGet = (

--- a/frontend/src/api/generated/ai-settings/ai-settings.ts
+++ b/frontend/src/api/generated/ai-settings/ai-settings.ts
@@ -41,7 +41,7 @@ import type { ErrorType, BodyType } from "../../mutator";
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 /**
- * Get platform-level AI settings. Platform admin only.
+ * Get platform-level AI settings (``config.manage`` — owner only, owner-scoped).
  * @summary Get Platform Ai Settings
  */
 export const getPlatformAiSettingsApiV1SettingsAiPlatformGet = (
@@ -187,7 +187,10 @@ export function useGetPlatformAiSettingsApiV1SettingsAiPlatformGet<
 }
 
 /**
- * Update platform-level AI settings. Platform admin only.
+ * Update platform-level AI settings (``config.manage`` — owner only).
+ *
+ * Owner-scoped session: ``app_settings`` is owner-only after Phase 2 (GRANT + RLS),
+ * so this write runs as ``platform_owner`` rather than the bare login role.
  * @summary Update Platform Ai Settings
  */
 export const updatePlatformAiSettingsApiV1SettingsAiPlatformPut = (


### PR DESCRIPTION
## Problem

Phase 1 ([#714 era] migration `0106`) created the `platform_<tier>` ladder and routes the public/platform request path through `SET ROLE platform_<tier>`, but left RLS untouched — every tier still behaved like the broad login role, and platform-admin/config operations ran on the BYPASSRLS `app_admin` engine gated only by app-layer capability checks. Phase 2 ("the bulk of the security win" per the design doc) adds the database backstop.

Implements **Phase 2** of [`history/platform-postgres-roles-design.md`](history/platform-postgres-roles-design.md) §4 / §11.2.

## Changes

**Migration `0109` — least-privilege RLS on the three purely-platform tables:**
- **`users`** — decompose the wide-open `users_open` into: an `app_user` floor (unauthenticated/bootstrap, narrowing still deferred), an `app_guild_base` guild-path floor (preserves guild reads/writes of the shared table), `platform_base` own-row (member floor), `platform_support+` read-all (`users.read`), `platform_moderator+` update-all (`users.manage`). DELETE stays denied (admin engine).
- **`access_grants`** — own-row for everyone + `platform_admin+` manage; `is_superadmin` retired.
- **`app_settings`** — `ENABLE`/`FORCE` RLS; public `SELECT`; **owner-only write** via both table `GRANT` and a `TO platform_owner` policy.

`is_superadmin` is retired **only** from these three tables' policies. The dual-path guild tables (`guilds`, `guild_memberships`, `guild_invites`, `oidc_claim_mappings`) keep their `is_super` leg so admins are never locked out mid-migration — that reach is removed in **Phase 3** alongside break-glass.

**Endpoints moved off the BYPASSRLS admin engine → role-scoped session:**
- Platform user reads: `GET /admin/users`, `/admin/users/export.csv`, `/admin/platform-admin-count`.
- All owner-only app-config reads+writes: `/settings/auth`, `/settings/interface`, `/settings/roles`, `/settings/email` (+ `/email/test`), `/settings/ai/platform`.

**Platform vs guild separation:** the platform user list/export no longer load guild-scoped initiative roles — they run as a pure platform-role read. The `initiative_roles` column was dropped from the platform CSV export.

**`app_settings` lazy create/reseed** is now privilege-tolerant (savepoint): a non-owner read returns a transient env-seeded default instead of faulting, since the unauthenticated OIDC-login and email-service paths read config as `app_user`.

## Residual `AdminSessionDep` (intentionally deferred to Phase 3)

Left on the admin engine and flagged in-code: the `oidc-mappings` CRUD (guild-scoped/dual-path), user delete (RLS DELETE deny → cross-schema cascade), guild/initiative admin management, and the bootstrap/unauthenticated surface (register, create-guild, accept-invite, login, password reset, OIDC callback).

## Tests

- New `app/db/platform_role_rls_test.py` — DB-backstop ceilings via direct `SET ROLE` (member own-row only; support reads all; support can't update others, moderator can; nobody deletes; access-grants self-vs-admin; owner-only `app_settings` write) plus end-to-end checks via the real-role client.
- Updated the CSV export test for the dropped column.

Targeted suites pass (`admin`, `settings`, `access_grants`, `auth`, `users`, guild-path `tasks`/`initiatives`/`projects`, `ai_settings`). The 4 pre-existing `*_blocks_private_ip` SSRF tests fail only in this WSL network env (a live gateway at `192.168.1.1`) and are unrelated.

## Notes for review
- Migration role names use `settings.PLATFORM_ROLE_PREFIX` read at apply time (matches `0106`); `app_user`/`app_guild_base` are the fixed unprefixed roles.
- `app_settings` SELECT is deliberately broad (documented in the migration): unauthenticated OIDC login + the email service must read config as `app_user`; sensitive columns are encrypted at rest, and the owner-only boundary is on writes. A future column-level split could tighten reads.