### PR TITLE
Fix Synology container startup (PATH + PUID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The platform users CSV export (`/admin/users/export.csv`) no longer includes the `initiative_roles` column. Initiative roles are guild-scoped; a platform-level user export now contains platform data only.
 
+### Fixed
+
+- Container failing to start on Synology NAS (and other runtimes that re-apply a stale `PATH` on image upgrade) with `start.sh: exec: uvicorn: not found`. The startup scripts now put the bundled virtualenv on `PATH` explicitly instead of relying on the image's `ENV PATH`.
+- `adduser`/`addgroup` warning and failure for the default `PUID`/`PGID` of `1000` (`uid 1000 is greater than SYS_UID_MAX 999`); the container user is no longer created in the system-account range.
+
 ## [0.51.1] - 2026-06-15
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /app
 COPY backend/pyproject.toml backend/uv.lock backend/.python-version ./
 RUN uv sync --frozen --no-dev
 COPY backend/ .
-# Put the synced venv on PATH so uvicorn/alembic/python resolve to it (start.sh/entrypoint.sh unchanged).
+# Put the synced venv on PATH so uvicorn/alembic/python resolve to it
 ENV PATH="/app/.venv/bin:$PATH"
 COPY VERSION ./VERSION
 COPY MIN_NATIVE_VERSION ./MIN_NATIVE_VERSION

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Ensure the uv-managed virtualenv is on PATH even when the runtime re-applies a
+# stale PATH captured from a previous image (e.g. Synology Container Manager
+# persists the old container's env on upgrade, clobbering the image's ENV PATH).
+export PATH="/app/.venv/bin:$PATH"
+
 # Default to UID/GID 1000 if not specified
 APP_UID="${PUID:-1000}"
 APP_GID="${PGID:-1000}"
@@ -16,16 +21,20 @@ if [ "$APP_UID" -eq 0 ] || [ "$APP_GID" -eq 0 ]; then
   echo "ERROR: PUID and PGID must not be 0 (root)" >&2; exit 1
 fi
 
-# Create group with requested GID (skip if GID already exists)
+# Create group with requested GID (skip if GID already exists).
+# Not --system: the default GID 1000 is outside the system range (<=999), which
+# makes a strict adduser/useradd refuse it ("gid 1000 is greater than SYS_GID_MAX").
 if ! getent group "$APP_GID" >/dev/null 2>&1; then
-    addgroup --system --gid "$APP_GID" app
+    addgroup --gid "$APP_GID" app
 fi
 
-# Create user with requested UID (skip if UID already exists)
+# Create user with requested UID (skip if UID already exists). See the group note
+# above re: --system. --disabled-password/--gecos keep adduser non-interactive.
 if ! getent passwd "$APP_UID" >/dev/null 2>&1; then
     # Resolve the group name for the target GID
     APP_GROUP=$(getent group "$APP_GID" | cut -d: -f1)
-    adduser --system --uid "$APP_UID" --ingroup "$APP_GROUP" --no-create-home app
+    adduser --uid "$APP_UID" --ingroup "$APP_GROUP" --no-create-home \
+        --disabled-password --gecos "" app
 fi
 
 # Ensure uploads directory is writable

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# Resolve uvicorn/alembic/python from the uv-managed venv even if the runtime
+# overrode the image's ENV PATH (e.g. Synology re-applying a stale container env).
+export PATH="/app/.venv/bin:$PATH"
+
 ARGS="app.main:app --host 0.0.0.0 --port 8173"
 
 if [ "${BEHIND_PROXY:-false}" = "true" ]; then


### PR DESCRIPTION
## Problem

Fixes #718. On a Synology NAS, upgrading to the latest image fails to start:

```
start.sh: 12: exec: uvicorn: not found
useradd warning: app's uid 1000 is greater than SYS_UID_MAX 999
```

Two independent regressions:

1. **`uvicorn: not found` (the actual crash).** The uv migration (`7cce73b6`) moved `uvicorn` from `/usr/local/bin` (pip — always on the default `PATH`) into `/app/.venv/bin`, relying on the image's `ENV PATH="/app/.venv/bin:$PATH"`. Synology's Container Manager persists a container's environment and **re-applies it on image upgrade**, clobbering the new image's `PATH` with the stale value captured from the old pip-based image. The venv never lands on `PATH`, so `uvicorn` can't be resolved.
2. **`SYS_UID_MAX` warning/failure.** `entrypoint.sh` created the runtime user with `adduser --system`, which forces a system-range UID (≤999). The default `PUID=1000` is out of range, so it warns/fails on strict `adduser`/`useradd` builds.

## Changes

- `backend/entrypoint.sh` — `export PATH="/app/.venv/bin:$PATH"` at the top (inherited by the `gosu`-spawned process); drop `--system` from `addgroup`/`adduser` so the default UID/GID 1000 is valid (kept non-interactive with `--disabled-password --gecos ""`).
- `backend/start.sh` — same `PATH` export, so the script is self-contained.
- `CHANGELOG.md` — `Fixed` entries under `[Unreleased]`.

This fixes the root cause (startup no longer depends on the runtime honoring the image's `ENV PATH`) rather than the Synology symptom alone.

## Testing

Built the production image and ran it against the exact failure scenario:

- **Negative control** (stale pip-era `PATH`, no venv): `uvicorn NOT found` — reproduces the bug.
- **With the fix**: `uvicorn` resolves to `/app/.venv/bin/uvicorn` and the server boots (`INFO: Started server process [1]`); it then exits only at `run_migrations()` because the test had no Postgres (expected, unrelated).
- **User creation**: old `--system` path reproduced `uid 1000 is greater than SYS_UID_MAX 999`; new path creates UID/GID 1000 cleanly with no warning and is idempotent on restart.

Commands:
```bash
docker build -t initiative:synology-test .
docker run --rm --entrypoint sh -e PATH=/usr/local/bin:/usr/bin:/bin \
  initiative:synology-test -c 'command -v uvicorn'   # before: not found; after: /app/.venv/bin/uvicorn
docker run --rm -e PUID=1000 -e PGID=1000 \
  -e PATH=/usr/local/bin:/usr/bin:/bin initiative:synology-test   # uvicorn starts
```
