### PR TITLE
Configurable recents limit and tab context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Rename built-in initiative roles.** The built-in "Project manager" and "Member" roles can now be renamed per initiative (e.g. "Project manager" → "Dungeon Master") from the initiative's Roles settings tab. The chosen name shows up wherever that member's role appears — rosters, badges, and the initiative list.
+- **Configurable recent-items tab bar.** A new "Recent items in tab bar" setting (Profile → Interface) controls how many recently-opened items the header tab bar keeps and shows, from 1 to 100 (default 20). Right-clicking a tab now opens a context menu with Close, Close others, and Close all.
 
 ### Changed
 

--- a/backend/alembic/versions/20260616_0113_add_recent_tabs_limit.py
+++ b/backend/alembic/versions/20260616_0113_add_recent_tabs_limit.py
@@ -1,0 +1,34 @@
+"""Add recent_tabs_limit column to users table.
+
+Per-user cap on how many recently-opened items the header tabs bar keeps and
+shows, across all entity types and guilds. Default 20 preserves the historic
+fixed behavior.
+
+Revision ID: 20260616_0113
+Revises: 20260616_0112
+Create Date: 2026-06-16
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260616_0113"
+down_revision = "20260616_0112"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "recent_tabs_limit",
+            sa.Integer(),
+            nullable=False,
+            server_default="20",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "recent_tabs_limit")

--- a/backend/app/api/v1/guild_endpoints/counters.py
+++ b/backend/app/api/v1/guild_endpoints/counters.py
@@ -1150,6 +1150,7 @@ async def record_counter_group_view(
         entity_type="counter_group",
         entity_id=group.id,
         persist=not guild_context.is_pam,
+        limit=current_user.recent_tabs_limit,
     )
     return RecentViewWrite(
         entity_type="counter_group",

--- a/backend/app/api/v1/guild_endpoints/documents.py
+++ b/backend/app/api/v1/guild_endpoints/documents.py
@@ -2481,6 +2481,7 @@ async def record_document_view(
         entity_type="document",
         entity_id=document.id,
         persist=not guild_context.is_pam,
+        limit=current_user.recent_tabs_limit,
     )
     return RecentViewWrite(
         entity_type="document",

--- a/backend/app/api/v1/guild_endpoints/projects.py
+++ b/backend/app/api/v1/guild_endpoints/projects.py
@@ -1573,6 +1573,7 @@ async def record_project_view(
         entity_type="project",
         entity_id=project.id,
         persist=not guild_context.is_pam,
+        limit=current_user.recent_tabs_limit,
     )
     return RecentViewWrite(
         entity_type="project",

--- a/backend/app/api/v1/guild_endpoints/queues.py
+++ b/backend/app/api/v1/guild_endpoints/queues.py
@@ -1377,6 +1377,7 @@ async def record_queue_view(
         entity_type="queue",
         entity_id=queue.id,
         persist=not guild_context.is_pam,
+        limit=current_user.recent_tabs_limit,
     )
     return RecentViewWrite(
         entity_type="queue",

--- a/backend/app/api/v1/guild_endpoints/recents.py
+++ b/backend/app/api/v1/guild_endpoints/recents.py
@@ -255,9 +255,11 @@ async def list_recents(
     ).all()
     role_by_guild = {m.guild_id: m.role for m in memberships}
 
+    limit = recent_views_service.clamp_recent_limit(current_user.recent_tabs_limit)
+
     async def _fetch(guild_session, guild_id: int) -> List[RecentItemRead]:  # type: ignore[no-untyped-def]
         rows = await recent_views_service.list_recent_views(
-            guild_session, user_id=current_user.id
+            guild_session, user_id=current_user.id, limit=limit
         )
         if not rows:
             return []
@@ -273,7 +275,7 @@ async def list_recents(
         session, current_user.id, list(role_by_guild.keys()), _fetch
     )
     items.sort(key=lambda item: item.last_viewed_at, reverse=True)
-    return items[: recent_views_service.MAX_RECENT_VIEWS]
+    return items[:limit]
 
 
 @guild_router.delete(

--- a/backend/app/api/v1/guild_endpoints/recents_test.py
+++ b/backend/app/api/v1/guild_endpoints/recents_test.py
@@ -176,6 +176,62 @@ async def test_recents_are_cross_guild_names_only(
 
 
 @pytest.mark.integration
+async def test_recent_tabs_limit_caps_list_and_prune(
+    client: AsyncClient, session: AsyncSession
+):
+    """The user's ``recent_tabs_limit`` bounds both what's stored (prune) and
+    what the tabs-bar endpoint returns."""
+    user, guild, initiative = await _make_user_with_guild_and_initiative(
+        session, email="limit@example.com"
+    )
+    headers = await get_guild_headers(session, guild, user)
+
+    # Lower the user's recents cap to 2 via self-update.
+    r = await client.patch(
+        "/api/v1/users/me", json={"recent_tabs_limit": 2}, headers=headers
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["recent_tabs_limit"] == 2
+
+    # Open four projects, oldest first.
+    projects = [
+        await create_project(session, initiative, user, name=f"P{i}") for i in range(4)
+    ]
+    for project in projects:
+        rv = await client.post(
+            f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
+        )
+        assert rv.status_code == 200
+        await asyncio.sleep(0.02)
+
+    # Only the two most-recently-opened survive — the rest were pruned.
+    r = await client.get("/api/v1/recents/", headers=headers)
+    assert r.status_code == 200
+    items = r.json()
+    assert [i["entity_id"] for i in items] == [projects[3].id, projects[2].id]
+
+
+@pytest.mark.integration
+async def test_recent_tabs_limit_rejects_out_of_range(
+    client: AsyncClient, session: AsyncSession
+):
+    """The cap is validated to [1, 100]."""
+    user, guild, _ = await _make_user_with_guild_and_initiative(
+        session, email="limit-bad@example.com"
+    )
+    headers = await get_guild_headers(session, guild, user)
+
+    r = await client.patch(
+        "/api/v1/users/me", json={"recent_tabs_limit": 0}, headers=headers
+    )
+    assert r.status_code == 422
+    r = await client.patch(
+        "/api/v1/users/me", json={"recent_tabs_limit": 101}, headers=headers
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.integration
 async def test_clear_recent_is_guild_addressed(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/api/v1/public_endpoints/users.py
+++ b/backend/app/api/v1/public_endpoints/users.py
@@ -56,6 +56,7 @@ from app.services import api_keys as api_keys_service
 from app.services import csv_export
 from app.services import stats_service
 from app.services import user_tokens as user_tokens_service
+from app.services import recent_views as recent_views_service
 
 # Allowed values for the optional "task completion visual feedback" effect.
 # Mirrored on the frontend in src/lib/taskCompletionVisualFeedback.ts; keep
@@ -316,6 +317,10 @@ async def update_users_me(
         normalized_week_start = normalize_week_starts_on(update_data["week_starts_on"])
         if normalized_week_start is not None:
             current_user.week_starts_on = normalized_week_start
+    if "recent_tabs_limit" in update_data:
+        current_user.recent_tabs_limit = recent_views_service.clamp_recent_limit(
+            update_data["recent_tabs_limit"]
+        )
     if "timezone" in update_data:
         normalized_timezone = normalize_timezone(update_data["timezone"])
         if normalized_timezone:

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -81,6 +81,14 @@ class User(SQLModel, table=True):
         default=0,
         sa_column=Column(Integer, nullable=False, server_default="0"),
     )
+    # How many recently-opened items the header tabs bar keeps and shows for
+    # this user, across all entity types and guilds. Drives both the display
+    # count and the per-guild prune cap (see app.services.recent_views).
+    # Clamped to [1, 100] on write; default 20 preserves the historic behavior.
+    recent_tabs_limit: int = Field(
+        default=20,
+        sa_column=Column(Integer, nullable=False, server_default="20"),
+    )
     email_verified: bool = Field(
         default=True,
         sa_column=Column(Boolean, nullable=False, server_default="true"),

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -68,6 +68,7 @@ class UserUpdate(SanitizedBaseModel):
     )
     avatar_url: Optional[str] = None
     week_starts_on: Optional[int] = None
+    recent_tabs_limit: Optional[int] = Field(default=None, ge=1, le=100)
     timezone: Optional[str] = None
     overdue_notification_time: Optional[str] = None
     email_initiative_addition: Optional[bool] = None
@@ -143,6 +144,7 @@ class UserRead(UserBase):
     avatar_base64: Optional[RawTextStr] = None
     avatar_url: Optional[str] = None
     week_starts_on: int = 0
+    recent_tabs_limit: int = 20
     timezone: str = "UTC"
     overdue_notification_time: str = "21:00"
     email_initiative_addition: bool = True
@@ -210,6 +212,7 @@ class UserSelfUpdate(SanitizedBaseModel):
     )
     avatar_url: Optional[str] = None
     week_starts_on: Optional[int] = None
+    recent_tabs_limit: Optional[int] = Field(default=None, ge=1, le=100)
     timezone: Optional[str] = None
     overdue_notification_time: Optional[str] = None
     email_initiative_addition: Optional[bool] = None

--- a/backend/app/services/recent_views.py
+++ b/backend/app/services/recent_views.py
@@ -20,9 +20,23 @@ from app.models.recent_view import RecentView
 
 RecentEntityType = Literal["project", "document", "queue", "counter_group"]
 
-# Maximum entries kept per user, across all entity types. Matches the cap
-# the layout bar displays.
-MAX_RECENT_VIEWS = 20
+# Per-user cap on entries kept/displayed, across all entity types. The user's
+# ``recent_tabs_limit`` (Interface settings) drives the actual value; these
+# bound it. ``DEFAULT_RECENT_VIEWS`` preserves the historic behavior for users
+# who never touched the setting.
+MIN_RECENT_VIEWS = 1
+MAX_RECENT_VIEWS = 100
+DEFAULT_RECENT_VIEWS = 20
+
+
+def clamp_recent_limit(value: int | None) -> int:
+    """Clamp a user's ``recent_tabs_limit`` to the allowed range.
+
+    Falls back to ``DEFAULT_RECENT_VIEWS`` for ``None`` (legacy rows / unset).
+    """
+    if value is None:
+        return DEFAULT_RECENT_VIEWS
+    return max(MIN_RECENT_VIEWS, min(MAX_RECENT_VIEWS, value))
 
 
 async def record_view(
@@ -32,8 +46,9 @@ async def record_view(
     entity_type: RecentEntityType,
     entity_id: int,
     persist: bool = True,
+    limit: int | None = None,
 ) -> RecentView:
-    """Upsert a recent-view row, then prune per-user to ``MAX_RECENT_VIEWS``.
+    """Upsert a recent-view row, then prune per-user to the user's cap.
 
     The DB trigger ``fn_recent_views_set_guild_id`` populates ``guild_id``
     from the underlying entity, so callers don't pass it.
@@ -43,6 +58,7 @@ async def record_view(
     policies would reject their INSERT; their browsing is also transient by
     design, so we simply don't record it.
     """
+    cap = clamp_recent_limit(limit)
     now = datetime.now(timezone.utc)
     if not persist:
         return RecentView(
@@ -80,7 +96,7 @@ async def record_view(
         select(RecentView)
         .where(RecentView.user_id == user_id)
         .order_by(RecentView.last_viewed_at.desc())
-        .offset(MAX_RECENT_VIEWS)
+        .offset(cap)
     )
     stale = (await session.exec(prune_stmt)).all()
     if stale:
@@ -116,7 +132,7 @@ async def list_recent_views(
     session: AsyncSession,
     *,
     user_id: int,
-    limit: int = MAX_RECENT_VIEWS,
+    limit: int = DEFAULT_RECENT_VIEWS,
 ) -> Sequence[RecentView]:
     """Return the user's most recent N rows, ordered by ``last_viewed_at`` desc.
 

--- a/frontend/public/locales/de/projects.json
+++ b/frontend/public/locales/de/projects.json
@@ -155,7 +155,10 @@
 
   "tabsBar": {
     "loadingRecent": "Aktuelle Elemente werden geladen…",
-    "closeItem": "{{name}} schließen"
+    "closeItem": "{{name}} schließen",
+    "close": "Schließen",
+    "closeOthers": "Andere schließen",
+    "closeAll": "Alle schließen"
   },
 
   "favorite": {

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -181,6 +181,8 @@
     "colorThemeDescription": "Wähle ein Farbdesign für die Anwendung.",
     "weekStartsOn": "Woche beginnt am",
     "weekStartsOnDescription": "Wähle, welcher Tag in Kalendern und Datumsauswahlfeldern zuerst angezeigt wird.",
+    "recentTabsLimit": "Aktuelle Elemente in der Tab-Leiste",
+    "recentTabsLimitDescription": "Wie viele kürzlich geöffnete Elemente in der Tab-Leiste der Kopfzeile behalten werden (1–100).",
     "language": "Sprache",
     "languageDescription": "Wähle deine bevorzugte Sprache für die Oberfläche.",
     "updateSuccess": "Oberflächeneinstellungen aktualisiert",

--- a/frontend/public/locales/en/projects.json
+++ b/frontend/public/locales/en/projects.json
@@ -155,7 +155,10 @@
 
   "tabsBar": {
     "loadingRecent": "Loading recent items\u2026",
-    "closeItem": "Close {{name}}"
+    "closeItem": "Close {{name}}",
+    "close": "Close",
+    "closeOthers": "Close others",
+    "closeAll": "Close all"
   },
 
   "favorite": {

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -181,6 +181,8 @@
     "colorThemeDescription": "Choose a color theme for the application.",
     "weekStartsOn": "Week starts on",
     "weekStartsOnDescription": "Choose which day to show first on calendars and date pickers.",
+    "recentTabsLimit": "Recent items in tab bar",
+    "recentTabsLimitDescription": "How many recently-opened items to keep in the header tab bar (1–100).",
     "language": "Language",
     "languageDescription": "Choose your preferred language for the interface.",
     "updateSuccess": "Interface preferences updated",

--- a/frontend/public/locales/es/projects.json
+++ b/frontend/public/locales/es/projects.json
@@ -146,7 +146,10 @@
   },
   "tabsBar": {
     "loadingRecent": "Cargando elementos recientes\u2026",
-    "closeItem": "Cerrar {{name}}"
+    "closeItem": "Cerrar {{name}}",
+    "close": "Cerrar",
+    "closeOthers": "Cerrar las dem\u00e1s",
+    "closeAll": "Cerrar todas"
   },
   "favorite": {
     "remove": "Quitar de favoritos",

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -181,6 +181,8 @@
     "colorThemeDescription": "Elige un tema de color para la aplicación.",
     "weekStartsOn": "La semana comienza el",
     "weekStartsOnDescription": "Elige qué día mostrar primero en calendarios y selectores de fecha.",
+    "recentTabsLimit": "Elementos recientes en la barra de pestañas",
+    "recentTabsLimitDescription": "Cuántos elementos abiertos recientemente mantener en la barra de pestañas del encabezado (1–100).",
     "language": "Idioma",
     "languageDescription": "Elige tu idioma preferido para la interfaz.",
     "updateSuccess": "Preferencias de interfaz actualizadas",

--- a/frontend/public/locales/fr/projects.json
+++ b/frontend/public/locales/fr/projects.json
@@ -145,7 +145,10 @@
   },
   "tabsBar": {
     "loadingRecent": "Chargement des éléments récents\u2026",
-    "closeItem": "Fermer {{name}}"
+    "closeItem": "Fermer {{name}}",
+    "close": "Fermer",
+    "closeOthers": "Fermer les autres",
+    "closeAll": "Fermer tout"
   },
   "favorite": {
     "remove": "Retirer des favoris",

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -181,6 +181,8 @@
     "colorThemeDescription": "Choisissez un thème de couleur pour l'application.",
     "weekStartsOn": "La semaine commence le",
     "weekStartsOnDescription": "Choisissez quel jour afficher en premier sur les calendriers et sélecteurs de date.",
+    "recentTabsLimit": "Éléments récents dans la barre d'onglets",
+    "recentTabsLimitDescription": "Nombre d'éléments récemment ouverts à conserver dans la barre d'onglets de l'en-tête (1–100).",
     "language": "Langue",
     "languageDescription": "Choisissez votre langue préférée pour l'interface.",
     "updateSuccess": "Préférences d'interface mises à jour",

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3222,6 +3222,7 @@ export interface UserRead {
   avatar_base64: string | null;
   avatar_url: string | null;
   week_starts_on: number;
+  recent_tabs_limit: number;
   timezone: string;
   overdue_notification_time: string;
   email_initiative_addition: boolean;
@@ -3264,6 +3265,7 @@ export interface UserSelfUpdate {
   avatar_base64?: string | null;
   avatar_url?: string | null;
   week_starts_on?: number | null;
+  recent_tabs_limit?: number | null;
   timezone?: string | null;
   overdue_notification_time?: string | null;
   email_initiative_addition?: boolean | null;
@@ -3347,6 +3349,7 @@ export interface UserUpdate {
   avatar_base64?: string | null;
   avatar_url?: string | null;
   week_starts_on?: number | null;
+  recent_tabs_limit?: number | null;
   timezone?: string | null;
   overdue_notification_time?: string | null;
   email_initiative_addition?: boolean | null;

--- a/frontend/src/components/recents/RecentTabsBar.test.tsx
+++ b/frontend/src/components/recents/RecentTabsBar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -27,7 +27,13 @@ import { RecentTabsBar } from "./RecentTabsBar";
 describe("RecentTabsBar", () => {
   it("renders nothing when there are no items and we're not loading", () => {
     const { container } = renderWithProviders(
-      <RecentTabsBar items={[]} loading={false} onClose={() => {}} />
+      <RecentTabsBar
+        items={[]}
+        loading={false}
+        onClose={() => {}}
+        onCloseOthers={() => {}}
+        onCloseAll={() => {}}
+      />
     );
     expect(container.firstChild).toBeNull();
   });
@@ -39,7 +45,14 @@ describe("RecentTabsBar", () => {
       buildRecentQueueItem({ name: "Combat" }),
       buildRecentCounterGroupItem({ name: "HP Trackers" }),
     ];
-    renderWithProviders(<RecentTabsBar items={items} onClose={() => {}} />);
+    renderWithProviders(
+      <RecentTabsBar
+        items={items}
+        onClose={() => {}}
+        onCloseOthers={() => {}}
+        onCloseAll={() => {}}
+      />
+    );
 
     expect(screen.getByText("Lost Mines")).toBeInTheDocument();
     expect(screen.getByText("Session Notes")).toBeInTheDocument();
@@ -56,7 +69,14 @@ describe("RecentTabsBar", () => {
       buildRecentQueueItem({ entity_id: 33, name: "QueueZ" }),
       buildRecentCounterGroupItem({ entity_id: 44, name: "GroupW" }),
     ];
-    renderWithProviders(<RecentTabsBar items={items} onClose={() => {}} />);
+    renderWithProviders(
+      <RecentTabsBar
+        items={items}
+        onClose={() => {}}
+        onCloseOthers={() => {}}
+        onCloseAll={() => {}}
+      />
+    );
 
     expect(screen.getByRole("link", { name: /ProjectX/ })).toHaveAttribute(
       "href",
@@ -73,12 +93,59 @@ describe("RecentTabsBar", () => {
   it("dispatches onClose with the item when the X is clicked", async () => {
     const onClose = vi.fn();
     const queue = buildRecentQueueItem({ entity_id: 7, name: "Combat" });
-    renderWithProviders(<RecentTabsBar items={[queue]} onClose={onClose} />);
+    renderWithProviders(
+      <RecentTabsBar
+        items={[queue]}
+        onClose={onClose}
+        onCloseOthers={() => {}}
+        onCloseAll={() => {}}
+      />
+    );
 
-    const closeButton = screen.getByLabelText(/close/i);
+    const closeButton = screen.getByLabelText(/close combat/i);
     await userEvent.click(closeButton);
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledWith(queue);
+  });
+
+  it("dispatches close / close others / close all from the right-click menu", async () => {
+    const onClose = vi.fn();
+    const onCloseOthers = vi.fn();
+    const onCloseAll = vi.fn();
+    const alpha = buildRecentProjectItem({ entity_id: 1, name: "Alpha" });
+    const beta = buildRecentProjectItem({ entity_id: 2, name: "Beta" });
+    renderWithProviders(
+      <RecentTabsBar
+        items={[alpha, beta]}
+        onClose={onClose}
+        onCloseOthers={onCloseOthers}
+        onCloseAll={onCloseAll}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByText("Alpha"));
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Close others" }));
+    expect(onCloseOthers).toHaveBeenCalledWith(alpha);
+
+    fireEvent.contextMenu(screen.getByText("Alpha"));
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Close all" }));
+    expect(onCloseAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables 'close others' when only one tab is open", async () => {
+    const only = buildRecentProjectItem({ entity_id: 1, name: "Solo" });
+    renderWithProviders(
+      <RecentTabsBar
+        items={[only]}
+        onClose={() => {}}
+        onCloseOthers={() => {}}
+        onCloseAll={() => {}}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByText("Solo"));
+    const closeOthers = await screen.findByRole("menuitem", { name: "Close others" });
+    expect(closeOthers).toHaveAttribute("aria-disabled", "true");
   });
 });

--- a/frontend/src/components/recents/RecentTabsBar.tsx
+++ b/frontend/src/components/recents/RecentTabsBar.tsx
@@ -4,6 +4,13 @@ import { useTranslation } from "react-i18next";
 
 import type { RecentItemRead } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { renderRecentIcon } from "@/lib/recentIcon";
 import { type RecentKey, recentKeyMatches, recentRoute } from "@/lib/recentRoute";
@@ -14,14 +21,27 @@ interface RecentTabsBarProps {
   activeKey?: RecentKey | null;
   loading?: boolean;
   onClose: (item: RecentItemRead) => void;
+  onCloseOthers: (item: RecentItemRead) => void;
+  onCloseAll: () => void;
 }
 
 /**
- * Sticky-header tabs bar for the 20 most-recently-opened guild-scoped items
- * (projects, documents, queues, counter groups). Replaces the projects-only
+ * Sticky-header tabs bar for the most-recently-opened guild-scoped items
+ * (projects, documents, queues, counter groups), capped per user by their
+ * ``recent_tabs_limit`` interface setting. Replaces the projects-only
  * ``ProjectTabsBar``.
+ *
+ * Each tab has a right-click context menu (close / close others / close all)
+ * in addition to its inline X button.
  */
-export const RecentTabsBar = ({ items, activeKey, loading, onClose }: RecentTabsBarProps) => {
+export const RecentTabsBar = ({
+  items,
+  activeKey,
+  loading,
+  onClose,
+  onCloseOthers,
+  onCloseAll,
+}: RecentTabsBarProps) => {
   const { t } = useTranslation("projects");
 
   if (!loading && (!items || items.length === 0)) {
@@ -37,36 +57,52 @@ export const RecentTabsBar = ({ items, activeKey, loading, onClose }: RecentTabs
           items?.map((item) => {
             const isActive = recentKeyMatches(activeKey ?? null, item);
             return (
-              <div
-                key={`${item.guild_id}-${item.entity_type}-${item.entity_id}`}
-                className="flex items-center"
-              >
-                <Link
-                  to={recentRoute(item)}
-                  className={cn(
-                    "group inline-flex items-center gap-2 rounded-t-md border border-transparent px-3 py-2 text-sm transition",
-                    isActive
-                      ? "border-border bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  )}
-                >
-                  {renderRecentIcon(item)}
-                  <span className="max-w-40 truncate">{item.name}</span>
-                </Link>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="ml-1 h-7 w-7 text-muted-foreground hover:text-foreground"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    onClose(item);
-                  }}
-                  aria-label={t("tabsBar.closeItem", { name: item.name })}
-                >
-                  <X className="h-3.5 w-3.5" />
-                </Button>
-              </div>
+              <ContextMenu key={`${item.guild_id}-${item.entity_type}-${item.entity_id}`}>
+                <ContextMenuTrigger asChild>
+                  <div className="flex items-center">
+                    <Link
+                      to={recentRoute(item)}
+                      className={cn(
+                        "group inline-flex items-center gap-2 rounded-t-md border border-transparent px-3 py-2 text-sm transition",
+                        isActive
+                          ? "border-border bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                    >
+                      {renderRecentIcon(item)}
+                      <span className="max-w-40 truncate">{item.name}</span>
+                    </Link>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="ml-1 h-7 w-7 text-muted-foreground hover:text-foreground"
+                      onClick={(event) => {
+                        event.preventDefault();
+                        onClose(item);
+                      }}
+                      aria-label={t("tabsBar.closeItem", { name: item.name })}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem onSelect={() => onClose(item)}>
+                    {t("tabsBar.close")}
+                  </ContextMenuItem>
+                  <ContextMenuItem
+                    onSelect={() => onCloseOthers(item)}
+                    disabled={(items?.length ?? 0) <= 1}
+                  >
+                    {t("tabsBar.closeOthers")}
+                  </ContextMenuItem>
+                  <ContextMenuSeparator />
+                  <ContextMenuItem onSelect={() => onCloseAll()}>
+                    {t("tabsBar.closeAll")}
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
             );
           })
         )}

--- a/frontend/src/hooks/useRecents.ts
+++ b/frontend/src/hooks/useRecents.ts
@@ -85,3 +85,30 @@ export const useClearRecentView = () => {
     },
   });
 };
+
+export interface ClearRecentTarget {
+  entityType: RecentEntityType;
+  entityId: number;
+  guildId: number;
+}
+
+/**
+ * Mutation that closes several tabs at once (the "close others" / "close all"
+ * context-menu actions). Issues one guild-addressed delete per tab in
+ * parallel — each tab can live in a different guild — then invalidates the
+ * recents query a single time.
+ */
+export const useClearRecentViews = () => {
+  return useMutation({
+    mutationFn: async (targets: ClearRecentTarget[]) => {
+      await Promise.all(
+        targets.map(({ entityType, entityId, guildId }) =>
+          clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete(guildId, entityType, entityId)
+        )
+      );
+    },
+    onSuccess: () => {
+      void invalidateRecents();
+    },
+  });
+};

--- a/frontend/src/hooks/useRecents.ts
+++ b/frontend/src/hooks/useRecents.ts
@@ -97,6 +97,11 @@ export interface ClearRecentTarget {
  * context-menu actions). Issues one guild-addressed delete per tab in
  * parallel — each tab can live in a different guild — then invalidates the
  * recents query a single time.
+ *
+ * Uses ``onSettled`` (not ``onSuccess``) so the cache is refreshed even on a
+ * partial failure: ``Promise.all`` rejects on the first failed DELETE, but
+ * earlier deletes may already have succeeded server-side, so we must resync
+ * regardless of outcome rather than leave stale tabs until the query expires.
  */
 export const useClearRecentViews = () => {
   return useMutation({
@@ -107,7 +112,7 @@ export const useClearRecentViews = () => {
         )
       );
     },
-    onSuccess: () => {
+    onSettled: () => {
       void invalidateRecents();
     },
   });

--- a/frontend/src/pages/user/settings/UserSettingsInterfacePage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsInterfacePage.tsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { UserRead } from "@/api/generated/initiativeAPI.schemas";
+import { invalidateRecents } from "@/api/query-keys";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -35,6 +37,16 @@ const WEEK_START_OPTIONS = [
   { labelKey: "dates:weekdays.friday", value: 5 },
   { labelKey: "dates:weekdays.saturday", value: 6 },
 ];
+
+const RECENT_TABS_LIMIT_MIN = 1;
+const RECENT_TABS_LIMIT_MAX = 100;
+const RECENT_TABS_LIMIT_DEFAULT = 20;
+
+const clampRecentTabsLimit = (value: number): number =>
+  Math.min(
+    RECENT_TABS_LIMIT_MAX,
+    Math.max(RECENT_TABS_LIMIT_MIN, Math.round(value || RECENT_TABS_LIMIT_DEFAULT))
+  );
 
 const LANGUAGE_OPTIONS = [
   { label: "English", value: "en" },
@@ -169,6 +181,9 @@ export const UserSettingsInterfacePage = ({
 }: UserSettingsInterfacePageProps) => {
   const { t, i18n } = useTranslation(["settings", "dates"]);
   const [weekStartsOn, setWeekStartsOn] = useState(user.week_starts_on ?? 0);
+  const [recentTabsLimit, setRecentTabsLimit] = useState(
+    user.recent_tabs_limit ?? RECENT_TABS_LIMIT_DEFAULT
+  );
   const [colorTheme, setColorTheme] = useState(user.color_theme ?? "kobold");
   const [locale, setLocale] = useState(user.locale ?? "en");
   const [visualFeedback, setVisualFeedback] = useState<TaskCompletionVisualFeedback>(() =>
@@ -188,6 +203,7 @@ export const UserSettingsInterfacePage = ({
 
   useEffect(() => {
     setWeekStartsOn(user.week_starts_on ?? 0);
+    setRecentTabsLimit(user.recent_tabs_limit ?? RECENT_TABS_LIMIT_DEFAULT);
     setColorTheme(user.color_theme ?? "kobold");
     setLocale(user.locale ?? "en");
     setVisualFeedback(parseTaskCompletionVisualFeedback(user.task_completion_visual_feedback));
@@ -199,6 +215,12 @@ export const UserSettingsInterfacePage = ({
     onSuccess: async (_, variables) => {
       if (variables.week_starts_on !== undefined) {
         setWeekStartsOn(Number(variables.week_starts_on));
+      }
+      if (variables.recent_tabs_limit !== undefined) {
+        setRecentTabsLimit(Number(variables.recent_tabs_limit));
+        // The header tabs bar caches recents for 30s; refetch so a higher
+        // limit surfaces more items immediately.
+        void invalidateRecents();
       }
       if (variables.color_theme !== undefined) {
         setColorTheme(String(variables.color_theme));
@@ -225,6 +247,7 @@ export const UserSettingsInterfacePage = ({
     onError: () => {
       toast.error(t("interface.updateError"));
       setWeekStartsOn(user.week_starts_on ?? 0);
+      setRecentTabsLimit(user.recent_tabs_limit ?? RECENT_TABS_LIMIT_DEFAULT);
       setColorTheme(user.color_theme ?? "kobold");
       setLocale(user.locale ?? "en");
       setVisualFeedback(parseTaskCompletionVisualFeedback(user.task_completion_visual_feedback));
@@ -232,6 +255,14 @@ export const UserSettingsInterfacePage = ({
       setHapticFeedback(user.task_completion_haptic_feedback ?? true);
     },
   });
+
+  const commitRecentTabsLimit = () => {
+    const clamped = clampRecentTabsLimit(recentTabsLimit);
+    setRecentTabsLimit(clamped);
+    if (clamped !== (user.recent_tabs_limit ?? RECENT_TABS_LIMIT_DEFAULT)) {
+      updateInterfacePrefs.mutate({ recent_tabs_limit: clamped });
+    }
+  };
 
   return (
     <div className="space-y-4">
@@ -329,6 +360,30 @@ export const UserSettingsInterfacePage = ({
                 ))}
               </SelectContent>
             </Select>
+          </div>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-medium">{t("interface.recentTabsLimit")}</p>
+              <p className="text-muted-foreground text-sm">
+                {t("interface.recentTabsLimitDescription")}
+              </p>
+            </div>
+            <Input
+              type="number"
+              min={RECENT_TABS_LIMIT_MIN}
+              max={RECENT_TABS_LIMIT_MAX}
+              value={recentTabsLimit}
+              onChange={(event) => setRecentTabsLimit(Number(event.target.value))}
+              onBlur={commitRecentTabsLimit}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.currentTarget.blur();
+                }
+              }}
+              disabled={updateInterfacePrefs.isPending}
+              aria-label={t("interface.recentTabsLimit")}
+              className="sm:w-52"
+            />
           </div>
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -31,7 +31,12 @@ import { useGuilds } from "@/hooks/useGuilds";
 import { useLegacyFilterStorageMigration } from "@/hooks/useLegacyFilterStorageMigration";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { useRealtimeUpdates } from "@/hooks/useRealtimeUpdates";
-import { useClearRecentView, useRecents } from "@/hooks/useRecents";
+import {
+  type ClearRecentTarget,
+  useClearRecentView,
+  useClearRecentViews,
+  useRecents,
+} from "@/hooks/useRecents";
 import { useServer } from "@/hooks/useServer";
 import { useVersionCheck } from "@/hooks/useVersionCheck";
 import { chooseNoGuildLayout } from "@/lib/noGuildLayout";
@@ -105,6 +110,7 @@ function AppLayout() {
   });
 
   const clearRecent = useClearRecentView();
+  const clearRecents = useClearRecentViews();
 
   // Now we can have conditional returns
   // Show loading state while auth or guild membership is being determined
@@ -149,13 +155,41 @@ function AppLayout() {
     // layout === "main" → fall through to the standard sidebar layout.
   }
 
+  const toClearTarget = (item: RecentItemRead): ClearRecentTarget => ({
+    entityType: item.entity_type,
+    entityId: item.entity_id,
+    guildId: item.guild_id,
+  });
+
   const handleClearRecent = (item: RecentItemRead) => {
-    clearRecent.mutate({
-      entityType: item.entity_type,
-      entityId: item.entity_id,
-      guildId: item.guild_id,
-    });
+    clearRecent.mutate(toClearTarget(item));
   };
+
+  const handleCloseOtherRecents = (keep: RecentItemRead) => {
+    const others = (recentQuery.data ?? []).filter(
+      (item) =>
+        !(
+          item.guild_id === keep.guild_id &&
+          item.entity_type === keep.entity_type &&
+          item.entity_id === keep.entity_id
+        )
+    );
+    if (others.length > 0) {
+      clearRecents.mutate(others.map(toClearTarget));
+    }
+  };
+
+  const handleCloseAllRecents = () => {
+    const all = recentQuery.data ?? [];
+    if (all.length > 0) {
+      clearRecents.mutate(all.map(toClearTarget));
+    }
+  };
+
+  // The backend already caps the list to the user's ``recent_tabs_limit``, but
+  // slice client-side too so lowering the setting takes effect immediately
+  // (before the 30s-stale recents query refetches).
+  const recentItems = recentQuery.data?.slice(0, user?.recent_tabs_limit ?? 20);
 
   const activeRecentKey = getActiveRecentKey(location.pathname);
   // ProjectActivitySidebar still wants the active project id directly.
@@ -208,10 +242,12 @@ function AppLayout() {
                   </Tooltip>
                   <div className="min-w-0 flex-1">
                     <RecentTabsBar
-                      items={recentQuery.data}
+                      items={recentItems}
                       loading={recentQuery.isLoading}
                       activeKey={activeRecentKey}
                       onClose={handleClearRecent}
+                      onCloseOthers={handleCloseOtherRecents}
+                      onCloseAll={handleCloseAllRecents}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Closes #713

## Problem

The header "recent items" tab bar had a fixed cap (20) with no user control, and the only way to clear tabs was the per-tab X button. The issue asked for a user-chosen limit and a way to close all / close others.

## Changes

### Recents limit (Profile → Interface → "Recent items in tab bar")
- New per-user `recent_tabs_limit` setting, a number input clamped to **1–100** (default **20**, preserving current behavior).
- The limit drives **both** the displayed count **and** the per-guild stored prune cap (`recent_views`).
- Backend: new `recent_tabs_limit` column on `users` (migration `20260616_0113`), exposed/validated in `UserRead` / `UserUpdate` / `UserSelfUpdate` (`ge=1, le=100`); `record_view` prunes to the user's cap and the cross-guild list endpoint slices to it. The four view-recording endpoints (projects/documents/queues/counters) pass the user's limit.
- Frontend: setting commits on blur/Enter via `useUpdateCurrentUser` and invalidates the recents query so a higher limit surfaces more items immediately; the layout also slices client-side for instant feedback when lowering it.

### Tab context menu
- Right-clicking a recent tab opens a context menu with **Close**, **Close others**, **Close all** (the inline X still works). "Close others" is disabled when only one tab is open.
- New `useClearRecentViews` bulk mutation issues parallel guild-addressed deletes (each tab may live in a different guild) with a single cache invalidation.

### Misc
- Regenerated Orval types; added i18n keys to **en/es/fr/de**.
- Updated `CHANGELOG.md`.

## Testing
- Backend: `pytest` for `recents_test` (incl. 2 new tests: cap+prune and 1–100 range validation), `users_test`, `user_test` — all pass; `ruff` clean.
- Frontend: `pnpm typecheck`, `pnpm lint`, recents component tests (incl. new context-menu coverage), and locale-key parity — all pass.