### PR TITLE
Fix empty initiative dropdown in OIDC claim mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- OIDC claim mappings with the "initiative" target type showed an empty initiative dropdown after picking a guild, and saving such a mapping failed. The admin settings endpoint looked for initiatives and roles in the shared schema, where they don't live, instead of inside each guild's own schema; it now routes into every guild to list them, and the role dropdown is correctly scoped to the selected guild.
 - Container failing to start on Synology NAS (and other runtimes that re-apply a stale `PATH` on image upgrade) with `start.sh: exec: uvicorn: not found`. The startup scripts now put the bundled virtualenv on `PATH` explicitly instead of relying on the image's `ENV PATH`.
 - `adduser`/`addgroup` warning and failure for the default `PUID`/`PGID` of `1000` (`uid 1000 is greater than SYS_UID_MAX 999`); the container user is no longer created in the system-account range.
 

--- a/backend/app/api/v1/public_endpoints/settings.py
+++ b/backend/app/api/v1/public_endpoints/settings.py
@@ -15,7 +15,7 @@ from app.api.deps import (
 from app.api.v1.public_endpoints.admin import ConfigManageDep
 from app.core.config import settings as app_config
 from app.core.rate_limit import limiter
-from app.db.session import get_admin_session
+from app.db.session import get_admin_session, set_rls_context
 from app.models.app_setting import AppSetting
 from app.models.guild import Guild, GuildRole
 from app.models.initiative import Initiative, InitiativeRoleModel
@@ -237,6 +237,68 @@ async def get_fcm_config(request: Request) -> FCMConfigResponse:
 # --- OIDC Claim Mapping endpoints ---
 
 
+async def _route_admin_to_guild(session: AsyncSession, guild_id: int) -> None:
+    """Route the admin session into a guild's ``guild_<id>`` schema.
+
+    Initiatives and initiative roles are guild-scoped content: their rows live in
+    each guild's schema, not in the empty ``public`` template copies. Reading them
+    requires routing the session into that schema. ``expunge_all`` first because
+    row ids are unique only within a schema — a cached object from a previously
+    routed guild could otherwise be returned for a colliding id.
+    """
+    session.expunge_all()
+    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+
+
+async def _reset_admin_session(session: AsyncSession) -> None:
+    """Return the admin session to its neutral public / login-role baseline.
+
+    After routing into a guild schema the session has assumed that guild's role,
+    which has no write access to shared ``public`` config tables. Reset to the
+    BYPASSRLS admin login role (``SET ROLE none``, ``search_path public``) before
+    writing the mapping back to ``public``.
+    """
+    await set_rls_context(session)
+
+
+async def _lookup_guild_initiative(
+    session: AsyncSession,
+    guild_id: int,
+    initiative_id: int,
+    initiative_role_id: int | None,
+) -> tuple[Initiative | None, InitiativeRoleModel | None]:
+    """Look up an initiative (and optional role) inside a guild's schema.
+
+    Routes the session into ``guild_<id>`` for the read, then resets it back to
+    the neutral admin baseline so callers can write the mapping to the shared
+    ``public.oidc_claim_mappings`` table as the BYPASSRLS admin login role (the
+    guild role has no write grant on config tables). ``populate_existing`` keeps
+    a colliding id from another guild already in the identity map from being
+    returned stale — ids are unique only within a schema.
+    """
+    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+    try:
+        initiative = (
+            await session.exec(
+                select(Initiative)
+                .where(Initiative.id == initiative_id)
+                .execution_options(populate_existing=True)
+            )
+        ).one_or_none()
+        role: InitiativeRoleModel | None = None
+        if initiative_role_id is not None:
+            role = (
+                await session.exec(
+                    select(InitiativeRoleModel)
+                    .where(InitiativeRoleModel.id == initiative_role_id)
+                    .execution_options(populate_existing=True)
+                )
+            ).one_or_none()
+        return initiative, role
+    finally:
+        await _reset_admin_session(session)
+
+
 async def _enrich_mapping(
     session: AsyncSession, mapping: OIDCClaimMapping
 ) -> OIDCClaimMappingRead:
@@ -252,22 +314,16 @@ async def _enrich_mapping(
         guild_name = guild.name
 
     if mapping.initiative_id is not None:
-        initiative = (
-            await session.exec(
-                select(Initiative).where(Initiative.id == mapping.initiative_id)
-            )
-        ).one_or_none()
+        # Initiatives/roles are guild-scoped: resolve their names inside the
+        # mapping's guild schema, not the empty public copies.
+        initiative, role = await _lookup_guild_initiative(
+            session,
+            mapping.guild_id,
+            mapping.initiative_id,
+            mapping.initiative_role_id,
+        )
         if initiative:
             initiative_name = initiative.name
-
-    if mapping.initiative_role_id is not None:
-        role = (
-            await session.exec(
-                select(InitiativeRoleModel).where(
-                    InitiativeRoleModel.id == mapping.initiative_role_id
-                )
-            )
-        ).one_or_none()
         if role:
             initiative_role_name = role.display_name
 
@@ -357,11 +413,12 @@ async def create_oidc_mapping(
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_ROLE_ID_REQUIRED
             )
-        initiative = (
-            await session.exec(
-                select(Initiative).where(Initiative.id == payload.initiative_id)
-            )
-        ).one_or_none()
+        initiative, role = await _lookup_guild_initiative(
+            session,
+            payload.guild_id,
+            payload.initiative_id,
+            payload.initiative_role_id,
+        )
         if not initiative:
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_NOT_FOUND
@@ -370,13 +427,6 @@ async def create_oidc_mapping(
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_WRONG_GUILD
             )
-        role = (
-            await session.exec(
-                select(InitiativeRoleModel).where(
-                    InitiativeRoleModel.id == payload.initiative_role_id
-                )
-            )
-        ).one_or_none()
         if not role:
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_ROLE_NOT_FOUND
@@ -454,11 +504,12 @@ async def update_oidc_mapping(
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_FIELDS_REQUIRED
             )
-        initiative = (
-            await session.exec(
-                select(Initiative).where(Initiative.id == mapping.initiative_id)
-            )
-        ).one_or_none()
+        initiative, role = await _lookup_guild_initiative(
+            session,
+            mapping.guild_id,
+            mapping.initiative_id,
+            mapping.initiative_role_id,
+        )
         if not initiative:
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_NOT_FOUND
@@ -467,13 +518,6 @@ async def update_oidc_mapping(
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_WRONG_GUILD
             )
-        role = (
-            await session.exec(
-                select(InitiativeRoleModel).where(
-                    InitiativeRoleModel.id == mapping.initiative_role_id
-                )
-            )
-        ).one_or_none()
         if not role:
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_ROLE_NOT_FOUND
@@ -513,22 +557,43 @@ async def get_oidc_mapping_options(
     _admin: ConfigManageDep,
 ) -> dict:
     """Return all guilds, initiatives, and initiative roles for the mapping form."""
+    # Guilds live in shared public; materialize them before routing into any guild
+    # schema (routing expunges the ORM objects).
     guilds = (await session.exec(select(Guild).order_by(Guild.name))).all()
-    initiatives = (
-        await session.exec(select(Initiative).order_by(Initiative.name))
-    ).all()
-    roles = (
-        await session.exec(
-            select(InitiativeRoleModel).order_by(InitiativeRoleModel.position)
-        )
-    ).all()
-    return {
-        "guilds": [{"id": g.id, "name": g.name} for g in guilds],
-        "initiatives": [
+    guild_payload = [{"id": g.id, "name": g.name} for g in guilds]
+
+    # Initiatives and initiative roles are guild-scoped content: their rows live in
+    # each guild's guild_<id> schema, not in the empty public copies. Route into
+    # every guild's schema in turn and collect them. Row ids are unique only within
+    # a schema, so each role carries its guild_id for the client to disambiguate
+    # against colliding initiative ids across guilds.
+    initiatives_payload: list[dict] = []
+    roles_payload: list[dict] = []
+    for g in guild_payload:
+        await _route_admin_to_guild(session, g["id"])
+        initiatives = (
+            await session.exec(select(Initiative).order_by(Initiative.name))
+        ).all()
+        roles = (
+            await session.exec(
+                select(InitiativeRoleModel).order_by(InitiativeRoleModel.position)
+            )
+        ).all()
+        initiatives_payload.extend(
             {"id": i.id, "name": i.name, "guild_id": i.guild_id} for i in initiatives
-        ],
-        "initiative_roles": [
-            {"id": r.id, "name": r.display_name, "initiative_id": r.initiative_id}
+        )
+        roles_payload.extend(
+            {
+                "id": r.id,
+                "name": r.display_name,
+                "initiative_id": r.initiative_id,
+                "guild_id": g["id"],
+            }
             for r in roles
-        ],
+        )
+
+    return {
+        "guilds": guild_payload,
+        "initiatives": initiatives_payload,
+        "initiative_roles": roles_payload,
     }

--- a/backend/app/api/v1/public_endpoints/settings.py
+++ b/backend/app/api/v1/public_endpoints/settings.py
@@ -423,6 +423,10 @@ async def create_oidc_mapping(
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_NOT_FOUND
             )
+        # Defence-in-depth: the lookup already routed into guild_<payload.guild_id>,
+        # so a found initiative's guild_id matches by construction. Retained to
+        # catch a data-integrity anomaly (an initiative row whose stored guild_id
+        # disagrees with its schema) rather than silently binding the mapping.
         if initiative.guild_id != payload.guild_id:
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_WRONG_GUILD
@@ -514,6 +518,9 @@ async def update_oidc_mapping(
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_NOT_FOUND
             )
+        # Defence-in-depth: structurally guaranteed now (the lookup routes into
+        # guild_<mapping.guild_id>), kept to catch a stored guild_id that disagrees
+        # with its schema rather than binding the mapping to a mismatched guild.
         if initiative.guild_id != mapping.guild_id:
             raise HTTPException(
                 status_code=400, detail=SettingsMessages.INITIATIVE_WRONG_GUILD
@@ -569,28 +576,34 @@ async def get_oidc_mapping_options(
     # against colliding initiative ids across guilds.
     initiatives_payload: list[dict] = []
     roles_payload: list[dict] = []
-    for g in guild_payload:
-        await _route_admin_to_guild(session, g["id"])
-        initiatives = (
-            await session.exec(select(Initiative).order_by(Initiative.name))
-        ).all()
-        roles = (
-            await session.exec(
-                select(InitiativeRoleModel).order_by(InitiativeRoleModel.position)
+    try:
+        for g in guild_payload:
+            await _route_admin_to_guild(session, g["id"])
+            initiatives = (
+                await session.exec(select(Initiative).order_by(Initiative.name))
+            ).all()
+            roles = (
+                await session.exec(
+                    select(InitiativeRoleModel).order_by(InitiativeRoleModel.position)
+                )
+            ).all()
+            initiatives_payload.extend(
+                {"id": i.id, "name": i.name, "guild_id": i.guild_id}
+                for i in initiatives
             )
-        ).all()
-        initiatives_payload.extend(
-            {"id": i.id, "name": i.name, "guild_id": i.guild_id} for i in initiatives
-        )
-        roles_payload.extend(
-            {
-                "id": r.id,
-                "name": r.display_name,
-                "initiative_id": r.initiative_id,
-                "guild_id": g["id"],
-            }
-            for r in roles
-        )
+            roles_payload.extend(
+                {
+                    "id": r.id,
+                    "name": r.display_name,
+                    "initiative_id": r.initiative_id,
+                    "guild_id": g["id"],
+                }
+                for r in roles
+            )
+    finally:
+        # Don't leave the pooled connection routed into the last guild's schema:
+        # reset to the neutral admin baseline like every write path in this file.
+        await _reset_admin_session(session)
 
     return {
         "guilds": guild_payload,

--- a/backend/app/api/v1/public_endpoints/settings_test.py
+++ b/backend/app/api/v1/public_endpoints/settings_test.py
@@ -170,3 +170,75 @@ async def test_create_initiative_oidc_mapping_resolves_guild_scoped_data(
     # Denormalized names are resolved from the guild schema for display.
     assert body["initiative_name"] == initiative.name
     assert body["initiative_role_name"] == role["name"]
+
+
+# The whole OIDC claim-mapping surface reads/writes guild-scoped data through the
+# BYPASSRLS admin engine, so the ONLY thing standing between a caller and every
+# guild's data is the owner-only ``config.manage`` capability gate. These tests
+# hard-pin that gate per endpoint so a future edit can't silently drop it and let
+# a non-owner (even a platform admin) through.
+_NON_OWNER_ROLES = [
+    UserRole.member,
+    UserRole.support,
+    UserRole.moderator,
+    UserRole.admin,
+]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("role", _NON_OWNER_ROLES)
+async def test_oidc_mapping_endpoints_reject_non_owner(
+    client: AsyncClient,
+    session: AsyncSession,
+    role: UserRole,
+) -> None:
+    """Every OIDC claim-mapping endpoint is owner-only (config.manage). No other
+    platform tier — not even ``admin`` — may read or write them."""
+    user = await create_user(
+        session, email=f"oidc-deny-{role.value}@example.com", role=role
+    )
+    headers = get_auth_headers(user)
+
+    # Every route on the surface, covering each HTTP method/verb.
+    requests = [
+        ("get", "/api/v1/settings/oidc-mappings", None),
+        ("get", "/api/v1/settings/oidc-mappings/options", None),
+        (
+            "post",
+            "/api/v1/settings/oidc-mappings",
+            {
+                "claim_value": "x",
+                "target_type": "guild",
+                "guild_id": 1,
+                "guild_role": "member",
+            },
+        ),
+        ("put", "/api/v1/settings/oidc-mappings/claim-path", {"claim_path": "groups"}),
+        ("put", "/api/v1/settings/oidc-mappings/1", {"claim_value": "x"}),
+        ("delete", "/api/v1/settings/oidc-mappings/1", None),
+    ]
+    for method, url, json_body in requests:
+        resp = await getattr(client, method)(
+            url, headers=headers, **({"json": json_body} if json_body else {})
+        )
+        # 403 (capability denied) before any handler logic runs — never 200/201/204,
+        # and never a 400/404 that would imply the request reached the handler.
+        assert resp.status_code == 403, (
+            f"{method.upper()} {url} as {role.value}: {resp.status_code}"
+        )
+        assert resp.json()["detail"] == "INSUFFICIENT_PRIVILEGES"
+
+
+@pytest.mark.integration
+async def test_oidc_mapping_endpoints_require_authentication(
+    client: AsyncClient,
+) -> None:
+    """Unauthenticated callers are rejected outright (401), never reaching the
+    admin-engine handlers."""
+    for method, url in [
+        ("get", "/api/v1/settings/oidc-mappings"),
+        ("get", "/api/v1/settings/oidc-mappings/options"),
+        ("delete", "/api/v1/settings/oidc-mappings/1"),
+    ]:
+        resp = await getattr(client, method)(url)
+        assert resp.status_code == 401, f"{method.upper()} {url}: {resp.status_code}"

--- a/backend/app/api/v1/public_endpoints/settings_test.py
+++ b/backend/app/api/v1/public_endpoints/settings_test.py
@@ -13,9 +13,16 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.models.guild import GuildRole
 from app.models.user import UserRole
 from app.services import email as email_service
-from app.testing import create_user, get_auth_headers
+from app.testing import (
+    create_guild,
+    create_guild_membership,
+    create_initiative,
+    create_user,
+    get_auth_headers,
+)
 
 
 @pytest.mark.integration
@@ -79,3 +86,87 @@ async def test_email_test_runtime_error_logs_details_server_side(
     assert resp.status_code == 502
     # The real cause is preserved for the operator in the server logs only.
     assert sensitive in caplog.text
+
+
+@pytest.mark.integration
+async def test_oidc_mapping_options_includes_guild_scoped_initiatives(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Regression: initiatives/roles are guild-scoped content (rows live in each
+    guild's schema, not the empty public copies). The options endpoint must route
+    into every guild schema, otherwise the form's initiative dropdown is empty."""
+    owner = await create_user(
+        session, email="owner-oidc-opts@example.com", role=UserRole.owner
+    )
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(
+        session, user=owner, guild=guild, role=GuildRole.admin
+    )
+    initiative = await create_initiative(session, guild=guild, creator=owner)
+
+    resp = await client.get(
+        "/api/v1/settings/oidc-mappings/options", headers=get_auth_headers(owner)
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    matched = next((i for i in data["initiatives"] if i["id"] == initiative.id), None)
+    assert matched is not None, "guild-scoped initiative missing from options"
+    assert matched["guild_id"] == guild.id
+
+    # Roles carry guild_id so the client can disambiguate initiative ids that
+    # collide across guild schemas.
+    roles = [
+        r
+        for r in data["initiative_roles"]
+        if r["initiative_id"] == initiative.id and r["guild_id"] == guild.id
+    ]
+    assert roles, "initiative roles missing from options"
+    assert all("guild_id" in r for r in data["initiative_roles"])
+
+
+@pytest.mark.integration
+async def test_create_initiative_oidc_mapping_resolves_guild_scoped_data(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Regression: creating an initiative-target mapping must validate the
+    initiative/role inside the guild schema (previously it queried the empty
+    public copy and always 400'd INITIATIVE_NOT_FOUND)."""
+    owner = await create_user(
+        session, email="owner-oidc-create@example.com", role=UserRole.owner
+    )
+    guild = await create_guild(session, creator=owner)
+    await create_guild_membership(
+        session, user=owner, guild=guild, role=GuildRole.admin
+    )
+    initiative = await create_initiative(session, guild=guild, creator=owner)
+
+    headers = get_auth_headers(owner)
+    options = (
+        await client.get("/api/v1/settings/oidc-mappings/options", headers=headers)
+    ).json()
+    role = next(
+        r
+        for r in options["initiative_roles"]
+        if r["initiative_id"] == initiative.id and r["guild_id"] == guild.id
+    )
+
+    resp = await client.post(
+        "/api/v1/settings/oidc-mappings",
+        json={
+            "claim_value": "eng-team",
+            "target_type": "initiative",
+            "guild_id": guild.id,
+            "guild_role": "member",
+            "initiative_id": initiative.id,
+            "initiative_role_id": role["id"],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    # Denormalized names are resolved from the guild schema for display.
+    assert body["initiative_name"] == initiative.name
+    assert body["initiative_role_name"] == role["name"]

--- a/frontend/src/components/admin/OidcClaimMappingsSection.tsx
+++ b/frontend/src/components/admin/OidcClaimMappingsSection.tsx
@@ -87,11 +87,13 @@ export const OidcClaimMappingsSection = () => {
   }, [optionsQuery.data, form.guild_id]);
 
   const filteredRoles = useMemo(() => {
-    if (!optionsQuery.data || !form.initiative_id) return [];
+    if (!optionsQuery.data || !form.initiative_id || !form.guild_id) return [];
+    // Initiative ids are unique only within a guild, so match guild_id too to
+    // avoid leaking roles from a colliding initiative id in another guild.
     return optionsQuery.data.initiative_roles.filter(
-      (r) => r.initiative_id === Number(form.initiative_id)
+      (r) => r.initiative_id === Number(form.initiative_id) && r.guild_id === Number(form.guild_id)
     );
-  }, [optionsQuery.data, form.initiative_id]);
+  }, [optionsQuery.data, form.initiative_id, form.guild_id]);
 
   const resetForm = () => {
     setFormOpen(false);

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -64,6 +64,7 @@ export interface MappingInitiativeOption extends MappingOptionItem {
 
 export interface MappingRoleOption extends MappingOptionItem {
   initiative_id: number;
+  guild_id: number;
 }
 
 export interface MappingOptions {


### PR DESCRIPTION
## Problem

When configuring an OIDC claim mapping with the **initiative** target type, the initiative dropdown stayed empty after selecting a guild — so initiative-scoped mappings couldn't be created at all.

Root cause: initiatives and initiative roles are **guild-scoped content** — their rows live in each guild's `guild_<id>` Postgres schema, not in `public`. But the OIDC claim-mapping settings endpoints query `Initiative` / `InitiativeRoleModel` on the admin session pinned to `search_path = public`, where those tables are only empty template copies. Consequences:

- The initiative dropdown was always empty (the guild dropdown worked because `Guild` is a shared `public` table).
- Creating an initiative mapping always failed with `INITIATIVE_NOT_FOUND`.
- The mappings list never resolved an initiative/role name for display.

A latent second bug: initiative and role IDs are unique only *within* a guild schema, so the flat options list could leak one guild's roles onto another guild's colliding initiative ID.

## Changes

**Backend** (`app/api/v1/public_endpoints/settings.py`)
- `GET /oidc-mappings/options` now routes the admin session into every guild's schema in turn and collects initiatives + roles. Each role carries `guild_id`.
- New `_lookup_guild_initiative(session, …)` (used by `_enrich_mapping`, `create_oidc_mapping`, `update_oidc_mapping`) routes into the mapping's guild for the read, then resets the session back to the neutral BYPASSRLS admin / `public` baseline before the write to the shared `public.oidc_claim_mappings` table. `populate_existing=True` guards against cross-guild identity-map ID collisions.

**Frontend**
- `MappingRoleOption` gains `guild_id`; the role dropdown filters by both guild and initiative.

## Notes
- The options endpoint is owner-only (`config.manage`) and intentionally surfaces initiatives across all guilds, including ones the owner isn't a member of — appropriate for this platform-wide SSO config surface.
- No schema/env changes. The endpoint returns an untyped `dict`, so no Orval regeneration was needed.

## Testing
- `cd backend && pytest app/api/v1/public_endpoints/settings_test.py` — added two regression tests (options surfaces guild-scoped initiatives/roles; creating an initiative mapping resolves guild-scoped data). 4 passed.
- `cd backend && pytest app/services/oidc_sync_test.py` — 8 passed.
- `cd backend && ruff check` on changed files — clean.
- `cd frontend && pnpm typecheck` + biome lint — clean.
- Manually verified in the app: dropdown populates and an initiative mapping saves.