### PR TITLE
Date picker: manual entry and year navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Creating a custom-property option now asks only for a label; the stored option value is derived from the label automatically (and de-duplicated), removing the redundant Value field from the editor.
+- The date picker now accepts a typed date — a text field at the top of the popover parses common formats (e.g. `2026-06-16`, `06/16/2026`, `Jun 16, 2026`) on Enter or blur — and exposes month/year dropdowns in the calendar header for quickly jumping across years instead of clicking month-by-month.
 
 ## [0.52.0] - 2026-06-16
 

--- a/frontend/public/locales/de/dates.json
+++ b/frontend/public/locales/de/dates.json
@@ -1,4 +1,10 @@
 {
+  "picker": {
+    "pickDate": "Datum auswählen",
+    "pickDateTime": "Datum und Uhrzeit auswählen",
+    "typeDate": "Datum eingeben oder auswählen",
+    "time": "Uhrzeit"
+  },
   "status": {
     "overdue": "Überfällig",
     "today": "Heute",

--- a/frontend/public/locales/en/dates.json
+++ b/frontend/public/locales/en/dates.json
@@ -1,4 +1,10 @@
 {
+  "picker": {
+    "pickDate": "Pick a date",
+    "pickDateTime": "Pick a date and time",
+    "typeDate": "Type or pick a date",
+    "time": "Time"
+  },
   "status": {
     "overdue": "Overdue",
     "today": "Today",

--- a/frontend/public/locales/es/dates.json
+++ b/frontend/public/locales/es/dates.json
@@ -1,4 +1,10 @@
 {
+  "picker": {
+    "pickDate": "Elegir una fecha",
+    "pickDateTime": "Elegir fecha y hora",
+    "typeDate": "Escribe o elige una fecha",
+    "time": "Hora"
+  },
   "status": {
     "overdue": "Vencida",
     "today": "Hoy",

--- a/frontend/public/locales/fr/dates.json
+++ b/frontend/public/locales/fr/dates.json
@@ -1,4 +1,10 @@
 {
+  "picker": {
+    "pickDate": "Choisir une date",
+    "pickDateTime": "Choisir une date et une heure",
+    "typeDate": "Saisir ou choisir une date",
+    "time": "Heure"
+  },
   "status": {
     "overdue": "En retard",
     "today": "Aujourd'hui",

--- a/frontend/src/components/ui/date-time-picker.tsx
+++ b/frontend/src/components/ui/date-time-picker.tsx
@@ -141,14 +141,16 @@ export const DateTimePicker = ({
     | 4
     | 5
     | 6;
-  const currentYear = new Date().getFullYear();
-  const mergedCalendarProps = {
-    captionLayout: "dropdown" as const,
-    startMonth: new Date(currentYear - 120, 0),
-    endMonth: new Date(currentYear + 10, 11),
-    ...(calendarProps ?? {}),
-    weekStartsOn: resolvedWeekStartsOn,
-  };
+  const mergedCalendarProps = React.useMemo(() => {
+    const currentYear = new Date().getFullYear();
+    return {
+      captionLayout: "dropdown" as const,
+      startMonth: new Date(currentYear - 120, 0),
+      endMonth: new Date(currentYear + 10, 11),
+      ...(calendarProps ?? {}),
+      weekStartsOn: resolvedWeekStartsOn,
+    };
+  }, [calendarProps, resolvedWeekStartsOn]);
 
   const handleSelectDate = (date: Date | undefined) => {
     if (!date) {
@@ -172,18 +174,35 @@ export const DateTimePicker = ({
     onChange(formatForStorage(next, includeTime));
   };
 
-  const commitInput = () => {
+  // `allowClear` distinguishes an explicit commit (Enter) from an incidental
+  // blur. On blur we must NOT emit onChange("") for an empty field: the browser
+  // fires blur (mousedown) before a calendar day's click (mouseup), so clearing
+  // here would send a spurious "clear" mutation right before the real "set".
+  // Clearing is intentional only via Enter or the Clear button.
+  const commitInput = (allowClear: boolean) => {
     const trimmed = inputValue.trim();
     if (!trimmed) {
-      onChange("");
+      if (allowClear) {
+        if (value) {
+          onChange("");
+        }
+      } else {
+        setInputValue(displayValue);
+      }
       return;
     }
     const parsed = parseManualDate(trimmed, includeTime, selectedDate ?? new Date());
-    if (parsed) {
-      onChange(formatForStorage(parsed, includeTime));
-    } else {
+    if (!parsed) {
       // Couldn't parse — revert to the last valid value.
       setInputValue(displayValue);
+      return;
+    }
+    const next = formatForStorage(parsed, includeTime);
+    if (next === value) {
+      // No change — just normalize the text to the canonical display.
+      setInputValue(displayValue);
+    } else {
+      onChange(next);
     }
   };
 
@@ -231,11 +250,11 @@ export const DateTimePicker = ({
             aria-label={t("picker.typeDate")}
             disabled={disabled}
             onChange={(event) => setInputValue(event.target.value)}
-            onBlur={commitInput}
+            onBlur={() => commitInput(false)}
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault();
-                commitInput();
+                commitInput(true);
               }
             }}
           />

--- a/frontend/src/components/ui/date-time-picker.tsx
+++ b/frontend/src/components/ui/date-time-picker.tsx
@@ -211,9 +211,12 @@ export const DateTimePicker = ({
   };
 
   const handleOpenChange = (next: boolean) => {
-    // Each time the popover opens, jump the calendar back to the selected date.
     if (next) {
+      // On open, jump the calendar back to the selected date and reset the text
+      // field — closing via Escape unmounts the input without firing onBlur, so
+      // any uncommitted text would otherwise linger until the value changes.
       setVisibleMonth(selectedDate ?? new Date());
+      setInputValue(displayValue);
     }
     setOpen(next);
   };

--- a/frontend/src/components/ui/date-time-picker.tsx
+++ b/frontend/src/components/ui/date-time-picker.tsx
@@ -1,5 +1,7 @@
-import { format } from "date-fns";
+import { format, isValid, parse } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
+import * as React from "react";
+import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -32,16 +34,64 @@ const applyTimeToDate = (date: Date, time: string) => {
   return next;
 };
 
+// Candidate formats tried (in order) when parsing a manually typed date.
+const DATE_FORMATS = [
+  "yyyy-MM-dd",
+  "MM/dd/yyyy",
+  "M/d/yyyy",
+  "MM-dd-yyyy",
+  "yyyy/MM/dd",
+  "MMMM d, yyyy",
+  "MMM d, yyyy",
+  "MMMM d yyyy",
+  "MMM d yyyy",
+  "d MMMM yyyy",
+  "d MMM yyyy",
+];
+
+const DATE_TIME_FORMATS = [
+  "yyyy-MM-dd HH:mm",
+  "yyyy-MM-dd'T'HH:mm",
+  "MM/dd/yyyy HH:mm",
+  "M/d/yyyy HH:mm",
+  "MM/dd/yyyy h:mm a",
+  "M/d/yyyy h:mm a",
+  "MMMM d, yyyy h:mm a",
+  "MMM d, yyyy h:mm a",
+  "MMMM d, yyyy HH:mm",
+  "MMM d, yyyy HH:mm",
+];
+
+// Parse a free-form typed string into a Date, trying known formats first and
+// falling back to native parsing. Fields absent from a matched format (e.g. the
+// time when only a date is typed) inherit from `reference`.
+const parseManualDate = (input: string, includeTime: boolean, reference: Date): Date | null => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const formats = includeTime ? [...DATE_TIME_FORMATS, ...DATE_FORMATS] : DATE_FORMATS;
+  for (const fmt of formats) {
+    const parsed = parse(trimmed, fmt, reference);
+    if (isValid(parsed)) {
+      return parsed;
+    }
+  }
+  const native = new Date(trimmed);
+  return isValid(native) ? native : null;
+};
+
 export const DateTimePicker = ({
   id,
   value,
   onChange,
   disabled = false,
   placeholder,
-  clearLabel = "Clear",
+  clearLabel,
   calendarProps,
   includeTime = true,
 }: DateTimePickerProps) => {
+  const { t } = useTranslation(["dates", "common"]);
   const { user } = useAuth();
   const selectedDate = value
     ? includeTime
@@ -56,7 +106,33 @@ export const DateTimePicker = ({
         })()
     : undefined;
   const timeValue = selectedDate ? format(selectedDate, "HH:mm") : "";
-  const defaultPlaceholder = includeTime ? "Pick a date and time" : "Pick a date";
+  const defaultPlaceholder = includeTime ? t("picker.pickDateTime") : t("picker.pickDate");
+
+  // Human-friendly representation of the current value for the manual-entry field.
+  const displayValue = selectedDate
+    ? format(selectedDate, includeTime ? "MMM d, yyyy h:mm a" : "MMM d, yyyy")
+    : "";
+  const [inputValue, setInputValue] = React.useState(displayValue);
+  // Keep the text field in sync whenever the committed value changes.
+  React.useEffect(() => {
+    setInputValue(displayValue);
+  }, [displayValue]);
+
+  const [open, setOpen] = React.useState(false);
+
+  // The month the calendar is displaying. Controlled so it follows both the
+  // month/year dropdowns and the selected date (e.g. when typed manually).
+  const [visibleMonth, setVisibleMonth] = React.useState(() => selectedDate ?? new Date());
+  const selectedMonthKey = selectedDate
+    ? `${selectedDate.getFullYear()}-${selectedDate.getMonth()}`
+    : null;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on selectedMonthKey so we only jump when the selected month changes, not on every render (selectedDate is a fresh object each render).
+  React.useEffect(() => {
+    if (selectedDate) {
+      setVisibleMonth(selectedDate);
+    }
+  }, [selectedMonthKey]);
+
   const resolvedWeekStartsOn = (calendarProps?.weekStartsOn ?? user?.week_starts_on ?? 0) as
     | 0
     | 1
@@ -65,7 +141,11 @@ export const DateTimePicker = ({
     | 4
     | 5
     | 6;
+  const currentYear = new Date().getFullYear();
   const mergedCalendarProps = {
+    captionLayout: "dropdown" as const,
+    startMonth: new Date(currentYear - 120, 0),
+    endMonth: new Date(currentYear + 10, 11),
     ...(calendarProps ?? {}),
     weekStartsOn: resolvedWeekStartsOn,
   };
@@ -92,12 +172,35 @@ export const DateTimePicker = ({
     onChange(formatForStorage(next, includeTime));
   };
 
+  const commitInput = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) {
+      onChange("");
+      return;
+    }
+    const parsed = parseManualDate(trimmed, includeTime, selectedDate ?? new Date());
+    if (parsed) {
+      onChange(formatForStorage(parsed, includeTime));
+    } else {
+      // Couldn't parse — revert to the last valid value.
+      setInputValue(displayValue);
+    }
+  };
+
   const handleClear = () => {
     onChange("");
   };
 
+  const handleOpenChange = (next: boolean) => {
+    // Each time the popover opens, jump the calendar back to the selected date.
+    if (next) {
+      setVisibleMonth(selectedDate ?? new Date());
+    }
+    setOpen(next);
+  };
+
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           id={id}
@@ -119,12 +222,31 @@ export const DateTimePicker = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
+        <div className="border-b p-3">
+          <Input
+            id={id ? `${id}-input` : undefined}
+            type="text"
+            value={inputValue}
+            placeholder={t("picker.typeDate")}
+            aria-label={t("picker.typeDate")}
+            disabled={disabled}
+            onChange={(event) => setInputValue(event.target.value)}
+            onBlur={commitInput}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                commitInput();
+              }
+            }}
+          />
+        </div>
         <Calendar
           {...mergedCalendarProps}
           mode="single"
           selected={selectedDate}
+          month={visibleMonth}
+          onMonthChange={setVisibleMonth}
           onSelect={handleSelectDate}
-          autoFocus
           className="w-75 p-3"
         />
         <div className="flex items-end gap-3 border-t bg-muted/30 p-3">
@@ -134,7 +256,7 @@ export const DateTimePicker = ({
                 htmlFor={`${id ?? "datetime"}-time`}
                 className="font-medium text-muted-foreground text-xs"
               >
-                Time
+                {t("picker.time")}
               </label>
               <Input
                 id={`${id ?? "datetime"}-time`}
@@ -154,7 +276,7 @@ export const DateTimePicker = ({
             onClick={handleClear}
             disabled={!selectedDate || disabled}
           >
-            {clearLabel}
+            {clearLabel ?? t("common:clear")}
           </Button>
         </div>
       </PopoverContent>


### PR DESCRIPTION
## Problem

The date picker was hard to use: there was no way to type a date directly, and navigating across years meant clicking the month chevron one month at a time.

## Changes

- **Manual entry** — a text field at the top of the popover parses common typed formats (`2026-06-16`, `06/16/2026`, `6/16/2026`, `Jun 16, 2026`, `June 16, 2026`, plus date+time variants) on **Enter** or **blur**. Unparseable input reverts to the last valid value.
- **Year/month navigation** — the calendar caption now uses month/year dropdowns (`captionLayout="dropdown"`) spanning `currentYear - 120` → `currentYear + 10`, so you can jump across years (incl. birthdates) without clicking month-by-month.
- **Opens to the selection** — the calendar's displayed month is controlled state that resets to the selected date each time the popover opens, and follows both the dropdowns and a manually-typed date while open.
- Previously-hardcoded strings ("Time", placeholders) now go through i18n under the `dates:picker.*` namespace; the Clear label falls back to `common:clear`.

## Schema / env

None.

## i18n

New `picker` keys added to `dates.json` across **en / de / es / fr**.

## Testing

- `pnpm typecheck` — passes
- `pnpm biome check` — clean
- `pnpm test:run src/components/properties/PropertyInput.test.tsx` — 18/18 pass (the picker's consumer with coverage)
- Manual: typing a date + Enter, year dropdown, and reopening on the selected month