### PR TITLE
Fix /me calendar test setup (admin membership)

### DIFF
--- a/backend/app/api/v1/guild_endpoints/calendar_events_test.py
+++ b/backend/app/api/v1/guild_endpoints/calendar_events_test.py
@@ -474,6 +474,9 @@ async def test_my_calendar_events_filters_events_without_member_grant(
     member = await create_user(session, email="me-member@example.com")
     guild = await create_guild(session, creator=admin)
     await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await create_guild_membership(
         session, user=member, guild=guild, role=GuildRole.member
     )
     initiative = await create_initiative(session, guild, admin, name="MeFilter")
@@ -529,6 +532,9 @@ async def test_my_calendar_events_admin_sees_events_outside_their_initiatives(
     admin = await create_user(session, email="me-admin2@example.com")
     other = await create_user(session, email="me-other@example.com")
     guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
     await create_guild_membership(
         session, user=other, guild=guild, role=GuildRole.member
     )


### PR DESCRIPTION
## Problem

The two cross-guild `/me` calendar visibility tests added in #727
(`test_my_calendar_events_filters_events_without_member_grant` and
`test_my_calendar_events_admin_sees_events_outside_their_initiatives`)
were merged in an in-progress state: they relied on `create_guild(creator=admin)`
making the admin a guild member, but the factory only creates the guild row
and provisions the schema — it does **not** add a `GuildMembership`.

As a result `member_guild_ids(admin)` returns empty, `gather_across_guilds`
visits no guilds, and both `/me` assertions fail on `dev`.

## Fix

Add the admin's `GuildMembership` explicitly in both tests (mirroring the
existing `_setup_event` / `_setup_organizer_and_attendee` helpers, which also
add membership separately from `create_guild`).

Test-only; no source change. Both tests pass with this fix.