### PR TITLE
Unify resource sharing into one grants model

### DIFF
--- a/backend/alembic/guild/guild_schema.sql
+++ b/backend/alembic/guild/guild_schema.sql
@@ -376,7 +376,7 @@ CREATE TABLE IF NOT EXISTS resource_grants (
 	created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
 	all_initiative_members BOOLEAN DEFAULT false NOT NULL, 
 	CONSTRAINT resource_grants_pkey PRIMARY KEY (id), 
-	CONSTRAINT resource_grants_unique_grantee UNIQUE NULLS DISTINCT (resource_type, resource_id, user_id, role_id)
+	CONSTRAINT resource_grants_unique_grantee UNIQUE NULLS NOT DISTINCT (resource_type, resource_id, user_id, role_id)
 );
 CREATE TABLE IF NOT EXISTS subtasks (
 	id SERIAL NOT NULL, 

--- a/backend/alembic/guild/guild_schema.sql
+++ b/backend/alembic/guild/guild_schema.sql
@@ -374,8 +374,9 @@ CREATE TABLE IF NOT EXISTS resource_grants (
 	role_id INTEGER, 
 	level VARCHAR(16) NOT NULL, 
 	created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+	all_initiative_members BOOLEAN DEFAULT false NOT NULL, 
 	CONSTRAINT resource_grants_pkey PRIMARY KEY (id), 
-	CONSTRAINT resource_grants_unique_grantee UNIQUE NULLS NOT DISTINCT (resource_type, resource_id, user_id, role_id)
+	CONSTRAINT resource_grants_unique_grantee UNIQUE NULLS DISTINCT (resource_type, resource_id, user_id, role_id)
 );
 CREATE TABLE IF NOT EXISTS subtasks (
 	id SERIAL NOT NULL, 
@@ -618,7 +619,7 @@ CREATE INDEX IF NOT EXISTS ix_webhook_subscriptions_guild_id ON webhook_subscrip
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ck_comments_task_or_document' AND connamespace = current_schema()::regnamespace) THEN ALTER TABLE "comments" ADD CONSTRAINT "ck_comments_task_or_document" CHECK (((task_id IS NULL) <> (document_id IS NULL))); END IF; END $$;
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ck_initiative_role_permissions_permission_key' AND connamespace = current_schema()::regnamespace) THEN ALTER TABLE "initiative_role_permissions" ADD CONSTRAINT "ck_initiative_role_permissions_permission_key" CHECK (((permission_key)::text = ANY ((ARRAY['docs_enabled'::character varying, 'projects_enabled'::character varying, 'create_docs'::character varying, 'create_projects'::character varying, 'queues_enabled'::character varying, 'create_queues'::character varying, 'events_enabled'::character varying, 'create_events'::character varying, 'advanced_tool_enabled'::character varying, 'create_advanced_tool'::character varying, 'counters_enabled'::character varying, 'create_counters'::character varying])::text[]))); END IF; END $$;
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ck_recent_views_entity_type' AND connamespace = current_schema()::regnamespace) THEN ALTER TABLE "recent_views" ADD CONSTRAINT "ck_recent_views_entity_type" CHECK ((entity_type = ANY (ARRAY['project'::text, 'document'::text, 'queue'::text, 'counter_group'::text]))); END IF; END $$;
-DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'resource_grants_one_grantee' AND connamespace = current_schema()::regnamespace) THEN ALTER TABLE "resource_grants" ADD CONSTRAINT "resource_grants_one_grantee" CHECK (((user_id IS NULL) <> (role_id IS NULL))); END IF; END $$;
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'resource_grants_one_grantee' AND connamespace = current_schema()::regnamespace) THEN ALTER TABLE "resource_grants" ADD CONSTRAINT "resource_grants_one_grantee" CHECK ((((((user_id IS NOT NULL))::integer + ((role_id IS NOT NULL))::integer) + (all_initiative_members)::integer) = 1)); END IF; END $$;
 
 -- intra-schema FOREIGN KEYs
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'calendar_event_attendees_calendar_event_id_fkey' AND connamespace = current_schema()::regnamespace) THEN ALTER TABLE "calendar_event_attendees" ADD CONSTRAINT "calendar_event_attendees_calendar_event_id_fkey" FOREIGN KEY (calendar_event_id) REFERENCES calendar_events(id) ON DELETE CASCADE; END IF; END $$;

--- a/backend/alembic/versions/20260617_0117_resource_grants_general_access.py
+++ b/backend/alembic/versions/20260617_0117_resource_grants_general_access.py
@@ -1,0 +1,105 @@
+"""Add general-access (all-initiative-members) share column to resource_grants.
+
+Adds a single ``all_initiative_members`` boolean and swaps the
+``resource_grants_one_grantee`` check from the old user-XOR-role to "exactly one
+grantee kind" (user, role, OR the whole initiative). A share row has no
+user_id/role_id, ``all_initiative_members = true`` and its level in the existing
+``level`` column (read = Viewer, write = Editor); the boolean may not be set when
+a user/role grantee is present.
+
+Applied to ``public`` (the reflection source for guild_schema.sql) AND every
+existing ``guild_*`` schema — the generated guild_schema.sql only
+``CREATE TABLE IF NOT EXISTS`` (a no-op on existing tables), so the new column
+reaches existing guilds only via this explicit ALTER. New guilds pick it up from
+the regenerated guild_schema.sql. See history/general-access-sharing-design.md.
+
+Revision ID: 20260617_0117
+Revises: 20260616_0116
+Create Date: 2026-06-17
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260617_0117"
+down_revision = "20260616_0116"
+branch_labels = None
+depends_on = None
+
+_NEW_CHECK = (
+    "(user_id IS NOT NULL)::int + (role_id IS NOT NULL)::int "
+    "+ (all_initiative_members)::int = 1"
+)
+_OLD_CHECK = "(user_id IS NULL) <> (role_id IS NULL)"
+
+
+def _guild_schemas(conn) -> list[str]:
+    # Matches every guild_<id> AND guild_template.
+    rows = conn.execute(
+        text("SELECT nspname FROM pg_namespace WHERE nspname LIKE 'guild\\_%'")
+    ).all()
+    return [r[0] for r in rows]
+
+
+def _apply(conn) -> None:
+    """Idempotently add the share column + set the grantee check on the
+    ``resource_grants`` table resolved by the current search_path."""
+    conn.execute(
+        text(
+            "ALTER TABLE resource_grants "
+            "ADD COLUMN IF NOT EXISTS all_initiative_members "
+            "BOOLEAN NOT NULL DEFAULT FALSE"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE resource_grants DROP CONSTRAINT IF EXISTS resource_grants_one_grantee"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE resource_grants ADD CONSTRAINT resource_grants_one_grantee "
+            f"CHECK ({_NEW_CHECK})"
+        )
+    )
+
+
+def _revert(conn) -> None:
+    """Drop the share column + restore the old XOR check on the search-path
+    ``resource_grants``. Share rows (no grantee) violate the XOR, so clear them
+    first."""
+    conn.execute(
+        text("DELETE FROM resource_grants WHERE user_id IS NULL AND role_id IS NULL")
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE resource_grants DROP CONSTRAINT IF EXISTS resource_grants_one_grantee"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE resource_grants ADD CONSTRAINT resource_grants_one_grantee "
+            f"CHECK ({_OLD_CHECK})"
+        )
+    )
+    conn.execute(
+        text("ALTER TABLE resource_grants DROP COLUMN IF EXISTS all_initiative_members")
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _apply(conn)
+    conn.execute(text("SET search_path TO public"))
+    _apply(conn)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _revert(conn)
+    conn.execute(text("SET search_path TO public"))
+    _revert(conn)

--- a/backend/alembic/versions/20260622_0118_calendar_grants_all_members.py
+++ b/backend/alembic/versions/20260622_0118_calendar_grants_all_members.py
@@ -1,0 +1,101 @@
+"""Normalize backfilled calendar-event grants to all-initiative-members Viewer.
+
+Before per-event DAC, every initiative member could see all calendar events by
+virtue of membership. The ``0115`` backfill stood that up as one grant *per
+initiative role* (write for managers, read for the rest), because the
+``all_initiative_members`` column didn't exist yet (it arrives in ``0117``).
+
+Functionally those per-role grants keep the events visible, but in the unified
+2-mode sharing model they render as "Restricted" with every role listed instead
+of "All members" — which is not their original shape. This migration restores
+that shape: for every pre-existing calendar event, drop the per-role backfill
+grants and seed a single ``all_initiative_members`` / ``read`` grant, exactly
+what ``create_calendar_event`` now writes for new events. The creator's owner
+grant is left untouched.
+
+Revision ID: 20260622_0118
+Revises: 20260617_0117
+Create Date: 2026-06-22
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260622_0118"
+down_revision = "20260617_0117"
+branch_labels = None
+depends_on = None
+
+
+def _guild_schemas(conn) -> list[str]:
+    rows = conn.execute(
+        text("SELECT nspname FROM pg_namespace WHERE nspname LIKE 'guild\\_%'")
+    ).all()
+    return [r[0] for r in rows]
+
+
+def _to_all_members(conn) -> None:
+    # Drop the per-role backfill grants on calendar events (the stand-in for
+    # "every member can see it"); we now express that directly.
+    conn.execute(
+        text(
+            "DELETE FROM resource_grants "
+            "WHERE resource_type = 'calendar_event' AND role_id IS NOT NULL"
+        )
+    )
+    # Seed one all-initiative-members Viewer grant per event, mirroring the
+    # create flow. Creator owner grants (user_id set) are left as-is.
+    conn.execute(
+        text(
+            """
+            INSERT INTO resource_grants
+                (guild_id, initiative_id, resource_type, resource_id,
+                 all_initiative_members, level, created_at)
+            SELECT ce.guild_id, ce.initiative_id, 'calendar_event', ce.id,
+                   true, 'read', ce.created_at
+            FROM calendar_events ce
+            ON CONFLICT DO NOTHING
+            """
+        )
+    )
+
+
+def _to_per_role(conn) -> None:
+    # Reverse: remove the all-members grants and re-seed per-role grants exactly
+    # the way the 0115 backfill did (write for managers, read for everyone else).
+    conn.execute(
+        text(
+            "DELETE FROM resource_grants "
+            "WHERE resource_type = 'calendar_event' AND all_initiative_members IS TRUE"
+        )
+    )
+    conn.execute(
+        text(
+            """
+            INSERT INTO resource_grants
+                (guild_id, initiative_id, resource_type, resource_id,
+                 role_id, level, created_at)
+            SELECT ce.guild_id, ce.initiative_id, 'calendar_event', ce.id, ir.id,
+                   CASE WHEN ir.is_manager THEN 'write' ELSE 'read' END, ce.created_at
+            FROM calendar_events ce
+            JOIN initiative_roles ir ON ir.initiative_id = ce.initiative_id
+            ON CONFLICT DO NOTHING
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _to_all_members(conn)
+    conn.execute(text("SET search_path TO public"))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _to_per_role(conn)
+    conn.execute(text("SET search_path TO public"))

--- a/backend/app/api/v1/guild_endpoints/calendar_events.py
+++ b/backend/app/api/v1/guild_endpoints/calendar_events.py
@@ -227,7 +227,11 @@ async def list_my_calendar_events(
                 selectinload(CalendarEvent.attendees).selectinload(
                     CalendarEventAttendee.user,
                 ),
-                selectinload(CalendarEvent.initiative),
+                # memberships are needed by my_permission_level (effective_level
+                # reads the requester's roles + membership off the initiative).
+                selectinload(CalendarEvent.initiative).selectinload(
+                    Initiative.memberships
+                ),
                 selectinload(CalendarEvent.tag_links).selectinload(
                     CalendarEventTag.tag
                 ),

--- a/backend/app/api/v1/guild_endpoints/calendar_events.py
+++ b/backend/app/api/v1/guild_endpoints/calendar_events.py
@@ -1,7 +1,8 @@
 """Calendar event endpoints — CRUD, attendees, tags, and documents.
 
-Initiative-scoped calendar events. Access is controlled at the initiative
-level via events_enabled + create_events permission keys. No per-event DAC.
+Initiative-scoped calendar events. Creation is gated at the initiative level
+(events_enabled + create_events); per-event access is the unified resource-grant
+DAC (``resource_grants`` + ``PUT /{id}/grants``), like the other resources.
 """
 
 import logging
@@ -49,6 +50,7 @@ from app.schemas.ical import (
     ICalParseResult,
 )
 from app.schemas.property import PropertyValuesSetRequest
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.api import resource_access
 from app.models.resource_grant import ResourceGrant, ResourceAccessLevel
 from app.services import permissions as permissions_service
@@ -229,6 +231,7 @@ async def list_my_calendar_events(
                 selectinload(CalendarEvent.tag_links).selectinload(
                     CalendarEventTag.tag
                 ),
+                selectinload(CalendarEvent.grants).selectinload(ResourceGrant.role),
                 selectinload(CalendarEvent.property_values).selectinload(
                     CalendarEventPropertyValue.property_definition
                 ),
@@ -250,7 +253,10 @@ async def list_my_calendar_events(
     start = (page - 1) * page_size
     page_events = events[start : start + page_size]
 
-    items = [serialize_calendar_event_summary(e) for e in page_events]
+    items = [
+        serialize_calendar_event_summary(e, user_id=current_user.id)
+        for e in page_events
+    ]
     has_next = page * page_size < total_count
     return CalendarEventListResponse(
         items=items,
@@ -523,6 +529,7 @@ async def list_calendar_events(
             ),
             selectinload(CalendarEvent.initiative).selectinload(Initiative.memberships),
             selectinload(CalendarEvent.tag_links).selectinload(CalendarEventTag.tag),
+            selectinload(CalendarEvent.grants).selectinload(ResourceGrant.role),
             selectinload(CalendarEvent.property_values).selectinload(
                 CalendarEventPropertyValue.property_definition
             ),
@@ -537,7 +544,9 @@ async def list_calendar_events(
     result = await session.exec(stmt)
     events = result.unique().all()
 
-    items = [serialize_calendar_event_summary(e) for e in events]
+    items = [
+        serialize_calendar_event_summary(e, user_id=current_user.id) for e in events
+    ]
     has_next = page * page_size < total_count
     return CalendarEventListResponse(
         items=items,
@@ -556,7 +565,7 @@ async def read_calendar_event(
     guild_context: GuildContextDep,
 ) -> CalendarEventRead:
     event = await _get_event_or_404(session, event_id, current_user, guild_context)
-    return serialize_calendar_event(event)
+    return serialize_calendar_event(event, user_id=current_user.id)
 
 
 @router.post("/", response_model=CalendarEventRead, status_code=status.HTTP_201_CREATED)
@@ -601,9 +610,8 @@ async def create_calendar_event(
     session.add(event)
     await session.flush()
 
-    # Per-event DAC: creator owns it; each initiative role gets write (managers)
-    # or read so events stay member-visible by default. Restrict later via the
-    # grant endpoints.
+    # Per-event DAC: the creator always owns it. The rest of the sharing flows
+    # through the unified grant list — exactly the way edits do.
     session.add(
         ResourceGrant(
             resource_type="calendar_event",
@@ -614,20 +622,19 @@ async def create_calendar_event(
             initiative_id=initiative.id,
         )
     )
-    for role in initiative.roles:
-        session.add(
-            ResourceGrant(
-                resource_type="calendar_event",
-                resource_id=event.id,
-                role_id=role.id,
-                level=ResourceAccessLevel.write
-                if role.is_manager
-                else ResourceAccessLevel.read,
-                guild_id=guild_context.guild_id,
-                initiative_id=initiative.id,
-            )
-        )
     await session.flush()
+
+    # Apply the initial sharing exactly the way edits do — one grant list, one
+    # code path (defaults to Viewer for all members, set on CalendarEventCreate).
+    await permissions_service.replace_resource_grants(
+        session,
+        resource_type="calendar_event",
+        resource_id=event.id,
+        guild_id=guild_context.guild_id,
+        initiative_id=initiative.id,
+        owner_id=current_user.id,
+        grants=event_in.grants,
+    )
 
     if event_in.attendee_ids:
         await events_service.set_event_attendees(
@@ -667,7 +674,7 @@ async def create_calendar_event(
     await session.commit()
     await reapply_rls_context(session)
     hydrated = await _refetch_event(session, event.id)
-    return serialize_calendar_event(hydrated)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)
 
 
 @router.patch("/{event_id}", response_model=CalendarEventRead)
@@ -763,7 +770,7 @@ async def update_calendar_event(
         await reapply_rls_context(session)
 
     hydrated = await _refetch_event(session, event.id)
-    return serialize_calendar_event(hydrated)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)
 
 
 @router.delete("/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -852,7 +859,7 @@ async def set_attendees(
     await session.commit()
     await reapply_rls_context(session)
     hydrated = await _refetch_event(session, event.id)
-    return serialize_calendar_event(hydrated)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)
 
 
 @router.patch("/{event_id}/rsvp", response_model=CalendarEventRead)
@@ -898,7 +905,7 @@ async def update_rsvp(
     await session.commit()
     await reapply_rls_context(session)
     hydrated = await _refetch_event(session, event.id)
-    return serialize_calendar_event(hydrated)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)
 
 
 # ---------------------------------------------------------------------------
@@ -926,7 +933,7 @@ async def set_tags(
     await session.commit()
     await reapply_rls_context(session)
     hydrated = await _refetch_event(session, event.id)
-    return serialize_calendar_event(hydrated)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)
 
 
 @router.put("/{event_id}/documents", response_model=CalendarEventRead)
@@ -955,7 +962,7 @@ async def set_documents(
     await session.commit()
     await reapply_rls_context(session)
     hydrated = await _refetch_event(session, event.id)
-    return serialize_calendar_event(hydrated)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)
 
 
 # ---------------------------------------------------------------------------
@@ -991,4 +998,58 @@ async def set_event_properties(
     await session.commit()
     await reapply_rls_context(session)
     hydrated = await _refetch_event(session, event.id)
-    return serialize_calendar_event(hydrated)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)
+
+
+# ---------------------------------------------------------------------------
+# Sharing (resource grants)
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{event_id}/grants", response_model=CalendarEventRead)
+async def set_calendar_event_grants(
+    event_id: int,
+    grants: List[ResourceGrantSchema],
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> CalendarEventRead:
+    """Replace the event's entire sharing state in one call — the body is the
+    full list of grants (all-initiative-members / per-user / per-role). Every
+    non-owner grant is rebuilt from it; the owner is always preserved.
+    """
+    event = await _get_event_or_404(
+        session, event_id, current_user, guild_context, access="write"
+    )
+    # Managing sharing additionally rejects PAM grantees — a grant never manages
+    # access (mirrors the projects/documents/counters grant endpoints).
+    resource_access.authorize(
+        "calendar_event",
+        event,
+        current_user,
+        access="write",
+        manage_access=True,
+        guild_role=guild_context.role,
+    )
+
+    # The owner is the user holding the owner-level grant, else the creator.
+    owner_id = event.created_by_id
+    for g in event.grants or []:
+        if g.user_id is not None and g.level == ResourceAccessLevel.owner:
+            owner_id = g.user_id
+            break
+
+    await permissions_service.replace_resource_grants(
+        session,
+        resource_type="calendar_event",
+        resource_id=event.id,
+        guild_id=event.guild_id,
+        initiative_id=event.initiative_id,
+        owner_id=owner_id,
+        grants=grants,
+    )
+
+    await session.commit()
+    await reapply_rls_context(session)
+    hydrated = await _refetch_event(session, event.id)
+    return serialize_calendar_event(hydrated, user_id=current_user.id)

--- a/backend/app/api/v1/guild_endpoints/counters.py
+++ b/backend/app/api/v1/guild_endpoints/counters.py
@@ -16,7 +16,7 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
-from sqlalchemy import delete as sa_delete, func
+from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
@@ -32,28 +32,22 @@ from app.db.session import AsyncSessionLocal, reapply_rls_context, set_rls_conte
 from app.models.counter import (
     Counter,
     CounterGroup,
-    CounterPermissionLevel,
     CounterViewMode,
 )
 from app.models.guild import GuildMembership
 from app.models.initiative import (
     Initiative,
-    InitiativeMember,
-    InitiativeRoleModel,
     PermissionKey,
 )
 from app.models.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.user import User
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.counter import (
     CounterCreate,
     CounterGroupCreate,
     CounterGroupDuplicateRequest,
     CounterGroupListResponse,
-    CounterGroupPermissionCreate,
-    CounterGroupPermissionRead,
     CounterGroupRead,
-    CounterGroupRolePermissionCreate,
-    CounterGroupRolePermissionRead,
     CounterGroupUpdate,
     CounterRead,
     CounterSetCountRequest,
@@ -65,6 +59,7 @@ from app.schemas.counter import (
     _validate_counter_constraints,
 )
 from app.services import counters as counters_service
+from app.services import permissions as permissions_service
 from app.services import recent_views as recent_views_service
 from app.api import resource_access
 from app.services import rls as rls_service
@@ -329,67 +324,17 @@ async def create_counter_group(
     )
     session.add(owner_perm)
 
-    if group_in.role_permissions:
-        role_ids = {
-            rp.initiative_role_id
-            for rp in group_in.role_permissions
-            if rp.level != CounterPermissionLevel.owner
-        }
-        valid_role_ids: set[int] = set()
-        if role_ids:
-            result = await session.exec(
-                select(InitiativeRoleModel.id).where(
-                    InitiativeRoleModel.id.in_(role_ids),
-                    InitiativeRoleModel.initiative_id == initiative.id,
-                )
-            )
-            valid_role_ids = set(result.all())
-        for rp in group_in.role_permissions:
-            if (
-                rp.initiative_role_id not in valid_role_ids
-                or rp.level == CounterPermissionLevel.owner
-            ):
-                continue
-            session.add(
-                ResourceGrant(
-                    resource_type="counter_group",
-                    resource_id=group.id,
-                    user_id=None,
-                    role_id=rp.initiative_role_id,
-                    level=rp.level,
-                    guild_id=guild_context.guild_id,
-                    initiative_id=group.initiative_id,
-                )
-            )
-
-    if group_in.user_permissions:
-        requested = {
-            up.user_id
-            for up in group_in.user_permissions
-            if up.user_id != current_user.id
-        }
-        valid_ids: set[int] = set()
-        if requested:
-            result = await session.exec(
-                select(InitiativeMember.user_id).where(
-                    InitiativeMember.initiative_id == initiative.id,
-                    InitiativeMember.user_id.in_(requested),
-                )
-            )
-            valid_ids = set(result.all())
-        for up in group_in.user_permissions:
-            if up.user_id in valid_ids and up.level != CounterPermissionLevel.owner:
-                session.add(
-                    ResourceGrant(
-                        resource_type="counter_group",
-                        resource_id=group.id,
-                        user_id=up.user_id,
-                        role_id=None,
-                        level=up.level,
-                        guild_id=guild_context.guild_id,
-                        initiative_id=group.initiative_id,
-                    )
-                )
+    # Apply the initial sharing exactly the way edits do — one grant list, one
+    # code path (empty default = owner-only until shared).
+    await permissions_service.replace_resource_grants(
+        session,
+        resource_type="counter_group",
+        resource_id=group.id,
+        guild_id=guild_context.guild_id,
+        initiative_id=group.initiative_id,
+        owner_id=current_user.id,
+        grants=group_in.grants,
+    )
 
     await session.commit()
     await reapply_rls_context(session)
@@ -843,62 +788,24 @@ async def sort_counters(
 
 
 # ---------------------------------------------------------------------------
-# Permissions (DAC)
+# Sharing (resource grants)
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{group_id}/permissions")
-async def list_counter_group_permissions(
+@router.put("/{group_id}/grants", response_model=CounterGroupRead)
+async def set_counter_group_grants(
     group_id: int,
+    grants: List[ResourceGrantSchema],
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> dict:
-    group = await _get_counter_group_with_access(
-        session, group_id, current_user, guild_context, access="read"
-    )
-
-    permissions = [
-        CounterGroupPermissionRead(
-            user_id=g.user_id,
-            level=g.level,
-            created_at=g.created_at,
-        )
-        for g in (group.grants or [])
-        if g.user_id is not None
-    ]
-
-    role_permissions = []
-    for g in group.grants or []:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        role_permissions.append(
-            CounterGroupRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
-
-    return {
-        "permissions": permissions,
-        "role_permissions": role_permissions,
-    }
-
-
-@router.put("/{group_id}/permissions", response_model=List[CounterGroupPermissionRead])
-async def set_counter_group_permissions(
-    group_id: int,
-    permissions_in: List[CounterGroupPermissionCreate],
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> List[CounterGroupPermissionRead]:
-    # Write access is sufficient to manage permissions; only deleting the group
-    # is reserved for owners. The owner row itself is preserved below regardless.
+) -> CounterGroupRead:
+    """Replace the counter group's entire sharing state in one call — the body
+    is the full list of grants (all-initiative-members / per-user / per-role).
+    Every non-owner grant is rebuilt from it; the owner is always preserved.
+    """
+    # Write access is sufficient to manage sharing; only deleting the group is
+    # reserved for owners. The owner row itself is preserved regardless.
     group = await _get_counter_group_with_access(
         session,
         group_id,
@@ -908,135 +815,39 @@ async def set_counter_group_permissions(
         manage_access=True,
     )
 
-    owner_user_id: int | None = None
+    # The owner is the user holding the owner-level grant, else the creator.
+    owner_id = group.created_by_id
     for g in group.grants or []:
         if g.user_id is not None and g.level == ResourceAccessLevel.owner:
-            owner_user_id = g.user_id
+            owner_id = g.user_id
             break
 
-    # Delete all non-owner user grants (role grants are managed separately)
-    base_conditions = [
-        ResourceGrant.resource_type == "counter_group",
-        ResourceGrant.resource_id == group.id,
-        ResourceGrant.user_id.is_not(None),
-    ]
-    if owner_user_id is not None:
-        delete_stmt = sa_delete(ResourceGrant).where(
-            *base_conditions,
-            ResourceGrant.user_id != owner_user_id,
-        )
-    else:
-        delete_stmt = sa_delete(ResourceGrant).where(
-            *base_conditions,
-            ResourceGrant.level != ResourceAccessLevel.owner,
-        )
-    await session.exec(delete_stmt)
-
-    for perm_in in permissions_in:
-        if perm_in.user_id == owner_user_id:
-            continue
-        if perm_in.level == CounterPermissionLevel.owner:
-            continue
-        session.add(
-            ResourceGrant(
-                resource_type="counter_group",
-                resource_id=group.id,
-                user_id=perm_in.user_id,
-                role_id=None,
-                level=perm_in.level,
-                guild_id=group.guild_id,
-                initiative_id=group.initiative_id,
-            )
-        )
-
-    await session.commit()
-    await reapply_rls_context(session)
-
-    hydrated = await _refetch_group(session, group.id)
-    perms_result = [
-        CounterGroupPermissionRead(
-            user_id=g.user_id,
-            level=g.level,
-            created_at=g.created_at,
-        )
-        for g in (hydrated.grants or [])
-        if g.user_id is not None
-    ]
-    await counter_manager.broadcast(
-        group_id,
-        "permissions_changed",
-        {"permissions": [p.model_dump(mode="json") for p in perms_result]},
-    )
-    return perms_result
-
-
-@router.put(
-    "/{group_id}/role-permissions", response_model=List[CounterGroupRolePermissionRead]
-)
-async def set_counter_group_role_permissions(
-    group_id: int,
-    role_permissions_in: List[CounterGroupRolePermissionCreate],
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> List[CounterGroupRolePermissionRead]:
-    # Write access is sufficient to manage role permissions (delete is owner-only).
-    group = await _get_counter_group_with_access(
+    await permissions_service.replace_resource_grants(
         session,
-        group_id,
-        current_user,
-        guild_context,
-        access="write",
-        manage_access=True,
+        resource_type="counter_group",
+        resource_id=group.id,
+        guild_id=group.guild_id,
+        initiative_id=group.initiative_id,
+        owner_id=owner_id,
+        grants=grants,
     )
-
-    # Delete all existing role grants (user grants are managed separately)
-    delete_stmt = sa_delete(ResourceGrant).where(
-        ResourceGrant.resource_type == "counter_group",
-        ResourceGrant.resource_id == group.id,
-        ResourceGrant.role_id.is_not(None),
-    )
-    await session.exec(delete_stmt)
-
-    for rp_in in role_permissions_in:
-        if rp_in.level == CounterPermissionLevel.owner:
-            continue
-        session.add(
-            ResourceGrant(
-                resource_type="counter_group",
-                resource_id=group.id,
-                user_id=None,
-                role_id=rp_in.initiative_role_id,
-                level=rp_in.level,
-                guild_id=group.guild_id,
-                initiative_id=group.initiative_id,
-            )
-        )
 
     await session.commit()
     await reapply_rls_context(session)
 
     hydrated = await _refetch_group(session, group.id)
-    role_perms_result: List[CounterGroupRolePermissionRead] = []
-    for g in hydrated.grants or []:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        role_perms_result.append(
-            CounterGroupRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
+    result = serialize_counter_group(
+        hydrated,
+        my_permission_level=_compute_my_permission(
+            hydrated, current_user, guild_context
+        ),
+    )
     await counter_manager.broadcast(
         group_id,
         "permissions_changed",
-        {"role_permissions": [rp.model_dump(mode="json") for rp in role_perms_result]},
+        {"grants": [g.model_dump(mode="json") for g in result.grants]},
     )
-    return role_perms_result
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/v1/guild_endpoints/counters_test.py
+++ b/backend/app/api/v1/guild_endpoints/counters_test.py
@@ -715,7 +715,7 @@ async def test_sort_counters_read_only_forbidden(
 
     # Grant the member read-only access on the group.
     grant = await client.put(
-        f"/api/v1/g/{guild.id}/counter-groups/{gid}/permissions",
+        f"/api/v1/g/{guild.id}/counter-groups/{gid}/grants",
         headers=admin_headers,
         json=[{"user_id": member.id, "level": "read"}],
     )
@@ -829,7 +829,7 @@ async def test_duplicate_counter_group_read_user_becomes_owner(
     await _add_counter(client, admin_headers, guild, sid, name="A", position="0")
 
     grant = await client.put(
-        f"/api/v1/g/{guild.id}/counter-groups/{sid}/permissions",
+        f"/api/v1/g/{guild.id}/counter-groups/{sid}/grants",
         headers=admin_headers,
         json=[{"user_id": member.id, "level": "read"}],
     )

--- a/backend/app/api/v1/guild_endpoints/documents.py
+++ b/backend/app/api/v1/guild_endpoints/documents.py
@@ -42,7 +42,6 @@ from app.models.access_grant import AccessLevel
 from app.models.document import (
     Document,
     DocumentFileVersion,
-    DocumentPermissionLevel,
     DocumentType,
     ProjectDocument,
 )
@@ -67,15 +66,7 @@ from app.schemas.document import (
     DocumentDuplicateRequest,
     DocumentListResponse,
     DocumentSummary,
-    DocumentPermissionBulkCreate,
-    DocumentPermissionBulkDelete,
-    DocumentPermissionCreate,
-    DocumentPermissionRead,
-    DocumentPermissionUpdate,
     DocumentRead,
-    DocumentRolePermissionCreate,
-    DocumentRolePermissionRead,
-    DocumentRolePermissionUpdate,
     DocumentFileVersionRead,
     DocumentUpdate,
     serialize_document,
@@ -83,6 +74,7 @@ from app.schemas.document import (
     serialize_document_file_versions,
     serialize_document_summary,
 )
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.ai_generation import GenerateDocumentSummaryResponse
 from app.schemas.property import PropertyValuesSetRequest
 from app.schemas.tag import TagSetRequest
@@ -894,70 +886,17 @@ async def create_document(
     )
     session.add(owner_permission)
 
-    # Process optional role permissions from request
-    if document_in.role_permissions:
-        # Validate each role belongs to this initiative
-        role_ids = {
-            rp.initiative_role_id
-            for rp in document_in.role_permissions
-            if rp.level != DocumentPermissionLevel.owner
-        }
-        valid_role_ids: set[int] = set()
-        if role_ids:
-            result = await session.exec(
-                select(InitiativeRoleModel.id).where(
-                    InitiativeRoleModel.id.in_(role_ids),
-                    InitiativeRoleModel.initiative_id == initiative.id,
-                )
-            )
-            valid_role_ids = set(result.all())
-        for rp in document_in.role_permissions:
-            if (
-                rp.initiative_role_id not in valid_role_ids
-                or rp.level == DocumentPermissionLevel.owner
-            ):
-                continue
-            session.add(
-                ResourceGrant(
-                    resource_type="document",
-                    resource_id=document.id,
-                    user_id=None,
-                    role_id=rp.initiative_role_id,
-                    level=rp.level,
-                    guild_id=guild_context.guild_id,
-                    initiative_id=document.initiative_id,
-                )
-            )
-
-    # Process optional user permissions (batch-validate initiative membership)
-    if document_in.user_permissions:
-        requested = {
-            up.user_id
-            for up in document_in.user_permissions
-            if up.user_id != current_user.id
-        }
-        valid_ids: set[int] = set()
-        if requested:
-            result = await session.exec(
-                select(InitiativeMember.user_id).where(
-                    InitiativeMember.initiative_id == initiative.id,
-                    InitiativeMember.user_id.in_(requested),
-                )
-            )
-            valid_ids = set(result.all())
-        for up in document_in.user_permissions:
-            if up.user_id in valid_ids and up.level != DocumentPermissionLevel.owner:
-                session.add(
-                    ResourceGrant(
-                        resource_type="document",
-                        resource_id=document.id,
-                        user_id=up.user_id,
-                        role_id=None,
-                        level=up.level,
-                        guild_id=guild_context.guild_id,
-                        initiative_id=document.initiative_id,
-                    )
-                )
+    # Apply the initial sharing exactly the way edits do — one grant list, one
+    # code path (defaults to Viewer for all members, set on DocumentCreate.grants).
+    await permissions_service.replace_resource_grants(
+        session,
+        resource_type="document",
+        resource_id=document.id,
+        guild_id=guild_context.guild_id,
+        initiative_id=document.initiative_id,
+        owner_id=current_user.id,
+        grants=document_in.grants,
+    )
 
     # Sync wikilinks to document_links table
     await documents_service.sync_document_links(
@@ -1098,6 +1037,19 @@ async def upload_document_file(
 
     session.add(owner_permission)
     session.add(initial_version)
+    # File uploads default to Viewer for all members, like native docs.
+    session.add(
+        ResourceGrant(
+            resource_type="document",
+            resource_id=document.id,
+            user_id=None,
+            role_id=None,
+            all_initiative_members=True,
+            level=ResourceAccessLevel.read,
+            guild_id=guild_context.guild_id,
+            initiative_id=document.initiative_id,
+        )
+    )
     await session.commit()
     await reapply_rls_context(session)
 
@@ -1626,254 +1578,6 @@ async def copy_document(
     )
 
 
-@router.post(
-    "/{document_id}/members",
-    response_model=DocumentPermissionRead,
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_document_member(
-    document_id: int,
-    member_in: DocumentPermissionCreate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> ResourceGrant:
-    """Add a member to a document with specified permission level."""
-    document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
-    )
-    _require_document_access(document, current_user, access="write", manage_access=True)
-    if member_in.level == DocumentPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.CANNOT_ASSIGN_OWNER,
-        )
-
-    # Verify user is an initiative member
-    initiative_membership = await initiatives_service.get_initiative_membership(
-        session,
-        initiative_id=document.initiative_id,
-        user_id=member_in.user_id,
-    )
-    if not initiative_membership:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.USER_MUST_BE_MEMBER,
-        )
-
-    # Check if user already has a permission
-    existing = _get_document_permission(document, member_in.user_id)
-    if existing:
-        if existing.level == DocumentPermissionLevel.owner:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=DocumentMessages.CANNOT_MODIFY_OWNER,
-            )
-        existing.level = member_in.level
-        session.add(existing)
-        await session.commit()
-        await reapply_rls_context(session)
-        await session.refresh(existing)
-        return existing
-
-    permission = ResourceGrant(
-        resource_type="document",
-        resource_id=document_id,
-        user_id=member_in.user_id,
-        role_id=None,
-        level=member_in.level,
-        guild_id=guild_context.guild_id,
-        initiative_id=document.initiative_id,
-    )
-    session.add(permission)
-    await session.commit()
-    await reapply_rls_context(session)
-    await session.refresh(permission)
-    return permission
-
-
-@router.post(
-    "/{document_id}/members/bulk",
-    response_model=List[DocumentPermissionRead],
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_document_members_bulk(
-    document_id: int,
-    bulk_in: DocumentPermissionBulkCreate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> List[ResourceGrant]:
-    """Add multiple members to a document with the same permission level."""
-    document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
-    )
-    _require_document_access(document, current_user, access="write", manage_access=True)
-    if bulk_in.level == DocumentPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.CANNOT_ASSIGN_OWNER,
-        )
-
-    if not bulk_in.user_ids:
-        return []
-
-    # Get all initiative members in one query
-    initiative_members_result = await session.exec(
-        select(InitiativeMember.user_id).where(
-            InitiativeMember.initiative_id == document.initiative_id,
-            InitiativeMember.user_id.in_(bulk_in.user_ids),
-        )
-    )
-    valid_member_ids = set(initiative_members_result.all())
-
-    # Get existing user grants (role grants have user_id NULL)
-    user_grants = [g for g in (document.grants or []) if g.user_id is not None]
-    existing_user_ids = {g.user_id for g in user_grants}
-    owner_ids = {
-        g.user_id for g in user_grants if g.level == DocumentPermissionLevel.owner
-    }
-
-    created_permissions: List[ResourceGrant] = []
-    for user_id in bulk_in.user_ids:
-        # Skip invalid users (not initiative members)
-        if user_id not in valid_member_ids:
-            continue
-        # Skip owners - cannot modify their permission
-        if user_id in owner_ids:
-            continue
-        # Update existing permission
-        if user_id in existing_user_ids:
-            existing = next((g for g in user_grants if g.user_id == user_id), None)
-            if existing and existing.level != DocumentPermissionLevel.owner:
-                existing.level = bulk_in.level
-                session.add(existing)
-                created_permissions.append(existing)
-            continue
-        # Create new permission
-        permission = ResourceGrant(
-            resource_type="document",
-            resource_id=document_id,
-            user_id=user_id,
-            role_id=None,
-            level=bulk_in.level,
-            guild_id=guild_context.guild_id,
-            initiative_id=document.initiative_id,
-        )
-        session.add(permission)
-        created_permissions.append(permission)
-
-    await session.commit()
-    await reapply_rls_context(session)
-    for permission in created_permissions:
-        await session.refresh(permission)
-    return created_permissions
-
-
-@router.post(
-    "/{document_id}/members/bulk-delete", status_code=status.HTTP_204_NO_CONTENT
-)
-async def remove_document_members_bulk(
-    document_id: int,
-    bulk_in: DocumentPermissionBulkDelete,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> None:
-    """Remove multiple members from a document."""
-    document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
-    )
-    _require_document_access(document, current_user, access="write", manage_access=True)
-
-    if not bulk_in.user_ids:
-        return
-
-    # Get owner IDs to exclude from deletion (user grants only)
-    owner_ids = {
-        g.user_id
-        for g in (document.grants or [])
-        if g.user_id is not None and g.level == DocumentPermissionLevel.owner
-    }
-
-    for user_id in bulk_in.user_ids:
-        # Skip owners - cannot remove them
-        if user_id in owner_ids:
-            continue
-        permission = _get_document_permission(document, user_id)
-        if permission:
-            await session.delete(permission)
-
-    await session.commit()
-
-
-@router.patch("/{document_id}/members/{user_id}", response_model=DocumentPermissionRead)
-async def update_document_member(
-    document_id: int,
-    user_id: int,
-    update_in: DocumentPermissionUpdate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> ResourceGrant:
-    """Update a document member's permission level."""
-    document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
-    )
-    _require_document_access(document, current_user, access="write", manage_access=True)
-    if update_in.level == DocumentPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.CANNOT_ASSIGN_OWNER,
-        )
-
-    permission = _get_document_permission(document, user_id)
-    if not permission:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=DocumentMessages.PERMISSION_NOT_FOUND,
-        )
-    if permission.level == DocumentPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.CANNOT_MODIFY_OWNER,
-        )
-
-    permission.level = update_in.level
-    session.add(permission)
-    await session.commit()
-    await reapply_rls_context(session)
-    await session.refresh(permission)
-    return permission
-
-
-@router.delete(
-    "/{document_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT
-)
-async def remove_document_member(
-    document_id: int,
-    user_id: int,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> None:
-    """Remove a member's permission from a document."""
-    document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
-    )
-    _require_document_access(document, current_user, access="write", manage_access=True)
-    permission = _get_document_permission(document, user_id)
-    if not permission:
-        return
-    if permission.level == DocumentPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.CANNOT_REMOVE_OWNER,
-        )
-    await session.delete(permission)
-    await session.commit()
-
-
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_document(
     document_id: int,
@@ -2120,172 +1824,50 @@ async def set_document_properties(
     )
 
 
-# ── Role-based permission CRUD ───────────────────────────────────
-
-
-@router.post(
-    "/{document_id}/role-permissions",
-    response_model=DocumentRolePermissionRead,
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_document_role_permission(
+@router.put("/{document_id}/grants", response_model=DocumentRead)
+async def set_document_grants(
     document_id: int,
-    role_perm_in: DocumentRolePermissionCreate,
+    grants: list[ResourceGrantSchema],
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> DocumentRolePermissionRead:
-    """Add a role-based permission to a document."""
+) -> DocumentRead:
+    """Replace the document's entire sharing state in one call — the body is the
+    full list of grants (all-initiative-members / per-user / per-role). Every
+    non-owner grant is rebuilt from it; the owner is always preserved.
+    """
     document = await _get_document_or_404(
         session, document_id=document_id, guild_id=guild_context.guild_id
     )
     _require_document_access(document, current_user, access="write", manage_access=True)
-
-    if role_perm_in.level == DocumentPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.CANNOT_ASSIGN_OWNER_TO_ROLE,
-        )
-
-    # Validate the role belongs to the same initiative as the document
-    stmt = select(InitiativeRoleModel).where(
-        InitiativeRoleModel.id == role_perm_in.initiative_role_id
+    owner_id = next(
+        (
+            g.user_id
+            for g in document.grants
+            if g.level == ResourceAccessLevel.owner and g.user_id is not None
+        ),
+        document.created_by_id,
     )
-    result = await session.exec(stmt)
-    role = result.one_or_none()
-    if not role or role.initiative_id != document.initiative_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.ROLE_WRONG_INITIATIVE,
-        )
 
-    # Check if already exists
-    existing_stmt = select(ResourceGrant).where(
-        ResourceGrant.resource_type == "document",
-        ResourceGrant.resource_id == document_id,
-        ResourceGrant.role_id == role_perm_in.initiative_role_id,
-    )
-    existing_result = await session.exec(existing_stmt)
-    existing = existing_result.one_or_none()
-    if existing:
-        existing.level = role_perm_in.level
-        session.add(existing)
-        await session.commit()
-        await reapply_rls_context(session)
-        await session.refresh(existing)
-        return DocumentRolePermissionRead(
-            initiative_role_id=existing.role_id,
-            role_name=role.name,
-            role_display_name=role.display_name,
-            level=existing.level,
-            created_at=existing.created_at,
-        )
-
-    role_perm = ResourceGrant(
+    await permissions_service.replace_resource_grants(
+        session,
         resource_type="document",
         resource_id=document_id,
-        user_id=None,
-        role_id=role_perm_in.initiative_role_id,
-        level=role_perm_in.level,
         guild_id=guild_context.guild_id,
         initiative_id=document.initiative_id,
+        owner_id=owner_id,
+        grants=grants,
     )
-    session.add(role_perm)
+
     await session.commit()
     await reapply_rls_context(session)
-    await session.refresh(role_perm)
-    return DocumentRolePermissionRead(
-        initiative_role_id=role_perm.role_id,
-        role_name=role.name,
-        role_display_name=role.display_name,
-        level=role_perm.level,
-        created_at=role_perm.created_at,
-    )
-
-
-@router.patch(
-    "/{document_id}/role-permissions/{role_id}",
-    response_model=DocumentRolePermissionRead,
-)
-async def update_document_role_permission(
-    document_id: int,
-    role_id: int,
-    update_in: DocumentRolePermissionUpdate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> DocumentRolePermissionRead:
-    """Update a role-based permission level on a document."""
-    document = await _get_document_or_404(
+    hydrated = await _get_document_or_404(
         session, document_id=document_id, guild_id=guild_context.guild_id
     )
-    _require_document_access(document, current_user, access="write", manage_access=True)
-
-    if update_in.level == DocumentPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=DocumentMessages.CANNOT_ASSIGN_OWNER_TO_ROLE,
-        )
-
-    stmt = select(ResourceGrant).where(
-        ResourceGrant.resource_type == "document",
-        ResourceGrant.resource_id == document_id,
-        ResourceGrant.role_id == role_id,
+    return serialize_document(
+        hydrated,
+        my_permission_level=_compute_my_doc_permission_level(hydrated, current_user.id),
     )
-    result = await session.exec(stmt)
-    role_perm = result.one_or_none()
-    if not role_perm:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=DocumentMessages.ROLE_PERMISSION_NOT_FOUND,
-        )
-
-    role_perm.level = update_in.level
-    session.add(role_perm)
-    await session.commit()
-    await reapply_rls_context(session)
-    await session.refresh(role_perm)
-
-    # Get role info
-    role_stmt = select(InitiativeRoleModel).where(InitiativeRoleModel.id == role_id)
-    role_result = await session.exec(role_stmt)
-    role = role_result.one_or_none()
-    return DocumentRolePermissionRead(
-        initiative_role_id=role_perm.role_id,
-        role_name=role.name if role else "",
-        role_display_name=role.display_name if role else "",
-        level=role_perm.level,
-        created_at=role_perm.created_at,
-    )
-
-
-@router.delete(
-    "/{document_id}/role-permissions/{role_id}", status_code=status.HTTP_204_NO_CONTENT
-)
-async def remove_document_role_permission(
-    document_id: int,
-    role_id: int,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> None:
-    """Remove a role-based permission from a document."""
-    document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
-    )
-    _require_document_access(document, current_user, access="write", manage_access=True)
-
-    stmt = select(ResourceGrant).where(
-        ResourceGrant.resource_type == "document",
-        ResourceGrant.resource_id == document_id,
-        ResourceGrant.role_id == role_id,
-    )
-    result = await session.exec(stmt)
-    role_perm = result.one_or_none()
-    if not role_perm:
-        return
-    await session.delete(role_perm)
-    await session.commit()
 
 
 def _download_document_options():

--- a/backend/app/api/v1/guild_endpoints/documents_scope_test.py
+++ b/backend/app/api/v1/guild_endpoints/documents_scope_test.py
@@ -54,12 +54,12 @@ async def test_initiative_removal_ends_document_access(
     assert response.status_code == 201
     doc_id = response.json()["id"]
 
-    response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc_id}/members",
+    response = await client.put(
+        f"/api/v1/g/{guild.id}/documents/{doc_id}/grants",
         headers=admin_headers,
-        json={"user_id": member.id, "level": "write"},
+        json=[{"user_id": member.id, "level": "write"}],
     )
-    assert response.status_code == 201
+    assert response.status_code == 200
 
     # Member can open and list the document while in the initiative.
     response = await client.get(

--- a/backend/app/api/v1/guild_endpoints/documents_test.py
+++ b/backend/app/api/v1/guild_endpoints/documents_test.py
@@ -105,7 +105,7 @@ async def test_create_document_with_permissions(
         "title": "Doc With Permissions",
         "initiative_id": initiative.id,
         "grants": [
-            {"initiative_role_id": member_role.id, "level": "read"},
+            {"role_id": member_role.id, "level": "read"},
             {"user_id": member.id, "level": "write"},
         ],
     }
@@ -191,7 +191,7 @@ async def test_create_document_rejects_foreign_initiative_role(
         "title": "Doc Cross Initiative",
         "initiative_id": initiative_a.id,
         "grants": [
-            {"initiative_role_id": foreign_role.id, "level": "read"},
+            {"role_id": foreign_role.id, "level": "read"},
         ],
     }
 

--- a/backend/app/api/v1/guild_endpoints/documents_test.py
+++ b/backend/app/api/v1/guild_endpoints/documents_test.py
@@ -104,10 +104,8 @@ async def test_create_document_with_permissions(
     payload = {
         "title": "Doc With Permissions",
         "initiative_id": initiative.id,
-        "role_permissions": [
+        "grants": [
             {"initiative_role_id": member_role.id, "level": "read"},
-        ],
-        "user_permissions": [
             {"user_id": member.id, "level": "write"},
         ],
     }
@@ -120,26 +118,23 @@ async def test_create_document_with_permissions(
     data = response.json()
     assert data["title"] == "Doc With Permissions"
 
-    # Owner permission exists
-    perm_user_ids = {p["user_id"] for p in data["permissions"]}
-    assert admin.id in perm_user_ids
-    assert member.id in perm_user_ids
-
-    # Role permission exists
-    assert len(data["role_permissions"]) == 1
-    assert data["role_permissions"][0]["initiative_role_id"] == member_role.id
-    assert data["role_permissions"][0]["level"] == "read"
-
-    # Member's user permission is write
-    member_perm = next(p for p in data["permissions"] if p["user_id"] == member.id)
-    assert member_perm["level"] == "write"
+    grants = data["grants"]
+    # Owner grant + member's write user grant.
+    user_grants = {g["user_id"]: g["level"] for g in grants if g["user_id"]}
+    assert user_grants.get(admin.id) == "owner"
+    assert user_grants.get(member.id) == "write"
+    # Role grant for the member role at read.
+    role_grants = [g for g in grants if g["role_id"] is not None]
+    assert len(role_grants) == 1
+    assert role_grants[0]["role_id"] == member_role.id
+    assert role_grants[0]["level"] == "read"
 
 
 @pytest.mark.integration
-async def test_create_document_without_permissions(
+async def test_create_document_defaults_to_all_members_viewer(
     client: AsyncClient, session: AsyncSession
 ):
-    """Test creating a document without extra permissions yields only owner."""
+    """Omitting `grants` defaults to Viewer for all initiative members (+ owner)."""
     admin = await create_user(session, email="admin@example.com")
     guild = await create_guild(session)
     await create_guild_membership(
@@ -150,7 +145,7 @@ async def test_create_document_without_permissions(
 
     headers = await get_guild_headers(session, guild, admin)
     payload = {
-        "title": "Doc No Perms",
+        "title": "Doc Default Share",
         "initiative_id": initiative.id,
     }
 
@@ -160,11 +155,12 @@ async def test_create_document_without_permissions(
 
     assert response.status_code == 201
     data = response.json()
-    # Only the owner permission should exist
-    assert len(data["permissions"]) == 1
-    assert data["permissions"][0]["user_id"] == admin.id
-    assert data["permissions"][0]["level"] == "owner"
-    assert len(data["role_permissions"]) == 0
+    assert any(
+        g["user_id"] == admin.id and g["level"] == "owner" for g in data["grants"]
+    )
+    assert any(
+        g["all_initiative_members"] and g["level"] == "read" for g in data["grants"]
+    )
 
 
 @pytest.mark.integration
@@ -194,7 +190,7 @@ async def test_create_document_rejects_foreign_initiative_role(
     payload = {
         "title": "Doc Cross Initiative",
         "initiative_id": initiative_a.id,
-        "role_permissions": [
+        "grants": [
             {"initiative_role_id": foreign_role.id, "level": "read"},
         ],
     }
@@ -206,7 +202,7 @@ async def test_create_document_rejects_foreign_initiative_role(
     assert response.status_code == 201
     data = response.json()
     # Foreign role must have been silently dropped
-    assert len(data["role_permissions"]) == 0
+    assert len([g for g in data["grants"] if g["role_id"] is not None]) == 0
 
 
 @pytest.mark.integration
@@ -228,7 +224,7 @@ async def test_create_document_skips_owner_level_grants(
     payload = {
         "title": "Doc Owner Skip",
         "initiative_id": initiative.id,
-        "user_permissions": [{"user_id": member.id, "level": "owner"}],
+        "grants": [{"user_id": member.id, "level": "owner"}],
     }
 
     response = await client.post(
@@ -236,10 +232,8 @@ async def test_create_document_skips_owner_level_grants(
     )
 
     assert response.status_code == 201
-    member_perms = [
-        p for p in response.json()["permissions"] if p["user_id"] == member.id
-    ]
-    assert len(member_perms) == 0
+    member_grants = [g for g in response.json()["grants"] if g["user_id"] == member.id]
+    assert len(member_grants) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -337,8 +331,10 @@ async def test_copy_template_with_read_only_access(
     assert data["created_by_id"] == reader.id
 
     # Reader is owner of the new doc.
-    new_perm_levels = {p["user_id"]: p["level"] for p in data["permissions"]}
-    assert new_perm_levels.get(reader.id) == "owner"
+    new_grant_levels = {
+        g["user_id"]: g["level"] for g in data["grants"] if g["user_id"]
+    }
+    assert new_grant_levels.get(reader.id) == "owner"
 
     # Source template is unchanged.
     await session.refresh(template)

--- a/backend/app/api/v1/guild_endpoints/projects.py
+++ b/backend/app/api/v1/guild_endpoints/projects.py
@@ -21,7 +21,6 @@ from app.db.session import reapply_rls_context
 from app.services.cross_guild import gather_across_guilds, member_guild_ids
 from app.models.project import (
     Project,
-    ProjectPermissionLevel,
 )
 from app.models.resource_grant import ResourceGrant, ResourceAccessLevel
 from app.models.project_order import ProjectOrder
@@ -51,19 +50,12 @@ from app.core.config import settings as app_settings
 from app.db.query import unbounded_page_limit
 from app.core.pam_context import has_active_grant
 from app.services.realtime import broadcast_event
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.project import (
     ProjectCreate,
     ProjectDuplicateRequest,
     ProjectListResponse,
-    ProjectPermissionBulkCreate,
-    ProjectPermissionBulkDelete,
-    ProjectPermissionCreate,
-    ProjectPermissionRead,
-    ProjectPermissionUpdate,
     ProjectRead,
-    ProjectRolePermissionCreate,
-    ProjectRolePermissionRead,
-    ProjectRolePermissionUpdate,
     ProjectTaskSummary,
     ProjectReorderRequest,
     ProjectUpdate,
@@ -96,34 +88,6 @@ GuildAdminContext = Annotated[
 ]
 
 MAX_RECENT_PROJECTS = 20
-
-
-def _project_permissions(project: Project) -> List[ProjectPermissionRead]:
-    """Serialize project user permissions from user-scoped resource grants."""
-    return [
-        ProjectPermissionRead(user_id=g.user_id, level=g.level, created_at=g.created_at)
-        for g in getattr(project, "grants", None) or []
-        if g.user_id is not None
-    ]
-
-
-def _project_role_permissions(project: Project) -> List[ProjectRolePermissionRead]:
-    """Serialize project role permissions from role-scoped resource grants."""
-    result: List[ProjectRolePermissionRead] = []
-    for g in getattr(project, "grants", None) or []:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        result.append(
-            ProjectRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
-    return result
 
 
 def _project_tags(project: Project) -> List[TagSummary]:
@@ -227,8 +191,7 @@ def _project_payload(
         update={
             "documents": _project_documents(project, user_id=user_id),
             "task_summary": summary,
-            "permissions": _project_permissions(project),
-            "role_permissions": _project_role_permissions(project),
+            "grants": permissions_service.serialize_grants(project),
             "my_permission_level": my_permission_level,
         }
     )
@@ -390,32 +353,6 @@ def _ensure_not_archived(project: Project) -> None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=ProjectMessages.IS_ARCHIVED
         )
-
-
-async def _remove_user_task_assignments(
-    session: SessionDep,
-    project_id: int,
-    user_id: int,
-) -> None:
-    """Remove all task assignments for a user in a project.
-
-    Called when a user loses write access to a project (permission removed or
-    downgraded to read), since users cannot be assigned to tasks they can't edit.
-    """
-    # Get task IDs for this project
-    task_ids_stmt = select(Task.id).where(Task.project_id == project_id)
-    task_ids_result = await session.exec(task_ids_stmt)
-    task_ids = list(task_ids_result.all())
-
-    if not task_ids:
-        return
-
-    # Delete assignments for this user on these tasks
-    delete_stmt = sa_delete(TaskAssignee).where(
-        TaskAssignee.task_id.in_(task_ids),
-        TaskAssignee.user_id == user_id,
-    )
-    await session.exec(delete_stmt)
 
 
 async def _duplicate_template_tasks(
@@ -751,8 +688,7 @@ def _build_project_payload(
             "documents": _project_documents(project, user_id=user_id),
             "task_summary": summary,
             "tags": _project_tags(project),
-            "permissions": _project_permissions(project),
-            "role_permissions": _project_role_permissions(project),
+            "grants": permissions_service.serialize_grants(project),
             "my_permission_level": my_permission_level,
         }
     )
@@ -1126,70 +1062,17 @@ async def create_project(
     )
     session.add(owner_permission)
 
-    # Process optional role permissions from request
-    granted_user_ids: set[int] = set()
-    valid_role_ids: set[int] = set()
-    if project_in.role_permissions:
-        # Validate each role belongs to this initiative
-        role_ids = {
-            rp.initiative_role_id
-            for rp in project_in.role_permissions
-            if rp.level != ProjectPermissionLevel.owner
-        }
-        if role_ids:
-            result = await session.exec(
-                select(InitiativeRoleModel.id).where(
-                    InitiativeRoleModel.id.in_(role_ids),
-                    InitiativeRoleModel.initiative_id == initiative_id,
-                )
-            )
-            valid_role_ids = set(result.all())
-        for rp in project_in.role_permissions:
-            if (
-                rp.initiative_role_id not in valid_role_ids
-                or rp.level == ProjectPermissionLevel.owner
-            ):
-                continue
-            session.add(
-                ResourceGrant(
-                    resource_type="project",
-                    resource_id=project.id,
-                    user_id=None,
-                    role_id=rp.initiative_role_id,
-                    level=rp.level,
-                    guild_id=guild_context.guild_id,
-                    initiative_id=project.initiative_id,
-                )
-            )
-
-    # Process optional user permissions (batch-validate initiative membership)
-    if project_in.user_permissions:
-        requested = {
-            up.user_id for up in project_in.user_permissions if up.user_id != owner_id
-        }
-        valid_ids: set[int] = set()
-        if requested:
-            result = await session.exec(
-                select(InitiativeMember.user_id).where(
-                    InitiativeMember.initiative_id == initiative_id,
-                    InitiativeMember.user_id.in_(requested),
-                )
-            )
-            valid_ids = set(result.all())
-        for up in project_in.user_permissions:
-            if up.user_id in valid_ids and up.level != ProjectPermissionLevel.owner:
-                session.add(
-                    ResourceGrant(
-                        resource_type="project",
-                        resource_id=project.id,
-                        user_id=up.user_id,
-                        role_id=None,
-                        level=up.level,
-                        guild_id=guild_context.guild_id,
-                        initiative_id=project.initiative_id,
-                    )
-                )
-                granted_user_ids.add(up.user_id)
+    # Apply the initial sharing exactly the way edits do — one grant list, one
+    # code path (defaults to Viewer for all members, set on ProjectCreate.grants).
+    await permissions_service.replace_resource_grants(
+        session,
+        resource_type="project",
+        resource_id=project.id,
+        guild_id=guild_context.guild_id,
+        initiative_id=project.initiative_id,
+        owner_id=owner_id,
+        grants=project_in.grants,
+    )
 
     if template_project:
         await _duplicate_template_tasks(
@@ -1217,24 +1100,20 @@ async def create_project(
 
     project = await _get_project_or_404(project.id, session, guild_context.guild_id)
     if project.initiative_id and project.initiative:
-        # Collect user IDs who hold a validated granted role
-        if project_in.role_permissions and valid_role_ids:
-            for rp_schema in project_in.role_permissions:
-                if rp_schema.initiative_role_id not in valid_role_ids:
-                    continue
-                for membership in project.initiative.memberships:
-                    if membership.role_id == rp_schema.initiative_role_id:
-                        granted_user_ids.add(membership.user_id)
-
-        # Only notify users who were explicitly granted access
-        has_any_grants = bool(
-            project_in.role_permissions or project_in.user_permissions
-        )
+        # Notify every member the project is shared with, derived from the grants:
+        # all members, members of a granted role, or a directly granted user.
+        share_all = any(g.all_initiative_members for g in project_in.grants)
+        granted_roles = {g.role_id for g in project_in.grants if g.role_id is not None}
+        granted_users = {g.user_id for g in project_in.grants if g.user_id is not None}
         for membership in project.initiative.memberships:
             member = membership.user
             if not member or member.id == current_user.id:
                 continue
-            if not has_any_grants or member.id not in granted_user_ids:
+            if not (
+                share_all
+                or membership.role_id in granted_roles
+                or membership.user_id in granted_users
+            ):
                 continue
             await notifications_service.notify_project_added(
                 session,
@@ -1901,296 +1780,6 @@ async def detach_project_document(
     )
 
 
-@router.post(
-    "/{project_id}/members",
-    response_model=ProjectPermissionRead,
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_project_member(
-    project_id: int,
-    member_in: ProjectPermissionCreate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> ResourceGrant:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
-    await _require_project_membership(
-        project,
-        current_user,
-        session,
-        access="write",
-        manage_access=True,
-    )
-    _ensure_not_archived(project)
-    if member_in.level == ProjectPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_ASSIGN_OWNER,
-        )
-    if member_in.user_id == project.owner_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.OWNER_HAS_FULL_ACCESS,
-        )
-    if project.initiative_id:
-        await _ensure_user_in_initiative(
-            project.initiative_id, member_in.user_id, session
-        )
-
-    existing = await _get_project_permission(project, member_in.user_id, session)
-    if existing:
-        existing.level = member_in.level
-        session.add(existing)
-        await session.commit()
-        await reapply_rls_context(session)
-        await session.refresh(existing)
-        return existing
-
-    permission = ResourceGrant(
-        resource_type="project",
-        resource_id=project_id,
-        user_id=member_in.user_id,
-        role_id=None,
-        level=member_in.level,
-        guild_id=guild_context.guild_id,
-        initiative_id=project.initiative_id,
-    )
-    session.add(permission)
-    await session.commit()
-    await reapply_rls_context(session)
-    await session.refresh(permission)
-    return permission
-
-
-@router.post(
-    "/{project_id}/members/bulk",
-    response_model=List[ProjectPermissionRead],
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_project_members_bulk(
-    project_id: int,
-    bulk_in: ProjectPermissionBulkCreate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> List[ResourceGrant]:
-    """Add multiple members to a project with the same permission level."""
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
-    await _require_project_membership(
-        project,
-        current_user,
-        session,
-        access="write",
-        manage_access=True,
-    )
-    _ensure_not_archived(project)
-
-    if bulk_in.level == ProjectPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_ASSIGN_OWNER,
-        )
-
-    if not bulk_in.user_ids:
-        return []
-
-    # Validate all users are initiative members (if project belongs to initiative)
-    valid_member_ids: set[int] = set()
-    if project.initiative_id:
-        initiative_members_result = await session.exec(
-            select(InitiativeMember.user_id).where(
-                InitiativeMember.initiative_id == project.initiative_id,
-                InitiativeMember.user_id.in_(bulk_in.user_ids),
-            )
-        )
-        valid_member_ids = set(initiative_members_result.all())
-    else:
-        valid_member_ids = set(bulk_in.user_ids)
-
-    # Get existing user permissions (role grants have user_id None — exclude them)
-    existing_permissions_result = await session.exec(
-        select(ResourceGrant).where(
-            ResourceGrant.resource_type == "project",
-            ResourceGrant.resource_id == project_id,
-            ResourceGrant.user_id.in_(bulk_in.user_ids),
-        )
-    )
-    existing_permissions = {p.user_id: p for p in existing_permissions_result.all()}
-
-    created_permissions: List[ResourceGrant] = []
-    for user_id in bulk_in.user_ids:
-        # Skip invalid users (not initiative members)
-        if user_id not in valid_member_ids:
-            continue
-        # Skip owner - they already have full access
-        if user_id == project.owner_id:
-            continue
-        # Update existing permission
-        if user_id in existing_permissions:
-            existing = existing_permissions[user_id]
-            if existing.level != ResourceAccessLevel.owner:
-                existing.level = bulk_in.level
-                session.add(existing)
-                created_permissions.append(existing)
-            continue
-        # Create new permission
-        permission = ResourceGrant(
-            resource_type="project",
-            resource_id=project_id,
-            user_id=user_id,
-            role_id=None,
-            level=bulk_in.level,
-            guild_id=guild_context.guild_id,
-            initiative_id=project.initiative_id,
-        )
-        session.add(permission)
-        created_permissions.append(permission)
-
-    await session.commit()
-    await reapply_rls_context(session)
-    for permission in created_permissions:
-        await session.refresh(permission)
-    return created_permissions
-
-
-@router.post(
-    "/{project_id}/members/bulk-delete", status_code=status.HTTP_204_NO_CONTENT
-)
-async def remove_project_members_bulk(
-    project_id: int,
-    bulk_in: ProjectPermissionBulkDelete,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> None:
-    """Remove multiple members from a project."""
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
-    await _require_project_membership(
-        project,
-        current_user,
-        session,
-        access="write",
-        manage_access=True,
-    )
-    _ensure_not_archived(project)
-
-    if not bulk_in.user_ids:
-        return
-
-    # Get existing user permissions to delete (role grants have user_id None,
-    # so the user-id IN filter already excludes them)
-    permissions_result = await session.exec(
-        select(ResourceGrant).where(
-            ResourceGrant.resource_type == "project",
-            ResourceGrant.resource_id == project_id,
-            ResourceGrant.user_id.in_(bulk_in.user_ids),
-        )
-    )
-    permissions = permissions_result.all()
-
-    removed_user_ids: list[int] = []
-    for permission in permissions:
-        # Skip owner - cannot remove them
-        if permission.user_id == project.owner_id:
-            continue
-        removed_user_ids.append(permission.user_id)
-        await session.delete(permission)
-
-    # Remove task assignments for removed users
-    for removed_user_id in removed_user_ids:
-        await _remove_user_task_assignments(session, project.id, removed_user_id)
-
-    await session.commit()
-
-
-@router.patch("/{project_id}/members/{user_id}", response_model=ProjectPermissionRead)
-async def update_project_member(
-    project_id: int,
-    user_id: int,
-    update_in: ProjectPermissionUpdate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> ResourceGrant:
-    """Update a project member's permission level."""
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
-    await _require_project_membership(
-        project,
-        current_user,
-        session,
-        access="write",
-        manage_access=True,
-    )
-    _ensure_not_archived(project)
-
-    if update_in.level == ProjectPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_ASSIGN_OWNER,
-        )
-    if user_id == project.owner_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_MODIFY_OWNER,
-        )
-
-    permission = await _get_project_permission(project, user_id, session)
-    if not permission:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ProjectMessages.PERMISSION_NOT_FOUND,
-        )
-    if permission.level == ResourceAccessLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_MODIFY_OWNER,
-        )
-
-    # If downgrading to read, remove task assignments
-    if update_in.level == ProjectPermissionLevel.read:
-        await _remove_user_task_assignments(session, project.id, user_id)
-
-    permission.level = update_in.level
-    session.add(permission)
-    await session.commit()
-    await reapply_rls_context(session)
-    await session.refresh(permission)
-    return permission
-
-
-@router.delete(
-    "/{project_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT
-)
-async def remove_project_member(
-    project_id: int,
-    user_id: int,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> None:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
-    await _require_project_membership(
-        project,
-        current_user,
-        session,
-        access="write",
-        manage_access=True,
-    )
-    _ensure_not_archived(project)
-    if user_id == project.owner_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_REMOVE_OWNER,
-        )
-    permission = await _get_project_permission(project, user_id, session)
-    if not permission:
-        return
-    await session.delete(permission)
-    # Remove task assignments since user no longer has access
-    await _remove_user_task_assignments(session, project.id, user_id)
-    await session.commit()
-
-
 @router.post("/reorder", response_model=List[ProjectRead])
 async def reorder_projects(
     reorder_in: ProjectReorderRequest,
@@ -2356,174 +1945,38 @@ async def set_project_tags(
     )
 
 
-# ── Role-based permission CRUD ───────────────────────────────────
-
-
-@router.post(
-    "/{project_id}/role-permissions",
-    response_model=ProjectRolePermissionRead,
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_project_role_permission(
+@router.put("/{project_id}/grants", response_model=ProjectRead)
+async def set_project_grants(
     project_id: int,
-    role_perm_in: ProjectRolePermissionCreate,
+    grants: list[ResourceGrantSchema],
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> ProjectRolePermissionRead:
-    """Add a role-based permission to a project."""
+) -> ProjectRead:
+    """Replace the project's entire sharing state in one call — the body is the
+    full list of grants (all-initiative-members / per-user / per-role). Every
+    non-owner grant is rebuilt from it; the owner is always preserved.
+    """
     project = await _get_project_or_404(project_id, session, guild_context.guild_id)
     await _require_project_membership(
         project, current_user, session, access="write", manage_access=True
     )
     _ensure_not_archived(project)
 
-    if role_perm_in.level == ProjectPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_ASSIGN_OWNER_TO_ROLE,
-        )
-
-    # Validate the role belongs to the same initiative as the project
-    stmt = select(InitiativeRoleModel).where(
-        InitiativeRoleModel.id == role_perm_in.initiative_role_id
-    )
-    result = await session.exec(stmt)
-    role = result.one_or_none()
-    if not role or role.initiative_id != project.initiative_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.ROLE_WRONG_INITIATIVE,
-        )
-
-    # Check if already exists
-    existing_stmt = select(ResourceGrant).where(
-        ResourceGrant.resource_type == "project",
-        ResourceGrant.resource_id == project_id,
-        ResourceGrant.role_id == role_perm_in.initiative_role_id,
-    )
-    existing_result = await session.exec(existing_stmt)
-    existing = existing_result.one_or_none()
-    if existing:
-        existing.level = role_perm_in.level
-        session.add(existing)
-        await session.commit()
-        await reapply_rls_context(session)
-        await session.refresh(existing)
-        return ProjectRolePermissionRead(
-            initiative_role_id=existing.role_id,
-            role_name=role.name,
-            role_display_name=role.display_name,
-            level=existing.level,
-            created_at=existing.created_at,
-        )
-
-    role_perm = ResourceGrant(
+    await permissions_service.replace_resource_grants(
+        session,
         resource_type="project",
         resource_id=project_id,
-        user_id=None,
-        role_id=role_perm_in.initiative_role_id,
-        level=role_perm_in.level,
         guild_id=guild_context.guild_id,
         initiative_id=project.initiative_id,
+        owner_id=project.owner_id,
+        grants=grants,
     )
-    session.add(role_perm)
+
     await session.commit()
     await reapply_rls_context(session)
-    await session.refresh(role_perm)
-    return ProjectRolePermissionRead(
-        initiative_role_id=role_perm.role_id,
-        role_name=role.name,
-        role_display_name=role.display_name,
-        level=role_perm.level,
-        created_at=role_perm.created_at,
-    )
-
-
-@router.patch(
-    "/{project_id}/role-permissions/{role_id}", response_model=ProjectRolePermissionRead
-)
-async def update_project_role_permission(
-    project_id: int,
-    role_id: int,
-    update_in: ProjectRolePermissionUpdate,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> ProjectRolePermissionRead:
-    """Update a role-based permission level on a project."""
     project = await _get_project_or_404(project_id, session, guild_context.guild_id)
-    await _require_project_membership(
-        project, current_user, session, access="write", manage_access=True
-    )
-    _ensure_not_archived(project)
-
-    if update_in.level == ProjectPermissionLevel.owner:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ProjectMessages.CANNOT_ASSIGN_OWNER_TO_ROLE,
-        )
-
-    stmt = select(ResourceGrant).where(
-        ResourceGrant.resource_type == "project",
-        ResourceGrant.resource_id == project_id,
-        ResourceGrant.role_id == role_id,
-    )
-    result = await session.exec(stmt)
-    role_perm = result.one_or_none()
-    if not role_perm:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ProjectMessages.ROLE_PERMISSION_NOT_FOUND,
-        )
-
-    role_perm.level = update_in.level
-    session.add(role_perm)
-    await session.commit()
-    await reapply_rls_context(session)
-    await session.refresh(role_perm)
-
-    # Get role info
-    role_stmt = select(InitiativeRoleModel).where(InitiativeRoleModel.id == role_id)
-    role_result = await session.exec(role_stmt)
-    role = role_result.one_or_none()
-    return ProjectRolePermissionRead(
-        initiative_role_id=role_perm.role_id,
-        role_name=role.name if role else "",
-        role_display_name=role.display_name if role else "",
-        level=role_perm.level,
-        created_at=role_perm.created_at,
-    )
-
-
-@router.delete(
-    "/{project_id}/role-permissions/{role_id}", status_code=status.HTTP_204_NO_CONTENT
-)
-async def remove_project_role_permission(
-    project_id: int,
-    role_id: int,
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> None:
-    """Remove a role-based permission from a project."""
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
-    await _require_project_membership(
-        project, current_user, session, access="write", manage_access=True
-    )
-    _ensure_not_archived(project)
-
-    stmt = select(ResourceGrant).where(
-        ResourceGrant.resource_type == "project",
-        ResourceGrant.resource_id == project_id,
-        ResourceGrant.role_id == role_id,
-    )
-    result = await session.exec(stmt)
-    role_perm = result.one_or_none()
-    if not role_perm:
-        return
-    await session.delete(role_perm)
-    await session.commit()
+    return await _project_read_for_user(session, current_user, project)
 
 
 # ── Export / Import ──────────────────────────────────────────────

--- a/backend/app/api/v1/guild_endpoints/projects.py
+++ b/backend/app/api/v1/guild_endpoints/projects.py
@@ -1945,6 +1945,42 @@ async def set_project_tags(
     )
 
 
+def _project_write_holder_ids(project: Project) -> set[int]:
+    """Initiative-member user IDs with effective write+ (write/owner) access to the
+    project — i.e. those eligible to be task assignees. Pure read of the
+    eager-loaded ``grants`` + ``initiative.memberships`` (no DB I/O)."""
+    resource = permissions_service.DAC_RESOURCES["project"]
+    memberships = getattr(project.initiative, "memberships", None) or []
+    return {
+        m.user_id
+        for m in memberships
+        if m.user_id is not None
+        and permissions_service.effective_level(resource, project, m.user_id)
+        in ("write", "owner")
+    }
+
+
+async def _remove_user_task_assignments(
+    session: SessionDep, project_id: int, user_ids: set[int]
+) -> None:
+    """Unassign the given users from every task in the project. Called when a grant
+    change drops a user below write access, since a user cannot be assigned to
+    tasks they can no longer edit."""
+    if not user_ids:
+        return
+    task_ids = (
+        await session.exec(select(Task.id).where(Task.project_id == project_id))
+    ).all()
+    if not task_ids:
+        return
+    await session.exec(
+        sa_delete(TaskAssignee).where(
+            TaskAssignee.task_id.in_(task_ids),
+            TaskAssignee.user_id.in_(list(user_ids)),
+        )
+    )
+
+
 @router.put("/{project_id}/grants", response_model=ProjectRead)
 async def set_project_grants(
     project_id: int,
@@ -1956,12 +1992,18 @@ async def set_project_grants(
     """Replace the project's entire sharing state in one call — the body is the
     full list of grants (all-initiative-members / per-user / per-role). Every
     non-owner grant is rebuilt from it; the owner is always preserved.
+
+    Anyone the new grants drop below write access is unassigned from the project's
+    tasks (you can't be assigned to tasks you can't edit).
     """
     project = await _get_project_or_404(project_id, session, guild_context.guild_id)
     await _require_project_membership(
         project, current_user, session, access="write", manage_access=True
     )
     _ensure_not_archived(project)
+
+    # Snapshot who can edit the project before the change, to diff against after.
+    writers_before = _project_write_holder_ids(project)
 
     await permissions_service.replace_resource_grants(
         session,
@@ -1972,10 +2014,20 @@ async def set_project_grants(
         owner_id=project.owner_id,
         grants=grants,
     )
-
     await session.commit()
     await reapply_rls_context(session)
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+
+    # replace_resource_grants rewrites resource_grants rows directly (by
+    # resource_type/resource_id), so the cached Project.grants collection is now
+    # stale — reload just that one collection rather than re-fetching the whole graph.
+    await session.refresh(project, attribute_names=["grants"])
+
+    demoted = writers_before - _project_write_holder_ids(project)
+    if demoted:
+        await _remove_user_task_assignments(session, project_id, demoted)
+        await session.commit()
+        await reapply_rls_context(session)
+
     return await _project_read_for_user(session, current_user, project)
 
 

--- a/backend/app/api/v1/guild_endpoints/projects_test.py
+++ b/backend/app/api/v1/guild_endpoints/projects_test.py
@@ -836,7 +836,7 @@ async def test_create_project_with_role_permissions(
         "name": "Project With Role Perms",
         "initiative_id": initiative.id,
         "grants": [
-            {"initiative_role_id": member_role.id, "level": "read"},
+            {"role_id": member_role.id, "level": "read"},
         ],
     }
 
@@ -959,7 +959,7 @@ async def test_create_project_rejects_foreign_initiative_role(
         "name": "Project Cross Initiative",
         "initiative_id": initiative_a.id,
         "grants": [
-            {"initiative_role_id": foreign_role.id, "level": "read"},
+            {"role_id": foreign_role.id, "level": "read"},
         ],
     }
 

--- a/backend/app/api/v1/guild_endpoints/projects_test.py
+++ b/backend/app/api/v1/guild_endpoints/projects_test.py
@@ -600,8 +600,10 @@ async def test_mark_project_as_viewed(client: AsyncClient, session: AsyncSession
 
 
 @pytest.mark.integration
-async def test_add_project_member(client: AsyncClient, session: AsyncSession):
-    """Test adding a member to a project."""
+async def test_set_project_access_grants_user(
+    client: AsyncClient, session: AsyncSession
+):
+    """PUT /access grants an individual user (Restrict-by-user)."""
     owner = await create_user(session, email="owner@example.com")
     new_member = await create_user(session, email="member@example.com")
     guild = await create_guild(session)
@@ -609,32 +611,32 @@ async def test_add_project_member(client: AsyncClient, session: AsyncSession):
     await create_guild_membership(session, user=new_member, guild=guild)
 
     initiative = await _create_initiative_with_member(session, guild, owner)
-
-    # Add new_member to initiative
     from app.testing.factories import create_initiative_member
 
     await create_initiative_member(session, initiative, new_member, role_name="member")
-
     project = await _create_project(session, initiative, owner)
 
     headers = await get_guild_headers(session, guild, owner)
-    payload = {"user_id": new_member.id, "level": "write"}
-
-    response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/members",
+    response = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
         headers=headers,
-        json=payload,
+        json=[{"user_id": new_member.id, "level": "write"}],
     )
 
-    assert response.status_code == 201
-    data = response.json()
-    assert data["user_id"] == new_member.id
-    assert data["level"] == "write"
+    assert response.status_code == 200
+    grants = {
+        g["user_id"]: g["level"]
+        for g in response.json()["grants"]
+        if g["user_id"] is not None
+    }
+    assert grants.get(new_member.id) == "write"
 
 
 @pytest.mark.integration
-async def test_remove_project_member(client: AsyncClient, session: AsyncSession):
-    """Test removing a member from a project."""
+async def test_set_project_access_replaces_grants(
+    client: AsyncClient, session: AsyncSession
+):
+    """PUT /access replaces the full non-owner grant set; the owner is preserved."""
     owner = await create_user(session, email="owner@example.com")
     member = await create_user(session, email="member@example.com")
     guild = await create_guild(session)
@@ -644,25 +646,75 @@ async def test_remove_project_member(client: AsyncClient, session: AsyncSession)
     initiative = await _create_initiative_with_member(session, guild, owner)
     project = await _create_project(session, initiative, owner)
 
-    # Add member permission
-    permission = ResourceGrant(
-        resource_type="project",
-        resource_id=project.id,
-        user_id=member.id,
-        level=ResourceAccessLevel.write,
-        guild_id=project.guild_id,
-        initiative_id=project.initiative_id,
+    session.add(
+        ResourceGrant(
+            resource_type="project",
+            resource_id=project.id,
+            user_id=member.id,
+            level=ResourceAccessLevel.write,
+            guild_id=project.guild_id,
+            initiative_id=project.initiative_id,
+        )
     )
-    session.add(permission)
     await session.commit()
 
     headers = await get_guild_headers(session, guild, owner)
-    response = await client.delete(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/members/{member.id}",
+    response = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
         headers=headers,
+        json=[],
     )
 
-    assert response.status_code == 204
+    assert response.status_code == 200
+    user_ids = {
+        g["user_id"] for g in response.json()["grants"] if g["user_id"] is not None
+    }
+    assert member.id not in user_ids  # grant removed
+    assert owner.id in user_ids  # owner preserved
+
+
+@pytest.mark.integration
+async def test_set_project_access_all_members(
+    client: AsyncClient, session: AsyncSession
+):
+    """all_initiative_members grants every member access with no personal grant."""
+    owner = await create_user(session, email="owner@example.com")
+    member = await create_user(session, email="member@example.com")
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=owner, guild=guild)
+    await create_guild_membership(session, user=member, guild=guild)
+
+    initiative = await _create_initiative_with_member(session, guild, owner)
+    from app.testing.factories import create_initiative_member
+
+    await create_initiative_member(session, initiative, member, role_name="member")
+    project = await _create_project(session, initiative, owner)
+
+    member_headers = await get_guild_headers(session, guild, member)
+    # Restricted: a member with no grant is denied (the row is RLS-visible to a
+    # member, so DAC denies with 403 rather than hiding it as 404).
+    r = await client.get(
+        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=member_headers
+    )
+    assert r.status_code == 403
+
+    owner_headers = await get_guild_headers(session, guild, owner)
+    r = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
+        headers=owner_headers,
+        json=[{"all_initiative_members": True, "level": "read"}],
+    )
+    assert r.status_code == 200
+    assert any(
+        g["all_initiative_members"] and g["level"] == "read" for g in r.json()["grants"]
+    )
+
+    # Now the member can read it via all-initiative-members access alone.
+    r = await client.get(
+        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=member_headers
+    )
+    assert r.status_code == 200
+    assert r.json()["my_permission_level"] == "read"
 
 
 @pytest.mark.integration
@@ -736,7 +788,7 @@ async def test_create_project_with_user_permissions(
     payload = {
         "name": "Project With Permissions",
         "initiative_id": initiative.id,
-        "user_permissions": [
+        "grants": [
             {"user_id": member.id, "level": "write"},
         ],
     }
@@ -748,12 +800,10 @@ async def test_create_project_with_user_permissions(
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "Project With Permissions"
-    # Owner permission + explicitly granted member
-    perm_user_ids = {p["user_id"] for p in data["permissions"]}
-    assert admin.id in perm_user_ids  # owner
-    assert member.id in perm_user_ids  # granted write
-    member_perm = next(p for p in data["permissions"] if p["user_id"] == member.id)
-    assert member_perm["level"] == "write"
+    # Owner grant + explicitly granted member (no all-members grant was sent)
+    user_grants = {g["user_id"]: g["level"] for g in data["grants"] if g["user_id"]}
+    assert user_grants.get(admin.id) == "owner"
+    assert user_grants.get(member.id) == "write"
 
 
 @pytest.mark.integration
@@ -785,7 +835,7 @@ async def test_create_project_with_role_permissions(
     payload = {
         "name": "Project With Role Perms",
         "initiative_id": initiative.id,
-        "role_permissions": [
+        "grants": [
             {"initiative_role_id": member_role.id, "level": "read"},
         ],
     }
@@ -796,16 +846,17 @@ async def test_create_project_with_role_permissions(
 
     assert response.status_code == 201
     data = response.json()
-    assert len(data["role_permissions"]) == 1
-    assert data["role_permissions"][0]["initiative_role_id"] == member_role.id
-    assert data["role_permissions"][0]["level"] == "read"
+    role_grants = [g for g in data["grants"] if g["role_id"] is not None]
+    assert len(role_grants) == 1
+    assert role_grants[0]["role_id"] == member_role.id
+    assert role_grants[0]["level"] == "read"
 
 
 @pytest.mark.integration
-async def test_create_project_without_permissions(
+async def test_create_project_defaults_to_all_members_viewer(
     client: AsyncClient, session: AsyncSession
 ):
-    """Test creating a project without any explicit permissions yields only owner."""
+    """Omitting `grants` defaults to Viewer for all initiative members (+ owner)."""
     admin = await create_user(session, email="admin@example.com")
     guild = await create_guild(session)
     await create_guild_membership(
@@ -816,7 +867,7 @@ async def test_create_project_without_permissions(
 
     headers = await get_guild_headers(session, guild, admin)
     payload = {
-        "name": "Project No Extra Perms",
+        "name": "Project Default Share",
         "initiative_id": initiative.id,
     }
 
@@ -826,11 +877,14 @@ async def test_create_project_without_permissions(
 
     assert response.status_code == 201
     data = response.json()
-    # Only the owner permission should exist
-    assert len(data["permissions"]) == 1
-    assert data["permissions"][0]["user_id"] == admin.id
-    assert data["permissions"][0]["level"] == "owner"
-    assert len(data["role_permissions"]) == 0
+    # Owner grant + an all-initiative-members Viewer (read) grant.
+    assert any(
+        g["user_id"] == admin.id and g["level"] == "owner" for g in data["grants"]
+    )
+    assert any(
+        g["all_initiative_members"] and g["level"] == "read" for g in data["grants"]
+    )
+    assert data["my_permission_level"] == "owner"
 
 
 @pytest.mark.integration
@@ -855,7 +909,7 @@ async def test_create_project_skips_owner_level_grants(
     payload = {
         "name": "Project Owner Skip",
         "initiative_id": initiative.id,
-        "user_permissions": [
+        "grants": [
             {"user_id": member.id, "level": "owner"},
         ],
     }
@@ -867,8 +921,8 @@ async def test_create_project_skips_owner_level_grants(
     assert response.status_code == 201
     data = response.json()
     # Member should NOT have been granted owner
-    member_perms = [p for p in data["permissions"] if p["user_id"] == member.id]
-    assert len(member_perms) == 0
+    member_grants = [g for g in data["grants"] if g["user_id"] == member.id]
+    assert len(member_grants) == 0
 
 
 @pytest.mark.integration
@@ -904,7 +958,7 @@ async def test_create_project_rejects_foreign_initiative_role(
     payload = {
         "name": "Project Cross Initiative",
         "initiative_id": initiative_a.id,
-        "role_permissions": [
+        "grants": [
             {"initiative_role_id": foreign_role.id, "level": "read"},
         ],
     }
@@ -916,4 +970,4 @@ async def test_create_project_rejects_foreign_initiative_role(
     assert response.status_code == 201
     data = response.json()
     # Foreign role must have been silently dropped
-    assert len(data["role_permissions"]) == 0
+    assert len([g for g in data["grants"] if g["role_id"] is not None]) == 0

--- a/backend/app/api/v1/guild_endpoints/projects_test.py
+++ b/backend/app/api/v1/guild_endpoints/projects_test.py
@@ -14,6 +14,7 @@ Tests the project API endpoints at /api/v1/projects including:
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.guild import GuildRole
@@ -715,6 +716,97 @@ async def test_set_project_access_all_members(
     )
     assert r.status_code == 200
     assert r.json()["my_permission_level"] == "read"
+
+
+async def _task_assignee_ids(session, guild_id: int, task_id: int) -> set[int]:
+    """Read task_assignees straight from the guild schema (superuser session)."""
+    await session.commit()
+    await session.execute(text(f'SET search_path TO "guild_{guild_id}", public'))
+    return set(
+        (
+            await session.execute(
+                text("SELECT user_id FROM task_assignees WHERE task_id = :tid"),
+                {"tid": task_id},
+            )
+        ).scalars()
+    )
+
+
+@pytest.mark.integration
+async def test_set_project_grants_unassigns_demoted_user(
+    client: AsyncClient, session: AsyncSession
+):
+    """A user dropped below write by a grant change is unassigned from the
+    project's tasks (you can't be assigned to tasks you can't edit)."""
+    owner = await create_user(session, email="owner@example.com")
+    member = await create_user(session, email="member@example.com")
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=owner, guild=guild)
+    await create_guild_membership(session, user=member, guild=guild)
+
+    initiative = await _create_initiative_with_member(session, guild, owner)
+    from app.testing.factories import create_initiative_member, create_task
+
+    await create_initiative_member(session, initiative, member, role_name="member")
+    project = await _create_project(session, initiative, owner)
+
+    owner_headers = await get_guild_headers(session, guild, owner)
+    # Grant the member write, then assign them to a task.
+    r = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
+        headers=owner_headers,
+        json=[{"user_id": member.id, "level": "write"}],
+    )
+    assert r.status_code == 200
+    task = await create_task(session, project, assignees=[member])
+    assert member.id in await _task_assignee_ids(session, guild.id, task.id)
+
+    # Remove the member's grant entirely -> they lose write -> get unassigned.
+    r = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
+        headers=owner_headers,
+        json=[],
+    )
+    assert r.status_code == 200
+    assert member.id not in await _task_assignee_ids(session, guild.id, task.id)
+
+
+@pytest.mark.integration
+async def test_set_project_grants_keeps_assignment_when_still_writable(
+    client: AsyncClient, session: AsyncSession
+):
+    """A user who keeps write via another grant (all-members write) stays assigned —
+    the cleanup is effective-access based, not a blunt per-user wipe."""
+    owner = await create_user(session, email="owner@example.com")
+    member = await create_user(session, email="member@example.com")
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=owner, guild=guild)
+    await create_guild_membership(session, user=member, guild=guild)
+
+    initiative = await _create_initiative_with_member(session, guild, owner)
+    from app.testing.factories import create_initiative_member, create_task
+
+    await create_initiative_member(session, initiative, member, role_name="member")
+    project = await _create_project(session, initiative, owner)
+
+    owner_headers = await get_guild_headers(session, guild, owner)
+    r = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
+        headers=owner_headers,
+        json=[{"user_id": member.id, "level": "write"}],
+    )
+    assert r.status_code == 200
+    task = await create_task(session, project, assignees=[member])
+
+    # Swap the per-user grant for an all-members WRITE grant: the member still has
+    # write, so the assignment must survive.
+    r = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
+        headers=owner_headers,
+        json=[{"all_initiative_members": True, "level": "write"}],
+    )
+    assert r.status_code == 200
+    assert member.id in await _task_assignee_ids(session, guild.id, task.id)
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/guild_endpoints/queues.py
+++ b/backend/app/api/v1/guild_endpoints/queues.py
@@ -19,7 +19,7 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
-from sqlalchemy import delete as sa_delete, func
+from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
@@ -34,18 +34,16 @@ from app.db.session import AsyncSessionLocal, reapply_rls_context, set_rls_conte
 from app.models.queue import (
     Queue,
     QueueItem,
-    QueuePermissionLevel,
 )
 from app.models.resource_grant import ResourceGrant, ResourceAccessLevel
 from app.models.guild import GuildMembership
 from app.models.initiative import (
     Initiative,
-    InitiativeMember,
-    InitiativeRoleModel,
     PermissionKey,
 )
 from app.models.user import User
 from app.core.messages import QueueMessages, InitiativeMessages
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.queue import (
     QueueCreate,
     QueueUpdate,
@@ -56,15 +54,12 @@ from app.schemas.queue import (
     QueueItemRead,
     QueueItemReorderRequest,
     QueueReleaseRequest,
-    QueuePermissionCreate,
-    QueuePermissionRead,
-    QueueRolePermissionCreate,
-    QueueRolePermissionRead,
     serialize_queue,
     serialize_queue_summary,
     serialize_queue_item,
 )
 from app.api import resource_access
+from app.services import permissions as permissions_service
 from app.services import queues as queues_service
 from app.services import recent_views as recent_views_service
 from app.services import rls as rls_service
@@ -335,69 +330,17 @@ async def create_queue(
     )
     session.add(owner_perm)
 
-    # Process optional role permissions
-    if queue_in.role_permissions:
-        role_ids = {
-            rp.initiative_role_id
-            for rp in queue_in.role_permissions
-            if rp.level != QueuePermissionLevel.owner
-        }
-        valid_role_ids: set[int] = set()
-        if role_ids:
-            result = await session.exec(
-                select(InitiativeRoleModel.id).where(
-                    InitiativeRoleModel.id.in_(role_ids),
-                    InitiativeRoleModel.initiative_id == initiative.id,
-                )
-            )
-            valid_role_ids = set(result.all())
-        for rp in queue_in.role_permissions:
-            if (
-                rp.initiative_role_id not in valid_role_ids
-                or rp.level == QueuePermissionLevel.owner
-            ):
-                continue
-            session.add(
-                ResourceGrant(
-                    resource_type="queue",
-                    resource_id=queue.id,
-                    user_id=None,
-                    role_id=rp.initiative_role_id,
-                    level=rp.level,
-                    guild_id=guild_context.guild_id,
-                    initiative_id=queue.initiative_id,
-                )
-            )
-
-    # Process optional user permissions
-    if queue_in.user_permissions:
-        requested = {
-            up.user_id
-            for up in queue_in.user_permissions
-            if up.user_id != current_user.id
-        }
-        valid_ids: set[int] = set()
-        if requested:
-            result = await session.exec(
-                select(InitiativeMember.user_id).where(
-                    InitiativeMember.initiative_id == initiative.id,
-                    InitiativeMember.user_id.in_(requested),
-                )
-            )
-            valid_ids = set(result.all())
-        for up in queue_in.user_permissions:
-            if up.user_id in valid_ids and up.level != QueuePermissionLevel.owner:
-                session.add(
-                    ResourceGrant(
-                        resource_type="queue",
-                        resource_id=queue.id,
-                        user_id=up.user_id,
-                        role_id=None,
-                        level=up.level,
-                        guild_id=guild_context.guild_id,
-                        initiative_id=queue.initiative_id,
-                    )
-                )
+    # Apply the initial sharing exactly the way edits do — one grant list, one
+    # code path (empty default = owner-only until shared).
+    await permissions_service.replace_resource_grants(
+        session,
+        resource_type="queue",
+        resource_id=queue.id,
+        guild_id=guild_context.guild_id,
+        initiative_id=queue.initiative_id,
+        owner_id=current_user.id,
+        grants=queue_in.grants,
+    )
 
     await session.commit()
     await reapply_rls_context(session)
@@ -1056,203 +999,65 @@ async def set_queue_item_tasks(
 
 
 # ---------------------------------------------------------------------------
-# Permissions (DAC)
+# Sharing (resource grants)
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{queue_id}/permissions")
-async def list_queue_permissions(
+@router.put("/{queue_id}/grants", response_model=QueueRead)
+async def set_queue_grants(
     queue_id: int,
+    grants: List[ResourceGrantSchema],
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
-) -> dict:
-    """List user and role permissions on a queue. Requires read access."""
-    queue = await _get_queue_with_access(
-        session, queue_id, current_user, guild_context, access="read"
-    )
-
-    permissions = [
-        QueuePermissionRead(
-            user_id=g.user_id,
-            level=g.level,
-            created_at=g.created_at,
-        )
-        for g in (queue.grants or [])
-        if g.user_id is not None
-    ]
-
-    role_permissions = []
-    for g in queue.grants or []:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        role_permissions.append(
-            QueueRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
-
-    return {
-        "permissions": permissions,
-        "role_permissions": role_permissions,
-    }
-
-
-@router.put("/{queue_id}/permissions", response_model=List[QueuePermissionRead])
-async def set_queue_permissions(
-    queue_id: int,
-    permissions_in: List[QueuePermissionCreate],
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> List[QueuePermissionRead]:
-    """Set user permissions on a queue. Requires owner or guild admin.
-
-    Replaces all non-owner permissions. The owner's permission cannot be changed.
+) -> QueueRead:
+    """Replace the queue's entire sharing state in one call — the body is the
+    full list of grants (all-initiative-members / per-user / per-role). Every
+    non-owner grant is rebuilt from it; the owner is always preserved.
     """
-    queue = await _get_queue_with_access(
-        session, queue_id, current_user, guild_context, access="read"
+    queue = await resource_access.load_authorized(
+        session,
+        "queue",
+        queue_id,
+        current_user,
+        guild_context,
+        access="write",
+        manage_access=True,
     )
-    if not rls_service.is_guild_admin(guild_context.role):
-        queues_service.require_queue_access(queue, current_user, require_owner=True)
 
-    # Find the owner's user_id
-    owner_user_id: int | None = None
+    # The owner is the user holding the owner-level grant, else the creator.
+    owner_id = queue.created_by_id
     for g in queue.grants or []:
         if g.user_id is not None and g.level == ResourceAccessLevel.owner:
-            owner_user_id = g.user_id
+            owner_id = g.user_id
             break
 
-    # Delete all non-owner user grants (role grants are managed separately)
-    base_conditions = [
-        ResourceGrant.resource_type == "queue",
-        ResourceGrant.resource_id == queue.id,
-        ResourceGrant.user_id.is_not(None),
-    ]
-    if owner_user_id is not None:
-        delete_stmt = sa_delete(ResourceGrant).where(
-            *base_conditions,
-            ResourceGrant.user_id != owner_user_id,
-        )
-    else:
-        delete_stmt = sa_delete(ResourceGrant).where(
-            *base_conditions,
-            ResourceGrant.level != ResourceAccessLevel.owner,
-        )
-    await session.exec(delete_stmt)
-
-    # Add new permissions (skip owner-level and skip the current owner)
-    for perm_in in permissions_in:
-        if perm_in.user_id == owner_user_id:
-            continue
-        if perm_in.level == QueuePermissionLevel.owner:
-            continue
-        session.add(
-            ResourceGrant(
-                resource_type="queue",
-                resource_id=queue.id,
-                user_id=perm_in.user_id,
-                role_id=None,
-                level=perm_in.level,
-                guild_id=queue.guild_id,
-                initiative_id=queue.initiative_id,
-            )
-        )
+    await permissions_service.replace_resource_grants(
+        session,
+        resource_type="queue",
+        resource_id=queue.id,
+        guild_id=queue.guild_id,
+        initiative_id=queue.initiative_id,
+        owner_id=owner_id,
+        grants=grants,
+    )
 
     await session.commit()
     await reapply_rls_context(session)
 
     hydrated = await _refetch_queue(session, queue.id)
-    perms_result = [
-        QueuePermissionRead(
-            user_id=g.user_id,
-            level=g.level,
-            created_at=g.created_at,
-        )
-        for g in (hydrated.grants or [])
-        if g.user_id is not None
-    ]
+    result = serialize_queue(
+        hydrated,
+        my_permission_level=_compute_my_permission(
+            hydrated, current_user, guild_context
+        ),
+    )
     await queue_manager.broadcast(
         queue_id,
         "permissions_changed",
-        {"permissions": [p.model_dump(mode="json") for p in perms_result]},
+        {"grants": [g.model_dump(mode="json") for g in result.grants]},
     )
-    return perms_result
-
-
-@router.put(
-    "/{queue_id}/role-permissions", response_model=List[QueueRolePermissionRead]
-)
-async def set_queue_role_permissions(
-    queue_id: int,
-    role_permissions_in: List[QueueRolePermissionCreate],
-    session: RLSSessionDep,
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> List[QueueRolePermissionRead]:
-    """Set role permissions on a queue. Requires owner or guild admin.
-
-    Replaces all existing role permissions.
-    """
-    queue = await _get_queue_with_access(
-        session, queue_id, current_user, guild_context, access="read"
-    )
-    if not rls_service.is_guild_admin(guild_context.role):
-        queues_service.require_queue_access(queue, current_user, require_owner=True)
-
-    # Delete all existing role grants (user grants are managed separately)
-    delete_stmt = sa_delete(ResourceGrant).where(
-        ResourceGrant.resource_type == "queue",
-        ResourceGrant.resource_id == queue.id,
-        ResourceGrant.role_id.is_not(None),
-    )
-    await session.exec(delete_stmt)
-
-    # Add new role permissions (skip owner-level)
-    for rp_in in role_permissions_in:
-        if rp_in.level == QueuePermissionLevel.owner:
-            continue
-        session.add(
-            ResourceGrant(
-                resource_type="queue",
-                resource_id=queue.id,
-                user_id=None,
-                role_id=rp_in.initiative_role_id,
-                level=rp_in.level,
-                guild_id=queue.guild_id,
-                initiative_id=queue.initiative_id,
-            )
-        )
-
-    await session.commit()
-    await reapply_rls_context(session)
-
-    hydrated = await _refetch_queue(session, queue.id)
-    role_perms_result: List[QueueRolePermissionRead] = []
-    for g in hydrated.grants or []:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        role_perms_result.append(
-            QueueRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
-    await queue_manager.broadcast(
-        queue_id,
-        "permissions_changed",
-        {"role_permissions": [rp.model_dump(mode="json") for rp in role_perms_result]},
-    )
-    return role_perms_result
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/v1/guild_endpoints/queues_test.py
+++ b/backend/app/api/v1/guild_endpoints/queues_test.py
@@ -838,28 +838,29 @@ async def test_hold_requires_write_access(client: AsyncClient, session: AsyncSes
 
 
 @pytest.mark.integration
-async def test_set_queue_permissions(client: AsyncClient, session: AsyncSession):
-    """Owner can set user permissions on a queue."""
+async def test_set_queue_grants(client: AsyncClient, session: AsyncSession):
+    """Owner can set user grants on a queue via the unified grants endpoint."""
     admin, member, guild, initiative = await _setup_with_member(session)
     headers = await get_guild_headers(session, guild, admin)
     queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/permissions",
+        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
         headers=headers,
         json=[{"user_id": member.id, "level": "write"}],
     )
 
     assert response.status_code == 200
     data = response.json()
-    member_perms = [p for p in data if p["user_id"] == member.id]
-    assert len(member_perms) == 1
-    assert member_perms[0]["level"] == "write"
+    member_grants = [
+        g for g in data["grants"] if g["user_id"] == member.id and g["level"] == "write"
+    ]
+    assert len(member_grants) == 1
 
 
 @pytest.mark.integration
-async def test_set_queue_role_permissions(client: AsyncClient, session: AsyncSession):
-    """Owner can set role permissions on a queue."""
+async def test_set_queue_role_grants(client: AsyncClient, session: AsyncSession):
+    """Owner can set role grants on a queue via the unified grants endpoint."""
     admin, guild, initiative = await _setup_guild_and_initiative(session)
     headers = await get_guild_headers(session, guild, admin)
     queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
@@ -874,16 +875,19 @@ async def test_set_queue_role_permissions(client: AsyncClient, session: AsyncSes
     member_role = result.one()
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/role-permissions",
+        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
         headers=headers,
-        json=[{"initiative_role_id": member_role.id, "level": "read"}],
+        json=[{"role_id": member_role.id, "level": "read"}],
     )
 
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 1
-    assert data[0]["initiative_role_id"] == member_role.id
-    assert data[0]["level"] == "read"
+    role_grants = [
+        g
+        for g in data["grants"]
+        if g["role_id"] == member_role.id and g["level"] == "read"
+    ]
+    assert len(role_grants) == 1
 
 
 @pytest.mark.integration
@@ -899,7 +903,7 @@ async def test_member_with_read_can_view_queue(
 
     # Grant read to member
     await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/permissions",
+        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
         headers=admin_headers,
         json=[{"user_id": member.id, "level": "read"}],
     )
@@ -975,10 +979,8 @@ async def test_set_queue_item_tags(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_create_queue_with_permissions(
-    client: AsyncClient, session: AsyncSession
-):
-    """Create a queue with inline role and user permissions."""
+async def test_create_queue_with_grants(client: AsyncClient, session: AsyncSession):
+    """Create a queue with inline role and user grants."""
     admin, member, guild, initiative = await _setup_with_member(session)
     headers = await get_guild_headers(session, guild, admin)
 
@@ -996,16 +998,22 @@ async def test_create_queue_with_permissions(
         json={
             "name": "With Perms",
             "initiative_id": initiative.id,
-            "role_permissions": [
-                {"initiative_role_id": member_role.id, "level": "read"}
+            "grants": [
+                {"role_id": member_role.id, "level": "read"},
+                {"user_id": member.id, "level": "write"},
             ],
-            "user_permissions": [{"user_id": member.id, "level": "write"}],
         },
     )
 
     assert response.status_code == 201
     data = response.json()
-    assert len(data["role_permissions"]) == 1
-    user_perms = [p for p in data["permissions"] if p["user_id"] == member.id]
-    assert len(user_perms) == 1
-    assert user_perms[0]["level"] == "write"
+    role_grants = [
+        g
+        for g in data["grants"]
+        if g["role_id"] == member_role.id and g["user_id"] is None
+    ]
+    assert len(role_grants) == 1
+    user_grants = [
+        g for g in data["grants"] if g["user_id"] == member.id and g["level"] == "write"
+    ]
+    assert len(user_grants) == 1

--- a/backend/app/api/v1/guild_endpoints/queues_test.py
+++ b/backend/app/api/v1/guild_endpoints/queues_test.py
@@ -935,6 +935,14 @@ async def test_member_without_permission_cannot_view(
     queue_data = await _create_queue_via_api(
         client, admin_headers, guild, initiative.id
     )
+    # New queues default to all-members Viewer; restrict to owner-only so a member
+    # without a grant is genuinely denied.
+    restrict = await client.put(
+        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
+        headers=admin_headers,
+        json=[],
+    )
+    assert restrict.status_code == 200
 
     member_headers = await get_guild_headers(session, guild, member)
     response = await client.get(

--- a/backend/app/api/v1/public_endpoints/access_grants_test.py
+++ b/backend/app/api/v1/public_endpoints/access_grants_test.py
@@ -345,9 +345,9 @@ async def test_grant_cannot_manage_project_members(
     )
 
     headers = await get_guild_headers(session, guild, support)
-    resp = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/members",
-        json={"user_id": target.id, "level": "write"},
+    resp = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
+        json=[{"user_id": target.id, "level": "write"}],
         headers=headers,
     )
     assert resp.status_code == 403, resp.text
@@ -358,8 +358,8 @@ async def test_grant_cannot_manage_project_members(
 async def test_grant_cannot_manage_counter_group_access(
     client: AsyncClient, session: AsyncSession
 ):
-    """A read_write grant can't manage counter group access (writes
-    counter_group_permissions, which RLS blocks) — clean 403, not 500."""
+    """A read_write grant can't manage counter group access (a grant confers
+    content read/write only) — clean 403, not 500."""
     from app.models.counter import CounterGroup
 
     owner = await create_user(
@@ -382,7 +382,7 @@ async def test_grant_cannot_manage_counter_group_access(
 
     headers = await get_guild_headers(session, guild, support)
     resp = await client.put(
-        f"/api/v1/g/{guild.id}/counter-groups/{cg.id}/permissions",
+        f"/api/v1/g/{guild.id}/counter-groups/{cg.id}/grants",
         json=[],
         headers=headers,
     )

--- a/backend/app/api/v1/public_endpoints/break_glass_test.py
+++ b/backend/app/api/v1/public_endpoints/break_glass_test.py
@@ -196,14 +196,14 @@ async def test_break_glass_read_write_is_full_guild_admin(
     )
     assert resp.status_code == 201, resp.text
 
-    # Management: add a member to an existing project (a regular grant is blocked
-    # with PROJECT_GRANT_CANNOT_MANAGE_MEMBERS — break-glass has no limits).
-    resp = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/members",
-        json={"user_id": target.id, "level": "write"},
+    # Management: change project access (a regular grant is blocked with
+    # PROJECT_GRANT_CANNOT_MANAGE_MEMBERS — break-glass has no limits).
+    resp = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
+        json=[{"user_id": target.id, "level": "write"}],
         headers=headers,
     )
-    assert resp.status_code in (200, 201, 204), resp.text
+    assert resp.status_code == 200, resp.text
 
 
 @pytest.mark.integration

--- a/backend/app/models/resource_grant.py
+++ b/backend/app/models/resource_grant.py
@@ -1,8 +1,20 @@
 """Polymorphic per-resource access grants — the single DAC table.
 
-One row = a user OR an initiative role may access a resource at a level. Replaces
-the per-resource ``*_permissions`` / ``*_role_permissions`` tables (see
-history/resource-grants-consolidation-design.md).
+One row grants access to a resource at a level for exactly one of three grantee
+kinds:
+
+- a **user** (``user_id`` set),
+- an **initiative role** (``role_id`` set), or
+- the **whole initiative** — a "general access" row with neither ``user_id`` nor
+  ``role_id`` set and ``all_initiative_members`` true; ``level`` (read/write)
+  gives the Viewer/Editor level. The backend aggregates every member of the
+  row's ``initiative_id`` for it (see ``app.services.permissions``).
+  ``all_initiative_members`` may only be set when there is no user/role grantee
+  (enforced by the ``resource_grants_one_grantee`` check).
+
+Replaces the per-resource ``*_permissions`` / ``*_role_permissions`` tables (see
+history/resource-grants-consolidation-design.md). General access:
+history/general-access-sharing-design.md.
 """
 
 from datetime import datetime, timezone
@@ -10,6 +22,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     Column,
     DateTime,
@@ -17,6 +30,7 @@ from sqlalchemy import (
     Integer,
     String,
     UniqueConstraint,
+    text,
 )
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -40,8 +54,13 @@ class ResourceGrant(SQLModel, table=True):
     __tablename__ = "resource_grants"
 
     __table_args__ = (
+        # Exactly one grantee kind per row: a user, an initiative role, or the
+        # whole initiative (all_initiative_members). This keeps the old XOR (never
+        # user AND role) and forbids the share boolean whenever a user/role
+        # grantee is set.
         CheckConstraint(
-            "(user_id IS NULL) <> (role_id IS NULL)",
+            "(user_id IS NOT NULL)::int + (role_id IS NOT NULL)::int "
+            "+ (all_initiative_members)::int = 1",
             name="resource_grants_one_grantee",
         ),
         # NULLS NOT DISTINCT so the unused grantee column (NULL) compares equal —
@@ -93,6 +112,14 @@ class ResourceGrant(SQLModel, table=True):
     )
     level: ResourceAccessLevel = Field(
         sa_column=Column(String(length=16), nullable=False)
+    )
+    # All-initiative-members grant — when true (and there is no user/role
+    # grantee), the row grants every member of ``initiative_id`` access at
+    # ``level`` (read = Viewer, write = Editor). The constraint forbids it being
+    # set alongside a user/role.
+    all_initiative_members: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default=text("false")),
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/backend/app/schemas/calendar_event.py
+++ b/backend/app/schemas/calendar_event.py
@@ -9,6 +9,7 @@ from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 from app.models.calendar_event import RSVPStatus
 from app.schemas.property import PropertySummary
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.tag import TagSummary
 from app.schemas.user import UserPublic
 
@@ -103,6 +104,13 @@ class CalendarEventCreate(CalendarEventBase):
     attendee_ids: Optional[List[int]] = None
     tag_ids: Optional[List[int]] = None
     document_ids: Optional[List[int]] = None
+    # Initial sharing — the same grant list the PUT /grants endpoint takes.
+    # Defaults to Viewer for all initiative members.
+    grants: List[ResourceGrantSchema] = Field(
+        default_factory=lambda: [
+            ResourceGrantSchema(all_initiative_members=True, level="read")
+        ]
+    )
 
 
 class CalendarEventUpdate(SanitizedBaseModel):
@@ -149,6 +157,10 @@ class CalendarEventSummary(CalendarEventBase):
     attendee_previews: List[CalendarEventAttendeePreview] = Field(default_factory=list)
     property_values: List[PropertySummary] = Field(default_factory=list)
     tags: List[TagSummary] = Field(default_factory=list)
+    # The full sharing state — every resource_grants row for this event.
+    grants: List[ResourceGrantSchema] = Field(default_factory=list)
+    # The current user's effective level on this event (what *I* can do).
+    my_permission_level: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 
@@ -241,7 +253,20 @@ def _parse_recurrence(event: "CalendarEvent") -> Optional[EventRecurrence]:
         return None
 
 
-def serialize_calendar_event_summary(event: "CalendarEvent") -> CalendarEventSummary:
+def serialize_calendar_event_summary(
+    event: "CalendarEvent", *, user_id: Optional[int] = None
+) -> CalendarEventSummary:
+    # Local import avoids a schema -> service import cycle.
+    from app.services.permissions import (
+        compute_calendar_event_permission,
+        serialize_grants,
+    )
+
+    my_permission_level = (
+        compute_calendar_event_permission(event, user_id)
+        if user_id is not None
+        else None
+    )
     attendees_list = getattr(event, "attendees", None) or []
     names: List[str] = []
     previews: List[CalendarEventAttendeePreview] = []
@@ -276,13 +301,17 @@ def serialize_calendar_event_summary(event: "CalendarEvent") -> CalendarEventSum
         attendee_previews=previews,
         property_values=_serialize_event_properties(event),
         tags=_serialize_tags(event),
+        grants=serialize_grants(event),
+        my_permission_level=my_permission_level,
         created_at=event.created_at,
         updated_at=event.updated_at,
     )
 
 
-def serialize_calendar_event(event: "CalendarEvent") -> CalendarEventRead:
-    summary = serialize_calendar_event_summary(event)
+def serialize_calendar_event(
+    event: "CalendarEvent", *, user_id: Optional[int] = None
+) -> CalendarEventRead:
+    summary = serialize_calendar_event_summary(event, user_id=user_id)
     return CalendarEventRead(
         **summary.model_dump(),
         attendees=_serialize_attendees(event),

--- a/backend/app/schemas/counter.py
+++ b/backend/app/schemas/counter.py
@@ -8,48 +8,12 @@ from typing import List, Optional, TYPE_CHECKING
 from pydantic import ConfigDict, Field, model_validator
 
 from app.core.messages import CounterMessages
-from app.models.counter import CounterPermissionLevel, CounterViewMode
+from app.models.counter import CounterViewMode
 from app.schemas.base import SanitizedBaseModel
+from app.schemas.resource_grant import ResourceGrantSchema
 
 if TYPE_CHECKING:  # pragma: no cover
     from app.models.counter import Counter, CounterGroup
-
-
-# ---------------------------------------------------------------------------
-# Permission schemas
-# ---------------------------------------------------------------------------
-
-
-class CounterGroupPermissionCreate(SanitizedBaseModel):
-    user_id: int
-    level: CounterPermissionLevel = CounterPermissionLevel.write
-
-
-class CounterGroupPermissionRead(SanitizedBaseModel):
-    model_config = ConfigDict(
-        from_attributes=True, json_schema_serialization_defaults_required=True
-    )
-
-    user_id: int
-    level: CounterPermissionLevel
-    created_at: datetime
-
-
-class CounterGroupRolePermissionCreate(SanitizedBaseModel):
-    initiative_role_id: int
-    level: CounterPermissionLevel = CounterPermissionLevel.read
-
-
-class CounterGroupRolePermissionRead(SanitizedBaseModel):
-    model_config = ConfigDict(
-        from_attributes=True, json_schema_serialization_defaults_required=True
-    )
-
-    initiative_role_id: int
-    role_name: str = ""
-    role_display_name: str = ""
-    level: CounterPermissionLevel
-    created_at: datetime
 
 
 # ---------------------------------------------------------------------------
@@ -172,8 +136,13 @@ class CounterGroupBase(SanitizedBaseModel):
 
 class CounterGroupCreate(CounterGroupBase):
     initiative_id: int
-    role_permissions: Optional[List[CounterGroupRolePermissionCreate]] = None
-    user_permissions: Optional[List[CounterGroupPermissionCreate]] = None
+    # Initial sharing — the same grant list the PUT /grants endpoint takes.
+    # Defaults to Viewer for all initiative members.
+    grants: List[ResourceGrantSchema] = Field(
+        default_factory=lambda: [
+            ResourceGrantSchema(all_initiative_members=True, level="read")
+        ]
+    )
 
 
 class CounterGroupUpdate(SanitizedBaseModel):
@@ -212,23 +181,8 @@ class CounterGroupListResponse(SanitizedBaseModel):
 
 class CounterGroupRead(CounterGroupSummary):
     counters: List[CounterRead] = Field(default_factory=list)
-    permissions: List[CounterGroupPermissionRead] = Field(default_factory=list)
-    role_permissions: List[CounterGroupRolePermissionRead] = Field(default_factory=list)
-
-
-# ---------------------------------------------------------------------------
-# Permission-update payloads (for PUT /permissions and /role-permissions)
-# ---------------------------------------------------------------------------
-
-
-class CounterGroupPermissionsUpdate(SanitizedBaseModel):
-    permissions: List[CounterGroupPermissionCreate] = Field(default_factory=list)
-
-
-class CounterGroupRolePermissionsUpdate(SanitizedBaseModel):
-    role_permissions: List[CounterGroupRolePermissionCreate] = Field(
-        default_factory=list
-    )
+    # The full sharing state — every resource_grants row for this group.
+    grants: List[ResourceGrantSchema] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -274,38 +228,6 @@ def serialize_counter(counter: "Counter") -> CounterRead:
     )
 
 
-def _serialize_permissions(group: "CounterGroup") -> List[CounterGroupPermissionRead]:
-    grants = getattr(group, "grants", None) or []
-    return [
-        CounterGroupPermissionRead(
-            user_id=g.user_id, level=g.level, created_at=g.created_at
-        )
-        for g in grants
-        if g.user_id is not None
-    ]
-
-
-def _serialize_role_permissions(
-    group: "CounterGroup",
-) -> List[CounterGroupRolePermissionRead]:
-    grants = getattr(group, "grants", None) or []
-    result: List[CounterGroupRolePermissionRead] = []
-    for g in grants:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        result.append(
-            CounterGroupRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
-    return result
-
-
 def _active_counters(group: "CounterGroup") -> list:
     counters = getattr(group, "counters", None) or []
     return [c for c in counters if getattr(c, "deleted_at", None) is None]
@@ -339,9 +261,11 @@ def serialize_counter_group(
         group, my_permission_level=my_permission_level
     )
     counters = sorted(_active_counters(group), key=lambda c: c.position)
+    # Local import avoids a schema -> service import cycle.
+    from app.services.permissions import serialize_grants
+
     return CounterGroupRead(
         **summary.model_dump(),
         counters=[serialize_counter(c) for c in counters],
-        permissions=_serialize_permissions(group),
-        role_permissions=_serialize_role_permissions(group),
+        grants=serialize_grants(group),
     )

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -8,6 +8,7 @@ from pydantic import ConfigDict, Field
 from app.schemas.base import SanitizedBaseModel
 
 from app.models.document import DocumentPermissionLevel, DocumentType
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.initiative import InitiativeRead, serialize_initiative
 from app.schemas.property import PropertySummary
 from app.schemas.tag import TagSummary
@@ -36,8 +37,13 @@ class DocumentBase(SanitizedBaseModel):
 class DocumentCreate(DocumentBase):
     content: Optional[LexicalState] = Field(default_factory=dict)
     document_type: DocumentTypeStr = "native"
-    role_permissions: Optional[List[DocumentRolePermissionCreate]] = None
-    user_permissions: Optional[List[DocumentPermissionCreate]] = None
+    # Initial sharing — the same grant list the PUT /grants endpoint takes.
+    # Defaults to Viewer for all initiative members.
+    grants: List[ResourceGrantSchema] = Field(
+        default_factory=lambda: [
+            ResourceGrantSchema(all_initiative_members=True, level="read")
+        ]
+    )
 
 
 class DocumentUpdate(SanitizedBaseModel):
@@ -142,8 +148,8 @@ class DocumentSummary(DocumentBase):
     initiative: Optional[InitiativeRead] = None
     projects: List[DocumentProjectLink] = Field(default_factory=list)
     comment_count: int = 0
-    permissions: List[DocumentPermissionRead] = Field(default_factory=list)
-    role_permissions: List[DocumentRolePermissionRead] = Field(default_factory=list)
+    # The full sharing state — every resource_grants row for this document.
+    grants: List[ResourceGrantSchema] = Field(default_factory=list)
     tags: List[TagSummary] = Field(default_factory=list)
     properties: List[PropertySummary] = Field(default_factory=list)
     # File document fields
@@ -227,42 +233,6 @@ def _serialize_project_links(document: "Document") -> List[DocumentProjectLink]:
     return links
 
 
-def _serialize_permissions(document: "Document") -> List[DocumentPermissionRead]:
-    """Serialize all document user permissions from resource_grants."""
-    grants = getattr(document, "grants", None) or []
-    return [
-        DocumentPermissionRead(
-            user_id=g.user_id,
-            level=g.level,
-            created_at=g.created_at,
-        )
-        for g in grants
-        if g.user_id is not None
-    ]
-
-
-def _serialize_role_permissions(
-    document: "Document",
-) -> List[DocumentRolePermissionRead]:
-    """Serialize all document role permissions from resource_grants."""
-    grants = getattr(document, "grants", None) or []
-    result: List[DocumentRolePermissionRead] = []
-    for g in grants:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        result.append(
-            DocumentRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
-    return result
-
-
 def _serialize_document_tags(document: "Document") -> List[TagSummary]:
     """Serialize document tags to TagSummary list."""
     tag_links = getattr(document, "tag_links", None) or []
@@ -302,6 +272,8 @@ def serialize_document_summary(
         url = content.get("url") if isinstance(content, dict) else None
         if isinstance(url, str) and url:
             smart_link_url = url
+    from app.services.permissions import serialize_grants
+
     return DocumentSummary(
         id=document.id,
         guild_id=document.guild_id,
@@ -316,8 +288,7 @@ def serialize_document_summary(
         initiative=initiative,
         projects=_serialize_project_links(document),
         comment_count=getattr(document, "comment_count", 0),
-        permissions=_serialize_permissions(document),
-        role_permissions=_serialize_role_permissions(document),
+        grants=serialize_grants(document),
         tags=_serialize_document_tags(document),
         properties=_serialize_document_properties(document),
         document_type=document.document_type.value

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -8,6 +8,7 @@ from pydantic import ConfigDict, Field
 from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 from app.models.project import ProjectPermissionLevel
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.initiative import InitiativeRead
 from app.schemas.document import ProjectDocumentSummary
 from app.schemas.tag import TagSummary
@@ -26,8 +27,13 @@ class ProjectCreate(ProjectBase):
     initiative_id: Optional[int] = None
     is_template: bool = False
     template_id: Optional[int] = None
-    role_permissions: Optional[List[ProjectRolePermissionCreate]] = None
-    user_permissions: Optional[List[ProjectPermissionCreate]] = None
+    # Initial sharing — the same grant list the PUT /grants endpoint takes.
+    # Defaults to Viewer for all initiative members.
+    grants: List[ResourceGrantSchema] = Field(
+        default_factory=lambda: [
+            ResourceGrantSchema(all_initiative_members=True, level="read")
+        ]
+    )
 
 
 class ProjectUpdate(SanitizedBaseModel):
@@ -116,15 +122,16 @@ class ProjectRead(ProjectBase):
     pinned_at: Optional[datetime] = None
     owner: Optional[UserPublic] = None
     initiative: Optional[InitiativeRead] = None
-    permissions: List[ProjectPermissionRead] = Field(default_factory=list)
-    role_permissions: List[ProjectRolePermissionRead] = Field(default_factory=list)
     sort_order: Optional[float] = None
     is_favorited: bool = False
     last_viewed_at: Optional[datetime] = None
     documents: List[ProjectDocumentSummary] = Field(default_factory=list)
     task_summary: ProjectTaskSummary = Field(default_factory=ProjectTaskSummary)
     tags: List[TagSummary] = Field(default_factory=list)
+    # The current user's effective level on this resource (what *I* can do).
     my_permission_level: Optional[str] = None
+    # The full sharing state — every resource_grants row for this resource.
+    grants: List[ResourceGrantSchema] = Field(default_factory=list)
 
 
 class ProjectListResponse(SanitizedBaseModel):

--- a/backend/app/schemas/queue.py
+++ b/backend/app/schemas/queue.py
@@ -7,49 +7,12 @@ from pydantic import ConfigDict, Field
 
 from app.schemas.base import RichTextStr, SanitizedBaseModel
 
-from app.models.queue import QueuePermissionLevel
+from app.schemas.resource_grant import ResourceGrantSchema
 from app.schemas.tag import TagSummary
 from app.schemas.user import UserPublic
 
 if TYPE_CHECKING:  # pragma: no cover
     from app.models.queue import Queue, QueueItem
-
-
-# ---------------------------------------------------------------------------
-# Permission schemas (declared first so Queue schemas can reference them)
-# ---------------------------------------------------------------------------
-
-
-class QueuePermissionCreate(SanitizedBaseModel):
-    user_id: int
-    level: QueuePermissionLevel = QueuePermissionLevel.write
-
-
-class QueuePermissionRead(SanitizedBaseModel):
-    model_config = ConfigDict(
-        from_attributes=True, json_schema_serialization_defaults_required=True
-    )
-
-    user_id: int
-    level: QueuePermissionLevel
-    created_at: datetime
-
-
-class QueueRolePermissionCreate(SanitizedBaseModel):
-    initiative_role_id: int
-    level: QueuePermissionLevel = QueuePermissionLevel.read
-
-
-class QueueRolePermissionRead(SanitizedBaseModel):
-    model_config = ConfigDict(
-        from_attributes=True, json_schema_serialization_defaults_required=True
-    )
-
-    initiative_role_id: int
-    role_name: str = ""
-    role_display_name: str = ""
-    level: QueuePermissionLevel
-    created_at: datetime
 
 
 # ---------------------------------------------------------------------------
@@ -152,8 +115,13 @@ class QueueBase(SanitizedBaseModel):
 
 class QueueCreate(QueueBase):
     initiative_id: int
-    role_permissions: Optional[List[QueueRolePermissionCreate]] = None
-    user_permissions: Optional[List[QueuePermissionCreate]] = None
+    # Initial sharing — the same grant list the PUT /grants endpoint takes.
+    # Defaults to Viewer for all initiative members.
+    grants: List[ResourceGrantSchema] = Field(
+        default_factory=lambda: [
+            ResourceGrantSchema(all_initiative_members=True, level="read")
+        ]
+    )
 
 
 class QueueUpdate(SanitizedBaseModel):
@@ -191,8 +159,8 @@ class QueueListResponse(SanitizedBaseModel):
 class QueueRead(QueueSummary):
     items: List[QueueItemRead] = Field(default_factory=list)
     current_item: Optional[QueueItemRead] = None
-    permissions: List[QueuePermissionRead] = Field(default_factory=list)
-    role_permissions: List[QueueRolePermissionRead] = Field(default_factory=list)
+    # The full sharing state — every resource_grants row for this queue.
+    grants: List[ResourceGrantSchema] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -260,34 +228,6 @@ def serialize_queue_item(item: "QueueItem") -> QueueItemRead:
     )
 
 
-def _serialize_permissions(queue: "Queue") -> List[QueuePermissionRead]:
-    grants = getattr(queue, "grants", None) or []
-    return [
-        QueuePermissionRead(user_id=g.user_id, level=g.level, created_at=g.created_at)
-        for g in grants
-        if g.user_id is not None
-    ]
-
-
-def _serialize_role_permissions(queue: "Queue") -> List[QueueRolePermissionRead]:
-    grants = getattr(queue, "grants", None) or []
-    result: List[QueueRolePermissionRead] = []
-    for g in grants:
-        if g.role_id is None:
-            continue
-        role = getattr(g, "role", None)
-        result.append(
-            QueueRolePermissionRead(
-                initiative_role_id=g.role_id,
-                role_name=getattr(role, "name", "") if role else "",
-                role_display_name=getattr(role, "display_name", "") if role else "",
-                level=g.level,
-                created_at=g.created_at,
-            )
-        )
-    return result
-
-
 def serialize_queue_summary(
     queue: "Queue",
     *,
@@ -324,10 +264,12 @@ def serialize_queue(
                 current_item = item
                 break
     summary = serialize_queue_summary(queue, my_permission_level=my_permission_level)
+    # Local import avoids a schema -> service import cycle.
+    from app.services.permissions import serialize_grants
+
     return QueueRead(
         **summary.model_dump(),
         items=serialized_items,
         current_item=current_item,
-        permissions=_serialize_permissions(queue),
-        role_permissions=_serialize_role_permissions(queue),
+        grants=serialize_grants(queue),
     )

--- a/backend/app/schemas/resource_grant.py
+++ b/backend/app/schemas/resource_grant.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 
 from app.schemas.base import SanitizedBaseModel
 

--- a/backend/app/schemas/resource_grant.py
+++ b/backend/app/schemas/resource_grant.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
+from pydantic import ConfigDict
+
 from app.schemas.base import SanitizedBaseModel
 
 
@@ -25,6 +27,11 @@ class ResourceGrantSchema(SanitizedBaseModel):
     read-only or write-only. The server always preserves the resource's owner
     grant. Role display names are resolved client-side from the initiative's roles
     by ``role_id``."""
+
+    # from_attributes so a read model can validate straight off the ORM
+    # ResourceGrant row (e.g. ProjectRead.model_validate(project) reading
+    # project.grants).
+    model_config = ConfigDict(from_attributes=True)
 
     level: Literal["read", "write", "owner"]
     user_id: Optional[int] = None

--- a/backend/app/schemas/resource_grant.py
+++ b/backend/app/schemas/resource_grant.py
@@ -1,0 +1,32 @@
+"""The single resource-grant (sharing) schema for projects and documents.
+
+Everything is a row in ``resource_grants``, so there is **one** shape:
+``ResourceGrantSchema``. A resource's sharing state is just a list of them — the
+identical shape both reports the grants (``grants`` on the read models) and
+replaces them (the ``PUT /{id}/grants`` body). Lives in its own module so both
+the ``project`` and ``document`` schemas can import it without a cycle
+(``project`` already imports ``document``).
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from app.schemas.base import SanitizedBaseModel
+
+
+class ResourceGrantSchema(SanitizedBaseModel):
+    """One ``resource_grants`` row — exactly the columns that define a grant: a
+    ``level`` for a user (``user_id``), an initiative role (``role_id``), or all
+    initiative members (``all_initiative_members``). Exactly one grantee is set.
+
+    The identical shape both reports a resource's grants (``grants`` is a list of
+    these) and replaces them (the ``PUT /{id}/grants`` body) — no field is
+    read-only or write-only. The server always preserves the resource's owner
+    grant. Role display names are resolved client-side from the initiative's roles
+    by ``role_id``."""
+
+    level: Literal["read", "write", "owner"]
+    user_id: Optional[int] = None
+    role_id: Optional[int] = None
+    all_initiative_members: bool = False

--- a/backend/app/schemas/resource_grant.py
+++ b/backend/app/schemas/resource_grant.py
@@ -37,3 +37,16 @@ class ResourceGrantSchema(SanitizedBaseModel):
     user_id: Optional[int] = None
     role_id: Optional[int] = None
     all_initiative_members: bool = False
+
+    @model_validator(mode="after")
+    def exactly_one_grantee(self) -> "ResourceGrantSchema":
+        count = (
+            (self.user_id is not None)
+            + (self.role_id is not None)
+            + self.all_initiative_members
+        )
+        if count != 1:
+            raise ValueError(
+                "Exactly one of user_id, role_id, or all_initiative_members must be set"
+            )
+        return self

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import Any, TypeVar
 
 from fastapi import HTTPException, status
-from sqlalchemy import or_
+from sqlalchemy import and_, or_
 from sqlmodel import select
 
 from app.core.pam_context import active_grant_level, grant_satisfies, has_active_grant
@@ -35,7 +35,7 @@ from app.models.document import (
     Document,
     DocumentPermissionLevel,
 )
-from app.models.initiative import InitiativeMember
+from app.models.initiative import InitiativeMember, InitiativeRoleModel
 from app.models.user import User
 from app.core.messages import (
     ProjectMessages,
@@ -44,7 +44,7 @@ from app.core.messages import (
     CounterMessages,
     CalendarEventMessages,
 )
-from app.models.resource_grant import ResourceGrant
+from app.models.resource_grant import ResourceAccessLevel, ResourceGrant
 
 
 # ---------------------------------------------------------------------------
@@ -179,8 +179,12 @@ def lift_level_for_grant(dac_level: str | None, guild_id: int | None) -> str | N
 
 def visible_resource_ids_subquery(resource_type: str, user_id: int):
     """resource_ids of ``resource_type`` the user can access via a grant — their
-    own user grant OR a grant to one of their initiative roles."""
+    own user grant, a grant to one of their initiative roles, OR an
+    all-initiative-members grant on a resource in an initiative they belong to."""
     my_roles = select(InitiativeMember.role_id).where(
+        InitiativeMember.user_id == user_id
+    )
+    my_initiatives = select(InitiativeMember.initiative_id).where(
         InitiativeMember.user_id == user_id
     )
     return select(ResourceGrant.resource_id).where(
@@ -188,6 +192,10 @@ def visible_resource_ids_subquery(resource_type: str, user_id: int):
         or_(
             ResourceGrant.user_id == user_id,
             ResourceGrant.role_id.in_(my_roles),
+            and_(
+                ResourceGrant.all_initiative_members.is_(True),
+                ResourceGrant.initiative_id.in_(my_initiatives),
+            ),
         ),
     )
 
@@ -339,9 +347,27 @@ def _grant_level(level: Any) -> str:
     return level.value if hasattr(level, "value") else level
 
 
+def serialize_grants(row: Any) -> list:
+    """Serialize a resource's eager-loaded ``grants`` into the unified grant list
+    — one ``ResourceGrantSchema`` per ``resource_grants`` row (user, role, or
+    all-initiative-members), owner included."""
+    from app.schemas.resource_grant import ResourceGrantSchema
+
+    return [
+        ResourceGrantSchema(
+            level=_grant_level(g.level),
+            user_id=g.user_id,
+            role_id=g.role_id,
+            all_initiative_members=bool(getattr(g, "all_initiative_members", False)),
+        )
+        for g in getattr(row, "grants", None) or []
+    ]
+
+
 def effective_level(resource: DacResource, row: Any, user_id: int) -> str | None:
     """Highest grant level (read<write<owner) for ``user_id`` on ``row`` — from the
-    user's own grant or a grant to one of their initiative roles, else None. Reads
+    user's own grant, a grant to one of their initiative roles, or an
+    all-initiative-members grant when the user is a member, else None. Reads
     eagerly-loaded ``grants`` + ``initiative.memberships``."""
     grants = getattr(row, "grants", None) or []
     initiative = getattr(row, "initiative", None)
@@ -351,14 +377,110 @@ def effective_level(resource: DacResource, row: Any, user_id: int) -> str | None
     role_ids = {
         m.role_id for m in memberships if m.user_id == user_id and m.role_id is not None
     }
+    is_member = any(m.user_id == user_id for m in memberships)
     best: str | None = None
     best_rank = -1
     for g in grants:
-        if g.user_id == user_id or (g.role_id is not None and g.role_id in role_ids):
+        applies = (
+            g.user_id == user_id
+            or (g.role_id is not None and g.role_id in role_ids)
+            or (getattr(g, "all_initiative_members", False) and is_member)
+        )
+        if applies:
             lvl = _grant_level(g.level)
             if _LEVEL_RANK[lvl] > best_rank:
                 best_rank, best = _LEVEL_RANK[lvl], lvl
     return best
+
+
+async def replace_resource_grants(
+    session: Any,
+    *,
+    resource_type: str,
+    resource_id: int,
+    guild_id: int,
+    initiative_id: int,
+    owner_id: int,
+    grants: Any,
+) -> None:
+    """Rebuild a resource's non-owner grants from ``grants`` (a list of
+    ResourceAccessGrant rows). Each row is sorted by grantee kind — all-initiative-
+    members, per-user, or per-role. The owner grant is preserved; owner-level
+    entries and grantees outside the initiative are dropped. Caller commits +
+    reapplies RLS."""
+    all_members_level: str | None = None
+    user_levels: dict[int, str] = {}
+    role_levels: dict[int, str] = {}
+    for g in grants:
+        level = g.level
+        if level not in ("read", "write"):
+            continue  # owner is preserved server-side, never set via this list
+        if getattr(g, "all_initiative_members", False):
+            all_members_level = level
+        elif g.user_id is not None and g.user_id != owner_id:
+            user_levels[g.user_id] = level
+        elif g.role_id is not None:
+            role_levels[g.role_id] = level
+
+    valid_users: set[int] = set()
+    if user_levels:
+        valid_users = set(
+            (
+                await session.exec(
+                    select(InitiativeMember.user_id).where(
+                        InitiativeMember.initiative_id == initiative_id,
+                        InitiativeMember.user_id.in_(list(user_levels)),
+                    )
+                )
+            ).all()
+        )
+    valid_roles: set[int] = set()
+    if role_levels:
+        valid_roles = set(
+            (
+                await session.exec(
+                    select(InitiativeRoleModel.id).where(
+                        InitiativeRoleModel.initiative_id == initiative_id,
+                        InitiativeRoleModel.id.in_(list(role_levels)),
+                    )
+                )
+            ).all()
+        )
+
+    existing = (
+        await session.exec(
+            select(ResourceGrant).where(
+                ResourceGrant.resource_type == resource_type,
+                ResourceGrant.resource_id == resource_id,
+            )
+        )
+    ).all()
+    for g in existing:
+        if _grant_level(g.level) != "owner":
+            await session.delete(g)
+
+    def _grant(level: str, **kw: Any) -> ResourceGrant:
+        return ResourceGrant(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            guild_id=guild_id,
+            initiative_id=initiative_id,
+            level=ResourceAccessLevel(level),
+            **kw,
+        )
+
+    if all_members_level is not None:
+        session.add(_grant(all_members_level, all_initiative_members=True))
+    session.add_all(
+        _grant(level, user_id=uid)
+        for uid, level in user_levels.items()
+        if uid in valid_users
+    )
+    session.add_all(
+        _grant(level, role_id=rid)
+        for rid, level in role_levels.items()
+        if rid in valid_roles
+    )
 
 
 def require_access(
@@ -462,6 +584,11 @@ def compute_document_permission(
 ) -> str | None:
     """Effective document permission string for the client (delegates to the engine)."""
     return compute_permission(DAC_RESOURCES["document"], document, user_id)
+
+
+def compute_calendar_event_permission(event: Any, user_id: int) -> str | None:
+    """Effective calendar-event permission string for the client (delegates to the engine)."""
+    return compute_permission(DAC_RESOURCES["calendar_event"], event, user_id)
 
 
 def require_document_access(

--- a/frontend/src/api/generated/calendar-events/calendar-events.ts
+++ b/frontend/src/api/generated/calendar-events/calendar-events.ts
@@ -36,6 +36,7 @@ import type {
   ListCalendarEventsApiV1GGuildIdCalendarEventsGetParams,
   ListMyCalendarEventsApiV1MeCalendarEventsGetParams,
   PropertyValuesSetRequest,
+  ResourceGrantSchema,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -1558,6 +1559,109 @@ export const useSetEventPropertiesApiV1GGuildIdCalendarEventsEventIdPropertiesPu
 > => {
   return useMutation(
     getSetEventPropertiesApiV1GGuildIdCalendarEventsEventIdPropertiesPutMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Replace the event's entire sharing state in one call — the body is the
+ * full list of grants (all-initiative-members / per-user / per-role). Every
+ * non-owner grant is rebuilt from it; the owner is always preserved.
+ * @summary Set Calendar Event Grants
+ */
+export const setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut = (
+  guildId: number,
+  eventId: number,
+  resourceGrantSchema: BodyType<ResourceGrantSchema[]>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<CalendarEventRead>(
+    {
+      url: `/api/v1/g/${guildId}/calendar-events/${eventId}/grants`,
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      data: resourceGrantSchema,
+      signal,
+    },
+    options
+  );
+};
+
+export const getSetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPutMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut>>,
+    TError,
+    { guildId: number; eventId: number; data: BodyType<ResourceGrantSchema[]> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut>>,
+  TError,
+  { guildId: number; eventId: number; data: BodyType<ResourceGrantSchema[]> },
+  TContext
+> => {
+  const mutationKey = ["setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut>>,
+    { guildId: number; eventId: number; data: BodyType<ResourceGrantSchema[]> }
+  > = (props) => {
+    const { guildId, eventId, data } = props ?? {};
+
+    return setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut(
+      guildId,
+      eventId,
+      data,
+      requestOptions
+    );
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type SetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPutMutationResult =
+  NonNullable<
+    Awaited<ReturnType<typeof setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut>>
+  >;
+export type SetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPutMutationBody =
+  BodyType<ResourceGrantSchema[]>;
+export type SetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPutMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Set Calendar Event Grants
+ */
+export const useSetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut>>,
+      TError,
+      { guildId: number; eventId: number; data: BodyType<ResourceGrantSchema[]> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof setCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPut>>,
+  TError,
+  { guildId: number; eventId: number; data: BodyType<ResourceGrantSchema[]> },
+  TContext
+> => {
+  return useMutation(
+    getSetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPutMutationOptions(options),
     queryClient
   );
 };

--- a/frontend/src/api/generated/counters/counters.ts
+++ b/frontend/src/api/generated/counters/counters.ts
@@ -25,20 +25,16 @@ import type {
   CounterGroupCreate,
   CounterGroupDuplicateRequest,
   CounterGroupListResponse,
-  CounterGroupPermissionCreate,
-  CounterGroupPermissionRead,
   CounterGroupRead,
-  CounterGroupRolePermissionCreate,
-  CounterGroupRolePermissionRead,
   CounterGroupUpdate,
   CounterRead,
   CounterSetCountRequest,
   CounterSortRequest,
   CounterUpdate,
   HTTPValidationError,
-  ListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet200,
   ListCounterGroupsApiV1GGuildIdCounterGroupsGetParams,
   RecentViewWrite,
+  ResourceGrantSchema,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -1770,482 +1766,109 @@ export const useSortCountersApiV1GGuildIdCounterGroupsGroupIdSortPost = <
   );
 };
 /**
- * @summary List Counter Group Permissions
+ * Replace the counter group's entire sharing state in one call — the body
+ * is the full list of grants (all-initiative-members / per-user / per-role).
+ * Every non-owner grant is rebuilt from it; the owner is always preserved.
+ * @summary Set Counter Group Grants
  */
-export const listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet = (
+export const setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut = (
   guildId: number,
   groupId: number,
+  resourceGrantSchema: BodyType<ResourceGrantSchema[]>,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<ListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet200>(
-    { url: `/api/v1/g/${guildId}/counter-groups/${groupId}/permissions`, method: "GET", signal },
-    options
-  );
-};
-
-export const getListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGetQueryKey =
-  (guildId: number, groupId: number) => {
-    return [`/api/v1/g/${guildId}/counter-groups/${groupId}/permissions`] as const;
-  };
-
-export const getListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGetQueryOptions =
-  <
-    TData = Awaited<
-      ReturnType<typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet>
-    >,
-    TError = ErrorType<HTTPValidationError>,
-  >(
-    guildId: number,
-    groupId: number,
-    options?: {
-      query?: Partial<
-        UseQueryOptions<
-          Awaited<
-            ReturnType<
-              typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-            >
-          >,
-          TError,
-          TData
-        >
-      >;
-      request?: SecondParameter<typeof apiMutator>;
-    }
-  ) => {
-    const { query: queryOptions, request: requestOptions } = options ?? {};
-
-    const queryKey =
-      queryOptions?.queryKey ??
-      getListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGetQueryKey(
-        guildId,
-        groupId
-      );
-
-    const queryFn: QueryFunction<
-      Awaited<
-        ReturnType<
-          typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-        >
-      >
-    > = ({ signal }) =>
-      listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet(
-        guildId,
-        groupId,
-        requestOptions,
-        signal
-      );
-
-    return {
-      queryKey,
-      queryFn,
-      enabled:
-        guildId !== null && guildId !== undefined && groupId !== null && groupId !== undefined,
-      ...queryOptions,
-    } as UseQueryOptions<
-      Awaited<
-        ReturnType<
-          typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-        >
-      >,
-      TError,
-      TData
-    > & { queryKey: DataTag<QueryKey, TData, TError> };
-  };
-
-export type ListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGetQueryResult =
-  NonNullable<
-    Awaited<
-      ReturnType<typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet>
-    >
-  >;
-export type ListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGetQueryError =
-  ErrorType<HTTPValidationError>;
-
-export function useListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet<
-  TData = Awaited<
-    ReturnType<typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet>
-  >,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  groupId: number,
-  options: {
-    query: Partial<
-      UseQueryOptions<
-        Awaited<
-          ReturnType<
-            typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-          >
-        >,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<
-            ReturnType<
-              typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-            >
-          >,
-          TError,
-          Awaited<
-            ReturnType<
-              typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-            >
-          >
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet<
-  TData = Awaited<
-    ReturnType<typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet>
-  >,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  groupId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<
-          ReturnType<
-            typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-          >
-        >,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<
-            ReturnType<
-              typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-            >
-          >,
-          TError,
-          Awaited<
-            ReturnType<
-              typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-            >
-          >
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet<
-  TData = Awaited<
-    ReturnType<typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet>
-  >,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  groupId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<
-          ReturnType<
-            typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-          >
-        >,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-/**
- * @summary List Counter Group Permissions
- */
-
-export function useListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet<
-  TData = Awaited<
-    ReturnType<typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet>
-  >,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  groupId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<
-          ReturnType<
-            typeof listCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet
-          >
-        >,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions =
-    getListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGetQueryOptions(
-      guildId,
-      groupId,
-      options
-    );
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-
-  return { ...query, queryKey: queryOptions.queryKey };
-}
-
-/**
- * @summary Set Counter Group Permissions
- */
-export const setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut = (
-  guildId: number,
-  groupId: number,
-  counterGroupPermissionCreate: BodyType<CounterGroupPermissionCreate[]>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<CounterGroupPermissionRead[]>(
+  return apiMutator<CounterGroupRead>(
     {
-      url: `/api/v1/g/${guildId}/counter-groups/${groupId}/permissions`,
+      url: `/api/v1/g/${guildId}/counter-groups/${groupId}/grants`,
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      data: counterGroupPermissionCreate,
+      data: resourceGrantSchema,
       signal,
     },
     options
   );
 };
 
-export const getSetCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPutMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut>
-      >,
-      TError,
-      { guildId: number; groupId: number; data: BodyType<CounterGroupPermissionCreate[]> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<typeof setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut>
-    >,
+export const getSetCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPutMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut>>,
     TError,
-    { guildId: number; groupId: number; data: BodyType<CounterGroupPermissionCreate[]> },
+    { guildId: number; groupId: number; data: BodyType<ResourceGrantSchema[]> },
     TContext
-  > => {
-    const mutationKey = [
-      "setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut>>,
+  TError,
+  { guildId: number; groupId: number; data: BodyType<ResourceGrantSchema[]> },
+  TContext
+> => {
+  const mutationKey = ["setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
 
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut>
-      >,
-      { guildId: number; groupId: number; data: BodyType<CounterGroupPermissionCreate[]> }
-    > = (props) => {
-      const { guildId, groupId, data } = props ?? {};
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut>>,
+    { guildId: number; groupId: number; data: BodyType<ResourceGrantSchema[]> }
+  > = (props) => {
+    const { guildId, groupId, data } = props ?? {};
 
-      return setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut(
-        guildId,
-        groupId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
+    return setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut(
+      guildId,
+      groupId,
+      data,
+      requestOptions
+    );
   };
 
-export type SetCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPutMutationResult =
+  return { mutationFn, ...mutationOptions };
+};
+
+export type SetCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPutMutationResult =
   NonNullable<
-    Awaited<
-      ReturnType<typeof setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut>
-    >
+    Awaited<ReturnType<typeof setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut>>
   >;
-export type SetCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPutMutationBody =
-  BodyType<CounterGroupPermissionCreate[]>;
-export type SetCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPutMutationError =
+export type SetCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPutMutationBody = BodyType<
+  ResourceGrantSchema[]
+>;
+export type SetCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPutMutationError =
   ErrorType<HTTPValidationError>;
 
 /**
- * @summary Set Counter Group Permissions
+ * @summary Set Counter Group Grants
  */
-export const useSetCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut = <
+export const useSetCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut = <
   TError = ErrorType<HTTPValidationError>,
   TContext = unknown,
 >(
   options?: {
     mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut>
-      >,
+      Awaited<ReturnType<typeof setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut>>,
       TError,
-      { guildId: number; groupId: number; data: BodyType<CounterGroupPermissionCreate[]> },
+      { guildId: number; groupId: number; data: BodyType<ResourceGrantSchema[]> },
       TContext
     >;
     request?: SecondParameter<typeof apiMutator>;
   },
   queryClient?: QueryClient
 ): UseMutationResult<
-  Awaited<
-    ReturnType<typeof setCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPut>
-  >,
+  Awaited<ReturnType<typeof setCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPut>>,
   TError,
-  { guildId: number; groupId: number; data: BodyType<CounterGroupPermissionCreate[]> },
+  { guildId: number; groupId: number; data: BodyType<ResourceGrantSchema[]> },
   TContext
 > => {
   return useMutation(
-    getSetCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsPutMutationOptions(
-      options
-    ),
+    getSetCounterGroupGrantsApiV1GGuildIdCounterGroupsGroupIdGrantsPutMutationOptions(options),
     queryClient
   );
 };
-/**
- * @summary Set Counter Group Role Permissions
- */
-export const setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut = (
-  guildId: number,
-  groupId: number,
-  counterGroupRolePermissionCreate: BodyType<CounterGroupRolePermissionCreate[]>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<CounterGroupRolePermissionRead[]>(
-    {
-      url: `/api/v1/g/${guildId}/counter-groups/${groupId}/role-permissions`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: counterGroupRolePermissionCreate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getSetCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPutMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut
-        >
-      >,
-      TError,
-      { guildId: number; groupId: number; data: BodyType<CounterGroupRolePermissionCreate[]> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<
-        typeof setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut
-      >
-    >,
-    TError,
-    { guildId: number; groupId: number; data: BodyType<CounterGroupRolePermissionCreate[]> },
-    TContext
-  > => {
-    const mutationKey = [
-      "setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut
-        >
-      >,
-      { guildId: number; groupId: number; data: BodyType<CounterGroupRolePermissionCreate[]> }
-    > = (props) => {
-      const { guildId, groupId, data } = props ?? {};
-
-      return setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut(
-        guildId,
-        groupId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type SetCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPutMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<
-        typeof setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut
-      >
-    >
-  >;
-export type SetCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPutMutationBody =
-  BodyType<CounterGroupRolePermissionCreate[]>;
-export type SetCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPutMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Set Counter Group Role Permissions
- */
-export const useSetCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(
-    options?: {
-      mutation?: UseMutationOptions<
-        Awaited<
-          ReturnType<
-            typeof setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut
-          >
-        >,
-        TError,
-        { guildId: number; groupId: number; data: BodyType<CounterGroupRolePermissionCreate[]> },
-        TContext
-      >;
-      request?: SecondParameter<typeof apiMutator>;
-    },
-    queryClient?: QueryClient
-  ): UseMutationResult<
-    Awaited<
-      ReturnType<
-        typeof setCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPut
-      >
-    >,
-    TError,
-    { guildId: number; groupId: number; data: BodyType<CounterGroupRolePermissionCreate[]> },
-    TContext
-  > => {
-    return useMutation(
-      getSetCounterGroupRolePermissionsApiV1GGuildIdCounterGroupsGroupIdRolePermissionsPutMutationOptions(
-        options
-      ),
-      queryClient
-    );
-  };
 /**
  * @summary Record Counter Group View
  */

--- a/frontend/src/api/generated/documents/documents.ts
+++ b/frontend/src/api/generated/documents/documents.ts
@@ -33,15 +33,7 @@ import type {
   DocumentDuplicateRequest,
   DocumentFileVersionRead,
   DocumentListResponse,
-  DocumentPermissionBulkCreate,
-  DocumentPermissionBulkDelete,
-  DocumentPermissionCreate,
-  DocumentPermissionRead,
-  DocumentPermissionUpdate,
   DocumentRead,
-  DocumentRolePermissionCreate,
-  DocumentRolePermissionRead,
-  DocumentRolePermissionUpdate,
   DocumentUpdate,
   GenerateDocumentSummaryResponse,
   GetDocumentCountsApiV1GGuildIdDocumentsCountsGetParams,
@@ -50,6 +42,7 @@ import type {
   ListMyDocumentsApiV1MeDocumentsGetParams,
   PropertyValuesSetRequest,
   RecentViewWrite,
+  ResourceGrantSchema,
   TagSetRequest,
 } from "../initiativeAPI.schemas";
 
@@ -1990,590 +1983,6 @@ export const useCopyDocumentApiV1GGuildIdDocumentsDocumentIdCopyPost = <
   );
 };
 /**
- * Add a member to a document with specified permission level.
- * @summary Add Document Member
- */
-export const addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost = (
-  guildId: number,
-  documentId: number,
-  documentPermissionCreate: BodyType<DocumentPermissionCreate>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<DocumentPermissionRead>(
-    {
-      url: `/api/v1/g/${guildId}/documents/${documentId}/members`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: documentPermissionCreate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getAddDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPostMutationOptions = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost>>,
-    TError,
-    { guildId: number; documentId: number; data: BodyType<DocumentPermissionCreate> },
-    TContext
-  >;
-  request?: SecondParameter<typeof apiMutator>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost>>,
-  TError,
-  { guildId: number; documentId: number; data: BodyType<DocumentPermissionCreate> },
-  TContext
-> => {
-  const mutationKey = ["addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost"];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost>>,
-    { guildId: number; documentId: number; data: BodyType<DocumentPermissionCreate> }
-  > = (props) => {
-    const { guildId, documentId, data } = props ?? {};
-
-    return addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost(
-      guildId,
-      documentId,
-      data,
-      requestOptions
-    );
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type AddDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPostMutationResult =
-  NonNullable<
-    Awaited<ReturnType<typeof addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost>>
-  >;
-export type AddDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPostMutationBody =
-  BodyType<DocumentPermissionCreate>;
-export type AddDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPostMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Add Document Member
- */
-export const useAddDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost>>,
-      TError,
-      { guildId: number; documentId: number; data: BodyType<DocumentPermissionCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<ReturnType<typeof addDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPost>>,
-  TError,
-  { guildId: number; documentId: number; data: BodyType<DocumentPermissionCreate> },
-  TContext
-> => {
-  return useMutation(
-    getAddDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersPostMutationOptions(options),
-    queryClient
-  );
-};
-/**
- * Add multiple members to a document with the same permission level.
- * @summary Add Document Members Bulk
- */
-export const addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost = (
-  guildId: number,
-  documentId: number,
-  documentPermissionBulkCreate: BodyType<DocumentPermissionBulkCreate>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<DocumentPermissionRead[]>(
-    {
-      url: `/api/v1/g/${guildId}/documents/${documentId}/members/bulk`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: documentPermissionBulkCreate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getAddDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPostMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost>
-      >,
-      TError,
-      { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<typeof addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost>
-    >,
-    TError,
-    { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkCreate> },
-    TContext
-  > => {
-    const mutationKey = ["addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost"];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost>
-      >,
-      { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkCreate> }
-    > = (props) => {
-      const { guildId, documentId, data } = props ?? {};
-
-      return addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost(
-        guildId,
-        documentId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type AddDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPostMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<typeof addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost>
-    >
-  >;
-export type AddDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPostMutationBody =
-  BodyType<DocumentPermissionBulkCreate>;
-export type AddDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPostMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Add Document Members Bulk
- */
-export const useAddDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost>
-      >,
-      TError,
-      { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<ReturnType<typeof addDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPost>>,
-  TError,
-  { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkCreate> },
-  TContext
-> => {
-  return useMutation(
-    getAddDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkPostMutationOptions(
-      options
-    ),
-    queryClient
-  );
-};
-/**
- * Remove multiple members from a document.
- * @summary Remove Document Members Bulk
- */
-export const removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost = (
-  guildId: number,
-  documentId: number,
-  documentPermissionBulkDelete: BodyType<DocumentPermissionBulkDelete>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<void>(
-    {
-      url: `/api/v1/g/${guildId}/documents/${documentId}/members/bulk-delete`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: documentPermissionBulkDelete,
-      signal,
-    },
-    options
-  );
-};
-
-export const getRemoveDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePostMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost
-        >
-      >,
-      TError,
-      { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkDelete> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<
-        typeof removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost
-      >
-    >,
-    TError,
-    { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkDelete> },
-    TContext
-  > => {
-    const mutationKey = [
-      "removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost
-        >
-      >,
-      { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkDelete> }
-    > = (props) => {
-      const { guildId, documentId, data } = props ?? {};
-
-      return removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost(
-        guildId,
-        documentId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type RemoveDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePostMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<
-        typeof removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost
-      >
-    >
-  >;
-export type RemoveDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePostMutationBody =
-  BodyType<DocumentPermissionBulkDelete>;
-export type RemoveDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePostMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Remove Document Members Bulk
- */
-export const useRemoveDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost
-        >
-      >,
-      TError,
-      { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkDelete> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<
-    ReturnType<
-      typeof removeDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePost
-    >
-  >,
-  TError,
-  { guildId: number; documentId: number; data: BodyType<DocumentPermissionBulkDelete> },
-  TContext
-> => {
-  return useMutation(
-    getRemoveDocumentMembersBulkApiV1GGuildIdDocumentsDocumentIdMembersBulkDeletePostMutationOptions(
-      options
-    ),
-    queryClient
-  );
-};
-/**
- * Update a document member's permission level.
- * @summary Update Document Member
- */
-export const updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch = (
-  guildId: number,
-  documentId: number,
-  userId: number,
-  documentPermissionUpdate: BodyType<DocumentPermissionUpdate>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<DocumentPermissionRead>(
-    {
-      url: `/api/v1/g/${guildId}/documents/${documentId}/members/${userId}`,
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      data: documentPermissionUpdate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getUpdateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatchMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch>
-      >,
-      TError,
-      {
-        guildId: number;
-        documentId: number;
-        userId: number;
-        data: BodyType<DocumentPermissionUpdate>;
-      },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<typeof updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch>
-    >,
-    TError,
-    {
-      guildId: number;
-      documentId: number;
-      userId: number;
-      data: BodyType<DocumentPermissionUpdate>;
-    },
-    TContext
-  > => {
-    const mutationKey = ["updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch"];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch>
-      >,
-      {
-        guildId: number;
-        documentId: number;
-        userId: number;
-        data: BodyType<DocumentPermissionUpdate>;
-      }
-    > = (props) => {
-      const { guildId, documentId, userId, data } = props ?? {};
-
-      return updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch(
-        guildId,
-        documentId,
-        userId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type UpdateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatchMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<typeof updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch>
-    >
-  >;
-export type UpdateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatchMutationBody =
-  BodyType<DocumentPermissionUpdate>;
-export type UpdateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatchMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Update Document Member
- */
-export const useUpdateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch>
-      >,
-      TError,
-      {
-        guildId: number;
-        documentId: number;
-        userId: number;
-        data: BodyType<DocumentPermissionUpdate>;
-      },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<
-    ReturnType<typeof updateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatch>
-  >,
-  TError,
-  { guildId: number; documentId: number; userId: number; data: BodyType<DocumentPermissionUpdate> },
-  TContext
-> => {
-  return useMutation(
-    getUpdateDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdPatchMutationOptions(
-      options
-    ),
-    queryClient
-  );
-};
-/**
- * Remove a member's permission from a document.
- * @summary Remove Document Member
- */
-export const removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete = (
-  guildId: number,
-  documentId: number,
-  userId: number,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<void>(
-    {
-      url: `/api/v1/g/${guildId}/documents/${documentId}/members/${userId}`,
-      method: "DELETE",
-      signal,
-    },
-    options
-  );
-};
-
-export const getRemoveDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDeleteMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete>
-      >,
-      TError,
-      { guildId: number; documentId: number; userId: number },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<typeof removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete>
-    >,
-    TError,
-    { guildId: number; documentId: number; userId: number },
-    TContext
-  > => {
-    const mutationKey = ["removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete"];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete>
-      >,
-      { guildId: number; documentId: number; userId: number }
-    > = (props) => {
-      const { guildId, documentId, userId } = props ?? {};
-
-      return removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete(
-        guildId,
-        documentId,
-        userId,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type RemoveDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDeleteMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<typeof removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete>
-    >
-  >;
-
-export type RemoveDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDeleteMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Remove Document Member
- */
-export const useRemoveDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete>
-      >,
-      TError,
-      { guildId: number; documentId: number; userId: number },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<
-    ReturnType<typeof removeDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDelete>
-  >,
-  TError,
-  { guildId: number; documentId: number; userId: number },
-  TContext
-> => {
-  return useMutation(
-    getRemoveDocumentMemberApiV1GGuildIdDocumentsDocumentIdMembersUserIdDeleteMutationOptions(
-      options
-    ),
-    queryClient
-  );
-};
-/**
  * Notify users that they were mentioned in a document.
  * @summary Notify Mentions
  */
@@ -2998,406 +2407,108 @@ export const useSetDocumentPropertiesApiV1GGuildIdDocumentsDocumentIdPropertiesP
   );
 };
 /**
- * Add a role-based permission to a document.
- * @summary Add Document Role Permission
+ * Replace the document's entire sharing state in one call — the body is the
+ * full list of grants (all-initiative-members / per-user / per-role). Every
+ * non-owner grant is rebuilt from it; the owner is always preserved.
+ * @summary Set Document Grants
  */
-export const addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost = (
+export const setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut = (
   guildId: number,
   documentId: number,
-  documentRolePermissionCreate: BodyType<DocumentRolePermissionCreate>,
+  resourceGrantSchema: BodyType<ResourceGrantSchema[]>,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<DocumentRolePermissionRead>(
+  return apiMutator<DocumentRead>(
     {
-      url: `/api/v1/g/${guildId}/documents/${documentId}/role-permissions`,
-      method: "POST",
+      url: `/api/v1/g/${guildId}/documents/${documentId}/grants`,
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
-      data: documentRolePermissionCreate,
+      data: resourceGrantSchema,
       signal,
     },
     options
   );
 };
 
-export const getAddDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPostMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost
-        >
-      >,
-      TError,
-      { guildId: number; documentId: number; data: BodyType<DocumentRolePermissionCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<
-        typeof addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost
-      >
-    >,
+export const getSetDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPutMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut>>,
     TError,
-    { guildId: number; documentId: number; data: BodyType<DocumentRolePermissionCreate> },
+    { guildId: number; documentId: number; data: BodyType<ResourceGrantSchema[]> },
     TContext
-  > => {
-    const mutationKey = [
-      "addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut>>,
+  TError,
+  { guildId: number; documentId: number; data: BodyType<ResourceGrantSchema[]> },
+  TContext
+> => {
+  const mutationKey = ["setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
 
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost
-        >
-      >,
-      { guildId: number; documentId: number; data: BodyType<DocumentRolePermissionCreate> }
-    > = (props) => {
-      const { guildId, documentId, data } = props ?? {};
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut>>,
+    { guildId: number; documentId: number; data: BodyType<ResourceGrantSchema[]> }
+  > = (props) => {
+    const { guildId, documentId, data } = props ?? {};
 
-      return addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost(
-        guildId,
-        documentId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
+    return setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut(
+      guildId,
+      documentId,
+      data,
+      requestOptions
+    );
   };
 
-export type AddDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPostMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<
-        typeof addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost
-      >
-    >
-  >;
-export type AddDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPostMutationBody =
-  BodyType<DocumentRolePermissionCreate>;
-export type AddDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPostMutationError =
+  return { mutationFn, ...mutationOptions };
+};
+
+export type SetDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPutMutationResult = NonNullable<
+  Awaited<ReturnType<typeof setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut>>
+>;
+export type SetDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPutMutationBody = BodyType<
+  ResourceGrantSchema[]
+>;
+export type SetDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPutMutationError =
   ErrorType<HTTPValidationError>;
 
 /**
- * @summary Add Document Role Permission
+ * @summary Set Document Grants
  */
-export const useAddDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost = <
+export const useSetDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut = <
   TError = ErrorType<HTTPValidationError>,
   TContext = unknown,
 >(
   options?: {
     mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost
-        >
-      >,
+      Awaited<ReturnType<typeof setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut>>,
       TError,
-      { guildId: number; documentId: number; data: BodyType<DocumentRolePermissionCreate> },
+      { guildId: number; documentId: number; data: BodyType<ResourceGrantSchema[]> },
       TContext
     >;
     request?: SecondParameter<typeof apiMutator>;
   },
   queryClient?: QueryClient
 ): UseMutationResult<
-  Awaited<
-    ReturnType<typeof addDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPost>
-  >,
+  Awaited<ReturnType<typeof setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut>>,
   TError,
-  { guildId: number; documentId: number; data: BodyType<DocumentRolePermissionCreate> },
+  { guildId: number; documentId: number; data: BodyType<ResourceGrantSchema[]> },
   TContext
 > => {
   return useMutation(
-    getAddDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsPostMutationOptions(
-      options
-    ),
+    getSetDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPutMutationOptions(options),
     queryClient
   );
 };
-/**
- * Update a role-based permission level on a document.
- * @summary Update Document Role Permission
- */
-export const updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch =
-  (
-    guildId: number,
-    documentId: number,
-    roleId: number,
-    documentRolePermissionUpdate: BodyType<DocumentRolePermissionUpdate>,
-    options?: SecondParameter<typeof apiMutator>,
-    signal?: AbortSignal
-  ) => {
-    return apiMutator<DocumentRolePermissionRead>(
-      {
-        url: `/api/v1/g/${guildId}/documents/${documentId}/role-permissions/${roleId}`,
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        data: documentRolePermissionUpdate,
-        signal,
-      },
-      options
-    );
-  };
-
-export const getUpdateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatchMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch
-        >
-      >,
-      TError,
-      {
-        guildId: number;
-        documentId: number;
-        roleId: number;
-        data: BodyType<DocumentRolePermissionUpdate>;
-      },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<
-        typeof updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch
-      >
-    >,
-    TError,
-    {
-      guildId: number;
-      documentId: number;
-      roleId: number;
-      data: BodyType<DocumentRolePermissionUpdate>;
-    },
-    TContext
-  > => {
-    const mutationKey = [
-      "updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch
-        >
-      >,
-      {
-        guildId: number;
-        documentId: number;
-        roleId: number;
-        data: BodyType<DocumentRolePermissionUpdate>;
-      }
-    > = (props) => {
-      const { guildId, documentId, roleId, data } = props ?? {};
-
-      return updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch(
-        guildId,
-        documentId,
-        roleId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type UpdateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatchMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<
-        typeof updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch
-      >
-    >
-  >;
-export type UpdateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatchMutationBody =
-  BodyType<DocumentRolePermissionUpdate>;
-export type UpdateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatchMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Update Document Role Permission
- */
-export const useUpdateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(
-    options?: {
-      mutation?: UseMutationOptions<
-        Awaited<
-          ReturnType<
-            typeof updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch
-          >
-        >,
-        TError,
-        {
-          guildId: number;
-          documentId: number;
-          roleId: number;
-          data: BodyType<DocumentRolePermissionUpdate>;
-        },
-        TContext
-      >;
-      request?: SecondParameter<typeof apiMutator>;
-    },
-    queryClient?: QueryClient
-  ): UseMutationResult<
-    Awaited<
-      ReturnType<
-        typeof updateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatch
-      >
-    >,
-    TError,
-    {
-      guildId: number;
-      documentId: number;
-      roleId: number;
-      data: BodyType<DocumentRolePermissionUpdate>;
-    },
-    TContext
-  > => {
-    return useMutation(
-      getUpdateDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdPatchMutationOptions(
-        options
-      ),
-      queryClient
-    );
-  };
-/**
- * Remove a role-based permission from a document.
- * @summary Remove Document Role Permission
- */
-export const removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete =
-  (
-    guildId: number,
-    documentId: number,
-    roleId: number,
-    options?: SecondParameter<typeof apiMutator>,
-    signal?: AbortSignal
-  ) => {
-    return apiMutator<void>(
-      {
-        url: `/api/v1/g/${guildId}/documents/${documentId}/role-permissions/${roleId}`,
-        method: "DELETE",
-        signal,
-      },
-      options
-    );
-  };
-
-export const getRemoveDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDeleteMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete
-        >
-      >,
-      TError,
-      { guildId: number; documentId: number; roleId: number },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<
-        typeof removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete
-      >
-    >,
-    TError,
-    { guildId: number; documentId: number; roleId: number },
-    TContext
-  > => {
-    const mutationKey = [
-      "removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete
-        >
-      >,
-      { guildId: number; documentId: number; roleId: number }
-    > = (props) => {
-      const { guildId, documentId, roleId } = props ?? {};
-
-      return removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete(
-        guildId,
-        documentId,
-        roleId,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type RemoveDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDeleteMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<
-        typeof removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete
-      >
-    >
-  >;
-
-export type RemoveDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDeleteMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Remove Document Role Permission
- */
-export const useRemoveDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(
-    options?: {
-      mutation?: UseMutationOptions<
-        Awaited<
-          ReturnType<
-            typeof removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete
-          >
-        >,
-        TError,
-        { guildId: number; documentId: number; roleId: number },
-        TContext
-      >;
-      request?: SecondParameter<typeof apiMutator>;
-    },
-    queryClient?: QueryClient
-  ): UseMutationResult<
-    Awaited<
-      ReturnType<
-        typeof removeDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDelete
-      >
-    >,
-    TError,
-    { guildId: number; documentId: number; roleId: number },
-    TContext
-  > => {
-    return useMutation(
-      getRemoveDocumentRolePermissionApiV1GGuildIdDocumentsDocumentIdRolePermissionsRoleIdDeleteMutationOptions(
-        options
-      ),
-      queryClient
-    );
-  };
 /**
  * Record a recent-view for the layout tabs bar.
  * @summary Record Document View

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -453,6 +453,33 @@ export interface EventRecurrence {
   end_date?: string | null;
 }
 
+export type ResourceGrantSchemaLevel =
+  (typeof ResourceGrantSchemaLevel)[keyof typeof ResourceGrantSchemaLevel];
+
+export const ResourceGrantSchemaLevel = {
+  read: "read",
+  write: "write",
+  owner: "owner",
+} as const;
+
+/**
+ * One ``resource_grants`` row — exactly the columns that define a grant: a
+ * ``level`` for a user (``user_id``), an initiative role (``role_id``), or all
+ * initiative members (``all_initiative_members``). Exactly one grantee is set.
+ *
+ * The identical shape both reports a resource's grants (``grants`` is a list of
+ * these) and replaces them (the ``PUT /{id}/grants`` body) — no field is
+ * read-only or write-only. The server always preserves the resource's owner
+ * grant. Role display names are resolved client-side from the initiative's roles
+ * by ``role_id``.
+ */
+export interface ResourceGrantSchema {
+  level: ResourceGrantSchemaLevel;
+  user_id?: number | null;
+  role_id?: number | null;
+  all_initiative_members?: boolean;
+}
+
 export interface CalendarEventCreate {
   /**
    * @minLength 1
@@ -470,6 +497,7 @@ export interface CalendarEventCreate {
   attendee_ids?: number[] | null;
   tag_ids?: number[] | null;
   document_ids?: number[] | null;
+  grants?: ResourceGrantSchema[];
 }
 
 export interface CalendarEventDocumentRead {
@@ -559,6 +587,8 @@ export interface CalendarEventSummary {
   attendee_previews: CalendarEventAttendeePreview[];
   property_values: PropertySummary[];
   tags: TagSummary[];
+  grants: ResourceGrantSchema[];
+  my_permission_level: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -597,6 +627,8 @@ export interface CalendarEventRead {
   attendee_previews: CalendarEventAttendeePreview[];
   property_values: PropertySummary[];
   tags: TagSummary[];
+  grants: ResourceGrantSchema[];
+  my_permission_level: string | null;
   created_at: string;
   updated_at: string;
   attendees: CalendarEventAttendeeRead[];
@@ -673,25 +705,6 @@ export interface CounterCreate {
   position?: number | string;
 }
 
-export type CounterPermissionLevel =
-  (typeof CounterPermissionLevel)[keyof typeof CounterPermissionLevel];
-
-export const CounterPermissionLevel = {
-  owner: "owner",
-  write: "write",
-  read: "read",
-} as const;
-
-export interface CounterGroupRolePermissionCreate {
-  initiative_role_id: number;
-  level?: CounterPermissionLevel;
-}
-
-export interface CounterGroupPermissionCreate {
-  user_id: number;
-  level?: CounterPermissionLevel;
-}
-
 export interface CounterGroupCreate {
   /**
    * @minLength 1
@@ -700,8 +713,7 @@ export interface CounterGroupCreate {
   name: string;
   description?: string | null;
   initiative_id: number;
-  role_permissions?: CounterGroupRolePermissionCreate[] | null;
-  user_permissions?: CounterGroupPermissionCreate[] | null;
+  grants?: ResourceGrantSchema[];
 }
 
 export interface CounterGroupDuplicateRequest {
@@ -733,12 +745,6 @@ export interface CounterGroupListResponse {
   has_next: boolean;
 }
 
-export interface CounterGroupPermissionRead {
-  user_id: number;
-  level: CounterPermissionLevel;
-  created_at: string;
-}
-
 /**
  * Serialized counter. Numeric fields are returned as plain decimal
  * strings (e.g. "0", "12.5") rather than ``Decimal`` so JSON never emits
@@ -762,14 +768,6 @@ export interface CounterRead {
   updated_at: string;
 }
 
-export interface CounterGroupRolePermissionRead {
-  initiative_role_id: number;
-  role_name: string;
-  role_display_name: string;
-  level: CounterPermissionLevel;
-  created_at: string;
-}
-
 export interface CounterGroupRead {
   /**
    * @minLength 1
@@ -786,8 +784,7 @@ export interface CounterGroupRead {
   created_at: string;
   updated_at: string;
   counters: CounterRead[];
-  permissions: CounterGroupPermissionRead[];
-  role_permissions: CounterGroupRolePermissionRead[];
+  grants: ResourceGrantSchema[];
 }
 
 export interface CounterGroupUpdate {
@@ -915,25 +912,6 @@ export const DocumentCreateDocumentType = {
   spreadsheet: "spreadsheet",
 } as const;
 
-export type DocumentPermissionLevel =
-  (typeof DocumentPermissionLevel)[keyof typeof DocumentPermissionLevel];
-
-export const DocumentPermissionLevel = {
-  owner: "owner",
-  write: "write",
-  read: "read",
-} as const;
-
-export interface DocumentRolePermissionCreate {
-  initiative_role_id: number;
-  level?: DocumentPermissionLevel;
-}
-
-export interface DocumentPermissionCreate {
-  user_id: number;
-  level?: DocumentPermissionLevel;
-}
-
 export interface DocumentCreate {
   title: string;
   initiative_id: number;
@@ -941,8 +919,7 @@ export interface DocumentCreate {
   is_template?: boolean;
   content?: DocumentCreateContent;
   document_type?: DocumentCreateDocumentType;
-  role_permissions?: DocumentRolePermissionCreate[] | null;
-  user_permissions?: DocumentPermissionCreate[] | null;
+  grants?: ResourceGrantSchema[];
 }
 
 export interface DocumentDuplicateRequest {
@@ -1014,20 +991,6 @@ export interface DocumentProjectLink {
   attached_at: string;
 }
 
-export interface DocumentPermissionRead {
-  user_id: number;
-  level: DocumentPermissionLevel;
-  created_at: string;
-}
-
-export interface DocumentRolePermissionRead {
-  initiative_role_id: number;
-  role_name: string;
-  role_display_name: string;
-  level: DocumentPermissionLevel;
-  created_at: string;
-}
-
 export type DocumentSummaryDocumentType =
   (typeof DocumentSummaryDocumentType)[keyof typeof DocumentSummaryDocumentType];
 
@@ -1053,8 +1016,7 @@ export interface DocumentSummary {
   initiative: InitiativeRead | null;
   projects: DocumentProjectLink[];
   comment_count: number;
-  permissions: DocumentPermissionRead[];
-  role_permissions: DocumentRolePermissionRead[];
+  grants: ResourceGrantSchema[];
   tags: TagSummary[];
   properties: PropertySummary[];
   document_type: DocumentSummaryDocumentType;
@@ -1075,19 +1037,6 @@ export interface DocumentListResponse {
   has_next: boolean;
   sort_by: string | null;
   sort_dir: string | null;
-}
-
-export interface DocumentPermissionBulkCreate {
-  user_ids: number[];
-  level?: DocumentPermissionLevel;
-}
-
-export interface DocumentPermissionBulkDelete {
-  user_ids: number[];
-}
-
-export interface DocumentPermissionUpdate {
-  level: DocumentPermissionLevel;
 }
 
 export type DocumentReadDocumentType =
@@ -1117,8 +1066,7 @@ export interface DocumentRead {
   initiative: InitiativeRead | null;
   projects: DocumentProjectLink[];
   comment_count: number;
-  permissions: DocumentPermissionRead[];
-  role_permissions: DocumentRolePermissionRead[];
+  grants: ResourceGrantSchema[];
   tags: TagSummary[];
   properties: PropertySummary[];
   document_type: DocumentReadDocumentType;
@@ -1130,10 +1078,6 @@ export interface DocumentRead {
   my_permission_level: string | null;
   yjs_updated_at: string | null;
   content: DocumentReadContent;
-}
-
-export interface DocumentRolePermissionUpdate {
-  level: DocumentPermissionLevel;
 }
 
 export type DocumentUpdateContent = { [key: string]: unknown } | null;
@@ -1815,25 +1759,6 @@ export interface ProjectActivityResponse {
   next_page: number | null;
 }
 
-export type ProjectPermissionLevel =
-  (typeof ProjectPermissionLevel)[keyof typeof ProjectPermissionLevel];
-
-export const ProjectPermissionLevel = {
-  owner: "owner",
-  write: "write",
-  read: "read",
-} as const;
-
-export interface ProjectRolePermissionCreate {
-  initiative_role_id: number;
-  level?: ProjectPermissionLevel;
-}
-
-export interface ProjectPermissionCreate {
-  user_id: number;
-  level?: ProjectPermissionLevel;
-}
-
 export interface ProjectCreate {
   name: string;
   description?: string | null;
@@ -1842,8 +1767,7 @@ export interface ProjectCreate {
   initiative_id?: number | null;
   is_template?: boolean;
   template_id?: number | null;
-  role_permissions?: ProjectRolePermissionCreate[] | null;
-  user_permissions?: ProjectPermissionCreate[] | null;
+  grants?: ResourceGrantSchema[];
 }
 
 export interface ProjectDocumentSummary {
@@ -2026,20 +1950,6 @@ export interface ProjectImportResult {
   assignee_unmatched_emails?: string[];
 }
 
-export interface ProjectPermissionRead {
-  user_id: number;
-  level: ProjectPermissionLevel;
-  created_at: string;
-}
-
-export interface ProjectRolePermissionRead {
-  initiative_role_id: number;
-  role_name: string;
-  role_display_name: string;
-  level: ProjectPermissionLevel;
-  created_at: string;
-}
-
 export interface ProjectTaskSummary {
   total: number;
   completed: number;
@@ -2060,8 +1970,6 @@ export interface ProjectRead {
   pinned_at: string | null;
   owner: UserPublic | null;
   initiative: InitiativeRead | null;
-  permissions: ProjectPermissionRead[];
-  role_permissions: ProjectRolePermissionRead[];
   sort_order: number | null;
   is_favorited: boolean;
   last_viewed_at: string | null;
@@ -2069,6 +1977,7 @@ export interface ProjectRead {
   task_summary: ProjectTaskSummary;
   tags: TagSummary[];
   my_permission_level: string | null;
+  grants: ResourceGrantSchema[];
 }
 
 export interface ProjectListResponse {
@@ -2079,25 +1988,8 @@ export interface ProjectListResponse {
   has_next: boolean;
 }
 
-export interface ProjectPermissionBulkCreate {
-  user_ids: number[];
-  level?: ProjectPermissionLevel;
-}
-
-export interface ProjectPermissionBulkDelete {
-  user_ids: number[];
-}
-
-export interface ProjectPermissionUpdate {
-  level: ProjectPermissionLevel;
-}
-
 export interface ProjectReorderRequest {
   project_ids?: number[];
-}
-
-export interface ProjectRolePermissionUpdate {
-  level: ProjectPermissionLevel;
 }
 
 export interface ProjectUpdate {
@@ -2247,24 +2139,6 @@ export interface PushTokenUnregisterRequest {
   push_token: string;
 }
 
-export type QueuePermissionLevel = (typeof QueuePermissionLevel)[keyof typeof QueuePermissionLevel];
-
-export const QueuePermissionLevel = {
-  owner: "owner",
-  write: "write",
-  read: "read",
-} as const;
-
-export interface QueueRolePermissionCreate {
-  initiative_role_id: number;
-  level?: QueuePermissionLevel;
-}
-
-export interface QueuePermissionCreate {
-  user_id: number;
-  level?: QueuePermissionLevel;
-}
-
 export interface QueueCreate {
   /**
    * @minLength 1
@@ -2273,8 +2147,7 @@ export interface QueueCreate {
   name: string;
   description?: string | null;
   initiative_id: number;
-  role_permissions?: QueueRolePermissionCreate[] | null;
-  user_permissions?: QueuePermissionCreate[] | null;
+  grants?: ResourceGrantSchema[];
 }
 
 export interface QueueItemCreate {
@@ -2371,20 +2244,6 @@ export interface QueueListResponse {
   has_next: boolean;
 }
 
-export interface QueuePermissionRead {
-  user_id: number;
-  level: QueuePermissionLevel;
-  created_at: string;
-}
-
-export interface QueueRolePermissionRead {
-  initiative_role_id: number;
-  role_name: string;
-  role_display_name: string;
-  level: QueuePermissionLevel;
-  created_at: string;
-}
-
 export interface QueueRead {
   /**
    * @minLength 1
@@ -2404,8 +2263,7 @@ export interface QueueRead {
   my_permission_level: string | null;
   items: QueueItemRead[];
   current_item: QueueItemRead | null;
-  permissions: QueuePermissionRead[];
-  role_permissions: QueueRolePermissionRead[];
+  grants: ResourceGrantSchema[];
 }
 
 /**
@@ -3846,10 +3704,6 @@ export type ListQueuesApiV1GGuildIdQueuesGetParams = {
   page_size?: number;
 };
 
-export type ListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet200 = {
-  [key: string]: unknown;
-};
-
 export type ListCounterGroupsApiV1GGuildIdCounterGroupsGetParams = {
   initiative_id?: number | null;
   /**
@@ -3861,10 +3715,6 @@ export type ListCounterGroupsApiV1GGuildIdCounterGroupsGetParams = {
    * @maximum 100
    */
   page_size?: number;
-};
-
-export type ListCounterGroupPermissionsApiV1GGuildIdCounterGroupsGroupIdPermissionsGet200 = {
-  [key: string]: unknown;
 };
 
 export type ExportCalendarEventsIcsApiV1GGuildIdCalendarEventsExportIcsGetParams = {

--- a/frontend/src/api/generated/projects/projects.ts
+++ b/frontend/src/api/generated/projects/projects.ts
@@ -33,18 +33,11 @@ import type {
   ProjectImportRequest,
   ProjectImportResult,
   ProjectListResponse,
-  ProjectPermissionBulkCreate,
-  ProjectPermissionBulkDelete,
-  ProjectPermissionCreate,
-  ProjectPermissionRead,
-  ProjectPermissionUpdate,
   ProjectRead,
   ProjectReorderRequest,
-  ProjectRolePermissionCreate,
-  ProjectRolePermissionRead,
-  ProjectRolePermissionUpdate,
   ProjectUpdate,
   RecentViewWrite,
+  ResourceGrantSchema,
   TagSetRequest,
 } from "../initiativeAPI.schemas";
 
@@ -2075,556 +2068,6 @@ export const useDetachProjectDocumentApiV1GGuildIdProjectsProjectIdDocumentsDocu
   );
 };
 /**
- * @summary Add Project Member
- */
-export const addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost = (
-  guildId: number,
-  projectId: number,
-  projectPermissionCreate: BodyType<ProjectPermissionCreate>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<ProjectPermissionRead>(
-    {
-      url: `/api/v1/g/${guildId}/projects/${projectId}/members`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: projectPermissionCreate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getAddProjectMemberApiV1GGuildIdProjectsProjectIdMembersPostMutationOptions = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost>>,
-    TError,
-    { guildId: number; projectId: number; data: BodyType<ProjectPermissionCreate> },
-    TContext
-  >;
-  request?: SecondParameter<typeof apiMutator>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost>>,
-  TError,
-  { guildId: number; projectId: number; data: BodyType<ProjectPermissionCreate> },
-  TContext
-> => {
-  const mutationKey = ["addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost"];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost>>,
-    { guildId: number; projectId: number; data: BodyType<ProjectPermissionCreate> }
-  > = (props) => {
-    const { guildId, projectId, data } = props ?? {};
-
-    return addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost(
-      guildId,
-      projectId,
-      data,
-      requestOptions
-    );
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type AddProjectMemberApiV1GGuildIdProjectsProjectIdMembersPostMutationResult = NonNullable<
-  Awaited<ReturnType<typeof addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost>>
->;
-export type AddProjectMemberApiV1GGuildIdProjectsProjectIdMembersPostMutationBody =
-  BodyType<ProjectPermissionCreate>;
-export type AddProjectMemberApiV1GGuildIdProjectsProjectIdMembersPostMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Add Project Member
- */
-export const useAddProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost>>,
-      TError,
-      { guildId: number; projectId: number; data: BodyType<ProjectPermissionCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<ReturnType<typeof addProjectMemberApiV1GGuildIdProjectsProjectIdMembersPost>>,
-  TError,
-  { guildId: number; projectId: number; data: BodyType<ProjectPermissionCreate> },
-  TContext
-> => {
-  return useMutation(
-    getAddProjectMemberApiV1GGuildIdProjectsProjectIdMembersPostMutationOptions(options),
-    queryClient
-  );
-};
-/**
- * Add multiple members to a project with the same permission level.
- * @summary Add Project Members Bulk
- */
-export const addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost = (
-  guildId: number,
-  projectId: number,
-  projectPermissionBulkCreate: BodyType<ProjectPermissionBulkCreate>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<ProjectPermissionRead[]>(
-    {
-      url: `/api/v1/g/${guildId}/projects/${projectId}/members/bulk`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: projectPermissionBulkCreate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getAddProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPostMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost>
-      >,
-      TError,
-      { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<ReturnType<typeof addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost>>,
-    TError,
-    { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkCreate> },
-    TContext
-  > => {
-    const mutationKey = ["addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost"];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost>
-      >,
-      { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkCreate> }
-    > = (props) => {
-      const { guildId, projectId, data } = props ?? {};
-
-      return addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost(
-        guildId,
-        projectId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type AddProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPostMutationResult =
-  NonNullable<
-    Awaited<ReturnType<typeof addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost>>
-  >;
-export type AddProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPostMutationBody =
-  BodyType<ProjectPermissionBulkCreate>;
-export type AddProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPostMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Add Project Members Bulk
- */
-export const useAddProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost>
-      >,
-      TError,
-      { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<ReturnType<typeof addProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPost>>,
-  TError,
-  { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkCreate> },
-  TContext
-> => {
-  return useMutation(
-    getAddProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkPostMutationOptions(options),
-    queryClient
-  );
-};
-/**
- * Remove multiple members from a project.
- * @summary Remove Project Members Bulk
- */
-export const removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost = (
-  guildId: number,
-  projectId: number,
-  projectPermissionBulkDelete: BodyType<ProjectPermissionBulkDelete>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<void>(
-    {
-      url: `/api/v1/g/${guildId}/projects/${projectId}/members/bulk-delete`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: projectPermissionBulkDelete,
-      signal,
-    },
-    options
-  );
-};
-
-export const getRemoveProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePostMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost
-        >
-      >,
-      TError,
-      { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkDelete> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<typeof removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost>
-    >,
-    TError,
-    { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkDelete> },
-    TContext
-  > => {
-    const mutationKey = [
-      "removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost
-        >
-      >,
-      { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkDelete> }
-    > = (props) => {
-      const { guildId, projectId, data } = props ?? {};
-
-      return removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost(
-        guildId,
-        projectId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type RemoveProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePostMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<typeof removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost>
-    >
-  >;
-export type RemoveProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePostMutationBody =
-  BodyType<ProjectPermissionBulkDelete>;
-export type RemoveProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePostMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Remove Project Members Bulk
- */
-export const useRemoveProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost
-        >
-      >,
-      TError,
-      { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkDelete> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<
-    ReturnType<typeof removeProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePost>
-  >,
-  TError,
-  { guildId: number; projectId: number; data: BodyType<ProjectPermissionBulkDelete> },
-  TContext
-> => {
-  return useMutation(
-    getRemoveProjectMembersBulkApiV1GGuildIdProjectsProjectIdMembersBulkDeletePostMutationOptions(
-      options
-    ),
-    queryClient
-  );
-};
-/**
- * Update a project member's permission level.
- * @summary Update Project Member
- */
-export const updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch = (
-  guildId: number,
-  projectId: number,
-  userId: number,
-  projectPermissionUpdate: BodyType<ProjectPermissionUpdate>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<ProjectPermissionRead>(
-    {
-      url: `/api/v1/g/${guildId}/projects/${projectId}/members/${userId}`,
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      data: projectPermissionUpdate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getUpdateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatchMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch>
-      >,
-      TError,
-      {
-        guildId: number;
-        projectId: number;
-        userId: number;
-        data: BodyType<ProjectPermissionUpdate>;
-      },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<ReturnType<typeof updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch>>,
-    TError,
-    { guildId: number; projectId: number; userId: number; data: BodyType<ProjectPermissionUpdate> },
-    TContext
-  > => {
-    const mutationKey = ["updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch"];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch>
-      >,
-      {
-        guildId: number;
-        projectId: number;
-        userId: number;
-        data: BodyType<ProjectPermissionUpdate>;
-      }
-    > = (props) => {
-      const { guildId, projectId, userId, data } = props ?? {};
-
-      return updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch(
-        guildId,
-        projectId,
-        userId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type UpdateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatchMutationResult =
-  NonNullable<
-    Awaited<ReturnType<typeof updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch>>
-  >;
-export type UpdateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatchMutationBody =
-  BodyType<ProjectPermissionUpdate>;
-export type UpdateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatchMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Update Project Member
- */
-export const useUpdateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch>
-      >,
-      TError,
-      {
-        guildId: number;
-        projectId: number;
-        userId: number;
-        data: BodyType<ProjectPermissionUpdate>;
-      },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<ReturnType<typeof updateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatch>>,
-  TError,
-  { guildId: number; projectId: number; userId: number; data: BodyType<ProjectPermissionUpdate> },
-  TContext
-> => {
-  return useMutation(
-    getUpdateProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdPatchMutationOptions(options),
-    queryClient
-  );
-};
-/**
- * @summary Remove Project Member
- */
-export const removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete = (
-  guildId: number,
-  projectId: number,
-  userId: number,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<void>(
-    {
-      url: `/api/v1/g/${guildId}/projects/${projectId}/members/${userId}`,
-      method: "DELETE",
-      signal,
-    },
-    options
-  );
-};
-
-export const getRemoveProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDeleteMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete>
-      >,
-      TError,
-      { guildId: number; projectId: number; userId: number },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<typeof removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete>
-    >,
-    TError,
-    { guildId: number; projectId: number; userId: number },
-    TContext
-  > => {
-    const mutationKey = ["removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete"];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete>
-      >,
-      { guildId: number; projectId: number; userId: number }
-    > = (props) => {
-      const { guildId, projectId, userId } = props ?? {};
-
-      return removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete(
-        guildId,
-        projectId,
-        userId,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type RemoveProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDeleteMutationResult =
-  NonNullable<
-    Awaited<ReturnType<typeof removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete>>
-  >;
-
-export type RemoveProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDeleteMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Remove Project Member
- */
-export const useRemoveProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete>
-      >,
-      TError,
-      { guildId: number; projectId: number; userId: number },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<ReturnType<typeof removeProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDelete>>,
-  TError,
-  { guildId: number; projectId: number; userId: number },
-  TContext
-> => {
-  return useMutation(
-    getRemoveProjectMemberApiV1GGuildIdProjectsProjectIdMembersUserIdDeleteMutationOptions(options),
-    queryClient
-  );
-};
-/**
  * @summary Reorder Projects
  */
 export const reorderProjectsApiV1GGuildIdProjectsReorderPost = (
@@ -2818,395 +2261,108 @@ export const useSetProjectTagsApiV1GGuildIdProjectsProjectIdTagsPut = <
   );
 };
 /**
- * Add a role-based permission to a project.
- * @summary Add Project Role Permission
+ * Replace the project's entire sharing state in one call — the body is the
+ * full list of grants (all-initiative-members / per-user / per-role). Every
+ * non-owner grant is rebuilt from it; the owner is always preserved.
+ * @summary Set Project Grants
  */
-export const addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost = (
+export const setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut = (
   guildId: number,
   projectId: number,
-  projectRolePermissionCreate: BodyType<ProjectRolePermissionCreate>,
+  resourceGrantSchema: BodyType<ResourceGrantSchema[]>,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<ProjectRolePermissionRead>(
+  return apiMutator<ProjectRead>(
     {
-      url: `/api/v1/g/${guildId}/projects/${projectId}/role-permissions`,
-      method: "POST",
+      url: `/api/v1/g/${guildId}/projects/${projectId}/grants`,
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
-      data: projectRolePermissionCreate,
+      data: resourceGrantSchema,
       signal,
     },
     options
   );
 };
 
-export const getAddProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPostMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost>
-      >,
-      TError,
-      { guildId: number; projectId: number; data: BodyType<ProjectRolePermissionCreate> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<typeof addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost>
-    >,
+export const getSetProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPutMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut>>,
     TError,
-    { guildId: number; projectId: number; data: BodyType<ProjectRolePermissionCreate> },
+    { guildId: number; projectId: number; data: BodyType<ResourceGrantSchema[]> },
     TContext
-  > => {
-    const mutationKey = [
-      "addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut>>,
+  TError,
+  { guildId: number; projectId: number; data: BodyType<ResourceGrantSchema[]> },
+  TContext
+> => {
+  const mutationKey = ["setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
 
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost>
-      >,
-      { guildId: number; projectId: number; data: BodyType<ProjectRolePermissionCreate> }
-    > = (props) => {
-      const { guildId, projectId, data } = props ?? {};
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut>>,
+    { guildId: number; projectId: number; data: BodyType<ResourceGrantSchema[]> }
+  > = (props) => {
+    const { guildId, projectId, data } = props ?? {};
 
-      return addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost(
-        guildId,
-        projectId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
+    return setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut(
+      guildId,
+      projectId,
+      data,
+      requestOptions
+    );
   };
 
-export type AddProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPostMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<typeof addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost>
-    >
-  >;
-export type AddProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPostMutationBody =
-  BodyType<ProjectRolePermissionCreate>;
-export type AddProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPostMutationError =
+  return { mutationFn, ...mutationOptions };
+};
+
+export type SetProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPutMutationResult = NonNullable<
+  Awaited<ReturnType<typeof setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut>>
+>;
+export type SetProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPutMutationBody = BodyType<
+  ResourceGrantSchema[]
+>;
+export type SetProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPutMutationError =
   ErrorType<HTTPValidationError>;
 
 /**
- * @summary Add Project Role Permission
+ * @summary Set Project Grants
  */
-export const useAddProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost = <
+export const useSetProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut = <
   TError = ErrorType<HTTPValidationError>,
   TContext = unknown,
 >(
   options?: {
     mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost>
-      >,
+      Awaited<ReturnType<typeof setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut>>,
       TError,
-      { guildId: number; projectId: number; data: BodyType<ProjectRolePermissionCreate> },
+      { guildId: number; projectId: number; data: BodyType<ResourceGrantSchema[]> },
       TContext
     >;
     request?: SecondParameter<typeof apiMutator>;
   },
   queryClient?: QueryClient
 ): UseMutationResult<
-  Awaited<
-    ReturnType<typeof addProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPost>
-  >,
+  Awaited<ReturnType<typeof setProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPut>>,
   TError,
-  { guildId: number; projectId: number; data: BodyType<ProjectRolePermissionCreate> },
+  { guildId: number; projectId: number; data: BodyType<ResourceGrantSchema[]> },
   TContext
 > => {
   return useMutation(
-    getAddProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsPostMutationOptions(
-      options
-    ),
+    getSetProjectGrantsApiV1GGuildIdProjectsProjectIdGrantsPutMutationOptions(options),
     queryClient
   );
 };
-/**
- * Update a role-based permission level on a project.
- * @summary Update Project Role Permission
- */
-export const updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch = (
-  guildId: number,
-  projectId: number,
-  roleId: number,
-  projectRolePermissionUpdate: BodyType<ProjectRolePermissionUpdate>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<ProjectRolePermissionRead>(
-    {
-      url: `/api/v1/g/${guildId}/projects/${projectId}/role-permissions/${roleId}`,
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      data: projectRolePermissionUpdate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getUpdateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatchMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch
-        >
-      >,
-      TError,
-      {
-        guildId: number;
-        projectId: number;
-        roleId: number;
-        data: BodyType<ProjectRolePermissionUpdate>;
-      },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<
-        typeof updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch
-      >
-    >,
-    TError,
-    {
-      guildId: number;
-      projectId: number;
-      roleId: number;
-      data: BodyType<ProjectRolePermissionUpdate>;
-    },
-    TContext
-  > => {
-    const mutationKey = [
-      "updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch
-        >
-      >,
-      {
-        guildId: number;
-        projectId: number;
-        roleId: number;
-        data: BodyType<ProjectRolePermissionUpdate>;
-      }
-    > = (props) => {
-      const { guildId, projectId, roleId, data } = props ?? {};
-
-      return updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch(
-        guildId,
-        projectId,
-        roleId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type UpdateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatchMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<
-        typeof updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch
-      >
-    >
-  >;
-export type UpdateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatchMutationBody =
-  BodyType<ProjectRolePermissionUpdate>;
-export type UpdateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatchMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Update Project Role Permission
- */
-export const useUpdateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(
-    options?: {
-      mutation?: UseMutationOptions<
-        Awaited<
-          ReturnType<
-            typeof updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch
-          >
-        >,
-        TError,
-        {
-          guildId: number;
-          projectId: number;
-          roleId: number;
-          data: BodyType<ProjectRolePermissionUpdate>;
-        },
-        TContext
-      >;
-      request?: SecondParameter<typeof apiMutator>;
-    },
-    queryClient?: QueryClient
-  ): UseMutationResult<
-    Awaited<
-      ReturnType<
-        typeof updateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatch
-      >
-    >,
-    TError,
-    {
-      guildId: number;
-      projectId: number;
-      roleId: number;
-      data: BodyType<ProjectRolePermissionUpdate>;
-    },
-    TContext
-  > => {
-    return useMutation(
-      getUpdateProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdPatchMutationOptions(
-        options
-      ),
-      queryClient
-    );
-  };
-/**
- * Remove a role-based permission from a project.
- * @summary Remove Project Role Permission
- */
-export const removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete =
-  (
-    guildId: number,
-    projectId: number,
-    roleId: number,
-    options?: SecondParameter<typeof apiMutator>,
-    signal?: AbortSignal
-  ) => {
-    return apiMutator<void>(
-      {
-        url: `/api/v1/g/${guildId}/projects/${projectId}/role-permissions/${roleId}`,
-        method: "DELETE",
-        signal,
-      },
-      options
-    );
-  };
-
-export const getRemoveProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDeleteMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<
-          typeof removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete
-        >
-      >,
-      TError,
-      { guildId: number; projectId: number; roleId: number },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<
-      ReturnType<
-        typeof removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete
-      >
-    >,
-    TError,
-    { guildId: number; projectId: number; roleId: number },
-    TContext
-  > => {
-    const mutationKey = [
-      "removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete",
-    ];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<
-          typeof removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete
-        >
-      >,
-      { guildId: number; projectId: number; roleId: number }
-    > = (props) => {
-      const { guildId, projectId, roleId } = props ?? {};
-
-      return removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete(
-        guildId,
-        projectId,
-        roleId,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type RemoveProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDeleteMutationResult =
-  NonNullable<
-    Awaited<
-      ReturnType<
-        typeof removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete
-      >
-    >
-  >;
-
-export type RemoveProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDeleteMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Remove Project Role Permission
- */
-export const useRemoveProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(
-    options?: {
-      mutation?: UseMutationOptions<
-        Awaited<
-          ReturnType<
-            typeof removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete
-          >
-        >,
-        TError,
-        { guildId: number; projectId: number; roleId: number },
-        TContext
-      >;
-      request?: SecondParameter<typeof apiMutator>;
-    },
-    queryClient?: QueryClient
-  ): UseMutationResult<
-    Awaited<
-      ReturnType<
-        typeof removeProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDelete
-      >
-    >,
-    TError,
-    { guildId: number; projectId: number; roleId: number },
-    TContext
-  > => {
-    return useMutation(
-      getRemoveProjectRolePermissionApiV1GGuildIdProjectsProjectIdRolePermissionsRoleIdDeleteMutationOptions(
-        options
-      ),
-      queryClient
-    );
-  };
 /**
  * Serialize a project to a self-contained JSON envelope.
  *

--- a/frontend/src/api/generated/queues/queues.ts
+++ b/frontend/src/api/generated/queues/queues.ts
@@ -22,7 +22,6 @@ import type {
 
 import type {
   HTTPValidationError,
-  ListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet200,
   ListQueuesApiV1GGuildIdQueuesGetParams,
   QueueCreate,
   QueueItemCreate,
@@ -30,14 +29,11 @@ import type {
   QueueItemReorderRequest,
   QueueItemUpdate,
   QueueListResponse,
-  QueuePermissionCreate,
-  QueuePermissionRead,
   QueueRead,
   QueueReleaseRequest,
-  QueueRolePermissionCreate,
-  QueueRolePermissionRead,
   QueueUpdate,
   RecentViewWrite,
+  ResourceGrantSchema,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -2087,227 +2083,48 @@ export const useSetQueueItemTasksApiV1GGuildIdQueuesQueueIdItemsItemIdTasksPut =
   );
 };
 /**
- * List user and role permissions on a queue. Requires read access.
- * @summary List Queue Permissions
+ * Replace the queue's entire sharing state in one call — the body is the
+ * full list of grants (all-initiative-members / per-user / per-role). Every
+ * non-owner grant is rebuilt from it; the owner is always preserved.
+ * @summary Set Queue Grants
  */
-export const listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet = (
+export const setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut = (
   guildId: number,
   queueId: number,
+  resourceGrantSchema: BodyType<ResourceGrantSchema[]>,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<ListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet200>(
-    { url: `/api/v1/g/${guildId}/queues/${queueId}/permissions`, method: "GET", signal },
-    options
-  );
-};
-
-export const getListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGetQueryKey = (
-  guildId: number,
-  queueId: number
-) => {
-  return [`/api/v1/g/${guildId}/queues/${queueId}/permissions`] as const;
-};
-
-export const getListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGetQueryOptions = <
-  TData = Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  queueId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey =
-    queryOptions?.queryKey ??
-    getListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGetQueryKey(guildId, queueId);
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>
-  > = ({ signal }) =>
-    listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet(
-      guildId,
-      queueId,
-      requestOptions,
-      signal
-    );
-
-  return {
-    queryKey,
-    queryFn,
-    enabled: guildId !== null && guildId !== undefined && queueId !== null && queueId !== undefined,
-    ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-    TError,
-    TData
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-};
-
-export type ListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGetQueryResult = NonNullable<
-  Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>
->;
-export type ListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGetQueryError =
-  ErrorType<HTTPValidationError>;
-
-export function useListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet<
-  TData = Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  queueId: number,
-  options: {
-    query: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-          TError,
-          Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet<
-  TData = Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  queueId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-          TError,
-          Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet<
-  TData = Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  queueId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-/**
- * @summary List Queue Permissions
- */
-
-export function useListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet<
-  TData = Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  queueId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGet>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getListQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsGetQueryOptions(
-    guildId,
-    queueId,
-    options
-  );
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-
-  return { ...query, queryKey: queryOptions.queryKey };
-}
-
-/**
- * Set user permissions on a queue. Requires owner or guild admin.
- *
- * Replaces all non-owner permissions. The owner's permission cannot be changed.
- * @summary Set Queue Permissions
- */
-export const setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut = (
-  guildId: number,
-  queueId: number,
-  queuePermissionCreate: BodyType<QueuePermissionCreate[]>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<QueuePermissionRead[]>(
+  return apiMutator<QueueRead>(
     {
-      url: `/api/v1/g/${guildId}/queues/${queueId}/permissions`,
+      url: `/api/v1/g/${guildId}/queues/${queueId}/grants`,
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      data: queuePermissionCreate,
+      data: resourceGrantSchema,
       signal,
     },
     options
   );
 };
 
-export const getSetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPutMutationOptions = <
+export const getSetQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPutMutationOptions = <
   TError = ErrorType<HTTPValidationError>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut>>,
+    Awaited<ReturnType<typeof setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut>>,
     TError,
-    { guildId: number; queueId: number; data: BodyType<QueuePermissionCreate[]> },
+    { guildId: number; queueId: number; data: BodyType<ResourceGrantSchema[]> },
     TContext
   >;
   request?: SecondParameter<typeof apiMutator>;
 }): UseMutationOptions<
-  Awaited<ReturnType<typeof setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut>>,
+  Awaited<ReturnType<typeof setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut>>,
   TError,
-  { guildId: number; queueId: number; data: BodyType<QueuePermissionCreate[]> },
+  { guildId: number; queueId: number; data: BodyType<ResourceGrantSchema[]> },
   TContext
 > => {
-  const mutationKey = ["setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut"];
+  const mutationKey = ["setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut"];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
       ? options
@@ -2315,12 +2132,12 @@ export const getSetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPutMutat
     : { mutation: { mutationKey }, request: undefined };
 
   const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut>>,
-    { guildId: number; queueId: number; data: BodyType<QueuePermissionCreate[]> }
+    Awaited<ReturnType<typeof setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut>>,
+    { guildId: number; queueId: number; data: BodyType<ResourceGrantSchema[]> }
   > = (props) => {
     const { guildId, queueId, data } = props ?? {};
 
-    return setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut(
+    return setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut(
       guildId,
       queueId,
       data,
@@ -2331,147 +2148,40 @@ export const getSetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPutMutat
   return { mutationFn, ...mutationOptions };
 };
 
-export type SetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPutMutationResult = NonNullable<
-  Awaited<ReturnType<typeof setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut>>
+export type SetQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPutMutationResult = NonNullable<
+  Awaited<ReturnType<typeof setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut>>
 >;
-export type SetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPutMutationBody = BodyType<
-  QueuePermissionCreate[]
+export type SetQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPutMutationBody = BodyType<
+  ResourceGrantSchema[]
 >;
-export type SetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPutMutationError =
+export type SetQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPutMutationError =
   ErrorType<HTTPValidationError>;
 
 /**
- * @summary Set Queue Permissions
+ * @summary Set Queue Grants
  */
-export const useSetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut = <
+export const useSetQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut = <
   TError = ErrorType<HTTPValidationError>,
   TContext = unknown,
 >(
   options?: {
     mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut>>,
+      Awaited<ReturnType<typeof setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut>>,
       TError,
-      { guildId: number; queueId: number; data: BodyType<QueuePermissionCreate[]> },
+      { guildId: number; queueId: number; data: BodyType<ResourceGrantSchema[]> },
       TContext
     >;
     request?: SecondParameter<typeof apiMutator>;
   },
   queryClient?: QueryClient
 ): UseMutationResult<
-  Awaited<ReturnType<typeof setQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPut>>,
+  Awaited<ReturnType<typeof setQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPut>>,
   TError,
-  { guildId: number; queueId: number; data: BodyType<QueuePermissionCreate[]> },
+  { guildId: number; queueId: number; data: BodyType<ResourceGrantSchema[]> },
   TContext
 > => {
   return useMutation(
-    getSetQueuePermissionsApiV1GGuildIdQueuesQueueIdPermissionsPutMutationOptions(options),
-    queryClient
-  );
-};
-/**
- * Set role permissions on a queue. Requires owner or guild admin.
- *
- * Replaces all existing role permissions.
- * @summary Set Queue Role Permissions
- */
-export const setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut = (
-  guildId: number,
-  queueId: number,
-  queueRolePermissionCreate: BodyType<QueueRolePermissionCreate[]>,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<QueueRolePermissionRead[]>(
-    {
-      url: `/api/v1/g/${guildId}/queues/${queueId}/role-permissions`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: queueRolePermissionCreate,
-      signal,
-    },
-    options
-  );
-};
-
-export const getSetQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPutMutationOptions =
-  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut>
-      >,
-      TError,
-      { guildId: number; queueId: number; data: BodyType<QueueRolePermissionCreate[]> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }): UseMutationOptions<
-    Awaited<ReturnType<typeof setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut>>,
-    TError,
-    { guildId: number; queueId: number; data: BodyType<QueueRolePermissionCreate[]> },
-    TContext
-  > => {
-    const mutationKey = ["setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut"];
-    const { mutation: mutationOptions, request: requestOptions } = options
-      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-        ? options
-        : { ...options, mutation: { ...options.mutation, mutationKey } }
-      : { mutation: { mutationKey }, request: undefined };
-
-    const mutationFn: MutationFunction<
-      Awaited<
-        ReturnType<typeof setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut>
-      >,
-      { guildId: number; queueId: number; data: BodyType<QueueRolePermissionCreate[]> }
-    > = (props) => {
-      const { guildId, queueId, data } = props ?? {};
-
-      return setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut(
-        guildId,
-        queueId,
-        data,
-        requestOptions
-      );
-    };
-
-    return { mutationFn, ...mutationOptions };
-  };
-
-export type SetQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPutMutationResult =
-  NonNullable<
-    Awaited<ReturnType<typeof setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut>>
-  >;
-export type SetQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPutMutationBody =
-  BodyType<QueueRolePermissionCreate[]>;
-export type SetQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPutMutationError =
-  ErrorType<HTTPValidationError>;
-
-/**
- * @summary Set Queue Role Permissions
- */
-export const useSetQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut = <
-  TError = ErrorType<HTTPValidationError>,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<
-        ReturnType<typeof setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut>
-      >,
-      TError,
-      { guildId: number; queueId: number; data: BodyType<QueueRolePermissionCreate[]> },
-      TContext
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseMutationResult<
-  Awaited<ReturnType<typeof setQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPut>>,
-  TError,
-  { guildId: number; queueId: number; data: BodyType<QueueRolePermissionCreate[]> },
-  TContext
-> => {
-  return useMutation(
-    getSetQueueRolePermissionsApiV1GGuildIdQueuesQueueIdRolePermissionsPutMutationOptions(options),
+    getSetQueueGrantsApiV1GGuildIdQueuesQueueIdGrantsPutMutationOptions(options),
     queryClient
   );
 };


### PR DESCRIPTION
## Problem

The permissions layer for projects & documents was "overly technical" (two tables of role grants + per-user grants, `read`/`write`/`owner`), and the five DAC resources each had their own divergent permission surface. This reworks the **backend + API** into one Google-Docs-style sharing model applied identically to **projects, documents, queues, counters, and calendar events**.

> ⚠️ **Backend + regenerated API types only.** The redesigned sharing UI (a 3-mode `ShareControl`) and the frontend consumers of the now-removed endpoints/fields are a **follow-up**. The frontend will **not type-check/build** against the regenerated types until that lands — so this PR's frontend CI is expected red until the follow-up. Design + plan: `history/general-access-sharing-design.md`.

## What changed (backend)

- **Data model:** `resource_grants` gains an `all_initiative_members` boolean — the "everyone in the initiative" grantee kind (no new tables). The grantee `CHECK` becomes *exactly one of* user / role / all-members. Migration `20260617_0117` ALTERs `public` **and every `guild_*` schema**; `guild_schema.sql` regenerated. **No backfill** (existing resources keep their current grants). RLS unchanged.
- **One schema shape:** `ResourceGrantSchema` (`{ level, user_id, role_id, all_initiative_members }`), used for **both** read and write — no read-only/write-only fields.
- **One read field:** every resource read exposes `grants: List[ResourceGrantSchema]` (replacing separate `permissions`/`role_permissions`), plus `my_permission_level` (now added to calendar events too).
- **One write endpoint:** `PUT /{id}/grants` per resource → `permissions.replace_resource_grants(...)` (validate grantees, delete every non-owner grant, rebuild; **owner always preserved**). Replace semantics make bulk add/remove/level-change one atomic call.
- **Removed:** all granular `/members`, `/members/bulk`, `/role-permissions` endpoints (projects/documents) and `/permissions` + `/role-permissions` (queues/counters). Calendar events gained `PUT /{id}/grants` (had none).
- **Create:** each Create schema takes the same `grants` list, **defaulting to all-initiative-members Viewer**; create and edit share one code path.
- **Layers stay distinct:** initiative membership/RBAC (mandatory, RLS) gates *who's in the initiative*; DAC `resource_grants` is *which resources you can view/edit/own*. Effective access = MAX; owner + guild-admin/PAM always above it.

## Tests

Backend tests updated to `PUT /{id}/grants` + the `grants` list across projects, documents, queues, counters, and the access-grant/break-glass suites. **Not run here** — the dev sandbox has cross-file test-ordering flakiness; please run `cd backend && pytest` locally/CI.

## Follow-up (not in this PR)

- Build the 3-mode `ShareControl` (Everyone in Initiative / Restrict by user / Restrict by role) and wire it into the settings Access tabs, detail pages, and create dialogs; remove the old access-UI consumers + hooks; i18n.
- Frontend tests for the new control.