### PR TITLE
Add Full access (share override) for the Project Manager role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Full access for the Project Manager role.** Guild admins can now grant the Project Manager role **Full access** from an initiative's Roles settings. Members with that role can view and edit every item in the initiative — projects, documents, queues, counters, calendar events — even when an item isn't shared with them, and can manage who else has access. It applies only within that one initiative, and shows on each item's Share control as a locked editor that can't be removed. Only guild admins can turn it on, and only on the Project Manager role (so a manager can't grant it to themselves).
+
 ### Fixed
 
 - Adding an option to a select / multi-select custom property lost input focus after each keystroke, so only one character could be typed at a time. Option rows are no longer re-keyed by the value being edited.

--- a/backend/alembic/guild/guild_schema.sql
+++ b/backend/alembic/guild/guild_schema.sql
@@ -220,6 +220,7 @@ CREATE TABLE IF NOT EXISTS initiative_roles (
 	is_builtin BOOLEAN DEFAULT false NOT NULL, 
 	is_manager BOOLEAN DEFAULT false NOT NULL, 
 	position INTEGER DEFAULT 0 NOT NULL, 
+	override_share_restrictions BOOLEAN DEFAULT false NOT NULL, 
 	CONSTRAINT initiative_roles_pkey PRIMARY KEY (id), 
 	CONSTRAINT uq_initiative_role_name UNIQUE NULLS DISTINCT (initiative_id, name)
 );

--- a/backend/alembic/versions/20260622_0119_initiative_role_override_share.py
+++ b/backend/alembic/versions/20260622_0119_initiative_role_override_share.py
@@ -1,0 +1,74 @@
+"""Add "Full access" (override_share_restrictions) to initiative_roles.
+
+A single boolean on ``initiative_roles``. A role with it set lets its members
+view/edit ALL content in the initiative regardless of how each item is shared,
+and manage sharing — the gate-4 (DAC) override, scoped to one initiative (the
+initiative-scoped sibling of the guild-admin override). Off by default; only a
+guild admin may turn it on, and only on the built-in project_manager role.
+
+``initiative_roles`` is a structural guild-scoped table, so the column is added
+to ``public`` (the reflection source for guild_schema.sql) AND every existing
+``guild_*`` schema — the generated guild_schema.sql only
+``CREATE TABLE IF NOT EXISTS`` (a no-op on existing tables), so the new column
+reaches existing guilds only via this explicit ALTER. New guilds pick it up from
+the regenerated guild_schema.sql. No RLS change: structural initiative tables
+carry no initiative-member policies, and the override is enforced in the DAC
+engine (app layer), not RLS. See history/initiative-admin-override-design.md.
+
+Revision ID: 20260622_0119
+Revises: 20260622_0118
+Create Date: 2026-06-22
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260622_0119"
+down_revision = "20260622_0118"
+branch_labels = None
+depends_on = None
+
+
+def _guild_schemas(conn) -> list[str]:
+    # Matches every guild_<id> AND guild_template.
+    rows = conn.execute(
+        text("SELECT nspname FROM pg_namespace WHERE nspname LIKE 'guild\\_%'")
+    ).all()
+    return [r[0] for r in rows]
+
+
+def _apply(conn) -> None:
+    conn.execute(
+        text(
+            "ALTER TABLE initiative_roles "
+            "ADD COLUMN IF NOT EXISTS override_share_restrictions "
+            "BOOLEAN NOT NULL DEFAULT FALSE"
+        )
+    )
+
+
+def _revert(conn) -> None:
+    conn.execute(
+        text(
+            "ALTER TABLE initiative_roles "
+            "DROP COLUMN IF EXISTS override_share_restrictions"
+        )
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _apply(conn)
+    conn.execute(text("SET search_path TO public"))
+    _apply(conn)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _revert(conn)
+    conn.execute(text("SET search_path TO public"))
+    _revert(conn)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -12,7 +12,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.capabilities import Capability, user_has_capability
 from app.core.config import settings
 from app.core.pam_context import set_active_grant
-from app.core.role_context import set_active_role
+from app.core.role_context import set_active_role, set_override_sharing_initiatives
 from app.core.messages import AuthMessages, GuildMessages
 from app.core.security import (
     AutoDelegationVerificationError,
@@ -465,6 +465,9 @@ async def _apply_guild_session_context(
         # Still grant-gated: this path is only reached because a live grant exists.
         set_active_grant(None, None)
         set_active_role(guild_context.guild_id, GuildRole.admin.value)
+        # Break-glass acts as a full guild admin, which already bypasses gate 4
+        # everywhere; the per-initiative "Full access" set is moot here.
+        set_override_sharing_initiatives(None)
         await set_rls_context(
             session,
             user_id=current_user.id,
@@ -490,6 +493,8 @@ async def _apply_guild_session_context(
         # paths (initiative-scope guild-admin bypass) don't treat the grantee
         # as a member.
         set_active_role(None, None)
+        # A PAM grantee holds no initiative role, so no "Full access" override.
+        set_override_sharing_initiatives(None)
         # Leave current_guild_id unset — the existing write policies treat a
         # matching current_guild_id as proof of membership. Scope the grant via
         # pam_guild_id instead.
@@ -519,6 +524,15 @@ async def _apply_guild_session_context(
         guild_id=guild_context.guild_id,
         guild_role=guild_context.role.value,
     )
+    # Precompute the initiatives where this member holds "Full access" so the
+    # sync DAC checks can apply the gate-4 override without an async query. Runs
+    # in the routed guild schema (after SET ROLE), so it sees this guild's roles.
+    from app.services import rls as rls_service
+
+    override_ids = await rls_service.override_sharing_initiative_ids(
+        session, user_id=current_user.id
+    )
+    set_override_sharing_initiatives(frozenset(override_ids))
     return session
 
 

--- a/backend/app/api/v1/guild_endpoints/initiative_share_override_test.py
+++ b/backend/app/api/v1/guild_endpoints/initiative_share_override_test.py
@@ -1,0 +1,231 @@
+"""Tests for the initiative "Full access" share-override (PM-only).
+
+A guild admin can set ``override_share_restrictions`` on the built-in
+``project_manager`` role; members with that role then view/edit ALL content in
+the initiative regardless of per-item sharing, and may manage sharing — the
+gate-4 (DAC) override, scoped to one initiative (the initiative-scoped sibling of
+the guild-admin override). Only a guild admin may set it, and only on the PM
+role. See history/initiative-admin-override-design.md.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.pam_context import set_active_grant
+from app.core.role_context import (
+    set_active_role,
+    set_override_sharing_initiatives,
+)
+from app.models.guild import GuildRole
+from app.models.initiative import InitiativeRoleModel
+from app.services.permissions import (
+    DAC_RESOURCES,
+    compute_permission,
+    request_bypasses_dac,
+)
+from app.testing.factories import (
+    create_guild,
+    create_guild_membership,
+    create_initiative,
+    create_initiative_member,
+    create_user,
+    get_guild_headers,
+)
+
+
+async def _role_by_name(session: AsyncSession, initiative, name: str):
+    return (
+        await session.exec(
+            select(InitiativeRoleModel).where(
+                InitiativeRoleModel.initiative_id == initiative.id,
+                InitiativeRoleModel.name == name,
+            )
+        )
+    ).one()
+
+
+async def _setup(session: AsyncSession):
+    """admin = guild admin + initiative creator (PM); owner = a PM who owns a
+    restricted project; pm = a PM whose access we toggle via the override."""
+    admin = await create_user(session, email="admin@example.com")
+    owner = await create_user(session, email="owner@example.com")
+    pm = await create_user(session, email="pm@example.com")
+    guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await create_guild_membership(
+        session, user=owner, guild=guild, role=GuildRole.member
+    )
+    await create_guild_membership(session, user=pm, guild=guild, role=GuildRole.member)
+    initiative = await create_initiative(session, guild, admin)  # admin -> PM
+    await create_initiative_member(
+        session, initiative, owner, role_name="project_manager"
+    )
+    await create_initiative_member(session, initiative, pm, role_name="project_manager")
+    return admin, owner, pm, guild, initiative
+
+
+# ── Enforcement: the gate-4 override leg (unit) ──────────────────────────────
+
+
+def test_request_overrides_sharing_bypasses_dac():
+    """A "Full access" initiative bypasses DAC (incl. owner-only ops), scoped to
+    that initiative; compute_permission reports owner there and nothing extra
+    elsewhere."""
+    set_active_role(None, None)
+    set_active_grant(None, None)
+    set_override_sharing_initiatives(frozenset({42}))
+
+    class _Row:
+        def __init__(self, guild_id, initiative_id):
+            self.guild_id = guild_id
+            self.initiative_id = initiative_id
+            self.grants = []
+            self.initiative = None
+
+    try:
+        assert request_bypasses_dac(1, initiative_id=42, access="write") is True
+        # Ignores require_owner — a full-access PM may manage sharing.
+        assert (
+            request_bypasses_dac(
+                1, initiative_id=42, access="write", require_owner=True
+            )
+            is True
+        )
+        # Scope-bound: a different initiative is not covered.
+        assert request_bypasses_dac(1, initiative_id=99, access="write") is False
+        assert (
+            compute_permission(DAC_RESOURCES["project"], _Row(1, 42), user_id=7)
+            == "owner"
+        )
+        assert (
+            compute_permission(DAC_RESOURCES["project"], _Row(1, 99), user_id=7)
+            != "owner"
+        )
+    finally:
+        set_override_sharing_initiatives(None)
+
+
+# ── Enforcement: end-to-end through the API (integration) ────────────────────
+
+
+@pytest.mark.integration
+async def test_full_access_pm_reaches_restricted_content(
+    client: AsyncClient, session: AsyncSession
+):
+    admin, owner, pm, guild, initiative = await _setup(session)
+    admin_headers = await get_guild_headers(session, guild, admin)
+    owner_headers = await get_guild_headers(session, guild, owner)
+    pm_headers = await get_guild_headers(session, guild, pm)
+
+    # owner (a PM/manager) creates a RESTRICTED project: grants=[] drops the
+    # default all-members Viewer grant, so only the owner can reach it.
+    resp = await client.post(
+        f"/api/v1/g/{guild.id}/projects/",
+        headers=owner_headers,
+        json={"name": "Secret", "initiative_id": initiative.id, "grants": []},
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+
+    # Before the override: pm holds the PM role (a manager) but has no grant on
+    # this project — manager status is gate-3, not a DAC bypass — so 403.
+    resp = await client.get(
+        f"/api/v1/g/{guild.id}/projects/{project_id}", headers=pm_headers
+    )
+    assert resp.status_code == 403
+
+    # Guild admin grants the PM role "Full access".
+    pm_role = await _role_by_name(session, initiative, "project_manager")
+    resp = await client.patch(
+        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/roles/{pm_role.id}",
+        headers=admin_headers,
+        json={"override_share_restrictions": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["override_share_restrictions"] is True
+
+    # After the override: pm can read, edit content, and manage sharing.
+    resp = await client.get(
+        f"/api/v1/g/{guild.id}/projects/{project_id}", headers=pm_headers
+    )
+    assert resp.status_code == 200
+
+    resp = await client.patch(
+        f"/api/v1/g/{guild.id}/projects/{project_id}",
+        headers=pm_headers,
+        json={"name": "Renamed by full-access PM"},
+    )
+    assert resp.status_code == 200
+
+    resp = await client.put(
+        f"/api/v1/g/{guild.id}/projects/{project_id}/grants",
+        headers=pm_headers,
+        json=[{"all_initiative_members": True, "level": "read"}],
+    )
+    assert resp.status_code == 200
+
+    # my-permissions reflects the capability for the client.
+    resp = await client.get(
+        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/my-permissions",
+        headers=pm_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["override_share_restrictions"] is True
+
+
+# ── Setting the flag: guild-admin-only + PM-only (no self-escalation) ─────────
+
+
+@pytest.mark.integration
+async def test_only_guild_admin_can_grant_full_access(
+    client: AsyncClient, session: AsyncSession
+):
+    admin, owner, pm, guild, initiative = await _setup(session)
+    pm_headers = await get_guild_headers(session, guild, pm)
+    pm_role = await _role_by_name(session, initiative, "project_manager")
+
+    # pm is an initiative manager (can edit roles) but NOT a guild admin — it must
+    # not be able to flip the override on its own role (self-escalation).
+    resp = await client.patch(
+        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/roles/{pm_role.id}",
+        headers=pm_headers,
+        json={"override_share_restrictions": True},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "INITIATIVE_OVERRIDE_REQUIRES_GUILD_ADMIN"
+
+
+@pytest.mark.integration
+async def test_full_access_only_on_pm_role(client: AsyncClient, session: AsyncSession):
+    admin, owner, pm, guild, initiative = await _setup(session)
+    admin_headers = await get_guild_headers(session, guild, admin)
+
+    # The built-in "member" role is ineligible — 422.
+    member_role = await _role_by_name(session, initiative, "member")
+    resp = await client.patch(
+        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/roles/{member_role.id}",
+        headers=admin_headers,
+        json={"override_share_restrictions": True},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "INITIATIVE_OVERRIDE_PM_ONLY"
+
+    # A custom manager role is also ineligible — Full access is PM-only.
+    resp = await client.post(
+        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/roles",
+        headers=admin_headers,
+        json={"name": "leads", "display_name": "Leads", "is_manager": True},
+    )
+    assert resp.status_code == 201, resp.text
+    custom_role_id = resp.json()["id"]
+    resp = await client.patch(
+        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/roles/{custom_role_id}",
+        headers=admin_headers,
+        json={"override_share_restrictions": True},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "INITIATIVE_OVERRIDE_PM_ONLY"

--- a/backend/app/api/v1/guild_endpoints/initiatives.py
+++ b/backend/app/api/v1/guild_endpoints/initiatives.py
@@ -485,6 +485,31 @@ async def update_initiative_role(
             detail=InitiativeMessages.CANNOT_MODIFY_PM_PERMISSIONS,
         )
 
+    # "Full access" (override_share_restrictions): the endpoint is manager-
+    # accessible (a PM can edit roles), so this single field needs its own,
+    # stricter guard — otherwise a PM could flip it on their own role and
+    # self-escalate. Field-level, not endpoint-level:
+    #   * only a guild admin may change it (no in-initiative escalation), and
+    #   * only on the built-in project_manager role (its tool permissions are
+    #     already locked on, so "view/edit everything regardless of sharing" is
+    #     coherent there; on a lesser role it would contradict gate-3).
+    if (
+        role_in.override_share_restrictions is not None
+        and role_in.override_share_restrictions != role.override_share_restrictions
+    ):
+        if not rls_service.is_guild_admin(guild_context.role):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=InitiativeMessages.OVERRIDE_REQUIRES_GUILD_ADMIN,
+            )
+        if not (role.is_builtin and role.name == "project_manager"):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=InitiativeMessages.OVERRIDE_PM_ONLY,
+            )
+        role.override_share_restrictions = role_in.override_share_restrictions
+        session.add(role)
+
     # Update display name if provided
     if role_in.display_name is not None:
         role.display_name = role_in.display_name
@@ -592,6 +617,8 @@ async def get_my_initiative_permissions(
     if rls_service.is_guild_admin(guild_context.role):
         return MyInitiativePermissions(
             is_manager=True,
+            # Guild admins view/edit everything regardless of sharing.
+            override_share_restrictions=True,
             permissions={
                 "docs_enabled": True,
                 "projects_enabled": True,
@@ -684,6 +711,7 @@ async def get_my_initiative_permissions(
         role_name=role.name,
         role_display_name=role.display_name,
         is_manager=role.is_manager,
+        override_share_restrictions=role.override_share_restrictions,
         permissions=permissions,
         advanced_tool_enabled=advanced_tool_enabled,
     )

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -85,6 +85,11 @@ class InitiativeMessages:
     # hold the manager role (for manager-style features), never a standard
     # member or custom role.
     GUILD_ADMIN_ROLE_RESTRICTED = "INITIATIVE_GUILD_ADMIN_ROLE_RESTRICTED"
+    # "Full access" (override_share_restrictions) may be changed only by a guild
+    # admin (so an initiative role can't escalate itself), and only on the
+    # built-in project_manager role.
+    OVERRIDE_REQUIRES_GUILD_ADMIN = "INITIATIVE_OVERRIDE_REQUIRES_GUILD_ADMIN"
+    OVERRIDE_PM_ONLY = "INITIATIVE_OVERRIDE_PM_ONLY"
 
 
 class ProjectMessages:

--- a/backend/app/core/role_context.py
+++ b/backend/app/core/role_context.py
@@ -15,11 +15,20 @@ deliberately leave this unset — grant semantics flow through ``pam_context``.
 from __future__ import annotations
 
 import contextvars
-from typing import Optional, Tuple
+from typing import FrozenSet, Optional, Tuple
 
 # (guild_id, role) for the request's active guild membership, or None.
 _active_role: contextvars.ContextVar[Optional[Tuple[int, str]]] = (
     contextvars.ContextVar("active_guild_role", default=None)
+)
+
+# Initiative ids (in the request's active guild) where the user holds a role with
+# "Full access" (``override_share_restrictions``). The initiative-scoped sibling
+# of the guild-admin override: the sync DAC checks consult this so a full-access
+# PM bypasses gate 4 (sharing) for those initiatives' resources. Precomputed once
+# per request (set alongside the active role) so the sync checks stay sync.
+_override_initiatives: contextvars.ContextVar[FrozenSet[int]] = contextvars.ContextVar(
+    "override_share_initiatives", default=frozenset()
 )
 
 
@@ -40,3 +49,22 @@ def active_guild_role(guild_id: Optional[int]) -> Optional[str]:
         return None
     recorded_guild, role = current
     return role if recorded_guild == guild_id else None
+
+
+def set_override_sharing_initiatives(initiative_ids: Optional[FrozenSet[int]]) -> None:
+    """Record (or clear) the initiatives where the user has "Full access" this
+    request. Set alongside :func:`set_active_role`; cleared (empty) for PAM /
+    break-glass / no-context paths."""
+    _override_initiatives.set(
+        frozenset(initiative_ids) if initiative_ids else frozenset()
+    )
+
+
+def request_overrides_sharing(initiative_id: Optional[int]) -> bool:
+    """Whether the request holds "Full access" in ``initiative_id`` — the
+    initiative-scoped sibling of ``is_request_guild_admin``. Reads the per-request
+    set populated at guild-session establishment (initiative ids are globally
+    unique, so the set need not be keyed by guild)."""
+    if initiative_id is None:
+        return False
+    return initiative_id in _override_initiatives.get()

--- a/backend/app/models/initiative.py
+++ b/backend/app/models/initiative.py
@@ -125,6 +125,15 @@ class InitiativeRoleModel(SQLModel, table=True):
     display_name: str = Field(max_length=100)  # e.g., "Project Manager"
     is_builtin: bool = Field(default=False)  # true for PM/Member
     is_manager: bool = Field(default=False)  # counts toward manager constraint
+    # "Full access": members with this role view/edit ALL content in the
+    # initiative regardless of how each item is shared, and may manage sharing
+    # (the gate-4 / DAC override, scoped to this one initiative). Off by default;
+    # only a guild admin may turn it on, and only on the built-in project_manager
+    # role. See history/initiative-admin-override-design.md.
+    override_share_restrictions: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default="false"),
+    )
     position: int = Field(default=0)  # for ordering in UI
 
     initiative: Optional["Initiative"] = Relationship(back_populates="roles")

--- a/backend/app/schemas/initiative.py
+++ b/backend/app/schemas/initiative.py
@@ -63,6 +63,9 @@ class InitiativeRoleRead(SanitizedBaseModel):
     display_name: str
     is_builtin: bool
     is_manager: bool
+    # "Full access": this role views/edits all initiative content regardless of
+    # sharing and may manage sharing. Guild-admin-settable, project_manager only.
+    override_share_restrictions: bool = False
     position: int
     permissions: Dict[PermissionKey, bool] = Field(default_factory=dict)
     member_count: int = 0
@@ -82,6 +85,9 @@ class InitiativeRoleUpdate(SanitizedBaseModel):
 
     display_name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     is_manager: Optional[bool] = None
+    # "Full access" toggle. Only a guild admin may change it, and only on the
+    # built-in project_manager role (enforced in the endpoint).
+    override_share_restrictions: Optional[bool] = None
     permissions: Optional[Dict[PermissionKey, bool]] = None
 
 
@@ -115,6 +121,11 @@ class MyInitiativePermissions(SanitizedBaseModel):
     role_name: Optional[str] = None
     role_display_name: Optional[str] = None
     is_manager: bool = False
+    # True when the current user can view/edit every item in this initiative
+    # regardless of sharing, and manage sharing — a guild admin, or a member
+    # whose role has "Full access" (override_share_restrictions). Drives the
+    # client's manage-sharing affordances.
+    override_share_restrictions: bool = False
     permissions: Dict[PermissionKey, bool] = Field(default_factory=dict)
     # Flat initiative-level master switch for the optional embedded
     # advanced tool. Mirrored here so the proprietary embed backend can
@@ -200,6 +211,7 @@ def serialize_role(
         display_name=role.display_name,
         is_builtin=role.is_builtin,
         is_manager=role.is_manager,
+        override_share_restrictions=getattr(role, "override_share_restrictions", False),
         position=role.position,
         permissions=permissions,
         member_count=member_count,

--- a/backend/app/services/cross_guild.py
+++ b/backend/app/services/cross_guild.py
@@ -12,7 +12,7 @@ from typing import Awaitable, Callable, Optional, Sequence, TypeVar
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.role_context import set_active_role
+from app.core.role_context import set_active_role, set_override_sharing_initiatives
 from app.db.session import set_rls_context
 from app.models.guild import GuildMembership
 
@@ -85,8 +85,18 @@ async def gather_across_guilds(
             # guild-admin short-circuit in permissions.py (so my_permission_level /
             # require_*_access see the admin as owner when fetch() serializes here).
             set_active_role(guild_id, role_value)
+            # And the per-initiative "Full access" override for this guild, so a
+            # full-access PM's restricted content surfaces in cross-guild views too.
+            from app.services import rls as rls_service
+
+            override_ids = await rls_service.override_sharing_initiative_ids(
+                session, user_id=user_id
+            )
+            set_override_sharing_initiatives(frozenset(override_ids))
             results.extend(await fetch(session, guild_id))
     finally:
-        # Don't let the last guild's role linger in the request contextvar.
+        # Don't let the last guild's role/override set linger in the request
+        # contextvars.
         set_active_role(None, None)
+        set_override_sharing_initiatives(None)
     return results

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -257,10 +257,17 @@ def request_bypasses_dac(
     The initiative "Full access" leg (``request_overrides_sharing``) is the
     initiative-scoped sibling of the guild-admin leg: like guild admin, it
     ignores ``require_owner`` (a full-access PM may manage an item's sharing —
-    an owner-only operation — within their initiative)."""
+    an owner-only operation — within their initiative).
+
+    A guild-scoped resource always carries a ``guild_id`` (the override set is
+    itself computed within a guild context), so no ``guild_id`` means no guild
+    context to reason about — fail closed before any leg, including the override
+    one."""
+    if guild_id is None:
+        return False
     if grant_satisfies(guild_id, access=access, require_owner=require_owner):
         return True
-    if guild_id is not None and is_request_guild_admin(guild_id, guild_role=guild_role):
+    if is_request_guild_admin(guild_id, guild_role=guild_role):
         return True
     return request_overrides_sharing(initiative_id)
 

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -23,7 +23,7 @@ from sqlalchemy import and_, or_
 from sqlmodel import select
 
 from app.core.pam_context import active_grant_level, grant_satisfies, has_active_grant
-from app.core.role_context import active_guild_role
+from app.core.role_context import active_guild_role, request_overrides_sharing
 from app.services.membership import guild_member_clause
 
 from app.models.guild import GuildRole
@@ -244,18 +244,25 @@ def is_request_guild_admin(
 def request_bypasses_dac(
     guild_id: int | None,
     *,
+    initiative_id: int | None = None,
     access: str = "read",
     require_owner: bool = False,
     guild_role: GuildRole | str | None = None,
 ) -> bool:
     """The single "sees/edits regardless of DAC rows?" check — satisfying PAM
-    grant OR guild admin. Defined once so a call site can't apply one leg and
-    drop the other (the regression that hid a guild admin's tasks)."""
-    if guild_id is None:
-        return False
+    grant OR guild admin OR initiative "Full access". Defined once so a call site
+    can't apply one leg and drop the other (the regression that hid a guild
+    admin's tasks).
+
+    The initiative "Full access" leg (``request_overrides_sharing``) is the
+    initiative-scoped sibling of the guild-admin leg: like guild admin, it
+    ignores ``require_owner`` (a full-access PM may manage an item's sharing —
+    an owner-only operation — within their initiative)."""
     if grant_satisfies(guild_id, access=access, require_owner=require_owner):
         return True
-    return is_request_guild_admin(guild_id, guild_role=guild_role)
+    if guild_id is not None and is_request_guild_admin(guild_id, guild_role=guild_role):
+        return True
+    return request_overrides_sharing(initiative_id)
 
 
 def initiative_scope_ok(
@@ -492,11 +499,17 @@ def require_access(
     require_owner: bool = False,
     guild_role: GuildRole | str | None = None,
 ) -> None:
-    """Raise 403 unless ``user`` may act on ``row``: bypass (admin/PAM) →
-    (scope_gate) initiative scope → effective DAC level vs requested access."""
+    """Raise 403 unless ``user`` may act on ``row``: bypass (admin/PAM/Full
+    access) → (scope_gate) initiative scope → effective DAC level vs requested
+    access."""
     guild_id = getattr(row, "guild_id", None)
+    initiative_id = getattr(row, "initiative_id", None)
     if request_bypasses_dac(
-        guild_id, access=access, require_owner=require_owner, guild_role=guild_role
+        guild_id,
+        initiative_id=initiative_id,
+        access=access,
+        require_owner=require_owner,
+        guild_role=guild_role,
     ):
         return
     if resource.scope_gate and not initiative_scope_ok(
@@ -526,10 +539,11 @@ def require_access(
 
 
 def compute_permission(resource: DacResource, row: Any, user_id: int) -> str | None:
-    """``my_permission_level`` for the client: guild admin → owner, else effective
-    DAC level lifted to any active PAM grant."""
+    """``my_permission_level`` for the client: guild admin / initiative "Full
+    access" → owner, else effective DAC level lifted to any active PAM grant."""
     guild_id = getattr(row, "guild_id", None)
-    if is_request_guild_admin(guild_id):
+    initiative_id = getattr(row, "initiative_id", None)
+    if is_request_guild_admin(guild_id) or request_overrides_sharing(initiative_id):
         return "owner"
     return lift_level_for_grant(effective_level(resource, row, user_id), guild_id)
 

--- a/backend/app/services/rls.py
+++ b/backend/app/services/rls.py
@@ -252,6 +252,35 @@ async def accessible_initiative_ids(
     return {m.initiative_id for m in rows if _role_grants(m.role_ref, permission_key)}
 
 
+async def override_sharing_initiative_ids(
+    session: AsyncSession,
+    *,
+    user_id: int,
+) -> set[int]:
+    """Initiative ids (in the routed guild schema) where the user holds a role
+    with ``override_share_restrictions`` ("Full access") — the set the request's
+    DAC override consults (``role_context.request_overrides_sharing``).
+
+    One indexed query over the user's memberships, joined to their role. Called
+    once per guild request at session establishment; usually returns the empty
+    set (most users are full-access PMs nowhere).
+    """
+    from sqlmodel import select
+
+    stmt = (
+        select(InitiativeMember.initiative_id)
+        .join(
+            InitiativeRoleModel,
+            InitiativeRoleModel.id == InitiativeMember.role_id,
+        )
+        .where(
+            InitiativeMember.user_id == user_id,
+            InitiativeRoleModel.override_share_restrictions.is_(True),
+        )
+    )
+    return set((await session.exec(stmt)).all())
+
+
 async def has_feature_access(
     session: AsyncSession,
     *,

--- a/frontend/public/locales/de/access.json
+++ b/frontend/public/locales/de/access.json
@@ -21,6 +21,8 @@
     "noPeople": "Keine Personen gefunden.",
     "noRoles": "Keine Rollen gefunden.",
     "remove": "Entfernen",
+    "fullAccess": "Vollzugriff",
+    "fullAccessHint": "Diese Rolle kann alle Inhalte dieser Initiative ansehen und bearbeiten und ist daher hier immer Bearbeiter.",
     "settingsDescription": "Legen Sie fest, wer dies ansehen und bearbeiten kann."
   }
 }

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -64,6 +64,8 @@
   "INITIATIVE_CANNOT_DELETE_BUILTIN": "Integrierte Rollen können nicht gelöscht werden",
   "INITIATIVE_ROLE_HAS_MEMBERS": "Rolle kann nicht gelöscht werden: Es sind noch Mitglieder zugewiesen",
   "INITIATIVE_GUILD_ADMIN_ROLE_RESTRICTED": "Gildenadministratoren haben bereits vollen Zugriff und können nur als Projektmanager zugewiesen werden",
+  "INITIATIVE_OVERRIDE_REQUIRES_GUILD_ADMIN": "Nur Gildenadministratoren können den Vollzugriff einer Rolle ändern",
+  "INITIATIVE_OVERRIDE_PM_ONLY": "Vollzugriff kann nur der Projektmanager-Rolle gewährt werden",
   "OIDC_NOT_ENABLED": "OIDC ist nicht aktiviert",
   "OIDC_METADATA_INCOMPLETE": "OIDC-Metadaten unvollständig",
   "SMTP_NOT_CONFIGURED": "SMTP-Einstellungen sind unvollständig.",

--- a/frontend/public/locales/de/initiatives.json
+++ b/frontend/public/locales/de/initiatives.json
@@ -104,6 +104,8 @@
     "addCustomRole": "Benutzerdefinierte Rolle hinzufügen",
     "builtIn": "Integriert",
     "manager": "Manager",
+    "fullAccess": "Vollzugriff",
+    "fullAccessDescription": "Überschreibt die Freigabe einzelner Elemente: Diese Rolle kann jedes Element der Initiative öffnen und bearbeiten, auch wenn es nicht für sie freigegeben ist, und kann verwalten, wer sonst Zugriff hat.",
     "membersCount": "Mitglieder",
     "dangerTitle": "Gefahrenzone",
     "dangerDescription": "Beim Löschen einer Initiative werden alle ihre Projekte, Aufgaben und Dokumente entfernt.",

--- a/frontend/public/locales/en/access.json
+++ b/frontend/public/locales/en/access.json
@@ -21,6 +21,8 @@
     "noPeople": "No people found.",
     "noRoles": "No roles found.",
     "remove": "Remove",
+    "fullAccess": "Full access",
+    "fullAccessHint": "This role can view and edit everything in this initiative, so it's always an editor here.",
     "settingsDescription": "Choose who can view and edit this."
   }
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -60,6 +60,8 @@
   "INITIATIVE_CANNOT_DELETE_BUILTIN": "Cannot delete built-in roles",
   "INITIATIVE_ROLE_HAS_MEMBERS": "Cannot delete role: members are still assigned to it",
   "INITIATIVE_GUILD_ADMIN_ROLE_RESTRICTED": "Guild admins already have full access and can only be assigned the project manager role",
+  "INITIATIVE_OVERRIDE_REQUIRES_GUILD_ADMIN": "Only guild admins can change Full access for a role",
+  "INITIATIVE_OVERRIDE_PM_ONLY": "Full access can only be granted to the Project Manager role",
   "OIDC_NOT_ENABLED": "OIDC is not enabled",
   "OIDC_METADATA_INCOMPLETE": "OIDC metadata incomplete",
   "OIDC_EMAIL_UNVERIFIED": "Your identity provider did not confirm your email is verified, so we can't sign you in to an existing account. Verify your email with your provider and try again.",

--- a/frontend/public/locales/en/initiatives.json
+++ b/frontend/public/locales/en/initiatives.json
@@ -104,6 +104,8 @@
     "addCustomRole": "Add custom role",
     "builtIn": "Built-in",
     "manager": "Manager",
+    "fullAccess": "Full access",
+    "fullAccessDescription": "Overrides item sharing: this role can open and edit every item in the initiative even when it isn't shared with them, and can manage who else has access.",
     "membersCount": "Members",
     "dangerTitle": "Danger zone",
     "dangerDescription": "Deleting an initiative removes all of its projects, tasks, and documents.",

--- a/frontend/public/locales/es/access.json
+++ b/frontend/public/locales/es/access.json
@@ -21,6 +21,8 @@
     "noPeople": "No se encontraron personas.",
     "noRoles": "No se encontraron roles.",
     "remove": "Eliminar",
+    "fullAccess": "Acceso total",
+    "fullAccessHint": "Este rol puede ver y editar todo en esta iniciativa, por lo que siempre es editor aquí.",
     "settingsDescription": "Elige quién puede ver y editar esto."
   }
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -62,6 +62,8 @@
   "INITIATIVE_CANNOT_DELETE_BUILTIN": "No se pueden eliminar los roles integrados",
   "INITIATIVE_ROLE_HAS_MEMBERS": "No se puede eliminar el rol: aún hay miembros asignados",
   "INITIATIVE_GUILD_ADMIN_ROLE_RESTRICTED": "Los administradores del gremio ya tienen acceso completo y solo se les puede asignar el rol de gerente de proyecto",
+  "INITIATIVE_OVERRIDE_REQUIRES_GUILD_ADMIN": "Solo los administradores del gremio pueden cambiar el acceso total de un rol",
+  "INITIATIVE_OVERRIDE_PM_ONLY": "El acceso total solo puede otorgarse al rol de gerente de proyecto",
   "OIDC_NOT_ENABLED": "OIDC no está habilitado",
   "OIDC_METADATA_INCOMPLETE": "Metadatos de OIDC incompletos",
   "SMTP_NOT_CONFIGURED": "La configuración SMTP está incompleta.",

--- a/frontend/public/locales/es/initiatives.json
+++ b/frontend/public/locales/es/initiatives.json
@@ -104,6 +104,8 @@
     "addCustomRole": "Agregar rol personalizado",
     "builtIn": "Integrado",
     "manager": "Gerente",
+    "fullAccess": "Acceso total",
+    "fullAccessDescription": "Anula el uso compartido de los elementos: este rol puede abrir y editar cualquier elemento de la iniciativa aunque no se comparta con él, y puede gestionar quién más tiene acceso.",
     "membersCount": "Miembros",
     "dangerTitle": "Zona de peligro",
     "dangerDescription": "Eliminar una iniciativa la envía a la papelera junto con sus proyectos, tareas y documentos. Pueden restaurarse antes de que finalice el período de retención.",

--- a/frontend/public/locales/fr/access.json
+++ b/frontend/public/locales/fr/access.json
@@ -21,6 +21,8 @@
     "noPeople": "Aucune personne trouvée.",
     "noRoles": "Aucun rôle trouvé.",
     "remove": "Supprimer",
+    "fullAccess": "Accès complet",
+    "fullAccessHint": "Ce rôle peut consulter et modifier tout le contenu de cette initiative ; il est donc toujours éditeur ici.",
     "settingsDescription": "Choisissez qui peut consulter et modifier ceci."
   }
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -62,6 +62,8 @@
   "INITIATIVE_CANNOT_DELETE_BUILTIN": "Impossible de supprimer les rôles intégrés",
   "INITIATIVE_ROLE_HAS_MEMBERS": "Impossible de supprimer le rôle : des membres lui sont encore attribués",
   "INITIATIVE_GUILD_ADMIN_ROLE_RESTRICTED": "Les administrateurs du groupe ont déjà un accès complet et ne peuvent se voir attribuer que le rôle de chef de projet",
+  "INITIATIVE_OVERRIDE_REQUIRES_GUILD_ADMIN": "Seuls les administrateurs du groupe peuvent modifier l'accès complet d'un rôle",
+  "INITIATIVE_OVERRIDE_PM_ONLY": "L'accès complet ne peut être attribué qu'au rôle de chef de projet",
   "OIDC_NOT_ENABLED": "L'OIDC n'est pas activé",
   "OIDC_METADATA_INCOMPLETE": "Métadonnées OIDC incomplètes",
   "SMTP_NOT_CONFIGURED": "Les paramètres SMTP sont incomplets.",

--- a/frontend/public/locales/fr/initiatives.json
+++ b/frontend/public/locales/fr/initiatives.json
@@ -104,6 +104,8 @@
     "addCustomRole": "Ajouter un rôle personnalisé",
     "builtIn": "Intégré",
     "manager": "Gestionnaire",
+    "fullAccess": "Accès complet",
+    "fullAccessDescription": "Remplace le partage des éléments : ce rôle peut ouvrir et modifier chaque élément de l'initiative même s'il ne lui est pas partagé, et peut gérer qui d'autre y a accès.",
     "membersCount": "Membres",
     "dangerTitle": "Zone de danger",
     "dangerDescription": "Supprimer une initiative l'envoie à la corbeille avec ses projets, tâches et documents. Ils peuvent être restaurés avant la fin de la période de rétention.",

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1473,6 +1473,7 @@ export interface InitiativeRoleRead {
   display_name: string;
   is_builtin: boolean;
   is_manager: boolean;
+  override_share_restrictions: boolean;
   position: number;
   permissions: Partial<Record<PermissionKey, boolean>>;
   member_count: number;
@@ -1484,6 +1485,7 @@ export interface InitiativeRoleRead {
 export interface InitiativeRoleUpdate {
   display_name?: string | null;
   is_manager?: boolean | null;
+  override_share_restrictions?: boolean | null;
   permissions?: Partial<Record<PermissionKey, boolean>> | null;
 }
 
@@ -1571,6 +1573,7 @@ export interface MyInitiativePermissions {
   role_name: string | null;
   role_display_name: string | null;
   is_manager: boolean;
+  override_share_restrictions: boolean;
   permissions: Partial<Record<PermissionKey, boolean>>;
   advanced_tool_enabled: boolean;
 }

--- a/frontend/src/components/access/ShareControl.test.tsx
+++ b/frontend/src/components/access/ShareControl.test.tsx
@@ -29,9 +29,21 @@ const roles: InitiativeRoleRead[] = [
     display_name: "Player",
     is_builtin: false,
     is_manager: false,
+    override_share_restrictions: false,
     position: 0,
     permissions: {},
     member_count: 2,
+  },
+  {
+    id: 202,
+    name: "project_manager",
+    display_name: "Project Manager",
+    is_builtin: true,
+    is_manager: true,
+    override_share_restrictions: true,
+    position: 1,
+    permissions: {},
+    member_count: 1,
   },
 ];
 
@@ -97,6 +109,21 @@ describe("ShareControl", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     const next = onChange.mock.calls[0][0] as ResourceGrantSchema[];
     expect(next).toContainEqual({ user_id: 101, level: "read" });
+  });
+
+  it("renders a full-access role as a locked, non-removable Editor in restricted mode", () => {
+    // Restricted mode (no all-members grant) and no stored role grant for the PM
+    // role — its presence in the Roles list is purely from override_share_restrictions.
+    const onChange = vi.fn();
+
+    renderWithProviders(<ShareControl initiativeId={1} grants={[]} onChange={onChange} />);
+
+    const rolesSection = screen.getByText("Roles").closest("div")?.parentElement as HTMLElement;
+    expect(within(rolesSection).getByText("Project Manager")).toBeInTheDocument();
+    expect(within(rolesSection).getByText("Full access")).toBeInTheDocument();
+    expect(within(rolesSection).getByText("Editor")).toBeInTheDocument();
+    // No remove control — a full-access role can't be removed from sharing.
+    expect(within(rolesSection).queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
   });
 
   it("shows the owner as a fixed, non-editable row when ownerId is given", () => {

--- a/frontend/src/components/access/ShareControl.tsx
+++ b/frontend/src/components/access/ShareControl.tsx
@@ -69,6 +69,25 @@ export const ShareControl = ({
   );
   const roleGrants = useMemo(() => grants.filter((g) => g.role_id != null), [grants]);
 
+  // Roles with "Full access" (override_share_restrictions) always view/edit
+  // everything in the initiative, so they show as a locked Editor that can't be
+  // removed or downgraded — even in Restricted mode. It's implied by the role
+  // (not a stored grant), so it's injected here and never emitted in onChange.
+  const fullAccessRoles = useMemo(
+    () => roles.filter((r) => r.override_share_restrictions),
+    [roles]
+  );
+  const fullAccessRoleIds = useMemo(
+    () => new Set(fullAccessRoles.map((r) => r.id)),
+    [fullAccessRoles]
+  );
+  // Real role grants minus any full-access role (rendered as locked instead, so
+  // a stray stored grant to it doesn't double-render or look editable).
+  const editableRoleGrants = useMemo(
+    () => roleGrants.filter((g) => !fullAccessRoleIds.has(g.role_id as number)),
+    [roleGrants, fullAccessRoleIds]
+  );
+
   const allLevel: ShareLevel = allMembersGrant?.level === "write" ? "write" : "read";
 
   // ── Lookup helpers ───────────────────────────────────────────────────────
@@ -114,8 +133,9 @@ export const ShareControl = ({
     [members, ownerId, grantedUserIds]
   );
   const availableRoles = useMemo(
-    () => roles.filter((r) => !grantedRoleIds.has(r.id)),
-    [roles, grantedRoleIds]
+    // Full-access roles already have access (shown locked), so they're not pickable.
+    () => roles.filter((r) => !grantedRoleIds.has(r.id) && !fullAccessRoleIds.has(r.id)),
+    [roles, grantedRoleIds, fullAccessRoleIds]
   );
 
   // ── Mutators ─────────────────────────────────────────────────────────────
@@ -418,7 +438,28 @@ export const ShareControl = ({
             </div>
 
             <div className="space-y-1">
-              {roleGrants.map((grant) => {
+              {/* Full-access roles: locked Editor, non-removable, non-downgradable */}
+              {fullAccessRoles.map((role) => (
+                <div
+                  key={`full-access-${role.id}`}
+                  className="flex items-center gap-2 rounded-md border px-3 py-2"
+                  title={t("share.fullAccessHint")}
+                >
+                  <span className="min-w-0 flex-1 truncate text-sm">{role.display_name}</span>
+                  <Badge variant="secondary" className="gap-1">
+                    <Lock className="h-3 w-3" />
+                    {t("share.fullAccess")}
+                  </Badge>
+                  <span className="w-[110px] shrink-0 px-3 text-muted-foreground text-sm">
+                    {t("share.editor")}
+                  </span>
+                  <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center text-muted-foreground">
+                    <Lock className="h-4 w-4" />
+                  </span>
+                </div>
+              ))}
+
+              {editableRoleGrants.map((grant) => {
                 const roleId = grant.role_id as number;
                 return (
                   <div key={roleId} className="flex items-center gap-2 rounded-md border px-3 py-2">

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsRolesTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsRolesTab.tsx
@@ -30,6 +30,10 @@ import {
 interface InitiativeSettingsRolesTabProps {
   initiativeId: number;
   canManageMembers: boolean;
+  // "Full access" (override_share_restrictions) is guild-admin-settable only —
+  // a stricter gate than canManageMembers (which also includes PM managers), so
+  // a PM can't grant its own role the share override (self-escalation).
+  isGuildAdmin: boolean;
   onOpenCreateRoleDialog: () => void;
   onDeleteRole: (role: InitiativeRoleRead) => void;
   onRenameRole: (role: InitiativeRoleRead) => void;
@@ -72,6 +76,7 @@ const PermissionGroupSection = ({
 export const InitiativeSettingsRolesTab = ({
   initiativeId,
   canManageMembers,
+  isGuildAdmin,
   onOpenCreateRoleDialog,
   onDeleteRole,
   onRenameRole,
@@ -95,6 +100,16 @@ export const InitiativeSettingsRolesTab = ({
       if (role.name === "project_manager") return;
       const newPermissions = { ...role.permissions, [key]: enabled };
       updateRoleMutation.mutate({ roleId: role.id, data: { permissions: newPermissions } });
+    },
+    [updateRoleMutation]
+  );
+
+  const handleToggleFullAccess = useCallback(
+    (role: InitiativeRoleRead, enabled: boolean) => {
+      updateRoleMutation.mutate({
+        roleId: role.id,
+        data: { override_share_restrictions: enabled },
+      });
     },
     [updateRoleMutation]
   );
@@ -131,6 +146,9 @@ export const InitiativeSettingsRolesTab = ({
                           {t("settings.manager")}
                         </Badge>
                       )}
+                      {role.override_share_restrictions && (
+                        <Badge className="text-xs">{t("settings.fullAccess")}</Badge>
+                      )}
                       <Badge variant="outline" className="text-xs">
                         {t("settings.memberCountBadge", { count: role.member_count })}
                       </Badge>
@@ -159,6 +177,22 @@ export const InitiativeSettingsRolesTab = ({
                     )}
                   </CardHeader>
                   <CardContent className="space-y-4">
+                    {isPM && isGuildAdmin && (
+                      <div className="flex items-start justify-between gap-4 rounded-md border p-3">
+                        <div className="space-y-1">
+                          <Label className="font-medium">{t("settings.fullAccess")}</Label>
+                          <p className="text-muted-foreground text-xs">
+                            {t("settings.fullAccessDescription")}
+                          </p>
+                        </div>
+                        <Switch
+                          checked={role.override_share_restrictions}
+                          disabled={updateRoleMutation.isPending}
+                          onCheckedChange={(checked) => handleToggleFullAccess(role, checked)}
+                        />
+                      </div>
+                    )}
+
                     {CORE_PERMISSION_GROUPS.map((group) => (
                       <PermissionGroupSection
                         key={group.labelKey}

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -285,6 +285,7 @@ export const InitiativeSettingsPage = () => {
         <InitiativeSettingsRolesTab
           initiativeId={initiativeId}
           canManageMembers={canManageMembers}
+          isGuildAdmin={isGuildAdmin}
           onOpenCreateRoleDialog={() => setShowNewRoleDialog(true)}
           onDeleteRole={setRoleToDelete}
           onRenameRole={(role) => {


### PR DESCRIPTION
## Problem

There was no way to give an initiative role full, override-level access **within a single initiative**. The only overrides were whole-guild (guild admin) or platform-wide (PAM/break-glass). A Project Manager could fully manage the initiative's tooling yet still be a plain Viewer on a note someone shared "Restricted" — and there was no way to lift them over that per-item sharing layer just for their initiative.

## What this adds

A guild admin can mark the **Project Manager** role as **"Full access"** (`override_share_restrictions`). Members with that role can then view and edit **every item in the initiative** (projects, documents, queues, counters, calendar events) regardless of how each is shared, and can manage sharing — scoped to that one initiative.

In the six-gate model this is a **gate-4 (DAC/sharing) bypass, bounded by gate 2 (initiative)** — the initiative-scoped sibling of the guild-admin override. A full-access PM is already an initiative member (passes gate 2), so the flag only lifts them over per-item sharing.

## Backend

- `override_share_restrictions` column on `initiative_roles` — a **structural** guild-scoped table, so it's a column add + `guild_schema.sql` regen, applied to existing guilds via an explicit per-schema `ALTER` (migration `20260622_0119`). No RLS change.
- New `request_overrides_sharing` leg in `request_bypasses_dac` / `compute_permission`, fed by a per-request set of "Full access" initiative ids computed once at guild-session establishment (`deps._apply_guild_session_context` + `cross_guild`). Mirrors the existing guild-admin override path — one engine, one new leg; all five DAC tools (and the realtime spine) inherit it.
- **Field-level** guild-admin guard on the role-update endpoint: the endpoint is manager-accessible (a PM can edit roles), so the flag's guard lives inside the handler — only a guild admin may change it, and only on the built-in `project_manager` role (422 otherwise). Prevents self-escalation.
- Exposed on `InitiativeRoleRead` + `MyInitiativePermissions`.

## Frontend

- Guild-admin-only **"Full access"** toggle on the PM role card (others see a read-only badge).
- In the Share control, a full-access role renders as a **locked, non-removable Editor** entry tagged "Full access" (and is removed from the role picker).
- i18n across **en / de / es / fr**.

## Tests

- Backend (`initiative_share_override_test.py`): the override leg (unit) + end-to-end (a full-access PM reaches a restricted project, edits it, manages its sharing, and `my-permissions` reflects it); guild-admin-only + PM-only guards (no self-escalation).
- Frontend: ShareControl locked-Editor row; locale-key parity across all four languages.

## Schema / generated

- Alembic migration `20260622_0119` (reversible).
- Regenerated `guild_schema.sql` and Orval types committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)