### PR TITLE
Adopt SQLAlchemy 2.0 async session + exec API

### DIFF
--- a/backend/app/api/uploads_test.py
+++ b/backend/app/api/uploads_test.py
@@ -341,20 +341,20 @@ async def test_upload_row_in_guild_schema_is_served(
         schema = guild_schema_name(guild.id)
         # Insert the row into the guild schema ONLY (mimicking the production
         # request path, where set_rls_context routes search_path there).
-        await session.execute(
+        await session.exec(
             text(
                 f'INSERT INTO "{schema}".uploads'
                 " (filename, guild_id, uploader_user_id, size_bytes, created_at)"
                 " VALUES (:fn, :gid, :uid, 5, now())"
             ),
-            {"fn": "test_guild_schema_row.txt", "gid": guild.id, "uid": user.id},
+            params={"fn": "test_guild_schema_row.txt", "gid": guild.id, "uid": user.id},
         )
         await session.commit()
         # Prove the row is invisible from public.uploads.
         public_hit = (
-            await session.execute(
+            await session.exec(
                 text("SELECT 1 FROM public.uploads WHERE filename = :fn"),
-                {"fn": "test_guild_schema_row.txt"},
+                params={"fn": "test_guild_schema_row.txt"},
             )
         ).first()
         assert public_hit is None
@@ -413,7 +413,7 @@ async def test_app_admin_needs_set_role_for_guild_schema(session, role_session):
 
     # Raw cross-schema read as app_admin → permission denied (the old bug).
     with pytest.raises(Exception) as exc:  # asyncpg InsufficientPrivilegeError
-        await admin.execute(
+        await admin.exec(
             text(f'SELECT 1 FROM "{schema}".uploads LIMIT 1')  # noqa: S608
         )
     assert "permission denied" in str(exc.value).lower()
@@ -422,7 +422,7 @@ async def test_app_admin_needs_set_role_for_guild_schema(session, role_session):
     # The production pattern (SET ROLE via set_rls_context) succeeds.
     await set_rls_context(admin, guild_id=guild.id, is_superadmin=True)
     row = (
-        await admin.execute(
+        await admin.exec(
             text("SELECT filename FROM uploads WHERE filename = 'grant_probe.jpg'")
         )
     ).first()

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -1209,7 +1209,7 @@ async def test_register_rolls_back_when_guild_seed_fails(
     async def _boom(seed_session, *args, **kwargs):
         # Simulate a real DB failure: abort the transaction like a failing query
         # would, so the cleanup path MUST rollback before it can delete anything.
-        await seed_session.execute(text("SELECT * FROM does_not_exist_xyz"))
+        await seed_session.exec(text("SELECT * FROM does_not_exist_xyz"))
 
     monkeypatch.setattr(guilds_service, "seed_guild_content", _boom)
 

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -396,7 +396,7 @@ async def delete_guild(
     # reads of public.guilds/users. A failed cleanup must NEVER undo the committed
     # deletion: an orphaned, empty schema is harmless and reclaimed on a retry or
     # the next provision of that id.
-    await session.execute(text("SELECT set_config('role', 'none', false)"))
+    await session.exec(text("SELECT set_config('role', 'none', false)"))
     await session.commit()
     try:
         await deprovision_guild(guild_id)

--- a/backend/app/api/v1/tenant_endpoints/calendar_events.py
+++ b/backend/app/api/v1/tenant_endpoints/calendar_events.py
@@ -168,8 +168,8 @@ async def _fetch_users(session: RLSSessionDep, user_ids: list[int]) -> list[User
 
 async def _exec_events(session, stmt) -> list[CalendarEvent]:
     """Run a CalendarEvent select and return de-duplicated rows as a list."""
-    result = await session.execute(stmt)
-    return list(result.unique().scalars().all())
+    result = await session.exec(stmt)
+    return list(result.unique().all())
 
 
 def _cross_guild_event_dac_clause(guild_id: int, user_id: int):

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1909,9 +1909,9 @@ async def _load_download_document(
     # establish_guild_access would fault rather than 404. (The session is the
     # BYPASSRLS admin engine, so this lookup runs regardless of context.)
     schema_exists = (
-        await session.execute(
+        await session.exec(
             text("SELECT 1 FROM pg_namespace WHERE nspname = :ns"),
-            {"ns": guild_schema_name(int(guild_id))},
+            params={"ns": guild_schema_name(int(guild_id))},
         )
     ).first()
     if schema_exists is None:

--- a/backend/app/api/v1/tenant_endpoints/events.py
+++ b/backend/app/api/v1/tenant_endpoints/events.py
@@ -102,7 +102,7 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
         # Reset any stale GUCs the pooled connection may carry (e.g. a SET ROLE to
         # a since-dropped guild role would make every query error) before the auth
         # query — AsyncSessionLocal doesn't run get_session's per-request reset.
-        await session.execute(
+        await session.exec(
             text(
                 "SELECT set_config('role', 'none', false), set_config('search_path', 'public', false)"
             )

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -721,12 +721,12 @@ async def test_set_project_access_all_members(
 async def _task_assignee_ids(session, guild_id: int, task_id: int) -> set[int]:
     """Read task_assignees straight from the guild schema (superuser session)."""
     await session.commit()
-    await session.execute(text(f'SET search_path TO "guild_{guild_id}", public'))
+    await session.exec(text(f'SET search_path TO "guild_{guild_id}", public'))
     return set(
         (
-            await session.execute(
+            await session.exec(
                 text("SELECT user_id FROM task_assignees WHERE task_id = :tid"),
-                {"tid": task_id},
+                params={"tid": task_id},
             )
         ).scalars()
     )

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -978,8 +978,8 @@ async def _allowed_project_ids(
         if not include_templates:
             full_conditions.append(Project.is_template == False)  # noqa: E712
         full_stmt = select(Project.id).join(Project.initiative).where(*full_conditions)
-        full_result = await session.execute(full_stmt)
-        return {row[0] for row in full_result.all() if row[0] is not None}
+        full_result = await session.exec(full_stmt)
+        return {pid for pid in full_result.all() if pid is not None}
 
     # Projects the user has a grant on (own or via an initiative role), scoped to
     # the guild and (optionally) excluding archived/template projects.
@@ -993,8 +993,8 @@ async def _allowed_project_ids(
     if not include_templates:
         conditions.append(Project.is_template == False)  # noqa: E712
     stmt = select(Project.id).join(Project.initiative).where(*conditions)
-    result = await session.execute(stmt)
-    return {row[0] for row in result.all() if row[0] is not None}
+    result = await session.exec(stmt)
+    return {pid for pid in result.all() if pid is not None}
 
 
 def _property_value_filter_clauses(
@@ -1769,7 +1769,7 @@ async def move_task(
         source_initiative_id is not None
         and source_initiative_id != target_project.initiative_id
     ):
-        await session.execute(
+        await session.exec(
             delete(TaskPropertyValue).where(TaskPropertyValue.task_id == task.id)
         )
 

--- a/backend/app/db/init_db_test.py
+++ b/backend/app/db/init_db_test.py
@@ -39,7 +39,7 @@ async def test_init_superuser_cleans_up_when_guild_seed_fails(engine, monkeypatc
     async def _boom(seed_session, *args, **kwargs):
         # Abort the transaction like a real failing query would, so the cleanup
         # path must rollback before it can delete the stranded rows.
-        await seed_session.execute(text("SELECT * FROM does_not_exist_xyz"))
+        await seed_session.exec(text("SELECT * FROM does_not_exist_xyz"))
 
     monkeypatch.setattr(guilds_service, "seed_guild_content", _boom)
 

--- a/backend/app/db/platform_role_rls_test.py
+++ b/backend/app/db/platform_role_rls_test.py
@@ -28,17 +28,17 @@ from app.testing import create_guild, create_user
 async def _assume(session, tier: str, user_id: int) -> None:
     """Assume ``platform_<tier>`` with ``current_user_id`` set, on the session's
     connection — mirrors what ``set_rls_context`` does for a public-path request."""
-    await session.execute(
+    await session.exec(
         text(
             "SELECT set_config('app.current_user_id', :uid, false), "
             "set_config('role', :role, false)"
         ),
-        {"uid": str(user_id), "role": platform_role_name(tier)},
+        params={"uid": str(user_id), "role": platform_role_name(tier)},
     )
 
 
 async def _reset(session) -> None:
-    await session.execute(
+    await session.exec(
         text(
             "SELECT set_config('role', 'none', false), "
             "set_config('app.current_user_id', '', false)"
@@ -55,9 +55,7 @@ async def test_member_sees_only_own_user_row(session):
     u1 = await create_user(session)
     u2 = await create_user(session)
     await _assume(session, "member", u1.id)
-    ids = {
-        r[0] for r in (await session.execute(text("SELECT id FROM users"))).fetchall()
-    }
+    ids = {r[0] for r in (await session.exec(text("SELECT id FROM users"))).fetchall()}
     await _reset(session)
     assert u1.id in ids
     assert u2.id not in ids
@@ -68,9 +66,7 @@ async def test_support_reads_all_users(session):
     u1 = await create_user(session)
     u2 = await create_user(session)
     await _assume(session, "support", u1.id)
-    ids = {
-        r[0] for r in (await session.execute(text("SELECT id FROM users"))).fetchall()
-    }
+    ids = {r[0] for r in (await session.exec(text("SELECT id FROM users"))).fetchall()}
     await _reset(session)
     assert {u1.id, u2.id} <= ids
 
@@ -83,15 +79,17 @@ async def test_support_cannot_update_others_but_moderator_can(session):
     target = await create_user(session)
 
     await _assume(session, "support", actor.id)
-    res = await session.execute(
-        text("UPDATE users SET full_name = 'sx' WHERE id = :id"), {"id": target.id}
+    res = await session.exec(
+        text("UPDATE users SET full_name = 'sx' WHERE id = :id"),
+        params={"id": target.id},
     )
     await _reset(session)
     assert res.rowcount == 0
 
     await _assume(session, "moderator", actor.id)
-    res = await session.execute(
-        text("UPDATE users SET full_name = 'mx' WHERE id = :id"), {"id": target.id}
+    res = await session.exec(
+        text("UPDATE users SET full_name = 'mx' WHERE id = :id"),
+        params={"id": target.id},
     )
     await _reset(session)
     assert res.rowcount == 1
@@ -103,8 +101,8 @@ async def test_no_tier_can_delete_users(session):
     actor = await create_user(session)
     target = await create_user(session)
     await _assume(session, "owner", actor.id)
-    res = await session.execute(
-        text("DELETE FROM users WHERE id = :id"), {"id": target.id}
+    res = await session.exec(
+        text("DELETE FROM users WHERE id = :id"), params={"id": target.id}
     )
     await _reset(session)
     assert res.rowcount == 0
@@ -114,13 +112,13 @@ async def test_no_tier_can_delete_users(session):
 
 
 async def _insert_grant(session, user_id: int, guild_id: int) -> None:
-    await session.execute(
+    await session.exec(
         text(
             "INSERT INTO access_grants "
             "(user_id, guild_id, reason, requested_duration_minutes, requested_by_id) "
             "VALUES (:u, :g, 'r', 60, :u)"
         ),
-        {"u": user_id, "g": guild_id},
+        params={"u": user_id, "g": guild_id},
     )
 
 
@@ -137,7 +135,7 @@ async def test_access_grants_self_vs_admin(session):
     own = {
         r[0]
         for r in (
-            await session.execute(text("SELECT user_id FROM access_grants"))
+            await session.exec(text("SELECT user_id FROM access_grants"))
         ).fetchall()
     }
     await _reset(session)
@@ -147,7 +145,7 @@ async def test_access_grants_self_vs_admin(session):
     allrows = {
         r[0]
         for r in (
-            await session.execute(text("SELECT user_id FROM access_grants"))
+            await session.exec(text("SELECT user_id FROM access_grants"))
         ).fetchall()
     }
     await _reset(session)
@@ -162,7 +160,7 @@ async def test_app_settings_write_is_owner_only(session):
     insufficient-privilege (42501), the owner's lands."""
     owner = await create_user(session, role=UserRole.owner)
     member = await create_user(session, role=UserRole.member)
-    await session.execute(
+    await session.exec(
         text(
             "INSERT INTO app_settings (id, oidc_enabled, oidc_scopes) "
             "VALUES (1, false, '[]'::json) ON CONFLICT (id) DO NOTHING"
@@ -172,7 +170,7 @@ async def test_app_settings_write_is_owner_only(session):
     await _assume(session, "member", member.id)
     with pytest.raises(DBAPIError):
         async with session.begin_nested():
-            await session.execute(
+            await session.exec(
                 text(
                     "UPDATE app_settings SET light_accent_color = '#000000' WHERE id = 1"
                 )
@@ -180,7 +178,7 @@ async def test_app_settings_write_is_owner_only(session):
     await _reset(session)
 
     await _assume(session, "owner", owner.id)
-    res = await session.execute(
+    res = await session.exec(
         text("UPDATE app_settings SET light_accent_color = '#abcdef' WHERE id = 1")
     )
     await _reset(session)
@@ -190,7 +188,7 @@ async def test_app_settings_write_is_owner_only(session):
 async def test_app_settings_readable_by_every_tier(session):
     """Everyone may SELECT config (``app_settings_read`` TO PUBLIC) — public reads
     like interface colors must work for any tier."""
-    await session.execute(
+    await session.exec(
         text(
             "INSERT INTO app_settings (id, oidc_enabled, oidc_scopes) "
             "VALUES (1, false, '[]'::json) ON CONFLICT (id) DO NOTHING"
@@ -199,7 +197,7 @@ async def test_app_settings_readable_by_every_tier(session):
     member = await create_user(session, role=UserRole.member)
     await _assume(session, "member", member.id)
     rows = (
-        await session.execute(text("SELECT id FROM app_settings WHERE id = 1"))
+        await session.exec(text("SELECT id FROM app_settings WHERE id = 1"))
     ).fetchall()
     await _reset(session)
     assert len(rows) == 1
@@ -217,7 +215,7 @@ async def test_app_settings_reseed_degrades_to_transient_for_non_owner(
     from app.services.platform import app_settings as svc
 
     # Existing singleton with an empty oidc_issuer.
-    await session.execute(
+    await session.exec(
         text(
             "INSERT INTO app_settings (id, oidc_enabled, oidc_scopes) "
             "VALUES (1, false, '[]'::json) ON CONFLICT (id) DO NOTHING"
@@ -234,7 +232,7 @@ async def test_app_settings_reseed_degrades_to_transient_for_non_owner(
 
     # The non-owner read did NOT persist the env value into the row.
     db_issuer = (
-        await session.execute(text("SELECT oidc_issuer FROM app_settings WHERE id = 1"))
+        await session.exec(text("SELECT oidc_issuer FROM app_settings WHERE id = 1"))
     ).scalar_one()
     assert db_issuer is None
 

--- a/backend/app/db/platform_roles_test.py
+++ b/backend/app/db/platform_roles_test.py
@@ -18,7 +18,7 @@ from app.db.session import reapply_rls_context, set_rls_context
 
 
 async def _reset_role(session) -> None:
-    await session.execute(text("SELECT set_config('role', 'none', false)"))
+    await session.exec(text("SELECT set_config('role', 'none', false)"))
 
 
 async def test_platform_roles_exist_and_are_least_privilege(session):
@@ -28,12 +28,12 @@ async def test_platform_roles_exist_and_are_least_privilege(session):
         platform_role_name(tier) for tier in PLATFORM_TIERS
     }
     rows = (
-        await session.execute(
+        await session.exec(
             text(
                 "SELECT rolname, rolcanlogin, rolbypassrls FROM pg_roles "
                 "WHERE rolname ~ :pat"
             ),
-            {"pat": f"^{settings.PLATFORM_ROLE_PREFIX}platform_"},
+            params={"pat": f"^{settings.PLATFORM_ROLE_PREFIX}platform_"},
         )
     ).all()
     found = {name: (canlogin, bypassrls) for name, canlogin, bypassrls in rows}
@@ -51,14 +51,14 @@ async def test_each_tier_inherits_the_base_floor(session):
     base = f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
     members = (
         (
-            await session.execute(
+            await session.exec(
                 text(
                     "SELECT m.rolname FROM pg_auth_members am "
                     "JOIN pg_roles base ON base.oid = am.roleid "
                     "JOIN pg_roles m ON m.oid = am.member "
                     "WHERE base.rolname = :base"
                 ),
-                {"base": base},
+                params={"base": base},
             )
         )
         .scalars()
@@ -73,7 +73,7 @@ async def test_public_path_assumes_platform_role(session, tier):
     """A no-guild request with a platform tier assumes platform_<tier>, not the
     bare login role."""
     await set_rls_context(session, user_id=1, platform_role=tier)
-    current = (await session.execute(text("SELECT current_user"))).scalar_one()
+    current = (await session.exec(text("SELECT current_user"))).scalar_one()
     assert current == platform_role_name(tier)
     await _reset_role(session)
 
@@ -84,7 +84,7 @@ async def test_no_tier_stays_on_login_role(session):
     await set_rls_context(session, user_id=1)
     # current_user is the connection's login role (superuser in tests); the point
     # is that no platform_* role was assumed.
-    current = (await session.execute(text("SELECT current_user"))).scalar_one()
+    current = (await session.exec(text("SELECT current_user"))).scalar_one()
     assert not current.startswith(f"{settings.PLATFORM_ROLE_PREFIX}platform_")
     await _reset_role(session)
 
@@ -94,7 +94,7 @@ async def test_reapply_preserves_platform_role(session):
     platform role, so post-commit queries stay role-scoped."""
     await set_rls_context(session, user_id=1, platform_role="support")
     await reapply_rls_context(session)
-    current = (await session.execute(text("SELECT current_user"))).scalar_one()
+    current = (await session.exec(text("SELECT current_user"))).scalar_one()
     assert current == platform_role_name("support")
     await _reset_role(session)
 

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -6,36 +6,31 @@ from typing import AsyncGenerator, Optional
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
 from app.db import base  # noqa: F401  # ensure models are imported for Alembic
 
 # Primary engine: non-superuser (DATABASE_URL_APP) for RLS-enforced queries.
-engine = create_async_engine(settings.DATABASE_URL_APP, echo=False, future=True)
+engine = create_async_engine(settings.DATABASE_URL_APP, echo=False)
 
 # Admin engine: for background jobs and startup seeding (BYPASSRLS).
-admin_engine = create_async_engine(settings.DATABASE_URL_ADMIN, echo=False, future=True)
+admin_engine = create_async_engine(settings.DATABASE_URL_ADMIN, echo=False)
 
 # Provisioning engine: superuser credentials (same as migrations) for privileged
 # DDL — CREATE SCHEMA / CREATE ROLE — which app_user and app_admin can't do.
-provisioning_engine = create_async_engine(
-    settings.DATABASE_URL, echo=False, future=True
-)
+provisioning_engine = create_async_engine(settings.DATABASE_URL, echo=False)
 
-AsyncSessionLocal = sessionmaker(
+AsyncSessionLocal = async_sessionmaker(
     bind=engine,
-    autocommit=False,
     autoflush=False,
     expire_on_commit=False,
     class_=AsyncSession,
 )
 
-AdminSessionLocal = sessionmaker(
+AdminSessionLocal = async_sessionmaker(
     bind=admin_engine,
-    autocommit=False,
     autoflush=False,
     expire_on_commit=False,
     class_=AsyncSession,
@@ -46,7 +41,7 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with AsyncSessionLocal() as session:
         # Reset RLS variables from any previous request on this pooled connection.
         # Uses set_config() in a single round-trip for efficiency.
-        await session.execute(
+        await session.exec(
             text(
                 "SELECT set_config('app.current_user_id', '', false), "
                 "set_config('app.current_guild_id', '', false), "
@@ -74,7 +69,7 @@ async def get_admin_session() -> AsyncGenerator[AsyncSession, None]:
         # (or `public`) nondeterministically. Start every admin session from a
         # clean public, login-role baseline; callers that need a guild schema
         # call set_rls_context() explicitly.
-        await session.execute(
+        await session.exec(
             text(
                 "SELECT set_config('app.current_user_id', '', false), "
                 "set_config('app.current_guild_id', '', false), "
@@ -210,8 +205,8 @@ async def set_rls_context(
     # Reset to the login role first: a session already SET ROLE'd into guild A
     # cannot SET ROLE into guild B (it isn't a member). 'none' returns to the
     # authenticated login role, which IS a member of every provisioned guild role.
-    await session.execute(text("SELECT set_config('role', 'none', false)"))
-    await session.execute(
+    await session.exec(text("SELECT set_config('role', 'none', false)"))
+    await session.exec(
         text(
             "SELECT set_config('app.current_user_id', :uid, false), "
             "set_config('app.current_guild_id', :gid, false), "
@@ -223,7 +218,7 @@ async def set_rls_context(
             "set_config('search_path', :sp, false), "
             "set_config('role', :role, false)"
         ),
-        {
+        params={
             "uid": uid,
             "gid": gid,
             "grole": grole,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -204,18 +204,18 @@ async def serve_upload_file(
     fname = FilePath(filename).name
     schema = guild_schema_name(int(guild_id))
     exists = (
-        await session.execute(
+        await session.exec(
             text("SELECT 1 FROM pg_namespace WHERE nspname = :ns"),
-            {"ns": schema},
+            params={"ns": schema},
         )
     ).first()
     if exists is None:
         raise HTTPException(status_code=404)
     await set_rls_context(session, guild_id=int(guild_id), is_superadmin=True)
     hit = (
-        await session.execute(
+        await session.exec(
             text("SELECT 1 FROM uploads WHERE filename = :fn LIMIT 1"),
-            {"fn": fname},
+            params={"fn": fname},
         )
     ).first()
     if hit is None:

--- a/backend/app/services/access_grants_rls_test.py
+++ b/backend/app/services/access_grants_rls_test.py
@@ -26,11 +26,11 @@ from app.testing import (
 
 
 async def _set_app_user(session: AsyncSession) -> None:
-    await session.execute(text("SET ROLE app_user"))
+    await session.exec(text("SET ROLE app_user"))
 
 
 async def _reset_role(session: AsyncSession) -> None:
-    await session.execute(text("RESET ROLE"))
+    await session.exec(text("RESET ROLE"))
 
 
 @pytest.mark.integration
@@ -75,8 +75,8 @@ async def test_pam_read_grant_sees_only_granted_guild(session: AsyncSession):
         # it to build the request context, so without this every guild-scoped
         # endpoint 500s for a grantee.
         visible_guild = (
-            await session.execute(
-                text("SELECT id FROM guilds WHERE id = :g"), {"g": guild_a.id}
+            await session.exec(
+                text("SELECT id FROM guilds WHERE id = :g"), params={"g": guild_a.id}
             )
         ).all()
         assert len(visible_guild) == 1, (
@@ -86,8 +86,9 @@ async def test_pam_read_grant_sees_only_granted_guild(session: AsyncSession):
         # Initiatives of the granted guild are visible (the sidebar list) — this
         # is the exact RLS path the empty-guild bug would break.
         visible_inits = (
-            await session.execute(
-                text("SELECT id FROM initiatives WHERE id = :i"), {"i": init_a.id}
+            await session.exec(
+                text("SELECT id FROM initiatives WHERE id = :i"),
+                params={"i": init_a.id},
             )
         ).all()
         assert len(visible_inits) == 1, (
@@ -95,8 +96,8 @@ async def test_pam_read_grant_sees_only_granted_guild(session: AsyncSession):
         )
 
         visible_a = (
-            await session.execute(
-                text("SELECT id FROM projects WHERE id = :p"), {"p": proj_a.id}
+            await session.exec(
+                text("SELECT id FROM projects WHERE id = :p"), params={"p": proj_a.id}
             )
         ).all()
         assert len(visible_a) == 1, "read grant should see the granted guild's project"
@@ -104,8 +105,8 @@ async def test_pam_read_grant_sees_only_granted_guild(session: AsyncSession):
         # Documents must be visible too — the collaboration WebSocket loads the
         # document under this exact pam_read context before authorizing.
         visible_doc = (
-            await session.execute(
-                text("SELECT id FROM documents WHERE id = :d"), {"d": doc_a.id}
+            await session.exec(
+                text("SELECT id FROM documents WHERE id = :d"), params={"d": doc_a.id}
             )
         ).all()
         assert len(visible_doc) == 1, (
@@ -115,14 +116,14 @@ async def test_pam_read_grant_sees_only_granted_guild(session: AsyncSession):
         # Cross-guild isolation: guild B's project lives in another schema, so it
         # is invisible here. (Query by name — its per-schema id collides with A's.)
         visible_b = (
-            await session.execute(text("SELECT id FROM projects WHERE name = 'Bravo'"))
+            await session.exec(text("SELECT id FROM projects WHERE name = 'Bravo'"))
         ).all()
         assert len(visible_b) == 0, "read grant must NOT see other guilds"
 
         # Read grant is read-only: the read-only role has no write on the schema,
         # so a write is denied at the role level (raises permission denied).
         with pytest.raises(Exception):
-            await session.execute(
+            await session.exec(
                 text("UPDATE projects SET name = 'hacked' WHERE name = 'Alpha'")
             )
         await session.rollback()
@@ -167,9 +168,9 @@ async def test_grantee_guild_settings_lazy_create_does_not_fault(session: AsyncS
 
     # Nothing was written.
     persisted = (
-        await session.execute(
+        await session.exec(
             text("SELECT count(*) FROM guild_settings WHERE guild_id = :g"),
-            {"g": guild.id},
+            params={"g": guild.id},
         )
     ).scalar_one()
     assert persisted == 0, "grantee read must not create a guild_settings row"
@@ -214,14 +215,14 @@ async def test_pam_read_grant_does_not_fault_legacy_isolation_tables(
         )
         # Each of these would raise InvalidTextRepresentationError pre-0095.
         visible_q = (
-            await session.execute(
-                text("SELECT id FROM queues WHERE id = :q"), {"q": queue.id}
+            await session.exec(
+                text("SELECT id FROM queues WHERE id = :q"), params={"q": queue.id}
             )
         ).all()
         assert len(visible_q) == 1, "read grant should see the granted guild's queues"
         visible_cg = (
-            await session.execute(
-                text("SELECT id FROM counter_groups WHERE id = :c"), {"c": cg.id}
+            await session.exec(
+                text("SELECT id FROM counter_groups WHERE id = :c"), params={"c": cg.id}
             )
         ).all()
         assert len(visible_cg) == 1, (
@@ -252,8 +253,8 @@ async def test_no_pam_flag_sees_nothing(session: AsyncSession):
             pam_write=False,
         )
         rows = (
-            await session.execute(
-                text("SELECT id FROM projects WHERE id = :p"), {"p": proj.id}
+            await session.exec(
+                text("SELECT id FROM projects WHERE id = :p"), params={"p": proj.id}
             )
         ).all()
         assert len(rows) == 0
@@ -281,8 +282,9 @@ async def test_pam_write_grant_can_update(session: AsyncSession):
             pam_read=True,
             pam_write=True,
         )
-        result = await session.execute(
-            text("UPDATE projects SET name = 'edited' WHERE id = :p"), {"p": proj.id}
+        result = await session.exec(
+            text("UPDATE projects SET name = 'edited' WHERE id = :p"),
+            params={"p": proj.id},
         )
         assert result.rowcount == 1, "read_write grant should be able to update content"
     finally:

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -259,12 +259,12 @@ async def import_todoist_tasks(
         return result
 
     # Get the next position for the project
-    max_order_result = await session.execute(
+    max_order_result = await session.exec(
         select(func.coalesce(func.max(Task.position), 0)).where(
             Task.project_id == project_id
         )
     )
-    next_position = float(max_order_result.scalar() or 0) + 1
+    next_position = float(max_order_result.first() or 0) + 1
 
     # Track parent tasks for subtask creation
     last_parent_task: Optional[Task] = None
@@ -454,12 +454,12 @@ async def import_vikunja_tasks(
         return result
 
     # Get the next position for the project
-    max_order_result = await session.execute(
+    max_order_result = await session.exec(
         select(func.coalesce(func.max(Task.position), 0)).where(
             Task.project_id == project_id
         )
     )
-    next_position = float(max_order_result.scalar() or 0) + 1
+    next_position = float(max_order_result.first() or 0) + 1
 
     for task_data in tasks:
         try:
@@ -690,12 +690,12 @@ async def import_ticktick_tasks(
         return result
 
     # Get the next position for the project
-    max_order_result = await session.execute(
+    max_order_result = await session.exec(
         select(func.coalesce(func.max(Task.position), 0)).where(
             Task.project_id == project_id
         )
     )
-    next_position = float(max_order_result.scalar() or 0) + 1
+    next_position = float(max_order_result.first() or 0) + 1
 
     # Track created tasks for subtask linking
     created_tasks: Dict[str, Task] = {}

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -264,7 +264,7 @@ async def import_todoist_tasks(
             Task.project_id == project_id
         )
     )
-    next_position = float(max_order_result.first() or 0) + 1
+    next_position = float(max_order_result.scalar() or 0) + 1
 
     # Track parent tasks for subtask creation
     last_parent_task: Optional[Task] = None
@@ -459,7 +459,7 @@ async def import_vikunja_tasks(
             Task.project_id == project_id
         )
     )
-    next_position = float(max_order_result.first() or 0) + 1
+    next_position = float(max_order_result.scalar() or 0) + 1
 
     for task_data in tasks:
         try:
@@ -695,7 +695,7 @@ async def import_ticktick_tasks(
             Task.project_id == project_id
         )
     )
-    next_position = float(max_order_result.first() or 0) + 1
+    next_position = float(max_order_result.scalar() or 0) + 1
 
     # Track created tasks for subtask linking
     created_tasks: Dict[str, Task] = {}

--- a/backend/app/services/initiative_rls_test.py
+++ b/backend/app/services/initiative_rls_test.py
@@ -49,7 +49,7 @@ async def test_non_admin_member_sees_only_their_initiatives_content(
     await set_rls_context(
         session, user_id=member.id, guild_id=guild.id, guild_role="member"
     )
-    member_view = set((await session.execute(select(Project.name))).scalars().all())
+    member_view = set((await session.exec(select(Project.name))).all())
     assert "A-Proj" in member_view, "member must see their own initiative's project"
     assert "B-Proj" not in member_view, (
         "RLS must hide a project in an initiative the member doesn't belong to"
@@ -59,7 +59,7 @@ async def test_non_admin_member_sees_only_their_initiatives_content(
     await set_rls_context(
         session, user_id=member.id, guild_id=guild.id, guild_role="admin"
     )
-    admin_view = set((await session.execute(select(Project.name))).scalars().all())
+    admin_view = set((await session.exec(select(Project.name))).all())
     assert {"A-Proj", "B-Proj"} <= admin_view
 
-    await session.execute(text("RESET ROLE"))
+    await session.exec(text("RESET ROLE"))

--- a/backend/app/services/membership.py
+++ b/backend/app/services/membership.py
@@ -115,7 +115,7 @@ async def initiative_member_user_ids(
         if not user_ids:
             return set()
         stmt = stmt.where(InitiativeMember.user_id.in_(tuple(set(user_ids))))
-    return set((await session.exec(stmt)).all())
+    return set((await session.exec(stmt)).scalars().all())
 
 
 async def user_member_initiative_ids(
@@ -134,7 +134,7 @@ async def user_member_initiative_ids(
         stmt = stmt.where(
             InitiativeMember.initiative_id.in_(tuple(set(initiative_ids)))
         )
-    return set((await session.exec(stmt)).all())
+    return set((await session.exec(stmt)).scalars().all())
 
 
 async def is_initiative_member(
@@ -156,7 +156,7 @@ async def guild_member_user_ids(
         if not user_ids:
             return set()
         stmt = stmt.where(GuildMembership.user_id.in_(tuple(set(user_ids))))
-    return set((await session.exec(stmt)).all())
+    return set((await session.exec(stmt)).scalars().all())
 
 
 async def guild_role_map(

--- a/backend/app/services/membership.py
+++ b/backend/app/services/membership.py
@@ -115,7 +115,7 @@ async def initiative_member_user_ids(
         if not user_ids:
             return set()
         stmt = stmt.where(InitiativeMember.user_id.in_(tuple(set(user_ids))))
-    return set((await session.execute(stmt)).scalars().all())
+    return set((await session.exec(stmt)).all())
 
 
 async def user_member_initiative_ids(
@@ -134,7 +134,7 @@ async def user_member_initiative_ids(
         stmt = stmt.where(
             InitiativeMember.initiative_id.in_(tuple(set(initiative_ids)))
         )
-    return set((await session.execute(stmt)).scalars().all())
+    return set((await session.exec(stmt)).all())
 
 
 async def is_initiative_member(
@@ -156,7 +156,7 @@ async def guild_member_user_ids(
         if not user_ids:
             return set()
         stmt = stmt.where(GuildMembership.user_id.in_(tuple(set(user_ids))))
-    return set((await session.execute(stmt)).scalars().all())
+    return set((await session.exec(stmt)).all())
 
 
 async def guild_role_map(
@@ -169,7 +169,7 @@ async def guild_role_map(
     ids = tuple(set(user_ids))
     if not ids:
         return {}
-    rows = await session.execute(
+    rows = await session.exec(
         select(GuildMembership.user_id, GuildMembership.role).where(
             GuildMembership.guild_id == guild_id,
             GuildMembership.user_id.in_(ids),

--- a/backend/app/services/membership_test.py
+++ b/backend/app/services/membership_test.py
@@ -102,7 +102,7 @@ async def test_initiative_member_clause_filters_rows(session: AsyncSession):
         stmt = select(Initiative.id).where(
             membership_service.initiative_member_clause(user.id, Initiative.id)
         )
-        assert list((await session.execute(stmt)).scalars().all()) == expected
+        assert list((await session.exec(stmt)).all()) == expected
 
 
 @pytest.mark.integration
@@ -121,7 +121,7 @@ async def test_initiative_scope_clause_legs(session: AsyncSession):
                 user.id, Initiative.id, Initiative.guild_id
             )
         )
-        return list((await session.execute(stmt)).scalars().all())
+        return list((await session.exec(stmt)).all())
 
     assert await scoped_ids(member) == [initiative.id]  # member leg
     assert await scoped_ids(admin) == [initiative.id]  # guild-admin leg
@@ -153,10 +153,10 @@ async def test_initiative_scope_clause_pam_leg(session: AsyncSession):
     await set_rls_context(
         session, user_id=outsider.id, pam_guild_id=guild.id, pam_read=True
     )
-    assert list((await session.execute(stmt())).scalars().all()) == [initiative.id]
+    assert list((await session.exec(stmt())).all()) == [initiative.id]
 
     # Same outsider routed as a (non-)member with no grant: matches nothing.
     await set_rls_context(
         session, user_id=outsider.id, guild_id=guild.id, guild_role="member"
     )
-    assert list((await session.execute(stmt())).scalars().all()) == []
+    assert list((await session.exec(stmt())).all()) == []

--- a/backend/app/services/platform/access_grants.py
+++ b/backend/app/services/platform/access_grants.py
@@ -297,9 +297,9 @@ async def break_glass(
     # makes a second concurrent request wait, then see the first's grant and hit
     # ALREADY_LIVE. The two-int key space is distinct from any single-bigint
     # advisory lock used elsewhere; the lock auto-releases on commit/rollback.
-    await session.execute(
+    await session.exec(
         text("SELECT pg_advisory_xact_lock(:uid, :gid)"),
-        {"uid": int(actor.id), "gid": int(payload.guild_id)},
+        params={"uid": int(actor.id), "gid": int(payload.guild_id)},
     )
 
     # Don't stack grants: a still-live grant already confers the access, and a

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -154,11 +154,11 @@ async def reorder_memberships(
     # guild_id = current_guild_id), so a direct ORM UPDATE would silently touch 0
     # rows. The function updates ONLY `position`, scoped to this user's own rows —
     # the same safe path for every platform tier.
-    await session.execute(
+    await session.exec(
         text("SELECT reorder_guild_memberships(:uid, :gids)").bindparams(
             bindparam("gids", type_=ARRAY(Integer))
         ),
-        {"uid": user_id, "gids": final_order},
+        params={"uid": user_id, "gids": final_order},
     )
 
 

--- a/backend/app/services/platform/guilds_test.py
+++ b/backend/app/services/platform/guilds_test.py
@@ -24,7 +24,7 @@ from app.testing.factories import create_guild, create_guild_membership, create_
 async def test_get_primary_guild_creates_if_missing(session: AsyncSession):
     """Test that primary guild is created if none exists."""
     # Clear any migration-seeded guilds so we test the creation path
-    await session.execute(text("TRUNCATE TABLE guilds RESTART IDENTITY CASCADE"))
+    await session.exec(text("TRUNCATE TABLE guilds RESTART IDENTITY CASCADE"))
     guild = await guild_service.get_primary_guild(session)
 
     assert guild.id is not None

--- a/backend/app/services/platform/push_tokens.py
+++ b/backend/app/services/platform/push_tokens.py
@@ -43,7 +43,7 @@ async def register_push_token(
         )
         .returning(PushToken)
     )
-    result = await session.execute(stmt)
+    result = await session.exec(stmt)
     await session.commit()
     await reapply_rls_context(session)
     return result.scalars().one()

--- a/backend/app/services/stream_authz.py
+++ b/backend/app/services/stream_authz.py
@@ -177,7 +177,7 @@ class StreamAuthority:
             async with AsyncSessionLocal() as session:
                 # AsyncSessionLocal skips get_session's per-request reset; clear
                 # any stale pooled-connection GUCs before establishing context.
-                await session.execute(
+                await session.exec(
                     text(
                         "SELECT set_config('role', 'none', false), "
                         "set_config('search_path', 'public', false)"

--- a/backend/app/services/stream_authz_test.py
+++ b/backend/app/services/stream_authz_test.py
@@ -132,7 +132,7 @@ def _patch_recheck(monkeypatch, *, establish_ok: bool, authorized: bool):
         async def __aexit__(self, *_a):
             return False
 
-        async def execute(self, *_a, **_k):
+        async def exec(self, *_a, **_k):
             return None
 
     async def fake_establish(_session, _user, _guild_id):

--- a/backend/app/services/tenant/properties.py
+++ b/backend/app/services/tenant/properties.py
@@ -342,7 +342,7 @@ async def _set_property_values(
     fk_column = binding.fk_column
 
     # Always wipe existing rows for the entity — replace-all semantics.
-    await session.execute(delete(value_model).where(fk_column == entity_id))
+    await session.exec(delete(value_model).where(fk_column == entity_id))
 
     if not values:
         return

--- a/backend/app/services/tenant/recent_views.py
+++ b/backend/app/services/tenant/recent_views.py
@@ -80,7 +80,7 @@ async def record_view(
             set_={"last_viewed_at": now},
         )
     )
-    await session.execute(stmt)
+    await session.exec(stmt)
     await session.commit()
     await reapply_rls_context(session)
 

--- a/backend/app/services/tenant/soft_delete_test.py
+++ b/backend/app/services/tenant/soft_delete_test.py
@@ -253,7 +253,7 @@ async def test_restrictive_delete_policy_exists_on_each_soft_delete_table(
         "queue_items",
         "calendar_events",
     }
-    result = await session.execute(
+    result = await session.exec(
         text(
             "SELECT tablename, policyname, cmd, permissive "
             "FROM pg_policies "

--- a/backend/app/services/tenant/trash_purge_test.py
+++ b/backend/app/services/tenant/trash_purge_test.py
@@ -82,15 +82,15 @@ async def test_auto_purge_does_not_double_purge_cascaded_descendants(
     # own AdminSessionLocal, so the test session's identity map is stale
     # for these rows.
     initiative_count = (
-        await session.execute(
+        await session.exec(
             text("SELECT COUNT(*) FROM initiatives WHERE id = :id"),
-            {"id": initiative_id},
+            params={"id": initiative_id},
         )
     ).scalar_one()
     project_count = (
-        await session.execute(
+        await session.exec(
             text("SELECT COUNT(*) FROM projects WHERE id = :id"),
-            {"id": project_id},
+            params={"id": project_id},
         )
     ).scalar_one()
     assert initiative_count == 0
@@ -142,9 +142,9 @@ async def test_auto_purge_sweeps_every_guild_schema(
     for guild_id, initiative_id in targets:
         await set_rls_context(admin, guild_id=guild_id, is_superadmin=True)
         count = (
-            await admin.execute(
+            await admin.exec(
                 text("SELECT COUNT(*) FROM initiatives WHERE id = :id"),
-                {"id": initiative_id},
+                params={"id": initiative_id},
             )
         ).scalar_one()
         assert count == 0, f"guild {guild_id} initiative {initiative_id} not purged"
@@ -185,8 +185,9 @@ async def test_auto_purge_clears_content_table_guard(
     await _purge_all_guilds(admin, now=datetime.now(timezone.utc))
 
     count = (
-        await admin.execute(
-            text("SELECT COUNT(*) FROM projects WHERE id = :id"), {"id": project_id}
+        await admin.exec(
+            text("SELECT COUNT(*) FROM projects WHERE id = :id"),
+            params={"id": project_id},
         )
     ).scalar_one()
     assert count == 0, "trashed project was not hard-purged by the worker"

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -22,8 +22,7 @@ from alembic import command
 from alembic.config import Config
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import event, text
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -213,9 +212,7 @@ def _disable_hibp_check(monkeypatch):
 @pytest.fixture(scope="function")
 async def engine():
     """Create a test database engine."""
-    test_engine = create_async_engine(
-        TEST_DATABASE_URL, echo=False, future=True, pool_pre_ping=True
-    )
+    test_engine = create_async_engine(TEST_DATABASE_URL, echo=False, pool_pre_ping=True)
     yield test_engine
     await test_engine.dispose()
 
@@ -261,9 +258,11 @@ async def role_session():
 
     async def _make(role: str = "app_admin") -> AsyncSession:
         eng = create_async_engine(
-            _test_url_for_role(role), echo=False, future=True, pool_pre_ping=True
+            _test_url_for_role(role), echo=False, pool_pre_ping=True
         )
-        maker = sessionmaker(bind=eng, class_=AsyncSession, expire_on_commit=False)
+        maker = async_sessionmaker(
+            bind=eng, class_=AsyncSession, expire_on_commit=False
+        )
         sess = maker()
         created.append((eng, sess))
         return sess
@@ -334,11 +333,10 @@ async def session(engine) -> AsyncGenerator[AsyncSession, None]:
     transaction, which is why a flush-then-refresh would otherwise lose the route.
     """
     async with engine.connect() as bound_conn:
-        async_session = sessionmaker(
+        async_session = async_sessionmaker(
             bind=bound_conn,
             class_=AsyncSession,
             expire_on_commit=False,
-            autocommit=False,
             autoflush=False,
         )
 
@@ -485,10 +483,10 @@ async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
     ``SET ROLE`` / ``search_path`` GUCs persist across the request's statements.
     """
     app_engine = create_async_engine(
-        _test_url_for_role("app_user"), echo=False, future=True, pool_pre_ping=True
+        _test_url_for_role("app_user"), echo=False, pool_pre_ping=True
     )
     admin_engine = create_async_engine(
-        _test_url_for_role("app_admin"), echo=False, future=True, pool_pre_ping=True
+        _test_url_for_role("app_admin"), echo=False, pool_pre_ping=True
     )
     req_conn = await app_engine.connect()
     admin_conn = await admin_engine.connect()
@@ -498,10 +496,10 @@ async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
     # The net is the DATABASE-level statement_timeout armed in _run_test_migrations
     # (covers EVERY connection, incl. the privileged setup/provisioning conn that a
     # per-connection SET here would miss — which is what hung admin_test).
-    req_session = sessionmaker(
+    req_session = async_sessionmaker(
         bind=req_conn, class_=AsyncSession, expire_on_commit=False, autoflush=False
     )()
-    admin_session = sessionmaker(
+    admin_session = async_sessionmaker(
         bind=admin_conn, class_=AsyncSession, expire_on_commit=False, autoflush=False
     )()
 
@@ -531,7 +529,7 @@ async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
     # write on the SAME row, which then blocks until statement_timeout.
     async def override_get_session() -> AsyncGenerator[AsyncSession, None]:
         await _publish_setup_state()
-        await req_session.execute(text(_REQUEST_RESET_SQL))
+        await req_session.exec(text(_REQUEST_RESET_SQL))
         try:
             yield req_session
         finally:
@@ -539,7 +537,7 @@ async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
 
     async def override_get_admin_session() -> AsyncGenerator[AsyncSession, None]:
         await _publish_setup_state()
-        await admin_session.execute(text(_REQUEST_RESET_SQL))
+        await admin_session.exec(text(_REQUEST_RESET_SQL))
         try:
             yield admin_session
         finally:


### PR DESCRIPTION
## Problem

The backend already runs on SQLAlchemy 2.0 / SQLModel, but two 1.x-era patterns lingered:

1. **Engine/session construction** used `sessionmaker(class_=AsyncSession)` plus the now-redundant `future=True` (a no-op in 2.0) and `autocommit=False` (removed from `Session` in 2.0).
2. **`session.execute()` on SQLModel sessions** is deprecated — SQLModel emits a loud `DeprecationWarning` recommending `session.exec()`. These warnings surfaced repeatedly in the test output.

## Changes

- **`session.py` / `conftest.py`**: `sessionmaker` → `async_sessionmaker` (the 2.0-native async factory, already used in `init_db_test.py`); dropped `future=True` and `autocommit=False`.
- **Migrated every SQLModel-session `execute()` → `exec()`** across production and test code:
  - `text()`, `update()`, `delete()`, `insert()` pass straight through (`exec()` returns a plain `Result`/`CursorResult`); positional params moved to the `params=` keyword (`exec()` only accepts params as a keyword).
  - For `select(<single entity/column>)` (a `SelectOfScalar`), `exec()` already returns scalars, so the redundant `.scalars()` was dropped (`.scalars().all()` → `.all()`, `.scalar()` → `.first()`, etc.).
- **Left untouched**: raw asyncpg / SQLAlchemy `AsyncConnection` `.execute()` calls (no `.exec()` exists on connections) and Alembic `op.execute`.

No behavior change — `exec()` runs the same statement; only the deprecated call path and dead flags are removed.

## Schema / env

None.

## Testing

- `ruff check app conftest.py` — passes; `ruff format` applied.
- Grep confirms zero remaining SQLModel-session `.execute(` and zero `sessionmaker(`/`future=True`.
- Targeted test runs in progress (RLS / membership / platform-role suites).