### PR TITLE
Record content_type + content_hash on uploads (storage Phase 2)

### DIFF
--- a/backend/alembic/guild/guild_schema.sql
+++ b/backend/alembic/guild/guild_schema.sql
@@ -484,6 +484,8 @@ CREATE TABLE IF NOT EXISTS uploads (
 	uploader_user_id INTEGER NOT NULL, 
 	size_bytes INTEGER DEFAULT 0 NOT NULL, 
 	created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
+	content_type VARCHAR(255), 
+	content_hash VARCHAR(64), 
 	CONSTRAINT uploads_pkey PRIMARY KEY (id)
 );
 CREATE TABLE IF NOT EXISTS webhook_subscriptions (

--- a/backend/alembic/versions/20260624_0124_add_upload_content_metadata.py
+++ b/backend/alembic/versions/20260624_0124_add_upload_content_metadata.py
@@ -1,0 +1,67 @@
+"""Add content_type and content_hash to uploads.
+
+Records the MIME type and a SHA-256 of the stored bytes at upload time, so
+serving can set ``Content-Type`` without sniffing (and a future object-store
+backend can set it on the object), and blobs can be integrity-checked during the
+eventual migration / deduped later.
+
+``uploads`` is a guild-scoped table, so the columns are added to ``public`` (the
+reflection source for guild_schema.sql) AND every existing ``guild_*`` schema —
+the generated guild_schema.sql only ``CREATE TABLE IF NOT EXISTS`` (a no-op on
+existing tables), so existing guilds get the columns only via this explicit
+ALTER. New guilds pick them up from the regenerated guild_schema.sql. Both
+columns are nullable: existing rows stay NULL and are backfilled lazily / during
+the object-store migration. Mirrors 20260624_0122.
+
+Revision ID: 20260624_0124
+Revises: 20260624_0123
+Create Date: 2026-06-24
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260624_0124"
+down_revision = "20260624_0123"
+branch_labels = None
+depends_on = None
+
+
+def _guild_schemas(conn) -> list[str]:
+    # Matches every guild_<id> AND guild_template.
+    rows = conn.execute(
+        text("SELECT nspname FROM pg_namespace WHERE nspname LIKE 'guild\\_%'")
+    ).all()
+    return [r[0] for r in rows]
+
+
+def _apply(conn) -> None:
+    conn.execute(
+        text("ALTER TABLE uploads ADD COLUMN IF NOT EXISTS content_type VARCHAR(255)")
+    )
+    conn.execute(
+        text("ALTER TABLE uploads ADD COLUMN IF NOT EXISTS content_hash VARCHAR(64)")
+    )
+
+
+def _revert(conn) -> None:
+    conn.execute(text("ALTER TABLE uploads DROP COLUMN IF EXISTS content_hash"))
+    conn.execute(text("ALTER TABLE uploads DROP COLUMN IF EXISTS content_type"))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _apply(conn)
+    conn.execute(text("SET search_path TO public"))
+    _apply(conn)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for schema in _guild_schemas(conn):
+        conn.execute(text(f'SET search_path TO "{schema}", public'))
+        _revert(conn)
+    conn.execute(text("SET search_path TO public"))
+    _revert(conn)

--- a/backend/app/api/v1/tenant_endpoints/attachments.py
+++ b/backend/app/api/v1/tenant_endpoints/attachments.py
@@ -19,6 +19,7 @@ from app.schemas.tenant.attachment import AttachmentUploadResponse
 from app.services.attachments import (
     FileTooLargeError,
     StorageQuotaExceededError,
+    compute_content_hash,
     enforce_storage_quota,
     read_upload_bounded,
 )
@@ -108,6 +109,8 @@ async def upload_attachment(
         guild_id=guild_context.guild_id,
         uploader_user_id=current_user.id,
         size_bytes=len(contents),
+        content_type=file.content_type or f"image/{detected_format}",
+        content_hash=compute_content_hash(contents),
     )
     session.add(upload)
     await session.commit()

--- a/backend/app/api/v1/tenant_endpoints/attachments.py
+++ b/backend/app/api/v1/tenant_endpoints/attachments.py
@@ -29,6 +29,20 @@ router = APIRouter()
 
 MAX_IMAGE_BYTES = 10 * 1024 * 1024
 
+# Magic-byte detection yields a short format token; map it to a real MIME type
+# for the rare case the client omits Content-Type. The image-only guard normally
+# rejects a missing Content-Type first, so this is defense-in-depth -- but it must
+# still emit valid MIME types (e.g. image/svg+xml, not image/svg).
+_FORMAT_TO_MIME = {
+    "png": "image/png",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "tiff": "image/tiff",
+    "svg": "image/svg+xml",
+    "ico": "image/x-icon",
+}
+
 ImageUploadUser = Annotated[User, Depends(get_current_active_user)]
 GuildContextDep = Annotated[GuildContext, Depends(get_guild_membership)]
 
@@ -109,7 +123,7 @@ async def upload_attachment(
         guild_id=guild_context.guild_id,
         uploader_user_id=current_user.id,
         size_bytes=len(contents),
-        content_type=file.content_type or f"image/{detected_format}",
+        content_type=file.content_type or _FORMAT_TO_MIME[detected_format],
         content_hash=compute_content_hash(contents),
     )
     session.add(upload)
@@ -119,6 +133,6 @@ async def upload_attachment(
         filename=file.filename or filename,
         # Guild in the path so the served media self-describes its guild.
         url=f"/uploads/{guild_context.guild_id}/{filename}",
-        content_type=file.content_type or f"image/{detected_format}",
+        content_type=file.content_type or _FORMAT_TO_MIME[detected_format],
         size=len(contents),
     )

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -999,6 +999,8 @@ async def upload_document_file(
         guild_id=guild_context.guild_id,
         uploader_user_id=current_user.id,
         size_bytes=len(contents),
+        content_type=mime_type,
+        content_hash=attachments_service.compute_content_hash(contents),
     )
     session.add(upload_record)
 
@@ -1161,6 +1163,8 @@ async def upload_document_version(
         guild_id=guild_context.guild_id,
         uploader_user_id=current_user.id,
         size_bytes=len(contents),
+        content_type=mime_type,
+        content_hash=attachments_service.compute_content_hash(contents),
     )
     session.add(upload_record)
 

--- a/backend/app/models/tenant/upload.py
+++ b/backend/app/models/tenant/upload.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Column, DateTime
+from sqlalchemy import Column, DateTime, String
 from sqlmodel import Field, SQLModel
 
 
@@ -15,6 +15,17 @@ class Upload(SQLModel, table=True):
     guild_id: int = Field(foreign_key="guilds.id", index=True)
     uploader_user_id: int = Field(foreign_key="users.id")
     size_bytes: int = Field(default=0)
+    # MIME type recorded at upload time, so serving can set Content-Type without
+    # sniffing the bytes (and a future object-store backend can set it on the
+    # object). Nullable: legacy rows stay NULL until backfilled.
+    content_type: Optional[str] = Field(
+        default=None, sa_column=Column(String(255), nullable=True)
+    )
+    # SHA-256 hex of the stored bytes — integrity verification for the eventual
+    # object-store migration, and the basis for future content dedup.
+    content_hash: Optional[str] = Field(
+        default=None, sa_column=Column(String(64), nullable=True)
+    )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         sa_column=Column(DateTime(timezone=True), nullable=False),

--- a/backend/app/services/attachments.py
+++ b/backend/app/services/attachments.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Set, Tuple
@@ -60,6 +61,12 @@ async def read_upload_bounded(file: UploadFile, max_size: int) -> bytes:
     if len(contents) > max_size:
         raise FileTooLargeError(max_size)
     return contents
+
+
+def compute_content_hash(data: bytes) -> str:
+    """SHA-256 hex of blob bytes — recorded on the ``uploads`` row for integrity
+    verification (object-store migration) and future content dedup."""
+    return hashlib.sha256(data).hexdigest()
 
 
 # Supported MIME types for document file uploads (based on react-doc-viewer support)
@@ -495,6 +502,35 @@ async def get_upload_bytes_for_urls(session, urls: Iterable[str]) -> int:
             )
         )
     ).one()
+
+
+async def get_upload_metadata_for_urls(
+    session, urls: Iterable[str]
+) -> Dict[str, Tuple[str | None, str | None]]:
+    """Map ``{filename: (content_type, content_hash)}`` for the uploads referenced
+    by ``urls`` (matched by filename).
+
+    Used to carry metadata onto byte-identical copies (clones) without re-reading
+    the blobs — a copy shares its source's content type and hash. Runs under the
+    guild-routed RLS session.
+    """
+    from sqlmodel import select
+
+    from app.models.tenant.upload import Upload
+
+    filenames = {
+        Path(normalized).name
+        for url in urls
+        if (normalized := normalize_upload_url(url))
+    }
+    if not filenames:
+        return {}
+    rows = await session.exec(
+        select(Upload.filename, Upload.content_type, Upload.content_hash).where(
+            Upload.filename.in_(filenames)
+        )
+    )
+    return {fn: (ct, ch) for fn, ct, ch in rows.all()}
 
 
 # Advisory-lock namespace for per-guild storage-quota admission. A large fixed

--- a/backend/app/services/tenant/documents.py
+++ b/backend/app/services/tenant/documents.py
@@ -269,11 +269,25 @@ async def duplicate_document(
         upload_dir = Path(settings.UPLOADS_DIR)
         new_upload_records: list[Upload] = []
         new_urls = list(replacements.values())
+        # Map each new blob back to its source so we can carry the source's
+        # content_type/content_hash onto the copy (it is byte-identical).
+        new_to_source = {new: old for old, new in replacements.items()}
         if featured_image_url and featured_image_url != source.featured_image_url:
             new_urls.append(featured_image_url)
+            new_to_source[featured_image_url] = source.featured_image_url
+        source_meta = await attachments_service.get_upload_metadata_for_urls(
+            session, list(new_to_source.values())
+        )
         for new_url in new_urls:
             fname = new_url.split("/")[-1]
             if fname:
+                source_url = new_to_source.get(new_url)
+                source_fname = source_url.split("/")[-1] if source_url else None
+                content_type, content_hash = (
+                    source_meta.get(source_fname, (None, None))
+                    if source_fname
+                    else (None, None)
+                )
                 fpath = upload_dir / fname
                 new_upload_records.append(
                     Upload(
@@ -281,6 +295,8 @@ async def duplicate_document(
                         guild_id=effective_guild_id,
                         uploader_user_id=user_id,
                         size_bytes=fpath.stat().st_size if fpath.exists() else 0,
+                        content_type=content_type,
+                        content_hash=content_hash,
                     )
                 )
         if new_upload_records:


### PR DESCRIPTION
## Problem

Phase 2 of the cloud storage rebuild — groundwork for the S3 backend. `uploads` doesn't record a blob's MIME type (it's sniffed at serve time) or a content hash, both of which Phase 3 needs: `Content-Type` on `GetObject`, and integrity verification during the migration.

## Changes

- `uploads.content_type` (VARCHAR 255, nullable) and `uploads.content_hash` (SHA-256 hex, VARCHAR 64, nullable) on the `Upload` model.
- Populated on write at all three upload paths (image attachment, document file, document version) via a `compute_content_hash` helper.
- Clone path carries `content_type`/`content_hash` from the source rows — a copy is byte-identical, so no re-hashing (new `get_upload_metadata_for_urls` helper).
- No serve-path or behavior change: this only *stores* the metadata; using `content_type` on the response is left to the S3 phase.

## Schema

- Migration `20260624_0124`. `uploads` is **guild-scoped**, so it fans the columns out to `public` (the reflection source) **and** every existing `guild_*` schema; `alembic/guild/guild_schema.sql` regenerated for new guilds. Both columns nullable — existing rows stay NULL and backfill lazily / during the S3 migration.

## Testing

- `ruff check` / `ruff format` — clean.
- Applied the migration to the dev DB and verified the columns reached `public.uploads` and every existing guild schema (`guild_1/2/3`); `gen_guild_schema.py` regen is a clean 2-line diff (just the two columns on `uploads`).
- Import smoke clean; existing upload/document tests exercise the population in CI.
