### PR TITLE
Per-guild prefix for local storage + prefix-delete on guild deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Per-guild storage limit.** A guild can now have a maximum total upload storage; uploads that would push the guild over its limit are rejected. Defaults to unlimited, so existing guilds are unaffected until a limit is set.
 - **Optional S3-compatible object storage for uploads.** Uploads can now be stored in an S3-compatible object store you point it at (a self-hosted Garage instance, AWS S3, R2, etc.) instead of the local filesystem, via `STORAGE_BACKEND=s3` and the new `S3_*` settings. The filesystem remains the default, so existing deployments are unaffected. See `docs/OBJECT_STORAGE.md`.
 
+### Fixed
+
+- **Deleting a guild now also removes its uploaded files.** Previously a deleted guild's stored blobs were left orphaned on disk (or in the object store); guild deletion now sweeps the guild's storage namespace. Local uploads are also organized into per-guild folders (`uploads/guild_<id>/`), with any existing files relocated automatically on startup — no action needed.
+
 ## [0.53.1] - 2026-06-24
 
 ### Fixed

--- a/backend/app/api/uploads_test.py
+++ b/backend/app/api/uploads_test.py
@@ -24,6 +24,22 @@ def _uploads_dir() -> Path:
     return path
 
 
+@pytest.fixture(autouse=True)
+def _isolated_uploads_dir(tmp_path, monkeypatch):
+    """Point UPLOADS_DIR at a throwaway dir so staged blobs don't litter the repo
+    and never leak across tests."""
+    monkeypatch.setattr(settings, "UPLOADS_DIR", str(tmp_path / "uploads"))
+
+
+def _stage_upload(guild_id: int, filename: str, content: bytes = b"hello") -> None:
+    """Write a blob where the per-guild storage backend serves it from
+    (``UPLOADS_DIR/guild_<id>/``), via the real resolver — so tests track the
+    production layout instead of hardcoding it."""
+    from app.services.storage import get_guild_storage
+
+    get_guild_storage(guild_id).write(filename, content)
+
+
 @pytest.mark.integration
 async def test_upload_unauthenticated_returns_401(client: AsyncClient) -> None:
     """GET /uploads/<file> without any auth token returns 401."""
@@ -44,30 +60,25 @@ async def test_upload_accessible_with_auth_header(
     """GET /uploads/<file> with Authorization Bearer header returns 200."""
     from app.models.tenant.upload import Upload
 
-    uploads_dir = _uploads_dir()
-    test_file = uploads_dir / "test_auth_header.txt"
-    test_file.write_text("hello")
-    try:
-        user = await create_user(session)
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(session, user=user, guild=guild)
-        session.add(
-            Upload(
-                filename="test_auth_header.txt",
-                guild_id=guild.id,
-                uploader_user_id=user.id,
-                size_bytes=5,
-            )
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    _stage_upload(guild.id, "test_auth_header.txt")
+    session.add(
+        Upload(
+            filename="test_auth_header.txt",
+            guild_id=guild.id,
+            uploader_user_id=user.id,
+            size_bytes=5,
         )
-        await session.commit()
+    )
+    await session.commit()
 
-        headers = await get_guild_headers(session, guild, user)
-        response = await client.get(
-            f"/uploads/{guild.id}/test_auth_header.txt", headers=headers
-        )
-        assert response.status_code == 200
-    finally:
-        test_file.unlink(missing_ok=True)
+    headers = await get_guild_headers(session, guild, user)
+    response = await client.get(
+        f"/uploads/{guild.id}/test_auth_header.txt", headers=headers
+    )
+    assert response.status_code == 200
 
 
 @pytest.mark.integration
@@ -97,31 +108,26 @@ async def test_upload_accessible_with_scoped_upload_token(
     """A short-lived, uploads-scoped token IS accepted via ?token=. SEC-12."""
     from app.models.tenant.upload import Upload
 
-    uploads_dir = _uploads_dir()
-    test_file = uploads_dir / "test_query_upload_token.txt"
-    test_file.write_text("hello")
-    try:
-        user = await create_user(session)
-        # SEC-6 (merged): files are only served with a matching Upload row and
-        # guild membership — the scoped token answers "who", not "may".
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(session, user=user, guild=guild)
-        session.add(
-            Upload(
-                filename="test_query_upload_token.txt",
-                guild_id=guild.id,
-                uploader_user_id=user.id,
-                size_bytes=5,
-            )
+    user = await create_user(session)
+    # SEC-6 (merged): files are only served with a matching Upload row and
+    # guild membership — the scoped token answers "who", not "may".
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    _stage_upload(guild.id, "test_query_upload_token.txt")
+    session.add(
+        Upload(
+            filename="test_query_upload_token.txt",
+            guild_id=guild.id,
+            uploader_user_id=user.id,
+            size_bytes=5,
         )
-        await session.commit()
-        token, _ = create_upload_token(user_id=user.id)
-        response = await client.get(
-            f"/uploads/{guild.id}/test_query_upload_token.txt?token={token}",
-        )
-        assert response.status_code == 200
-    finally:
-        test_file.unlink(missing_ok=True)
+    )
+    await session.commit()
+    token, _ = create_upload_token(user_id=user.id)
+    response = await client.get(
+        f"/uploads/{guild.id}/test_query_upload_token.txt?token={token}",
+    )
+    assert response.status_code == 200
 
 
 @pytest.mark.integration
@@ -144,37 +150,32 @@ async def test_issue_upload_token_endpoint(
     """POST /auth/upload-token mints a token that opens /uploads. SEC-12."""
     from app.models.tenant.upload import Upload
 
-    uploads_dir = _uploads_dir()
-    test_file = uploads_dir / "test_minted_token.txt"
-    test_file.write_text("hello")
-    try:
-        user = await create_user(session)
-        # SEC-6 (merged): serving requires a matching Upload row + membership.
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(session, user=user, guild=guild)
-        session.add(
-            Upload(
-                filename="test_minted_token.txt",
-                guild_id=guild.id,
-                uploader_user_id=user.id,
-                size_bytes=5,
-            )
+    user = await create_user(session)
+    # SEC-6 (merged): serving requires a matching Upload row + membership.
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    _stage_upload(guild.id, "test_minted_token.txt")
+    session.add(
+        Upload(
+            filename="test_minted_token.txt",
+            guild_id=guild.id,
+            uploader_user_id=user.id,
+            size_bytes=5,
         )
-        await session.commit()
-        mint = await client.post(
-            "/api/v1/auth/upload-token", headers=get_auth_headers(user)
-        )
-        assert mint.status_code == 200
-        body = mint.json()
-        assert body["token_type"] == "upload_token"
-        assert body["expires_in"] > 0
-        token = body["upload_token"]
-        response = await client.get(
-            f"/uploads/{guild.id}/test_minted_token.txt?token={token}"
-        )
-        assert response.status_code == 200
-    finally:
-        test_file.unlink(missing_ok=True)
+    )
+    await session.commit()
+    mint = await client.post(
+        "/api/v1/auth/upload-token", headers=get_auth_headers(user)
+    )
+    assert mint.status_code == 200
+    body = mint.json()
+    assert body["token_type"] == "upload_token"
+    assert body["expires_in"] > 0
+    token = body["upload_token"]
+    response = await client.get(
+        f"/uploads/{guild.id}/test_minted_token.txt?token={token}"
+    )
+    assert response.status_code == 200
 
 
 @pytest.mark.integration
@@ -216,30 +217,25 @@ async def test_upload_guild_member_can_access_file(
     """Authenticated guild member can access a file uploaded by that guild."""
     from app.models.tenant.upload import Upload
 
-    uploads_dir = _uploads_dir()
-    test_file = uploads_dir / "test_guild_access.png"
-    test_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)  # minimal PNG header
-    try:
-        user = await create_user(session)
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(session, user=user, guild=guild)
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    _stage_upload(guild.id, "test_guild_access.png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
 
-        upload = Upload(
-            filename="test_guild_access.png",
-            guild_id=guild.id,
-            uploader_user_id=user.id,
-            size_bytes=16,
-        )
-        session.add(upload)
-        await session.commit()
+    upload = Upload(
+        filename="test_guild_access.png",
+        guild_id=guild.id,
+        uploader_user_id=user.id,
+        size_bytes=16,
+    )
+    session.add(upload)
+    await session.commit()
 
-        headers = await get_guild_headers(session, guild, user)
-        response = await client.get(
-            f"/uploads/{guild.id}/test_guild_access.png", headers=headers
-        )
-        assert response.status_code == 200
-    finally:
-        test_file.unlink(missing_ok=True)
+    headers = await get_guild_headers(session, guild, user)
+    response = await client.get(
+        f"/uploads/{guild.id}/test_guild_access.png", headers=headers
+    )
+    assert response.status_code == 200
 
 
 @pytest.mark.integration
@@ -331,52 +327,47 @@ async def test_upload_row_in_guild_schema_is_served(
 
     from app.db.schema_provisioning import guild_schema_name
 
-    uploads_dir = _uploads_dir()
-    test_file = uploads_dir / "test_guild_schema_row.txt"
-    test_file.write_text("hello")
-    try:
-        user = await create_user(session)
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(session, user=user, guild=guild)
-        schema = guild_schema_name(guild.id)
-        # Insert the row into the guild schema ONLY (mimicking the production
-        # request path, where set_rls_context routes search_path there).
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    _stage_upload(guild.id, "test_guild_schema_row.txt")
+    schema = guild_schema_name(guild.id)
+    # Insert the row into the guild schema ONLY (mimicking the production
+    # request path, where set_rls_context routes search_path there).
+    await session.exec(
+        text(
+            f'INSERT INTO "{schema}".uploads'
+            " (filename, guild_id, uploader_user_id, size_bytes, created_at)"
+            " VALUES (:fn, :gid, :uid, 5, now())"
+        ),
+        params={"fn": "test_guild_schema_row.txt", "gid": guild.id, "uid": user.id},
+    )
+    await session.commit()
+    # Prove the row is invisible from public.uploads.
+    public_hit = (
         await session.exec(
-            text(
-                f'INSERT INTO "{schema}".uploads'
-                " (filename, guild_id, uploader_user_id, size_bytes, created_at)"
-                " VALUES (:fn, :gid, :uid, 5, now())"
-            ),
-            params={"fn": "test_guild_schema_row.txt", "gid": guild.id, "uid": user.id},
+            text("SELECT 1 FROM public.uploads WHERE filename = :fn"),
+            params={"fn": "test_guild_schema_row.txt"},
         )
-        await session.commit()
-        # Prove the row is invisible from public.uploads.
-        public_hit = (
-            await session.exec(
-                text("SELECT 1 FROM public.uploads WHERE filename = :fn"),
-                params={"fn": "test_guild_schema_row.txt"},
-            )
-        ).first()
-        assert public_hit is None
+    ).first()
+    assert public_hit is None
 
-        response = await client.get(
-            f"/uploads/{guild.id}/test_guild_schema_row.txt",
-            headers=await get_guild_headers(session, guild, user),
-        )
-        assert response.status_code == 200
-        assert response.text == "hello"
+    response = await client.get(
+        f"/uploads/{guild.id}/test_guild_schema_row.txt",
+        headers=await get_guild_headers(session, guild, user),
+    )
+    assert response.status_code == 200
+    assert response.text == "hello"
 
-        # A user outside the guild fails membership validation → 404
-        # (existence not confirmed), not the file — even with their flag
-        # pointed at the guild.
-        outsider = await create_user(session, email="outsider-schema@example.com")
-        response = await client.get(
-            f"/uploads/{guild.id}/test_guild_schema_row.txt",
-            headers=await get_guild_headers(session, guild, outsider),
-        )
-        assert response.status_code == 404
-    finally:
-        test_file.unlink(missing_ok=True)
+    # A user outside the guild fails membership validation → 404
+    # (existence not confirmed), not the file — even with their flag
+    # pointed at the guild.
+    outsider = await create_user(session, email="outsider-schema@example.com")
+    response = await client.get(
+        f"/uploads/{guild.id}/test_guild_schema_row.txt",
+        headers=await get_guild_headers(session, guild, outsider),
+    )
+    assert response.status_code == 404
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_test.py
@@ -36,6 +36,13 @@ def _uploads_dir() -> Path:
     return path
 
 
+@pytest.fixture(autouse=True)
+def _isolated_uploads_dir(tmp_path, monkeypatch):
+    """Point UPLOADS_DIR at a throwaway dir so staged blobs (now in per-guild
+    subdirs) don't litter the repo and never leak across tests."""
+    monkeypatch.setattr(settings, "UPLOADS_DIR", str(tmp_path / "uploads"))
+
+
 async def _create_file_document(
     session: AsyncSession,
     *,
@@ -44,8 +51,11 @@ async def _create_file_document(
     filename: str,
 ) -> Document:
     """Create a file-type Document with a dummy file on disk and owner permission."""
-    file_path = _uploads_dir() / filename
-    file_path.write_bytes(b"%PDF-1.4 test")
+    # Stage the blob via the real resolver so it lands where the serve path reads
+    # it (UPLOADS_DIR/guild_<id>/), and use the canonical guild-scoped URL.
+    from app.services.storage import get_guild_storage
+
+    get_guild_storage(initiative.guild_id).write(filename, b"%PDF-1.4 test")
 
     doc = Document(
         title="Test File Doc",
@@ -54,7 +64,7 @@ async def _create_file_document(
         created_by_id=owner.id,
         updated_by_id=owner.id,
         document_type=DocumentType.file,
-        file_url=f"/uploads/{filename}",
+        file_url=f"/uploads/{initiative.guild_id}/{filename}",
         original_filename=filename,
         file_content_type="application/pdf",
         file_size=13,

--- a/backend/app/db/local_upload_migration.py
+++ b/backend/app/db/local_upload_migration.py
@@ -1,0 +1,124 @@
+"""One-time relocation of legacy flat local uploads into per-guild dirs.
+
+Earlier local-filesystem builds stored every blob flat at ``UPLOADS_DIR/<file>``.
+The storage backend now namespaces a guild's blobs under
+``UPLOADS_DIR/guild_<id>/<file>`` (matching the S3 ``guild_<id>/`` layout), so a
+pre-existing install's flat files must be moved once.
+
+This runs at startup (see ``app.main`` lifespan), is **local-only**,
+**idempotent**, and **self-disabling**: once the uploads root has no top-level
+flat files it returns immediately without touching the database. Only file
+locations change — the ``uploads`` rows and the ``/uploads/{guild_id}/{file}``
+URLs are untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.db import session as db_session
+from app.db.schema_provisioning import guild_schema_name
+
+logger = logging.getLogger(__name__)
+
+
+def _legacy_flat_files(root: Path) -> list[Path]:
+    """Regular files directly under the uploads root (the pre-prefix layout).
+
+    Per-guild dirs (``guild_<id>/``) are subdirectories, so they're skipped — only
+    loose files at the top level are legacy blobs awaiting relocation.
+    """
+    if not root.is_dir():
+        return []
+    return [p for p in root.iterdir() if p.is_file()]
+
+
+def relocate_flat_uploads(
+    root: Path, filename_to_guild: dict[str, int]
+) -> tuple[int, int]:
+    """Move legacy flat files into ``root/guild_<id>/``. Pure filesystem + a map.
+
+    Returns ``(moved, unmatched)``. Idempotent: a destination that already exists
+    means the file was migrated before, so the stray flat copy is dropped. A file
+    whose name isn't in the map (no ``uploads`` row) is left in place and counted
+    as unmatched, so nothing is silently destroyed.
+    """
+    moved = 0
+    unmatched = 0
+    for f in _legacy_flat_files(root):
+        guild_id = filename_to_guild.get(f.name)
+        if guild_id is None:
+            unmatched += 1
+            continue
+        dest_dir = root / f"guild_{guild_id}"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f.name
+        if dest.exists():
+            f.unlink(missing_ok=True)  # already relocated; drop the duplicate
+        else:
+            shutil.move(str(f), str(dest))
+        moved += 1
+    return moved, unmatched
+
+
+async def _build_filename_guild_map() -> dict[str, int]:
+    """Map every guild's ``uploads.filename`` -> guild id (filenames are UUIDs,
+    so they're globally unique and never collide across guilds)."""
+    engine = db_session.provisioning_engine  # superuser: can read every schema
+    mapping: dict[str, int] = {}
+    async with engine.connect() as conn:
+        guild_ids = (
+            (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
+            .scalars()
+            .all()
+        )
+        for gid in guild_ids:
+            schema = guild_schema_name(gid)
+            exists = (
+                await conn.execute(
+                    text("SELECT to_regclass(:t)"), {"t": f"{schema}.uploads"}
+                )
+            ).scalar()
+            if exists is None:  # schema missing/partial — skip
+                continue
+            rows = (
+                (await conn.execute(text(f'SELECT filename FROM "{schema}".uploads')))
+                .scalars()
+                .all()
+            )
+            for filename in rows:
+                if filename:
+                    mapping[filename] = gid
+    return mapping
+
+
+async def migrate_local_uploads_to_guild_prefix() -> None:
+    """Relocate any legacy flat uploads into their ``guild_<id>/`` subdir.
+
+    No-op unless ``STORAGE_BACKEND=local`` and the uploads root still holds
+    top-level flat files. Safe to run on every boot.
+    """
+    if (settings.STORAGE_BACKEND or "local").lower() != "local":
+        return
+    root = Path(settings.UPLOADS_DIR)
+    if not _legacy_flat_files(root):
+        return  # already migrated / nothing to relocate
+    mapping = await _build_filename_guild_map()
+    moved, unmatched = relocate_flat_uploads(root, mapping)
+    if unmatched:
+        logger.warning(
+            "local upload migration: relocated %d file(s) into guild_<id>/ dirs; "
+            "%d had no uploads row and were left in place",
+            moved,
+            unmatched,
+        )
+    else:
+        logger.info(
+            "local upload migration: relocated %d file(s) into guild_<id>/ dirs",
+            moved,
+        )

--- a/backend/app/db/local_upload_migration_test.py
+++ b/backend/app/db/local_upload_migration_test.py
@@ -1,0 +1,59 @@
+"""Unit tests for the legacy flat-upload relocation (file-move logic only).
+
+``relocate_flat_uploads`` is pure (filesystem + a filename->guild map), so these
+run without a database. The DB-backed map builder and the boot orchestration are
+covered by integration runs.
+"""
+
+from app.db.local_upload_migration import _legacy_flat_files, relocate_flat_uploads
+
+
+def test_relocate_moves_flat_files_into_guild_dirs(tmp_path):
+    (tmp_path / "a.png").write_bytes(b"1")
+    (tmp_path / "b.png").write_bytes(b"2")
+    # A pre-existing per-guild dir must be left alone by the scan.
+    (tmp_path / "guild_9").mkdir()
+    (tmp_path / "guild_9" / "kept.png").write_bytes(b"keep")
+
+    moved, unmatched = relocate_flat_uploads(tmp_path, {"a.png": 5, "b.png": 6})
+
+    assert (moved, unmatched) == (2, 0)
+    assert (tmp_path / "guild_5" / "a.png").read_bytes() == b"1"
+    assert (tmp_path / "guild_6" / "b.png").read_bytes() == b"2"
+    assert not (tmp_path / "a.png").exists()
+    assert not (tmp_path / "b.png").exists()
+    # The already-prefixed file is untouched.
+    assert (tmp_path / "guild_9" / "kept.png").read_bytes() == b"keep"
+
+
+def test_relocate_leaves_unmatched_files_in_place(tmp_path):
+    (tmp_path / "orphan.png").write_bytes(b"x")
+    moved, unmatched = relocate_flat_uploads(tmp_path, {})  # no uploads row
+    assert (moved, unmatched) == (0, 1)
+    assert (tmp_path / "orphan.png").exists()  # not destroyed
+
+
+def test_relocate_is_idempotent_when_dest_exists(tmp_path):
+    (tmp_path / "a.png").write_bytes(b"new")
+    dest_dir = tmp_path / "guild_5"
+    dest_dir.mkdir()
+    (dest_dir / "a.png").write_bytes(b"already")
+
+    moved, unmatched = relocate_flat_uploads(tmp_path, {"a.png": 5})
+
+    assert (moved, unmatched) == (1, 0)
+    # Existing destination wins; the stray flat duplicate is dropped.
+    assert (dest_dir / "a.png").read_bytes() == b"already"
+    assert not (tmp_path / "a.png").exists()
+
+
+def test_legacy_flat_files_ignores_subdirs(tmp_path):
+    (tmp_path / "flat.png").write_bytes(b"1")
+    (tmp_path / "guild_1").mkdir()
+    (tmp_path / "guild_1" / "nested.png").write_bytes(b"2")
+    flat = _legacy_flat_files(tmp_path)
+    assert [p.name for p in flat] == ["flat.png"]
+
+
+def test_legacy_flat_files_missing_root(tmp_path):
+    assert _legacy_flat_files(tmp_path / "nope") == []

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -244,9 +244,21 @@ async def provision_guild(guild_id: int) -> str:
 
 
 async def deprovision_guild(guild_id: int) -> None:
-    """Drop a guild's schema + role on the superuser engine."""
+    """Drop a guild's schema + role on the superuser engine, and remove its blobs."""
     async with db_session.provisioning_engine.begin() as conn:
         await drop_guild_schema(conn, guild_id)
+    # Remove the guild's stored blobs (the ``guild_<id>/`` storage namespace).
+    # Best-effort and after the schema drop succeeds: a storage hiccup must not
+    # strand a half-deleted guild, and delete_prefix needs no DB so order is moot.
+    try:
+        from app.services.storage import purge_guild_blobs
+
+        removed = purge_guild_blobs(guild_id)
+        logger.info(
+            "deprovision guild %s: removed %d stored blob(s)", guild_id, removed
+        )
+    except Exception:  # noqa: BLE001 — blob cleanup must not block teardown
+        logger.exception("failed to purge stored blobs for guild %s", guild_id)
 
 
 @dataclass

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -23,6 +23,7 @@ plain sequential loop heals both with no extra bookkeeping.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -253,7 +254,9 @@ async def deprovision_guild(guild_id: int) -> None:
     try:
         from app.services.storage import purge_guild_blobs
 
-        removed = purge_guild_blobs(guild_id)
+        # Offload to a thread: the S3 path makes paginated blocking calls, and this
+        # runs on the event loop. A one-shot teardown shouldn't stall the loop.
+        removed = await asyncio.to_thread(purge_guild_blobs, guild_id)
         logger.info(
             "deprovision guild %s: removed %d stored blob(s)", guild_id, removed
         )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,6 +90,12 @@ async def lifespan(app: FastAPI):
             backfill.provisioned,
             backfill.total,
         )
+    # Relocate any legacy flat local uploads into per-guild dirs (guild_<id>/),
+    # matching the object-store layout. Local-only, idempotent, self-disabling —
+    # a no-op once converted, so packaged deploys convert themselves on boot.
+    from app.db.local_upload_migration import migrate_local_uploads_to_guild_prefix
+
+    await migrate_local_uploads_to_guild_prefix()
     # Rotate SECRET_KEY-derived data (encrypted fields + email_hash) when
     # PREVIOUS_SECRET_KEY names a prior key. Runs after guild schemas exist and
     # before traffic is served, so a packaged deploy rotates itself on boot.

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -309,10 +309,21 @@ class S3Storage:
             resp = self._client.list_objects_v2(**kwargs)
             objects = [{"Key": o["Key"]} for o in resp.get("Contents", [])]
             if objects:
-                self._client.delete_objects(
+                result = self._client.delete_objects(
                     Bucket=self._bucket, Delete={"Objects": objects, "Quiet": True}
                 )
-                deleted += len(objects)
+                # Quiet=True returns only per-object failures; surface them and
+                # count only the ones that actually deleted (an unlogged failure
+                # would silently re-orphan the very blobs this is meant to purge).
+                errors = result.get("Errors") or []
+                for err in errors:
+                    logger.error(
+                        "delete_prefix could not delete %s: %s %s",
+                        err.get("Key"),
+                        err.get("Code"),
+                        err.get("Message"),
+                    )
+                deleted += len(objects) - len(errors)
             if resp.get("IsTruncated"):
                 token = resp.get("NextContinuationToken")
             else:

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -14,7 +14,8 @@ per-request IAM prefix scopes to; design §6). Callers still pass the flat
 filename and own the ``/uploads/{guild_id}/{filename}`` URL scheme.
 
 Phases delivered here:
-- ``LocalFilesystemStorage`` — today's behavior verbatim (flat ``UPLOADS_DIR``).
+- ``LocalFilesystemStorage`` — files under ``UPLOADS_DIR/guild_<id>/`` (same
+  per-guild layout as S3; legacy flat files are relocated on boot).
 - ``S3Storage`` — boto3 against any S3-compatible endpoint; serves via streaming
   proxy (:func:`build_upload_response`) and can presign for opt-in offload.
 
@@ -89,6 +90,8 @@ class StorageBackend(Protocol):
 
     def copy(self, src_key: str, dst_key: str) -> bool: ...
 
+    def delete_prefix(self) -> int: ...
+
     def exists(self, key: str) -> bool: ...
 
     def open_readable(self, key: str) -> ReadableBlob | None: ...
@@ -99,23 +102,31 @@ class StorageBackend(Protocol):
 
 
 class LocalFilesystemStorage:
-    """Stores objects as flat files under ``UPLOADS_DIR``.
+    """Stores objects as files under ``UPLOADS_DIR[/<prefix>]``.
 
-    ``key`` is the stored filename. Keys are reduced to a basename before they
-    touch the filesystem, so a key can never escape the base directory — this
-    centralizes the path-traversal guard the two serve endpoints previously
-    duplicated. The base dir is created on demand.
+    ``key`` is the stored filename; ``prefix`` is the resolver-supplied guild
+    namespace (``guild_<id>/``), so a guild's blobs live under
+    ``UPLOADS_DIR/guild_<id>/`` — the same per-guild layout as the S3 backend.
+    Keys are reduced to a basename before they touch the filesystem, so a key
+    can never escape the (prefixed) base directory; this centralizes the
+    path-traversal guard the two serve endpoints previously duplicated. The
+    directory is created on demand.
 
-    The guild prefix the resolver carries for S3 is intentionally ignored here:
-    the local layout stays flat (the guild rides in the URL), so existing
-    self-host installs keep working byte-for-byte across the upgrade.
+    (Legacy flat files written before this layout are relocated into their
+    ``guild_<id>/`` subdir by the one-time startup migration in
+    ``app.db.local_upload_migration``.)
     """
 
-    def __init__(self, base_dir: str | None = None) -> None:
+    def __init__(self, base_dir: str | None = None, prefix: str = "") -> None:
         self._base_dir = base_dir
+        self._prefix = prefix
+
+    def _root(self) -> Path:
+        return Path(self._base_dir or settings.UPLOADS_DIR)
 
     def _dir(self) -> Path:
-        path = Path(self._base_dir or settings.UPLOADS_DIR)
+        # ``Path / ""`` is a no-op, so an empty prefix yields the flat root.
+        path = self._root() / self._prefix
         path.mkdir(parents=True, exist_ok=True)
         return path
 
@@ -162,6 +173,24 @@ class LocalFilesystemStorage:
         except OSError as exc:
             logger.error("Failed to copy blob %s -> %s: %s", src, dst, exc)
             return False
+
+    def delete_prefix(self) -> int:
+        """Remove this backend's whole namespace dir (``UPLOADS_DIR/<prefix>``).
+
+        Used to tear down a guild's content on deprovision. Refuses an empty
+        prefix so it can never wipe the entire uploads root. Returns the number
+        of files removed.
+        """
+        if not self._prefix:
+            raise ValueError(
+                "delete_prefix refused: empty prefix would target all uploads"
+            )
+        target_dir = self._root() / self._prefix
+        if not target_dir.is_dir():
+            return 0
+        count = sum(1 for p in target_dir.rglob("*") if p.is_file())
+        shutil.rmtree(target_dir, ignore_errors=True)
+        return count
 
     def exists(self, key: str) -> bool:
         target = self._safe_path(key)
@@ -260,6 +289,36 @@ class S3Storage:
         )
         return True
 
+    def delete_prefix(self) -> int:
+        """Delete every object under this backend's namespace (``self._prefix``).
+
+        Used to tear down a guild's content on deprovision. Refuses an empty
+        prefix so it can never target the whole bucket. Returns the number of
+        objects deleted.
+        """
+        if not self._prefix:
+            raise ValueError(
+                "delete_prefix refused: empty prefix would target the whole bucket"
+            )
+        deleted = 0
+        token: str | None = None
+        while True:
+            kwargs: dict = {"Bucket": self._bucket, "Prefix": self._prefix}
+            if token:
+                kwargs["ContinuationToken"] = token
+            resp = self._client.list_objects_v2(**kwargs)
+            objects = [{"Key": o["Key"]} for o in resp.get("Contents", [])]
+            if objects:
+                self._client.delete_objects(
+                    Bucket=self._bucket, Delete={"Objects": objects, "Quiet": True}
+                )
+                deleted += len(objects)
+            if resp.get("IsTruncated"):
+                token = resp.get("NextContinuationToken")
+            else:
+                break
+        return deleted
+
     def exists(self, key: str) -> bool:
         return self._head(self._object_key(key))
 
@@ -327,7 +386,7 @@ def build_upload_response(
     return StreamingResponse(blob.stream or iter(()), media_type=media, headers=headers)
 
 
-_local_backend: LocalFilesystemStorage | None = None
+_local_backends: dict[str, LocalFilesystemStorage] = {}
 _s3_client: "BaseClient | None" = None
 
 
@@ -335,11 +394,12 @@ def _backend_name() -> str:
     return (settings.STORAGE_BACKEND or "local").lower()
 
 
-def _local() -> LocalFilesystemStorage:
-    global _local_backend
-    if _local_backend is None:
-        _local_backend = LocalFilesystemStorage()
-    return _local_backend
+def _local(prefix: str = "") -> LocalFilesystemStorage:
+    backend = _local_backends.get(prefix)
+    if backend is None:
+        backend = LocalFilesystemStorage(prefix=prefix)
+        _local_backends[prefix] = backend
+    return backend
 
 
 def _get_s3_client() -> "BaseClient":
@@ -378,7 +438,7 @@ def _require_bucket() -> str:
 def _make(prefix: str) -> StorageBackend:
     name = _backend_name()
     if name == "local":
-        return _local()
+        return _local(prefix)
     if name == "s3":
         return S3Storage(
             bucket=_require_bucket(),
@@ -409,10 +469,21 @@ def get_storage() -> StorageBackend:
 def get_guild_storage(guild_id: int) -> StorageBackend:
     """Return a content-plane backend scoped to ``guild_id`` (the resolver).
 
-    Local: flat ``UPLOADS_DIR`` (the guild rides in the URL; no behavior change).
-    S3: keys are namespaced under ``guild_<id>/`` — the object-store twin of the
-    schema-per-guild boundary, and exactly what the per-request IAM prefix scopes
-    to (design §6). Pooled-cloud per-request STS downscope plugs in here; today
-    the resolver uses the ambient credential (works for Garage, siloed IRSA, dev).
+    Both backends namespace the guild's blobs under ``guild_<id>/`` — the
+    object-store twin of the schema-per-guild boundary, and exactly what the
+    per-request IAM prefix scopes to on S3 (design §6). Local writes them under
+    ``UPLOADS_DIR/guild_<id>/``. Pooled-cloud per-request STS downscope plugs in
+    here; today the resolver uses the ambient credential (works for Garage,
+    siloed IRSA, dev).
     """
     return _make(f"guild_{int(guild_id)}/")
+
+
+def purge_guild_blobs(guild_id: int) -> int:
+    """Remove all of a guild's stored blobs — called on guild deprovision.
+
+    Both backends sweep the guild's ``guild_<id>/`` namespace in one pass (S3:
+    batch object delete; local: remove the directory tree), so this is uniform
+    and needs no per-file bookkeeping. Returns the number of objects removed.
+    """
+    return get_guild_storage(guild_id).delete_prefix()

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -188,9 +188,19 @@ class LocalFilesystemStorage:
         target_dir = self._root() / self._prefix
         if not target_dir.is_dir():
             return 0
-        count = sum(1 for p in target_dir.rglob("*") if p.is_file())
+        total = sum(1 for p in target_dir.rglob("*") if p.is_file())
         shutil.rmtree(target_dir, ignore_errors=True)
-        return count
+        # Count only what actually went away and surface the rest: a file rmtree
+        # couldn't remove (e.g. permissions) would otherwise be silently reported
+        # as deleted — the very orphan it's meant to prevent.
+        remaining = (
+            [p for p in target_dir.rglob("*") if p.is_file()]
+            if target_dir.exists()
+            else []
+        )
+        for leftover in remaining:
+            logger.error("delete_prefix could not remove %s", leftover)
+        return total - len(remaining)
 
     def exists(self, key: str) -> bool:
         target = self._safe_path(key)

--- a/backend/app/services/storage_test.py
+++ b/backend/app/services/storage_test.py
@@ -101,6 +101,8 @@ class FakeS3Client:
     def __init__(self) -> None:
         self.objects: dict[tuple[str, str], dict] = {}
         self.presigned: list[tuple] = []
+        # Keys delete_objects should report as failed (not actually removed).
+        self.delete_errors: set[str] = set()
 
     @staticmethod
     def _missing(op: str) -> ClientError:
@@ -150,9 +152,14 @@ class FakeS3Client:
         return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
 
     def delete_objects(self, *, Bucket, Delete):
+        errors = []
         for obj in Delete["Objects"]:
-            self.objects.pop((Bucket, obj["Key"]), None)
-        return {}
+            key = obj["Key"]
+            if key in self.delete_errors:
+                errors.append({"Key": key, "Code": "AccessDenied", "Message": "denied"})
+                continue
+            self.objects.pop((Bucket, key), None)
+        return {"Errors": errors} if errors else {}
 
 
 def _s3(prefix="guild_7/", kms_key_id=None):
@@ -324,6 +331,19 @@ def test_s3_delete_prefix_refuses_empty_prefix():
     _, storage = _s3(prefix="")
     with pytest.raises(ValueError, match="empty prefix"):
         storage.delete_prefix()
+
+
+def test_s3_delete_prefix_counts_only_successful_deletes():
+    client, storage = _s3()
+    storage.write("a.bin", b"1")
+    storage.write("b.bin", b"2")
+    # Simulate S3 reporting one key as failed (object lock, perms, …).
+    client.delete_errors.add("guild_7/b.bin")
+    removed = storage.delete_prefix()
+    # Only the successful delete is counted; the failed object remains.
+    assert removed == 1
+    assert ("bucket", "guild_7/b.bin") in client.objects
+    assert ("bucket", "guild_7/a.bin") not in client.objects
 
 
 # --- LocalFilesystemStorage prefix + delete_prefix ---------------------------

--- a/backend/app/services/storage_test.py
+++ b/backend/app/services/storage_test.py
@@ -145,6 +145,15 @@ class FakeS3Client:
         disp = Params.get("ResponseContentDisposition", "")
         return f"https://s3.test/{Params['Key']}?exp={ExpiresIn}&disp={disp}"
 
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = [k for (b, k) in self.objects if b == Bucket and k.startswith(Prefix)]
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+    def delete_objects(self, *, Bucket, Delete):
+        for obj in Delete["Objects"]:
+            self.objects.pop((Bucket, obj["Key"]), None)
+        return {}
+
 
 def _s3(prefix="guild_7/", kms_key_id=None):
     client = FakeS3Client()
@@ -286,7 +295,72 @@ def test_resolver_requires_bucket_for_s3(monkeypatch):
         get_guild_storage(1)
 
 
-def test_resolver_local_ignores_guild_prefix():
-    # Default backend is local; the guild prefix is a no-op there (flat layout).
+def test_resolver_local_honors_guild_prefix():
+    # Default backend is local; it now namespaces by guild like S3.
     backend = get_guild_storage(99)
     assert isinstance(backend, LocalFilesystemStorage)
+    assert backend._prefix == "guild_99/"
+
+
+# --- S3Storage.delete_prefix -------------------------------------------------
+
+
+def test_s3_delete_prefix_sweeps_namespace():
+    client, storage = _s3()
+    storage.write("a.bin", b"1")
+    storage.write("b.bin", b"2")
+    # An object in a *different* guild's namespace must survive.
+    other = S3Storage(bucket="bucket", client=client, prefix="guild_8/")
+    other.write("c.bin", b"3")
+
+    removed = storage.delete_prefix()
+    assert removed == 2
+    assert ("bucket", "guild_7/a.bin") not in client.objects
+    assert ("bucket", "guild_7/b.bin") not in client.objects
+    assert ("bucket", "guild_8/c.bin") in client.objects  # untouched
+
+
+def test_s3_delete_prefix_refuses_empty_prefix():
+    _, storage = _s3(prefix="")
+    with pytest.raises(ValueError, match="empty prefix"):
+        storage.delete_prefix()
+
+
+# --- LocalFilesystemStorage prefix + delete_prefix ---------------------------
+
+
+def test_local_prefix_writes_under_guild_dir(tmp_path):
+    storage = LocalFilesystemStorage(base_dir=str(tmp_path), prefix="guild_3/")
+    storage.write("img.png", b"data")
+    assert (tmp_path / "guild_3" / "img.png").read_bytes() == b"data"
+    # Round-trips through the prefixed namespace.
+    assert storage.open_readable("img.png").path == tmp_path / "guild_3" / "img.png"
+
+
+def test_local_delete_prefix_removes_dir_and_counts(tmp_path):
+    storage = LocalFilesystemStorage(base_dir=str(tmp_path), prefix="guild_3/")
+    storage.write("a.png", b"1")
+    storage.write("b.png", b"2")
+    removed = storage.delete_prefix()
+    assert removed == 2
+    assert not (tmp_path / "guild_3").exists()
+    # Missing dir -> 0, no error.
+    assert storage.delete_prefix() == 0
+
+
+def test_local_delete_prefix_refuses_empty_prefix(tmp_path):
+    storage = LocalFilesystemStorage(base_dir=str(tmp_path))  # prefix=""
+    with pytest.raises(ValueError, match="empty prefix"):
+        storage.delete_prefix()
+
+
+def test_purge_guild_blobs_local(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage_module.settings, "STORAGE_BACKEND", "local")
+    monkeypatch.setattr(storage_module.settings, "UPLOADS_DIR", str(tmp_path))
+    storage_module._local_backends.clear()
+    get_guild_storage(5).write("x.png", b"data")
+    assert (tmp_path / "guild_5" / "x.png").exists()
+    removed = storage_module.purge_guild_blobs(5)
+    assert removed == 1
+    assert not (tmp_path / "guild_5").exists()
+    storage_module._local_backends.clear()

--- a/docs/OBJECT_STORAGE.md
+++ b/docs/OBJECT_STORAGE.md
@@ -19,11 +19,16 @@ own — you bring your own.
 
 ## How keys are laid out
 
-- **Local:** files are stored flat under `UPLOADS_DIR` (e.g. `uploads/<uuid>.png`),
-  exactly as before.
-- **Object storage:** objects are namespaced per guild under a `guild_<id>/` key
-  prefix (e.g. `guild_7/<uuid>.png`). This mirrors the database's
-  schema-per-guild tenant boundary.
+Both backends namespace a guild's blobs per guild, mirroring the database's
+schema-per-guild tenant boundary:
+
+- **Local:** `UPLOADS_DIR/guild_<id>/<uuid>.png`.
+- **Object storage:** objects under the `guild_<id>/` key prefix (e.g.
+  `guild_7/<uuid>.png`) — exactly what the per-request S3 IAM policy scopes to.
+
+(Installs from before this layout stored local files flat under `UPLOADS_DIR`; a
+one-time, self-disabling startup migration relocates them into `guild_<id>/`
+dirs. Only file locations change.)
 
 In both cases the public URL stays `/uploads/{guild_id}/{filename}`, and every
 download still passes the same authorization checks (guild membership / access


### PR DESCRIPTION
## Problem

Two related gaps after the S3 backend landed:

1. **Orphaned blobs on guild deletion.** `deprovision_guild` dropped the schema + roles but left the guild's uploaded files behind (CLAUDE.md flags this).
2. **Flat-vs-prefixed layout split.** S3 namespaces blobs under `guild_<id>/` (required for IAM prefix-scoping), but local stored everything flat — an asymmetry needing an `isinstance`/row-driven special-case to clean up.

We're pre-v1 and just did the schema-per-guild move, so this unifies the layout now rather than carrying the split forever.

## Changes

- **Local storage is now per-guild**, mirroring S3: a guild's blobs live under `UPLOADS_DIR/guild_<id>/`. `LocalFilesystemStorage` honors the resolver's prefix; the path-traversal guard now contains within the prefixed dir.
- **`delete_prefix()` on the backend** — S3: paginated batch delete of the `guild_<id>/` key space; local: removes the dir tree. Both **refuse an empty prefix** so they can never target the whole bucket / uploads root.
- **`purge_guild_blobs(guild_id)`** collapses to a uniform `get_guild_storage(guild_id).delete_prefix()` — no `isinstance`, no row-driven path — and is wired into `deprovision_guild` (best-effort, after the schema drop succeeds). **Fixes the orphan bug.**
- **One-time startup migration** (`app/db/local_upload_migration.py`): local-only, idempotent, self-disabling — relocates legacy flat `UPLOADS_DIR/<file>` into `UPLOADS_DIR/guild_<id>/<file>` using the `uploads` rows. Only file locations change; DB rows and `/uploads/{guild_id}/{file}` URLs are untouched. Skips instantly once the root has no top-level flat files.

## Schema / generated

- None. No model changes, no DB migration (the relocation only moves files), no Orval regen.

## Testing

- `ruff check` / `ruff format` — clean.
- New unit tests (fake S3 client + tmp dirs, no DB): `delete_prefix` sweep + empty-prefix guard (both backends), local per-guild write/read, `purge_guild_blobs`, and the migration's `relocate_flat_uploads` (move / unmatched-left-in-place / idempotent-when-dest-exists / subdir-skip).
- Validated the new local-prefix + migration + purge logic end-to-end against real temp dirs via a standalone script (the full pytest suite needs Postgres; CI covers it).

## Notes

- Best-effort purge: a storage hiccup is logged but never blocks tearing down the guild (orphans can be swept later; S3 lifecycle as backstop).