### PR TITLE
Local→S3 backfill + dual-read cutover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Archive an initiative to hide it from the sidebar.** Archiving keeps everything intact (projects, documents, tasks, queues) but removes the initiative from the main sidebar for everyone; unarchive any time to bring it back. Available from the new Initiatives tab and from an initiative's **Danger zone** settings. Archiving is guild-admin only.
 - **Per-guild storage limit.** A guild can now have a maximum total upload storage; uploads that would push the guild over its limit are rejected. Defaults to unlimited, so existing guilds are unaffected until a limit is set.
 - **Optional S3-compatible object storage for uploads.** Uploads can now be stored in an S3-compatible object store you point it at (a self-hosted Garage instance, AWS S3, R2, etc.) instead of the local filesystem, via `STORAGE_BACKEND=s3` and the new `S3_*` settings. The filesystem remains the default, so existing deployments are unaffected. See `docs/OBJECT_STORAGE.md`.
+- **Zero-downtime migration from local to S3 storage.** A `python -m app.db.backfill_uploads_to_s3` job copies existing local uploads into the bucket (idempotent, content-type preserved, integrity-verified), and a new `S3_LOCAL_FALLBACK` setting serves any not-yet-copied blob from local disk during the cutover — so flipping a deployment with existing uploads onto S3 never drops a file. See `docs/OBJECT_STORAGE.md`.
 
 ### Fixed
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -136,6 +136,7 @@ S3_ACCESS_KEY_ID=           # leave blank to use the ambient credential chain
 S3_SECRET_ACCESS_KEY=
 S3_USE_PATH_STYLE=true      # true for Garage and most self-hosted/non-AWS stores
 S3_KMS_KEY_ID=              # optional SSE-KMS key id/ARN; blank otherwise
+S3_LOCAL_FALLBACK=false     # migration window only: serve S3 read-misses from local disk
 
 # Initial superuser
 FIRST_SUPERUSER_EMAIL=admin@example.com

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -372,6 +372,11 @@ class Settings(BaseSettings):
     S3_SECRET_ACCESS_KEY: str | None = None
     S3_USE_PATH_STYLE: bool = False
     S3_KMS_KEY_ID: str | None = None
+    # Migration safety net: while cutting a deployment over from "local" to "s3",
+    # set true so a read that misses in S3 falls back to the local filesystem
+    # (serves blobs not yet copied by the backfill). Turn off once the backfill is
+    # verified complete. Only consulted when STORAGE_BACKEND="s3".
+    S3_LOCAL_FALLBACK: bool = False
     STATIC_DIR: str = "static"
 
     FIRST_SUPERUSER_EMAIL: EmailStr | None = None

--- a/backend/app/db/backfill_uploads_to_s3.py
+++ b/backend/app/db/backfill_uploads_to_s3.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
 
 from app.core.config import settings
 from app.db import session as db_session
@@ -99,7 +100,7 @@ def backfill_guild_dir(
 
 
 async def _guild_upload_meta(
-    conn, schema: str
+    conn: AsyncConnection, schema: str
 ) -> dict[str, tuple[str | None, str | None]]:
     """filename -> (content_type, content_hash) for a guild's uploads, or {} if
     the schema/table is absent."""

--- a/backend/app/db/backfill_uploads_to_s3.py
+++ b/backend/app/db/backfill_uploads_to_s3.py
@@ -50,7 +50,7 @@ class BackfillSummary:
 def backfill_guild_dir(
     guild_dir: Path,
     meta: dict[str, tuple[str | None, str | None]],
-    dest: StorageBackend | None,
+    dest: StorageBackend,
     summary: BackfillSummary,
     *,
     guild_id: int,
@@ -59,9 +59,11 @@ def backfill_guild_dir(
     """Copy one guild's local blobs into ``dest`` (S3). Pure of the DB.
 
     ``meta`` maps filename -> (content_type, content_hash) from the ``uploads``
-    rows. ``dest`` is None on a dry run. Updates ``summary`` in place. Idempotent:
-    an object already in ``dest`` is skipped; a content_hash mismatch is treated
-    as a failure (the blob is NOT copied) so corruption isn't propagated.
+    rows. Updates ``summary`` in place. Idempotent: an object already in ``dest``
+    is skipped; a content_hash mismatch is treated as a failure (the blob is NOT
+    copied) so corruption isn't propagated. ``dry_run`` skips only the write — the
+    ``exists`` check still runs against ``dest``, so a dry run reports the real
+    remaining work rather than re-counting already-copied files.
     """
     for path in sorted(guild_dir.iterdir()):
         if not path.is_file():
@@ -72,7 +74,7 @@ def backfill_guild_dir(
             content_type = mimetypes.guess_type(key)[0]
         label = f"guild_{guild_id}/{key}"
         try:
-            if dest is not None and dest.exists(key):
+            if dest.exists(key):
                 summary.skipped += 1
                 continue
             data = path.read_bytes()
@@ -133,7 +135,9 @@ async def backfill_uploads_to_s3(*, dry_run: bool = False) -> BackfillSummary:
             if not guild_dir.is_dir():
                 continue
             meta = await _guild_upload_meta(conn, guild_schema_name(gid))
-            dest = None if dry_run else s3_guild_storage(gid)
+            # Always a real S3 backend, even on a dry run, so the exists() skip
+            # check reflects what's already in the bucket.
+            dest = s3_guild_storage(gid)
             backfill_guild_dir(
                 guild_dir, meta, dest, summary, guild_id=gid, dry_run=dry_run
             )
@@ -148,13 +152,14 @@ def main() -> None:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="report what would be copied without writing to S3",
+        help="report what would be copied (checking the bucket for already-present "
+        "objects) without writing",
     )
     args = parser.parse_args()
-    if not args.dry_run and not settings.S3_BUCKET:
+    if not settings.S3_BUCKET:
         raise SystemExit(
             "S3_BUCKET (and the other S3_* settings) must point at your object "
-            "store to run the backfill."
+            "store to run the backfill (a dry run queries the bucket too)."
         )
     summary = asyncio.run(backfill_uploads_to_s3(dry_run=args.dry_run))
     logger.info(

--- a/backend/app/db/backfill_uploads_to_s3.py
+++ b/backend/app/db/backfill_uploads_to_s3.py
@@ -1,0 +1,174 @@
+"""Backfill: copy existing local uploads into the configured S3 bucket.
+
+The final step of the local→S3 migration (see
+``history/blob-storage-tenancy-design.md`` §11). Run it with the ``S3_*`` settings
+pointed at your object store **while the app is still on
+``STORAGE_BACKEND=local``**: it copies every blob under
+``UPLOADS_DIR/guild_<id>/`` to the S3 key ``guild_<id>/<file>``, setting the
+content-type recorded on the ``uploads`` row (falling back to a guess from the
+extension). It's **idempotent** — an object already present in S3 is skipped — so
+it is safe to re-run and resume.
+
+After it reports 0 failures, cut over: set ``STORAGE_BACKEND=s3`` (with
+``S3_LOCAL_FALLBACK=true`` for a verification window, then turn it off).
+
+    python -m app.db.backfill_uploads_to_s3 [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import logging
+import mimetypes
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.db import session as db_session
+from app.db.schema_provisioning import guild_schema_name
+from app.services.storage import StorageBackend, s3_guild_storage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BackfillSummary:
+    """Outcome of a backfill run, for the final log line / exit code."""
+
+    copied: int = 0
+    skipped: int = 0
+    failed: int = 0
+    hash_mismatches: int = 0
+    failed_keys: list[str] = field(default_factory=list)
+
+
+def backfill_guild_dir(
+    guild_dir: Path,
+    meta: dict[str, tuple[str | None, str | None]],
+    dest: StorageBackend | None,
+    summary: BackfillSummary,
+    *,
+    guild_id: int,
+    dry_run: bool,
+) -> None:
+    """Copy one guild's local blobs into ``dest`` (S3). Pure of the DB.
+
+    ``meta`` maps filename -> (content_type, content_hash) from the ``uploads``
+    rows. ``dest`` is None on a dry run. Updates ``summary`` in place. Idempotent:
+    an object already in ``dest`` is skipped; a content_hash mismatch is treated
+    as a failure (the blob is NOT copied) so corruption isn't propagated.
+    """
+    for path in sorted(guild_dir.iterdir()):
+        if not path.is_file():
+            continue
+        key = path.name
+        content_type, content_hash = meta.get(key, (None, None))
+        if content_type is None:
+            content_type = mimetypes.guess_type(key)[0]
+        label = f"guild_{guild_id}/{key}"
+        try:
+            if dest is not None and dest.exists(key):
+                summary.skipped += 1
+                continue
+            data = path.read_bytes()
+            if content_hash and hashlib.sha256(data).hexdigest() != content_hash:
+                logger.warning("content_hash mismatch for %s — not copying", label)
+                summary.hash_mismatches += 1
+                summary.failed += 1
+                summary.failed_keys.append(label)
+                continue
+            if dry_run:
+                logger.info(
+                    "[dry-run] would copy %s (%d bytes, %s)",
+                    label,
+                    len(data),
+                    content_type,
+                )
+                summary.copied += 1
+                continue
+            dest.write(key, data, content_type=content_type)
+            summary.copied += 1
+        except Exception:  # noqa: BLE001 — one bad blob must not abort the run
+            logger.exception("failed to back up %s", label)
+            summary.failed += 1
+            summary.failed_keys.append(label)
+
+
+async def _guild_upload_meta(
+    conn, schema: str
+) -> dict[str, tuple[str | None, str | None]]:
+    """filename -> (content_type, content_hash) for a guild's uploads, or {} if
+    the schema/table is absent."""
+    exists = (
+        await conn.execute(text("SELECT to_regclass(:t)"), {"t": f"{schema}.uploads"})
+    ).scalar()
+    if exists is None:
+        return {}
+    rows = (
+        await conn.execute(
+            text(f'SELECT filename, content_type, content_hash FROM "{schema}".uploads')
+        )
+    ).all()
+    return {row[0]: (row[1], row[2]) for row in rows if row[0]}
+
+
+async def backfill_uploads_to_s3(*, dry_run: bool = False) -> BackfillSummary:
+    """Copy every guild's local blobs into S3. See module docstring."""
+    summary = BackfillSummary()
+    root = Path(settings.UPLOADS_DIR)
+    engine = db_session.provisioning_engine  # superuser: reads every guild schema
+    async with engine.connect() as conn:
+        guild_ids = (
+            (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
+            .scalars()
+            .all()
+        )
+        for gid in guild_ids:
+            guild_dir = root / f"guild_{gid}"
+            if not guild_dir.is_dir():
+                continue
+            meta = await _guild_upload_meta(conn, guild_schema_name(gid))
+            dest = None if dry_run else s3_guild_storage(gid)
+            backfill_guild_dir(
+                guild_dir, meta, dest, summary, guild_id=gid, dry_run=dry_run
+            )
+    return summary
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(
+        description="Copy existing local uploads into the configured S3 bucket."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be copied without writing to S3",
+    )
+    args = parser.parse_args()
+    if not args.dry_run and not settings.S3_BUCKET:
+        raise SystemExit(
+            "S3_BUCKET (and the other S3_* settings) must point at your object "
+            "store to run the backfill."
+        )
+    summary = asyncio.run(backfill_uploads_to_s3(dry_run=args.dry_run))
+    logger.info(
+        "backfill complete: copied=%d skipped=%d failed=%d hash_mismatches=%d",
+        summary.copied,
+        summary.skipped,
+        summary.failed,
+        summary.hash_mismatches,
+    )
+    if summary.failed:
+        logger.error(
+            "backfill had %d failure(s): %s", summary.failed, summary.failed_keys
+        )
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/db/backfill_uploads_to_s3_test.py
+++ b/backend/app/db/backfill_uploads_to_s3_test.py
@@ -1,0 +1,93 @@
+"""Unit tests for the local->S3 backfill's per-guild copy logic.
+
+``backfill_guild_dir`` is pure of the DB (a tmp dir + a filename->metadata map +
+a destination backend), so these run without a database. The DB-backed guild
+iteration is a thin shell over it.
+"""
+
+from app.db.backfill_uploads_to_s3 import BackfillSummary, backfill_guild_dir
+
+
+class _FakeDest:
+    """Minimal StorageBackend stub — backfill_guild_dir only calls exists/write."""
+
+    def __init__(self) -> None:
+        self.written: dict[str, tuple[bytes, str | None]] = {}
+
+    def exists(self, key: str) -> bool:
+        return key in self.written
+
+    def write(self, key: str, data: bytes, *, content_type: str | None = None) -> None:
+        self.written[key] = (data, content_type)
+
+
+def test_backfill_copies_with_content_type_from_meta(tmp_path):
+    gd = tmp_path / "guild_5"
+    gd.mkdir()
+    (gd / "a.png").write_bytes(b"img")
+    (gd / "b.dat").write_bytes(b"x")
+    dest = _FakeDest()
+    meta = {"a.png": ("image/png", None)}  # b.dat has no row
+    summary = BackfillSummary()
+
+    backfill_guild_dir(gd, meta, dest, summary, guild_id=5, dry_run=False)
+
+    assert summary.copied == 2
+    assert summary.failed == 0
+    assert dest.written["a.png"] == (b"img", "image/png")
+    # No row -> content_type guessed from the extension (".dat" is unknown -> None).
+    assert dest.written["b.dat"][1] is None
+
+
+def test_backfill_guesses_content_type_from_extension(tmp_path):
+    gd = tmp_path / "guild_5"
+    gd.mkdir()
+    (gd / "doc.pdf").write_bytes(b"%PDF")
+    dest = _FakeDest()
+    summary = BackfillSummary()
+
+    backfill_guild_dir(gd, {}, dest, summary, guild_id=5, dry_run=False)
+
+    assert dest.written["doc.pdf"][1] == "application/pdf"
+
+
+def test_backfill_skips_already_present(tmp_path):
+    gd = tmp_path / "guild_5"
+    gd.mkdir()
+    (gd / "a.png").write_bytes(b"img")
+    dest = _FakeDest()
+    dest.written["a.png"] = (b"already", "image/png")  # pretend it's in S3
+    summary = BackfillSummary()
+
+    backfill_guild_dir(gd, {}, dest, summary, guild_id=5, dry_run=False)
+
+    assert summary.skipped == 1
+    assert summary.copied == 0
+    assert dest.written["a.png"][0] == b"already"  # not overwritten
+
+
+def test_backfill_hash_mismatch_is_not_copied(tmp_path):
+    gd = tmp_path / "guild_5"
+    gd.mkdir()
+    (gd / "c.bin").write_bytes(b"actual-bytes")
+    dest = _FakeDest()
+    meta = {"c.bin": (None, "00deadbeef")}  # wrong hash
+    summary = BackfillSummary()
+
+    backfill_guild_dir(gd, meta, dest, summary, guild_id=5, dry_run=False)
+
+    assert summary.hash_mismatches == 1
+    assert summary.failed == 1
+    assert "c.bin" not in dest.written  # corruption not propagated
+
+
+def test_backfill_dry_run_writes_nothing(tmp_path):
+    gd = tmp_path / "guild_5"
+    gd.mkdir()
+    (gd / "a.png").write_bytes(b"img")
+    (gd / "b.png").write_bytes(b"img2")
+    summary = BackfillSummary()
+
+    backfill_guild_dir(gd, {}, None, summary, guild_id=5, dry_run=True)
+
+    assert summary.copied == 2  # counted, but no dest to write to

--- a/backend/app/db/backfill_uploads_to_s3_test.py
+++ b/backend/app/db/backfill_uploads_to_s3_test.py
@@ -81,13 +81,19 @@ def test_backfill_hash_mismatch_is_not_copied(tmp_path):
     assert "c.bin" not in dest.written  # corruption not propagated
 
 
-def test_backfill_dry_run_writes_nothing(tmp_path):
+def test_backfill_dry_run_checks_dest_and_writes_nothing(tmp_path):
     gd = tmp_path / "guild_5"
     gd.mkdir()
     (gd / "a.png").write_bytes(b"img")
     (gd / "b.png").write_bytes(b"img2")
+    dest = _FakeDest()
+    dest.written["a.png"] = (b"x", "image/png")  # already in S3
     summary = BackfillSummary()
 
-    backfill_guild_dir(gd, {}, None, summary, guild_id=5, dry_run=True)
+    backfill_guild_dir(gd, {}, dest, summary, guild_id=5, dry_run=True)
 
-    assert summary.copied == 2  # counted, but no dest to write to
+    # The exists() skip check runs in dry-run too, so already-copied files aren't
+    # re-counted — the report reflects the real remaining work.
+    assert summary.skipped == 1
+    assert summary.copied == 1
+    assert "b.png" not in dest.written  # dry-run writes nothing

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -26,6 +26,7 @@ is configured.
 from __future__ import annotations
 
 import logging
+import mimetypes
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -67,8 +68,9 @@ class ReadableBlob:
     """A served blob, backend-agnostic.
 
     Local sets ``path`` (so the serve adapter keeps ``FileResponse`` sendfile +
-    range support). S3 sets ``stream`` plus whatever metadata ``GetObject``
-    returned (``content_type`` / ``content_length``).
+    range support); S3 sets ``stream``. Both populate ``content_type`` and
+    ``content_length`` — S3 from the object metadata, local from the file's
+    extension/size — so the blob is consistent regardless of backend.
     """
 
     path: Path | None = None
@@ -215,7 +217,16 @@ class LocalFilesystemStorage:
 
     def open_readable(self, key: str) -> ReadableBlob | None:
         target = self.resolve_readable(key)
-        return ReadableBlob(path=target) if target is not None else None
+        if target is None:
+            return None
+        # The filesystem stores no object metadata (unlike S3), so derive the
+        # content-type from the extension — keeping ReadableBlob consistent across
+        # backends, and giving a cross-store copy a type to carry over.
+        return ReadableBlob(
+            path=target,
+            content_type=mimetypes.guess_type(target.name)[0],
+            content_length=target.stat().st_size,
+        )
 
     def presign_get(
         self, key: str, *, ttl: int, filename: str | None = None
@@ -402,7 +413,12 @@ class DualReadStorage:
         blob = self._fallback.open_readable(src_key)
         if blob is None or blob.path is None:
             return False
-        self._primary.write(dst_key, blob.path.read_bytes())
+        # Carry the source's content-type onto the S3 object so it isn't served as
+        # octet-stream once the fallback window closes (open_readable populates it
+        # for both backends).
+        self._primary.write(
+            dst_key, blob.path.read_bytes(), content_type=blob.content_type
+        )
         return True
 
     def delete_prefix(self) -> int:

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -373,6 +373,57 @@ class S3Storage:
         )
 
 
+class DualReadStorage:
+    """Local→S3 cutover safety net (enabled by ``S3_LOCAL_FALLBACK``).
+
+    Writes and deletes go to the primary (S3); reads fall back to the local
+    fallback on a miss, so blobs the backfill hasn't copied yet still serve while
+    a deployment is being moved onto S3. ``delete_prefix`` purges **both** stores
+    (guild teardown). Flip the flag off once the backfill is verified complete.
+    """
+
+    def __init__(self, *, primary: StorageBackend, fallback: StorageBackend) -> None:
+        self._primary = primary
+        self._fallback = fallback
+
+    def write(self, key: str, data: bytes, *, content_type: str | None = None) -> None:
+        self._primary.write(key, data, content_type=content_type)
+
+    def delete(self, key: str) -> bool:
+        # Remove from both stores so a deleted blob can't reappear via fallback.
+        primary_deleted = self._primary.delete(key)
+        fallback_deleted = self._fallback.delete(key)
+        return primary_deleted or fallback_deleted
+
+    def copy(self, src_key: str, dst_key: str) -> bool:
+        if self._primary.copy(src_key, dst_key):
+            return True
+        # Source not yet backfilled into S3: read it from local, write to S3.
+        blob = self._fallback.open_readable(src_key)
+        if blob is None or blob.path is None:
+            return False
+        self._primary.write(dst_key, blob.path.read_bytes())
+        return True
+
+    def delete_prefix(self) -> int:
+        return self._primary.delete_prefix() + self._fallback.delete_prefix()
+
+    def exists(self, key: str) -> bool:
+        return self._primary.exists(key) or self._fallback.exists(key)
+
+    def open_readable(self, key: str) -> ReadableBlob | None:
+        return self._primary.open_readable(key) or self._fallback.open_readable(key)
+
+    def presign_get(
+        self, key: str, *, ttl: int, filename: str | None = None
+    ) -> str | None:
+        # Only S3 can sign; if the object is still local-only, return None so the
+        # caller proxy-serves it instead.
+        if self._primary.exists(key):
+            return self._primary.presign_get(key, ttl=ttl, filename=filename)
+        return None
+
+
 def build_upload_response(
     blob: ReadableBlob,
     *,
@@ -461,12 +512,16 @@ def _make(prefix: str) -> StorageBackend:
     if name == "local":
         return _local(prefix)
     if name == "s3":
-        return S3Storage(
+        s3 = S3Storage(
             bucket=_require_bucket(),
             client=_get_s3_client(),
             prefix=prefix,
             kms_key_id=settings.S3_KMS_KEY_ID,
         )
+        # Cutover window: serve blobs the backfill hasn't copied yet from local.
+        if settings.S3_LOCAL_FALLBACK:
+            return DualReadStorage(primary=s3, fallback=_local(prefix))
+        return s3
     raise ValueError(f"Unsupported STORAGE_BACKEND={name!r} (expected 'local' or 's3')")
 
 
@@ -498,6 +553,21 @@ def get_guild_storage(guild_id: int) -> StorageBackend:
     siloed IRSA, dev).
     """
     return _make(f"guild_{int(guild_id)}/")
+
+
+def s3_guild_storage(guild_id: int) -> S3Storage:
+    """Build an S3 backend scoped to a guild prefix, regardless of
+    ``STORAGE_BACKEND``.
+
+    For the local→S3 backfill, which writes to S3 while the app may still be
+    running on the local backend. Raises if S3 isn't configured (``S3_BUCKET``).
+    """
+    return S3Storage(
+        bucket=_require_bucket(),
+        client=_get_s3_client(),
+        prefix=f"guild_{int(guild_id)}/",
+        kms_key_id=settings.S3_KMS_KEY_ID,
+    )
 
 
 def purge_guild_blobs(guild_id: int) -> int:

--- a/backend/app/services/storage_test.py
+++ b/backend/app/services/storage_test.py
@@ -13,6 +13,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 
 from app.services import storage as storage_module
 from app.services.storage import (
+    DualReadStorage,
     LocalFilesystemStorage,
     ReadableBlob,
     S3Storage,
@@ -384,3 +385,67 @@ def test_purge_guild_blobs_local(tmp_path, monkeypatch):
     assert removed == 1
     assert not (tmp_path / "guild_5").exists()
     storage_module._local_backends.clear()
+
+
+# --- DualReadStorage (local->S3 cutover fallback) ----------------------------
+
+
+def _dual(tmp_path):
+    client = FakeS3Client()
+    s3 = S3Storage(bucket="bucket", client=client, prefix="guild_7/")
+    local = LocalFilesystemStorage(base_dir=str(tmp_path), prefix="guild_7/")
+    return client, s3, local, DualReadStorage(primary=s3, fallback=local)
+
+
+def test_dualread_write_goes_to_primary_only(tmp_path):
+    client, _, local, dual = _dual(tmp_path)
+    dual.write("x.png", b"data", content_type="image/png")
+    assert ("bucket", "guild_7/x.png") in client.objects
+    assert not (tmp_path / "guild_7" / "x.png").exists()
+
+
+def test_dualread_read_falls_back_to_local_then_prefers_s3(tmp_path):
+    _, s3, local, dual = _dual(tmp_path)
+    # Un-backfilled blob: only on local -> served from local (path).
+    local.write("old.png", b"local-bytes")
+    blob = dual.open_readable("old.png")
+    assert blob is not None and blob.path is not None
+    assert blob.path.read_bytes() == b"local-bytes"
+    # Backfilled blob: present in S3 -> served from S3 (stream) even if absent local.
+    s3.write("new.png", b"s3-bytes", content_type="image/png")
+    blob2 = dual.open_readable("new.png")
+    assert blob2 is not None and blob2.stream is not None
+    assert b"".join(blob2.stream) == b"s3-bytes"
+
+
+def test_dualread_exists_checks_both(tmp_path):
+    _, s3, local, dual = _dual(tmp_path)
+    local.write("a", b"1")
+    s3.write("b", b"2")
+    assert dual.exists("a") is True
+    assert dual.exists("b") is True
+    assert dual.exists("missing") is False
+
+
+def test_dualread_delete_removes_from_both(tmp_path):
+    _, s3, local, dual = _dual(tmp_path)
+    s3.write("d", b"1")
+    local.write("d", b"1")
+    assert dual.delete("d") is True
+    assert dual.exists("d") is False
+
+
+def test_dualread_delete_prefix_sums_both(tmp_path):
+    _, s3, local, dual = _dual(tmp_path)
+    s3.write("a", b"1")
+    s3.write("b", b"2")
+    local.write("c", b"3")
+    assert dual.delete_prefix() == 3
+
+
+def test_dualread_copy_cross_store(tmp_path):
+    client, _, local, dual = _dual(tmp_path)
+    # Source only on local (not yet backfilled): copy reads local, writes to S3.
+    local.write("src.bin", b"payload")
+    assert dual.copy("src.bin", "dst.bin") is True
+    assert ("bucket", "guild_7/dst.bin") in client.objects

--- a/backend/app/services/storage_test.py
+++ b/backend/app/services/storage_test.py
@@ -354,8 +354,11 @@ def test_local_prefix_writes_under_guild_dir(tmp_path):
     storage = LocalFilesystemStorage(base_dir=str(tmp_path), prefix="guild_3/")
     storage.write("img.png", b"data")
     assert (tmp_path / "guild_3" / "img.png").read_bytes() == b"data"
-    # Round-trips through the prefixed namespace.
-    assert storage.open_readable("img.png").path == tmp_path / "guild_3" / "img.png"
+    # Round-trips through the prefixed namespace, with metadata consistent with S3.
+    blob = storage.open_readable("img.png")
+    assert blob.path == tmp_path / "guild_3" / "img.png"
+    assert blob.content_type == "image/png"  # derived from extension
+    assert blob.content_length == 4
 
 
 def test_local_delete_prefix_removes_dir_and_counts(tmp_path):
@@ -446,6 +449,8 @@ def test_dualread_delete_prefix_sums_both(tmp_path):
 def test_dualread_copy_cross_store(tmp_path):
     client, _, local, dual = _dual(tmp_path)
     # Source only on local (not yet backfilled): copy reads local, writes to S3.
-    local.write("src.bin", b"payload")
-    assert dual.copy("src.bin", "dst.bin") is True
-    assert ("bucket", "guild_7/dst.bin") in client.objects
+    local.write("src.png", b"payload")
+    assert dual.copy("src.png", "dst.png") is True
+    obj = client.objects[("bucket", "guild_7/dst.png")]
+    # Content-type recovered from the extension so it isn't served as octet-stream.
+    assert obj["extra"]["ContentType"] == "image/png"

--- a/docs/OBJECT_STORAGE.md
+++ b/docs/OBJECT_STORAGE.md
@@ -74,11 +74,39 @@ See Garage's
 [quick-start](https://garagehq.deuxfleurs.fr/documentation/quick-start/) for
 standing up a node and creating the bucket + access key.
 
-## Migrating existing files
+## Migrating an existing deployment from local to S3
 
-Switching `STORAGE_BACKEND` to `s3` only affects *new* uploads. Files already on
-local disk are not moved automatically; a backfill job that copies
-`UPLOADS_DIR/*` into the bucket under each file's `guild_<id>/` prefix is the
-next phase of the storage rollout. Until that runs, keep both the local volume
-and the object store available if you flip the switch on a deployment that
-already has local uploads.
+Switching `STORAGE_BACKEND` to `s3` only changes where *new* uploads go — files
+already on local disk must be copied into the bucket first. The migration is
+designed to be zero-downtime:
+
+**1. Configure S3 and run the backfill (while still on `local`).** With the
+`S3_*` settings pointed at your store but `STORAGE_BACKEND` still `local`, copy
+existing blobs into the bucket:
+
+```bash
+# preview first
+python -m app.db.backfill_uploads_to_s3 --dry-run
+# then copy for real
+python -m app.db.backfill_uploads_to_s3
+```
+
+It walks `UPLOADS_DIR/guild_<id>/`, uploads each blob to the matching S3 key with
+its recorded content-type, and verifies against the stored `content_hash`. It's
+**idempotent** (an object already in the bucket is skipped), so it's safe to
+re-run until it reports `failed=0`.
+
+**2. Cut over with a fallback window.** Set:
+
+```bash
+STORAGE_BACKEND=s3
+S3_LOCAL_FALLBACK=true
+```
+
+`S3_LOCAL_FALLBACK` makes a read that misses in S3 fall back to the local
+filesystem, so anything the backfill hasn't copied still serves — no 404s during
+the transition. New uploads now go to S3.
+
+**3. Finish.** Once you've confirmed everything serves from S3 (and a final
+backfill run reports `failed=0`), set `S3_LOCAL_FALLBACK=false` and retire the
+local uploads volume.


### PR DESCRIPTION
## Problem

The storage rebuild can store/serve/delete on S3, but there was no safe way to move an *existing* deployment's local uploads onto S3. This adds the migration tooling — the final step of the rollout (design §11).

## Changes

- **Backfill CLI** — `python -m app.db.backfill_uploads_to_s3 [--dry-run]`. Run it with `S3_*` pointed at your store while still on `STORAGE_BACKEND=local`: it walks `UPLOADS_DIR/guild_<id>/`, uploads each blob to the matching S3 key with the content-type recorded on the `uploads` row (or guessed from the extension), and verifies against the stored `content_hash`. **Idempotent** (skips objects already in the bucket), resumable, non-zero exit on any failure. The per-guild copy logic is factored into `backfill_guild_dir` and unit-tested without a DB.
- **Dual-read cutover** — new `DualReadStorage` + `S3_LOCAL_FALLBACK` setting. When set during cutover, writes/deletes go to S3 but a read that misses in S3 falls back to local, so blobs the backfill hasn't copied yet still serve (no 404s). `delete_prefix` purges both stores; cross-store `copy` reads local + writes S3. Turn the flag off once verified.
- `s3_guild_storage(guild_id)` — builds an explicit S3 backend regardless of `STORAGE_BACKEND` (the backfill writes to S3 while the app is still on local).
- Docs: a migration runbook in `docs/OBJECT_STORAGE.md`; `.env.example` + changelog.

## Migration flow

1. Configure `S3_*`, keep `STORAGE_BACKEND=local`, run the backfill until `failed=0`.
2. Set `STORAGE_BACKEND=s3` + `S3_LOCAL_FALLBACK=true` (fallback window).
3. Confirm, then `S3_LOCAL_FALLBACK=false` and retire the local volume.

## Schema / generated

- None. No model changes, no migration, no Orval regen. The backfill only moves bytes; it reads `uploads` rows (content-type/hash) but doesn't write them.

## Testing

- `ruff check` / `ruff format` — clean.
- 45 passed across `storage_test.py` (+ `DualReadStorage`: write-to-primary-only, read-fallback, exists-either, delete-both, delete_prefix-sums-both, cross-store copy) and `backfill_uploads_to_s3_test.py` (copy with/without meta content-type, skip-existing, hash-mismatch-not-copied, dry-run). Run against real Postgres.
- CLI `--help` smoke; import smoke clean. (`S3Storage` itself was previously validated end-to-end against a live Garage node.)