### PR TITLE
Add floating pill bottom navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Floating pill bottom navigation.** On phones the top toolbar (menu, search, recents) is replaced by a floating pill at the bottom of the screen with menu (showing your unread-notification count), search, and home buttons. A separate **add** button — shown on every screen size — opens the right "create" dialog for wherever you are (new task in a project, new project in the project list, new document, queue, queue item, counter, counter group, or calendar event), and expands to Add Task / Add Document everywhere else. It hides automatically when you can't create anything in the current view, and replaces the old bottom-right add buttons.
+
 ## [0.53.3] - 2026-06-27
 
 ### Added

--- a/frontend/public/locales/de/nav.json
+++ b/frontend/public/locales/de/nav.json
@@ -54,6 +54,15 @@
   "events": "Kalender",
   "allEvents": "Alle Termine",
   "createEvent": "Neuer Termin",
+  "bottomNav": {
+    "label": "Schnellnavigation",
+    "menu": "Menü öffnen",
+    "search": "Suchen",
+    "home": "Startseite",
+    "add": "Erstellen",
+    "addTask": "Aufgabe hinzufügen",
+    "addDocument": "Dokument hinzufügen"
+  },
   "navigate": {
     "signInRequired": "Bitte melde dich erneut an, um diesem Link zu folgen.",
     "missingDestination": "Diesem Link fehlen Zielangaben.",

--- a/frontend/public/locales/en/nav.json
+++ b/frontend/public/locales/en/nav.json
@@ -54,6 +54,15 @@
   "events": "Calendar",
   "allEvents": "All Events",
   "createEvent": "New Event",
+  "bottomNav": {
+    "label": "Quick navigation",
+    "menu": "Open menu",
+    "search": "Search",
+    "home": "Home",
+    "add": "Create",
+    "addTask": "Add Task",
+    "addDocument": "Add Document"
+  },
   "navigate": {
     "signInRequired": "Please sign in again to follow this link.",
     "missingDestination": "This link is missing destination details.",

--- a/frontend/public/locales/es/nav.json
+++ b/frontend/public/locales/es/nav.json
@@ -51,6 +51,15 @@
   "events": "Calendario",
   "allEvents": "Todos los eventos",
   "createEvent": "Nuevo evento",
+  "bottomNav": {
+    "label": "Navegación rápida",
+    "menu": "Abrir menú",
+    "search": "Buscar",
+    "home": "Inicio",
+    "add": "Crear",
+    "addTask": "Añadir tarea",
+    "addDocument": "Añadir documento"
+  },
   "navigate": {
     "signInRequired": "Por favor, inicia sesión de nuevo para seguir este enlace.",
     "missingDestination": "Este enlace no tiene detalles de destino.",

--- a/frontend/public/locales/fr/nav.json
+++ b/frontend/public/locales/fr/nav.json
@@ -51,6 +51,15 @@
   "events": "Calendrier",
   "allEvents": "Tous les événements",
   "createEvent": "Nouvel événement",
+  "bottomNav": {
+    "label": "Navigation rapide",
+    "menu": "Ouvrir le menu",
+    "search": "Rechercher",
+    "home": "Accueil",
+    "add": "Créer",
+    "addTask": "Ajouter une tâche",
+    "addDocument": "Ajouter un document"
+  },
   "navigate": {
     "signInRequired": "Veuillez vous reconnecter pour suivre ce lien.",
     "missingDestination": "Ce lien manque de détails de destination.",

--- a/frontend/src/components/navigation/BottomNav.tsx
+++ b/frontend/src/components/navigation/BottomNav.tsx
@@ -92,21 +92,23 @@ export function BottomNav() {
           (action ? (
             <Button
               size="icon"
-              className="pointer-events-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
+              className="pointer-events-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40 lg:w-auto lg:px-5"
               onClick={() => action.run()}
-              aria-label={t("bottomNav.add")}
+              aria-label={action.label || t("bottomNav.add")}
             >
               <Plus className="h-5 w-5" />
+              <span className="hidden lg:inline">{action.label}</span>
             </Button>
           ) : (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   size="icon"
-                  className="pointer-events-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
+                  className="pointer-events-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40 lg:w-auto lg:px-5"
                   aria-label={t("bottomNav.add")}
                 >
                   <Plus className="h-5 w-5" />
+                  <span className="hidden lg:inline">{t("bottomNav.add")}</span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" side="top" className="mb-2">

--- a/frontend/src/components/navigation/BottomNav.tsx
+++ b/frontend/src/components/navigation/BottomNav.tsx
@@ -50,7 +50,7 @@ export function BottomNav() {
       className="pointer-events-none fixed inset-x-0 bottom-0 z-40"
       style={{ paddingBottom: "var(--safe-area-inset-bottom)" }}
     >
-      <div className="flex w-full items-end gap-3 px-4 pb-4 sm:px-6 sm:pb-6">
+      <div className="flex w-full items-end justify-center gap-3 px-4 pb-4 sm:px-6 sm:pb-6 lg:justify-end">
         {isMobile && (
           <nav className={pillClass} aria-label={t("bottomNav.label")}>
             <Button
@@ -92,7 +92,7 @@ export function BottomNav() {
           (action ? (
             <Button
               size="icon"
-              className="pointer-events-auto ml-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
+              className="pointer-events-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
               onClick={() => action.run()}
               aria-label={t("bottomNav.add")}
             >
@@ -103,7 +103,7 @@ export function BottomNav() {
               <DropdownMenuTrigger asChild>
                 <Button
                   size="icon"
-                  className="pointer-events-auto ml-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
+                  className="pointer-events-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
                   aria-label={t("bottomNav.add")}
                 >
                   <Plus className="h-5 w-5" />

--- a/frontend/src/components/navigation/BottomNav.tsx
+++ b/frontend/src/components/navigation/BottomNav.tsx
@@ -1,0 +1,127 @@
+import { useNavigate } from "@tanstack/react-router";
+import { FilePlus, Home, Menu, Plus, Search, SquareCheckBig } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { getOpenCommandCenter } from "@/components/CommandCenter";
+import { getOpenCreateDocumentWizard } from "@/components/documents/CreateDocumentWizard";
+import { usePrimaryCreateAction } from "@/components/navigation/CreateActionContext";
+import { getOpenCreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useSidebar } from "@/components/ui/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useAuth } from "@/hooks/useAuth";
+import { useNotifications } from "@/hooks/useNotifications";
+
+const pillClass =
+  "pointer-events-auto flex items-center gap-1 rounded-full border bg-card/90 p-1 shadow-lg backdrop-blur supports-backdrop-filter:bg-card/70";
+
+/**
+ * App-wide floating bottom navigation. The hamburger/search/home pill is mobile
+ * only; the route-aware add pill renders at every viewport size and replaces the
+ * old per-page `fixed right-6 bottom-6` floating add buttons.
+ */
+export function BottomNav() {
+  const { t } = useTranslation("nav");
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+  const { setOpenMobile } = useSidebar();
+  const { user } = useAuth();
+  const { isCreateContext, action } = usePrimaryCreateAction();
+
+  const notificationsQuery = useNotifications({
+    refetchInterval: 30_000,
+    enabled: Boolean(user) && isMobile,
+  });
+  const unreadCount = notificationsQuery.data?.unread_count ?? 0;
+
+  // Hide the add button entirely on a create-context route where the user lacks
+  // permission. Non-create routes (no registration) fall back to the global menu.
+  const hideAdd = isCreateContext && action === null;
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-40"
+      style={{ paddingBottom: "var(--safe-area-inset-bottom)" }}
+    >
+      <div className="flex w-full items-end gap-3 px-4 pb-4 sm:px-6 sm:pb-6">
+        {isMobile && (
+          <nav className={pillClass} aria-label={t("bottomNav.label")}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative h-11 w-11 rounded-full"
+              onClick={() => setOpenMobile(true)}
+              aria-label={t("bottomNav.menu")}
+            >
+              <Menu className="h-5 w-5" />
+              {unreadCount > 0 ? (
+                <Badge className="absolute -top-0.5 -right-0.5 h-5 min-w-5 justify-center rounded-full px-1 py-0 text-[11px]">
+                  {unreadCount > 99 ? "99+" : unreadCount}
+                </Badge>
+              ) : null}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-11 w-11 rounded-full"
+              onClick={() => getOpenCommandCenter()?.()}
+              aria-label={t("bottomNav.search")}
+            >
+              <Search className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-11 w-11 rounded-full"
+              onClick={() => void navigate({ to: "/" })}
+              aria-label={t("bottomNav.home")}
+            >
+              <Home className="h-5 w-5" />
+            </Button>
+          </nav>
+        )}
+
+        {!hideAdd &&
+          (action ? (
+            <Button
+              size="icon"
+              className="pointer-events-auto ml-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
+              onClick={() => action.run()}
+              aria-label={t("bottomNav.add")}
+            >
+              <Plus className="h-5 w-5" />
+            </Button>
+          ) : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="icon"
+                  className="pointer-events-auto ml-auto h-12 w-12 rounded-full shadow-lg shadow-primary/40"
+                  aria-label={t("bottomNav.add")}
+                >
+                  <Plus className="h-5 w-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" side="top" className="mb-2">
+                <DropdownMenuItem onSelect={() => getOpenCreateTaskWizard()?.()}>
+                  <SquareCheckBig className="mr-2 h-4 w-4" />
+                  {t("bottomNav.addTask")}
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => getOpenCreateDocumentWizard()?.()}>
+                  <FilePlus className="mr-2 h-4 w-4" />
+                  {t("bottomNav.addDocument")}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/navigation/CreateActionContext.test.tsx
+++ b/frontend/src/components/navigation/CreateActionContext.test.tsx
@@ -14,6 +14,7 @@ function Consumer() {
     <>
       <span data-testid="ctx">{String(isCreateContext)}</span>
       <span data-testid="action">{action ? "yes" : "no"}</span>
+      <span data-testid="label">{action?.label ?? ""}</span>
       <button type="button" data-testid="run" onClick={() => action?.run()}>
         run
       </button>
@@ -44,20 +45,22 @@ describe("CreateActionContext", () => {
 
   it("exposes a registered action and runs the latest handler (permitted route)", () => {
     const run = vi.fn();
-    const { rerender } = render(<Tree mounted={true} action={{ run }} />);
+    const { rerender } = render(<Tree mounted={true} action={{ run, label: "Add Task" }} />);
 
     expect(screen.getByTestId("ctx").textContent).toBe("true");
     expect(screen.getByTestId("action").textContent).toBe("yes");
+    expect(screen.getByTestId("label").textContent).toBe("Add Task");
 
     fireEvent.click(screen.getByTestId("run"));
     expect(run).toHaveBeenCalledTimes(1);
 
     // A re-render with a fresh handler should run the new one, not the stale one.
     const nextRun = vi.fn();
-    rerender(<Tree mounted={true} action={{ run: nextRun }} />);
+    rerender(<Tree mounted={true} action={{ run: nextRun, label: "Add Document" }} />);
     fireEvent.click(screen.getByTestId("run"));
     expect(nextRun).toHaveBeenCalledTimes(1);
     expect(run).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("label").textContent).toBe("Add Document");
   });
 
   it("marks a create context but exposes a null action when unpermitted (button hidden)", () => {
@@ -69,7 +72,9 @@ describe("CreateActionContext", () => {
   });
 
   it("clears the registration when the create-able page unmounts", () => {
-    const { rerender } = render(<Tree mounted={true} action={{ run: vi.fn() }} />);
+    const { rerender } = render(
+      <Tree mounted={true} action={{ run: vi.fn(), label: "Add Item" }} />
+    );
     expect(screen.getByTestId("ctx").textContent).toBe("true");
 
     rerender(<Tree mounted={false} action={null} />);

--- a/frontend/src/components/navigation/CreateActionContext.test.tsx
+++ b/frontend/src/components/navigation/CreateActionContext.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CreateActionProvider,
+  type PrimaryCreateAction,
+  usePrimaryCreateAction,
+  useRegisterPrimaryCreateAction,
+} from "./CreateActionContext";
+
+function Consumer() {
+  const { isCreateContext, action } = usePrimaryCreateAction();
+  return (
+    <>
+      <span data-testid="ctx">{String(isCreateContext)}</span>
+      <span data-testid="action">{action ? "yes" : "no"}</span>
+      <button type="button" data-testid="run" onClick={() => action?.run()}>
+        run
+      </button>
+    </>
+  );
+}
+
+function Registrant({ action }: { action: PrimaryCreateAction | null }) {
+  useRegisterPrimaryCreateAction(action);
+  return null;
+}
+
+function Tree({ mounted, action }: { mounted: boolean; action: PrimaryCreateAction | null }) {
+  return (
+    <CreateActionProvider>
+      <Consumer />
+      {mounted ? <Registrant action={action} /> : null}
+    </CreateActionProvider>
+  );
+}
+
+describe("CreateActionContext", () => {
+  it("reports no create context and a null action when nothing is registered", () => {
+    render(<Tree mounted={false} action={null} />);
+    expect(screen.getByTestId("ctx").textContent).toBe("false");
+    expect(screen.getByTestId("action").textContent).toBe("no");
+  });
+
+  it("exposes a registered action and runs the latest handler (permitted route)", () => {
+    const run = vi.fn();
+    const { rerender } = render(<Tree mounted={true} action={{ run }} />);
+
+    expect(screen.getByTestId("ctx").textContent).toBe("true");
+    expect(screen.getByTestId("action").textContent).toBe("yes");
+
+    fireEvent.click(screen.getByTestId("run"));
+    expect(run).toHaveBeenCalledTimes(1);
+
+    // A re-render with a fresh handler should run the new one, not the stale one.
+    const nextRun = vi.fn();
+    rerender(<Tree mounted={true} action={{ run: nextRun }} />);
+    fireEvent.click(screen.getByTestId("run"));
+    expect(nextRun).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a create context but exposes a null action when unpermitted (button hidden)", () => {
+    render(<Tree mounted={true} action={null} />);
+    // isCreateContext is true so the nav knows to hide the add button rather
+    // than fall back to the global create menu.
+    expect(screen.getByTestId("ctx").textContent).toBe("true");
+    expect(screen.getByTestId("action").textContent).toBe("no");
+  });
+
+  it("clears the registration when the create-able page unmounts", () => {
+    const { rerender } = render(<Tree mounted={true} action={{ run: vi.fn() }} />);
+    expect(screen.getByTestId("ctx").textContent).toBe("true");
+
+    rerender(<Tree mounted={false} action={null} />);
+    expect(screen.getByTestId("ctx").textContent).toBe("false");
+    expect(screen.getByTestId("action").textContent).toBe("no");
+  });
+});

--- a/frontend/src/components/navigation/CreateActionContext.tsx
+++ b/frontend/src/components/navigation/CreateActionContext.tsx
@@ -95,11 +95,19 @@ export function useRegisterPrimaryCreateAction(action: PrimaryCreateAction | nul
   const available = action != null;
   const label = action?.label ?? "";
 
+  // Upsert on every change. `register` replaces the entry in a single state
+  // update, so flipping `available`/`label` (e.g. a locale switch) never empties
+  // the registry — `isCreateContext` stays stable and the nav can't flash the
+  // wrong add button. Unregistering happens only on unmount (separate effect).
   useEffect(() => {
     if (!api) return;
     api.register(id, available ? { run: () => actionRef.current?.run(), label } : null);
-    return () => api.unregister(id);
   }, [api, id, available, label]);
+
+  useEffect(() => {
+    if (!api) return;
+    return () => api.unregister(id);
+  }, [api, id]);
 }
 
 /** Read the currently-registered create action (for the bottom-nav add button). */

--- a/frontend/src/components/navigation/CreateActionContext.tsx
+++ b/frontend/src/components/navigation/CreateActionContext.tsx
@@ -16,6 +16,8 @@ import {
  */
 export type PrimaryCreateAction = {
   run: () => void;
+  /** Localized label of what gets created, e.g. "Add Task" — shown on wide screens. */
+  label: string;
 };
 
 type RegistryEntry = {
@@ -91,12 +93,13 @@ export function useRegisterPrimaryCreateAction(action: PrimaryCreateAction | nul
   const actionRef = useRef(action);
   actionRef.current = action;
   const available = action != null;
+  const label = action?.label ?? "";
 
   useEffect(() => {
     if (!api) return;
-    api.register(id, available ? { run: () => actionRef.current?.run() } : null);
+    api.register(id, available ? { run: () => actionRef.current?.run(), label } : null);
     return () => api.unregister(id);
-  }, [api, id, available]);
+  }, [api, id, available, label]);
 }
 
 /** Read the currently-registered create action (for the bottom-nav add button). */

--- a/frontend/src/components/navigation/CreateActionContext.tsx
+++ b/frontend/src/components/navigation/CreateActionContext.tsx
@@ -1,0 +1,105 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+/**
+ * A page's "primary create action" — what the app-wide bottom-nav add button
+ * does on that route (e.g. open the create-task dialog on a project page).
+ */
+export type PrimaryCreateAction = {
+  run: () => void;
+};
+
+type RegistryEntry = {
+  id: string;
+  /** `null` means "this route is a create context, but the user can't create here". */
+  action: PrimaryCreateAction | null;
+};
+
+type RegisterApi = {
+  register: (id: string, action: PrimaryCreateAction | null) => void;
+  unregister: (id: string) => void;
+};
+
+type CreateActionState = {
+  /** True when a create-able page is mounted (regardless of permission). */
+  isCreateContext: boolean;
+  /** The action to run, or `null` when the current context grants no permission. */
+  action: PrimaryCreateAction | null;
+};
+
+// Split the stable register API from the derived state so pages that only
+// register (and never read the state) don't re-render when the state changes.
+const RegisterApiContext = createContext<RegisterApi | null>(null);
+const CreateActionStateContext = createContext<CreateActionState>({
+  isCreateContext: false,
+  action: null,
+});
+
+export function CreateActionProvider({ children }: { children: ReactNode }) {
+  const [entries, setEntries] = useState<RegistryEntry[]>([]);
+
+  const register = useCallback((id: string, action: PrimaryCreateAction | null) => {
+    setEntries((prev) => {
+      const rest = prev.filter((entry) => entry.id !== id);
+      return [...rest, { id, action }];
+    });
+  }, []);
+
+  const unregister = useCallback((id: string) => {
+    setEntries((prev) => prev.filter((entry) => entry.id !== id));
+  }, []);
+
+  const api = useMemo<RegisterApi>(() => ({ register, unregister }), [register, unregister]);
+
+  // The most recently registered page wins. In practice only one create-able
+  // route is mounted at a time, so this is a single-slot lookup.
+  const last = entries[entries.length - 1];
+  const state = useMemo<CreateActionState>(
+    () => ({ isCreateContext: entries.length > 0, action: last?.action ?? null }),
+    [entries.length, last?.action]
+  );
+
+  return (
+    <RegisterApiContext.Provider value={api}>
+      <CreateActionStateContext.Provider value={state}>
+        {children}
+      </CreateActionStateContext.Provider>
+    </RegisterApiContext.Provider>
+  );
+}
+
+/**
+ * Register the current route's primary create action with the bottom-nav add
+ * button. Call this unconditionally from a create-able page (Rules of Hooks):
+ * pass an action when the user may create here, or `null` when they can't (the
+ * button is then hidden rather than falling back to the global create menu).
+ */
+export function useRegisterPrimaryCreateAction(action: PrimaryCreateAction | null) {
+  const id = useId();
+  const api = useContext(RegisterApiContext);
+  // Keep the latest action in a ref so the registered closure always runs the
+  // current handler without re-registering on every render.
+  const actionRef = useRef(action);
+  actionRef.current = action;
+  const available = action != null;
+
+  useEffect(() => {
+    if (!api) return;
+    api.register(id, available ? { run: () => actionRef.current?.run() } : null);
+    return () => api.unregister(id);
+  }, [api, id, available]);
+}
+
+/** Read the currently-registered create action (for the bottom-nav add button). */
+export function usePrimaryCreateAction(): CreateActionState {
+  return useContext(CreateActionStateContext);
+}

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -40,6 +40,7 @@ import {
   CalendarView,
   type CalendarViewMode,
 } from "@/components/calendar";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { ProjectGanttView } from "@/components/projects/ProjectGanttView";
 import { ProjectTaskComposer } from "@/components/projects/ProjectTaskComposer";
 import { ProjectTasksFilters } from "@/components/projects/ProjectTasksFilters";
@@ -291,6 +292,12 @@ export const ProjectTasksSection = ({
   useEffect(() => {
     onComposerOpenChange?.(isComposerOpen);
   }, [isComposerOpen, onComposerOpenChange]);
+
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(
+    canEditTaskDetails ? { run: () => setIsComposerOpen(true) } : null
+  );
+
   const [activeTaskId, setActiveTaskId] = useState<number | null>(null);
   const [selectedTasks, setSelectedTasks] = useState<TaskListRead[]>([]);
   const [isBulkEditDialogOpen, setIsBulkEditDialogOpen] = useState(false);
@@ -1079,22 +1086,6 @@ export const ProjectTasksSection = ({
 
       {canEditTaskDetails ? (
         <>
-          <TooltipProvider>
-            <Tooltip delayDuration={400}>
-              <TooltipTrigger asChild>
-                <Button
-                  className="fixed right-6 bottom-6 z-40 h-12 rounded-full px-6 shadow-lg shadow-primary/40"
-                  onClick={() => setIsComposerOpen(true)}
-                >
-                  <Plus className="h-4 w-4" />
-                  {t("tasks.addTask")}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={12}>
-                {t("tasks.enterTooltip")}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
           <Dialog open={isComposerOpen} onOpenChange={setIsComposerOpen}>
             <ProjectTaskComposer
               title={title}

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -295,7 +295,7 @@ export const ProjectTasksSection = ({
 
   // Drive the app-wide bottom-nav add button for this route.
   useRegisterPrimaryCreateAction(
-    canEditTaskDetails ? { run: () => setIsComposerOpen(true) } : null
+    canEditTaskDetails ? { run: () => setIsComposerOpen(true), label: t("tasks.addTask") } : null
   );
 
   const [activeTaskId, setActiveTaskId] = useState<number | null>(null);

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -469,7 +469,9 @@ export const DocumentsView = ({
 
   // Drive the app-wide bottom-nav add button for this route.
   useRegisterPrimaryCreateAction(
-    canCreateDocuments ? { run: () => setCreateDialogOpen(true) } : null
+    canCreateDocuments
+      ? { run: () => setCreateDialogOpen(true), label: t("page.newDocument") }
+      : null
   );
 
   // Open create dialog when ?create=true is in URL

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -18,6 +18,7 @@ import { DocumentsFilterBar } from "@/components/documents/DocumentsFilterBar";
 import { DocumentsListView } from "@/components/documents/DocumentsListView";
 import { DocumentsTagsView } from "@/components/documents/DocumentsTagsView";
 import { PaginationBar } from "@/components/documents/PaginationBar";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import type { PropertyFilterCondition } from "@/components/properties/PropertyFilter";
 import { UNTAGGED_PATH } from "@/components/tags/TagTreeView";
 import { Button } from "@/components/ui/button";
@@ -466,6 +467,11 @@ export const DocumentsView = ({
     creatableInitiatives,
   ]);
 
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(
+    canCreateDocuments ? { run: () => setCreateDialogOpen(true) } : null
+  );
+
   // Open create dialog when ?create=true is in URL
   useEffect(() => {
     const shouldCreate = searchParams.create === "true";
@@ -772,17 +778,6 @@ export const DocumentsView = ({
         documents={selectedDocuments}
         onSuccess={() => {}}
       />
-
-      {canCreateDocuments ? (
-        <Button
-          type="button"
-          className="fixed right-6 bottom-6 z-40 h-12 rounded-full px-6 shadow-lg shadow-primary/40"
-          onClick={() => setCreateDialogOpen(true)}
-        >
-          <Plus className="h-4 w-4" />
-          {t("page.newDocument")}
-        </Button>
-      ) : null}
     </div>
   );
 };

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -303,7 +303,9 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   }, [canCreate, filteredInitiativeId, filteredInitiativePermissions, isProjectManager]);
 
   // Drive the app-wide bottom-nav add button for this route.
-  useRegisterPrimaryCreateAction(canCreateProjects ? { run: () => setIsComposerOpen(true) } : null);
+  useRegisterPrimaryCreateAction(
+    canCreateProjects ? { run: () => setIsComposerOpen(true), label: t("addProject") } : null
+  );
 
   // Helper function for per-project DAC checks
   const hasProjectWritePermission = (project: ProjectRead): boolean => {

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import type { ProjectRead, TagRead, TagSummary } from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllProjects } from "@/api/query-keys";
 import { Markdown } from "@/components/Markdown";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { CreateProjectDialog } from "@/components/projects/CreateProjectDialog";
 import { ProjectImportDialog } from "@/components/projects/ProjectImportDialog";
@@ -300,6 +301,9 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
     // Fall back to legacy check (user is PM in any initiative)
     return isProjectManager;
   }, [canCreate, filteredInitiativeId, filteredInitiativePermissions, isProjectManager]);
+
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(canCreateProjects ? { run: () => setIsComposerOpen(true) } : null);
 
   // Helper function for per-project DAC checks
   const hasProjectWritePermission = (project: ProjectRead): boolean => {
@@ -838,16 +842,6 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
             )}
           </TabsContent>
         </Tabs>
-
-        {canCreateProjects && (
-          <Button
-            className="fixed right-6 bottom-6 z-40 h-12 rounded-full px-6 shadow-lg shadow-primary/40"
-            onClick={() => setIsComposerOpen(true)}
-          >
-            <Plus className="h-4 w-4" />
-            {t("addProject")}
-          </Button>
-        )}
 
         {canCreateProjects && (
           <CreateProjectDialog

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from "react-i18next";
 import type { CounterRead } from "@/api/generated/initiativeAPI.schemas";
 import { CounterFormDialog } from "@/components/initiativeTools/counters/CounterFormDialog";
 import { type CounterLayout, CounterRow } from "@/components/initiativeTools/counters/CounterRow";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -125,6 +126,9 @@ export function CounterGroupDetailPage() {
 
   const canWrite = group?.my_permission_level === "owner" || group?.my_permission_level === "write";
   const canManage = group?.my_permission_level === "owner";
+
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(canWrite ? { run: () => setAddOpen(true) } : null);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
@@ -128,7 +128,9 @@ export function CounterGroupDetailPage() {
   const canManage = group?.my_permission_level === "owner";
 
   // Drive the app-wide bottom-nav add button for this route.
-  useRegisterPrimaryCreateAction(canWrite ? { run: () => setAddOpen(true) } : null);
+  useRegisterPrimaryCreateAction(
+    canWrite ? { run: () => setAddOpen(true), label: t("addCounter") } : null
+  );
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -107,7 +107,9 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
   const [search, setSearch] = useState("");
 
   // Drive the app-wide bottom-nav add button for this route.
-  useRegisterPrimaryCreateAction(canCreateGroups ? { run: () => setCreateOpen(true) } : null);
+  useRegisterPrimaryCreateAction(
+    canCreateGroups ? { run: () => setCreateOpen(true), label: t("createGroup") } : null
+  );
 
   // Open the create dialog whenever ?create=true is present — including when
   // the sidebar "+" navigates here while already on the page (the useState

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { CounterGroupCard } from "@/components/initiativeTools/counters/CounterGroupCard";
 import { CountersFilterBar } from "@/components/initiativeTools/counters/CountersFilterBar";
 import { CreateCounterGroupDialog } from "@/components/initiativeTools/counters/CreateCounterGroupDialog";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useCounterGroupsList } from "@/hooks/useCounters";
@@ -104,6 +105,9 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
   const [createOpen, setCreateOpen] = useState(searchParams.create === "true");
   const isClosingCreateDialog = useRef(false);
   const [search, setSearch] = useState("");
+
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(canCreateGroups ? { run: () => setCreateOpen(true) } : null);
 
   // Open the create dialog whenever ?create=true is present — including when
   // the sidebar "+" navigates here while already on the page (the useState

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -1,7 +1,7 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { useRouter, useSearch } from "@tanstack/react-router";
 import { addYears, endOfYear, format, startOfYear, subYears } from "date-fns";
-import { ChevronDown, Download, Filter, Loader2, Plus, Upload } from "lucide-react";
+import { ChevronDown, Download, Filter, Loader2, Upload } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -22,6 +22,7 @@ import {
 } from "@/components/calendar";
 import { CreateEventDialog } from "@/components/initiativeTools/events/CreateEventDialog";
 import { ICalImportDialog } from "@/components/initiativeTools/events/ICalImportDialog";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import {
   PropertyFilter,
   type PropertyFilterCondition,
@@ -311,6 +312,18 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [createDefaultDate, setCreateDefaultDate] = useState<Date | null>(null);
 
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(
+    canCreateEvents && initiativeId
+      ? {
+          run: () => {
+            setCreateDefaultDate(null);
+            setCreateDialogOpen(true);
+          },
+        }
+      : null
+  );
+
   useEffect(() => {
     const shouldCreate = searchParams.create === "true";
     if (shouldCreate && !createDialogOpen && !isClosingCreateDialog.current) {
@@ -596,19 +609,6 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
         onOpenChange={setImportDialogOpen}
         fixedInitiativeId={initiativeId ?? undefined}
       />
-
-      {canCreateEvents && initiativeId && (
-        <Button
-          className="fixed right-6 bottom-6 z-40 h-12 rounded-full px-6 shadow-lg shadow-primary/40"
-          onClick={() => {
-            setCreateDefaultDate(null);
-            setCreateDialogOpen(true);
-          }}
-        >
-          <Plus className="h-4 w-4" />
-          {t("createEvent")}
-        </Button>
-      )}
     </div>
   );
 };

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -320,6 +320,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
             setCreateDefaultDate(null);
             setCreateDialogOpen(true);
           },
+          label: t("createEvent"),
         }
       : null
   );

--- a/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
@@ -11,6 +11,7 @@ import { QueueControls } from "@/components/initiativeTools/queues/QueueControls
 import { QueueItemRow } from "@/components/initiativeTools/queues/QueueItemRow";
 import { QueueTimeline } from "@/components/initiativeTools/queues/QueueTimeline";
 import { QueueViewToggle } from "@/components/initiativeTools/queues/QueueViewToggle";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { StatusMessage } from "@/components/StatusMessage";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -148,6 +149,9 @@ export function QueueDetailPage() {
   const [editingItem, setEditingItem] = useState<QueueItemRead | null>(null);
 
   const canEdit = queue?.my_permission_level === "owner" || queue?.my_permission_level === "write";
+
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(canEdit ? { run: () => setAddItemOpen(true) } : null);
 
   // Sort items by position descending (highest initiative goes first)
   const sortedItems = useMemo(() => {

--- a/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
@@ -151,7 +151,9 @@ export function QueueDetailPage() {
   const canEdit = queue?.my_permission_level === "owner" || queue?.my_permission_level === "write";
 
   // Drive the app-wide bottom-nav add button for this route.
-  useRegisterPrimaryCreateAction(canEdit ? { run: () => setAddItemOpen(true) } : null);
+  useRegisterPrimaryCreateAction(
+    canEdit ? { run: () => setAddItemOpen(true), label: t("addItem") } : null
+  );
 
   // Sort items by position descending (highest initiative goes first)
   const sortedItems = useMemo(() => {

--- a/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
@@ -9,6 +9,7 @@ import {
   QueuesFilterBar,
   type StatusFilter,
 } from "@/components/initiativeTools/queues/QueuesFilterBar";
+import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/hooks/useAuth";
@@ -169,6 +170,9 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
   const getDefaultFiltersVisibility = () =>
     typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches;
   const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+
+  // Drive the app-wide bottom-nav add button for this route.
+  useRegisterPrimaryCreateAction(canCreateQueues ? { run: () => setCreateDialogOpen(true) } : null);
 
   // Open create dialog when ?create=true is in URL
   useEffect(() => {
@@ -334,17 +338,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
         }
         onSuccess={handleQueueCreated}
       />
-
-      {canCreateQueues && (
-        <Button
-          type="button"
-          className="fixed right-6 bottom-6 z-40 h-12 rounded-full px-6 shadow-lg shadow-primary/40"
-          onClick={() => setCreateDialogOpen(true)}
-        >
-          <Plus className="h-4 w-4" />
-          {t("createQueue")}
-        </Button>
-      )}
     </div>
   );
 };

--- a/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
@@ -172,7 +172,9 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
   const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
 
   // Drive the app-wide bottom-nav add button for this route.
-  useRegisterPrimaryCreateAction(canCreateQueues ? { run: () => setCreateDialogOpen(true) } : null);
+  useRegisterPrimaryCreateAction(
+    canCreateQueues ? { run: () => setCreateDialogOpen(true), label: t("createQueue") } : null
+  );
 
   // Open create dialog when ?create=true is in URL
   useEffect(() => {

--- a/frontend/src/pages/user/MyCreatedTasksPage.tsx
+++ b/frontend/src/pages/user/MyCreatedTasksPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { CalendarDays, Loader2, Plus, Table2 } from "lucide-react";
+import { CalendarDays, Loader2, Table2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -14,7 +14,6 @@ import {
 } from "@/components/calendar";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { buildPropertyColumns, propertyColumnIds } from "@/components/properties/propertyColumns";
-import { getOpenCreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
 import { GlobalTaskFilters } from "@/components/tasks/GlobalTaskFilters";
 import { globalTaskColumns } from "@/components/tasks/globalTaskColumns";
 import { Button } from "@/components/ui/button";
@@ -136,10 +135,6 @@ export const MyCreatedTasksPage = () => {
             <p className="text-muted-foreground">{t("createdTasks.subtitle")}</p>
           </div>
           <div className="flex items-center gap-2">
-            <Button size="sm" onClick={() => getOpenCreateTaskWizard()?.()}>
-              <Plus className="mr-1 h-4 w-4" />
-              {t("createdTasks.addTask")}
-            </Button>
             <div className="flex items-center gap-1 rounded-lg border p-1">
               <Button
                 variant={viewMode === "table" ? "default" : "ghost"}

--- a/frontend/src/pages/user/MyDocumentsPage.tsx
+++ b/frontend/src/pages/user/MyDocumentsPage.tsx
@@ -2,13 +2,12 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { Link, useRouter, useSearch } from "@tanstack/react-router";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { ChevronDown, Filter, Loader2, Plus, Search } from "lucide-react";
+import { ChevronDown, Filter, Loader2, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { DocumentSummary } from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllDocuments } from "@/api/query-keys";
-import { getOpenCreateDocumentWizard } from "@/components/documents/CreateDocumentWizard";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { SortIcon } from "@/components/SortIcon";
 import { TagBadge } from "@/components/tags/TagBadge";
@@ -361,15 +360,9 @@ export const MyDocumentsPage = () => {
   return (
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="font-semibold text-3xl tracking-tight">{t("myDocuments.title")}</h1>
-            <p className="text-muted-foreground">{t("myDocuments.subtitle")}</p>
-          </div>
-          <Button size="sm" onClick={() => getOpenCreateDocumentWizard()?.()}>
-            <Plus className="mr-1 h-4 w-4" />
-            {t("page.newDocument")}
-          </Button>
+        <div>
+          <h1 className="font-semibold text-3xl tracking-tight">{t("myDocuments.title")}</h1>
+          <p className="text-muted-foreground">{t("myDocuments.subtitle")}</p>
         </div>
 
         <Collapsible open={filtersOpen} onOpenChange={setFiltersOpen} className="space-y-2">

--- a/frontend/src/pages/user/MyTasksPage.tsx
+++ b/frontend/src/pages/user/MyTasksPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { CalendarDays, Loader2, Plus, Table2 } from "lucide-react";
+import { CalendarDays, Loader2, Table2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -14,7 +14,6 @@ import {
 } from "@/components/calendar";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { buildPropertyColumns, propertyColumnIds } from "@/components/properties/propertyColumns";
-import { getOpenCreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
 import { GlobalTaskFilters } from "@/components/tasks/GlobalTaskFilters";
 import { globalTaskColumns } from "@/components/tasks/globalTaskColumns";
 import { Button } from "@/components/ui/button";
@@ -137,10 +136,6 @@ export const MyTasksPage = () => {
             <p className="text-muted-foreground">{t("myTasks.subtitle")}</p>
           </div>
           <div className="flex items-center gap-2">
-            <Button size="sm" onClick={() => getOpenCreateTaskWizard()?.()}>
-              <Plus className="mr-1 h-4 w-4" />
-              {t("myTasks.addTask")}
-            </Button>
             <div className="flex items-center gap-1 rounded-lg border p-1">
               <Button
                 variant={viewMode === "table" ? "default" : "ghost"}

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -16,6 +16,8 @@ import { AppSidebar } from "@/components/AppSidebar";
 import { CommandCenter, getOpenCommandCenter } from "@/components/CommandCenter";
 import { CreateDocumentWizard } from "@/components/documents/CreateDocumentWizard";
 import { GuildAccessBanner } from "@/components/guilds/GuildAccessBanner";
+import { BottomNav } from "@/components/navigation/BottomNav";
+import { CreateActionProvider } from "@/components/navigation/CreateActionContext";
 import { PushPermissionPrompt } from "@/components/notifications/PushPermissionPrompt";
 import { ProjectActivitySidebar } from "@/components/projects/ProjectActivitySidebar";
 import { RecentTabsBar } from "@/components/recents/RecentTabsBar";
@@ -199,7 +201,7 @@ function AppLayout() {
   // const isDark = document.documentElement.classList.contains("dark");
 
   return (
-    <>
+    <CreateActionProvider>
       <CommandCenter />
       <CreateTaskWizard />
       <CreateDocumentWizard />
@@ -218,10 +220,10 @@ function AppLayout() {
             <AppSidebar />
             <div className="min-w-0 flex-1 bg-muted/50 md:pl-0">
               <div
-                className="sticky top-0 z-50 flex flex-col border-b bg-card/70 backdrop-blur supports-backdrop-filter:bg-card/60"
+                className="sticky top-0 z-50 flex flex-col bg-card/70 backdrop-blur supports-backdrop-filter:bg-card/60 lg:border-b"
                 style={{ paddingTop: "var(--safe-area-inset-top)" }}
               >
-                <div className="flex h-12">
+                <div className="hidden h-12 lg:flex">
                   <SidebarTrigger
                     icon={<Menu />}
                     className="h-12 w-12 shrink-0 rounded-none border-r lg:hidden"
@@ -263,7 +265,7 @@ function AppLayout() {
                     backgroundSize: "37px 64px",
                   }}
                 />*/}
-                <main className="container mx-auto min-w-0 p-4 pb-20 md:p-8 md:pb-20">
+                <main className="container mx-auto min-w-0 p-4 pb-24 md:p-8 md:pb-24">
                   <Suspense fallback={<PageLoader />}>
                     <Outlet />
                   </Suspense>
@@ -271,6 +273,7 @@ function AppLayout() {
               </div>
             </div>
             <ProjectActivitySidebar projectId={activeProjectId} />
+            <BottomNav />
           </SidebarProvider>
         </div>
         <VersionDialog
@@ -281,7 +284,7 @@ function AppLayout() {
           onClose={closeDialog}
         />
       </div>
-    </>
+    </CreateActionProvider>
   );
 }
 

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -7,7 +7,7 @@ import {
   useLocation,
   useSearch,
 } from "@tanstack/react-router";
-import { Loader2, LogOut, Menu, Plus, Search, Settings, Ticket, UserCog } from "lucide-react";
+import { Loader2, LogOut, Plus, Search, Settings, Ticket, UserCog } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -24,7 +24,7 @@ import { RecentTabsBar } from "@/components/recents/RecentTabsBar";
 import { CreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { VersionDialog } from "@/components/VersionDialog";
 import { useAuth } from "@/hooks/useAuth";
@@ -224,10 +224,8 @@ function AppLayout() {
                 style={{ paddingTop: "var(--safe-area-inset-top)" }}
               >
                 <div className="hidden h-12 lg:flex">
-                  <SidebarTrigger
-                    icon={<Menu />}
-                    className="h-12 w-12 shrink-0 rounded-none border-r lg:hidden"
-                  />
+                  {/* Mobile hamburger now lives in BottomNav; this desktop-only
+                      row keeps search + recents. */}
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button


### PR DESCRIPTION
## Problem

On mobile, all navigation lived in a sticky top toolbar (hamburger, search, recents). Recents are already reachable from the Command Center and the search button just opens the Command Center, so the top bar was largely redundant and ate vertical space. We wanted to follow the common mobile pattern (Shopify/Gmail-style) of a floating pill bottom nav.

## What changed

**New floating bottom nav** (`BottomNav.tsx`)
- **Mobile-only main pill** (`lg:hidden`): hamburger (far left, with an unread-notification badge) opens the sidebar drawer; search opens the Command Center; home navigates to `/`.
- **App-wide add pill**: route-aware. Opens the correct create dialog for the current route, and expands to **Add Task / Add Document** on non-create routes. On `lg+` it shows a label of what it creates (e.g. "Add Task", "New Document"); icon-only on mobile.
- Centered on mobile; the add button right-aligns on `lg+`.

**Permission-aware via a registry** (`CreateActionContext.tsx`)
- Each create-able page calls `useRegisterPrimaryCreateAction({ run, label })` with its existing setter + `canCreate*` flag. Three states: registered+permitted → context button; create-context+unpermitted → **hidden**; no registration → global Add menu.
- Wired into 8 pages: projects, project tasks, documents, queues, queue detail, counter groups, counter-group detail, events.

**Layout** (`_authenticated.tsx`)
- Mobile top-bar row hidden (`hidden lg:flex`); the divider is now desktop-only so the bar fully disappears on web mobile while the safe-area inset (native status bar) and `GuildAccessBanner` still work.
- The 5 identical `fixed right-6 bottom-6` floating add buttons were deleted (Projects, Documents, Queues, Events, ProjectTasksSection) — superseded by the shared add pill.
- Removed the redundant header "Add task" / "New document" buttons on My Tasks, Tasks I Created, and My Documents (covered by the global add menu).

**i18n**
- New `nav.bottomNav.*` keys added to **all four locales** (en, de, es, fr). Existing contextual label keys verified present in every locale.

## Reviewer notes
- Native top padding is preserved: the sticky header container still renders on mobile (only its inner toolbar row is hidden) and keeps `paddingTop: var(--safe-area-inset-top)`.
- The add pill uses `z-40` (under modals/top bar at `z-50`); main content bottom padding bumped to `pb-24` to clear it.

## Testing
- `pnpm typecheck` — clean
- `pnpm lint` (biome) — clean
- New Vitest spec for `CreateActionContext` (register/consume + visibility logic) — passing; touched-area tests pass
- Verified all changed modules transform cleanly through the running Vite dev server. Full interactive browser walkthrough was not run (local dev server occupied the preview port).

PRs target `dev` per repo guidelines.