### PR TITLE
Add bulk edit-access to calendar events (list view)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Bulk-edit access on projects, queues, and counter groups.** Like documents, these lists now have a **Select** mode: pick several items, then **Edit access** to share them with people, roles, or all initiative members — in one step. The same tabbed dialog everywhere (People / Roles / All members, Viewer/Editor), and it only touches items you own or can edit.
+- **Bulk-edit access on projects, queues, counter groups, and calendar events.** Like documents, these now have a **Select** mode: pick several items, then **Edit access** to share them with people, roles, or all initiative members — in one step. The same tabbed dialog everywhere (People / Roles / All members, Viewer/Editor), and it only touches items you own or can edit. For calendar events, Select lives in the calendar's **list** view.
 
 ### Fixed
 

--- a/frontend/src/components/calendar/CalendarView.selection.test.tsx
+++ b/frontend/src/components/calendar/CalendarView.selection.test.tsx
@@ -43,21 +43,18 @@ function renderList(onToggle = vi.fn()) {
 }
 
 describe("CalendarView list-view selection", () => {
-  it("only event rows are selectable; task rows are disabled", async () => {
+  it("shows only selectable (event) rows and toggles them", async () => {
     const user = userEvent.setup();
     const onToggle = renderList();
 
-    const eventRow = screen.getByRole("button", { name: /Launch party/i });
-    const taskRow = screen.getByRole("button", { name: /Do the thing/i });
+    // Tasks can't be shared, so they're hidden entirely while selecting — the
+    // list is a picker for events only.
+    expect(screen.queryByRole("button", { name: /Do the thing/i })).toBeNull();
 
-    // Task entries can't be shared, so their row is inert during selection.
-    expect(taskRow).toBeDisabled();
+    const eventRow = screen.getByRole("button", { name: /Launch party/i });
     expect(eventRow).not.toBeDisabled();
 
     await user.click(eventRow);
     expect(onToggle).toHaveBeenCalledWith(expect.objectContaining({ id: "event-1" }));
-
-    await user.click(taskRow);
-    expect(onToggle).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/calendar/CalendarView.selection.test.tsx
+++ b/frontend/src/components/calendar/CalendarView.selection.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/__tests__/helpers/render";
+
+import { type CalendarEntry, CalendarView } from "./CalendarView";
+
+// Focus date + entries live in the same month so the list view keeps them.
+const FOCUS = new Date("2026-06-15T12:00:00Z");
+
+const eventEntry: CalendarEntry = {
+  id: "event-1",
+  title: "Launch party",
+  startAt: "2026-06-15T10:00:00Z",
+  endAt: "2026-06-15T11:00:00Z",
+  meta: { type: "event", eventId: 1 },
+};
+
+const taskEntry: CalendarEntry = {
+  id: "task-9",
+  title: "Do the thing",
+  startAt: "2026-06-16T10:00:00Z",
+  endAt: "2026-06-16T11:00:00Z",
+  meta: { type: "task" },
+};
+
+function renderList(onToggle = vi.fn()) {
+  renderWithProviders(
+    <CalendarView
+      entries={[eventEntry, taskEntry]}
+      viewMode="list"
+      onViewModeChange={vi.fn()}
+      focusDate={FOCUS}
+      onFocusDateChange={vi.fn()}
+      selectionActive
+      selectedEntryIds={new Set()}
+      isEntrySelectable={(e) => (e.meta as { type?: string } | undefined)?.type === "event"}
+      onToggleEntrySelection={onToggle}
+    />
+  );
+  return onToggle;
+}
+
+describe("CalendarView list-view selection", () => {
+  it("only event rows are selectable; task rows are disabled", async () => {
+    const user = userEvent.setup();
+    const onToggle = renderList();
+
+    const eventRow = screen.getByRole("button", { name: /Launch party/i });
+    const taskRow = screen.getByRole("button", { name: /Do the thing/i });
+
+    // Task entries can't be shared, so their row is inert during selection.
+    expect(taskRow).toBeDisabled();
+    expect(eventRow).not.toBeDisabled();
+
+    await user.click(eventRow);
+    expect(onToggle).toHaveBeenCalledWith(expect.objectContaining({ id: "event-1" }));
+
+    await user.click(taskRow);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -1438,6 +1438,11 @@ function ListView({
     const result: ListRow[] = [];
 
     for (const entry of entries) {
+      // In selection mode the list is a picker for shareable entries only — hide
+      // everything that can't be selected (e.g. tasks) so it can't be confused
+      // for something you can bulk-edit.
+      if (selectionActive && !(isEntrySelectable?.(entry) ?? false)) continue;
+
       const { start, end } = parseEntry(entry);
       if (Number.isNaN(start.getTime())) continue;
 
@@ -1462,7 +1467,7 @@ function ListView({
 
     result.sort((a, b) => a.displayDate.getTime() - b.displayDate.getTime());
     return result;
-  }, [entries, focusDate]);
+  }, [entries, focusDate, selectionActive, isEntrySelectable]);
 
   if (rows.length === 0) {
     return (

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -49,6 +49,7 @@ import { nonEmptyPropertySummaries } from "@/components/properties/propertyHelpe
 import { TagBadge } from "@/components/tags/TagBadge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { getInitials } from "@/lib/initials";
@@ -141,6 +142,12 @@ type CalendarViewProps = {
   isLoading?: boolean;
   /** Hide the list view option (e.g. for tasks where list doesn't make sense) */
   hideListView?: boolean;
+  /** Multi-select on the list view (opt-in — only the list view uses these, and
+   *  only the entries `isEntrySelectable` accepts get a checkbox). */
+  selectionActive?: boolean;
+  selectedEntryIds?: Set<CalendarEntry["id"]>;
+  isEntrySelectable?: (entry: CalendarEntry) => boolean;
+  onToggleEntrySelection?: (entry: CalendarEntry) => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -1407,10 +1414,18 @@ function ListView({
   entries,
   focusDate,
   onEntryClick,
+  selectionActive = false,
+  selectedEntryIds,
+  isEntrySelectable,
+  onToggleEntrySelection,
 }: {
   entries: CalendarEntry[];
   focusDate: Date;
   onEntryClick?: (entry: CalendarEntry) => void;
+  selectionActive?: boolean;
+  selectedEntryIds?: Set<CalendarEntry["id"]>;
+  isEntrySelectable?: (entry: CalendarEntry) => boolean;
+  onToggleEntrySelection?: (entry: CalendarEntry) => void;
 }) {
   const { t } = useTranslation(["common"]);
 
@@ -1467,17 +1482,39 @@ function ListView({
           const month = format(displayDate, "MMM");
           const weekday = format(displayDate, "EEEE");
 
+          // In selection mode, only selectable entries (events) can be picked;
+          // other rows (tasks) are shown dimmed and inert so they stay for
+          // context without navigating away or being selectable.
+          const selectable = selectionActive && (isEntrySelectable?.(entry) ?? false);
+          const selected = selectable && (selectedEntryIds?.has(entry.id) ?? false);
+          const interactive = selectionActive ? selectable : !!onEntryClick;
+
           return (
             <button
               key={`${entry.id}-${dateKey(displayDate)}`}
               type="button"
+              disabled={selectionActive && !selectable}
+              aria-pressed={selectable ? selected : undefined}
               className={cn(
                 "flex w-full items-start gap-4 rounded-md border px-3 py-2.5 text-left text-sm transition-colors",
                 isToday(displayDate) && "ring-1 ring-primary/60",
-                onEntryClick ? "cursor-pointer hover:bg-accent" : "cursor-default"
+                interactive ? "cursor-pointer hover:bg-accent" : "cursor-default",
+                selected && "bg-primary/5 ring-2 ring-primary",
+                selectionActive && !selectable && "opacity-50"
               )}
-              onClick={() => onEntryClick?.(entry)}
+              onClick={() =>
+                selectionActive
+                  ? selectable && onToggleEntrySelection?.(entry)
+                  : onEntryClick?.(entry)
+              }
             >
+              {selectable && (
+                <Checkbox
+                  checked={selected}
+                  className="pointer-events-none mt-0.5 shrink-0 border-2"
+                  aria-hidden="true"
+                />
+              )}
               {/* Date column: day + month */}
               <div className="flex w-14 shrink-0 flex-col items-center pt-0.5 leading-tight">
                 <span className="font-bold text-lg">{day}</span>
@@ -1676,6 +1713,10 @@ export const CalendarView = ({
   weekStartsOn = 0,
   isLoading = false,
   hideListView = false,
+  selectionActive = false,
+  selectedEntryIds,
+  isEntrySelectable,
+  onToggleEntrySelection,
 }: CalendarViewProps) => {
   const periodLabel = usePeriodLabel(viewMode, focusDate, weekStartsOn);
   const dndEnabled = !!onEntryReschedule;
@@ -1799,7 +1840,15 @@ export const CalendarView = ({
       ) : null}
 
       {viewMode === "list" ? (
-        <ListView entries={entries} focusDate={focusDate} onEntryClick={onEntryClick} />
+        <ListView
+          entries={entries}
+          focusDate={focusDate}
+          onEntryClick={onEntryClick}
+          selectionActive={selectionActive}
+          selectedEntryIds={selectedEntryIds}
+          isEntrySelectable={isEntrySelectable}
+          onToggleEntrySelection={onToggleEntrySelection}
+        />
       ) : null}
     </>
   );

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -343,9 +343,11 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   );
 
   // Selection only exists in the list view — leaving it cancels the selection.
+  // Depend on the stable primitive/callback, not the per-render selection object.
+  const { active: selectionModeActive, exit: exitSelection } = eventSelection;
   useEffect(() => {
-    if (viewMode !== "list" && eventSelection.active) eventSelection.exit();
-  }, [viewMode, eventSelection]);
+    if (viewMode !== "list" && selectionModeActive) exitSelection();
+  }, [viewMode, selectionModeActive, exitSelection]);
 
   // Create dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false);

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -7,11 +7,16 @@ import { useTranslation } from "react-i18next";
 
 import { apiClient } from "@/api/client";
 import type {
+  CalendarEventSummary,
   FilterCondition,
   ListTasksApiV1GGuildIdTasksGetParams,
   TaskPriority,
   TaskStatusCategory,
 } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
+import { invalidateAllCalendarEvents } from "@/api/query-keys";
+import { BulkAccessBar, canManageSharing } from "@/components/access/BulkAccessBar";
+import { BulkEditAccessDialog } from "@/components/access/BulkEditAccessDialog";
 import {
   buildTaskCalendarEntries,
   CALENDAR_VIEW_MODE_KEY,
@@ -34,6 +39,7 @@ import { MultiSelect } from "@/components/ui/multi-select";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useAuth } from "@/hooks/useAuth";
 import { useCalendarEventsList, useRescheduleCalendarEvent } from "@/hooks/useCalendarEvents";
+import { useGridSelection } from "@/hooks/useGridSelection";
 import {
   canCreate as canCreatePermission,
   useMyInitiativePermissions,
@@ -102,7 +108,7 @@ type EventsViewProps = {
 };
 
 export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) => {
-  const { t } = useTranslation(["events", "tasks", "common"]);
+  const { t } = useTranslation(["events", "tasks", "common", "access"]);
   const router = useRouter();
   const { user } = useAuth();
   const gp = useGuildPath();
@@ -306,6 +312,40 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
 
     return entries;
   }, [showEvents, showTasks, eventsQuery.data, tasksQuery.data, canCreateEvents, canEditTasks]);
+
+  // --- Bulk edit-access selection (list view only) ---
+  const eventSelection = useGridSelection<CalendarEventSummary>();
+  const [bulkAccessOpen, setBulkAccessOpen] = useState(false);
+
+  const eventsById = useMemo(() => {
+    const map = new Map<number, CalendarEventSummary>();
+    for (const event of eventsQuery.data?.items ?? []) map.set(event.id, event);
+    return map;
+  }, [eventsQuery.data]);
+
+  const selectedEntryIds = useMemo(
+    () => new Set<CalendarEntry["id"]>(eventSelection.selectedItems.map((e) => `event-${e.id}`)),
+    [eventSelection.selectedItems]
+  );
+
+  const isEntrySelectable = useCallback(
+    (entry: CalendarEntry) => (entry.meta as { type?: string } | undefined)?.type === "event",
+    []
+  );
+
+  const toggleEntrySelection = useCallback(
+    (entry: CalendarEntry) => {
+      const eventId = (entry.meta as { eventId?: number } | undefined)?.eventId;
+      const event = typeof eventId === "number" ? eventsById.get(eventId) : undefined;
+      if (event) eventSelection.toggle(event);
+    },
+    [eventsById, eventSelection]
+  );
+
+  // Selection only exists in the list view — leaving it cancels the selection.
+  useEffect(() => {
+    if (viewMode !== "list" && eventSelection.active) eventSelection.exit();
+  }, [viewMode, eventSelection]);
 
   // Create dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -582,17 +622,37 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
           {t("loading")}
         </div>
       ) : (
-        <CalendarView
-          entries={calendarEntries}
-          viewMode={viewMode}
-          onViewModeChange={setViewMode}
-          focusDate={focusDate}
-          onFocusDateChange={setFocusDate}
-          onEntryClick={handleEntryClick}
-          onSlotClick={canCreateEvents ? handleSlotClick : undefined}
-          onEntryReschedule={canCreateEvents || canEditTasks ? handleEntryReschedule : undefined}
-          weekStartsOn={weekStartsOn}
-        />
+        <div className="space-y-3">
+          {eventSelection.active ? (
+            <BulkAccessBar
+              count={eventSelection.selectedItems.length}
+              canManage={canManageSharing(eventSelection.selectedItems)}
+              onEditAccess={() => setBulkAccessOpen(true)}
+              onExit={eventSelection.exit}
+            />
+          ) : viewMode === "list" ? (
+            <div className="flex justify-end">
+              <Button variant="outline" size="sm" onClick={eventSelection.enter}>
+                {t("access:bulkBar.select")}
+              </Button>
+            </div>
+          ) : null}
+          <CalendarView
+            entries={calendarEntries}
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            focusDate={focusDate}
+            onFocusDateChange={setFocusDate}
+            onEntryClick={handleEntryClick}
+            onSlotClick={canCreateEvents ? handleSlotClick : undefined}
+            onEntryReschedule={canCreateEvents || canEditTasks ? handleEntryReschedule : undefined}
+            weekStartsOn={weekStartsOn}
+            selectionActive={eventSelection.active}
+            selectedEntryIds={selectedEntryIds}
+            isEntrySelectable={isEntrySelectable}
+            onToggleEntrySelection={toggleEntrySelection}
+          />
+        </div>
       )}
 
       {initiativeId && (
@@ -604,6 +664,15 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
           onSuccess={handleEventCreated}
         />
       )}
+
+      <BulkEditAccessDialog
+        open={bulkAccessOpen}
+        onOpenChange={setBulkAccessOpen}
+        items={eventSelection.selectedItems}
+        resourceType={Tool.calendar_event}
+        invalidate={invalidateAllCalendarEvents}
+        onSuccess={eventSelection.exit}
+      />
 
       <ICalImportDialog
         open={importDialogOpen}


### PR DESCRIPTION
The last of the tools. Calendar events render as a calendar (no card grid), so bulk selection hangs off the calendar's existing **list** view rather than a new UI.

## What

- **`CalendarView` gains opt-in selection props** — `selectionActive`, `selectedEntryIds`, `isEntrySelectable`, `onToggleEntrySelection` — threaded down to the list rows. They default off, so the other four `CalendarView` consumers (My Tasks / My Calendar / project tasks) are unaffected. In selection mode, only selectable entries (**events**, not tasks) get a checkbox and toggle; task rows are dimmed and `disabled` for context.
- **EventsPage wiring** — a `useGridSelection<CalendarEventSummary>()` over the events list; list entries carry `meta.eventId`, so a toggled row maps back to its `CalendarEventSummary` (which has `grants` / `initiative_id` / `my_permission_level`). Shows the shared **Select** button + `BulkAccessBar` + `BulkEditAccessDialog` (`resourceType: calendar_event`). Selection is **list-view only** and auto-cancels when you switch calendar views.
- **No new strings** — reuses the `access:bulkBar` keys and the `calendar_event` resource label added in the projects/queues/counters PR.

## Notes

- Events are paginated (100/page); selection persists by value across pages/filters (the shared `useGridSelection`), so a multi-page selection acts together.
- Sharing management is still DB-enforced per item; the bar only enables when you own/can edit every selected event.

## Testing

- `CalendarView.selection.test.tsx` — in the list view, event rows are selectable and toggle; task rows are disabled and don't.
- Full access + calendar + selection suites: **27 pass**. `tsgo --noEmit` clean; `biome check` clean.