### PR TITLE
Fix all-members documents hidden on the project view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Documents shared with "all initiative members" now show on the project they're attached to.** The project view filtered attached documents with its own check that only understood per-person and per-role sharing, so a document shared with everyone in the initiative disappeared for members without a personal grant. It now defers to the standard document access rules (which also covers guild admins and Full-access roles).
 - Chester toasts no longer overlay the bottom navigation pill and are limited to showing 2 at a time.
 
 ## [0.53.4] - 2026-06-27

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -124,36 +124,16 @@ def _project_documents(
     for link in getattr(project, "document_links", []) or []:
         doc = getattr(link, "document", None)
         if user_id is not None and doc is not None:
-            if not _user_can_access_document(doc, user_id, project):
+            # Single source of truth: the document DAC engine (per-user / per-role /
+            # all-initiative-members grants, plus guild-admin, Full-access, and PAM
+            # overrides) — no re-implementation here.
+            if permissions_service.compute_document_permission(doc, user_id) is None:
                 continue
         summary = serialize_project_document_link(link)
         if summary:
             documents.append(summary)
     documents.sort(key=lambda item: (item.title.lower(), item.document_id))
     return documents
-
-
-def _user_can_access_document(doc, user_id: int, project: Project) -> bool:
-    """Check if a user has access to a document via a user or role grant."""
-    grants = getattr(doc, "grants", None) or []
-    # Check explicit per-user grants
-    for grant in grants:
-        if grant.user_id == user_id:
-            return True
-    # Check role-based grants against the user's roles in the project's initiative
-    role_grant_ids = {g.role_id for g in grants if g.role_id is not None}
-    if role_grant_ids:
-        initiative = getattr(project, "initiative", None)
-        if initiative:
-            memberships = getattr(initiative, "memberships", None) or []
-            user_role_ids = {
-                m.role_id
-                for m in memberships
-                if m.user_id == user_id and m.role_id is not None
-            }
-            if role_grant_ids & user_role_ids:
-                return True
-    return False
 
 
 async def _attach_task_summaries(session: SessionDep, projects: List[Project]) -> None:
@@ -223,6 +203,9 @@ async def _get_project_or_404(
             .selectinload(ProjectDocument.document)
             .options(
                 selectinload(Document.grants).selectinload(ResourceGrant.role),
+                # Linked-doc visibility defers to the shared document DAC, which
+                # reads the doc's own initiative memberships (all-members grants).
+                selectinload(Document.initiative).selectinload(Initiative.memberships),
             ),
             selectinload(Project.tag_links).selectinload(ProjectTag.tag),
         )
@@ -497,6 +480,9 @@ async def _visible_projects(
             .selectinload(ProjectDocument.document)
             .options(
                 selectinload(Document.grants).selectinload(ResourceGrant.role),
+                # Linked-doc visibility defers to the shared document DAC, which
+                # reads the doc's own initiative memberships (all-members grants).
+                selectinload(Document.initiative).selectinload(Initiative.memberships),
             ),
             selectinload(Project.tag_links).selectinload(ProjectTag.tag),
         )
@@ -659,6 +645,9 @@ async def _projects_by_ids(
             .selectinload(ProjectDocument.document)
             .options(
                 selectinload(Document.grants).selectinload(ResourceGrant.role),
+                # Linked-doc visibility defers to the shared document DAC, which
+                # reads the doc's own initiative memberships (all-members grants).
+                selectinload(Document.initiative).selectinload(Initiative.memberships),
             ),
             selectinload(Project.tag_links).selectinload(ProjectTag.tag),
         )
@@ -848,6 +837,11 @@ async def _list_global_projects(
                 .selectinload(ProjectDocument.document)
                 .options(
                     selectinload(Document.grants).selectinload(ResourceGrant.role),
+                    # Linked-doc visibility defers to the shared document DAC, which
+                    # reads the doc's own initiative memberships (all-members grants).
+                    selectinload(Document.initiative).selectinload(
+                        Initiative.memberships
+                    ),
                 ),
                 selectinload(Project.tag_links).selectinload(ProjectTag.tag),
             )

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -1143,3 +1143,77 @@ async def test_set_project_access_remove_grant_keeps_all_members(
     assert r.status_code == 200, r.text
     assert [g for g in r.json()["grants"] if g["user_id"] == member.id] == []
     assert any(g["all_initiative_members"] for g in r.json()["grants"])
+
+
+@pytest.mark.integration
+async def test_project_shows_all_members_document_to_member(
+    client: AsyncClient, session: AsyncSession
+):
+    """A document attached to a project and shared with *all initiative members*
+    is visible to a plain member on the project view. Regression: the linked-doc
+    filter used to ignore all-members grants, so such docs vanished for anyone
+    without a personal/role grant."""
+    from app.models.tenant.document import Document, DocumentType, ProjectDocument
+    from app.testing.factories import create_initiative_member
+
+    owner = await create_user(session, email="owner@example.com")
+    member = await create_user(session, email="member@example.com")
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=owner, guild=guild)
+    await create_guild_membership(session, user=member, guild=guild)
+    initiative = await _create_initiative_with_member(session, guild, owner)
+    await create_initiative_member(session, initiative, member, role_name="member")
+    project = await _create_project(session, initiative, owner)
+
+    doc = Document(
+        title="Shared with everyone",
+        initiative_id=initiative.id,
+        guild_id=guild.id,
+        created_by_id=owner.id,
+        updated_by_id=owner.id,
+        document_type=DocumentType.native,
+    )
+    session.add(doc)
+    await session.flush()
+    session.add_all(
+        [
+            # Project shared with all members so the member can open it at all.
+            ResourceGrant(
+                resource_type="project",
+                resource_id=project.id,
+                all_initiative_members=True,
+                level=ResourceAccessLevel.read,
+                guild_id=guild.id,
+                initiative_id=initiative.id,
+            ),
+            ResourceGrant(
+                resource_type="document",
+                resource_id=doc.id,
+                user_id=owner.id,
+                level=ResourceAccessLevel.owner,
+                guild_id=guild.id,
+                initiative_id=initiative.id,
+            ),
+            ResourceGrant(
+                resource_type="document",
+                resource_id=doc.id,
+                all_initiative_members=True,
+                level=ResourceAccessLevel.read,
+                guild_id=guild.id,
+                initiative_id=initiative.id,
+            ),
+            ProjectDocument(
+                project_id=project.id,
+                document_id=doc.id,
+                guild_id=guild.id,
+                attached_by_id=owner.id,
+            ),
+        ]
+    )
+    await session.commit()
+
+    headers = await get_guild_headers(session, guild, member)
+    r = await client.get(f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers)
+    assert r.status_code == 200, r.text
+    doc_ids = [d["document_id"] for d in r.json()["documents"]]
+    assert doc.id in doc_ids

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -18,10 +18,12 @@ from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
+from app.models.tenant.document import Document, DocumentType, ProjectDocument
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
+    create_initiative_member,
     create_user,
     get_guild_headers,
 )
@@ -1153,9 +1155,6 @@ async def test_project_shows_all_members_document_to_member(
     is visible to a plain member on the project view. Regression: the linked-doc
     filter used to ignore all-members grants, so such docs vanished for anyone
     without a personal/role grant."""
-    from app.models.tenant.document import Document, DocumentType, ProjectDocument
-    from app.testing.factories import create_initiative_member
-
     owner = await create_user(session, email="owner@example.com")
     member = await create_user(session, email="member@example.com")
     guild = await create_guild(session)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1207,7 +1207,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2" },
     { name = "slowapi", specifier = ">=0.1.9,<0.2" },
     { name = "sqlalchemy", specifier = ">=2.0.49,<3" },
-    { name = "sqlmodel", specifier = ">=0.0.38,<0.0.39" },
+    { name = "sqlmodel", specifier = ">=0.0.38,<0.0.40" },
     { name = "tzdata", specifier = ">=2026.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0,<0.50" },
 ]

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2429,8 +2429,13 @@ export interface ResourceGrantBulkItemResult {
 
 /**
  * Replace sharing on many resources (possibly of different types) in one call.
+ * Capped at ``MAX_BULK_GRANT_ITEMS`` items (422 otherwise).
  */
 export interface ResourceGrantBulkRequest {
+  /**
+   * @minItems 1
+   * @maxItems 200
+   */
   items: ResourceGrantBulkItem[];
 }
 


### PR DESCRIPTION
## Problem

On a project view, a document attached to the project and shared with **"all initiative members"** didn't show up for members who lacked a personal or per-role grant.

The project serializer filtered its linked documents with a **hand-rolled** access check (`_user_can_access_document`) that only understood per-user and per-role grants — it never learned about the `all_initiative_members` ("general access") grant added with general-access sharing. (It also silently ignored guild-admin and Full-access-role overrides.)

## Fix

Delete the re-implementation and defer to the **single source of truth** — the shared document DAC engine, `permissions_service.compute_document_permission(doc, user_id)`. That one path already covers per-user, per-role, **all-initiative-members**, guild-admin, Full-access, and PAM consistently.

To let the engine evaluate all-members grants, each linked document's `initiative.memberships` is now eager-loaded alongside its `grants` in the four project loaders that serialize documents (linked docs share the project's initiative, so this is typically the same, already-loaded initiative object).

## Testing

- New regression test `test_project_shows_all_members_document_to_member`: a plain member sees an all-members-shared doc attached to a project they can open.
- `projects_test.py` + `documents_scope_test.py` + `initiative_share_override_test.py` — **40 pass**. `ruff check`/`format` clean.

Behavior is strictly a widening toward the documented access model (per the six authorization gates); nothing that was hidden-and-should-stay-hidden becomes visible — the same `compute_document_permission` used everywhere else decides.