### PR TITLE
Schema-native test harness + role-based suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Database migration history squashed to a v0.53.5 baseline.** Fresh installs now build the shared schema from a single baseline plus a `guild_template` schema, and never create the legacy public copies of guild content (tasks, projects, documents, …) — guild data lives only in per-guild schemas. Existing deployments are unaffected: their frozen legacy copies are kept untouched.
 - **Upgrade note:** deployments running a version older than **v0.53.2** must upgrade to any v0.53.x release and boot it once before upgrading to this version. The app refuses to start (with instructions) if the database is older.
 
+### Fixed
+
+- **`/users/me`, login/registration, and platform admin user responses no longer read guild content.** These platform endpoints enriched users with `initiative_roles` by querying initiative membership outside any guild context — on fresh post-squash installs this crashed, and on upgraded ones it silently served stale pre-conversion data. The field is now populated only by guild-scoped endpoints (member roster, guild CSV export); the app derives per-guild manager state from guild-scoped initiative data.
+
 ### Removed
 
 - The one-time schema-per-guild startup data conversion (every deployment that can cross the v0.53.x floor has already converted).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,31 +281,44 @@ Both backend and frontend provide factory functions for creating test data with 
 
 **Backend factories** live in `app/testing/factories.py` and are re-exported from `app/testing/__init__.py`. They are async functions that persist models to the test database and accept keyword overrides for any field.
 
+They are **schema-per-guild native**: tenant models (initiatives, projects, tasks, documents, queues, counters, events, tags, uploads, …) exist only in per-guild Postgres schemas (`guild_<id>`), never in `public`. Every tenant factory routes the session to the right guild schema automatically (derived from its parent argument). Raw `session.add(<tenant model>)` in a test works when the row carries a `guild_id` or the session is already routed; an unroutable tenant write **raises** (fail-closed — see `app/testing/schema_harness.py`). For raw tenant *reads* on a fresh session, call `await route_session_to_guild(session, guild_id)` first.
+
 Available factories:
 - `create_user(session, **overrides)` — creates a `User` with unique email, hashed password, and default notification preferences
-- `create_guild(session, creator=None, **overrides)` — creates a `Guild`; auto-creates a creator user if not provided
+- `create_guild(session, creator=None, **overrides)` — creates a `Guild` and provisions its `guild_<id>` schema + roles; auto-creates a creator user if not provided
 - `create_guild_membership(session, user=None, guild=None, role=GuildRole.member)` — links a user to a guild
 - `create_initiative(session, guild, creator, **overrides)` — creates an `Initiative` with built-in roles and adds the creator as project manager
 - `create_initiative_member(session, initiative, user, role_name="member")` — adds a user to an initiative with proper role lookup
-- `create_project(session, initiative, owner, **overrides)` — creates a `Project` with owner permission
+- `create_project(session, initiative, owner, **overrides)` — creates a `Project` with owner grant
+- `create_task(session, project, status_category=..., assignees=[...])`, `create_task_status`, `create_subtask`
+- `create_document(session, initiative, creator)` — native document + owner grant
+- `create_comment(session, author, task=... | document=...)`
+- `create_tag(session, guild)`, `create_upload(session, guild, uploader)`
+- `create_queue(session, initiative, creator)`, `create_queue_item(session, queue)`
+- `create_counter_group(session, initiative, creator)`, `create_counter(session, group)`
+- `create_calendar_event(session, initiative, creator)`, `create_property_definition(session, initiative)`, plus `create_{document,task,calendar_event}_property_value`
 
 Auth helpers:
 - `get_auth_token(user)` — returns a JWT string for the user
 - `get_auth_headers(user)` — returns `{"Authorization": "Bearer <token>"}` dict
-- `get_guild_headers(session, guild, user)` — async; a thin wrapper over `get_auth_headers` kept for call-site compatibility (guild context is path-based now, so it writes no state). Address the guild in the request URL: `await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)`
+
+**The role seam — `acting_user`** (fixture in `conftest.py`, backed by `app.testing.Actor`/`make_actor`): every endpoint test states its actor's platform and guild roles through this one seam and gets an `Actor` dataclass back. With the real-role `client` fixture the request then executes as the real `app_user` → `platform_<tier>`/`guild_<id>` roles — RLS enforced, like production.
 
 ```python
-from app.testing import create_user, create_guild, create_guild_membership, get_guild_headers
-from app.models.guild import GuildRole
+from app.models.platform.guild import GuildRole
 
-async def test_something(session, client):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    headers = await get_guild_headers(session, guild, user)
-    response = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
+async def test_something(client, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    # a.user / a.headers / a.guild / a.membership / a.initiative / a.project
+    response = await client.get(a.g("/initiatives/"), headers=a.headers)
     assert response.status_code == 200
+
+    # Second actor joining the same workspace at lower privilege:
+    b = await acting_user(guild_role=GuildRole.member, guild=a.guild,
+                          initiative=a.initiative, initiative_role="member")
 ```
+
+Platform role defaults: `owner` for public-path actors (`await acting_user()`), but `member` when `guild_role` is given — guild access must never depend on platform tier, and defaulting low keeps the suite proving that. Pass a platform tier explicitly (`await acting_user("support")`) to test platform ceilings. The superuser-backed `session` fixture is for setup/assertions only; `role_session` exercises the raw `app_user`/`app_admin` privilege boundary.
 
 **Frontend factories** live in `src/__tests__/factories/` and are pure functions that return typed API response objects. They use auto-incrementing IDs and accept partial overrides via a spread pattern.
 

--- a/backend/alembic/migrations_test.py
+++ b/backend/alembic/migrations_test.py
@@ -44,9 +44,9 @@ BACKEND_DIR = ALEMBIC_SCRIPT_LOCATION.parent
 ALEMBIC_INI_PATH = BACKEND_DIR / "alembic.ini"
 
 # The baseline is the new root: anything before it was squashed into
-# this migration and cannot be reached, so its ``downgrade()`` is a
-# permanent ``NotImplementedError``.
-BASELINE_REVISION = "20260216_0053"
+# this migration (the v0.53.5 snapshot) and cannot be reached, so its
+# ``downgrade()`` is a permanent ``NotImplementedError``.
+BASELINE_REVISION = "20260626_0125"
 
 # Migrations whose ``downgrade()`` intentionally raises
 # ``NotImplementedError`` and which therefore have to be skipped when
@@ -55,19 +55,10 @@ BASELINE_REVISION = "20260216_0053"
 INTENTIONALLY_IRREVERSIBLE = frozenset(
     {
         BASELINE_REVISION,
-        "20260426_0077",  # drop_automation_tables — domain removed from repo
-        # initiative RLS: dropping public.initiative_access would break boot-time
-        # guild provisioning (apply_guild_rls references it) for every guild, so
-        # there is no safe rollback past this point — roll forward only.
-        "20260616_0110",
-        # drop legacy is_initiative_member: reviving a dead, search_path-broken
-        # second access rule has no value — roll forward only.
-        "20260616_0111",
-        # drop legacy per-resource permission tables: their data was consolidated
-        # into resource_grants by 0115's backfill, then the 8 tables were dropped.
-        # Recreating them would mean rebuilding 8 schemas + repopulating from
-        # resource_grants — restore from a backup instead; roll forward only.
-        "20260616_0116",
+        # heal_guild_public_refs: cleanup of legacy state (public-schema
+        # sequence defaults, dead enums) — re-breaking it has no faithful
+        # inverse; roll forward only.
+        "20260701_0127",
     }
 )
 
@@ -231,24 +222,25 @@ def _current_alembic_revision() -> str | None:
     return asyncio.run(_fetch_current_revision_async())
 
 
-async def _table_exists_async(table_name: str) -> bool:
+async def _table_exists_async(table_name: str, schema: str = "public") -> bool:
     conn = await _connect_test_db()
     try:
         return bool(
             await conn.fetchval(
                 "SELECT EXISTS ("
                 "  SELECT 1 FROM information_schema.tables "
-                "  WHERE table_schema = 'public' AND table_name = $1"
+                "  WHERE table_schema = $2 AND table_name = $1"
                 ")",
                 table_name,
+                schema,
             )
         )
     finally:
         await conn.close()
 
 
-def _table_exists(table_name: str) -> bool:
-    return asyncio.run(_table_exists_async(table_name))
+def _table_exists(table_name: str, schema: str = "public") -> bool:
+    return asyncio.run(_table_exists_async(table_name, schema))
 
 
 async def _alembic_version_row_count_async() -> int:
@@ -308,17 +300,19 @@ class TestMigrationsAgainstDatabase:
             "after a successful upgrade"
         )
 
-        # Sanity-check that some core tables actually exist; if any of
-        # these are missing the baseline DDL silently failed.
-        for table in (
-            "users",
-            "guilds",
-            "initiatives",
-            "projects",
-            "tasks",
-            "alembic_version",
-        ):
+        # Sanity-check the squashed layout: shared tables in public, tenant
+        # content in guild_template — and, critically, NOT in public (fresh
+        # installs must never get the pre-squash public copies back).
+        for table in ("users", "guilds", "access_grants", "alembic_version"):
             assert _table_exists(table), f"expected table {table!r} after upgrade head"
+        for table in ("initiatives", "projects", "tasks", "documents"):
+            assert _table_exists(table, schema="guild_template"), (
+                f"expected table {table!r} in guild_template after upgrade head"
+            )
+            assert not _table_exists(table), (
+                f"tenant table {table!r} must not exist in public after the "
+                "baseline squash"
+            )
 
     def test_upgrade_head_is_idempotent(self, fresh_migrations_db: str) -> None:
         """Running ``upgrade head`` twice must not raise. Catches

--- a/backend/app/api/uploads_test.py
+++ b/backend/app/api/uploads_test.py
@@ -14,7 +14,6 @@ from app.testing.factories import (
     create_user,
     get_auth_headers,
     get_auth_token,
-    get_guild_headers,
 )
 
 
@@ -74,7 +73,7 @@ async def test_upload_accessible_with_auth_header(
     )
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get(
         f"/uploads/{guild.id}/test_auth_header.txt", headers=headers
     )
@@ -231,7 +230,7 @@ async def test_upload_guild_member_can_access_file(
     session.add(upload)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get(
         f"/uploads/{guild.id}/test_guild_access.png", headers=headers
     )
@@ -266,7 +265,7 @@ async def test_upload_non_member_cannot_access_file(
         # path is still rejected, since membership is validated per request
         # against the path-addressed guild.
         outsider = await create_user(session)
-        headers = await get_guild_headers(session, guild, outsider)
+        headers = get_auth_headers(outsider)
         response = await client.get(
             f"/uploads/{guild.id}/test_guild_forbidden.png", headers=headers
         )
@@ -293,7 +292,7 @@ async def test_upload_without_db_record_returns_404(
         user = await create_user(session)
         guild = await create_guild(session, creator=user)
         await create_guild_membership(session, user=user, guild=guild)
-        headers = await get_guild_headers(session, guild, user)
+        headers = get_auth_headers(user)
         response = await client.get(
             f"/uploads/{guild.id}/test_orphan_file.txt", headers=headers
         )
@@ -343,18 +342,17 @@ async def test_upload_row_in_guild_schema_is_served(
         params={"fn": "test_guild_schema_row.txt", "gid": guild.id, "uid": user.id},
     )
     await session.commit()
-    # Prove the row is invisible from public.uploads.
-    public_hit = (
-        await session.exec(
-            text("SELECT 1 FROM public.uploads WHERE filename = :fn"),
-            params={"fn": "test_guild_schema_row.txt"},
-        )
-    ).first()
-    assert public_hit is None
+    # Prove the row can't live in public: under schema-per-guild there is no
+    # public.uploads copy at all (uploads is guild-scoped), so the row exists
+    # only in guild_<id>.uploads.
+    public_table = (
+        await session.exec(text("SELECT to_regclass('public.uploads')"))
+    ).scalar()
+    assert public_table is None
 
     response = await client.get(
         f"/uploads/{guild.id}/test_guild_schema_row.txt",
-        headers=await get_guild_headers(session, guild, user),
+        headers=get_auth_headers(user),
     )
     assert response.status_code == 200
     assert response.text == "hello"
@@ -365,7 +363,7 @@ async def test_upload_row_in_guild_schema_is_served(
     outsider = await create_user(session, email="outsider-schema@example.com")
     response = await client.get(
         f"/uploads/{guild.id}/test_guild_schema_row.txt",
-        headers=await get_guild_headers(session, guild, outsider),
+        headers=get_auth_headers(outsider),
     )
     assert response.status_code == 404
 

--- a/backend/app/api/v1/platform_endpoints/access_grants_test.py
+++ b/backend/app/api/v1/platform_endpoints/access_grants_test.py
@@ -14,7 +14,6 @@ from app.testing import (
     create_project,
     create_user,
     get_auth_headers,
-    get_guild_headers,
 )
 
 
@@ -344,7 +343,7 @@ async def test_grant_cannot_manage_project_members(
         session, user=support, guild=guild, owner=owner, level="read_write"
     )
 
-    headers = await get_guild_headers(session, guild, support)
+    headers = get_auth_headers(support)
     resp = await client.put(
         f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
         json=[{"user_id": target.id, "level": "write"}],
@@ -380,7 +379,7 @@ async def test_grant_cannot_manage_counter_group_access(
         session, user=support, guild=guild, owner=owner, level="read_write"
     )
 
-    headers = await get_guild_headers(session, guild, support)
+    headers = get_auth_headers(support)
     resp = await client.put(
         f"/api/v1/g/{guild.id}/counter-groups/{cg.id}/grants",
         json=[],
@@ -406,7 +405,7 @@ async def test_grantee_sees_guild_content(client: AsyncClient, session: AsyncSes
     project = await create_project(session, init, owner, name="Alpha Site")
     await _approved_read_grant(session, user=support, guild=guild, owner=owner)
 
-    headers = await get_guild_headers(session, guild, support)
+    headers = get_auth_headers(support)
 
     resp = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
     assert resp.status_code == 200, resp.text

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -225,7 +225,8 @@ async def reactivate_user(
     session.add(user)
     await session.commit()
     await session.refresh(user)
-    await initiatives_service.load_user_initiative_roles(session, [user])
+    # Platform user management stays platform-table-only: initiative
+    # membership is guild-schema content this path cannot read.
     return user
 
 
@@ -308,7 +309,7 @@ async def update_platform_role(
     session.add(user)
     await session.commit()
     await session.refresh(user)
-    await initiatives_service.load_user_initiative_roles(session, [user])
+    # Platform user management stays platform-table-only (see reactivate).
     return user
 
 

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -57,7 +57,6 @@ from app.db.session import AdminSessionLocal
 from app.services.platform import app_settings as app_settings_service
 from app.services import email as email_service
 from app.services.platform import user_tokens
-from app.services.tenant import initiatives as initiatives_service
 from app.services.platform import guilds as guilds_service
 from app.services.oidc_sync import extract_claim_values, sync_oidc_assignments
 from app.models.platform.user_token import UserTokenPurpose
@@ -247,8 +246,6 @@ async def register_user(
         ) from exc
 
     await session.refresh(user)
-
-    await initiatives_service.load_user_initiative_roles(session, [user])
 
     if smtp_configured and not user.email_verified:
         try:

--- a/backend/app/api/v1/platform_endpoints/break_glass_test.py
+++ b/backend/app/api/v1/platform_endpoints/break_glass_test.py
@@ -24,7 +24,6 @@ from app.testing import (
     create_project,
     create_user,
     get_auth_headers,
-    get_guild_headers,
 )
 
 
@@ -96,7 +95,7 @@ async def test_admin_reaches_guild_only_after_clicking_through(
     guild = await create_guild(session, creator=owner)
     await create_initiative(session, guild, owner, name="Recon Wing")
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
 
     # BEFORE: no membership, no grant — the standing bypass is gone, so 403.
     resp = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
@@ -136,7 +135,7 @@ async def test_break_glass_read_default_is_read_only(
     guild = await create_guild(session, creator=owner)
     init = await create_initiative(session, guild, owner, name="Ops")
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     resp = await client.post(
         "/api/v1/access-grants/break-glass",
         json={"guild_id": guild.id, "reason": "read only look"},
@@ -175,7 +174,7 @@ async def test_break_glass_read_write_is_full_guild_admin(
     init = await create_initiative(session, guild, owner, name="War Room")
     project = await create_project(session, init, owner, name="Existing")
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     resp = await client.post(
         "/api/v1/access-grants/break-glass",
         json={

--- a/backend/app/api/v1/platform_endpoints/guilds_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_test.py
@@ -23,7 +23,6 @@ from app.testing.factories import (
     create_guild_membership,
     create_user,
     get_auth_headers,
-    get_guild_headers,
 )
 
 
@@ -702,7 +701,7 @@ async def test_guild_advanced_tool_handoff_returns_404_when_url_unset(
         session, user=admin, guild=guild, role=GuildRole.admin
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.post(
         f"/api/v1/guilds/{guild.id}/advanced-tool/handoff", headers=headers
     )
@@ -729,7 +728,7 @@ async def test_guild_advanced_tool_handoff_rejects_non_admin(
         session, user=member, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, member)
+    headers = get_auth_headers(member)
     response = await client.post(
         f"/api/v1/guilds/{guild.id}/advanced-tool/handoff", headers=headers
     )
@@ -756,7 +755,7 @@ async def test_guild_advanced_tool_handoff_rejects_non_member(
     target_guild = await create_guild(session, name="Target guild")
 
     # Use the outsider's auth but reference the target guild they aren't in
-    headers = await get_guild_headers(session, target_guild, outsider)
+    headers = get_auth_headers(outsider)
     response = await client.post(
         f"/api/v1/guilds/{target_guild.id}/advanced-tool/handoff", headers=headers
     )
@@ -783,7 +782,7 @@ async def test_guild_advanced_tool_handoff_succeeds_for_admin(
         session, user=admin, guild=guild, role=GuildRole.admin
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.post(
         f"/api/v1/guilds/{guild.id}/advanced-tool/handoff", headers=headers
     )

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -292,12 +292,16 @@ async def update_users_me(
     if not update_data:
         return current_user
 
-    if update_data.get("email_task_assignment") is False:
+    if (
+        update_data.get("email_task_assignment") is False
+        and current_user.email_task_assignment is not False
+    ):
         # The digest queue is guild-scoped, so it must be cleared inside each
         # of the user's guild schemas — before any mutation below, because the
         # fan-out expunges the identity map (per-schema ids collide). Restore
         # the platform context and re-fetch the user afterwards; the deletes
-        # ride this request's transaction and commit with it.
+        # ride this request's transaction and commit with it. Skipped when the
+        # preference is already off (nothing can be queued).
         user_id = current_user.id
         await notifications_service.clear_task_assignment_queue_across_guilds(
             session, user_id

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -88,7 +88,10 @@ async def read_users_me(
     session: UserSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> User:
-    await initiatives_service.load_user_initiative_roles(session, [current_user])
+    # No initiative_roles enrichment: initiative membership is guild-schema
+    # content, which a platform-path request cannot (and must not) read.
+    # Guild-scoped rosters (/g/{guild_id}/users/) still serve it; clients
+    # derive per-guild manager state from guild-scoped initiative data.
     return current_user
 
 
@@ -289,6 +292,21 @@ async def update_users_me(
     if not update_data:
         return current_user
 
+    if update_data.get("email_task_assignment") is False:
+        # The digest queue is guild-scoped, so it must be cleared inside each
+        # of the user's guild schemas — before any mutation below, because the
+        # fan-out expunges the identity map (per-schema ids collide). Restore
+        # the platform context and re-fetch the user afterwards; the deletes
+        # ride this request's transaction and commit with it.
+        user_id = current_user.id
+        await notifications_service.clear_task_assignment_queue_across_guilds(
+            session, user_id
+        )
+        await set_rls_context(session, user_id=user_id)
+        current_user = (
+            await session.exec(select(User).where(User.id == user_id))
+        ).one()
+
     new_full_name = update_data.get("full_name")
     if new_full_name is not None:
         current_user.full_name = new_full_name or None
@@ -389,12 +407,10 @@ async def update_users_me(
         "push_event_reminders",
     ]:
         if field in update_data:
-            new_value = bool(update_data[field])
-            setattr(current_user, field, new_value)
-            if field == "email_task_assignment" and not new_value:
-                await notifications_service.clear_task_assignment_queue_for_user(
-                    session, current_user.id
-                )
+            # email_task_assignment=False also cleared the guild-scoped digest
+            # queue — done up-front (before any mutation) via the cross-guild
+            # fan-out at the top of this handler.
+            setattr(current_user, field, bool(update_data[field]))
     if "color_theme" in update_data:
         current_user.color_theme = update_data["color_theme"]
     if "task_completion_visual_feedback" in update_data:
@@ -421,7 +437,7 @@ async def update_users_me(
     await session.commit()
     await reapply_rls_context(session)
     await session.refresh(current_user)
-    await initiatives_service.load_user_initiative_roles(session, [current_user])
+    # Platform path — no initiative_roles enrichment (see read_users_me).
     return current_user
 
 

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -23,7 +23,6 @@ from app.testing.factories import (
     create_user,
     get_auth_headers,
     get_auth_token,
-    get_guild_headers,
 )
 
 
@@ -105,7 +104,7 @@ async def test_list_users_in_guild(client: AsyncClient, session: AsyncSession):
     await create_guild_membership(session, user=user1, guild=guild)
     await create_guild_membership(session, user=user2, guild=guild)
 
-    headers = await get_guild_headers(session, guild, user1)
+    headers = get_auth_headers(user1)
 
     response = await client.get(f"/api/v1/g/{guild.id}/users/", headers=headers)
 
@@ -133,7 +132,7 @@ async def test_update_user_by_id_as_admin(client: AsyncClient, session: AsyncSes
         session, user=member, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
 
     update_data = {"full_name": "New Name"}
 
@@ -192,7 +191,7 @@ async def test_admin_password_reset_revokes_sessions_and_device_tokens(
     # Admin resets the member's password.
     reset = await client.patch(
         f"/api/v1/g/{guild.id}/users/{member.id}",
-        headers=await get_guild_headers(session, guild, admin),
+        headers=get_auth_headers(admin),
         json={"password": "brand-new-secret-123"},
     )
     assert reset.status_code == 200
@@ -290,7 +289,7 @@ async def test_update_user_as_member_forbidden(
         session, user=member2, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, member1)
+    headers = get_auth_headers(member1)
 
     update_data = {"full_name": "Hacked Name"}
 
@@ -344,7 +343,7 @@ async def test_delete_user_as_admin(client: AsyncClient, session: AsyncSession):
         session, user=member, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
 
     response = await client.delete(
         f"/api/v1/g/{guild.id}/users/{member.id}", headers=headers
@@ -369,7 +368,7 @@ async def test_delete_user_as_member_forbidden(
         session, user=member2, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, member1)
+    headers = get_auth_headers(member1)
 
     response = await client.delete(
         f"/api/v1/g/{guild.id}/users/{member2.id}", headers=headers
@@ -401,7 +400,7 @@ async def test_guild_removal_eligibility_lists_owned_projects(
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/users/{member.id}/guild-removal-eligibility",
-        headers=await get_guild_headers(session, guild, admin),
+        headers=get_auth_headers(admin),
     )
     assert response.status_code == 200
     data = response.json()
@@ -432,7 +431,7 @@ async def test_delete_user_blocks_when_owned_projects_lack_transfer(
 
     response = await client.delete(
         f"/api/v1/g/{guild.id}/users/{member.id}",
-        headers=await get_guild_headers(session, guild, admin),
+        headers=get_auth_headers(admin),
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "CANNOT_REMOVE_OWNS_PROJECTS"
@@ -473,7 +472,7 @@ async def test_delete_user_with_transfers_reassigns_and_succeeds(
     response = await client.request(
         "DELETE",
         f"/api/v1/g/{guild.id}/users/{member.id}",
-        headers=await get_guild_headers(session, guild, admin),
+        headers=get_auth_headers(admin),
         json={"project_transfers": {str(project.id): successor.id}},
     )
     assert response.status_code == 204
@@ -510,7 +509,7 @@ async def test_delete_user_with_deletion_soft_deletes_project(
     response = await client.request(
         "DELETE",
         f"/api/v1/g/{guild.id}/users/{member.id}",
-        headers=await get_guild_headers(session, guild, admin),
+        headers=get_auth_headers(admin),
         json={"project_deletions": [project.id]},
     )
     assert response.status_code == 204
@@ -719,7 +718,7 @@ async def test_list_users_only_shows_guild_members(
     await create_guild_membership(session, user=user1, guild=guild1)
     await create_guild_membership(session, user=user2, guild=guild2)
 
-    headers = await get_guild_headers(session, guild1, user1)
+    headers = get_auth_headers(user1)
 
     response = await client.get(f"/api/v1/g/{guild1.id}/users/", headers=headers)
 
@@ -758,7 +757,7 @@ async def test_export_users_csv_as_admin(client: AsyncClient, session: AsyncSess
         session, user=member, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.get(
         f"/api/v1/g/{guild.id}/users/export.csv", headers=headers
     )
@@ -796,7 +795,7 @@ async def test_export_users_csv_forbidden_for_member(
         session, user=member, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, member)
+    headers = get_auth_headers(member)
     response = await client.get(
         f"/api/v1/g/{guild.id}/users/export.csv", headers=headers
     )
@@ -821,7 +820,7 @@ async def test_export_users_csv_single_user_id(
         session, user=target, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.get(
         f"/api/v1/g/{guild.id}/users/export.csv?user_id={target.id}", headers=headers
     )
@@ -849,7 +848,7 @@ async def test_export_users_csv_multi_user_id(
     await create_guild_membership(session, user=a, guild=guild, role=GuildRole.member)
     await create_guild_membership(session, user=b, guild=guild, role=GuildRole.member)
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.get(
         f"/api/v1/g/{guild.id}/users/export.csv?user_id={a.id}&user_id={b.id}",
         headers=headers,
@@ -877,7 +876,7 @@ async def test_export_users_csv_partial_miss(
         session, user=target, guild=guild, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.get(
         f"/api/v1/g/{guild.id}/users/export.csv?user_id={target.id}&user_id=99999",
         headers=headers,
@@ -900,7 +899,7 @@ async def test_export_users_csv_no_matches_returns_404(
         session, user=admin, guild=guild, role=GuildRole.admin
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.get(
         f"/api/v1/g/{guild.id}/users/export.csv?user_id=99998&user_id=99999",
         headers=headers,
@@ -925,7 +924,7 @@ async def test_export_users_csv_user_outside_guild(
         session, user=outsider, guild=guild2, role=GuildRole.member
     )
 
-    headers = await get_guild_headers(session, guild1, admin)
+    headers = get_auth_headers(admin)
     response = await client.get(
         f"/api/v1/g/{guild1.id}/users/export.csv?user_id={outsider.id}", headers=headers
     )
@@ -1107,7 +1106,7 @@ async def test_create_user_ignores_requested_platform_role(
         session, user=admin, guild=guild, role=GuildRole.admin
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
 
     for requested_role in ("owner", "admin", "moderator", "support"):
         new_email = f"escalate-{requested_role}@example.com"
@@ -1146,7 +1145,7 @@ async def test_create_user_happy_path_creates_member(
         session, user=admin, guild=guild, role=GuildRole.admin
     )
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
 
     response = await client.post(
         f"/api/v1/g/{guild.id}/users/",

--- a/backend/app/api/v1/tenant_endpoints/attachments_test.py
+++ b/backend/app/api/v1/tenant_endpoints/attachments_test.py
@@ -4,29 +4,19 @@ import io
 
 import pytest
 from httpx import AsyncClient
-from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.testing import (
-    create_guild,
-    create_guild_membership,
-    create_user,
-    get_guild_headers,
-)
 from app.models.platform.guild import GuildRole
 
 
 @pytest.mark.integration
-async def test_upload_image_too_large(client: AsyncClient, session: AsyncSession):
+async def test_upload_image_too_large(client: AsyncClient, acting_user):
     """Uploading an image larger than MAX_IMAGE_BYTES returns 413."""
-    user = await create_user(session)
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    headers = await get_guild_headers(session, guild, user)
+    a = await acting_user(guild_role=GuildRole.admin)
 
     oversized = b"\x89PNG\r\n\x1a\n" + b"X" * (11 * 1024 * 1024)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/attachments/",
-        headers=headers,
+        a.g("/attachments/"),
+        headers=a.headers,
         files={"file": ("big.png", io.BytesIO(oversized), "image/png")},
     )
 
@@ -35,12 +25,9 @@ async def test_upload_image_too_large(client: AsyncClient, session: AsyncSession
 
 
 @pytest.mark.integration
-async def test_upload_image_within_limit(client: AsyncClient, session: AsyncSession):
+async def test_upload_image_within_limit(client: AsyncClient, acting_user):
     """A valid PNG under the size limit is accepted."""
-    user = await create_user(session)
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    headers = await get_guild_headers(session, guild, user)
+    a = await acting_user(guild_role=GuildRole.admin)
 
     tiny_png = (
         b"\x89PNG\r\n\x1a\n"
@@ -50,8 +37,8 @@ async def test_upload_image_within_limit(client: AsyncClient, session: AsyncSess
         b"\x00\x00\x00IEND\xaeB`\x82"
     )
     response = await client.post(
-        f"/api/v1/g/{guild.id}/attachments/",
-        headers=headers,
+        a.g("/attachments/"),
+        headers=a.headers,
         files={"file": ("pixel.png", io.BytesIO(tiny_png), "image/png")},
     )
 

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
@@ -29,11 +29,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core import config as config_module
 from app.models.platform.user import UserStatus
-from app.testing.factories import (
+from app.testing import (
     create_guild,
     create_guild_membership,
     create_user,
-    get_guild_headers,
 )
 
 
@@ -130,7 +129,6 @@ async def test_delegation_token_guild_claim_pins_context(
     guild = await create_guild(session, creator=user)
     await create_guild_membership(session, user=user, guild=guild)
     # The human is legitimately in their own guild...
-    await get_guild_headers(session, guild, user)
     # ...but the workflow's token names a guild they have no access to.
     token = _mint_delegation(user_id=user.id, guild_id=guild.id + 999)
 

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
@@ -13,13 +13,8 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient
 
-from app.models.platform.guild import Guild, GuildRole
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_user,
-    get_guild_headers,
-)
+from app.models.platform.guild import GuildRole
+from app.testing import Actor
 
 
 @pytest.fixture(autouse=True)
@@ -31,27 +26,22 @@ def _force_prod_flag(monkeypatch):
     monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
 
 
-async def _authed_post(
-    client: AsyncClient, *, guild: Guild, headers: dict[str, str], body: dict
-):
+async def _authed_post(client: AsyncClient, actor: Actor, body: dict):
     return await client.post(
-        f"/api/v1/g/{guild.id}/auto/subscriptions", json=body, headers=headers
+        actor.g("/auto/subscriptions"), json=body, headers=actor.headers
     )
 
 
 @pytest.mark.integration
-async def test_create_rejects_loopback_target_url(client: AsyncClient, session):
+async def test_create_rejects_loopback_target_url(client: AsyncClient, acting_user):
     """Registering a target that resolves to loopback must 400. Without
     this guard, every guild member could redirect outbound dispatches to
     internal services."""
-    user = await create_user(session, email="hook-loopback@example.com")
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
         client,
-        guild=guild,
-        headers=await get_guild_headers(session, guild, user),
+        a,
         body={
             "target_url": "https://127.0.0.1/hook",
             "event_types": ["task.created"],
@@ -62,17 +52,14 @@ async def test_create_rejects_loopback_target_url(client: AsyncClient, session):
 
 
 @pytest.mark.integration
-async def test_create_rejects_metadata_endpoint(client: AsyncClient, session):
+async def test_create_rejects_metadata_endpoint(client: AsyncClient, acting_user):
     """The cloud-metadata endpoint is the canonical SSRF target — keep
     it explicitly in the test suite so a regression is loud."""
-    user = await create_user(session, email="hook-metadata@example.com")
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
         client,
-        guild=guild,
-        headers=await get_guild_headers(session, guild, user),
+        a,
         body={
             "target_url": "https://169.254.169.254/latest/meta-data/iam/",
             "event_types": ["task.created"],
@@ -83,17 +70,14 @@ async def test_create_rejects_metadata_endpoint(client: AsyncClient, session):
 
 
 @pytest.mark.integration
-async def test_create_rejects_plain_http(client: AsyncClient, session):
+async def test_create_rejects_plain_http(client: AsyncClient, acting_user):
     """Plain http:// is rejected with the structural-invalid code so
     the operator sees a different error than for a private-IP target."""
-    user = await create_user(session, email="hook-http@example.com")
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
         client,
-        guild=guild,
-        headers=await get_guild_headers(session, guild, user),
+        a,
         body={
             "target_url": "http://hooks.example.com/in",
             "event_types": ["task.created"],
@@ -105,14 +89,12 @@ async def test_create_rejects_plain_http(client: AsyncClient, session):
 
 @pytest.mark.integration
 async def test_create_accepts_public_target_when_dns_resolves_public(
-    client: AsyncClient, session
+    client: AsyncClient, acting_user
 ):
     """Public-resolving hostnames are allowed. We mock DNS so the test
     isn't network-dependent; the value being a public unicast IP is
     what we're asserting on."""
-    user = await create_user(session, email="hook-public@example.com")
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    a = await acting_user(guild_role=GuildRole.admin)
 
     fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]  # example.com IPv4
     with patch(
@@ -121,8 +103,7 @@ async def test_create_accepts_public_target_when_dns_resolves_public(
     ):
         response = await _authed_post(
             client,
-            guild=guild,
-            headers=await get_guild_headers(session, guild, user),
+            a,
             body={
                 "target_url": "https://hooks.example.com/in",
                 "event_types": ["task.created"],
@@ -131,24 +112,17 @@ async def test_create_accepts_public_target_when_dns_resolves_public(
     assert response.status_code == 201, response.text
     body = response.json()
     assert body["target_url"] == "https://hooks.example.com/in"
-    assert body["created_by_user_id"] == user.id
+    assert body["created_by_user_id"] == a.user.id
     assert "hmac_secret" in body  # one-time payload includes the secret
 
 
 @pytest.mark.integration
-async def test_non_owner_member_cannot_delete(client: AsyncClient, session):
+async def test_non_owner_member_cannot_delete(client: AsyncClient, acting_user):
     """A guild member who didn't create the subscription must not be
     able to delete it. RLS keeps the row visible inside the guild but
     that's not the same as authority to mutate it."""
-    creator = await create_user(session, email="hook-creator@example.com")
-    other = await create_user(session, email="hook-other@example.com")
-    guild = await create_guild(session, creator=creator)
-    await create_guild_membership(
-        session, user=creator, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=other, guild=guild, role=GuildRole.member
-    )
+    creator = await acting_user(guild_role=GuildRole.admin)
+    other = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
 
     fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
     with patch(
@@ -157,8 +131,7 @@ async def test_non_owner_member_cannot_delete(client: AsyncClient, session):
     ):
         created = await _authed_post(
             client,
-            guild=guild,
-            headers=await get_guild_headers(session, guild, creator),
+            creator,
             body={
                 "target_url": "https://hooks.example.com/in",
                 "event_types": ["task.created"],
@@ -168,26 +141,19 @@ async def test_non_owner_member_cannot_delete(client: AsyncClient, session):
     sub_id = created.json()["id"]
 
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/auto/subscriptions/{sub_id}",
-        headers=await get_guild_headers(session, guild, other),
+        other.g(f"/auto/subscriptions/{sub_id}"),
+        headers=other.headers,
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "WEBHOOK_SUBSCRIPTION_NOT_OWNER"
 
 
 @pytest.mark.integration
-async def test_non_owner_member_cannot_update(client: AsyncClient, session):
+async def test_non_owner_member_cannot_update(client: AsyncClient, acting_user):
     """Same authority check on PATCH — flipping ``active`` or rewriting
     ``target_url`` are both mutations."""
-    creator = await create_user(session, email="hook-creator2@example.com")
-    other = await create_user(session, email="hook-other2@example.com")
-    guild = await create_guild(session, creator=creator)
-    await create_guild_membership(
-        session, user=creator, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=other, guild=guild, role=GuildRole.member
-    )
+    creator = await acting_user(guild_role=GuildRole.admin)
+    other = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
 
     fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
     with patch(
@@ -196,8 +162,7 @@ async def test_non_owner_member_cannot_update(client: AsyncClient, session):
     ):
         created = await _authed_post(
             client,
-            guild=guild,
-            headers=await get_guild_headers(session, guild, creator),
+            creator,
             body={
                 "target_url": "https://hooks.example.com/in",
                 "event_types": ["task.created"],
@@ -207,28 +172,23 @@ async def test_non_owner_member_cannot_update(client: AsyncClient, session):
     sub_id = created.json()["id"]
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/auto/subscriptions/{sub_id}",
+        other.g(f"/auto/subscriptions/{sub_id}"),
         json={"active": False},
-        headers=await get_guild_headers(session, guild, other),
+        headers=other.headers,
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "WEBHOOK_SUBSCRIPTION_NOT_OWNER"
 
 
 @pytest.mark.integration
-async def test_guild_admin_can_delete_others_subscription(client: AsyncClient, session):
+async def test_guild_admin_can_delete_others_subscription(
+    client: AsyncClient, acting_user
+):
     """Guild admins are the explicit exception to the creator-only rule
     — they can clean up subscriptions left behind by members who left
     or had access revoked."""
-    creator = await create_user(session, email="hook-creator3@example.com")
-    admin = await create_user(session, email="hook-admin3@example.com")
-    guild = await create_guild(session, creator=creator)
-    await create_guild_membership(
-        session, user=creator, guild=guild, role=GuildRole.member
-    )
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    creator = await acting_user(guild_role=GuildRole.member)
+    admin = await acting_user(guild_role=GuildRole.admin, guild=creator.guild)
 
     fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
     with patch(
@@ -237,8 +197,7 @@ async def test_guild_admin_can_delete_others_subscription(client: AsyncClient, s
     ):
         created = await _authed_post(
             client,
-            guild=guild,
-            headers=await get_guild_headers(session, guild, creator),
+            creator,
             body={
                 "target_url": "https://hooks.example.com/in",
                 "event_types": ["task.created"],
@@ -248,20 +207,16 @@ async def test_guild_admin_can_delete_others_subscription(client: AsyncClient, s
     sub_id = created.json()["id"]
 
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/auto/subscriptions/{sub_id}",
-        headers=await get_guild_headers(session, guild, admin),
+        admin.g(f"/auto/subscriptions/{sub_id}"),
+        headers=admin.headers,
     )
     assert response.status_code == 204
 
 
 @pytest.mark.integration
-async def test_creator_can_update_own_subscription(client: AsyncClient, session):
+async def test_creator_can_update_own_subscription(client: AsyncClient, acting_user):
     """The happy path: the creator can mutate their own subscription."""
-    user = await create_user(session, email="hook-self@example.com")
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(
-        session, user=user, guild=guild, role=GuildRole.member
-    )
+    a = await acting_user(guild_role=GuildRole.member)
 
     fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
     with patch(
@@ -270,8 +225,7 @@ async def test_creator_can_update_own_subscription(client: AsyncClient, session)
     ):
         created = await _authed_post(
             client,
-            guild=guild,
-            headers=await get_guild_headers(session, guild, user),
+            a,
             body={
                 "target_url": "https://hooks.example.com/in",
                 "event_types": ["task.created"],
@@ -281,9 +235,9 @@ async def test_creator_can_update_own_subscription(client: AsyncClient, session)
     sub_id = created.json()["id"]
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/auto/subscriptions/{sub_id}",
+        a.g(f"/auto/subscriptions/{sub_id}"),
         json={"active": False},
-        headers=await get_guild_headers(session, guild, user),
+        headers=a.headers,
     )
     assert response.status_code == 200
     assert response.json()["active"] is False

--- a/backend/app/api/v1/tenant_endpoints/calendar_events_test.py
+++ b/backend/app/api/v1/tenant_endpoints/calendar_events_test.py
@@ -5,9 +5,6 @@ assigned to an event are eager-loaded and embedded in the summary (not just
 the full ``CalendarEventRead`` detail response).
 """
 
-import importlib.util
-from pathlib import Path
-
 import pytest
 from httpx import AsyncClient
 from sqlmodel import delete, select
@@ -18,35 +15,12 @@ from app.db.schema_provisioning import guild_schema_name
 from app.models.platform.guild import GuildRole
 from app.models.tenant.initiative import InitiativeRoleModel
 from app.models.platform.notification import Notification, NotificationType
-from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
-from app.models.tenant.tag import Tag
+from app.models.tenant.resource_grant import ResourceGrant
 from app.testing import (
     create_calendar_event,
-    create_guild,
-    create_guild_membership,
-    create_initiative,
-    create_initiative_member,
-    create_user,
+    create_tag,
     get_auth_headers,
-    get_guild_headers,
 )
-
-
-def _load_backfill_migration():
-    """Import migration 0115 by path (its filename starts with a digit, so it
-    can't be a normal import)."""
-    root = next(
-        p
-        for p in Path(__file__).resolve().parents
-        if (p / "alembic" / "versions").is_dir()
-    )
-    mod_path = (
-        root / "alembic" / "versions" / "20260616_0115_backfill_resource_grants.py"
-    )
-    spec = importlib.util.spec_from_file_location("mig_0115_backfill", mod_path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
 
 
 async def _notifications_for(
@@ -61,64 +35,60 @@ async def _notifications_for(
     return list(result.all())
 
 
-async def _setup_organizer_and_attendee(session: AsyncSession):
-    """Events-enabled initiative with an admin organizer and a member attendee."""
-    organizer = await create_user(session, email="organizer@example.com")
-    attendee = await create_user(session, email="attendee@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=organizer, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=attendee, guild=guild, role=GuildRole.member
-    )
-    initiative = await create_initiative(session, guild, organizer, name="Events")
-    initiative.events_enabled = True
-    session.add(initiative)
-    await create_initiative_member(session, initiative, attendee, role_name="member")
-    await session.commit()
-    await session.refresh(initiative)
-    return organizer, attendee, guild, initiative
-
-
-async def _setup_event(session: AsyncSession, *, initiative_name: str = "Init"):
-    """admin user, guild, events-enabled initiative, event."""
-    user = await create_user(session, email=f"u-{initiative_name}@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name=initiative_name)
+async def _enable_events(session: AsyncSession, initiative):
+    """Toggle the events feature flag on and persist it."""
     initiative.events_enabled = True
     session.add(initiative)
     await session.commit()
     await session.refresh(initiative)
-    event = await create_calendar_event(session, initiative, user, title="E")
-    return user, guild, initiative, event
+
+
+async def _setup_organizer_and_attendee(session, acting_user):
+    """Events-enabled initiative with an admin organizer and a member attendee.
+
+    Returns ``(organizer, attendee, guild, initiative)`` where organizer and
+    attendee are ``Actor`` instances (``.user``/``.headers``)."""
+    organizer = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    attendee = await acting_user(
+        guild_role=GuildRole.member,
+        guild=organizer.guild,
+        initiative=organizer.initiative,
+        initiative_role="member",
+    )
+    await _enable_events(session, organizer.initiative)
+    return organizer, attendee, organizer.guild, organizer.initiative
+
+
+async def _setup_event(session, acting_user):
+    """admin user, guild, events-enabled initiative, event.
+
+    Returns ``(actor, guild, initiative, event)``."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_events(session, a.initiative)
+    event = await create_calendar_event(session, a.initiative, a.user, title="E")
+    return a, a.guild, a.initiative, event
 
 
 @pytest.mark.integration
 async def test_list_events_summary_includes_tags(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, event = await _setup_event(session)
-    headers = await get_guild_headers(session, guild, user)
+    a, guild, initiative, event = await _setup_event(session, acting_user)
 
-    tag = Tag(name="Priority", guild_id=guild.id, color="#ff0000")
-    session.add(tag)
-    await session.commit()
-    await session.refresh(tag)
+    tag = await create_tag(session, guild, name="Priority", color="#ff0000")
 
     # Assign the tag to the event.
     assign = await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/tags",
-        headers=headers,
+        a.g(f"/calendar-events/{event.id}/tags"),
+        headers=a.headers,
         json=[tag.id],
     )
     assert assign.status_code == 200
 
     # The list summary should embed the tag.
     response = await client.get(
-        f"/api/v1/g/{guild.id}/calendar-events/?initiative_id={initiative.id}",
-        headers=headers,
+        a.g(f"/calendar-events/?initiative_id={initiative.id}"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     items = {item["id"]: item for item in response.json()["items"]}
@@ -130,15 +100,14 @@ async def test_list_events_summary_includes_tags(
 
 @pytest.mark.integration
 async def test_list_events_summary_tags_default_empty(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """An event with no tags still serializes ``tags: []`` in the summary."""
-    user, guild, initiative, event = await _setup_event(session)
-    headers = await get_guild_headers(session, guild, user)
+    a, guild, initiative, event = await _setup_event(session, acting_user)
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/calendar-events/?initiative_id={initiative.id}",
-        headers=headers,
+        a.g(f"/calendar-events/?initiative_id={initiative.id}"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     items = {item["id"]: item for item in response.json()["items"]}
@@ -147,29 +116,28 @@ async def test_list_events_summary_tags_default_empty(
 
 @pytest.mark.integration
 async def test_create_event_notifies_attendees_not_creator(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    headers = await get_guild_headers(session, guild, organizer)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/calendar-events/",
-        headers=headers,
+        organizer.g("/calendar-events/"),
+        headers=organizer.headers,
         json={
             "initiative_id": initiative.id,
             "title": "Kickoff",
             "start_at": "2026-07-01T15:00:00Z",
             "end_at": "2026-07-01T16:00:00Z",
             "all_day": False,
-            "attendee_ids": [attendee.id],
+            "attendee_ids": [attendee.user.id],
         },
     )
     assert response.status_code == 201
 
     invites = await _notifications_for(
-        session, attendee.id, NotificationType.event_invitation
+        session, attendee.user.id, NotificationType.event_invitation
     )
     assert len(invites) == 1
     assert invites[0].data["event_title"] == "Kickoff"
@@ -177,7 +145,7 @@ async def test_create_event_notifies_attendees_not_creator(
     # The creator should not be notified about their own event.
     assert (
         await _notifications_for(
-            session, organizer.id, NotificationType.event_invitation
+            session, organizer.user.id, NotificationType.event_invitation
         )
         == []
     )
@@ -185,17 +153,16 @@ async def test_create_event_notifies_attendees_not_creator(
 
 @pytest.mark.integration
 async def test_create_multi_day_timed_event_is_allowed(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A timed (non-all-day) event may now span more than 24 hours / cross days."""
     organizer, _attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    headers = await get_guild_headers(session, guild, organizer)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/calendar-events/",
-        headers=headers,
+        organizer.g("/calendar-events/"),
+        headers=organizer.headers,
         json={
             "initiative_id": initiative.id,
             "title": "Conference",
@@ -212,17 +179,16 @@ async def test_create_multi_day_timed_event_is_allowed(
 
 @pytest.mark.integration
 async def test_create_event_rejects_end_before_start(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """end_at before start_at is still rejected."""
     organizer, _attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    headers = await get_guild_headers(session, guild, organizer)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/calendar-events/",
-        headers=headers,
+        organizer.g("/calendar-events/"),
+        headers=organizer.headers,
         json={
             "initiative_id": initiative.id,
             "title": "Backwards",
@@ -236,28 +202,29 @@ async def test_create_event_rejects_end_before_start(
 
 @pytest.mark.integration
 async def test_update_event_time_notifies_attendees_as_rescheduled(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    headers = await get_guild_headers(session, guild, organizer)
-    event = await create_calendar_event(session, initiative, organizer, title="Review")
+    event = await create_calendar_event(
+        session, initiative, organizer.user, title="Review"
+    )
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/attendees",
-        headers=headers,
-        json=[attendee.id],
+        organizer.g(f"/calendar-events/{event.id}/attendees"),
+        headers=organizer.headers,
+        json=[attendee.user.id],
     )
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}",
-        headers=headers,
+        organizer.g(f"/calendar-events/{event.id}"),
+        headers=organizer.headers,
         json={"start_at": "2026-08-01T15:00:00Z", "end_at": "2026-08-01T16:00:00Z"},
     )
     assert response.status_code == 200
 
     updates = await _notifications_for(
-        session, attendee.id, NotificationType.event_updated
+        session, attendee.user.id, NotificationType.event_updated
     )
     assert len(updates) == 1
     assert updates[0].data["time_changed"] is True
@@ -265,136 +232,141 @@ async def test_update_event_time_notifies_attendees_as_rescheduled(
 
 @pytest.mark.integration
 async def test_delete_event_notifies_attendees(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    headers = await get_guild_headers(session, guild, organizer)
-    event = await create_calendar_event(session, initiative, organizer, title="Retro")
+    event = await create_calendar_event(
+        session, initiative, organizer.user, title="Retro"
+    )
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/attendees",
-        headers=headers,
-        json=[attendee.id],
+        organizer.g(f"/calendar-events/{event.id}/attendees"),
+        headers=organizer.headers,
+        json=[attendee.user.id],
     )
 
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}", headers=headers
+        organizer.g(f"/calendar-events/{event.id}"), headers=organizer.headers
     )
     assert response.status_code == 204
 
     cancels = await _notifications_for(
-        session, attendee.id, NotificationType.event_cancelled
+        session, attendee.user.id, NotificationType.event_cancelled
     )
     assert len(cancels) == 1
 
 
 @pytest.mark.integration
 async def test_update_event_skips_declined_attendees(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """An attendee who declined doesn't get reschedule/update notifications."""
     organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    headers = await get_guild_headers(session, guild, organizer)
-    event = await create_calendar_event(session, initiative, organizer, title="Review")
+    event = await create_calendar_event(
+        session, initiative, organizer.user, title="Review"
+    )
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/attendees",
-        headers=headers,
-        json=[attendee.id],
+        organizer.g(f"/calendar-events/{event.id}/attendees"),
+        headers=organizer.headers,
+        json=[attendee.user.id],
     )
     declined = await client.patch(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/rsvp",
-        headers=await get_guild_headers(session, guild, attendee),
+        organizer.g(f"/calendar-events/{event.id}/rsvp"),
+        headers=attendee.headers,
         json={"rsvp_status": "declined"},
     )
     assert declined.status_code == 200
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}",
-        headers=headers,
+        organizer.g(f"/calendar-events/{event.id}"),
+        headers=organizer.headers,
         json={"start_at": "2026-08-01T15:00:00Z", "end_at": "2026-08-01T16:00:00Z"},
     )
     assert response.status_code == 200
 
     updates = await _notifications_for(
-        session, attendee.id, NotificationType.event_updated
+        session, attendee.user.id, NotificationType.event_updated
     )
     assert updates == []
 
 
 @pytest.mark.integration
 async def test_delete_event_skips_declined_attendees(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """An attendee who declined doesn't get the cancellation notice."""
     organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    headers = await get_guild_headers(session, guild, organizer)
-    event = await create_calendar_event(session, initiative, organizer, title="Retro")
+    event = await create_calendar_event(
+        session, initiative, organizer.user, title="Retro"
+    )
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/attendees",
-        headers=headers,
-        json=[attendee.id],
+        organizer.g(f"/calendar-events/{event.id}/attendees"),
+        headers=organizer.headers,
+        json=[attendee.user.id],
     )
     declined = await client.patch(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/rsvp",
-        headers=await get_guild_headers(session, guild, attendee),
+        organizer.g(f"/calendar-events/{event.id}/rsvp"),
+        headers=attendee.headers,
         json={"rsvp_status": "declined"},
     )
     assert declined.status_code == 200
 
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}", headers=headers
+        organizer.g(f"/calendar-events/{event.id}"), headers=organizer.headers
     )
     assert response.status_code == 204
 
     cancels = await _notifications_for(
-        session, attendee.id, NotificationType.event_cancelled
+        session, attendee.user.id, NotificationType.event_cancelled
     )
     assert cancels == []
 
 
 @pytest.mark.integration
-async def test_rsvp_notifies_organizer(client: AsyncClient, session: AsyncSession):
+async def test_rsvp_notifies_organizer(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     organizer, attendee, guild, initiative = await _setup_organizer_and_attendee(
-        session
+        session, acting_user
     )
-    organizer_headers = await get_guild_headers(session, guild, organizer)
-    event = await create_calendar_event(session, initiative, organizer, title="Demo")
+    event = await create_calendar_event(
+        session, initiative, organizer.user, title="Demo"
+    )
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/attendees",
-        headers=organizer_headers,
-        json=[attendee.id],
+        organizer.g(f"/calendar-events/{event.id}/attendees"),
+        headers=organizer.headers,
+        json=[attendee.user.id],
     )
 
-    attendee_headers = await get_guild_headers(session, guild, attendee)
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/rsvp",
-        headers=attendee_headers,
+        organizer.g(f"/calendar-events/{event.id}/rsvp"),
+        headers=attendee.headers,
         json={"rsvp_status": "accepted"},
     )
     assert response.status_code == 200
 
-    rsvps = await _notifications_for(session, organizer.id, NotificationType.event_rsvp)
+    rsvps = await _notifications_for(
+        session, organizer.user.id, NotificationType.event_rsvp
+    )
     assert len(rsvps) == 1
     assert rsvps[0].data["rsvp_status"] == "accepted"
 
 
 @pytest.mark.integration
 async def test_global_calendar_events_reads_guild_schema(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """The cross-guild /global list must read events from the per-guild schema
     (schema-per-guild), not the frozen public backup. The factory writes the
     event into guild_<id>; /global aggregates per guild and must surface it."""
-    user, guild, initiative, event = await _setup_event(
-        session, initiative_name="GlobalView"
-    )
+    a, guild, initiative, event = await _setup_event(session, acting_user)
     response = await client.get(
-        "/api/v1/me/calendar-events", headers=get_auth_headers(user)
+        "/api/v1/me/calendar-events", headers=get_auth_headers(a.user)
     )
     assert response.status_code == 200
     body = response.json()
@@ -402,89 +374,25 @@ async def test_global_calendar_events_reads_guild_schema(
 
 
 @pytest.mark.integration
-async def test_migration_backfills_calendar_event_grants(session: AsyncSession):
-    """Migration 0115 seeds default grants for pre-existing events (which had no
-    legacy permission table): creator owner, manager roles write, others read.
-
-    Without this, the DAC visibility subquery returns empty for non-admins after
-    upgrade and every pre-existing event silently disappears for members.
-    """
-    creator = await create_user(session, email="ev-creator@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=creator, guild=guild, role=GuildRole.admin
-    )
-    initiative = await create_initiative(session, guild, creator, name="Backfill")
-    event = await create_calendar_event(session, initiative, creator, title="Old")
-
-    # Capture each role's expected level while normal (routed) reads still work —
-    # initiative_roles is guild-scoped, so query it before the manual search_path.
-    roles = (
-        await session.exec(
-            select(InitiativeRoleModel).where(
-                InitiativeRoleModel.initiative_id == initiative.id
-            )
-        )
-    ).all()
-    assert roles, "initiative should have built-in roles to grant"
-    expected_role_levels = {
-        role.id: (
-            ResourceAccessLevel.write if role.is_manager else ResourceAccessLevel.read
-        )
-        for role in roles
-    }
-
-    schema = guild_schema_name(guild.id)
-    await session.exec(text(f'SET search_path TO "{schema}", public'))
-    # Simulate the pre-migration world: the event exists with no grants at all.
-    await session.exec(
-        delete(ResourceGrant).where(ResourceGrant.resource_type == "calendar_event")
-    )
-
-    # Run the real migration backfill against this guild schema.
-    mod = _load_backfill_migration()
-    conn = await session.connection()
-    await conn.run_sync(mod._backfill_calendar_events)
-
-    grants = (
-        await session.exec(
-            select(ResourceGrant).where(
-                ResourceGrant.resource_type == "calendar_event",
-                ResourceGrant.resource_id == event.id,
-            )
-        )
-    ).all()
-    await session.exec(text("SET search_path TO public"))
-
-    # Creator owns the event; every initiative role gets write (managers) or read.
-    user_grants = {g.user_id: g.level for g in grants if g.user_id is not None}
-    assert user_grants == {creator.id: ResourceAccessLevel.owner}
-    role_grants = {g.role_id: g.level for g in grants if g.role_id is not None}
-    assert role_grants == expected_role_levels
-
-
-@pytest.mark.integration
 async def test_my_calendar_events_filters_events_without_member_grant(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """The cross-guild /me list applies the same per-event DAC filter as the
     per-guild list: a non-admin member doesn't see an event they hold no grant
     for (even though they're an initiative member and RLS shows the row)."""
-    admin = await create_user(session, email="me-admin@example.com")
-    member = await create_user(session, email="me-member@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(
-        session, user=member, guild=guild, role=GuildRole.member
+    guild = admin.guild
+    initiative = admin.initiative
+    await _enable_events(session, initiative)
+    event = await create_calendar_event(
+        session, initiative, admin.user, title="NoGrant"
     )
-    initiative = await create_initiative(session, guild, admin, name="MeFilter")
-    initiative.events_enabled = True
-    session.add(initiative)
-    await create_initiative_member(session, initiative, member, role_name="member")
-    await session.commit()
-    event = await create_calendar_event(session, initiative, admin, title="NoGrant")
 
     # Strip the member-role grant so the member has no path to this event.
     schema = guild_schema_name(guild.id)
@@ -509,14 +417,14 @@ async def test_my_calendar_events_filters_events_without_member_grant(
 
     # Member: the ungranted event is hidden on /me.
     resp = await client.get(
-        "/api/v1/me/calendar-events", headers=get_auth_headers(member)
+        "/api/v1/me/calendar-events", headers=get_auth_headers(member.user)
     )
     assert resp.status_code == 200
     assert event.id not in {item["id"] for item in resp.json()["items"]}
 
     # Admin: sees it via the guild-admin bypass.
     resp = await client.get(
-        "/api/v1/me/calendar-events", headers=get_auth_headers(admin)
+        "/api/v1/me/calendar-events", headers=get_auth_headers(admin.user)
     )
     assert resp.status_code == 200
     assert event.id in {item["id"] for item in resp.json()["items"]}
@@ -524,29 +432,24 @@ async def test_my_calendar_events_filters_events_without_member_grant(
 
 @pytest.mark.integration
 async def test_my_calendar_events_admin_sees_events_outside_their_initiatives(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A guild admin sees events in initiatives they were never added to (the
     admin leg of initiative_access fires under their guild role). The /me DAC
     filter must not re-hide them."""
-    admin = await create_user(session, email="me-admin2@example.com")
-    other = await create_user(session, email="me-other@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=other, guild=guild, role=GuildRole.member
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
     # `other` owns the initiative; the admin is NOT a member of it.
-    initiative = await create_initiative(session, guild, other, name="NotMine")
-    initiative.events_enabled = True
-    session.add(initiative)
-    await session.commit()
-    event = await create_calendar_event(session, initiative, other, title="Foreign")
+    other = await acting_user(
+        guild_role=GuildRole.member, guild=admin.guild, initiative=True
+    )
+    initiative = other.initiative
+    await _enable_events(session, initiative)
+    event = await create_calendar_event(
+        session, initiative, other.user, title="Foreign"
+    )
 
     resp = await client.get(
-        "/api/v1/me/calendar-events", headers=get_auth_headers(admin)
+        "/api/v1/me/calendar-events", headers=get_auth_headers(admin.user)
     )
     assert resp.status_code == 200
     assert event.id in {item["id"] for item in resp.json()["items"]}

--- a/backend/app/api/v1/tenant_endpoints/collaboration_test.py
+++ b/backend/app/api/v1/tenant_endpoints/collaboration_test.py
@@ -16,15 +16,9 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.security import create_upload_token
 from app.models.platform.access_grant import AccessGrant
-from app.models.tenant.document import (
-    Document,
-    DocumentType,
-)
-from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
+from app.models.tenant.document import Document
 from app.testing import (
-    create_guild,
-    create_guild_membership,
-    create_initiative,
+    create_document,
     create_user,
     get_auth_token,
 )
@@ -38,45 +32,13 @@ from app.models.platform.user import UserRole
 from app.services import permissions as permissions_service
 
 
-async def _create_native_document(
-    session: AsyncSession,
-    *,
-    initiative,
-    owner,
-) -> Document:
-    """Create a native (Lexical) document with owner write permission."""
-    doc = Document(
-        title="Sync Target",
-        initiative_id=initiative.id,
-        guild_id=initiative.guild_id,
-        created_by_id=owner.id,
-        updated_by_id=owner.id,
-        document_type=DocumentType.native,
-        content={"root": {"children": []}},
-    )
-    session.add(doc)
-    await session.flush()
-
-    perm = ResourceGrant(
-        resource_type="document",
-        resource_id=doc.id,
-        user_id=owner.id,
-        level=ResourceAccessLevel.owner,
-        guild_id=initiative.guild_id,
-        initiative_id=doc.initiative_id,
-    )
-    session.add(perm)
-    await session.commit()
-    return doc
-
-
 def _sync_url(guild_id: int, document_id: int) -> str:
     return f"/api/v1/g/{guild_id}/collaboration/documents/{document_id}/sync-content"
 
 
 @pytest.mark.integration
 async def test_collaboration_guild_admin_gets_full_access(
-    session: AsyncSession,
+    session: AsyncSession, acting_user
 ) -> None:
     """A guild admin must get full collaboration access to a restricted document
     they hold no grant on and aren't an initiative member of — mirroring the REST
@@ -85,17 +47,11 @@ async def test_collaboration_guild_admin_gets_full_access(
     ``is_request_guild_admin`` check reads the active guild-role context that
     ``establish_guild_access`` records. Without that context the admin is wrongly
     denied — the original "access denied" bug."""
-    owner = await create_user(session, email="owner@example.com")
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
     # admin is deliberately NOT a member of this initiative and holds no grant.
-    initiative = await create_initiative(session, guild, owner)
-    doc = await _create_native_document(session, initiative=initiative, owner=owner)
-    document = await _get_document_with_permissions(session, doc.id, guild.id)
+    admin = await acting_user(guild_role=GuildRole.admin, guild=owner.guild)
+    doc = await create_document(session, owner.initiative, owner.user)
+    document = await _get_document_with_permissions(session, doc.id, owner.guild.id)
 
     set_active_grant(None, None)
 
@@ -103,15 +59,17 @@ async def test_collaboration_guild_admin_gets_full_access(
     # it would leave): the admin holds no grant and isn't an initiative member, so
     # the engine resolves no access.
     set_active_role(None, None)
-    assert permissions_service.compute_document_permission(document, admin.id) is None
+    assert (
+        permissions_service.compute_document_permission(document, admin.user.id) is None
+    )
 
     # With the guild-admin role recorded — as establish_guild_access now does for
     # every transport — the engine's guild-admin bypass returns full ("owner")
     # access.
-    set_active_role(guild.id, GuildRole.admin.value)
+    set_active_role(owner.guild.id, GuildRole.admin.value)
     try:
         assert (
-            permissions_service.compute_document_permission(document, admin.id)
+            permissions_service.compute_document_permission(document, admin.user.id)
             == "owner"
         )
     finally:
@@ -120,20 +78,17 @@ async def test_collaboration_guild_admin_gets_full_access(
 
 @pytest.mark.integration
 async def test_sync_content_scoped_upload_token_persists(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A short-lived, uploads-scoped ?token= authenticates the sync (the
     credential native WebViews carry in the URL) and the content is written."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
-    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    doc = await create_document(session, owner.initiative, owner.user)
 
-    token, _ = create_upload_token(user_id=owner.id)
+    token, _ = create_upload_token(user_id=owner.user.id)
     new_content = {"root": {"children": [{"type": "paragraph"}]}}
     response = await client.post(
-        f"{_sync_url(guild.id, doc.id)}?token={token}",
+        f"{_sync_url(owner.guild.id, doc.id)}?token={token}",
         json=new_content,
     )
 
@@ -148,19 +103,16 @@ async def test_sync_content_scoped_upload_token_persists(
 
 @pytest.mark.integration
 async def test_sync_content_session_jwt_rejected_in_query_param(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """The long-lived session JWT must NOT authenticate the sync via ?token=
     (it would leak a full-API credential through the URL). SEC-12."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
-    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    doc = await create_document(session, owner.initiative, owner.user)
 
-    session_jwt = get_auth_token(owner)
+    session_jwt = get_auth_token(owner.user)
     response = await client.post(
-        f"{_sync_url(guild.id, doc.id)}?token={session_jwt}",
+        f"{_sync_url(owner.guild.id, doc.id)}?token={session_jwt}",
         json={"root": {"children": []}},
     )
 
@@ -169,7 +121,7 @@ async def test_sync_content_session_jwt_rejected_in_query_param(
 
 @pytest.mark.integration
 async def test_sync_content_rejects_non_member(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A validly-authenticated user who is not a member of the path guild can't
     sync into it — the guild boundary holds independent of how auth arrived.
@@ -182,16 +134,13 @@ async def test_sync_content_rejects_non_member(
     *authentication* now hard-fails (401), because that is enforced by the
     ``UploadUserDep`` dependency before the handler runs.
     """
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
-    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    doc = await create_document(session, owner.initiative, owner.user)
 
     outsider = await create_user(session)
     token, _ = create_upload_token(user_id=outsider.id)
     response = await client.post(
-        f"{_sync_url(guild.id, doc.id)}?token={token}",
+        f"{_sync_url(owner.guild.id, doc.id)}?token={token}",
         json={"root": {"children": []}},
     )
 
@@ -221,30 +170,27 @@ async def _approved_grant(session, *, user, guild, owner, level: str) -> AccessG
 
 @pytest.mark.integration
 async def test_sync_content_break_glass_admin_can_write(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A platform admin (``data.bypass``) who is NOT a guild member but holds a
     live ``read_write`` break-glass grant can sync — ``establish_guild_access``
     elevates them to a full guild admin for the grant's window. The
     pre-consolidation handler did a membership-only check and would have rejected
     this; routing through the single entry point gains break-glass for free."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
-    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    doc = await create_document(session, owner.initiative, owner.user)
 
     # data.bypass platform admin, deliberately NOT a member of this guild —
     # reaches it only through the break-glass grant.
     bg_admin = await create_user(session, role=UserRole.admin)
     await _approved_grant(
-        session, user=bg_admin, guild=guild, owner=owner, level="read_write"
+        session, user=bg_admin, guild=owner.guild, owner=owner.user, level="read_write"
     )
 
     token, _ = create_upload_token(user_id=bg_admin.id)
     new_content = {"root": {"children": [{"type": "paragraph"}]}}
     response = await client.post(
-        f"{_sync_url(guild.id, doc.id)}?token={token}",
+        f"{_sync_url(owner.guild.id, doc.id)}?token={token}",
         json=new_content,
     )
 
@@ -258,26 +204,25 @@ async def test_sync_content_break_glass_admin_can_write(
 
 @pytest.mark.integration
 async def test_sync_content_pam_read_grant_cannot_write(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A scoped PAM *read* grantee (no ``data.bypass``, not a member) can reach
     the guild but not edit it: sync returns the soft ``No write access`` error,
     distinct from ``No guild access``. Confirms the grant's read/write scope
     flows through the single entry point to the per-document check — the handler
     no longer rejects non-members outright (it used to be membership-only)."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
-    doc = await _create_native_document(session, initiative=initiative, owner=owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    doc = await create_document(session, owner.initiative, owner.user)
 
     # Platform member (no data.bypass) → a read grant is a scoped PAM grant.
     grantee = await create_user(session)
-    await _approved_grant(session, user=grantee, guild=guild, owner=owner, level="read")
+    await _approved_grant(
+        session, user=grantee, guild=owner.guild, owner=owner.user, level="read"
+    )
 
     token, _ = create_upload_token(user_id=grantee.id)
     response = await client.post(
-        f"{_sync_url(guild.id, doc.id)}?token={token}",
+        f"{_sync_url(owner.guild.id, doc.id)}?token={token}",
         json={"root": {"children": [{"type": "paragraph"}]}},
     )
 

--- a/backend/app/api/v1/tenant_endpoints/counters_test.py
+++ b/backend/app/api/v1/tenant_endpoints/counters_test.py
@@ -5,51 +5,24 @@ from decimal import Decimal
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models.platform.guild import Guild, GuildRole
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_initiative,
-    create_initiative_member,
-    create_user,
-    get_guild_headers,
-)
-
+from app.models.platform.guild import GuildRole
+from app.testing import Actor
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-async def _setup_admin(session: AsyncSession):
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    initiative = await create_initiative(session, guild, admin, name="Test")
-    return admin, guild, initiative
-
-
-async def _setup_with_member(session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    member = await create_user(session, email="member@example.com")
-    await create_guild_membership(session, user=member, guild=guild)
-    await create_initiative_member(session, initiative, member, role_name="member")
-    return admin, member, guild, initiative
-
-
 async def _create_group(
     client: AsyncClient,
-    headers: dict,
-    guild: Guild,
-    initiative_id: int,
+    actor: Actor,
+    *,
     name: str = "Test Group",
 ) -> dict:
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/",
-        headers=headers,
-        json={"name": name, "initiative_id": initiative_id},
+        actor.g("/counter-groups/"),
+        headers=actor.headers,
+        json={"name": name, "initiative_id": actor.initiative.id},
     )
     assert response.status_code == 201, response.text
     return response.json()
@@ -57,8 +30,7 @@ async def _create_group(
 
 async def _add_counter(
     client: AsyncClient,
-    headers: dict,
-    guild: Guild,
+    actor: Actor,
     group_id: int,
     *,
     name: str = "HP",
@@ -83,8 +55,8 @@ async def _add_counter(
     if max_value is not None:
         payload["max"] = max_value
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group_id}/counters",
-        headers=headers,
+        actor.g(f"/counter-groups/{group_id}/counters"),
+        headers=actor.headers,
         json=payload,
     )
     assert response.status_code == 201, response.text
@@ -97,71 +69,69 @@ async def _add_counter(
 
 
 @pytest.mark.integration
-async def test_create_counter_group(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
+async def test_create_counter_group(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/",
-        headers=headers,
+        a.g("/counter-groups/"),
+        headers=a.headers,
         json={
             "name": "Combat Tracker",
             "description": "HP, AC, etc.",
-            "initiative_id": initiative.id,
+            "initiative_id": a.initiative.id,
         },
     )
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "Combat Tracker"
     assert data["description"] == "HP, AC, etc."
-    assert data["initiative_id"] == initiative.id
-    assert data["created_by_id"] == admin.id
+    assert data["initiative_id"] == a.initiative.id
+    assert data["created_by_id"] == a.user.id
     assert data["counter_count"] == 0
 
 
 @pytest.mark.integration
-async def test_create_counter_group_non_pm_forbidden(
-    client: AsyncClient, session: AsyncSession
-):
-    admin, member, guild, initiative = await _setup_with_member(session)
-    headers = await get_guild_headers(session, guild, member)
+async def test_create_counter_group_non_pm_forbidden(client: AsyncClient, acting_user):
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/",
-        headers=headers,
-        json={"name": "Nope", "initiative_id": initiative.id},
+        member.g("/counter-groups/"),
+        headers=member.headers,
+        json={"name": "Nope", "initiative_id": admin.initiative.id},
     )
     assert response.status_code == 403
 
 
 @pytest.mark.integration
 async def test_feature_disabled_blocks_creation(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    admin, guild, initiative = await _setup_admin(session)
-    initiative.counters_enabled = False
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    a.initiative.counters_enabled = False
     await session.commit()
-    headers = await get_guild_headers(session, guild, admin)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/",
-        headers=headers,
-        json={"name": "X", "initiative_id": initiative.id},
+        a.g("/counter-groups/"),
+        headers=a.headers,
+        json={"name": "X", "initiative_id": a.initiative.id},
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "COUNTERS_NOT_ENABLED"
 
 
 @pytest.mark.integration
-async def test_list_counter_groups(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    await _create_group(client, headers, guild, initiative.id, "Group A")
-    await _create_group(client, headers, guild, initiative.id, "Group B")
+async def test_list_counter_groups(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _create_group(client, a, name="Group A")
+    await _create_group(client, a, name="Group B")
 
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/counter-groups/", headers=headers
-    )
+    response = await client.get(a.g("/counter-groups/"), headers=a.headers)
     assert response.status_code == 200
     body = response.json()
     assert body["total_count"] == 2
@@ -174,17 +144,13 @@ async def test_list_counter_groups(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_add_counter_clamps_initial_and_count(
-    client: AsyncClient, session: AsyncSession
-):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_add_counter_clamps_initial_and_count(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
 
     counter = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         count="999",
         min_value="0",
@@ -196,14 +162,13 @@ async def test_add_counter_clamps_initial_and_count(
 
 
 @pytest.mark.integration
-async def test_progress_bar_requires_bounds(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_progress_bar_requires_bounds(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters"),
+        headers=a.headers,
         json={
             "name": "Bad",
             "count": "10",
@@ -222,14 +187,12 @@ async def test_progress_bar_requires_bounds(client: AsyncClient, session: AsyncS
 
 
 @pytest.mark.integration
-async def test_increment_clamps_at_max(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_increment_clamps_at_max(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     counter = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         count="99",
         min_value="0",
@@ -238,22 +201,20 @@ async def test_increment_clamps_at_max(client: AsyncClient, session: AsyncSessio
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}/increment",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}/increment"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     assert Decimal(response.json()["count"]) == Decimal("100")
 
 
 @pytest.mark.integration
-async def test_decrement_clamps_at_min(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_decrement_clamps_at_min(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     counter = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         count="2",
         min_value="0",
@@ -262,25 +223,22 @@ async def test_decrement_clamps_at_min(client: AsyncClient, session: AsyncSessio
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}/decrement",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}/decrement"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     assert Decimal(response.json()["count"]) == Decimal("0")
 
 
 @pytest.mark.integration
-async def test_set_count_clamps(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
-    counter = await _add_counter(
-        client, headers, guild, group["id"], min_value="0", max_value="100"
-    )
+async def test_set_count_clamps(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
+    counter = await _add_counter(client, a, group["id"], min_value="0", max_value="100")
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}/set",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}/set"),
+        headers=a.headers,
         json={"count": "9999"},
     )
     assert response.status_code == 200
@@ -288,14 +246,12 @@ async def test_set_count_clamps(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_reset_returns_to_initial(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_reset_returns_to_initial(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     counter = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         count="50",
         initial_count="80",
@@ -305,28 +261,26 @@ async def test_reset_returns_to_initial(client: AsyncClient, session: AsyncSessi
 
     # Drop the value first
     await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}/set",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}/set"),
+        headers=a.headers,
         json={"count": "10"},
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}/reset",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}/reset"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     assert Decimal(response.json()["count"]) == Decimal("80")
 
 
 @pytest.mark.integration
-async def test_reset_all_counters(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_reset_all_counters(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     c1 = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         name="A",
         initial_count="50",
@@ -335,8 +289,7 @@ async def test_reset_all_counters(client: AsyncClient, session: AsyncSession):
     )
     c2 = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         name="B",
         initial_count="25",
@@ -347,18 +300,18 @@ async def test_reset_all_counters(client: AsyncClient, session: AsyncSession):
 
     # Mutate both
     await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{c1['id']}/set",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{c1['id']}/set"),
+        headers=a.headers,
         json={"count": "1"},
     )
     await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{c2['id']}/set",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{c2['id']}/set"),
+        headers=a.headers,
         json={"count": "1"},
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/reset-all", headers=headers
+        a.g(f"/counter-groups/{group['id']}/reset-all"), headers=a.headers
     )
     assert response.status_code == 200
     counts = {c["name"]: Decimal(c["count"]) for c in response.json()["counters"]}
@@ -372,19 +325,16 @@ async def test_reset_all_counters(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_update_min_max_reclamps_count(
-    client: AsyncClient, session: AsyncSession
-):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_update_min_max_reclamps_count(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     counter = await _add_counter(
-        client, headers, guild, group["id"], count="100", min_value="0", max_value="100"
+        client, a, group["id"], count="100", min_value="0", max_value="100"
     )
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}"),
+        headers=a.headers,
         json={"max": "50"},
     )
     assert response.status_code == 200
@@ -393,17 +343,15 @@ async def test_update_min_max_reclamps_count(
 
 @pytest.mark.integration
 async def test_update_null_non_nullable_fields_is_noop(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Explicit null for NOT NULL columns (step/initial_count/position/name/
     view_mode) must not 500 — it's treated as 'field not provided'."""
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     counter = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         name="HP",
         count="5",
@@ -412,8 +360,8 @@ async def test_update_null_non_nullable_fields_is_noop(
     )
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}"),
+        headers=a.headers,
         json={"step": None, "initial_count": None, "position": None, "name": None},
     )
     assert response.status_code == 200
@@ -424,33 +372,28 @@ async def test_update_null_non_nullable_fields_is_noop(
 
 
 @pytest.mark.integration
-async def test_update_step_zero_rejected(client: AsyncClient, session: AsyncSession):
+async def test_update_step_zero_rejected(client: AsyncClient, acting_user):
     """A provided step of 0 is a clean 422, not a 500."""
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
-    counter = await _add_counter(client, headers, guild, group["id"])
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
+    counter = await _add_counter(client, a, group["id"])
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}"),
+        headers=a.headers,
         json={"step": "0"},
     )
     assert response.status_code == 422
 
 
 @pytest.mark.integration
-async def test_decimal_serialization_no_exponent(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_decimal_serialization_no_exponent(client: AsyncClient, acting_user):
     """Numeric(20, 10) zeros must not round-trip as ``0E-10``."""
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     counter = await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         group["id"],
         count="0",
         min_value="0",
@@ -468,21 +411,19 @@ async def test_decimal_serialization_no_exponent(
 
 @pytest.mark.integration
 async def test_delete_counter_soft_deletes_to_trash(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Deleting a counter sets deleted_at and shows it in the trash list."""
     from app.db.soft_delete_filter import select_including_deleted
     from app.models.tenant.counter import Counter
-    from sqlmodel import select as sqlmodel_select  # noqa: F401
 
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
-    counter = await _add_counter(client, headers, guild, group["id"], name="HP")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
+    counter = await _add_counter(client, a, group["id"], name="HP")
 
     resp = await client.delete(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}/counters/{counter['id']}",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}/counters/{counter['id']}"),
+        headers=a.headers,
     )
     assert resp.status_code == 204
 
@@ -490,10 +431,10 @@ async def test_delete_counter_soft_deletes_to_trash(
     stmt = select_including_deleted(Counter).where(Counter.id == counter["id"])
     row = (await session.exec(stmt)).one()
     assert row.deleted_at is not None
-    assert row.deleted_by == admin.id
+    assert row.deleted_by == a.user.id
 
     # And it should appear in the trash list.
-    trash = await client.get("/api/v1/me/trash", headers=headers)
+    trash = await client.get("/api/v1/me/trash", headers=a.headers)
     assert trash.status_code == 200
     entries = trash.json()["items"]
     assert any(
@@ -504,41 +445,34 @@ async def test_delete_counter_soft_deletes_to_trash(
 
 @pytest.mark.integration
 async def test_deleted_counter_group_hidden_from_list_and_read(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Soft-deleted groups must not appear in list/read or accept counter
     adds. The session-level soft-delete filter is what enforces this."""
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    keep = await _create_group(client, headers, guild, initiative.id, "Keep")
-    trashed = await _create_group(client, headers, guild, initiative.id, "Trash me")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    keep = await _create_group(client, a, name="Keep")
+    trashed = await _create_group(client, a, name="Trash me")
 
     # Delete the second one.
     assert (
-        await client.delete(
-            f"/api/v1/g/{guild.id}/counter-groups/{trashed['id']}", headers=headers
-        )
+        await client.delete(a.g(f"/counter-groups/{trashed['id']}"), headers=a.headers)
     ).status_code == 204
 
     # List returns only the surviving group.
-    listing = (
-        await client.get(f"/api/v1/g/{guild.id}/counter-groups/", headers=headers)
-    ).json()
+    listing = (await client.get(a.g("/counter-groups/"), headers=a.headers)).json()
     names = {item["name"] for item in listing["items"]}
     assert names == {"Keep"}
     assert listing["total_count"] == 1
 
     # Detail read returns 404.
     assert (
-        await client.get(
-            f"/api/v1/g/{guild.id}/counter-groups/{trashed['id']}", headers=headers
-        )
+        await client.get(a.g(f"/counter-groups/{trashed['id']}"), headers=a.headers)
     ).status_code == 404
 
     # Trying to add a counter to it also 404s (the group is no longer reachable).
     add_resp = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{trashed['id']}/counters",
-        headers=headers,
+        a.g(f"/counter-groups/{trashed['id']}/counters"),
+        headers=a.headers,
         json={
             "name": "Phantom",
             "count": "0",
@@ -552,8 +486,8 @@ async def test_deleted_counter_group_hidden_from_list_and_read(
 
     # The surviving group still accepts adds.
     add_keep = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{keep['id']}/counters",
-        headers=headers,
+        a.g(f"/counter-groups/{keep['id']}/counters"),
+        headers=a.headers,
         json={
             "name": "OK",
             "count": "0",
@@ -568,21 +502,20 @@ async def test_deleted_counter_group_hidden_from_list_and_read(
 
 @pytest.mark.integration
 async def test_delete_counter_group_soft_deletes_and_cascades(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Deleting a counter group soft-deletes it AND its counters; the group
     appears in the trash list but the cascaded counters are deduped out."""
     from app.db.soft_delete_filter import select_including_deleted
     from app.models.tenant.counter import Counter, CounterGroup
 
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
-    counter = await _add_counter(client, headers, guild, group["id"], name="HP")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
+    counter = await _add_counter(client, a, group["id"], name="HP")
 
     resp = await client.delete(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}",
-        headers=headers,
+        a.g(f"/counter-groups/{group['id']}"),
+        headers=a.headers,
     )
     assert resp.status_code == 204
 
@@ -603,7 +536,7 @@ async def test_delete_counter_group_soft_deletes_and_cascades(
         counter_row.deleted_at == group_row.deleted_at
     )  # cascaded with same timestamp
 
-    trash = await client.get("/api/v1/me/trash", headers=headers)
+    trash = await client.get("/api/v1/me/trash", headers=a.headers)
     assert trash.status_code == 200
     entries = trash.json()["items"]
     # Group is listed.
@@ -619,27 +552,24 @@ async def test_delete_counter_group_soft_deletes_and_cascades(
 
 
 @pytest.mark.integration
-async def test_fractional_position_sort(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group_resp = await _create_group(client, headers, guild, initiative.id)
+async def test_fractional_position_sort(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group_resp = await _create_group(client, a)
     group_id = group_resp["id"]
 
-    a = await _add_counter(client, headers, guild, group_id, name="A", position="10.0")
-    await _add_counter(client, headers, guild, group_id, name="B", position="20.0")
+    counter_a = await _add_counter(client, a, group_id, name="A", position="10.0")
+    await _add_counter(client, a, group_id, name="B", position="20.0")
 
     # Drop "A" between (would equal 15.0)
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/counter-groups/{group_id}/counters/{a['id']}",
-        headers=headers,
+        a.g(f"/counter-groups/{group_id}/counters/{counter_a['id']}"),
+        headers=a.headers,
         json={"position": "15.5"},
     )
     assert response.status_code == 200
 
     group = (
-        await client.get(
-            f"/api/v1/g/{guild.id}/counter-groups/{group_id}", headers=headers
-        )
+        await client.get(a.g(f"/counter-groups/{group_id}"), headers=a.headers)
     ).json()
     ordered = [c["name"] for c in group["counters"]]
     assert ordered == ["A", "B"] or ordered == ["B", "A"]  # position-ordered
@@ -660,27 +590,20 @@ def _ordered_names(group: dict) -> list[str]:
 
 
 @pytest.mark.integration
-async def test_sort_counters(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+async def test_sort_counters(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
     gid = group["id"]
 
     # Scrambled order; "alpha" is lowercase to exercise case-insensitive sort.
-    await _add_counter(
-        client, headers, guild, gid, name="Charlie", count="5", position="0"
-    )
-    await _add_counter(
-        client, headers, guild, gid, name="alpha", count="1", position="1"
-    )
-    await _add_counter(
-        client, headers, guild, gid, name="Bravo", count="3", position="2"
-    )
+    await _add_counter(client, a, gid, name="Charlie", count="5", position="0")
+    await _add_counter(client, a, gid, name="alpha", count="1", position="1")
+    await _add_counter(client, a, gid, name="Bravo", count="3", position="2")
 
     async def sort(field: str, direction: str) -> dict:
         resp = await client.post(
-            f"/api/v1/g/{guild.id}/counter-groups/{gid}/sort",
-            headers=headers,
+            a.g(f"/counter-groups/{gid}/sort"),
+            headers=a.headers,
             json={"field": field, "direction": direction},
         )
         assert resp.status_code == 200, resp.text
@@ -698,33 +621,35 @@ async def test_sort_counters(client: AsyncClient, session: AsyncSession):
 
     # The reorder persists on a fresh read.
     fetched = (
-        await client.get(f"/api/v1/g/{guild.id}/counter-groups/{gid}", headers=headers)
+        await client.get(a.g(f"/counter-groups/{gid}"), headers=a.headers)
     ).json()
     assert _ordered_names(fetched) == ["Charlie", "Bravo", "alpha"]
 
 
 @pytest.mark.integration
-async def test_sort_counters_read_only_forbidden(
-    client: AsyncClient, session: AsyncSession
-):
-    admin, member, guild, initiative = await _setup_with_member(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, admin_headers, guild, initiative.id)
+async def test_sort_counters_read_only_forbidden(client: AsyncClient, acting_user):
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    group = await _create_group(client, admin)
     gid = group["id"]
-    await _add_counter(client, admin_headers, guild, gid, name="A", position="0")
+    await _add_counter(client, admin, gid, name="A", position="0")
 
     # Grant the member read-only access on the group.
     grant = await client.put(
-        f"/api/v1/g/{guild.id}/counter-groups/{gid}/grants",
-        headers=admin_headers,
-        json=[{"user_id": member.id, "level": "read"}],
+        admin.g(f"/counter-groups/{gid}/grants"),
+        headers=admin.headers,
+        json=[{"user_id": member.user.id, "level": "read"}],
     )
     assert grant.status_code == 200, grant.text
 
-    member_headers = await get_guild_headers(session, guild, member)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{gid}/sort",
-        headers=member_headers,
+        member.g(f"/counter-groups/{gid}/sort"),
+        headers=member.headers,
         json={"field": "name", "direction": "asc"},
     )
     assert resp.status_code == 403
@@ -737,15 +662,13 @@ async def test_sort_counters_read_only_forbidden(
 
 
 @pytest.mark.integration
-async def test_duplicate_counter_group(client: AsyncClient, session: AsyncSession):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    source = await _create_group(client, headers, guild, initiative.id, name="Original")
+async def test_duplicate_counter_group(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    source = await _create_group(client, a, name="Original")
     sid = source["id"]
     await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         sid,
         name="HP",
         count="40",
@@ -754,8 +677,7 @@ async def test_duplicate_counter_group(client: AsyncClient, session: AsyncSessio
     )
     await _add_counter(
         client,
-        headers,
-        guild,
+        a,
         sid,
         name="Mana",
         count="5",
@@ -767,7 +689,7 @@ async def test_duplicate_counter_group(client: AsyncClient, session: AsyncSessio
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{sid}/duplicate", headers=headers, json={}
+        a.g(f"/counter-groups/{sid}/duplicate"), headers=a.headers, json={}
     )
     assert response.status_code == 201, response.text
     copy = response.json()
@@ -791,24 +713,19 @@ async def test_duplicate_counter_group(client: AsyncClient, session: AsyncSessio
     assert by_name["Mana"]["view_mode"] == "number"
 
     # The source group is untouched.
-    src = (
-        await client.get(f"/api/v1/g/{guild.id}/counter-groups/{sid}", headers=headers)
-    ).json()
+    src = (await client.get(a.g(f"/counter-groups/{sid}"), headers=a.headers)).json()
     assert src["name"] == "Original"
     assert len(src["counters"]) == 2
 
 
 @pytest.mark.integration
-async def test_duplicate_counter_group_custom_name(
-    client: AsyncClient, session: AsyncSession
-):
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    source = await _create_group(client, headers, guild, initiative.id, name="Original")
+async def test_duplicate_counter_group_custom_name(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    source = await _create_group(client, a, name="Original")
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{source['id']}/duplicate",
-        headers=headers,
+        a.g(f"/counter-groups/{source['id']}/duplicate"),
+        headers=a.headers,
         json={"name": "My Clone"},
     )
     assert response.status_code == 201, response.text
@@ -817,28 +734,30 @@ async def test_duplicate_counter_group_custom_name(
 
 @pytest.mark.integration
 async def test_duplicate_counter_group_read_user_becomes_owner(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """A read-only user can duplicate and owns the copy (read suffices to copy)."""
-    admin, member, guild, initiative = await _setup_with_member(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
-    source = await _create_group(
-        client, admin_headers, guild, initiative.id, name="Shared"
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
+    source = await _create_group(client, admin, name="Shared")
     sid = source["id"]
-    await _add_counter(client, admin_headers, guild, sid, name="A", position="0")
+    await _add_counter(client, admin, sid, name="A", position="0")
 
     grant = await client.put(
-        f"/api/v1/g/{guild.id}/counter-groups/{sid}/grants",
-        headers=admin_headers,
-        json=[{"user_id": member.id, "level": "read"}],
+        admin.g(f"/counter-groups/{sid}/grants"),
+        headers=admin.headers,
+        json=[{"user_id": member.user.id, "level": "read"}],
     )
     assert grant.status_code == 200, grant.text
 
-    member_headers = await get_guild_headers(session, guild, member)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/counter-groups/{sid}/duplicate",
-        headers=member_headers,
+        member.g(f"/counter-groups/{sid}/duplicate"),
+        headers=member.headers,
         json={},
     )
     assert response.status_code == 201, response.text
@@ -847,15 +766,14 @@ async def test_duplicate_counter_group_read_user_becomes_owner(
 
 @pytest.mark.integration
 async def test_delete_counter_group_still_emits_group_deleted(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, acting_user, monkeypatch
 ):
     """Deleting a group must still emit ``group_deleted``. Regression: the group
     is soft-deleted before _emit_counter runs, so its fallback guild lookup is
     hidden by the global deleted_at IS NULL filter — the delete path must pass
     guild_id explicitly or the event is silently dropped."""
-    admin, guild, initiative = await _setup_admin(session)
-    headers = await get_guild_headers(session, guild, admin)
-    group = await _create_group(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    group = await _create_group(client, a)
 
     from app.services import stream_authz
 
@@ -866,8 +784,6 @@ async def test_delete_counter_group_still_emits_group_deleted(
 
     monkeypatch.setattr(stream_authz.authority, "emit", _record)
 
-    resp = await client.delete(
-        f"/api/v1/g/{guild.id}/counter-groups/{group['id']}", headers=headers
-    )
+    resp = await client.delete(a.g(f"/counter-groups/{group['id']}"), headers=a.headers)
     assert resp.status_code == 204, resp.text
-    assert (guild.id, "counter_group", group["id"], "group_deleted") in emitted
+    assert (a.guild.id, "counter_group", group["id"], "group_deleted") in emitted

--- a/backend/app/api/v1/tenant_endpoints/documents_properties_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_properties_test.py
@@ -16,70 +16,19 @@ from httpx import AsyncClient
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models.tenant.document import (
-    Document,
-    DocumentType,
-)
 from app.models.platform.guild import GuildRole
-from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.tenant.property import (
     DocumentPropertyValue,
     PropertyType,
 )
 from app.testing import (
+    create_document,
     create_guild,
     create_guild_membership,
     create_initiative,
     create_property_definition,
     create_user,
-    get_guild_headers,
 )
-
-
-async def _create_document(
-    session: AsyncSession,
-    *,
-    initiative,
-    owner,
-    title: str = "Doc",
-    guild_id_override: int | None | str = "use_initiative",
-) -> Document:
-    """Create a native document owned by ``owner``.
-
-    ``guild_id_override`` controls the ``Document.guild_id`` column:
-    * ``"use_initiative"`` (default) uses ``initiative.guild_id``
-    * ``None`` leaves the column NULL (global document)
-    * any int explicitly sets the column
-    """
-    if guild_id_override == "use_initiative":
-        doc_guild_id = initiative.guild_id
-    else:
-        doc_guild_id = guild_id_override
-
-    doc = Document(
-        title=title,
-        initiative_id=initiative.id,
-        guild_id=doc_guild_id,
-        created_by_id=owner.id,
-        updated_by_id=owner.id,
-        document_type=DocumentType.native,
-        content={},
-    )
-    session.add(doc)
-    await session.flush()
-
-    perm = ResourceGrant(
-        resource_type="document",
-        resource_id=doc.id,
-        user_id=owner.id,
-        level=ResourceAccessLevel.owner,
-        guild_id=initiative.guild_id,
-        initiative_id=doc.initiative_id,
-    )
-    session.add(perm)
-    await session.commit()
-    await session.refresh(doc)
-    return doc
 
 
 # ---------------------------------------------------------------------------
@@ -89,22 +38,18 @@ async def _create_document(
 
 @pytest.mark.integration
 async def test_put_sets_multiple_property_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(session, a.initiative, a.user)
 
     text_defn = await create_property_definition(
-        session, initiative, name="Tag", type=PropertyType.text
+        session, a.initiative, name="Tag", type=PropertyType.text
     )
     number_defn = await create_property_definition(
-        session, initiative, name="Count", type=PropertyType.number
+        session, a.initiative, name="Count", type=PropertyType.number
     )
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
         "values": [
             {"property_id": text_defn.id, "value": "alpha"},
@@ -112,8 +57,8 @@ async def test_put_sets_multiple_property_values(
         ]
     }
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json=payload,
     )
 
@@ -128,30 +73,26 @@ async def test_put_sets_multiple_property_values(
 
 @pytest.mark.integration
 async def test_put_empty_values_clears_existing_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(session, a.initiative, a.user)
 
     defn = await create_property_definition(
-        session, initiative, name="Tag", type=PropertyType.text
+        session, a.initiative, name="Tag", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     # Populate first
     await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "to be cleared"}]},
     )
 
     # Now clear
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": []},
     )
     assert response.status_code == 200
@@ -171,24 +112,21 @@ async def test_put_empty_values_clears_existing_values(
 
 @pytest.mark.integration
 async def test_put_cross_initiative_definition_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A definition from initiative B can't be attached to a doc in A."""
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    init_a = a.initiative
+    init_b = await create_initiative(session, a.guild, a.user, name="B")
 
-    init_a = await create_initiative(session, guild, user, name="A")
-    init_b = await create_initiative(session, guild, user, name="B")
-
-    doc = await _create_document(session, initiative=init_a, owner=user)
+    doc = await create_document(session, init_a, a.user)
 
     # Definition lives in initiative B.
     defn_b = await create_property_definition(session, init_b, name="Foreign")
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn_b.id, "value": "x"}]},
     )
     assert response.status_code == 404
@@ -197,25 +135,24 @@ async def test_put_cross_initiative_definition_rejected(
 
 @pytest.mark.integration
 async def test_put_properties_on_foreign_guild_document_returns_404(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    """Document lives in guild B, client sends guild A header — 404."""
-    user = await create_user(session, email="u@example.com")
-    guild_a = await create_guild(session, name="A")
+    """Document lives in guild B, client sends guild A path — 404."""
+    a = await acting_user(guild_role=GuildRole.admin)
+    user = a.user
+    guild_a = a.guild
+
     guild_b = await create_guild(session, name="B")
-    await create_guild_membership(
-        session, user=user, guild=guild_a, role=GuildRole.admin
-    )
     await create_guild_membership(
         session, user=user, guild=guild_b, role=GuildRole.admin
     )
 
     initiative_b = await create_initiative(session, guild_b, user, name="Init B")
-    doc_b = await _create_document(session, initiative=initiative_b, owner=user)
+    doc_b = await create_document(session, initiative_b, user)
 
     response = await client.put(
         f"/api/v1/g/{guild_a.id}/documents/{doc_b.id}/properties",
-        headers=await get_guild_headers(session, guild_a, user),
+        headers=a.headers,
         json={"values": []},
     )
 
@@ -230,21 +167,18 @@ async def test_put_properties_on_foreign_guild_document_returns_404(
 
 @pytest.mark.integration
 async def test_put_text_value_against_number_type_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(session, a.initiative, a.user)
 
     defn = await create_property_definition(
-        session, initiative, name="Count", type=PropertyType.number
+        session, a.initiative, name="Count", type=PropertyType.number
     )
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "not a number"}]},
     )
     assert response.status_code == 400
@@ -253,25 +187,22 @@ async def test_put_text_value_against_number_type_rejected(
 
 @pytest.mark.integration
 async def test_put_select_unknown_option_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(session, a.initiative, a.user)
 
     defn = await create_property_definition(
         session,
-        initiative,
+        a.initiative,
         name="Phase",
         type=PropertyType.select,
         options=[{"value": "draft", "label": "Draft"}],
     )
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "nope"}]},
     )
     assert response.status_code == 400
@@ -280,25 +211,22 @@ async def test_put_select_unknown_option_rejected(
 
 @pytest.mark.integration
 async def test_put_multi_select_unknown_option_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(session, a.initiative, a.user)
 
     defn = await create_property_definition(
         session,
-        initiative,
+        a.initiative,
         name="Tags",
         type=PropertyType.multi_select,
         options=[{"value": "one", "label": "One"}, {"value": "two", "label": "Two"}],
     )
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": ["one", "ghost"]}]},
     )
     assert response.status_code == 400
@@ -307,27 +235,24 @@ async def test_put_multi_select_unknown_option_rejected(
 
 @pytest.mark.integration
 async def test_put_user_reference_non_initiative_member_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
     # outsider IS in the guild but NOT in the initiative.
+    outsider = await create_user(session, email="outsider@example.com")
     await create_guild_membership(
-        session, user=outsider, guild=guild, role=GuildRole.member
+        session, user=outsider, guild=a.guild, role=GuildRole.member
     )
 
-    initiative = await create_initiative(session, guild, user, name="Init")
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    doc = await create_document(session, a.initiative, a.user)
 
     defn = await create_property_definition(
-        session, initiative, name="Owner", type=PropertyType.user_reference
+        session, a.initiative, name="Owner", type=PropertyType.user_reference
     )
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": outsider.id}]},
     )
     assert response.status_code == 400
@@ -336,23 +261,19 @@ async def test_put_user_reference_non_initiative_member_rejected(
 
 @pytest.mark.integration
 async def test_put_url_accepts_valid_url_and_rejects_invalid(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(session, a.initiative, a.user)
 
     defn = await create_property_definition(
-        session, initiative, name="Site", type=PropertyType.url
+        session, a.initiative, name="Site", type=PropertyType.url
     )
 
-    headers = await get_guild_headers(session, guild, user)
     # Valid URL
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "https://example.com"}]},
     )
     assert response.status_code == 200
@@ -361,8 +282,8 @@ async def test_put_url_accepts_valid_url_and_rejects_invalid(
 
     # Invalid URL string
     bad = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "not a url"}]},
     )
     assert bad.status_code == 400
@@ -376,40 +297,32 @@ async def test_put_url_accepts_valid_url_and_rejects_invalid(
 
 @pytest.mark.integration
 async def test_list_documents_property_filter_text_eq(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     defn = await create_property_definition(
-        session, initiative, name="Tag", type=PropertyType.text
+        session, a.initiative, name="Tag", type=PropertyType.text
     )
 
-    doc_match = await _create_document(
-        session, initiative=initiative, owner=user, title="Match"
-    )
-    doc_other = await _create_document(
-        session, initiative=initiative, owner=user, title="Other"
-    )
+    doc_match = await create_document(session, a.initiative, a.user, title="Match")
+    doc_other = await create_document(session, a.initiative, a.user, title="Other")
 
-    headers = await get_guild_headers(session, guild, user)
     await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc_match.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc_match.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "findme"}]},
     )
     await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc_other.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc_other.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "skip"}]},
     )
 
     filt = json.dumps([{"property_id": defn.id, "op": "eq", "value": "findme"}])
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/?initiative_id={initiative.id}&property_filters={filt}",
-        headers=headers,
+        a.g(f"/documents/?initiative_id={a.initiative.id}&property_filters={filt}"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     ids = {item["id"] for item in response.json()["items"]}
@@ -419,35 +332,31 @@ async def test_list_documents_property_filter_text_eq(
 
 @pytest.mark.integration
 async def test_list_documents_property_filter_number_eq(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     defn = await create_property_definition(
-        session, initiative, name="Score", type=PropertyType.number
+        session, a.initiative, name="Score", type=PropertyType.number
     )
 
     docs = [
-        await _create_document(session, initiative=initiative, owner=user, title="D1"),
-        await _create_document(session, initiative=initiative, owner=user, title="D2"),
-        await _create_document(session, initiative=initiative, owner=user, title="D3"),
+        await create_document(session, a.initiative, a.user, title="D1"),
+        await create_document(session, a.initiative, a.user, title="D2"),
+        await create_document(session, a.initiative, a.user, title="D3"),
     ]
 
-    headers = await get_guild_headers(session, guild, user)
     for doc, score in zip(docs, [10, 20, 30]):
         await client.put(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-            headers=headers,
+            a.g(f"/documents/{doc.id}/properties"),
+            headers=a.headers,
             json={"values": [{"property_id": defn.id, "value": score}]},
         )
 
     filt = json.dumps([{"property_id": defn.id, "op": "eq", "value": 20}])
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/?initiative_id={initiative.id}&property_filters={filt}",
-        headers=headers,
+        a.g(f"/documents/?initiative_id={a.initiative.id}&property_filters={filt}"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     ids = {item["id"] for item in response.json()["items"]}
@@ -458,17 +367,14 @@ async def test_list_documents_property_filter_number_eq(
 
 @pytest.mark.integration
 async def test_list_documents_property_filter_multi_select_contains(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """multi_select uses JSONB @> (contains) semantics."""
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     defn = await create_property_definition(
         session,
-        initiative,
+        a.initiative,
         name="Labels",
         type=PropertyType.multi_select,
         options=[
@@ -478,29 +384,24 @@ async def test_list_documents_property_filter_multi_select_contains(
         ],
     )
 
-    doc_with_alpha = await _create_document(
-        session, initiative=initiative, owner=user, title="A"
-    )
-    doc_no_alpha = await _create_document(
-        session, initiative=initiative, owner=user, title="N"
-    )
+    doc_with_alpha = await create_document(session, a.initiative, a.user, title="A")
+    doc_no_alpha = await create_document(session, a.initiative, a.user, title="N")
 
-    headers = await get_guild_headers(session, guild, user)
     await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc_with_alpha.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc_with_alpha.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": ["alpha", "beta"]}]},
     )
     await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc_no_alpha.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc_no_alpha.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": ["gamma"]}]},
     )
 
     filt = json.dumps([{"property_id": defn.id, "op": "eq", "value": ["alpha"]}])
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/?initiative_id={initiative.id}&property_filters={filt}",
-        headers=headers,
+        a.g(f"/documents/?initiative_id={a.initiative.id}&property_filters={filt}"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     ids = {item["id"] for item in response.json()["items"]}
@@ -510,16 +411,13 @@ async def test_list_documents_property_filter_multi_select_contains(
 
 @pytest.mark.integration
 async def test_list_documents_invalid_property_filters_json_returns_400(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/?initiative_id={initiative.id}&property_filters=not-json",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/documents/?initiative_id={a.initiative.id}&property_filters=not-json"),
+        headers=a.headers,
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "QUERY_INVALID_CONDITIONS"
@@ -527,20 +425,17 @@ async def test_list_documents_invalid_property_filters_json_returns_400(
 
 @pytest.mark.integration
 async def test_list_documents_too_many_property_filters_returns_400(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     # Fabricate 6 predicates (cap is 5); ids don't need to exist.
     filt = json.dumps(
         [{"property_id": i, "op": "eq", "value": "x"} for i in range(1, 7)]
     )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/?initiative_id={initiative.id}&property_filters={filt}",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/documents/?initiative_id={a.initiative.id}&property_filters={filt}"),
+        headers=a.headers,
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "QUERY_INVALID_CONDITIONS"
@@ -553,31 +448,25 @@ async def test_list_documents_too_many_property_filters_returns_400(
 
 @pytest.mark.integration
 async def test_duplicate_document_same_initiative_carries_property_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Duplicating a document in place (same initiative) copies its values."""
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    doc = await _create_document(
-        session, initiative=initiative, owner=user, title="Src"
-    )
+    doc = await create_document(session, a.initiative, a.user, title="Src")
     defn = await create_property_definition(
-        session, initiative, name="Tag", type=PropertyType.text
+        session, a.initiative, name="Tag", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "carryover"}]},
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/duplicate",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/duplicate"),
+        headers=a.headers,
         json={"title": "Dup"},
     )
     assert response.status_code == 201
@@ -598,30 +487,27 @@ async def test_duplicate_document_same_initiative_carries_property_values(
 
 @pytest.mark.integration
 async def test_copy_document_cross_initiative_drops_property_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Copying a document to a different initiative drops its property values."""
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    init_a = await create_initiative(session, guild, user, name="A")
-    init_b = await create_initiative(session, guild, user, name="B")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    init_a = a.initiative
+    init_b = await create_initiative(session, a.guild, a.user, name="B")
 
-    doc = await _create_document(session, initiative=init_a, owner=user, title="Src")
+    doc = await create_document(session, init_a, a.user, title="Src")
     defn = await create_property_definition(
         session, init_a, name="Tag", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/properties",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "onlyA"}]},
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/copy",
-        headers=headers,
+        a.g(f"/documents/{doc.id}/copy"),
+        headers=a.headers,
         json={"title": "Copied", "target_initiative_id": init_b.id},
     )
     assert response.status_code == 201

--- a/backend/app/api/v1/tenant_endpoints/documents_scope_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_scope_test.py
@@ -9,45 +9,28 @@ cleaned up, and a stale row alone would not grant access anyway
 
 import pytest
 from httpx import AsyncClient
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_initiative,
-    create_initiative_member,
-    create_user,
-    get_guild_headers,
-)
-
-
-async def _setup(session: AsyncSession):
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=member, guild=guild, role=GuildRole.member
-    )
-    initiative = await create_initiative(session, guild, admin)
-    await create_initiative_member(session, initiative, member)
-    return admin, member, guild, initiative
 
 
 @pytest.mark.integration
 async def test_initiative_removal_ends_document_access(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
-    admin, member, guild, initiative = await _setup(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
-    member_headers = await get_guild_headers(session, guild, member)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    initiative = admin.initiative
+    admin_headers = admin.headers
+    member_headers = member.headers
 
     # Admin creates a document and shares it with the member.
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
+        admin.g("/documents/"),
         headers=admin_headers,
         json={"title": "Shared Doc", "initiative_id": initiative.id},
     )
@@ -55,25 +38,23 @@ async def test_initiative_removal_ends_document_access(
     doc_id = response.json()["id"]
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/documents/{doc_id}/grants",
+        admin.g(f"/documents/{doc_id}/grants"),
         headers=admin_headers,
-        json=[{"user_id": member.id, "level": "write"}],
+        json=[{"user_id": member.user.id, "level": "write"}],
     )
     assert response.status_code == 200
 
     # Member can open and list the document while in the initiative.
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc_id}", headers=member_headers
+        member.g(f"/documents/{doc_id}"), headers=member_headers
     )
     assert response.status_code == 200
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/", headers=member_headers
-    )
+    response = await client.get(member.g("/documents/"), headers=member_headers)
     assert doc_id in {d["id"] for d in response.json()["items"]}
 
     # Remove the member from the initiative.
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members/{member.id}",
+        admin.g(f"/initiatives/{initiative.id}/members/{member.user.id}"),
         headers=admin_headers,
     )
     assert response.status_code == 200
@@ -82,16 +63,12 @@ async def test_initiative_removal_ends_document_access(
     # document entirely — open is 404 (not a 403 existence leak), and the list no
     # longer contains it.
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc_id}", headers=member_headers
+        member.g(f"/documents/{doc_id}"), headers=member_headers
     )
     assert response.status_code == 404
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/", headers=member_headers
-    )
+    response = await client.get(member.g("/documents/"), headers=member_headers)
     assert doc_id not in {d["id"] for d in response.json()["items"]}
 
     # The admin (initiative PM here) is unaffected.
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc_id}", headers=admin_headers
-    )
+    response = await client.get(admin.g(f"/documents/{doc_id}"), headers=admin_headers)
     assert response.status_code == 200

--- a/backend/app/api/v1/tenant_endpoints/documents_spreadsheet_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_spreadsheet_test.py
@@ -9,18 +9,10 @@ from dataclasses import dataclass
 
 import pytest
 from httpx import AsyncClient
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import Guild, GuildRole
 from app.models.tenant.initiative import Initiative
 from app.models.platform.user import User
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_initiative,
-    create_user,
-    get_guild_headers,
-)
 
 
 @dataclass
@@ -32,21 +24,18 @@ class _SpreadsheetEnv:
 
 
 @pytest.fixture
-async def env(session: AsyncSession) -> _SpreadsheetEnv:
+async def env(acting_user) -> _SpreadsheetEnv:
     """Shared user / guild / membership / initiative setup for every
     spreadsheet endpoint test. Per-test scope so each gets a fresh
     initiative — the round-trip and PATCH tests don't need to be
     isolated from each other but the validation tests do, and a
     function-scoped fixture is the cheap, consistent default."""
-    user = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
     return _SpreadsheetEnv(
-        user=user,
-        guild=guild,
-        initiative=initiative,
-        headers=await get_guild_headers(session, guild, user),
+        user=a.user,
+        guild=a.guild,
+        initiative=a.initiative,
+        headers=a.headers,
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_test.py
@@ -18,15 +18,12 @@ from app.models.tenant.document import (
 from app.models.platform.guild import GuildRole
 from app.models.tenant.initiative import InitiativeRoleModel
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
+from app.testing import (
+    create_document,
     create_initiative,
-    create_initiative_member,
     create_user,
     get_auth_headers,
     get_auth_token,
-    get_guild_headers,
 )
 
 
@@ -87,19 +84,17 @@ async def _create_file_document(
 
 @pytest.mark.integration
 async def test_create_document_with_permissions(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test creating a document with both role and user permissions."""
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
-
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    await create_initiative_member(session, initiative, member, role_name="member")
+    initiative = admin.initiative
 
     # Find the member role
     result = await session.exec(
@@ -110,18 +105,17 @@ async def test_create_document_with_permissions(
     )
     member_role = result.one()
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "title": "Doc With Permissions",
         "initiative_id": initiative.id,
         "grants": [
             {"role_id": member_role.id, "level": "read"},
-            {"user_id": member.id, "level": "write"},
+            {"user_id": member.user.id, "level": "write"},
         ],
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/", headers=headers, json=payload
+        admin.g("/documents/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -131,8 +125,8 @@ async def test_create_document_with_permissions(
     grants = data["grants"]
     # Owner grant + member's write user grant.
     user_grants = {g["user_id"]: g["level"] for g in grants if g["user_id"]}
-    assert user_grants.get(admin.id) == "owner"
-    assert user_grants.get(member.id) == "write"
+    assert user_grants.get(admin.user.id) == "owner"
+    assert user_grants.get(member.user.id) == "write"
     # Role grant for the member role at read.
     role_grants = [g for g in grants if g["role_id"] is not None]
     assert len(role_grants) == 1
@@ -142,31 +136,24 @@ async def test_create_document_with_permissions(
 
 @pytest.mark.integration
 async def test_create_document_defaults_to_all_members_viewer(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Omitting `grants` defaults to Viewer for all initiative members (+ owner)."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "title": "Doc Default Share",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/", headers=headers, json=payload
+        admin.g("/documents/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
     data = response.json()
     assert any(
-        g["user_id"] == admin.id and g["level"] == "owner" for g in data["grants"]
+        g["user_id"] == admin.user.id and g["level"] == "owner" for g in data["grants"]
     )
     assert any(
         g["all_initiative_members"] and g["level"] == "read" for g in data["grants"]
@@ -175,17 +162,14 @@ async def test_create_document_defaults_to_all_members_viewer(
 
 @pytest.mark.integration
 async def test_create_document_rejects_foreign_initiative_role(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Role from a different initiative must be silently dropped."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    initiative_a = admin.initiative
+    initiative_b = await create_initiative(
+        session, admin.guild, admin.user, name="Initiative B"
     )
-
-    initiative_a = await create_initiative(session, guild, admin, name="Initiative A")
-    initiative_b = await create_initiative(session, guild, admin, name="Initiative B")
 
     # Get a role that belongs to initiative_b, not initiative_a
     result = await session.exec(
@@ -196,7 +180,6 @@ async def test_create_document_rejects_foreign_initiative_role(
     )
     foreign_role = result.one()
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "title": "Doc Cross Initiative",
         "initiative_id": initiative_a.id,
@@ -206,7 +189,7 @@ async def test_create_document_rejects_foreign_initiative_role(
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/", headers=headers, json=payload
+        admin.g("/documents/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -217,32 +200,31 @@ async def test_create_document_rejects_foreign_initiative_role(
 
 @pytest.mark.integration
 async def test_create_document_skips_owner_level_grants(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Owner-level grants in user_permissions must be silently ignored."""
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    await create_initiative_member(session, initiative, member, role_name="member")
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "title": "Doc Owner Skip",
-        "initiative_id": initiative.id,
-        "grants": [{"user_id": member.id, "level": "owner"}],
+        "initiative_id": admin.initiative.id,
+        "grants": [{"user_id": member.user.id, "level": "owner"}],
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/", headers=headers, json=payload
+        admin.g("/documents/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
-    member_grants = [g for g in response.json()["grants"] if g["user_id"] == member.id]
+    member_grants = [
+        g for g in response.json()["grants"] if g["user_id"] == member.user.id
+    ]
     assert len(member_grants) == 0
 
 
@@ -260,57 +242,36 @@ async def _make_native_doc(
     is_template: bool,
 ) -> Document:
     """Create a native document with creator as owner, optionally a template."""
-    doc = Document(
+    return await create_document(
+        session,
+        initiative,
+        creator,
         title=title,
-        initiative_id=initiative.id,
-        guild_id=initiative.guild_id,
-        created_by_id=creator.id,
-        updated_by_id=creator.id,
-        document_type=DocumentType.native,
         content={"root": {"type": "root", "children": []}},
         is_template=is_template,
     )
-    session.add(doc)
-    await session.flush()
-    session.add(
-        ResourceGrant(
-            resource_type="document",
-            resource_id=doc.id,
-            user_id=creator.id,
-            level=ResourceAccessLevel.owner,
-            guild_id=initiative.guild_id,
-            initiative_id=doc.initiative_id,
-        )
-    )
-    await session.commit()
-    return doc
 
 
 @pytest.mark.integration
 async def test_copy_template_with_read_only_access(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A user with only read on a template can still copy it into a new document."""
-    template_owner = await create_user(session, email="template-owner@example.com")
-    reader = await create_user(session, email="reader@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=template_owner, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(session, user=reader, guild=guild)
-
-    initiative = await create_initiative(
-        session, guild, template_owner, name="Templates Initiative"
-    )
+    template_owner = await acting_user(guild_role=GuildRole.admin, initiative=True)
     # Reader needs create_docs in the target initiative; PM role grants it by default.
-    await create_initiative_member(
-        session, initiative, reader, role_name="project_manager"
+    reader = await acting_user(
+        guild_role=GuildRole.member,
+        guild=template_owner.guild,
+        initiative=template_owner.initiative,
+        initiative_role="project_manager",
     )
+    guild = template_owner.guild
+    initiative = template_owner.initiative
 
     template = await _make_native_doc(
         session,
         initiative=initiative,
-        creator=template_owner,
+        creator=template_owner.user,
         title="Project Kickoff Template",
         is_template=True,
     )
@@ -319,7 +280,7 @@ async def test_copy_template_with_read_only_access(
         ResourceGrant(
             resource_type="document",
             resource_id=template.id,
-            user_id=reader.id,
+            user_id=reader.user.id,
             level=ResourceAccessLevel.read,
             guild_id=guild.id,
             initiative_id=template.initiative_id,
@@ -327,10 +288,9 @@ async def test_copy_template_with_read_only_access(
     )
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, reader)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{template.id}/copy",
-        headers=headers,
+        reader.g(f"/documents/{template.id}/copy"),
+        headers=reader.headers,
         json={"target_initiative_id": initiative.id, "title": "My Kickoff"},
     )
 
@@ -338,13 +298,13 @@ async def test_copy_template_with_read_only_access(
     data = response.json()
     assert data["title"] == "My Kickoff"
     assert data["is_template"] is False
-    assert data["created_by_id"] == reader.id
+    assert data["created_by_id"] == reader.user.id
 
     # Reader is owner of the new doc.
     new_grant_levels = {
         g["user_id"]: g["level"] for g in data["grants"] if g["user_id"]
     }
-    assert new_grant_levels.get(reader.id) == "owner"
+    assert new_grant_levels.get(reader.user.id) == "owner"
 
     # Source template is unchanged.
     await session.refresh(template)
@@ -354,26 +314,23 @@ async def test_copy_template_with_read_only_access(
 
 @pytest.mark.integration
 async def test_copy_non_template_still_requires_write_access(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Read-only access on a non-template document is still rejected by /copy."""
-    owner = await create_user(session, email="doc-owner@example.com")
-    reader = await create_user(session, email="reader@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=owner, guild=guild, role=GuildRole.admin
+    owner = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    reader = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="project_manager",
     )
-    await create_guild_membership(session, user=reader, guild=guild)
-
-    initiative = await create_initiative(session, guild, owner, name="Docs Initiative")
-    await create_initiative_member(
-        session, initiative, reader, role_name="project_manager"
-    )
+    guild = owner.guild
+    initiative = owner.initiative
 
     doc = await _make_native_doc(
         session,
         initiative=initiative,
-        creator=owner,
+        creator=owner.user,
         title="Confidential Notes",
         is_template=False,
     )
@@ -381,7 +338,7 @@ async def test_copy_non_template_still_requires_write_access(
         ResourceGrant(
             resource_type="document",
             resource_id=doc.id,
-            user_id=reader.id,
+            user_id=reader.user.id,
             level=ResourceAccessLevel.read,
             guild_id=guild.id,
             initiative_id=doc.initiative_id,
@@ -389,10 +346,9 @@ async def test_copy_non_template_still_requires_write_access(
     )
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, reader)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc.id}/copy",
-        headers=headers,
+        reader.g(f"/documents/{doc.id}/copy"),
+        headers=reader.headers,
         json={"target_initiative_id": initiative.id, "title": "My Copy"},
     )
 
@@ -407,21 +363,17 @@ async def test_copy_non_template_still_requires_write_access(
 
 @pytest.mark.integration
 async def test_download_owner_can_download(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Document owner can download their file document."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_owner.pdf"
+        session, initiative=owner.initiative, owner=owner.user, filename="dl_owner.pdf"
     )
     try:
-        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download", headers=headers
+            owner.g(f"/documents/{doc.id}/download"), headers=owner.headers
         )
         assert response.status_code == 200
         assert "attachment" in response.headers.get("content-disposition", "")
@@ -432,19 +384,16 @@ async def test_download_owner_can_download(
 
 @pytest.mark.integration
 async def test_download_unauthenticated_returns_401(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Unauthenticated request returns 401."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_unauth.pdf"
+        session, initiative=owner.initiative, owner=owner.user, filename="dl_unauth.pdf"
     )
     try:
-        response = await client.get(f"/api/v1/g/{guild.id}/documents/{doc.id}/download")
+        response = await client.get(owner.g(f"/documents/{doc.id}/download"))
         assert response.status_code == 401
     finally:
         (_uploads_dir() / "dl_unauth.pdf").unlink(missing_ok=True)
@@ -452,24 +401,26 @@ async def test_download_unauthenticated_returns_401(
 
 @pytest.mark.integration
 async def test_download_guild_member_without_permission_returns_403(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Guild member with no document permission gets 403."""
-    owner = await create_user(session)
-    other = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=other, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
-    await create_initiative_member(session, initiative, other)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    other = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_no_perm.pdf"
+        session,
+        initiative=owner.initiative,
+        owner=owner.user,
+        filename="dl_no_perm.pdf",
     )
     try:
-        headers = await get_guild_headers(session, guild, other)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download", headers=headers
+            other.g(f"/documents/{doc.id}/download"), headers=other.headers
         )
         assert response.status_code == 403
     finally:
@@ -478,22 +429,22 @@ async def test_download_guild_member_without_permission_returns_403(
 
 @pytest.mark.integration
 async def test_download_non_guild_member_returns_404(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """User from a different guild gets 404 (document not visible)."""
-    owner = await create_user(session)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
     outsider = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_outsider.pdf"
+        session,
+        initiative=owner.initiative,
+        owner=owner.user,
+        filename="dl_outsider.pdf",
     )
     try:
         headers = get_auth_headers(outsider)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download", headers=headers
+            owner.g(f"/documents/{doc.id}/download"), headers=headers
         )
         assert response.status_code == 404
     finally:
@@ -502,24 +453,25 @@ async def test_download_non_guild_member_returns_404(
 
 @pytest.mark.integration
 async def test_download_read_permission_grants_access(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """User with explicit read permission can download."""
-    owner = await create_user(session)
-    reader = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=reader, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
-    await create_initiative_member(session, initiative, reader)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    reader = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+    guild = owner.guild
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_reader.pdf"
+        session, initiative=owner.initiative, owner=owner.user, filename="dl_reader.pdf"
     )
     read_perm = ResourceGrant(
         resource_type="document",
         resource_id=doc.id,
-        user_id=reader.id,
+        user_id=reader.user.id,
         level=ResourceAccessLevel.read,
         guild_id=guild.id,
         initiative_id=doc.initiative_id,
@@ -528,9 +480,8 @@ async def test_download_read_permission_grants_access(
     await session.commit()
 
     try:
-        headers = await get_guild_headers(session, guild, reader)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download", headers=headers
+            owner.g(f"/documents/{doc.id}/download"), headers=reader.headers
         )
         assert response.status_code == 200
     finally:
@@ -539,22 +490,18 @@ async def test_download_read_permission_grants_access(
 
 @pytest.mark.integration
 async def test_download_inline_returns_no_attachment_header(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """?inline=1 serves the file without Content-Disposition: attachment."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_inline.pdf"
+        session, initiative=owner.initiative, owner=owner.user, filename="dl_inline.pdf"
     )
     try:
-        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download?inline=1",
-            headers=headers,
+            owner.g(f"/documents/{doc.id}/download?inline=1"),
+            headers=owner.headers,
         )
         assert response.status_code == 200
         assert "attachment" not in response.headers.get("content-disposition", "")
@@ -565,22 +512,18 @@ async def test_download_inline_returns_no_attachment_header(
 @pytest.mark.integration
 @pytest.mark.parametrize("filename", ["dl_inline.html", "dl_inline.svg"])
 async def test_download_inline_html_svg_is_same_origin_framable_but_scriptless(
-    client: AsyncClient, session: AsyncSession, filename: str
+    client: AsyncClient, session: AsyncSession, acting_user, filename: str
 ) -> None:
     """Inline HTML/SVG can be framed by the same-origin viewer but cannot run scripts."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename=filename
+        session, initiative=owner.initiative, owner=owner.user, filename=filename
     )
     try:
-        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download?inline=1",
-            headers=headers,
+            owner.g(f"/documents/{doc.id}/download?inline=1"),
+            headers=owner.headers,
         )
         assert response.status_code == 200
         # Same-origin framing allowed (overrides the global DENY middleware)
@@ -597,21 +540,17 @@ async def test_download_inline_html_svg_is_same_origin_framable_but_scriptless(
 @pytest.mark.integration
 @pytest.mark.parametrize("filename", ["dl_attach.html", "dl_attach.svg"])
 async def test_download_non_inline_html_svg_keeps_global_deny(
-    client: AsyncClient, session: AsyncSession, filename: str
+    client: AsyncClient, session: AsyncSession, acting_user, filename: str
 ) -> None:
     """Non-inline HTML/SVG downloads stay attachments and do not relax framing."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename=filename
+        session, initiative=owner.initiative, owner=owner.user, filename=filename
     )
     try:
-        headers = await get_guild_headers(session, guild, owner)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download", headers=headers
+            owner.g(f"/documents/{doc.id}/download"), headers=owner.headers
         )
         assert response.status_code == 200
         # Served as an attachment; the framing relaxation must not apply here
@@ -626,25 +565,19 @@ async def test_download_non_inline_html_svg_keeps_global_deny(
 
 @pytest.mark.integration
 async def test_download_scoped_upload_token_auth(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A short-lived, uploads-scoped ?token= authenticates the download (the
     credential native WebViews carry in the URL). SEC-12."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_token.pdf"
+        session, initiative=owner.initiative, owner=owner.user, filename="dl_token.pdf"
     )
     try:
-        # Download URLs carry no guild context — the server resolves it from
-        # the owner's flag, so enter the guild first.
-        await get_guild_headers(session, guild, owner)
-        token, _ = create_upload_token(user_id=owner.id)
+        token, _ = create_upload_token(user_id=owner.user.id)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download?token={token}"
+            owner.g(f"/documents/{doc.id}/download?token={token}")
         )
         assert response.status_code == 200
     finally:
@@ -653,22 +586,22 @@ async def test_download_scoped_upload_token_auth(
 
 @pytest.mark.integration
 async def test_download_session_jwt_rejected_in_query_param(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """The long-lived session JWT must NOT authenticate a download via ?token=
     (it would leak a full-API credential through the URL). SEC-12."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     doc = await _create_file_document(
-        session, initiative=initiative, owner=owner, filename="dl_session_jwt.pdf"
+        session,
+        initiative=owner.initiative,
+        owner=owner.user,
+        filename="dl_session_jwt.pdf",
     )
     try:
-        token = get_auth_token(owner)
+        token = get_auth_token(owner.user)
         response = await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc.id}/download?token={token}"
+            owner.g(f"/documents/{doc.id}/download?token={token}")
         )
         assert response.status_code == 401
     finally:
@@ -677,33 +610,29 @@ async def test_download_session_jwt_rejected_in_query_param(
 
 @pytest.mark.integration
 async def test_download_native_document_returns_404(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ) -> None:
     """Native (non-file) document returns 404 from the download endpoint."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
-        json={"title": "Native Doc", "initiative_id": initiative.id},
+        owner.g("/documents/"),
+        headers=owner.headers,
+        json={"title": "Native Doc", "initiative_id": owner.initiative.id},
     )
     assert response.status_code == 201
     doc_id = response.json()["id"]
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc_id}/download",
-        headers=get_auth_headers(owner),
+        owner.g(f"/documents/{doc_id}/download"),
+        headers=get_auth_headers(owner.user),
     )
     assert response.status_code == 404
 
 
 @pytest.mark.integration
 async def test_update_content_clears_yjs_state(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """PATCH /documents/{id} with content should clear yjs_state.
 
@@ -711,16 +640,12 @@ async def test_update_content_clears_yjs_state(
     which then overwrote the freshly-saved content when the user re-enabled
     collaboration (the CollaborationPlugin synced from the old Yjs state).
     """
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    headers = await get_guild_headers(session, guild, owner)
     create_resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
-        json={"title": "Collab Doc", "initiative_id": initiative.id},
+        owner.g("/documents/"),
+        headers=owner.headers,
+        json={"title": "Collab Doc", "initiative_id": owner.initiative.id},
     )
     assert create_resp.status_code == 201
     doc_id = create_resp.json()["id"]
@@ -734,8 +659,8 @@ async def test_update_content_clears_yjs_state(
 
     # PATCH the content via the REST endpoint (the non-collab save path)
     patch_resp = await client.patch(
-        f"/api/v1/g/{guild.id}/documents/{doc_id}",
-        headers=headers,
+        owner.g(f"/documents/{doc_id}"),
+        headers=owner.headers,
         json={
             "content": {
                 "root": {
@@ -757,27 +682,21 @@ async def test_update_content_clears_yjs_state(
 
 
 @pytest.mark.integration
-async def test_create_whiteboard_document(
-    client: AsyncClient, session: AsyncSession
-) -> None:
+async def test_create_whiteboard_document(client: AsyncClient, acting_user) -> None:
     """POST /documents/ with document_type='whiteboard' creates a whiteboard doc.
 
     The response's content should be the empty Excalidraw scene shape
     ({elements, appState, files}) rather than the Lexical root shape. This
     guards against normalize_document_content corrupting whiteboard payloads.
     """
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
+        owner.g("/documents/"),
+        headers=owner.headers,
         json={
             "title": "My Whiteboard",
-            "initiative_id": initiative.id,
+            "initiative_id": owner.initiative.id,
             "document_type": "whiteboard",
         },
     )
@@ -815,22 +734,16 @@ def test_normalize_native_still_injects_root() -> None:
 
 
 @pytest.mark.integration
-async def test_create_smart_link_document(
-    client: AsyncClient, session: AsyncSession
-) -> None:
+async def test_create_smart_link_document(client: AsyncClient, acting_user) -> None:
     """POST /documents/ with document_type='smart_link' stores only the URL."""
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
+        owner.g("/documents/"),
+        headers=owner.headers,
         json={
             "title": "Design file",
-            "initiative_id": initiative.id,
+            "initiative_id": owner.initiative.id,
             "document_type": "smart_link",
             "content": {"url": "https://www.figma.com/design/abc/Example"},
         },
@@ -843,20 +756,16 @@ async def test_create_smart_link_document(
 
 @pytest.mark.integration
 async def test_create_smart_link_rejects_missing_url(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ) -> None:
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
+        owner.g("/documents/"),
+        headers=owner.headers,
         json={
             "title": "Bad link",
-            "initiative_id": initiative.id,
+            "initiative_id": owner.initiative.id,
             "document_type": "smart_link",
             "content": {},
         },
@@ -867,20 +776,16 @@ async def test_create_smart_link_rejects_missing_url(
 
 @pytest.mark.integration
 async def test_create_smart_link_rejects_non_http_url(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ) -> None:
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await create_initiative(session, guild, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
+        owner.g("/documents/"),
+        headers=owner.headers,
         json={
             "title": "Bad scheme",
-            "initiative_id": initiative.id,
+            "initiative_id": owner.initiative.id,
             "document_type": "smart_link",
             "content": {"url": "ftp://example.com/file"},
         },

--- a/backend/app/api/v1/tenant_endpoints/documents_versions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_versions_test.py
@@ -19,14 +19,9 @@ from app.models.tenant.document import (
 from app.models.platform.guild import GuildRole
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.tenant.upload import Upload
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_initiative,
-    create_initiative_member,
+from app.testing import (
     create_user,
     get_auth_headers,
-    get_guild_headers,
 )
 
 PDF_BYTES = b"%PDF-1.4 first version body"
@@ -39,22 +34,18 @@ def _uploads_dir() -> Path:
     return path
 
 
-async def _setup_guild_with_owner(session: AsyncSession):
-    owner = await create_user(session)
-    guild = await create_guild(session, creator=owner)
-    await create_guild_membership(
-        session, user=owner, guild=guild, role=GuildRole.admin
-    )
-    initiative = await create_initiative(session, guild, owner)
-    return owner, guild, initiative
+async def _setup_guild_with_owner(acting_user):
+    """Owner is a guild admin and the initiative's project manager.
+
+    Returns ``(owner_actor, guild, initiative)`` for call-site compatibility."""
+    owner = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    return owner, owner.guild, owner.initiative
 
 
 async def _upload_initial_file_doc(
     client: AsyncClient,
-    session,
+    actor,
     *,
-    guild,
-    user,
     initiative,
     title: str = "Versioned Doc",
     content: bytes = PDF_BYTES,
@@ -62,10 +53,9 @@ async def _upload_initial_file_doc(
     content_type: str = "application/pdf",
 ) -> dict:
     """Create a file document through the real upload endpoint (creates v1)."""
-    headers = await get_guild_headers(session, guild, user)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/upload",
-        headers=headers,
+        actor.g("/documents/upload"),
+        headers=actor.headers,
         data={"title": title, "initiative_id": str(initiative.id)},
         files={"file": (filename, content, content_type)},
     )
@@ -75,17 +65,14 @@ async def _upload_initial_file_doc(
 
 @pytest.mark.integration
 async def test_initial_upload_creates_version_one(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Uploading a file document seeds version 1."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
-    headers = await get_guild_headers(session, guild, owner)
     resp = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions", headers=headers
+        owner.g(f"/documents/{doc['id']}/versions"), headers=owner.headers
     )
     assert resp.status_code == 200
     versions = resp.json()
@@ -103,23 +90,24 @@ async def test_initial_upload_creates_version_one(
 
 @pytest.mark.integration
 async def test_upload_version_creates_v2_and_mirrors_document(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A write user uploads v2; document mirror + Upload row + version row update."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    writer = await create_user(session)
-    await create_guild_membership(session, user=writer, guild=guild)
-    await create_initiative_member(session, initiative, writer)
-
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    writer = await acting_user(
+        guild_role=GuildRole.member,
+        guild=guild,
+        initiative=initiative,
+        initiative_role="member",
     )
+
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     # Grant the writer write access.
     session.add(
         ResourceGrant(
             resource_type="document",
             resource_id=doc["id"],
-            user_id=writer.id,
+            user_id=writer.user.id,
             level=ResourceAccessLevel.write,
             guild_id=guild.id,
             initiative_id=initiative.id,
@@ -127,10 +115,9 @@ async def test_upload_version_creates_v2_and_mirrors_document(
     )
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, writer)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=headers,
+        writer.g(f"/documents/{doc['id']}/versions"),
+        headers=writer.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
     assert resp.status_code == 201, resp.text
@@ -165,22 +152,23 @@ async def test_upload_version_creates_v2_and_mirrors_document(
 
 @pytest.mark.integration
 async def test_upload_version_read_user_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A read-only user cannot upload a new version."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    reader = await create_user(session)
-    await create_guild_membership(session, user=reader, guild=guild)
-    await create_initiative_member(session, initiative, reader)
-
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    reader = await acting_user(
+        guild_role=GuildRole.member,
+        guild=guild,
+        initiative=initiative,
+        initiative_role="member",
     )
+
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     session.add(
         ResourceGrant(
             resource_type="document",
             resource_id=doc["id"],
-            user_id=reader.id,
+            user_id=reader.user.id,
             level=ResourceAccessLevel.read,
             guild_id=guild.id,
             initiative_id=initiative.id,
@@ -188,10 +176,9 @@ async def test_upload_version_read_user_forbidden(
     )
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, reader)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=headers,
+        reader.g(f"/documents/{doc['id']}/versions"),
+        headers=reader.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
     assert resp.status_code == 403
@@ -208,18 +195,15 @@ async def test_upload_version_read_user_forbidden(
 
 @pytest.mark.integration
 async def test_upload_version_type_mismatch_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A new version must match the original file type."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
-    headers = await get_guild_headers(session, guild, owner)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("notes.txt", b"plain text not a pdf", "text/plain")},
     )
     assert resp.status_code == 400
@@ -237,22 +221,21 @@ async def test_upload_version_type_mismatch_rejected(
 
 @pytest.mark.integration
 async def test_upload_version_non_file_document_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ) -> None:
     """Native documents don't support versions."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    headers = await get_guild_headers(session, guild, owner)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
     create = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
+        owner.g("/documents/"),
+        headers=owner.headers,
         json={"title": "Native doc", "initiative_id": initiative.id},
     )
     assert create.status_code == 201
     native_id = create.json()["id"]
 
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{native_id}/versions",
-        headers=headers,
+        owner.g(f"/documents/{native_id}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
     assert resp.status_code == 400
@@ -260,7 +243,7 @@ async def test_upload_version_non_file_document_rejected(
 
     # Listing versions on a non-file document is rejected too.
     list_resp = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{native_id}/versions", headers=headers
+        owner.g(f"/documents/{native_id}/versions"), headers=owner.headers
     )
     assert list_resp.status_code == 400
     assert list_resp.json()["detail"] == "DOCUMENT_NOT_A_FILE_DOCUMENT"
@@ -268,18 +251,15 @@ async def test_upload_version_non_file_document_rejected(
 
 @pytest.mark.integration
 async def test_upload_version_unsupported_file_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """An unsupported/invalid file is rejected with a coded error."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
-    headers = await get_guild_headers(session, guild, owner)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={
             "file": (
                 "evil.exe",
@@ -303,22 +283,23 @@ async def test_upload_version_unsupported_file_rejected(
 
 @pytest.mark.integration
 async def test_list_versions_read_user_allowed_and_ordered(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Read users can list versions; newest first with is_current on the highest."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    reader = await create_user(session)
-    await create_guild_membership(session, user=reader, guild=guild)
-    await create_initiative_member(session, initiative, reader)
-
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    reader = await acting_user(
+        guild_role=GuildRole.member,
+        guild=guild,
+        initiative=initiative,
+        initiative_role="member",
     )
+
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     session.add(
         ResourceGrant(
             resource_type="document",
             resource_id=doc["id"],
-            user_id=reader.id,
+            user_id=reader.user.id,
             level=ResourceAccessLevel.read,
             guild_id=guild.id,
             initiative_id=initiative.id,
@@ -327,16 +308,14 @@ async def test_list_versions_read_user_allowed_and_ordered(
     await session.commit()
 
     # Owner uploads v2.
-    owner_headers = await get_guild_headers(session, guild, owner)
     await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=owner_headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
 
-    reader_headers = await get_guild_headers(session, guild, reader)
     resp = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions", headers=reader_headers
+        owner.g(f"/documents/{doc['id']}/versions"), headers=reader.headers
     )
     assert resp.status_code == 200
     versions = resp.json()
@@ -356,37 +335,34 @@ async def test_list_versions_read_user_allowed_and_ordered(
 
 @pytest.mark.integration
 async def test_download_specific_version_returns_its_bytes(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Downloading an old version returns that version's bytes, not the current one."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
-    guild_headers = await get_guild_headers(session, guild, owner)
     await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
 
     versions = (
         await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-            headers=guild_headers,
+            owner.g(f"/documents/{doc['id']}/versions"),
+            headers=owner.headers,
         )
     ).json()
     v1 = next(v for v in versions if v["version_number"] == 1)
     v2 = next(v for v in versions if v["version_number"] == 2)
 
-    auth_headers = get_auth_headers(owner)
+    auth_headers = get_auth_headers(owner.user)
     r1 = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/{v1['id']}/download",
+        owner.g(f"/documents/{doc['id']}/versions/{v1['id']}/download"),
         headers=auth_headers,
     )
     r2 = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/{v2['id']}/download",
+        owner.g(f"/documents/{doc['id']}/versions/{v2['id']}/download"),
         headers=auth_headers,
     )
     assert r1.status_code == 200 and r1.content == PDF_BYTES
@@ -404,17 +380,15 @@ async def test_download_specific_version_returns_its_bytes(
 
 @pytest.mark.integration
 async def test_download_version_unknown_returns_404(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A version id that doesn't belong to the document 404s."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
-    auth_headers = get_auth_headers(owner)
+    auth_headers = get_auth_headers(owner.user)
     resp = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/99999/download",
+        owner.g(f"/documents/{doc['id']}/versions/99999/download"),
         headers=auth_headers,
     )
     assert resp.status_code == 404
@@ -432,24 +406,22 @@ async def test_download_version_unknown_returns_404(
 
 @pytest.mark.integration
 async def test_download_version_cross_guild_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A user from another guild cannot download a version."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     versions = (
         await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-            headers=await get_guild_headers(session, guild, owner),
+            owner.g(f"/documents/{doc['id']}/versions"),
+            headers=owner.headers,
         )
     ).json()
     v1 = versions[0]
 
     outsider = await create_user(session)
     resp = await client.get(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/{v1['id']}/download",
+        owner.g(f"/documents/{doc['id']}/versions/{v1['id']}/download"),
         headers=get_auth_headers(outsider),
     )
     assert resp.status_code == 404
@@ -466,23 +438,20 @@ async def test_download_version_cross_guild_forbidden(
 
 @pytest.mark.integration
 async def test_delete_non_current_version_owner(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Owner deletes an old version; current stays, blob + Upload row removed."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
-    guild_headers = await get_guild_headers(session, guild, owner)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
     versions = (
         await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-            headers=guild_headers,
+            owner.g(f"/documents/{doc['id']}/versions"),
+            headers=owner.headers,
         )
     ).json()
     v1 = next(v for v in versions if v["version_number"] == 1)
@@ -496,8 +465,8 @@ async def test_delete_non_current_version_owner(
     v1_filename = v1_row.file_url.split("/")[-1]
 
     resp = await client.delete(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/{v1['id']}",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions/{v1['id']}"),
+        headers=owner.headers,
     )
     assert resp.status_code == 204
 
@@ -526,42 +495,34 @@ async def test_delete_non_current_version_owner(
 
 @pytest.mark.integration
 async def test_delete_current_version_promotes_previous(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Deleting the current version rolls the document back to the prior version."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
-    guild_headers = await get_guild_headers(session, guild, owner)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     v2_resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
     v2_id = v2_resp.json()["id"]
 
     resp = await client.delete(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/{v2_id}",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions/{v2_id}"),
+        headers=owner.headers,
     )
     assert resp.status_code == 204
 
-    # Document mirror reverts to v1. Capture guild.id first — expire_all() below
-    # expires the instance, and reading guild.id afterwards (outside an await)
-    # triggers a sync lazy-load (greenlet error).
-    guild_id = guild.id
+    # Document mirror reverts to v1. Capture the versions URL first — expire_all()
+    # below expires owner.guild, and building owner.g(...) afterwards would trigger
+    # a sync lazy-load of guild.id (greenlet error).
+    versions_url = owner.g(f"/documents/{doc['id']}/versions")
     session.expire_all()
     refreshed = await session.get(Document, doc["id"])
     assert refreshed.file_size == len(PDF_BYTES)
     assert refreshed.original_filename == "v1.pdf"
 
-    versions = (
-        await client.get(
-            f"/api/v1/g/{guild_id}/documents/{doc['id']}/versions",
-            headers=guild_headers,
-        )
-    ).json()
+    versions = (await client.get(versions_url, headers=owner.headers)).json()
     assert [v["version_number"] for v in versions] == [1]
     assert versions[0]["is_current"] is True
 
@@ -570,25 +531,22 @@ async def test_delete_current_version_promotes_previous(
 
 @pytest.mark.integration
 async def test_delete_last_version_blocked(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """The only remaining version can't be deleted."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
-    guild_headers = await get_guild_headers(session, guild, owner)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     versions = (
         await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-            headers=guild_headers,
+            owner.g(f"/documents/{doc['id']}/versions"),
+            headers=owner.headers,
         )
     ).json()
     v1_id = versions[0]["id"]
 
     resp = await client.delete(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/{v1_id}",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions/{v1_id}"),
+        headers=owner.headers,
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "DOCUMENT_CANNOT_DELETE_LAST_VERSION"
@@ -606,45 +564,45 @@ async def test_delete_last_version_blocked(
 
 @pytest.mark.integration
 async def test_delete_version_non_owner_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """A write (non-owner) user cannot delete versions."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    writer = await create_user(session)
-    await create_guild_membership(session, user=writer, guild=guild)
-    await create_initiative_member(session, initiative, writer)
-
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    writer = await acting_user(
+        guild_role=GuildRole.member,
+        guild=guild,
+        initiative=initiative,
+        initiative_role="member",
     )
+
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
     session.add(
         ResourceGrant(
             resource_type="document",
             resource_id=doc["id"],
-            user_id=writer.id,
+            user_id=writer.user.id,
             level=ResourceAccessLevel.write,
             guild_id=guild.id,
             initiative_id=initiative.id,
         )
     )
     await session.commit()
-    guild_headers = await get_guild_headers(session, guild, owner)
     await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
     versions = (
         await client.get(
-            f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-            headers=guild_headers,
+            owner.g(f"/documents/{doc['id']}/versions"),
+            headers=owner.headers,
         )
     ).json()
     v1_id = next(v for v in versions if v["version_number"] == 1)["id"]
 
     resp = await client.delete(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions/{v1_id}",
-        headers=await get_guild_headers(session, guild, writer),
+        writer.g(f"/documents/{doc['id']}/versions/{v1_id}"),
+        headers=writer.headers,
     )
     assert resp.status_code == 403
 
@@ -660,7 +618,7 @@ async def test_delete_version_non_owner_forbidden(
 
 @pytest.mark.integration
 async def test_upload_version_allowed_when_stored_content_type_is_null(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:
     """Legacy documents with NULL ``file_content_type`` still accept new versions.
 
@@ -668,10 +626,8 @@ async def test_upload_version_allowed_when_stored_content_type_is_null(
     mismatch the uploaded MIME type and permanently reject new versions
     with ``VERSION_TYPE_MISMATCH``.
     """
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
     # Simulate a legacy / backfilled row where the content type was never recorded.
     db_doc = await session.get(Document, doc["id"])
@@ -679,10 +635,9 @@ async def test_upload_version_allowed_when_stored_content_type_is_null(
     db_doc.file_content_type = None
     await session.commit()
 
-    guild_headers = await get_guild_headers(session, guild, owner)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=guild_headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", PDF_BYTES_V2, "application/pdf")},
     )
     assert resp.status_code == 201, resp.text
@@ -700,14 +655,13 @@ async def test_upload_version_allowed_when_stored_content_type_is_null(
 
 @pytest.mark.integration
 async def test_delete_version_non_file_document_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ) -> None:
     """Delete is rejected on non-file documents with the same code as upload/list."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    headers = await get_guild_headers(session, guild, owner)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
     create = await client.post(
-        f"/api/v1/g/{guild.id}/documents/",
-        headers=headers,
+        owner.g("/documents/"),
+        headers=owner.headers,
         json={"title": "Native doc", "initiative_id": initiative.id},
     )
     assert create.status_code == 201
@@ -715,8 +669,8 @@ async def test_delete_version_non_file_document_rejected(
 
     # Any version_id will do — the type check fires before the version lookup.
     resp = await client.delete(
-        f"/api/v1/g/{guild.id}/documents/{native_id}/versions/9999",
-        headers=headers,
+        owner.g(f"/documents/{native_id}/versions/9999"),
+        headers=owner.headers,
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "DOCUMENT_NOT_A_FILE_DOCUMENT"
@@ -734,19 +688,21 @@ _TINY_PDF = b"%PDF-1.4 tiny body for size tests"
 
 @pytest.mark.integration
 async def test_upload_document_file_over_limit_rejected(
-    client: AsyncClient, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    client: AsyncClient,
+    session: AsyncSession,
+    acting_user,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """POST /documents/upload rejects a body over the cap with 413."""
     cap = 1024
     monkeypatch.setattr(attachments_service, "MAX_DOCUMENT_FILE_SIZE", cap)
 
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    headers = await get_guild_headers(session, guild, owner)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
 
     oversized = b"%PDF-1.4 " + b"A" * (cap + 1)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/upload",
-        headers=headers,
+        owner.g("/documents/upload"),
+        headers=owner.headers,
         data={"title": "Too big", "initiative_id": str(initiative.id)},
         files={"file": ("big.pdf", oversized, "application/pdf")},
     )
@@ -765,20 +721,22 @@ async def test_upload_document_file_over_limit_rejected(
 
 @pytest.mark.integration
 async def test_upload_document_file_just_under_limit_succeeds(
-    client: AsyncClient, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    client: AsyncClient,
+    session: AsyncSession,
+    acting_user,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """POST /documents/upload accepts a body at/under the cap."""
     cap = 4096
     monkeypatch.setattr(attachments_service, "MAX_DOCUMENT_FILE_SIZE", cap)
 
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    headers = await get_guild_headers(session, guild, owner)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
 
     under = _TINY_PDF + b" " + b"B" * (cap - len(_TINY_PDF) - 1)
     assert len(under) == cap
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/upload",
-        headers=headers,
+        owner.g("/documents/upload"),
+        headers=owner.headers,
         data={"title": "Under cap", "initiative_id": str(initiative.id)},
         files={"file": ("under.pdf", under, "application/pdf")},
     )
@@ -799,23 +757,23 @@ async def test_upload_document_file_just_under_limit_succeeds(
 
 @pytest.mark.integration
 async def test_upload_document_version_over_limit_rejected(
-    client: AsyncClient, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    client: AsyncClient,
+    session: AsyncSession,
+    acting_user,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """POST /documents/{id}/versions rejects a body over the cap with 413."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
     # Seed v1 while the cap is still large so the document exists.
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
     cap = 1024
     monkeypatch.setattr(attachments_service, "MAX_DOCUMENT_FILE_SIZE", cap)
 
-    headers = await get_guild_headers(session, guild, owner)
     oversized = b"%PDF-1.4 " + b"A" * (cap + 1)
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("big.pdf", oversized, "application/pdf")},
     )
 
@@ -837,23 +795,23 @@ async def test_upload_document_version_over_limit_rejected(
 
 @pytest.mark.integration
 async def test_upload_document_version_just_under_limit_succeeds(
-    client: AsyncClient, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    client: AsyncClient,
+    session: AsyncSession,
+    acting_user,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """POST /documents/{id}/versions accepts a body at/under the cap."""
-    owner, guild, initiative = await _setup_guild_with_owner(session)
-    doc = await _upload_initial_file_doc(
-        client, session, guild=guild, user=owner, initiative=initiative
-    )
+    owner, guild, initiative = await _setup_guild_with_owner(acting_user)
+    doc = await _upload_initial_file_doc(client, owner, initiative=initiative)
 
     cap = 4096
     monkeypatch.setattr(attachments_service, "MAX_DOCUMENT_FILE_SIZE", cap)
 
-    headers = await get_guild_headers(session, guild, owner)
     under = _TINY_PDF + b" " + b"B" * (cap - len(_TINY_PDF) - 1)
     assert len(under) == cap
     resp = await client.post(
-        f"/api/v1/g/{guild.id}/documents/{doc['id']}/versions",
-        headers=headers,
+        owner.g(f"/documents/{doc['id']}/versions"),
+        headers=owner.headers,
         files={"file": ("v2.pdf", under, "application/pdf")},
     )
 

--- a/backend/app/api/v1/tenant_endpoints/events_properties_test.py
+++ b/backend/app/api/v1/tenant_endpoints/events_properties_test.py
@@ -24,30 +24,30 @@ from app.models.tenant.property import (
 )
 from app.testing import (
     create_calendar_event,
-    create_guild,
     create_guild_membership,
     create_initiative,
     create_property_definition,
     create_user,
-    get_guild_headers,
 )
 
 
-async def _setup_event(session: AsyncSession, *, initiative_name: str = "Init"):
-    """Boilerplate: admin user, guild, events-enabled initiative, event.
-
-    Returns ``(user, guild, initiative, event)``.
-    """
-    user = await create_user(session, email=f"u-{initiative_name}@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name=initiative_name)
+async def _enable_events(session: AsyncSession, initiative):
+    """Toggle the events feature flag on and persist it."""
     initiative.events_enabled = True
     session.add(initiative)
     await session.commit()
     await session.refresh(initiative)
-    event = await create_calendar_event(session, initiative, user, title="E")
-    return user, guild, initiative, event
+
+
+async def _setup_event(session, acting_user):
+    """Boilerplate: admin user, guild, events-enabled initiative, event.
+
+    Returns ``(actor, initiative, event)`` — ``actor`` carries user/guild/headers.
+    """
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_events(session, a.initiative)
+    event = await create_calendar_event(session, a.initiative, a.user, title="E")
+    return a, a.initiative, event
 
 
 # ---------------------------------------------------------------------------
@@ -57,9 +57,9 @@ async def _setup_event(session: AsyncSession, *, initiative_name: str = "Init"):
 
 @pytest.mark.integration
 async def test_put_event_properties_sets_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, event = await _setup_event(session)
+    a, initiative, event = await _setup_event(session, acting_user)
 
     text_defn = await create_property_definition(
         session, initiative, name="Note", type=PropertyType.text
@@ -68,10 +68,9 @@ async def test_put_event_properties_sets_values(
         session, initiative, name="Score", type=PropertyType.number
     )
 
-    headers = await get_guild_headers(session, guild, user)
     response = await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={
             "values": [
                 {"property_id": text_defn.id, "value": "alpha"},
@@ -88,23 +87,22 @@ async def test_put_event_properties_sets_values(
 
 @pytest.mark.integration
 async def test_put_event_properties_empty_clears_existing(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, event = await _setup_event(session)
+    a, initiative, event = await _setup_event(session, acting_user)
 
     defn = await create_property_definition(
         session, initiative, name="Tag", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "seed"}]},
     )
     response = await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={"values": []},
     )
 
@@ -120,18 +118,17 @@ async def test_put_event_properties_empty_clears_existing(
 
 @pytest.mark.integration
 async def test_put_event_properties_attach_without_value_persists_row(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Attaching without a value should still create the attached-empty row."""
-    user, guild, initiative, event = await _setup_event(session)
+    a, initiative, event = await _setup_event(session, acting_user)
     defn = await create_property_definition(
         session, initiative, name="Empty", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     response = await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": None}]},
     )
     assert response.status_code == 200
@@ -152,16 +149,16 @@ async def test_put_event_properties_attach_without_value_persists_row(
 
 @pytest.mark.integration
 async def test_put_event_date_rejects_garbage(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, event = await _setup_event(session)
+    a, initiative, event = await _setup_event(session, acting_user)
     defn = await create_property_definition(
         session, initiative, name="D", type=PropertyType.date
     )
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "not-a-date"}]},
     )
     assert response.status_code == 400
@@ -170,13 +167,13 @@ async def test_put_event_date_rejects_garbage(
 
 @pytest.mark.integration
 async def test_put_event_user_reference_non_initiative_member_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, event = await _setup_event(session)
+    a, initiative, event = await _setup_event(session, acting_user)
 
     outsider = await create_user(session, email="outsider@example.com")
     await create_guild_membership(
-        session, user=outsider, guild=guild, role=GuildRole.member
+        session, user=outsider, guild=a.guild, role=GuildRole.member
     )
 
     defn = await create_property_definition(
@@ -184,8 +181,8 @@ async def test_put_event_user_reference_non_initiative_member_rejected(
     )
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": outsider.id}]},
     )
     assert response.status_code == 400
@@ -199,26 +196,20 @@ async def test_put_event_user_reference_non_initiative_member_rejected(
 
 @pytest.mark.integration
 async def test_put_event_cross_initiative_definition_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A definition from initiative B can't be attached to an event in A."""
-    user = await create_user(session, email="u@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-
-    init_a = await create_initiative(session, guild, user, name="A")
-    init_a.events_enabled = True
-    init_b = await create_initiative(session, guild, user, name="B")
-    session.add(init_a)
-    await session.commit()
-    await session.refresh(init_a)
-    event_a = await create_calendar_event(session, init_a, user, title="Ea")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    init_a = a.initiative
+    await _enable_events(session, init_a)
+    init_b = await create_initiative(session, a.guild, a.user, name="B")
+    event_a = await create_calendar_event(session, init_a, a.user, title="Ea")
 
     defn_b = await create_property_definition(session, init_b, name="Foreign")
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event_a.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/calendar-events/{event_a.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn_b.id, "value": "x"}]},
     )
     assert response.status_code == 404
@@ -232,23 +223,20 @@ async def test_put_event_cross_initiative_definition_rejected(
 
 @pytest.mark.integration
 async def test_event_read_embeds_property_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, event = await _setup_event(session)
+    a, initiative, event = await _setup_event(session, acting_user)
     defn = await create_property_definition(
         session, initiative, name="Topic", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "onboarding"}]},
     )
 
-    read_resp = await client.get(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}", headers=headers
-    )
+    read_resp = await client.get(a.g(f"/calendar-events/{event.id}"), headers=a.headers)
     assert read_resp.status_code == 200
     body = read_resp.json()
     assert body["property_values"][0]["value"] == "onboarding"
@@ -256,26 +244,25 @@ async def test_event_read_embeds_property_values(
 
 @pytest.mark.integration
 async def test_list_events_filter_by_property_text_eq(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, _ = await _setup_event(session)
+    a, initiative, _ = await _setup_event(session, acting_user)
 
-    match = await create_calendar_event(session, initiative, user, title="Match")
-    skip = await create_calendar_event(session, initiative, user, title="Skip")
+    match = await create_calendar_event(session, initiative, a.user, title="Match")
+    skip = await create_calendar_event(session, initiative, a.user, title="Skip")
 
     defn = await create_property_definition(
         session, initiative, name="Topic", type=PropertyType.text
     )
-    headers = await get_guild_headers(session, guild, user)
 
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{match.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{match.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "findme"}]},
     )
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{skip.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{skip.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "other"}]},
     )
 
@@ -283,9 +270,11 @@ async def test_list_events_filter_by_property_text_eq(
         [{"property_id": defn.id, "op": "eq", "value": "findme"}]
     )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/calendar-events/?initiative_id={initiative.id}"
-        f"&property_filters={property_filters}",
-        headers=headers,
+        a.g(
+            f"/calendar-events/?initiative_id={initiative.id}"
+            f"&property_filters={property_filters}"
+        ),
+        headers=a.headers,
     )
     assert response.status_code == 200
     ids = {item["id"] for item in response.json()["items"]}
@@ -295,23 +284,24 @@ async def test_list_events_filter_by_property_text_eq(
 
 @pytest.mark.integration
 async def test_list_events_filter_is_empty_matches_unset(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative, _ = await _setup_event(session)
+    a, initiative, _ = await _setup_event(session, acting_user)
 
-    with_value = await create_calendar_event(session, initiative, user, title="WithVal")
+    with_value = await create_calendar_event(
+        session, initiative, a.user, title="WithVal"
+    )
     without_value = await create_calendar_event(
-        session, initiative, user, title="Blank"
+        session, initiative, a.user, title="Blank"
     )
 
     defn = await create_property_definition(
         session, initiative, name="Topic", type=PropertyType.text
     )
-    headers = await get_guild_headers(session, guild, user)
 
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{with_value.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{with_value.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "yes"}]},
     )
 
@@ -319,9 +309,11 @@ async def test_list_events_filter_is_empty_matches_unset(
         [{"property_id": defn.id, "op": "is_null", "value": True}]
     )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/calendar-events/?initiative_id={initiative.id}"
-        f"&property_filters={property_filters}",
-        headers=headers,
+        a.g(
+            f"/calendar-events/?initiative_id={initiative.id}"
+            f"&property_filters={property_filters}"
+        ),
+        headers=a.headers,
     )
     assert response.status_code == 200
     ids = {item["id"] for item in response.json()["items"]}
@@ -336,27 +328,26 @@ async def test_list_events_filter_is_empty_matches_unset(
 
 @pytest.mark.integration
 async def test_initiative_purge_cascades_event_property_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Soft-deleting then hard-purging an initiative should cascade-delete
     event property values via FK CASCADE. (Soft-delete alone keeps the
     rows so a restore brings everything back.)"""
-    user, guild, initiative, event = await _setup_event(session)
+    a, initiative, event = await _setup_event(session, acting_user)
     defn = await create_property_definition(
         session, initiative, name="Topic", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     await client.put(
-        f"/api/v1/g/{guild.id}/calendar-events/{event.id}/properties",
-        headers=headers,
+        a.g(f"/calendar-events/{event.id}/properties"),
+        headers=a.headers,
         json={"values": [{"property_id": defn.id, "value": "hold"}]},
     )
 
     # 1. Soft-delete the initiative — property values must still exist so
     # a restore brings them back.
     delete_resp = await client.delete(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}", headers=headers
+        a.g(f"/initiatives/{initiative.id}"), headers=a.headers
     )
     assert delete_resp.status_code in (200, 204)
     rows = await session.exec(
@@ -369,7 +360,7 @@ async def test_initiative_purge_cascades_event_property_values(
     # 2. Hard-purge via the admin trash endpoint — FK CASCADE drops the
     # event property values along with the initiative + descendants.
     purge_resp = await client.delete(
-        f"/api/v1/g/{guild.id}/trash/initiative/{initiative.id}/purge", headers=headers
+        a.g(f"/trash/initiative/{initiative.id}/purge"), headers=a.headers
     )
     assert purge_resp.status_code == 204
     rows = await session.exec(

--- a/backend/app/api/v1/tenant_endpoints/imports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/imports_test.py
@@ -2,27 +2,17 @@
 
 import pytest
 from httpx import AsyncClient
-from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.testing import (
-    create_guild,
-    create_guild_membership,
-    create_user,
-    get_auth_headers,
-)
+from app.models.platform.guild import GuildRole
 
 
 @pytest.mark.integration
-async def test_todoist_parse_bad_csv_opaque_error(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_todoist_parse_bad_csv_opaque_error(client: AsyncClient, acting_user):
     """Todoist CSV with a non-numeric INDENT triggers ValueError, returns the opaque constant."""
-    user = await create_user(session)
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/imports/todoist/parse",
-        headers={**get_auth_headers(user), "Content-Type": "text/plain"},
+        a.g("/imports/todoist/parse"),
+        headers={**a.headers, "Content-Type": "text/plain"},
         content=b"TYPE,CONTENT,INDENT\ntask,My Task,not-a-number",
     )
     assert response.status_code == 400
@@ -33,16 +23,12 @@ async def test_todoist_parse_bad_csv_opaque_error(
 
 
 @pytest.mark.integration
-async def test_vikunja_parse_bad_json_opaque_error(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_vikunja_parse_bad_json_opaque_error(client: AsyncClient, acting_user):
     """Malformed Vikunja JSON returns the constant, not a raw exception."""
-    user = await create_user(session)
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/imports/vikunja/parse",
-        headers={**get_auth_headers(user), "Content-Type": "text/plain"},
+        a.g("/imports/vikunja/parse"),
+        headers={**a.headers, "Content-Type": "text/plain"},
         content=b"this is not json }{{{",
     )
     assert response.status_code == 400
@@ -50,16 +36,12 @@ async def test_vikunja_parse_bad_json_opaque_error(
 
 
 @pytest.mark.integration
-async def test_ticktick_parse_bad_csv_opaque_error(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_ticktick_parse_bad_csv_opaque_error(client: AsyncClient, acting_user):
     """Malformed TickTick CSV returns the constant, not a raw exception."""
-    user = await create_user(session)
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/imports/ticktick/parse",
-        headers={**get_auth_headers(user), "Content-Type": "text/plain"},
+        a.g("/imports/ticktick/parse"),
+        headers={**a.headers, "Content-Type": "text/plain"},
         content=b"\x00\x01\x02\x03binary garbage",
     )
     assert response.status_code == 400

--- a/backend/app/api/v1/tenant_endpoints/initiative_share_override_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiative_share_override_test.py
@@ -25,14 +25,6 @@ from app.services.permissions import (
     compute_permission,
     request_bypasses_dac,
 )
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_initiative,
-    create_initiative_member,
-    create_user,
-    get_guild_headers,
-)
 
 
 async def _role_by_name(session: AsyncSession, initiative, name: str):
@@ -46,26 +38,28 @@ async def _role_by_name(session: AsyncSession, initiative, name: str):
     ).one()
 
 
-async def _setup(session: AsyncSession):
+async def _setup(session: AsyncSession, acting_user):
     """admin = guild admin + initiative creator (PM); owner = a PM who owns a
     restricted project; pm = a PM whose access we toggle via the override."""
-    admin = await create_user(session, email="admin@example.com")
-    owner = await create_user(session, email="owner@example.com")
-    pm = await create_user(session, email="pm@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(
+        guild_role=GuildRole.admin, initiative=True, email="admin@example.com"
     )
-    await create_guild_membership(
-        session, user=owner, guild=guild, role=GuildRole.member
+    initiative = admin.initiative  # admin -> PM
+    owner = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative,
+        initiative_role="project_manager",
+        email="owner@example.com",
     )
-    await create_guild_membership(session, user=pm, guild=guild, role=GuildRole.member)
-    initiative = await create_initiative(session, guild, admin)  # admin -> PM
-    await create_initiative_member(
-        session, initiative, owner, role_name="project_manager"
+    pm = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative,
+        initiative_role="project_manager",
+        email="pm@example.com",
     )
-    await create_initiative_member(session, initiative, pm, role_name="project_manager")
-    return admin, owner, pm, guild, initiative
+    return admin, owner, pm, admin.guild, initiative
 
 
 # ── Enforcement: the gate-4 override leg (unit) ──────────────────────────────
@@ -114,12 +108,12 @@ def test_request_overrides_sharing_bypasses_dac():
 
 @pytest.mark.integration
 async def test_full_access_pm_reaches_restricted_content(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    admin, owner, pm, guild, initiative = await _setup(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
-    owner_headers = await get_guild_headers(session, guild, owner)
-    pm_headers = await get_guild_headers(session, guild, pm)
+    admin, owner, pm, guild, initiative = await _setup(session, acting_user)
+    admin_headers = admin.headers
+    owner_headers = owner.headers
+    pm_headers = pm.headers
 
     # owner (a PM/manager) creates a RESTRICTED project: grants=[] drops the
     # default all-members Viewer grant, so only the owner can reach it.
@@ -182,10 +176,10 @@ async def test_full_access_pm_reaches_restricted_content(
 
 @pytest.mark.integration
 async def test_only_guild_admin_can_grant_full_access(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    admin, owner, pm, guild, initiative = await _setup(session)
-    pm_headers = await get_guild_headers(session, guild, pm)
+    admin, owner, pm, guild, initiative = await _setup(session, acting_user)
+    pm_headers = pm.headers
     pm_role = await _role_by_name(session, initiative, "project_manager")
 
     # pm is an initiative manager (can edit roles) but NOT a guild admin — it must
@@ -200,9 +194,11 @@ async def test_only_guild_admin_can_grant_full_access(
 
 
 @pytest.mark.integration
-async def test_full_access_only_on_pm_role(client: AsyncClient, session: AsyncSession):
-    admin, owner, pm, guild, initiative = await _setup(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
+async def test_full_access_only_on_pm_role(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    admin, owner, pm, guild, initiative = await _setup(session, acting_user)
+    admin_headers = admin.headers
 
     # The built-in "member" role is ineligible — 422.
     member_role = await _role_by_name(session, initiative, "member")

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -14,34 +14,21 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_initiative_member,
-    create_user,
-    get_guild_headers,
-)
+from app.testing.factories import create_initiative
 
 
 @pytest.mark.integration
 async def test_list_initiatives_as_admin_shows_all(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that guild admin can see all initiatives."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
 
     # Create multiple initiatives (factory creates builtin roles + PM membership)
-    await create_initiative(session, guild, admin, name="Initiative 1")
-    await create_initiative(session, guild, admin, name="Initiative 2")
+    await create_initiative(session, admin.guild, admin.user, name="Initiative 1")
+    await create_initiative(session, admin.guild, admin.user, name="Initiative 2")
 
-    headers = await get_guild_headers(session, guild, admin)
-    response = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
+    response = await client.get(admin.g("/initiatives/"), headers=admin.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -53,32 +40,26 @@ async def test_list_initiatives_as_admin_shows_all(
 
 @pytest.mark.integration
 async def test_list_initiatives_as_member_shows_only_membership(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that regular members only see initiatives they're part of."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=member, guild=guild, role=GuildRole.member
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
 
     # Create two initiatives
     initiative1 = await create_initiative(
-        session, guild, admin, name="Member's Initiative"
+        session, admin.guild, admin.user, name="Member's Initiative"
     )
-    await create_initiative(session, guild, admin, name="Other Initiative")
+    await create_initiative(session, admin.guild, admin.user, name="Other Initiative")
 
     # Add member to only initiative1
-    await create_initiative_member(session, initiative1, member, role_name="member")
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative1,
+        initiative_role="member",
+    )
 
-    headers = await get_guild_headers(session, guild, member)
-    response = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
+    response = await client.get(member.g("/initiatives/"), headers=member.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -88,15 +69,12 @@ async def test_list_initiatives_as_member_shows_only_membership(
 
 
 @pytest.mark.integration
-async def test_create_initiative_as_admin(client: AsyncClient, session: AsyncSession):
+async def test_create_initiative_as_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that guild admin can create initiatives."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "name": "New Initiative",
         "description": "A test initiative",
@@ -104,7 +82,7 @@ async def test_create_initiative_as_admin(client: AsyncClient, session: AsyncSes
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/", headers=headers, json=payload
+        admin.g("/initiatives/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -116,20 +94,15 @@ async def test_create_initiative_as_admin(client: AsyncClient, session: AsyncSes
 
 @pytest.mark.integration
 async def test_create_initiative_as_member_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that regular members cannot create initiatives."""
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=member, guild=guild, role=GuildRole.member
-    )
+    member = await acting_user(guild_role=GuildRole.member)
 
-    headers = await get_guild_headers(session, guild, member)
     payload = {"name": "New Initiative"}
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/", headers=headers, json=payload
+        member.g("/initiatives/"), headers=member.headers, json=payload
     )
 
     assert response.status_code == 403
@@ -137,25 +110,20 @@ async def test_create_initiative_as_member_forbidden(
 
 @pytest.mark.integration
 async def test_create_initiative_duplicate_name_fails(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that duplicate initiative names are rejected."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
 
     # Create first initiative
-    await create_initiative(session, guild, admin, name="Existing Initiative")
+    await create_initiative(
+        session, admin.guild, admin.user, name="Existing Initiative"
+    )
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {"name": "Existing Initiative"}
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/", headers=headers, json=payload
+        admin.g("/initiatives/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 409
@@ -164,50 +132,37 @@ async def test_create_initiative_duplicate_name_fails(
 
 @pytest.mark.integration
 async def test_create_initiative_makes_creator_manager(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that creating an initiative makes the creator a manager."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {"name": "New Initiative"}
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/", headers=headers, json=payload
+        admin.g("/initiatives/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
     data = response.json()
     assert len(data["members"]) == 1
-    assert data["members"][0]["user"]["id"] == admin.id
+    assert data["members"][0]["user"]["id"] == admin.user.id
     assert data["members"][0]["role"] == "project_manager"
 
 
 @pytest.mark.integration
-async def test_update_initiative_as_manager(client: AsyncClient, session: AsyncSession):
+async def test_update_initiative_as_manager(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that initiative manager can update initiative."""
-    from app.testing.factories import create_initiative
+    # A plain guild member who creates (and therefore manages) an initiative.
+    manager = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    manager = await create_user(session, email="manager@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=manager, guild=guild, role=GuildRole.member
-    )
-
-    initiative = await create_initiative(
-        session, guild, manager, name="Test Initiative"
-    )
-
-    headers = await get_guild_headers(session, guild, manager)
     payload = {"name": "Updated Initiative", "description": "Updated description"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
-        headers=headers,
+        manager.g(f"/initiatives/{manager.initiative.id}"),
+        headers=manager.headers,
         json=payload,
     )
 
@@ -218,30 +173,18 @@ async def test_update_initiative_as_manager(client: AsyncClient, session: AsyncS
 
 
 @pytest.mark.integration
-async def test_update_initiative_as_admin(client: AsyncClient, session: AsyncSession):
+async def test_update_initiative_as_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that guild admin can update any initiative."""
-    from app.testing.factories import create_initiative
+    manager = await acting_user(guild_role=GuildRole.member, initiative=True)
+    admin = await acting_user(guild_role=GuildRole.admin, guild=manager.guild)
 
-    admin = await create_user(session, email="admin@example.com")
-    manager = await create_user(session, email="manager@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=manager, guild=guild, role=GuildRole.member
-    )
-
-    initiative = await create_initiative(
-        session, guild, manager, name="Manager's Initiative"
-    )
-
-    headers = await get_guild_headers(session, guild, admin)
     payload = {"name": "Admin Updated"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
-        headers=headers,
+        admin.g(f"/initiatives/{manager.initiative.id}"),
+        headers=admin.headers,
         json=payload,
     )
 
@@ -252,30 +195,22 @@ async def test_update_initiative_as_admin(client: AsyncClient, session: AsyncSes
 
 @pytest.mark.integration
 async def test_update_initiative_as_regular_member_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that regular members cannot update initiatives."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=member, guild=guild, role=GuildRole.member
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
 
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    await create_initiative_member(session, initiative, member, role_name="member")
-
-    headers = await get_guild_headers(session, guild, member)
     payload = {"name": "Hacked Name"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
-        headers=headers,
+        member.g(f"/initiatives/{admin.initiative.id}"),
+        headers=member.headers,
         json=payload,
     )
 
@@ -284,26 +219,21 @@ async def test_update_initiative_as_regular_member_forbidden(
 
 @pytest.mark.integration
 async def test_update_initiative_duplicate_name_fails(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that renaming to existing name fails."""
-    from app.testing.factories import create_initiative
+    admin = await acting_user(guild_role=GuildRole.admin)
 
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    initiative1 = await create_initiative(
+        session, admin.guild, admin.user, name="Initiative 1"
     )
+    await create_initiative(session, admin.guild, admin.user, name="Initiative 2")
 
-    initiative1 = await create_initiative(session, guild, admin, name="Initiative 1")
-    await create_initiative(session, guild, admin, name="Initiative 2")
-
-    headers = await get_guild_headers(session, guild, admin)
     payload = {"name": "Initiative 2"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative1.id}",
-        headers=headers,
+        admin.g(f"/initiatives/{initiative1.id}"),
+        headers=admin.headers,
         json=payload,
     )
 
@@ -315,21 +245,14 @@ async def test_update_initiative_duplicate_name_fails(
 
 @pytest.mark.integration
 async def test_initiative_is_archived_defaults_false(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A freshly created initiative is not archived."""
-    from app.testing.factories import create_initiative
+    admin = await acting_user(guild_role=GuildRole.admin)
+    initiative = await create_initiative(session, admin.guild, admin.user, name="Fresh")
 
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    initiative = await create_initiative(session, guild, admin, name="Fresh")
-
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.get(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}", headers=headers
+        admin.g(f"/initiatives/{initiative.id}"), headers=admin.headers
     )
 
     assert response.status_code == 200
@@ -337,22 +260,19 @@ async def test_initiative_is_archived_defaults_false(
 
 
 @pytest.mark.integration
-async def test_archive_initiative_via_patch(client: AsyncClient, session: AsyncSession):
+async def test_archive_initiative_via_patch(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """A guild admin can archive (and unarchive) an initiative through PATCH; it
     stays in the list either way (the settings table manages it there)."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin)
+    initiative = await create_initiative(
+        session, admin.guild, admin.user, name="Archivable"
     )
-    initiative = await create_initiative(session, guild, admin, name="Archivable")
-    headers = await get_guild_headers(session, guild, admin)
 
     archive = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
-        headers=headers,
+        admin.g(f"/initiatives/{initiative.id}"),
+        headers=admin.headers,
         json={"is_archived": True},
     )
     assert archive.status_code == 200
@@ -360,14 +280,14 @@ async def test_archive_initiative_via_patch(client: AsyncClient, session: AsyncS
 
     # Archived initiatives are NOT removed from the list — only the sidebar
     # filters them client-side; the settings table must still see them.
-    listing = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
+    listing = await client.get(admin.g("/initiatives/"), headers=admin.headers)
     assert listing.status_code == 200
     archived = next(i for i in listing.json() if i["id"] == initiative.id)
     assert archived["is_archived"] is True
 
     unarchive = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
-        headers=headers,
+        admin.g(f"/initiatives/{initiative.id}"),
+        headers=admin.headers,
         json={"is_archived": False},
     )
     assert unarchive.status_code == 200
@@ -376,33 +296,25 @@ async def test_archive_initiative_via_patch(client: AsyncClient, session: AsyncS
 
 @pytest.mark.integration
 async def test_archive_initiative_as_manager_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Archiving is guild-admin only. A plain initiative manager (who may edit
     other settings here) is rejected when toggling is_archived."""
-    from app.testing.factories import create_initiative
-
-    manager = await create_user(session, email="manager@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=manager, guild=guild, role=GuildRole.member
-    )
     # Creator becomes the initiative's PM (manager) but is not a guild admin.
-    initiative = await create_initiative(session, guild, manager, name="Managed")
-    headers = await get_guild_headers(session, guild, manager)
+    manager = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     # A non-archive edit still works for a manager...
     ok = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
-        headers=headers,
+        manager.g(f"/initiatives/{manager.initiative.id}"),
+        headers=manager.headers,
         json={"description": "Edited by manager"},
     )
     assert ok.status_code == 200
 
     # ...but flipping is_archived is admin-only.
     forbidden = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
-        headers=headers,
+        manager.g(f"/initiatives/{manager.initiative.id}"),
+        headers=manager.headers,
         json={"is_archived": True},
     )
     assert forbidden.status_code == 403
@@ -410,21 +322,17 @@ async def test_archive_initiative_as_manager_forbidden(
 
 
 @pytest.mark.integration
-async def test_delete_initiative_as_admin(client: AsyncClient, session: AsyncSession):
+async def test_delete_initiative_as_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that guild admin can delete initiatives."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin)
+    initiative = await create_initiative(
+        session, admin.guild, admin.user, name="To Delete"
     )
 
-    initiative = await create_initiative(session, guild, admin, name="To Delete")
-
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}", headers=headers
+        admin.g(f"/initiatives/{initiative.id}"), headers=admin.headers
     )
 
     assert response.status_code == 204
@@ -432,24 +340,13 @@ async def test_delete_initiative_as_admin(client: AsyncClient, session: AsyncSes
 
 @pytest.mark.integration
 async def test_delete_initiative_as_manager_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that initiative manager cannot delete initiatives."""
-    from app.testing.factories import create_initiative
+    manager = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    manager = await create_user(session, email="manager@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=manager, guild=guild, role=GuildRole.member
-    )
-
-    initiative = await create_initiative(
-        session, guild, manager, name="Test Initiative"
-    )
-
-    headers = await get_guild_headers(session, guild, manager)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}", headers=headers
+        manager.g(f"/initiatives/{manager.initiative.id}"), headers=manager.headers
     )
 
     assert response.status_code == 403
@@ -457,25 +354,18 @@ async def test_delete_initiative_as_manager_forbidden(
 
 @pytest.mark.integration
 async def test_delete_default_initiative_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that default initiative cannot be deleted."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
 
     # Create and mark as default
     initiative = await create_initiative(
-        session, guild, admin, name="Default Initiative", is_default=True
+        session, admin.guild, admin.user, name="Default Initiative", is_default=True
     )
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}", headers=headers
+        admin.g(f"/initiatives/{initiative.id}"), headers=admin.headers
     )
 
     assert response.status_code == 400
@@ -483,102 +373,85 @@ async def test_delete_default_initiative_forbidden(
 
 
 @pytest.mark.integration
-async def test_get_initiative_members(client: AsyncClient, session: AsyncSession):
+async def test_get_initiative_members(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test getting all members of an initiative."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    member1 = await create_user(
-        session, email="member1@example.com", full_name="Member One"
+    admin = await acting_user(guild_role=GuildRole.admin)
+    initiative = await create_initiative(
+        session, admin.guild, admin.user, name="Test Initiative"
     )
-    member2 = await create_user(
-        session, email="member2@example.com", full_name="Member Two"
+    member1 = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative,
+        initiative_role="member",
+        email="member1@example.com",
+        full_name="Member One",
     )
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    member2 = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative,
+        initiative_role="member",
+        email="member2@example.com",
+        full_name="Member Two",
     )
-    await create_guild_membership(session, user=member1, guild=guild)
-    await create_guild_membership(session, user=member2, guild=guild)
 
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    await create_initiative_member(session, initiative, member1, role_name="member")
-    await create_initiative_member(session, initiative, member2, role_name="member")
-
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.get(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members", headers=headers
+        admin.g(f"/initiatives/{initiative.id}/members"), headers=admin.headers
     )
 
     assert response.status_code == 200
     data = response.json()
     assert len(data) >= 3
     emails = {user["email"] for user in data}
-    assert "admin@example.com" in emails
-    assert "member1@example.com" in emails
-    assert "member2@example.com" in emails
+    assert admin.user.email in emails
+    assert member1.user.email in emails
+    assert member2.user.email in emails
 
 
 @pytest.mark.integration
 async def test_add_initiative_member_as_manager(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that manager can add members to initiative."""
-    from app.testing.factories import create_initiative
+    manager = await acting_user(guild_role=GuildRole.member, initiative=True)
+    new_member = await acting_user(guild_role=GuildRole.member, guild=manager.guild)
 
-    manager = await create_user(session, email="manager@example.com")
-    new_member = await create_user(session, email="newmember@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=manager, guild=guild, role=GuildRole.member
-    )
-    await create_guild_membership(session, user=new_member, guild=guild)
-
-    initiative = await create_initiative(
-        session, guild, manager, name="Test Initiative"
-    )
-
-    headers = await get_guild_headers(session, guild, manager)
-    payload = {"user_id": new_member.id, "role": "member"}
+    payload = {"user_id": new_member.user.id, "role": "member"}
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members",
-        headers=headers,
+        manager.g(f"/initiatives/{manager.initiative.id}/members"),
+        headers=manager.headers,
         json=payload,
     )
 
     assert response.status_code == 200
     data = response.json()
     member_ids = {m["user"]["id"] for m in data["members"]}
-    assert new_member.id in member_ids
+    assert new_member.user.id in member_ids
 
 
 @pytest.mark.integration
 async def test_add_initiative_member_as_regular_member_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that regular members cannot add members."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    new_member = await create_user(session, email="newmember@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
-    await create_guild_membership(session, user=new_member, guild=guild)
+    new_member = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
 
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    await create_initiative_member(session, initiative, member, role_name="member")
-
-    headers = await get_guild_headers(session, guild, member)
-    payload = {"user_id": new_member.id, "role": "member"}
+    payload = {"user_id": new_member.user.id, "role": "member"}
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members",
-        headers=headers,
+        member.g(f"/initiatives/{admin.initiative.id}/members"),
+        headers=member.headers,
         json=payload,
     )
 
@@ -586,25 +459,19 @@ async def test_add_initiative_member_as_regular_member_forbidden(
 
 
 @pytest.mark.integration
-async def test_add_user_not_in_guild_fails(client: AsyncClient, session: AsyncSession):
+async def test_add_user_not_in_guild_fails(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that adding a user not in the guild fails."""
-    from app.testing.factories import create_initiative
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    # An outsider with no membership in the admin's guild.
+    outsider = await acting_user(email="outsider@example.com")
 
-    admin = await create_user(session, email="admin@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-
-    headers = await get_guild_headers(session, guild, admin)
-    payload = {"user_id": outsider.id, "role": "member"}
+    payload = {"user_id": outsider.user.id, "role": "member"}
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members",
-        headers=headers,
+        admin.g(f"/initiatives/{admin.initiative.id}/members"),
+        headers=admin.headers,
         json=payload,
     )
 
@@ -614,84 +481,69 @@ async def test_add_user_not_in_guild_fails(client: AsyncClient, session: AsyncSe
 
 @pytest.mark.integration
 async def test_update_initiative_member_role(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test updating an initiative member's role."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
-
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    await create_initiative_member(session, initiative, member, role_name="member")
 
     # Look up the PM role ID for this initiative
     from app.models.tenant.initiative import InitiativeRoleModel
     from sqlmodel import select
 
     pm_role_stmt = select(InitiativeRoleModel).where(
-        InitiativeRoleModel.initiative_id == initiative.id,
+        InitiativeRoleModel.initiative_id == admin.initiative.id,
         InitiativeRoleModel.name == "project_manager",
     )
     pm_role = (await session.exec(pm_role_stmt)).one()
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {"role_id": pm_role.id}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members/{member.id}",
-        headers=headers,
+        admin.g(f"/initiatives/{admin.initiative.id}/members/{member.user.id}"),
+        headers=admin.headers,
         json=payload,
     )
 
     assert response.status_code == 200
     data = response.json()
     member_roles = {m["user"]["id"]: m["role"] for m in data["members"]}
-    assert member_roles[member.id] == "project_manager"
+    assert member_roles[member.user.id] == "project_manager"
 
 
 @pytest.mark.integration
 async def test_guild_admin_cannot_be_assigned_member_role(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A guild admin is an implicit full-access member; assigning them a
     standard member (or custom) role is rejected — they may only be elevated to
     a manager role."""
     from app.models.tenant.initiative import InitiativeRoleModel
-    from app.testing.factories import create_initiative
     from sqlmodel import select
 
-    admin = await create_user(session, email="admin@example.com")
-    target_admin = await create_user(session, email="admin2@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    target_admin = await acting_user(
+        guild_role=GuildRole.admin, guild=admin.guild, email="admin2@example.com"
     )
-    await create_guild_membership(
-        session, user=target_admin, guild=guild, role=GuildRole.admin
-    )
-
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
 
     member_role = (
         await session.exec(
             select(InitiativeRoleModel).where(
-                InitiativeRoleModel.initiative_id == initiative.id,
+                InitiativeRoleModel.initiative_id == admin.initiative.id,
                 InitiativeRoleModel.name == "member",
             )
         )
     ).one()
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members",
-        headers=headers,
-        json={"user_id": target_admin.id, "role_id": member_role.id},
+        admin.g(f"/initiatives/{admin.initiative.id}/members"),
+        headers=admin.headers,
+        json={"user_id": target_admin.user.id, "role_id": member_role.id},
     )
 
     assert response.status_code == 400
@@ -700,95 +552,73 @@ async def test_guild_admin_cannot_be_assigned_member_role(
 
 @pytest.mark.integration
 async def test_guild_admin_can_be_assigned_manager_role(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A guild admin may be elevated to the manager role (for manager-style
     features like notifications)."""
     from app.models.tenant.initiative import InitiativeRoleModel
-    from app.testing.factories import create_initiative
     from sqlmodel import select
 
-    admin = await create_user(session, email="admin@example.com")
-    target_admin = await create_user(session, email="admin2@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    target_admin = await acting_user(
+        guild_role=GuildRole.admin, guild=admin.guild, email="admin2@example.com"
     )
-    await create_guild_membership(
-        session, user=target_admin, guild=guild, role=GuildRole.admin
-    )
-
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
 
     pm_role = (
         await session.exec(
             select(InitiativeRoleModel).where(
-                InitiativeRoleModel.initiative_id == initiative.id,
+                InitiativeRoleModel.initiative_id == admin.initiative.id,
                 InitiativeRoleModel.name == "project_manager",
             )
         )
     ).one()
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members",
-        headers=headers,
-        json={"user_id": target_admin.id, "role_id": pm_role.id},
+        admin.g(f"/initiatives/{admin.initiative.id}/members"),
+        headers=admin.headers,
+        json={"user_id": target_admin.user.id, "role_id": pm_role.id},
     )
 
     assert response.status_code == 200
     data = response.json()
     member_roles = {m["user"]["id"]: m["role"] for m in data["members"]}
-    assert member_roles[target_admin.id] == "project_manager"
+    assert member_roles[target_admin.user.id] == "project_manager"
 
 
 @pytest.mark.integration
-async def test_remove_initiative_member(client: AsyncClient, session: AsyncSession):
+async def test_remove_initiative_member(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test removing an initiative member."""
-    from app.testing.factories import create_initiative
-
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
 
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    await create_initiative_member(session, initiative, member, role_name="member")
-
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members/{member.id}",
-        headers=headers,
+        admin.g(f"/initiatives/{admin.initiative.id}/members/{member.user.id}"),
+        headers=admin.headers,
     )
 
     assert response.status_code == 200
     data = response.json()
     member_ids = {m["user"]["id"] for m in data["members"]}
-    assert member.id not in member_ids
+    assert member.user.id not in member_ids
 
 
 @pytest.mark.integration
-async def test_cannot_remove_last_manager(client: AsyncClient, session: AsyncSession):
+async def test_cannot_remove_last_manager(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that removing the last manager fails."""
-    from app.testing.factories import create_initiative
+    manager = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    manager = await create_user(session, email="manager@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=manager, guild=guild, role=GuildRole.member
-    )
-
-    initiative = await create_initiative(
-        session, guild, manager, name="Test Initiative"
-    )
-
-    headers = await get_guild_headers(session, guild, manager)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members/{manager.id}",
-        headers=headers,
+        manager.g(f"/initiatives/{manager.initiative.id}/members/{manager.user.id}"),
+        headers=manager.headers,
     )
 
     assert response.status_code == 400
@@ -796,36 +626,27 @@ async def test_cannot_remove_last_manager(client: AsyncClient, session: AsyncSes
 
 
 @pytest.mark.integration
-async def test_cannot_demote_last_manager(client: AsyncClient, session: AsyncSession):
+async def test_cannot_demote_last_manager(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that demoting the last manager fails."""
-    from app.testing.factories import create_initiative
-
-    manager = await create_user(session, email="manager@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=manager, guild=guild, role=GuildRole.member
-    )
-
-    initiative = await create_initiative(
-        session, guild, manager, name="Test Initiative"
-    )
+    manager = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     # Look up the member role ID for this initiative
     from app.models.tenant.initiative import InitiativeRoleModel
     from sqlmodel import select
 
     member_role_stmt = select(InitiativeRoleModel).where(
-        InitiativeRoleModel.initiative_id == initiative.id,
+        InitiativeRoleModel.initiative_id == manager.initiative.id,
         InitiativeRoleModel.name == "member",
     )
     member_role = (await session.exec(member_role_stmt)).one()
 
-    headers = await get_guild_headers(session, guild, manager)
     payload = {"role_id": member_role.id}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/members/{manager.id}",
-        headers=headers,
+        manager.g(f"/initiatives/{manager.initiative.id}/members/{manager.user.id}"),
+        headers=manager.headers,
         json=payload,
     )
 
@@ -834,30 +655,26 @@ async def test_cannot_demote_last_manager(client: AsyncClient, session: AsyncSes
 
 
 @pytest.mark.integration
-async def test_initiative_guild_isolation(client: AsyncClient, session: AsyncSession):
+async def test_initiative_guild_isolation(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that initiatives are isolated by guild."""
-    from app.testing.factories import create_initiative
+    from app.testing.factories import create_guild, create_guild_membership
 
-    user = await create_user(session, email="user@example.com")
-    guild1 = await create_guild(session, name="Guild 1")
-    guild2 = await create_guild(session, name="Guild 2")
+    # One user who is an admin of two distinct guilds.
+    a = await acting_user(guild_role=GuildRole.admin)
+    guild2 = await create_guild(session)
     await create_guild_membership(
-        session, user=user, guild=guild1, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=user, guild=guild2, role=GuildRole.admin
+        session, user=a.user, guild=guild2, role=GuildRole.admin
     )
 
     initiative1 = await create_initiative(
-        session, guild1, user, name="Guild 1 Initiative"
+        session, a.guild, a.user, name="Guild 1 Initiative"
     )
-    await create_initiative(session, guild2, user, name="Guild 2 Initiative")
+    await create_initiative(session, guild2, a.user, name="Guild 2 Initiative")
 
     # Request with guild1 context
-    headers1 = await get_guild_headers(session, guild1, user)
-    response1 = await client.get(
-        f"/api/v1/g/{guild1.id}/initiatives/", headers=headers1
-    )
+    response1 = await client.get(a.g("/initiatives/"), headers=a.headers)
 
     assert response1.status_code == 200
     data1 = response1.json()
@@ -868,9 +685,8 @@ async def test_initiative_guild_isolation(client: AsyncClient, session: AsyncSes
     # Cannot access guild1's initiative with guild2 context. Under schema-per-guild
     # ids are per-schema (not globally unique), so initiative1.id may collide with
     # a guild2 initiative — but it must never resolve to guild1's initiative.
-    headers2 = await get_guild_headers(session, guild2, user)
     response2 = await client.get(
-        f"/api/v1/g/{guild2.id}/initiatives/{initiative1.id}", headers=headers2
+        f"/api/v1/g/{guild2.id}/initiatives/{initiative1.id}", headers=a.headers
     )
 
     if response2.status_code == 200:
@@ -893,29 +709,23 @@ async def test_initiative_guild_isolation(client: AsyncClient, session: AsyncSes
 
 @pytest.mark.integration
 async def test_advanced_tool_handoff_returns_404_when_url_unset(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """Without ADVANCED_TOOL_URL the embed isn't deployed, so the
     endpoint must look like it doesn't exist — not even an authorized
     user should be able to mint a token that has nowhere to go."""
     from app.core.config import settings as app_settings
-    from app.testing.factories import create_initiative
 
     monkeypatch.setattr(app_settings, "ADVANCED_TOOL_URL", None)
 
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
     initiative = await create_initiative(
-        session, guild, admin, name="Init", advanced_tool_enabled=True
+        session, admin.guild, admin.user, name="Init", advanced_tool_enabled=True
     )
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/advanced-tool/handoff",
-        headers=headers,
+        admin.g(f"/initiatives/{initiative.id}/advanced-tool/handoff"),
+        headers=admin.headers,
     )
 
     assert response.status_code == 404
@@ -924,29 +734,23 @@ async def test_advanced_tool_handoff_returns_404_when_url_unset(
 
 @pytest.mark.integration
 async def test_advanced_tool_handoff_returns_403_when_master_switch_off(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """The per-initiative master switch is the manager's opt-in. Even a
     guild admin can't bypass it — the embed's data plane likely doesn't
     have the initiative provisioned yet."""
     from app.core.config import settings as app_settings
-    from app.testing.factories import create_initiative
 
     monkeypatch.setattr(app_settings, "ADVANCED_TOOL_URL", "https://embed.example.com")
 
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
     initiative = await create_initiative(
-        session, guild, admin, name="Init", advanced_tool_enabled=False
+        session, admin.guild, admin.user, name="Init", advanced_tool_enabled=False
     )
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/advanced-tool/handoff",
-        headers=headers,
+        admin.g(f"/initiatives/{initiative.id}/advanced-tool/handoff"),
+        headers=admin.headers,
     )
 
     assert response.status_code == 403
@@ -955,33 +759,24 @@ async def test_advanced_tool_handoff_returns_403_when_master_switch_off(
 
 @pytest.mark.integration
 async def test_advanced_tool_handoff_returns_403_for_non_member(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """Members of the guild who aren't members of the initiative get
     rejected — view access is initiative-scoped, not guild-scoped (for
     non-admins)."""
     from app.core.config import settings as app_settings
-    from app.testing.factories import create_initiative
 
     monkeypatch.setattr(app_settings, "ADVANCED_TOOL_URL", "https://embed.example.com")
 
-    admin = await create_user(session, email="admin@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=outsider, guild=guild, role=GuildRole.member
-    )
+    admin = await acting_user(guild_role=GuildRole.admin)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
     initiative = await create_initiative(
-        session, guild, admin, name="Init", advanced_tool_enabled=True
+        session, admin.guild, admin.user, name="Init", advanced_tool_enabled=True
     )
 
-    headers = await get_guild_headers(session, guild, outsider)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/advanced-tool/handoff",
-        headers=headers,
+        outsider.g(f"/initiatives/{initiative.id}/advanced-tool/handoff"),
+        headers=outsider.headers,
     )
 
     assert response.status_code == 403
@@ -989,36 +784,36 @@ async def test_advanced_tool_handoff_returns_403_for_non_member(
 
 @pytest.mark.integration
 async def test_advanced_tool_handoff_returns_403_when_role_lacks_view_permission(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """An initiative member whose role does NOT grant
     ``advanced_tool_enabled`` must be refused. The default ``member``
     role is exactly this case — view permission is opt-in per role.
     Without this gate, role-level access control would be a no-op."""
     from app.core.config import settings as app_settings
-    from app.testing.factories import create_initiative, create_initiative_member
 
     monkeypatch.setattr(app_settings, "ADVANCED_TOOL_URL", "https://embed.example.com")
 
-    pm = await create_user(session, email="pm@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    # Both users are guild members (not admins) so guild-admin bypass doesn't apply
-    await create_guild_membership(session, user=pm, guild=guild, role=GuildRole.member)
-    await create_guild_membership(
-        session, user=member, guild=guild, role=GuildRole.member
+    # Both users are guild members (not admins) so guild-admin bypass doesn't apply.
+    # pm creates the initiative and is auto-added as project_manager.
+    pm = await acting_user(
+        guild_role=GuildRole.member, initiative=True, email="pm@example.com"
     )
-    initiative = await create_initiative(
-        session, guild, pm, name="Init", advanced_tool_enabled=True
+    pm.initiative.advanced_tool_enabled = True
+    session.add(pm.initiative)
+    await session.commit()
+    # member joins with the default member role (advanced_tool_enabled=False)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=pm.guild,
+        initiative=pm.initiative,
+        initiative_role="member",
+        email="member@example.com",
     )
-    # pm is auto-added as project_manager by the factory; add member with the
-    # default member role (which has advanced_tool_enabled=False)
-    await create_initiative_member(session, initiative, member, role_name="member")
 
-    headers = await get_guild_headers(session, guild, member)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/advanced-tool/handoff",
-        headers=headers,
+        member.g(f"/initiatives/{pm.initiative.id}/advanced-tool/handoff"),
+        headers=member.headers,
     )
 
     assert response.status_code == 403
@@ -1027,29 +822,25 @@ async def test_advanced_tool_handoff_returns_403_when_role_lacks_view_permission
 
 @pytest.mark.integration
 async def test_advanced_tool_handoff_succeeds_for_initiative_manager(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """The happy path: manager opens the panel, gets a token with
     ``scope=initiative``, the right initiative_id, and ``can_create``
     set so the embed can show edit affordances."""
     from app.core.config import settings as app_settings
     from app.core.security import ADVANCED_TOOL_AUDIENCE
-    from app.testing.factories import create_initiative
     import jwt
 
     monkeypatch.setattr(app_settings, "ADVANCED_TOOL_URL", "https://embed.example.com")
 
-    pm = await create_user(session, email="pm@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=pm, guild=guild, role=GuildRole.member)
+    pm = await acting_user(guild_role=GuildRole.member, email="pm@example.com")
     initiative = await create_initiative(
-        session, guild, pm, name="Init", advanced_tool_enabled=True
+        session, pm.guild, pm.user, name="Init", advanced_tool_enabled=True
     )
 
-    headers = await get_guild_headers(session, guild, pm)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/advanced-tool/handoff",
-        headers=headers,
+        pm.g(f"/initiatives/{initiative.id}/advanced-tool/handoff"),
+        headers=pm.headers,
     )
 
     assert response.status_code == 200
@@ -1070,7 +861,7 @@ async def test_advanced_tool_handoff_succeeds_for_initiative_manager(
         algorithms=["HS256"],
         audience=ADVANCED_TOOL_AUDIENCE,
     )
-    assert payload["sub"] == str(pm.id)
+    assert payload["sub"] == str(pm.user.id)
     assert payload["scope"] == "initiative"
     assert payload["initiative_id"] == initiative.id
     assert payload["is_manager"] is True
@@ -1079,7 +870,7 @@ async def test_advanced_tool_handoff_succeeds_for_initiative_manager(
 
 @pytest.mark.integration
 async def test_advanced_tool_handoff_can_create_false_for_view_only_role(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """A custom role that grants view but not create gets a token with
     ``can_create=false`` so the embed hides creation UI. The token is
@@ -1091,31 +882,23 @@ async def test_advanced_tool_handoff_can_create_false_for_view_only_role(
         InitiativeRolePermission,
         PermissionKey,
     )
-    from app.testing.factories import (
-        create_initiative,
-        create_initiative_member,
-    )
     import jwt
     from sqlmodel import select
 
     monkeypatch.setattr(app_settings, "ADVANCED_TOOL_URL", "https://embed.example.com")
 
-    pm = await create_user(session, email="pm@example.com")
-    viewer = await create_user(session, email="viewer@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=pm, guild=guild, role=GuildRole.member)
-    await create_guild_membership(
-        session, user=viewer, guild=guild, role=GuildRole.member
+    pm = await acting_user(
+        guild_role=GuildRole.member, initiative=True, email="pm@example.com"
     )
-    initiative = await create_initiative(
-        session, guild, pm, name="Init", advanced_tool_enabled=True
-    )
+    pm.initiative.advanced_tool_enabled = True
+    session.add(pm.initiative)
+    await session.commit()
 
     # Flip the default member role to grant view but not create
     member_role = (
         await session.exec(
             select(InitiativeRoleModel).where(
-                InitiativeRoleModel.initiative_id == initiative.id,
+                InitiativeRoleModel.initiative_id == pm.initiative.id,
                 InitiativeRoleModel.name == "member",
             )
         )
@@ -1133,12 +916,17 @@ async def test_advanced_tool_handoff_can_create_false_for_view_only_role(
     session.add(view_perm)
     await session.commit()
 
-    await create_initiative_member(session, initiative, viewer, role_name="member")
+    viewer = await acting_user(
+        guild_role=GuildRole.member,
+        guild=pm.guild,
+        initiative=pm.initiative,
+        initiative_role="member",
+        email="viewer@example.com",
+    )
 
-    headers = await get_guild_headers(session, guild, viewer)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/advanced-tool/handoff",
-        headers=headers,
+        viewer.g(f"/initiatives/{pm.initiative.id}/advanced-tool/handoff"),
+        headers=viewer.headers,
     )
 
     assert response.status_code == 200
@@ -1159,32 +947,27 @@ async def test_advanced_tool_handoff_can_create_false_for_view_only_role(
 
 @pytest.mark.integration
 async def test_advanced_tool_handoff_succeeds_for_guild_admin_non_member(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """Guild admins can mint a token even if they aren't an initiative
     member — admin override is the existing pattern for guild-wide
     operational access."""
     from app.core.config import settings as app_settings
-    from app.testing.factories import create_initiative
 
     monkeypatch.setattr(app_settings, "ADVANCED_TOOL_URL", "https://embed.example.com")
 
-    admin = await create_user(session, email="admin@example.com")
-    pm = await create_user(session, email="pm@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, email="admin@example.com")
+    pm = await acting_user(
+        guild_role=GuildRole.member, guild=admin.guild, email="pm@example.com"
     )
-    await create_guild_membership(session, user=pm, guild=guild, role=GuildRole.member)
     initiative = await create_initiative(
-        session, guild, pm, name="Init", advanced_tool_enabled=True
+        session, admin.guild, pm.user, name="Init", advanced_tool_enabled=True
     )
     # Admin is intentionally NOT added as an initiative member
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}/advanced-tool/handoff",
-        headers=headers,
+        admin.g(f"/initiatives/{initiative.id}/advanced-tool/handoff"),
+        headers=admin.headers,
     )
 
     assert response.status_code == 200

--- a/backend/app/api/v1/tenant_endpoints/me_documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_documents_test.py
@@ -10,47 +10,35 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
-from app.testing.factories import (
+from app.testing import (
+    Actor,
     create_guild,
     create_guild_membership,
     create_initiative,
-    create_user,
-    get_guild_headers,
 )
 
 
-async def _create_document(client, session, guild, user, initiative, title="Test Doc"):
+async def _create_document(client, actor, initiative, title="Test Doc"):
     """Create a document via the API (sets created_by_id automatically)."""
-    headers = await get_guild_headers(session, guild, user)
     payload = {
         "title": title,
         "initiative_id": initiative.id,
     }
     response = await client.post(
-        f"/api/v1/g/{guild.id}/documents/", headers=headers, json=payload
+        actor.g("/documents/"), headers=actor.headers, json=payload
     )
     assert response.status_code == 201
     return response.json()
 
 
-async def _setup_guild_with_initiative(session, user, *, guild_name="Test Guild"):
-    """Create a guild, membership, and initiative for the user."""
-    guild = await create_guild(session, creator=user, name=guild_name)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Initiative")
-    return guild, initiative
-
-
 @pytest.mark.integration
-async def test_list_global_documents(client: AsyncClient, session: AsyncSession):
+async def test_list_global_documents(client: AsyncClient, acting_user):
     """GET /me/documents should return documents created by the current user."""
-    user = await create_user(session, email="user@example.com")
-    guild, initiative = await _setup_guild_with_initiative(session, user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    doc = await _create_document(client, session, guild, user, initiative, "My Doc")
+    doc = await _create_document(client, a, a.initiative, "My Doc")
 
-    headers = await get_guild_headers(session, guild, user)
-    response = await client.get("/api/v1/me/documents", headers=headers)
+    response = await client.get("/api/v1/me/documents", headers=a.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -60,23 +48,21 @@ async def test_list_global_documents(client: AsyncClient, session: AsyncSession)
 
 
 @pytest.mark.integration
-async def test_list_global_documents_excludes_others(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_list_global_documents_excludes_others(client: AsyncClient, acting_user):
     """GET /me/documents should NOT return documents created by other users."""
-    admin = await create_user(session, email="admin@example.com")
-    other = await create_user(session, email="other@example.com")
-    guild, initiative = await _setup_guild_with_initiative(session, admin)
-    await create_guild_membership(session, user=other, guild=guild)
-
-    # Admin creates a doc (via API, so created_by_id is set)
-    admin_doc = await _create_document(
-        client, session, guild, admin, initiative, "Admin's Doc"
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    other = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
 
+    # Admin creates a doc (via API, so created_by_id is set)
+    admin_doc = await _create_document(client, admin, admin.initiative, "Admin's Doc")
+
     # Other user queries global docs — should not see admin's doc
-    headers = await get_guild_headers(session, guild, other)
-    response = await client.get("/api/v1/me/documents", headers=headers)
+    response = await client.get("/api/v1/me/documents", headers=other.headers)
 
     assert response.status_code == 200
     doc_ids = {d["id"] for d in response.json()["items"]}
@@ -85,32 +71,33 @@ async def test_list_global_documents_excludes_others(
 
 @pytest.mark.integration
 async def test_list_global_documents_guild_filter(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """GET /me/documents with guild_ids should restrict to specific guilds."""
-    user = await create_user(session, email="user@example.com")
-    guild1, init1 = await _setup_guild_with_initiative(
-        session, user, guild_name="Guild 1"
-    )
-    guild2, init2 = await _setup_guild_with_initiative(
-        session, user, guild_name="Guild 2"
-    )
+    # First workspace via the actor seam; second guild + initiative for the SAME
+    # user via factories (acting_user always mints a fresh user).
+    a1 = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    user = a1.user
+    guild1, init1 = a1.guild, a1.initiative
 
-    doc1 = await _create_document(
-        client, session, guild1, user, init1, "Doc in Guild 1"
+    guild2 = await create_guild(session, creator=user, name="Guild 2")
+    await create_guild_membership(
+        session, user=user, guild=guild2, role=GuildRole.admin
     )
-    doc2 = await _create_document(
-        client, session, guild2, user, init2, "Doc in Guild 2"
-    )
+    init2 = await create_initiative(session, guild2, user, name="Initiative")
+    # A second actor view for the SAME user bound to guild2, so a2.g() addresses
+    # guild2 while a2.headers is still the user's auth.
+    a2 = Actor(user=user, headers=a1.headers, guild=guild2, initiative=init2)
 
-    headers = await get_guild_headers(session, guild1, user)
+    doc1 = await _create_document(client, a1, init1, "Doc in Guild 1")
+    doc2 = await _create_document(client, a2, init2, "Doc in Guild 2")
 
     def keyed(resp):
         return {(d["initiative"]["guild_id"], d["id"]) for d in resp.json()["items"]}
 
     # No filter: documents from BOTH guilds are aggregated (per-schema ids
     # collide, so key by (guild_id, id)).
-    response = await client.get("/api/v1/me/documents", headers=headers)
+    response = await client.get("/api/v1/me/documents", headers=a1.headers)
     assert response.status_code == 200
     found = keyed(response)
     assert (guild1.id, doc1["id"]) in found
@@ -118,7 +105,7 @@ async def test_list_global_documents_guild_filter(
 
     # Filtered to guild1: only guild1's document.
     response = await client.get(
-        f"/api/v1/me/documents?guild_ids={guild1.id}", headers=headers
+        f"/api/v1/me/documents?guild_ids={guild1.id}", headers=a1.headers
     )
     assert response.status_code == 200
     found = keyed(response)
@@ -127,19 +114,15 @@ async def test_list_global_documents_guild_filter(
 
 
 @pytest.mark.integration
-async def test_list_global_documents_search(client: AsyncClient, session: AsyncSession):
+async def test_list_global_documents_search(client: AsyncClient, acting_user):
     """GET /me/documents with search should filter by document title."""
-    user = await create_user(session, email="user@example.com")
-    guild, initiative = await _setup_guild_with_initiative(session, user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    await _create_document(
-        client, session, guild, user, initiative, "Architecture Notes"
-    )
-    await _create_document(client, session, guild, user, initiative, "Meeting Summary")
+    await _create_document(client, a, a.initiative, "Architecture Notes")
+    await _create_document(client, a, a.initiative, "Meeting Summary")
 
-    headers = await get_guild_headers(session, guild, user)
     response = await client.get(
-        "/api/v1/me/documents?search=architecture", headers=headers
+        "/api/v1/me/documents?search=architecture", headers=a.headers
     )
 
     assert response.status_code == 200
@@ -149,21 +132,16 @@ async def test_list_global_documents_search(client: AsyncClient, session: AsyncS
 
 
 @pytest.mark.integration
-async def test_list_global_documents_pagination(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_list_global_documents_pagination(client: AsyncClient, acting_user):
     """GET /me/documents should support pagination."""
-    user = await create_user(session, email="user@example.com")
-    guild, initiative = await _setup_guild_with_initiative(session, user)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     for i in range(3):
-        await _create_document(client, session, guild, user, initiative, f"Doc {i}")
-
-    headers = await get_guild_headers(session, guild, user)
+        await _create_document(client, a, a.initiative, f"Doc {i}")
 
     # Page 1 with page_size=2
     response = await client.get(
-        "/api/v1/me/documents?page=1&page_size=2", headers=headers
+        "/api/v1/me/documents?page=1&page_size=2", headers=a.headers
     )
     assert response.status_code == 200
     data = response.json()
@@ -173,7 +151,7 @@ async def test_list_global_documents_pagination(
 
     # Page 2
     response = await client.get(
-        "/api/v1/me/documents?page=2&page_size=2", headers=headers
+        "/api/v1/me/documents?page=2&page_size=2", headers=a.headers
     )
     assert response.status_code == 200
     data = response.json()

--- a/backend/app/api/v1/tenant_endpoints/me_projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_projects_test.py
@@ -16,7 +16,7 @@ from app.testing.factories import (
     create_initiative,
     create_project,
     create_user,
-    get_guild_headers,
+    get_auth_headers,
 )
 
 
@@ -35,7 +35,7 @@ async def test_list_global_projects(client: AsyncClient, session: AsyncSession):
     user = await create_user(session, email="user@example.com")
     guild, _, project = await _setup_guild_with_project(session, user)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/me/projects", headers=headers)
 
     assert response.status_code == 200
@@ -60,7 +60,7 @@ async def test_list_global_projects_excludes_archived(
     session.add(archived_project)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/me/projects", headers=headers)
 
     assert response.status_code == 200
@@ -84,7 +84,7 @@ async def test_list_global_projects_excludes_templates(
     session.add(template_project)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/me/projects", headers=headers)
 
     assert response.status_code == 200
@@ -114,7 +114,7 @@ async def test_list_global_projects_respects_permissions(
     )
 
     # Member requests global projects — should NOT see admin_project
-    headers = await get_guild_headers(session, guild, member)
+    headers = get_auth_headers(member)
     response = await client.get("/api/v1/me/projects", headers=headers)
 
     assert response.status_code == 200
@@ -138,7 +138,7 @@ async def test_list_global_projects_guild_filter(
     guild2, _, project2 = await _setup_guild_with_project(
         session, user, guild_name="Guild 2"
     )
-    headers = await get_guild_headers(session, guild1, user)
+    headers = get_auth_headers(user)
 
     def keyed(resp):
         return {(p["initiative"]["guild_id"], p["id"]) for p in resp.json()["items"]}
@@ -169,7 +169,7 @@ async def test_list_global_projects_search(client: AsyncClient, session: AsyncSe
     alpha = await create_project(session, initiative, user, name="Alpha Project")
     beta = await create_project(session, initiative, user, name="Beta Project")
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/me/projects?search=alpha", headers=headers)
 
     assert response.status_code == 200
@@ -190,7 +190,7 @@ async def test_list_global_projects_pagination(
     for i in range(3):
         await create_project(session, initiative, user, name=f"Extra {i}")
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
 
     # Page 1 with page_size=2
     response = await client.get(

--- a/backend/app/api/v1/tenant_endpoints/me_tasks_created_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_tasks_created_test.py
@@ -19,7 +19,7 @@ from app.testing.factories import (
     create_initiative,
     create_project,
     create_user,
-    get_guild_headers,
+    get_auth_headers,
 )
 
 
@@ -77,7 +77,7 @@ async def test_create_task_sets_created_by_id(
     await task_statuses_service.ensure_default_statuses(session, project.id)
     status = await task_statuses_service.get_default_status(session, project.id)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     payload = {
         "title": "Created via API",
         "project_id": project.id,
@@ -101,7 +101,7 @@ async def test_list_global_created_tasks(client: AsyncClient, session: AsyncSess
     task1 = await _create_task(session, project, "My Task 1", created_by_id=creator.id)
     task2 = await _create_task(session, project, "My Task 2", created_by_id=creator.id)
 
-    headers = await get_guild_headers(session, guild, creator)
+    headers = get_auth_headers(creator)
     response = await client.get("/api/v1/me/tasks/created", headers=headers)
 
     assert response.status_code == 200
@@ -127,7 +127,7 @@ async def test_list_global_created_tasks_excludes_others(
         session, project, "Other Task", created_by_id=other.id
     )
 
-    headers = await get_guild_headers(session, guild, creator)
+    headers = get_auth_headers(creator)
     response = await client.get("/api/v1/me/tasks/created", headers=headers)
 
     assert response.status_code == 200
@@ -148,7 +148,7 @@ async def test_list_global_created_tasks_excludes_null_created_by(
     legacy_task = await _create_task(session, project, "Legacy Task")
     my_task = await _create_task(session, project, "My Task", created_by_id=user.id)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/me/tasks/created", headers=headers)
 
     assert response.status_code == 200
@@ -178,7 +178,7 @@ async def test_list_global_created_tasks_priority_filter(
     session.add(low_task)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     conditions = json.dumps([{"field": "priority", "op": "in_", "value": ["high"]}])
     response = await client.get(
         f"/api/v1/me/tasks/created?conditions={conditions}", headers=headers
@@ -206,7 +206,7 @@ async def test_list_global_created_tasks_guild_filter(
     task1 = await _create_task(session, project1, "Guild 1 Task", created_by_id=user.id)
     task2 = await _create_task(session, project2, "Guild 2 Task", created_by_id=user.id)
 
-    headers = await get_guild_headers(session, guild1, user)
+    headers = get_auth_headers(user)
 
     def keyed(resp):
         # Task ids are per-guild (per-schema); key by (guild_id, id).
@@ -243,7 +243,7 @@ async def test_list_global_created_tasks_pagination(
     for i in range(3):
         await _create_task(session, project, f"Task {i}", created_by_id=user.id)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
 
     # Page 1 with page_size=2
     response = await client.get(

--- a/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
@@ -20,7 +20,7 @@ from app.testing.factories import (
     create_initiative,
     create_project,
     create_user,
-    get_guild_headers,
+    get_auth_headers,
 )
 
 
@@ -93,7 +93,7 @@ async def test_list_my_tasks_returns_assigned(
     await _assign(session, task1, user.id)
     await _assign(session, task2, user.id)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/me/tasks", headers=headers)
 
     assert response.status_code == 200, response.text
@@ -126,7 +126,7 @@ async def test_list_my_tasks_excludes_unassigned_and_others(
     others = await _create_task(session, project, "Others", created_by_id=user.id)
     await _assign(session, others, other.id)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.get("/api/v1/me/tasks", headers=headers)
 
     assert response.status_code == 200, response.text
@@ -166,7 +166,7 @@ async def test_admin_sees_assigned_task_in_non_member_initiative(
     )
     await _assign(session, task, admin.id)
 
-    headers = await get_guild_headers(session, guild, admin)
+    headers = get_auth_headers(admin)
     response = await client.get("/api/v1/me/tasks", headers=headers)
 
     assert response.status_code == 200, response.text
@@ -195,7 +195,7 @@ async def test_list_my_tasks_priority_filter(
     await _assign(session, high, user.id)
     await _assign(session, low, user.id)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     conditions = json.dumps([{"field": "priority", "op": "in_", "value": ["high"]}])
     response = await client.get(
         f"/api/v1/me/tasks?conditions={conditions}", headers=headers
@@ -234,7 +234,7 @@ async def test_list_my_tasks_guild_ids_filter(
     await _assign(session, task1, user.id)
     await _assign(session, task2, user.id)
 
-    headers = await get_guild_headers(session, guild1, user)
+    headers = get_auth_headers(user)
 
     def keyed(resp):
         # Task ids are per-guild (per-schema); key by (guild_id, id).
@@ -268,7 +268,7 @@ async def test_list_my_tasks_pagination(client: AsyncClient, session: AsyncSessi
         task = await _create_task(session, project, f"Task {i}", created_by_id=user.id)
         await _assign(session, task, user.id)
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
 
     # Page 1 with page_size=2
     response = await client.get("/api/v1/me/tasks?page=1&page_size=2", headers=headers)
@@ -331,7 +331,7 @@ async def test_list_my_tasks_date_group_sorted_across_guilds(
     for task in (g1_overdue, g1_later, g2_today, g2_week):
         await _assign(session, task, user.id)
 
-    headers = await get_guild_headers(session, guild1, user)
+    headers = get_auth_headers(user)
     sorting = json.dumps(
         [{"field": "date_group", "dir": "asc"}, {"field": "due_date", "dir": "asc"}]
     )
@@ -375,7 +375,7 @@ async def test_list_my_tasks_priority_sorted_desc_across_guilds(
     for task in (g1_low, g1_high, g2_medium, g2_urgent):
         await _assign(session, task, user.id)
 
-    headers = await get_guild_headers(session, guild1, user)
+    headers = get_auth_headers(user)
     sorting = json.dumps([{"field": "priority", "dir": "desc"}])
     response = await client.get(f"/api/v1/me/tasks?sorting={sorting}", headers=headers)
     assert response.status_code == 200, response.text

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -23,53 +23,25 @@ from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
-    create_initiative_member,
-    create_user,
-    get_guild_headers,
+    create_initiative,
+    create_project,
 )
-
-
-async def _create_initiative_with_member(session, guild, user):
-    """Helper to create an initiative and add the user as project manager."""
-    from app.testing.factories import create_initiative as factory_create_initiative
-
-    initiative = await factory_create_initiative(
-        session, guild, user, name="Test Initiative"
-    )
-    # Factory already adds creator as project_manager
-    return initiative
-
-
-async def _create_project(session, initiative, owner):
-    """Helper to create a project."""
-    from app.testing.factories import create_project as factory_create_project
-
-    project = await factory_create_project(
-        session, initiative, owner, name="Test Project", description="Test description"
-    )
-    return project
 
 
 @pytest.mark.integration
 async def test_list_projects_as_admin_shows_all(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that guild admin can see all projects."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await create_project(session, admin.initiative, admin.user, name="Test Project")
+    project2 = await create_project(
+        session, admin.initiative, admin.user, name="Project 2"
     )
-
-    initiative = await _create_initiative_with_member(session, guild, admin)
-    await _create_project(session, initiative, admin)
-    project2 = await _create_project(session, initiative, admin)
-    project2.name = "Project 2"
     session.add(project2)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, admin)
-    response = await client.get(f"/api/v1/g/{guild.id}/projects/", headers=headers)
+    response = await client.get(admin.g("/projects/"), headers=admin.headers)
 
     assert response.status_code == 200
     body = response.json()
@@ -83,31 +55,24 @@ async def test_list_projects_as_admin_shows_all(
 
 @pytest.mark.integration
 async def test_list_projects_member_sees_initiative_projects(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that initiative members see projects in their initiative."""
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
 
-    initiative = await _create_initiative_with_member(session, guild, admin)
-
-    # Add member to initiative
-    from app.testing.factories import create_initiative_member
-
-    await create_initiative_member(session, initiative, member, role_name="member")
-
-    project = await _create_project(session, initiative, admin)
+    project = await create_project(session, admin.initiative, admin.user)
 
     # Give member read access to the project (pure DAC requires explicit permission)
     member_permission = ResourceGrant(
         resource_type="project",
         resource_id=project.id,
-        user_id=member.id,
+        user_id=member.user.id,
         level=ResourceAccessLevel.read,
         guild_id=project.guild_id,
         initiative_id=project.initiative_id,
@@ -115,8 +80,7 @@ async def test_list_projects_member_sees_initiative_projects(
     session.add(member_permission)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, member)
-    response = await client.get(f"/api/v1/g/{guild.id}/projects/", headers=headers)
+    response = await client.get(member.g("/projects/"), headers=member.headers)
 
     assert response.status_code == 200
     data = response.json()["items"]
@@ -126,25 +90,18 @@ async def test_list_projects_member_sees_initiative_projects(
 
 @pytest.mark.integration
 async def test_list_projects_excludes_archived_by_default(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that archived projects are excluded by default."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-
-    initiative = await _create_initiative_with_member(session, guild, admin)
-    project = await _create_project(session, initiative, admin)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    project = await create_project(session, admin.initiative, admin.user)
 
     # Archive the project
     project.is_archived = True
     session.add(project)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, admin)
-    response = await client.get(f"/api/v1/g/{guild.id}/projects/", headers=headers)
+    response = await client.get(admin.g("/projects/"), headers=admin.headers)
 
     assert response.status_code == 200
     data = response.json()["items"]
@@ -154,24 +111,17 @@ async def test_list_projects_excludes_archived_by_default(
 
 @pytest.mark.integration
 async def test_list_projects_with_archived_filter(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test listing projects with archived filter."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-
-    initiative = await _create_initiative_with_member(session, guild, admin)
-    project = await _create_project(session, initiative, admin)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    project = await create_project(session, admin.initiative, admin.user)
     project.is_archived = True
     session.add(project)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.get(
-        f"/api/v1/g/{guild.id}/projects/?archived=true", headers=headers
+        admin.g("/projects/?archived=true"), headers=admin.headers
     )
 
     assert response.status_code == 200
@@ -181,51 +131,39 @@ async def test_list_projects_with_archived_filter(
 
 
 @pytest.mark.integration
-async def test_create_project(client: AsyncClient, session: AsyncSession):
+async def test_create_project(client: AsyncClient, acting_user):
     """Test creating a new project."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    initiative = await _create_initiative_with_member(session, guild, admin)
-
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "name": "New Project",
         "description": "Project description",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        admin.g("/projects/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "New Project"
     assert data["description"] == "Project description"
-    assert data["initiative"]["id"] == initiative.id
+    assert data["initiative"]["id"] == admin.initiative.id
 
 
 @pytest.mark.integration
-async def test_create_project_as_member(client: AsyncClient, session: AsyncSession):
+async def test_create_project_as_member(client: AsyncClient, acting_user):
     """Test that initiative members can create projects."""
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=member, guild=guild)
+    member = await acting_user(guild_role=GuildRole.member, initiative=True)
 
-    initiative = await _create_initiative_with_member(session, guild, member)
-
-    headers = await get_guild_headers(session, guild, member)
     payload = {
         "name": "Member Project",
-        "initiative_id": initiative.id,
+        "initiative_id": member.initiative.id,
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        member.g("/projects/"), headers=member.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -235,47 +173,34 @@ async def test_create_project_as_member(client: AsyncClient, session: AsyncSessi
 
 @pytest.mark.integration
 async def test_create_project_not_in_initiative_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Test that users not in initiative cannot create projects."""
-    admin = await create_user(session, email="admin@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(session, user=outsider, guild=guild)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
 
-    initiative = await _create_initiative_with_member(session, guild, admin)
-
-    headers = await get_guild_headers(session, guild, outsider)
     payload = {
         "name": "Forbidden Project",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        outsider.g("/projects/"), headers=outsider.headers, json=payload
     )
 
     assert response.status_code == 403
 
 
 @pytest.mark.integration
-async def test_get_project_by_id(client: AsyncClient, session: AsyncSession):
+async def test_get_project_by_id(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test getting a project by ID."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    project = await create_project(session, admin.initiative, admin.user)
 
-    initiative = await _create_initiative_with_member(session, guild, admin)
-    project = await _create_project(session, initiative, admin)
-
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.get(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers
+        admin.g(f"/projects/{project.id}"), headers=admin.headers
     )
 
     assert response.status_code == 200
@@ -285,35 +210,27 @@ async def test_get_project_by_id(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_get_project_not_found(client: AsyncClient, session: AsyncSession):
+async def test_get_project_not_found(client: AsyncClient, acting_user):
     """Test getting non-existent project."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    headers = await get_guild_headers(session, guild, admin)
-    response = await client.get(f"/api/v1/g/{guild.id}/projects/99999", headers=headers)
+    response = await client.get(admin.g("/projects/99999"), headers=admin.headers)
 
     assert response.status_code == 404
 
 
 @pytest.mark.integration
-async def test_update_project_as_owner(client: AsyncClient, session: AsyncSession):
+async def test_update_project_as_owner(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that project owner can update project."""
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, owner.initiative, owner.user)
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-
-    headers = await get_guild_headers(session, guild, owner)
     payload = {"name": "Updated Name", "description": "Updated description"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers, json=payload
+        owner.g(f"/projects/{project.id}"), headers=owner.headers, json=payload
     )
 
     assert response.status_code == 200
@@ -323,24 +240,24 @@ async def test_update_project_as_owner(client: AsyncClient, session: AsyncSessio
 
 
 @pytest.mark.integration
-async def test_update_project_as_admin(client: AsyncClient, session: AsyncSession):
+async def test_update_project_as_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that guild admin can update any project."""
-    admin = await create_user(session, email="admin@example.com")
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    owner = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=owner, guild=guild)
-
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
+    project = await create_project(session, admin.initiative, owner.user)
 
     # Give admin write access to the project (pure DAC requires explicit permission)
     admin_permission = ResourceGrant(
         resource_type="project",
         resource_id=project.id,
-        user_id=admin.id,
+        user_id=admin.user.id,
         level=ResourceAccessLevel.owner,
         guild_id=project.guild_id,
         initiative_id=project.initiative_id,
@@ -348,11 +265,10 @@ async def test_update_project_as_admin(client: AsyncClient, session: AsyncSessio
     session.add(admin_permission)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {"name": "Admin Updated"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers, json=payload
+        admin.g(f"/projects/{project.id}"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 200
@@ -362,23 +278,17 @@ async def test_update_project_as_admin(client: AsyncClient, session: AsyncSessio
 
 @pytest.mark.integration
 async def test_update_project_without_permission_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that users without permission cannot update project."""
-    owner = await create_user(session, email="owner@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=outsider, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=owner.guild)
+    project = await create_project(session, owner.initiative, owner.user)
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-
-    headers = await get_guild_headers(session, guild, outsider)
     payload = {"name": "Hacked Name"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers, json=payload
+        outsider.g(f"/projects/{project.id}"), headers=outsider.headers, json=payload
     )
 
     assert (
@@ -387,42 +297,39 @@ async def test_update_project_without_permission_forbidden(
 
 
 @pytest.mark.integration
-async def test_delete_project_as_owner(client: AsyncClient, session: AsyncSession):
+async def test_delete_project_as_owner(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that project owner can delete project."""
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, owner.initiative, owner.user)
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers
+        owner.g(f"/projects/{project.id}"), headers=owner.headers
     )
 
     assert response.status_code == 204
 
 
 @pytest.mark.integration
-async def test_delete_project_as_admin(client: AsyncClient, session: AsyncSession):
+async def test_delete_project_as_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that guild admin can delete any project."""
-    admin = await create_user(session, email="admin@example.com")
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    owner = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=owner, guild=guild)
-
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
+    project = await create_project(session, admin.initiative, owner.user)
 
     # Give admin owner access to the project (pure DAC requires explicit permission)
     admin_permission = ResourceGrant(
         resource_type="project",
         resource_id=project.id,
-        user_id=admin.id,
+        user_id=admin.user.id,
         level=ResourceAccessLevel.owner,
         guild_id=project.guild_id,
         initiative_id=project.initiative_id,
@@ -430,9 +337,8 @@ async def test_delete_project_as_admin(client: AsyncClient, session: AsyncSessio
     session.add(admin_permission)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, admin)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers
+        admin.g(f"/projects/{project.id}"), headers=admin.headers
     )
 
     assert response.status_code == 204
@@ -440,21 +346,15 @@ async def test_delete_project_as_admin(client: AsyncClient, session: AsyncSessio
 
 @pytest.mark.integration
 async def test_delete_project_without_permission_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that users without permission cannot delete project."""
-    owner = await create_user(session, email="owner@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=outsider, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=owner.guild)
+    project = await create_project(session, owner.initiative, owner.user)
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-
-    headers = await get_guild_headers(session, guild, outsider)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers
+        outsider.g(f"/projects/{project.id}"), headers=outsider.headers
     )
 
     assert (
@@ -463,18 +363,13 @@ async def test_delete_project_without_permission_forbidden(
 
 
 @pytest.mark.integration
-async def test_archive_project(client: AsyncClient, session: AsyncSession):
+async def test_archive_project(client: AsyncClient, session: AsyncSession, acting_user):
     """Test archiving a project."""
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, owner.initiative, owner.user)
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/archive", headers=headers
+        owner.g(f"/projects/{project.id}/archive"), headers=owner.headers
     )
 
     assert response.status_code == 200
@@ -483,21 +378,18 @@ async def test_archive_project(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_unarchive_project(client: AsyncClient, session: AsyncSession):
+async def test_unarchive_project(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test unarchiving a project."""
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, owner.initiative, owner.user)
     project.is_archived = True
     session.add(project)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/unarchive", headers=headers
+        owner.g(f"/projects/{project.id}/unarchive"), headers=owner.headers
     )
 
     assert response.status_code == 200
@@ -506,18 +398,15 @@ async def test_unarchive_project(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_add_project_favorite(client: AsyncClient, session: AsyncSession):
+async def test_add_project_favorite(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test adding a project to favorites."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    user = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, user.initiative, user.user)
 
-    initiative = await _create_initiative_with_member(session, guild, user)
-    project = await _create_project(session, initiative, user)
-
-    headers = await get_guild_headers(session, guild, user)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/favorite", headers=headers
+        user.g(f"/projects/{project.id}/favorite"), headers=user.headers
     )
 
     assert response.status_code == 200
@@ -526,25 +415,22 @@ async def test_add_project_favorite(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_remove_project_favorite(client: AsyncClient, session: AsyncSession):
+async def test_remove_project_favorite(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test removing a project from favorites."""
     from app.models.tenant.project_activity import ProjectFavorite
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative_with_member(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    user = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, user.initiative, user.user)
 
     # Add to favorites first
-    favorite = ProjectFavorite(user_id=user.id, project_id=project.id)
+    favorite = ProjectFavorite(user_id=user.user.id, project_id=project.id)
     session.add(favorite)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/favorite", headers=headers
+        user.g(f"/projects/{project.id}/favorite"), headers=user.headers
     )
 
     assert response.status_code == 200
@@ -553,26 +439,21 @@ async def test_remove_project_favorite(client: AsyncClient, session: AsyncSessio
 
 
 @pytest.mark.integration
-async def test_list_favorite_projects(client: AsyncClient, session: AsyncSession):
+async def test_list_favorite_projects(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test listing favorite projects."""
     from app.models.tenant.project_activity import ProjectFavorite
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative_with_member(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    user = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, user.initiative, user.user)
 
     # Add to favorites
-    favorite = ProjectFavorite(user_id=user.id, project_id=project.id)
+    favorite = ProjectFavorite(user_id=user.user.id, project_id=project.id)
     session.add(favorite)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/projects/favorites", headers=headers
-    )
+    response = await client.get(user.g("/projects/favorites"), headers=user.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -581,18 +462,15 @@ async def test_list_favorite_projects(client: AsyncClient, session: AsyncSession
 
 
 @pytest.mark.integration
-async def test_mark_project_as_viewed(client: AsyncClient, session: AsyncSession):
+async def test_mark_project_as_viewed(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test marking a project as recently viewed."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    user = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, user.initiative, user.user)
 
-    initiative = await _create_initiative_with_member(session, guild, user)
-    project = await _create_project(session, initiative, user)
-
-    headers = await get_guild_headers(session, guild, user)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
+        user.g(f"/projects/{project.id}/view"), headers=user.headers
     )
 
     assert response.status_code == 200
@@ -604,26 +482,22 @@ async def test_mark_project_as_viewed(client: AsyncClient, session: AsyncSession
 
 @pytest.mark.integration
 async def test_set_project_access_grants_user(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """PUT /access grants an individual user (Restrict-by-user)."""
-    owner = await create_user(session, email="owner@example.com")
-    new_member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=new_member, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    new_member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+    project = await create_project(session, owner.initiative, owner.user)
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    from app.testing.factories import create_initiative_member
-
-    await create_initiative_member(session, initiative, new_member, role_name="member")
-    project = await _create_project(session, initiative, owner)
-
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.put(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
-        headers=headers,
-        json=[{"user_id": new_member.id, "level": "write"}],
+        owner.g(f"/projects/{project.id}/grants"),
+        headers=owner.headers,
+        json=[{"user_id": new_member.user.id, "level": "write"}],
     )
 
     assert response.status_code == 200
@@ -632,28 +506,23 @@ async def test_set_project_access_grants_user(
         for g in response.json()["grants"]
         if g["user_id"] is not None
     }
-    assert grants.get(new_member.id) == "write"
+    assert grants.get(new_member.user.id) == "write"
 
 
 @pytest.mark.integration
 async def test_set_project_access_replaces_grants(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """PUT /access replaces the full non-owner grant set; the owner is preserved."""
-    owner = await create_user(session, email="owner@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=member, guild=guild)
-
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    member = await acting_user(guild_role=GuildRole.member, guild=owner.guild)
+    project = await create_project(session, owner.initiative, owner.user)
 
     session.add(
         ResourceGrant(
             resource_type="project",
             resource_id=project.id,
-            user_id=member.id,
+            user_id=member.user.id,
             level=ResourceAccessLevel.write,
             guild_id=project.guild_id,
             initiative_id=project.initiative_id,
@@ -661,10 +530,9 @@ async def test_set_project_access_replaces_grants(
     )
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, owner)
     response = await client.put(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
-        headers=headers,
+        owner.g(f"/projects/{project.id}/grants"),
+        headers=owner.headers,
         json=[],
     )
 
@@ -672,39 +540,32 @@ async def test_set_project_access_replaces_grants(
     user_ids = {
         g["user_id"] for g in response.json()["grants"] if g["user_id"] is not None
     }
-    assert member.id not in user_ids  # grant removed
-    assert owner.id in user_ids  # owner preserved
+    assert member.user.id not in user_ids  # grant removed
+    assert owner.user.id in user_ids  # owner preserved
 
 
 @pytest.mark.integration
 async def test_set_project_access_all_members(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """all_initiative_members grants every member access with no personal grant."""
-    owner = await create_user(session, email="owner@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=member, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+    project = await create_project(session, owner.initiative, owner.user)
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    from app.testing.factories import create_initiative_member
-
-    await create_initiative_member(session, initiative, member, role_name="member")
-    project = await _create_project(session, initiative, owner)
-
-    member_headers = await get_guild_headers(session, guild, member)
     # Restricted: a member with no grant is denied (the row is RLS-visible to a
     # member, so DAC denies with 403 rather than hiding it as 404).
-    r = await client.get(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=member_headers
-    )
+    r = await client.get(member.g(f"/projects/{project.id}"), headers=member.headers)
     assert r.status_code == 403
 
-    owner_headers = await get_guild_headers(session, guild, owner)
     r = await client.put(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
-        headers=owner_headers,
+        owner.g(f"/projects/{project.id}/grants"),
+        headers=owner.headers,
         json=[{"all_initiative_members": True, "level": "read"}],
     )
     assert r.status_code == 200
@@ -713,9 +574,7 @@ async def test_set_project_access_all_members(
     )
 
     # Now the member can read it via all-initiative-members access alone.
-    r = await client.get(
-        f"/api/v1/g/{guild.id}/projects/{project.id}", headers=member_headers
-    )
+    r = await client.get(member.g(f"/projects/{project.id}"), headers=member.headers)
     assert r.status_code == 200
     assert r.json()["my_permission_level"] == "read"
 
@@ -736,109 +595,104 @@ async def _task_assignee_ids(session, guild_id: int, task_id: int) -> set[int]:
 
 @pytest.mark.integration
 async def test_set_project_grants_unassigns_demoted_user(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A user dropped below write by a grant change is unassigned from the
     project's tasks (you can't be assigned to tasks you can't edit)."""
-    owner = await create_user(session, email="owner@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=member, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+    from app.testing.factories import create_task
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    from app.testing.factories import create_initiative_member, create_task
+    project = await create_project(session, owner.initiative, owner.user)
 
-    await create_initiative_member(session, initiative, member, role_name="member")
-    project = await _create_project(session, initiative, owner)
-
-    owner_headers = await get_guild_headers(session, guild, owner)
     # Grant the member write, then assign them to a task.
     r = await client.put(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
-        headers=owner_headers,
-        json=[{"user_id": member.id, "level": "write"}],
+        owner.g(f"/projects/{project.id}/grants"),
+        headers=owner.headers,
+        json=[{"user_id": member.user.id, "level": "write"}],
     )
     assert r.status_code == 200
-    task = await create_task(session, project, assignees=[member])
-    assert member.id in await _task_assignee_ids(session, guild.id, task.id)
+    task = await create_task(session, project, assignees=[member.user])
+    assert member.user.id in await _task_assignee_ids(session, owner.guild.id, task.id)
 
     # Remove the member's grant entirely -> they lose write -> get unassigned.
     r = await client.put(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
-        headers=owner_headers,
+        owner.g(f"/projects/{project.id}/grants"),
+        headers=owner.headers,
         json=[],
     )
     assert r.status_code == 200
-    assert member.id not in await _task_assignee_ids(session, guild.id, task.id)
+    assert member.user.id not in await _task_assignee_ids(
+        session, owner.guild.id, task.id
+    )
 
 
 @pytest.mark.integration
 async def test_set_project_grants_keeps_assignment_when_still_writable(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A user who keeps write via another grant (all-members write) stays assigned —
     the cleanup is effective-access based, not a blunt per-user wipe."""
-    owner = await create_user(session, email="owner@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=member, guild=guild)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+    from app.testing.factories import create_task
 
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    from app.testing.factories import create_initiative_member, create_task
+    project = await create_project(session, owner.initiative, owner.user)
 
-    await create_initiative_member(session, initiative, member, role_name="member")
-    project = await _create_project(session, initiative, owner)
-
-    owner_headers = await get_guild_headers(session, guild, owner)
     r = await client.put(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
-        headers=owner_headers,
-        json=[{"user_id": member.id, "level": "write"}],
+        owner.g(f"/projects/{project.id}/grants"),
+        headers=owner.headers,
+        json=[{"user_id": member.user.id, "level": "write"}],
     )
     assert r.status_code == 200
-    task = await create_task(session, project, assignees=[member])
+    task = await create_task(session, project, assignees=[member.user])
 
     # Swap the per-user grant for an all-members WRITE grant: the member still has
     # write, so the assignment must survive.
     r = await client.put(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/grants",
-        headers=owner_headers,
+        owner.g(f"/projects/{project.id}/grants"),
+        headers=owner.headers,
         json=[{"all_initiative_members": True, "level": "write"}],
     )
     assert r.status_code == 200
-    assert member.id in await _task_assignee_ids(session, guild.id, task.id)
+    assert member.user.id in await _task_assignee_ids(session, owner.guild.id, task.id)
 
 
 @pytest.mark.integration
-async def test_project_guild_isolation(client: AsyncClient, session: AsyncSession):
+async def test_project_guild_isolation(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that projects are isolated by guild."""
-    user = await create_user(session, email="user@example.com")
-    guild1 = await create_guild(session, name="Guild 1")
-    guild2 = await create_guild(session, name="Guild 2")
-    await create_guild_membership(
-        session, user=user, guild=guild1, role=GuildRole.admin
+    # Same user is a guild admin in two separate guilds/initiatives.
+    a1 = await acting_user(
+        guild_role=GuildRole.admin, initiative=True, email="user@example.com"
     )
+    user = a1.user
+    initiative1 = a1.initiative
+
+    guild2 = await create_guild(session, name="Guild 2")
     await create_guild_membership(
         session, user=user, guild=guild2, role=GuildRole.admin
     )
-
-    from app.testing.factories import create_project as factory_create_project
-
-    initiative1 = await _create_initiative_with_member(session, guild1, user)
-    initiative2 = await _create_initiative_with_member(session, guild2, user)
+    initiative2 = await create_initiative(session, guild2, user)
 
     # Distinct names so the cross-guild check below can tell them apart even when
     # their per-schema ids collide.
-    project1 = await factory_create_project(
-        session, initiative1, user, name="Guild 1 Project"
-    )
-    await factory_create_project(session, initiative2, user, name="Guild 2 Project")
+    project1 = await create_project(session, initiative1, user, name="Guild 1 Project")
+    await create_project(session, initiative2, user, name="Guild 2 Project")
 
     # Request with guild1 context
-    headers1 = await get_guild_headers(session, guild1, user)
-    response1 = await client.get(f"/api/v1/g/{guild1.id}/projects/", headers=headers1)
+    response1 = await client.get(a1.g("/projects/"), headers=a1.headers)
 
     assert response1.status_code == 200
     data1 = response1.json()["items"]
@@ -849,9 +703,8 @@ async def test_project_guild_isolation(client: AsyncClient, session: AsyncSessio
     # Cannot access guild1's project with guild2 context. Under schema-per-guild
     # ids are per-schema (not globally unique), so project1.id may collide with a
     # guild2 project — but it must never resolve to guild1's project.
-    headers2 = await get_guild_headers(session, guild2, user)
     response2 = await client.get(
-        f"/api/v1/g/{guild2.id}/projects/{project1.id}", headers=headers2
+        f"/api/v1/g/{guild2.id}/projects/{project1.id}", headers=a1.headers
     )
 
     if response2.status_code == 200:
@@ -861,34 +714,26 @@ async def test_project_guild_isolation(client: AsyncClient, session: AsyncSessio
 
 
 @pytest.mark.integration
-async def test_create_project_with_user_permissions(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_create_project_with_user_permissions(client: AsyncClient, acting_user):
     """Test creating a project with explicit user permissions."""
-    from app.testing.factories import create_initiative_member
-
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
 
-    initiative = await _create_initiative_with_member(session, guild, admin)
-    await create_initiative_member(session, initiative, member, role_name="member")
-
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "name": "Project With Permissions",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
         "grants": [
-            {"user_id": member.id, "level": "write"},
+            {"user_id": member.user.id, "level": "write"},
         ],
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        admin.g("/projects/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -896,46 +741,39 @@ async def test_create_project_with_user_permissions(
     assert data["name"] == "Project With Permissions"
     # Owner grant + explicitly granted member (no all-members grant was sent)
     user_grants = {g["user_id"]: g["level"] for g in data["grants"] if g["user_id"]}
-    assert user_grants.get(admin.id) == "owner"
-    assert user_grants.get(member.id) == "write"
+    assert user_grants.get(admin.user.id) == "owner"
+    assert user_grants.get(member.user.id) == "write"
 
 
 @pytest.mark.integration
 async def test_create_project_with_role_permissions(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test creating a project with role-based permissions."""
     from sqlmodel import select
     from app.models.tenant.initiative import InitiativeRoleModel
 
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-
-    initiative = await _create_initiative_with_member(session, guild, admin)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     # Find the member role
     result = await session.exec(
         select(InitiativeRoleModel).where(
-            InitiativeRoleModel.initiative_id == initiative.id,
+            InitiativeRoleModel.initiative_id == admin.initiative.id,
             InitiativeRoleModel.name == "member",
         )
     )
     member_role = result.one()
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "name": "Project With Role Perms",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
         "grants": [
             {"role_id": member_role.id, "level": "read"},
         ],
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        admin.g("/projects/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -948,32 +786,25 @@ async def test_create_project_with_role_permissions(
 
 @pytest.mark.integration
 async def test_create_project_defaults_to_all_members_viewer(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Omitting `grants` defaults to Viewer for all initiative members (+ owner)."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    initiative = await _create_initiative_with_member(session, guild, admin)
-
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "name": "Project Default Share",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        admin.g("/projects/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
     data = response.json()
     # Owner grant + an all-initiative-members Viewer (read) grant.
     assert any(
-        g["user_id"] == admin.id and g["level"] == "owner" for g in data["grants"]
+        g["user_id"] == admin.user.id and g["level"] == "owner" for g in data["grants"]
     )
     assert any(
         g["all_initiative_members"] and g["level"] == "read" for g in data["grants"]
@@ -983,60 +814,48 @@ async def test_create_project_defaults_to_all_members_viewer(
 
 @pytest.mark.integration
 async def test_create_project_skips_owner_level_grants(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Test that owner-level grants in user_permissions are silently ignored."""
-    from app.testing.factories import create_initiative_member
-
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
-    await create_guild_membership(session, user=member, guild=guild)
 
-    initiative = await _create_initiative_with_member(session, guild, admin)
-    await create_initiative_member(session, initiative, member, role_name="member")
-
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "name": "Project Owner Skip",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
         "grants": [
-            {"user_id": member.id, "level": "owner"},
+            {"user_id": member.user.id, "level": "owner"},
         ],
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        admin.g("/projects/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
     data = response.json()
     # Member should NOT have been granted owner
-    member_grants = [g for g in data["grants"] if g["user_id"] == member.id]
+    member_grants = [g for g in data["grants"] if g["user_id"] == member.user.id]
     assert len(member_grants) == 0
 
 
 @pytest.mark.integration
 async def test_create_project_rejects_foreign_initiative_role(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Role from a different initiative must be silently dropped."""
     from sqlmodel import select
     from app.models.tenant.initiative import InitiativeRoleModel
-    from app.testing.factories import create_initiative
 
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-
-    initiative_a = await _create_initiative_with_member(session, guild, admin)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    initiative_a = admin.initiative
     initiative_b = await create_initiative(
-        session, guild, admin, name="Other Initiative"
+        session, admin.guild, admin.user, name="Other Initiative"
     )
 
     # Get a role that belongs to initiative_b, not initiative_a
@@ -1048,7 +867,6 @@ async def test_create_project_rejects_foreign_initiative_role(
     )
     foreign_role = result.one()
 
-    headers = await get_guild_headers(session, guild, admin)
     payload = {
         "name": "Project Cross Initiative",
         "initiative_id": initiative_a.id,
@@ -1058,7 +876,7 @@ async def test_create_project_rejects_foreign_initiative_role(
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/projects/", headers=headers, json=payload
+        admin.g("/projects/"), headers=admin.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -1069,7 +887,7 @@ async def test_create_project_rejects_foreign_initiative_role(
 
 @pytest.mark.integration
 async def test_set_project_access_change_all_members_level(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Changing an EXISTING all-initiative-members grant's level (read -> write)
     must not trip ``resource_grants_unique_grantee``.
@@ -1081,23 +899,23 @@ async def test_set_project_access_change_all_members_level(
     a member hit switching a project's "all initiative members" share from Viewer
     to Editor.
     """
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-    headers = await get_guild_headers(session, guild, owner)
-    url = f"/api/v1/g/{guild.id}/projects/{project.id}/grants"
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, owner.initiative, owner.user)
+    url = owner.g(f"/projects/{project.id}/grants")
 
     # 1) create the all-members grant at read (Viewer)
     r = await client.put(
-        url, headers=headers, json=[{"all_initiative_members": True, "level": "read"}]
+        url,
+        headers=owner.headers,
+        json=[{"all_initiative_members": True, "level": "read"}],
     )
     assert r.status_code == 200, r.text
 
     # 2) change it to write (Editor) — the delete-then-reinsert collision path
     r = await client.put(
-        url, headers=headers, json=[{"all_initiative_members": True, "level": "write"}]
+        url,
+        headers=owner.headers,
+        json=[{"all_initiative_members": True, "level": "write"}],
     )
     assert r.status_code == 200, r.text
     members = [g for g in r.json()["grants"] if g["all_initiative_members"]]
@@ -1107,69 +925,70 @@ async def test_set_project_access_change_all_members_level(
 
 @pytest.mark.integration
 async def test_set_project_access_remove_grant_keeps_all_members(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Removing a per-user grant while keeping the all-members grant must not trip
     the unique constraint either — replace_resource_grants deletes ALL non-owner
     grants and re-inserts the kept set, so the all-members grant is deleted and
     re-inserted in the same flush. ("I also cannot remove access" — same cause.)
     """
-    owner = await create_user(session, email="owner@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=member, guild=guild)
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    from app.testing.factories import create_initiative_member
-
-    await create_initiative_member(session, initiative, member, role_name="member")
-    project = await _create_project(session, initiative, owner)
-    headers = await get_guild_headers(session, guild, owner)
-    url = f"/api/v1/g/{guild.id}/projects/{project.id}/grants"
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+    project = await create_project(session, owner.initiative, owner.user)
+    url = owner.g(f"/projects/{project.id}/grants")
 
     # all-members read + a per-user write grant
     r = await client.put(
         url,
-        headers=headers,
+        headers=owner.headers,
         json=[
             {"all_initiative_members": True, "level": "read"},
-            {"user_id": member.id, "level": "write"},
+            {"user_id": member.user.id, "level": "write"},
         ],
     )
     assert r.status_code == 200, r.text
 
     # remove the per-user grant, keep all-members
     r = await client.put(
-        url, headers=headers, json=[{"all_initiative_members": True, "level": "read"}]
+        url,
+        headers=owner.headers,
+        json=[{"all_initiative_members": True, "level": "read"}],
     )
     assert r.status_code == 200, r.text
-    assert [g for g in r.json()["grants"] if g["user_id"] == member.id] == []
+    assert [g for g in r.json()["grants"] if g["user_id"] == member.user.id] == []
     assert any(g["all_initiative_members"] for g in r.json()["grants"])
 
 
 @pytest.mark.integration
 async def test_project_shows_all_members_document_to_member(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A document attached to a project and shared with *all initiative members*
     is visible to a plain member on the project view. Regression: the linked-doc
     filter used to ignore all-members grants, so such docs vanished for anyone
     without a personal/role grant."""
-    owner = await create_user(session, email="owner@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=member, guild=guild)
-    initiative = await _create_initiative_with_member(session, guild, owner)
-    await create_initiative_member(session, initiative, member, role_name="member")
-    project = await _create_project(session, initiative, owner)
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+    guild = owner.guild
+    initiative = owner.initiative
+    project = await create_project(session, initiative, owner.user)
 
     doc = Document(
         title="Shared with everyone",
         initiative_id=initiative.id,
         guild_id=guild.id,
-        created_by_id=owner.id,
-        updated_by_id=owner.id,
+        created_by_id=owner.user.id,
+        updated_by_id=owner.user.id,
         document_type=DocumentType.native,
     )
     session.add(doc)
@@ -1188,7 +1007,7 @@ async def test_project_shows_all_members_document_to_member(
             ResourceGrant(
                 resource_type="document",
                 resource_id=doc.id,
-                user_id=owner.id,
+                user_id=owner.user.id,
                 level=ResourceAccessLevel.owner,
                 guild_id=guild.id,
                 initiative_id=initiative.id,
@@ -1205,14 +1024,13 @@ async def test_project_shows_all_members_document_to_member(
                 project_id=project.id,
                 document_id=doc.id,
                 guild_id=guild.id,
-                attached_by_id=owner.id,
+                attached_by_id=owner.user.id,
             ),
         ]
     )
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, member)
-    r = await client.get(f"/api/v1/g/{guild.id}/projects/{project.id}", headers=headers)
+    r = await client.get(member.g(f"/projects/{project.id}"), headers=member.headers)
     assert r.status_code == 200, r.text
     doc_ids = [d["document_id"] for d in r.json()["documents"]]
     assert doc.id in doc_ids

--- a/backend/app/api/v1/tenant_endpoints/property_definitions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/property_definitions_test.py
@@ -16,82 +16,22 @@ from httpx import AsyncClient
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models.tenant.document import (
-    Document,
-    DocumentType,
-)
 from app.models.platform.guild import GuildRole
-from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.tenant.property import (
     DocumentPropertyValue,
     PropertyDefinition,
     PropertyType,
     TaskPropertyValue,
 )
-from app.services.tenant import task_statuses as task_statuses_service
 from app.testing import (
+    create_document,
     create_document_property_value,
-    create_guild,
-    create_guild_membership,
     create_initiative,
-    create_initiative_member,
     create_project,
     create_property_definition,
+    create_task,
     create_task_property_value,
-    create_user,
-    get_guild_headers,
 )
-
-
-async def _create_task(session: AsyncSession, project, title: str = "Test Task"):
-    from app.models.tenant.task import Task
-
-    await task_statuses_service.ensure_default_statuses(session, project.id)
-    default_status = await task_statuses_service.get_default_status(session, project.id)
-
-    task = Task(
-        title=title,
-        project_id=project.id,
-        task_status_id=default_status.id,
-        guild_id=project.guild_id,
-    )
-    session.add(task)
-    await session.commit()
-    await session.refresh(task)
-    return task
-
-
-async def _create_document(
-    session: AsyncSession,
-    *,
-    initiative,
-    owner,
-    title: str = "Doc With Property",
-) -> Document:
-    doc = Document(
-        title=title,
-        initiative_id=initiative.id,
-        guild_id=initiative.guild_id,
-        created_by_id=owner.id,
-        updated_by_id=owner.id,
-        document_type=DocumentType.native,
-        content={},
-    )
-    session.add(doc)
-    await session.flush()
-
-    perm = ResourceGrant(
-        resource_type="document",
-        resource_id=doc.id,
-        user_id=owner.id,
-        level=ResourceAccessLevel.owner,
-        guild_id=initiative.guild_id,
-        initiative_id=doc.initiative_id,
-    )
-    session.add(perm)
-    await session.commit()
-    await session.refresh(doc)
-    return doc
 
 
 # ---------------------------------------------------------------------------
@@ -101,23 +41,20 @@ async def _create_document(
 
 @pytest.mark.integration
 async def test_list_property_definitions_returns_union_across_initiatives(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Without ``initiative_id`` the list endpoint returns the caller's
     accessible union — definitions across every initiative they're in."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-
-    init_a = await create_initiative(session, guild, user, name="A")
-    init_b = await create_initiative(session, guild, user, name="B")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    init_a = a.initiative
+    init_b = await create_initiative(session, a.guild, a.user, name="B")
 
     defn_a = await create_property_definition(session, init_a, name="In A")
     defn_b = await create_property_definition(session, init_b, name="In B")
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/property-definitions/",
-        headers=await get_guild_headers(session, guild, user),
+        a.g("/property-definitions/"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     ids = {item["id"] for item in response.json()}
@@ -127,22 +64,19 @@ async def test_list_property_definitions_returns_union_across_initiatives(
 
 @pytest.mark.integration
 async def test_list_property_definitions_filtered_by_initiative_id(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """``?initiative_id=X`` filters to that initiative's definitions only."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-
-    init_a = await create_initiative(session, guild, user, name="A")
-    init_b = await create_initiative(session, guild, user, name="B")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    init_a = a.initiative
+    init_b = await create_initiative(session, a.guild, a.user, name="B")
 
     defn_a = await create_property_definition(session, init_a, name="In A")
     defn_b = await create_property_definition(session, init_b, name="In B")
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/property-definitions/?initiative_id={init_a.id}",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/property-definitions/?initiative_id={init_a.id}"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     ids = {item["id"] for item in response.json()}
@@ -152,29 +86,24 @@ async def test_list_property_definitions_filtered_by_initiative_id(
 
 @pytest.mark.integration
 async def test_list_property_definitions_scoped_by_initiative_id_query(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Requesting a specific ``initiative_id`` scopes the result even when
     the caller technically has visibility across multiple initiatives
     (guild admin / superadmin bypass paths still respect explicit
     filtering through the query param).
     """
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-
-    init_a = await create_initiative(session, guild, admin, name="A")
-    init_b = await create_initiative(session, guild, admin, name="B")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    init_a = a.initiative
+    init_b = await create_initiative(session, a.guild, a.user, name="B")
 
     defn_a = await create_property_definition(session, init_a, name="In A")
     defn_b = await create_property_definition(session, init_b, name="In B")
 
     # Scoped to A
     response_a = await client.get(
-        f"/api/v1/g/{guild.id}/property-definitions/?initiative_id={init_a.id}",
-        headers=await get_guild_headers(session, guild, admin),
+        a.g(f"/property-definitions/?initiative_id={init_a.id}"),
+        headers=a.headers,
     )
     assert response_a.status_code == 200
     ids_a = {item["id"] for item in response_a.json()}
@@ -183,8 +112,8 @@ async def test_list_property_definitions_scoped_by_initiative_id_query(
 
     # Scoped to B
     response_b = await client.get(
-        f"/api/v1/g/{guild.id}/property-definitions/?initiative_id={init_b.id}",
-        headers=await get_guild_headers(session, guild, admin),
+        a.g(f"/property-definitions/?initiative_id={init_b.id}"),
+        headers=a.headers,
     )
     assert response_b.status_code == 200
     ids_b = {item["id"] for item in response_b.json()}
@@ -198,71 +127,51 @@ async def test_list_property_definitions_scoped_by_initiative_id_query(
 
 
 @pytest.mark.integration
-async def test_create_text_property_definition(
-    client: AsyncClient, session: AsyncSession
-):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+async def test_create_text_property_definition(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
         "name": "Status",
         "type": "text",
         "position": 1.0,
-        "initiative_id": initiative.id,
+        "initiative_id": a.initiative.id,
     }
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        a.g("/property-definitions/"), headers=a.headers, json=payload
     )
 
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "Status"
     assert data["type"] == "text"
-    assert data["initiative_id"] == initiative.id
+    assert data["initiative_id"] == a.initiative.id
 
 
 @pytest.mark.integration
 async def test_create_rejected_when_not_initiative_member(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """A plain (non-admin) guild member can't create definitions on an
     initiative they don't belong to.
     """
-    admin = await create_user(session, email="admin@example.com")
-    alice = await create_user(session, email="alice@example.com")
-    bob = await create_user(session, email="bob@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=alice, guild=guild, role=GuildRole.member
-    )
-    await create_guild_membership(session, user=bob, guild=guild, role=GuildRole.member)
+    # Alice owns the initiative; Bob is a guild member but NOT an initiative member.
+    alice = await acting_user(guild_role=GuildRole.member, initiative=True)
+    bob = await acting_user(guild_role=GuildRole.member, guild=alice.guild)
 
-    # Alice's initiative; Bob is NOT a member.
-    initiative = await create_initiative(session, guild, alice, name="Init")
-
-    headers = await get_guild_headers(session, guild, bob)
     payload = {
         "name": "Foo",
         "type": "text",
-        "initiative_id": initiative.id,
+        "initiative_id": alice.initiative.id,
     }
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        bob.g("/property-definitions/"), headers=bob.headers, json=payload
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "PROPERTY_NOT_INITIATIVE_MEMBER"
 
 
 @pytest.mark.integration
-async def test_create_allowed_for_initiative_member(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_create_allowed_for_initiative_member(client: AsyncClient, acting_user):
     """A plain (non-admin) guild member who belongs to the initiative can
     create a definition on it.
 
@@ -271,62 +180,46 @@ async def test_create_allowed_for_initiative_member(
     so a legitimate member is no longer false-403'd by a lookup against the
     frozen ``public`` backup.
     """
-    admin = await create_user(session, email="admin@example.com")
-    member = await create_user(session, email="member@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=member, guild=guild, role=GuildRole.member
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
 
-    initiative = await create_initiative(session, guild, admin, name="Init")
-    await create_initiative_member(session, initiative, member)
-
-    headers = await get_guild_headers(session, guild, member)
     payload = {
         "name": "Owner Tag",
         "type": "text",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
     }
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        member.g("/property-definitions/"), headers=member.headers, json=payload
     )
 
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "Owner Tag"
-    assert data["initiative_id"] == initiative.id
+    assert data["initiative_id"] == admin.initiative.id
 
 
 @pytest.mark.integration
 async def test_create_rejected_for_guild_member_not_in_initiative(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """A guild member who is NOT in the target initiative is rejected with
     the canonical NOT_INITIATIVE_MEMBER code."""
-    admin = await create_user(session, email="admin@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    await create_guild_membership(
-        session, user=outsider, guild=guild, role=GuildRole.member
-    )
-
     # Admin's initiative; outsider is a guild member but not an initiative member.
-    initiative = await create_initiative(session, guild, admin, name="Init")
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
 
-    headers = await get_guild_headers(session, guild, outsider)
     payload = {
         "name": "Foo",
         "type": "text",
-        "initiative_id": initiative.id,
+        "initiative_id": admin.initiative.id,
     }
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        outsider.g("/property-definitions/"), headers=outsider.headers, json=payload
     )
 
     assert response.status_code == 403
@@ -335,52 +228,38 @@ async def test_create_rejected_for_guild_member_not_in_initiative(
 
 @pytest.mark.integration
 async def test_create_allowed_for_guild_admin_not_in_initiative(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A guild admin can create a definition on any initiative in their
     guild even without an explicit initiative-member row — mirroring the
     restrictive RLS policy's admin bypass, now resolved off
     ``GuildContext.role``."""
-    creator = await create_user(session, email="creator@example.com")
-    guild_admin = await create_user(session, email="gadmin@example.com")
-    guild = await create_guild(session, creator=creator)
-    await create_guild_membership(
-        session, user=creator, guild=guild, role=GuildRole.member
-    )
-    await create_guild_membership(
-        session, user=guild_admin, guild=guild, role=GuildRole.admin
-    )
-
     # The creator owns the initiative; the guild admin is not a member of it.
-    initiative = await create_initiative(session, guild, creator, name="Init")
+    creator = await acting_user(guild_role=GuildRole.member, initiative=True)
+    guild_admin = await acting_user(guild_role=GuildRole.admin, guild=creator.guild)
 
-    headers = await get_guild_headers(session, guild, guild_admin)
     payload = {
         "name": "Admin Field",
         "type": "text",
-        "initiative_id": initiative.id,
+        "initiative_id": creator.initiative.id,
     }
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        guild_admin.g("/property-definitions/"),
+        headers=guild_admin.headers,
+        json=payload,
     )
 
     assert response.status_code == 201
-    assert response.json()["initiative_id"] == initiative.id
+    assert response.json()["initiative_id"] == creator.initiative.id
 
 
 @pytest.mark.integration
-async def test_create_select_requires_options(
-    client: AsyncClient, session: AsyncSession
-):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+async def test_create_select_requires_options(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    headers = await get_guild_headers(session, guild, user)
-    payload = {"name": "State", "type": "select", "initiative_id": initiative.id}
+    payload = {"name": "State", "type": "select", "initiative_id": a.initiative.id}
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        a.g("/property-definitions/"), headers=a.headers, json=payload
     )
 
     assert response.status_code == 422
@@ -390,19 +269,15 @@ async def test_create_select_requires_options(
 
 @pytest.mark.integration
 async def test_create_duplicate_name_case_insensitive_conflicts(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    await create_property_definition(session, initiative, name="Priority")
+    await create_property_definition(session, a.initiative, name="Priority")
 
-    headers = await get_guild_headers(session, guild, user)
-    payload = {"name": "priority", "type": "text", "initiative_id": initiative.id}
+    payload = {"name": "priority", "type": "text", "initiative_id": a.initiative.id}
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        a.g("/property-definitions/"), headers=a.headers, json=payload
     )
 
     assert response.status_code == 409
@@ -411,47 +286,40 @@ async def test_create_duplicate_name_case_insensitive_conflicts(
 
 @pytest.mark.integration
 async def test_create_same_name_in_different_initiatives_allowed(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """The uniqueness index is on (initiative_id, lower(name)) — two
     initiatives can each have their own 'Priority' without clashing."""
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    init_a = await create_initiative(session, guild, user, name="A")
-    init_b = await create_initiative(session, guild, user, name="B")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    init_a = a.initiative
+    init_b = await create_initiative(session, a.guild, a.user, name="B")
 
     await create_property_definition(session, init_a, name="Priority")
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {"name": "Priority", "type": "text", "initiative_id": init_b.id}
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        a.g("/property-definitions/"), headers=a.headers, json=payload
     )
     assert response.status_code == 201
 
 
 @pytest.mark.integration
 async def test_create_select_duplicate_option_values_rejected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
         "name": "Phase",
         "type": "select",
-        "initiative_id": initiative.id,
+        "initiative_id": a.initiative.id,
         "options": [
             {"value": "draft", "label": "Draft"},
             {"value": "draft", "label": "Also Draft"},
         ],
     }
     response = await client.post(
-        f"/api/v1/g/{guild.id}/property-definitions/", headers=headers, json=payload
+        a.g("/property-definitions/"), headers=a.headers, json=payload
     )
 
     assert response.status_code == 422
@@ -466,17 +334,14 @@ async def test_create_select_duplicate_option_values_rejected(
 
 @pytest.mark.integration
 async def test_get_definition_returns_definition(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    defn = await create_property_definition(session, initiative, name="Phase")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    defn = await create_property_definition(session, a.initiative, name="Phase")
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/property-definitions/{defn.id}",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/property-definitions/{defn.id}"),
+        headers=a.headers,
     )
 
     assert response.status_code == 200
@@ -485,16 +350,14 @@ async def test_get_definition_returns_definition(
 
 @pytest.mark.integration
 async def test_get_definition_for_missing_id_returns_404(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Unknown definition id → 404 with the canonical error code."""
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    a = await acting_user(guild_role=GuildRole.admin)
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/property-definitions/99999",
-        headers=await get_guild_headers(session, guild, user),
+        a.g("/property-definitions/99999"),
+        headers=a.headers,
     )
 
     assert response.status_code == 404
@@ -508,21 +371,17 @@ async def test_get_definition_for_missing_id_returns_404(
 
 @pytest.mark.integration
 async def test_patch_renames_color_and_position(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
     defn = await create_property_definition(
-        session, initiative, name="Old Name", position=0.0
+        session, a.initiative, name="Old Name", position=0.0
     )
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {"name": "New Name", "color": "#FF00AA", "position": 5.5}
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/property-definitions/{defn.id}",
-        headers=headers,
+        a.g(f"/property-definitions/{defn.id}"),
+        headers=a.headers,
         json=payload,
     )
 
@@ -536,22 +395,18 @@ async def test_patch_renames_color_and_position(
 
 @pytest.mark.integration
 async def test_patch_ignores_type_change_silently(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """The Update schema has no `type` field, so sending one is ignored."""
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
     defn = await create_property_definition(
-        session, initiative, name="Immutable", type=PropertyType.text
+        session, a.initiative, name="Immutable", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {"type": "number", "name": "Renamed"}
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/property-definitions/{defn.id}",
-        headers=headers,
+        a.g(f"/property-definitions/{defn.id}"),
+        headers=a.headers,
         json=payload,
     )
 
@@ -562,17 +417,14 @@ async def test_patch_ignores_type_change_silently(
 
 @pytest.mark.integration
 async def test_patch_removing_option_reports_orphaned_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Removing an option on a select with attached values reports the orphans."""
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     defn = await create_property_definition(
         session,
-        initiative,
+        a.initiative,
         name="Stage",
         type=PropertyType.select,
         options=[
@@ -582,15 +434,14 @@ async def test_patch_removing_option_reports_orphaned_values(
     )
 
     # Attach a document value that uses the "live" slug.
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    doc = await create_document(session, a.initiative, a.user)
     await create_document_property_value(session, doc, defn, value_text="live")
 
-    headers = await get_guild_headers(session, guild, user)
     # Remove "live" from the option list.
     payload = {"options": [{"value": "draft", "label": "Draft"}]}
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/property-definitions/{defn.id}",
-        headers=headers,
+        a.g(f"/property-definitions/{defn.id}"),
+        headers=a.headers,
         json=payload,
     )
 
@@ -614,24 +465,20 @@ async def test_patch_removing_option_reports_orphaned_values(
 
 @pytest.mark.integration
 async def test_delete_definition_cascades_to_values(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    defn = await create_property_definition(session, initiative, name="Meta")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    defn = await create_property_definition(session, a.initiative, name="Meta")
 
-    project = await create_project(session, initiative, user, name="Proj")
-    task = await _create_task(session, project)
-    doc = await _create_document(session, initiative=initiative, owner=user)
+    project = await create_project(session, a.initiative, a.user, name="Proj")
+    task = await create_task(session, project)
+    doc = await create_document(session, a.initiative, a.user)
 
     await create_document_property_value(session, doc, defn, value_text="a doc value")
     await create_task_property_value(session, task, defn, value_text="a task value")
 
-    headers = await get_guild_headers(session, guild, user)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/property-definitions/{defn.id}", headers=headers
+        a.g(f"/property-definitions/{defn.id}"), headers=a.headers
     )
     assert response.status_code == 204
 
@@ -663,26 +510,21 @@ async def test_delete_definition_cascades_to_values(
 
 @pytest.mark.integration
 async def test_get_entities_returns_attached_docs_and_tasks(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    defn = await create_property_definition(session, initiative, name="Owner Tag")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    defn = await create_property_definition(session, a.initiative, name="Owner Tag")
 
-    project = await create_project(session, initiative, user, name="Proj")
-    task = await _create_task(session, project, "Task 1")
-    doc = await _create_document(
-        session, initiative=initiative, owner=user, title="Doc 1"
-    )
+    project = await create_project(session, a.initiative, a.user, name="Proj")
+    task = await create_task(session, project, title="Task 1")
+    doc = await create_document(session, a.initiative, a.user, title="Doc 1")
 
     await create_document_property_value(session, doc, defn, value_text="x")
     await create_task_property_value(session, task, defn, value_text="y")
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/property-definitions/{defn.id}/entities",
-        headers=await get_guild_headers(session, guild, user),
+        a.g(f"/property-definitions/{defn.id}/entities"),
+        headers=a.headers,
     )
     assert response.status_code == 200
     data = response.json()

--- a/backend/app/api/v1/tenant_endpoints/queues_test.py
+++ b/backend/app/api/v1/tenant_endpoints/queues_test.py
@@ -7,16 +7,9 @@ from httpx import AsyncClient
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models.platform.guild import Guild, GuildRole
+from app.models.platform.guild import GuildRole
 from app.models.tenant.initiative import InitiativeRoleModel
-from app.testing.factories import (
-    create_guild,
-    create_guild_membership,
-    create_initiative,
-    create_initiative_member,
-    create_user,
-    get_guild_headers,
-)
+from app.testing import Actor
 
 
 # ---------------------------------------------------------------------------
@@ -24,38 +17,16 @@ from app.testing.factories import (
 # ---------------------------------------------------------------------------
 
 
-async def _setup_guild_and_initiative(session: AsyncSession):
-    """Create admin user, guild, membership, and initiative."""
-    admin = await create_user(session, email="admin@example.com")
-    guild = await create_guild(session, creator=admin)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
-    )
-    initiative = await create_initiative(session, guild, admin, name="Test Initiative")
-    return admin, guild, initiative
-
-
-async def _setup_with_member(session: AsyncSession):
-    """Create admin + regular member with guild/initiative membership."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    member = await create_user(session, email="member@example.com")
-    await create_guild_membership(session, user=member, guild=guild)
-    await create_initiative_member(session, initiative, member, role_name="member")
-    return admin, member, guild, initiative
-
-
 async def _create_queue_via_api(
     client: AsyncClient,
-    headers: dict,
-    guild: Guild,
-    initiative_id: int,
+    actor: Actor,
     name: str = "Test Queue",
 ) -> dict:
     """Create a queue via API and return the response data."""
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/",
-        headers=headers,
-        json={"name": name, "initiative_id": initiative_id},
+        actor.g("/queues/"),
+        headers=actor.headers,
+        json={"name": name, "initiative_id": actor.initiative.id},
     )
     assert response.status_code == 201
     return response.json()
@@ -63,16 +34,15 @@ async def _create_queue_via_api(
 
 async def _add_item_via_api(
     client: AsyncClient,
-    headers: dict,
-    guild: Guild,
+    actor: Actor,
     queue_id: int,
     label: str,
     position: float = 0,
 ) -> dict:
     """Add an item to a queue via API."""
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_id}/items",
-        headers=headers,
+        actor.g(f"/queues/{queue_id}/items"),
+        headers=actor.headers,
         json={"label": label, "position": position},
     )
     assert response.status_code == 201
@@ -85,18 +55,17 @@ async def _add_item_via_api(
 
 
 @pytest.mark.integration
-async def test_create_queue(client: AsyncClient, session: AsyncSession):
+async def test_create_queue(client: AsyncClient, acting_user):
     """PM can create a queue."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/",
-        headers=headers,
+        a.g("/queues/"),
+        headers=a.headers,
         json={
             "name": "Initiative Order",
             "description": "Turn tracker",
-            "initiative_id": initiative.id,
+            "initiative_id": a.initiative.id,
         },
     )
 
@@ -104,26 +73,29 @@ async def test_create_queue(client: AsyncClient, session: AsyncSession):
     data = response.json()
     assert data["name"] == "Initiative Order"
     assert data["description"] == "Turn tracker"
-    assert data["initiative_id"] == initiative.id
-    assert data["created_by_id"] == admin.id
+    assert data["initiative_id"] == a.initiative.id
+    assert data["created_by_id"] == a.user.id
     assert data["is_active"] is False
     assert data["current_round"] == 1
 
 
 @pytest.mark.integration
-async def test_create_queue_non_pm_forbidden(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_create_queue_non_pm_forbidden(client: AsyncClient, acting_user):
     """Non-PM member cannot create a queue (unless role allows it)."""
-    admin, member, guild, initiative = await _setup_with_member(session)
-    headers = await get_guild_headers(session, guild, member)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/",
-        headers=headers,
+        member.g("/queues/"),
+        headers=member.headers,
         json={
             "name": "Forbidden Queue",
-            "initiative_id": initiative.id,
+            "initiative_id": admin.initiative.id,
         },
     )
 
@@ -131,13 +103,12 @@ async def test_create_queue_non_pm_forbidden(
 
 
 @pytest.mark.integration
-async def test_list_queues(client: AsyncClient, session: AsyncSession):
+async def test_list_queues(client: AsyncClient, acting_user):
     """Admin can list queues."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    await _create_queue_via_api(client, headers, guild, initiative.id, "Listed Queue")
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _create_queue_via_api(client, a, "Listed Queue")
 
-    response = await client.get(f"/api/v1/g/{guild.id}/queues/", headers=headers)
+    response = await client.get(a.g("/queues/"), headers=a.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -147,15 +118,12 @@ async def test_list_queues(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_get_queue(client: AsyncClient, session: AsyncSession):
+async def test_get_queue(client: AsyncClient, acting_user):
     """Owner can fetch queue details."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
 
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}", headers=headers
-    )
+    response = await client.get(a.g(f"/queues/{queue_data['id']}"), headers=a.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -164,15 +132,14 @@ async def test_get_queue(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_update_queue(client: AsyncClient, session: AsyncSession):
+async def test_update_queue(client: AsyncClient, acting_user):
     """Owner can update queue name/description."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}"),
+        headers=a.headers,
         json={"name": "Updated Name", "description": "Updated desc"},
     )
 
@@ -183,21 +150,18 @@ async def test_update_queue(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_delete_queue(client: AsyncClient, session: AsyncSession):
+async def test_delete_queue(client: AsyncClient, acting_user):
     """Owner can delete a queue."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
 
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}", headers=headers
+        a.g(f"/queues/{queue_data['id']}"), headers=a.headers
     )
     assert response.status_code == 204
 
     # Verify gone
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}", headers=headers
-    )
+    response = await client.get(a.g(f"/queues/{queue_data['id']}"), headers=a.headers)
     assert response.status_code == 404
 
 
@@ -207,15 +171,14 @@ async def test_delete_queue(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_add_queue_item(client: AsyncClient, session: AsyncSession):
+async def test_add_queue_item(client: AsyncClient, acting_user):
     """Owner can add an item to a queue."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/items",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/items"),
+        headers=a.headers,
         json={"label": "Player 1", "position": 15, "color": "#FF0000"},
     )
 
@@ -227,18 +190,15 @@ async def test_add_queue_item(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_update_queue_item(client: AsyncClient, session: AsyncSession):
+async def test_update_queue_item(client: AsyncClient, acting_user):
     """Owner can update an item."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    item_data = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "Original"
-    )
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    item_data = await _add_item_via_api(client, a, queue_data["id"], "Original")
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/items/{item_data['id']}",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/items/{item_data['id']}"),
+        headers=a.headers,
         json={"label": "Renamed", "position": 5},
     )
 
@@ -249,38 +209,30 @@ async def test_update_queue_item(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_delete_queue_item(client: AsyncClient, session: AsyncSession):
+async def test_delete_queue_item(client: AsyncClient, acting_user):
     """Owner can delete an item."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    item_data = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "To Delete"
-    )
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    item_data = await _add_item_via_api(client, a, queue_data["id"], "To Delete")
 
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/items/{item_data['id']}",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/items/{item_data['id']}"),
+        headers=a.headers,
     )
     assert response.status_code == 204
 
 
 @pytest.mark.integration
-async def test_reorder_queue_items(client: AsyncClient, session: AsyncSession):
+async def test_reorder_queue_items(client: AsyncClient, acting_user):
     """Owner can bulk-reorder items."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    item_a = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "A", position=1
-    )
-    item_b = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "B", position=2
-    )
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    item_a = await _add_item_via_api(client, a, queue_data["id"], "A", position=1)
+    item_b = await _add_item_via_api(client, a, queue_data["id"], "B", position=2)
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/items/reorder",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/items/reorder"),
+        headers=a.headers,
         json={
             "items": [
                 {"id": item_a["id"], "position": 20},
@@ -297,20 +249,17 @@ async def test_reorder_queue_items(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_fractional_positions(client: AsyncClient, session: AsyncSession):
+async def test_fractional_positions(client: AsyncClient, acting_user):
     """Items with the same integer initiative can be split by a fractional position."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    item_a = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "A", position=10
-    )
-    await _add_item_via_api(client, headers, guild, queue_data["id"], "B", position=10)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    item_a = await _add_item_via_api(client, a, queue_data["id"], "A", position=10)
+    await _add_item_via_api(client, a, queue_data["id"], "B", position=10)
 
     # Drop C between A and B without renumbering either.
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/items",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/items"),
+        headers=a.headers,
         json={"label": "C", "position": 10.5},
     )
     assert response.status_code == 201
@@ -318,8 +267,8 @@ async def test_fractional_positions(client: AsyncClient, session: AsyncSession):
 
     # Persisted precision survives a round-trip.
     update = await client.patch(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/items/{item_a['id']}",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/items/{item_a['id']}"),
+        headers=a.headers,
         json={"position": 10.25},
     )
     assert update.status_code == 200
@@ -328,19 +277,19 @@ async def test_fractional_positions(client: AsyncClient, session: AsyncSession):
     # Positions are now C=10.5, A=10.25, B=10. Turn order must respect the
     # fractional ordering (descending), not collapse to the shared integer.
     start = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/start", headers=headers
+        a.g(f"/queues/{queue_data['id']}/start"), headers=a.headers
     )
     assert start.status_code == 200
     assert start.json()["current_item"]["label"] == "C"
 
     second = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/next", headers=headers
+        a.g(f"/queues/{queue_data['id']}/next"), headers=a.headers
     )
     assert second.status_code == 200
     assert second.json()["current_item"]["label"] == "A"
 
     third = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/next", headers=headers
+        a.g(f"/queues/{queue_data['id']}/next"), headers=a.headers
     )
     assert third.status_code == 200
     assert third.json()["current_item"]["label"] == "B"
@@ -352,16 +301,15 @@ async def test_fractional_positions(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_start_and_stop_queue(client: AsyncClient, session: AsyncSession):
+async def test_start_and_stop_queue(client: AsyncClient, acting_user):
     """Start activates the queue, stop deactivates it."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    await _add_item_via_api(client, headers, guild, queue_data["id"], "P1", position=10)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    await _add_item_via_api(client, a, queue_data["id"], "P1", position=10)
 
     # Start
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/start", headers=headers
+        a.g(f"/queues/{queue_data['id']}/start"), headers=a.headers
     )
     assert response.status_code == 200
     data = response.json()
@@ -370,7 +318,7 @@ async def test_start_and_stop_queue(client: AsyncClient, session: AsyncSession):
 
     # Stop
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/stop", headers=headers
+        a.g(f"/queues/{queue_data['id']}/stop"), headers=a.headers
     )
     assert response.status_code == 200
     data = response.json()
@@ -378,40 +326,34 @@ async def test_start_and_stop_queue(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_advance_turn(client: AsyncClient, session: AsyncSession):
+async def test_advance_turn(client: AsyncClient, acting_user):
     """Advancing cycles through visible items."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    await _add_item_via_api(client, headers, guild, queue_data["id"], "A", position=10)
-    await _add_item_via_api(client, headers, guild, queue_data["id"], "B", position=20)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    await _add_item_via_api(client, a, queue_data["id"], "A", position=10)
+    await _add_item_via_api(client, a, queue_data["id"], "B", position=20)
 
     # Start
-    await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/start", headers=headers
-    )
+    await client.post(a.g(f"/queues/{queue_data['id']}/start"), headers=a.headers)
 
     # Advance
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/next", headers=headers
+        a.g(f"/queues/{queue_data['id']}/next"), headers=a.headers
     )
     assert response.status_code == 200
 
 
 @pytest.mark.integration
-async def test_reset_queue(client: AsyncClient, session: AsyncSession):
+async def test_reset_queue(client: AsyncClient, acting_user):
     """Reset resets round to 1 and sets current to first visible item."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    await _add_item_via_api(client, headers, guild, queue_data["id"], "P1", position=5)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    await _add_item_via_api(client, a, queue_data["id"], "P1", position=5)
 
-    await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/start", headers=headers
-    )
+    await client.post(a.g(f"/queues/{queue_data['id']}/start"), headers=a.headers)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/reset", headers=headers
+        a.g(f"/queues/{queue_data['id']}/reset"), headers=a.headers
     )
     assert response.status_code == 200
     data = response.json()
@@ -425,21 +367,15 @@ async def test_reset_queue(client: AsyncClient, session: AsyncSession):
 
 
 async def _running_queue_with_abc(
-    client: AsyncClient, headers: dict, guild: Guild, initiative_id: int
+    client: AsyncClient, actor: Actor
 ) -> tuple[dict, dict, dict, dict]:
     """Helper: queue with three items A(30), B(20), C(10), started; current=A."""
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative_id)
-    a = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "A", position=30
-    )
-    b = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "B", position=20
-    )
-    c = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "C", position=10
-    )
+    queue_data = await _create_queue_via_api(client, actor)
+    a = await _add_item_via_api(client, actor, queue_data["id"], "A", position=30)
+    b = await _add_item_via_api(client, actor, queue_data["id"], "B", position=20)
+    c = await _add_item_via_api(client, actor, queue_data["id"], "C", position=10)
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/start", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/start"), headers=actor.headers
     )
     return queue_data, a, b, c
 
@@ -450,17 +386,14 @@ def _items_by_id(payload: dict) -> dict[int, dict]:
 
 @pytest.mark.integration
 async def test_hold_current_records_round_and_advances(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Hold the current item: held_at_round is set, current advances past it."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, b, _c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, b, _c = await _running_queue_with_abc(client, actor)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     assert response.status_code == 200
     payload = response.json()
@@ -471,22 +404,17 @@ async def test_hold_current_records_round_and_advances(
 
 
 @pytest.mark.integration
-async def test_hold_only_item_clears_current(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_hold_only_item_clears_current(client: AsyncClient, acting_user):
     """Holding the last rotation-eligible item leaves current_item = None."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    a = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "Solo", position=10
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, actor)
+    a = await _add_item_via_api(client, actor, queue_data["id"], "Solo", position=10)
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/start", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/start"), headers=actor.headers
     )
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     assert response.status_code == 200
     payload = response.json()
@@ -495,24 +423,19 @@ async def test_hold_only_item_clears_current(
 
 
 @pytest.mark.integration
-async def test_advance_auto_releases_at_natural_slot(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_advance_auto_releases_at_natural_slot(client: AsyncClient, acting_user):
     """Held A returns to current when round 2 reaches A's position-desc slot."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, b, c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, b, c = await _running_queue_with_abc(client, actor)
 
     # Hold A; current is now B in round 1.
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     # B -> C, still round 1.
     after_bc = (
         await client.post(
-            f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/next", headers=headers
+            actor.g(f"/queues/{queue_data['id']}/next"), headers=actor.headers
         )
     ).json()
     assert after_bc["current_item"]["id"] == c["id"]
@@ -521,7 +444,7 @@ async def test_advance_auto_releases_at_natural_slot(
     # auto-released because held_at_round (1) < new round (2).
     after_wrap = (
         await client.post(
-            f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/next", headers=headers
+            actor.g(f"/queues/{queue_data['id']}/next"), headers=actor.headers
         )
     ).json()
     assert after_wrap["current_item"]["id"] == a["id"]
@@ -532,27 +455,22 @@ async def test_advance_auto_releases_at_natural_slot(
 
 
 @pytest.mark.integration
-async def test_release_clears_hold_without_rewinding(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_release_clears_hold_without_rewinding(client: AsyncClient, acting_user):
     """Release clears `held_at_round` but leaves the current pointer alone.
 
     The released item rejoins the rotation; whoever was currently up stays up
     so the rotation doesn't double-act items that already took their turn.
     """
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, b, _c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, b, _c = await _running_queue_with_abc(client, actor)
 
     # Hold A; current is B.
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/release/{a['id']}",
-        headers=headers,
+        actor.g(f"/queues/{queue_data['id']}/release/{a['id']}"),
+        headers=actor.headers,
     )
     assert response.status_code == 200
     payload = response.json()
@@ -563,26 +481,23 @@ async def test_release_clears_hold_without_rewinding(
 
 @pytest.mark.integration
 async def test_release_with_reposition_lifts_target_above_current(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Reposition places the released item above current and makes them act now."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, b, c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, b, c = await _running_queue_with_abc(client, actor)
 
     # Hold A (pos 30) on its turn → current becomes B (pos 20). After hold,
     # the only items above B in the rotation are... none (A is held, so B is
     # effectively the top of the active rotation).
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     # Release A with reposition: A acts now (becomes current), and its new
     # position drops just above B (which was current).
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/release/{a['id']}",
-        headers=headers,
+        actor.g(f"/queues/{queue_data['id']}/release/{a['id']}"),
+        headers=actor.headers,
         json={"reposition": True},
     )
     assert response.status_code == 200
@@ -600,7 +515,7 @@ async def test_release_with_reposition_lifts_target_above_current(
     # Advancing from A goes to B next — A's elevated position persists.
     after_next = (
         await client.post(
-            f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/next", headers=headers
+            actor.g(f"/queues/{queue_data['id']}/next"), headers=actor.headers
         )
     ).json()
     assert after_next["current_item"]["id"] == b["id"]
@@ -608,37 +523,30 @@ async def test_release_with_reposition_lifts_target_above_current(
 
 @pytest.mark.integration
 async def test_release_with_reposition_between_current_and_higher(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """When other active items sit above current, target lands between them."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    a = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "A", position=30
-    )
-    b = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "B", position=20
-    )
-    c = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "C", position=10
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, actor)
+    a = await _add_item_via_api(client, actor, queue_data["id"], "A", position=30)
+    b = await _add_item_via_api(client, actor, queue_data["id"], "B", position=20)
+    c = await _add_item_via_api(client, actor, queue_data["id"], "C", position=10)
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/start", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/start"), headers=actor.headers
     )
     # Advance to B (current goes A → B). Then hold B → current becomes C.
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/next", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/next"), headers=actor.headers
     )
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     # Now A (pos 30) is active and above C (current, pos 10). Release B with
     # reposition: B's new position should land between C (10) and A (30) — the
     # midpoint is 20.
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/release/{b['id']}",
-        headers=headers,
+        actor.g(f"/queues/{queue_data['id']}/release/{b['id']}"),
+        headers=actor.headers,
         json={"reposition": True},
     )
     assert response.status_code == 200
@@ -657,22 +565,19 @@ async def test_release_with_reposition_between_current_and_higher(
 
 @pytest.mark.integration
 async def test_release_without_body_preserves_position(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, acting_user
 ):
     """Calling release with an empty body keeps the original behavior (no reposition)."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, _b, _c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, _b, _c = await _running_queue_with_abc(client, actor)
 
     original_position = a["position"]
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/release/{a['id']}",
-        headers=headers,
+        actor.g(f"/queues/{queue_data['id']}/release/{a['id']}"),
+        headers=actor.headers,
         json={},
     )
     assert response.status_code == 200
@@ -681,23 +586,20 @@ async def test_release_without_body_preserves_position(
 
 
 @pytest.mark.integration
-async def test_release_while_stopped(client: AsyncClient, session: AsyncSession):
+async def test_release_while_stopped(client: AsyncClient, acting_user):
     """Release works when the queue is stopped; is_active is preserved."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, b, _c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, b, _c = await _running_queue_with_abc(client, actor)
 
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/stop", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/stop"), headers=actor.headers
     )
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/release/{a['id']}",
-        headers=headers,
+        actor.g(f"/queues/{queue_data['id']}/release/{a['id']}"),
+        headers=actor.headers,
     )
     assert response.status_code == 200
     payload = response.json()
@@ -709,20 +611,17 @@ async def test_release_while_stopped(client: AsyncClient, session: AsyncSession)
 
 
 @pytest.mark.integration
-async def test_set_active_clears_held(client: AsyncClient, session: AsyncSession):
+async def test_set_active_clears_held(client: AsyncClient, acting_user):
     """set-active on a held item also clears its held_at_round."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, _b, _c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, _b, _c = await _running_queue_with_abc(client, actor)
 
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/set-active/{a['id']}",
-        headers=headers,
+        actor.g(f"/queues/{queue_data['id']}/set-active/{a['id']}"),
+        headers=actor.headers,
     )
     assert response.status_code == 200
     payload = response.json()
@@ -731,24 +630,19 @@ async def test_set_active_clears_held(client: AsyncClient, session: AsyncSession
 
 
 @pytest.mark.integration
-async def test_previous_skips_held_no_auto_release(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_previous_skips_held_no_auto_release(client: AsyncClient, acting_user):
     """Previous never lands on a held item, and never clears its hold."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, _b, c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, _b, c = await _running_queue_with_abc(client, actor)
 
     # Hold A (round 1, current was A); current becomes B.
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     # Previous from B should wrap (B is first in the active rotation now) to C
     # in round 0 → clamped to round 1.
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/previous", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/previous"), headers=actor.headers
     )
     assert response.status_code == 200
     payload = response.json()
@@ -758,19 +652,16 @@ async def test_previous_skips_held_no_auto_release(
 
 
 @pytest.mark.integration
-async def test_reset_preserves_held(client: AsyncClient, session: AsyncSession):
+async def test_reset_preserves_held(client: AsyncClient, acting_user):
     """Reset jumps to the highest un-held item; held items stay held."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, b, _c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, b, _c = await _running_queue_with_abc(client, actor)
 
     await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/hold"), headers=actor.headers
     )
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/reset", headers=headers
+        actor.g(f"/queues/{queue_data['id']}/reset"), headers=actor.headers
     )
     assert response.status_code == 200
     payload = response.json()
@@ -780,54 +671,48 @@ async def test_reset_preserves_held(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_hold_no_current_item(client: AsyncClient, session: AsyncSession):
+async def test_hold_no_current_item(client: AsyncClient, acting_user):
     """Hold with no current item returns 400 NO_CURRENT_ITEM."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "Solo", position=10
-    )
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    await _add_item_via_api(client, a, queue_data["id"], "Solo", position=10)
     # Don't start: current_item_id stays None.
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=headers
+        a.g(f"/queues/{queue_data['id']}/hold"), headers=a.headers
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "QUEUE_NO_CURRENT_ITEM"
 
 
 @pytest.mark.integration
-async def test_release_unheld_item_returns_400(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_release_unheld_item_returns_400(client: AsyncClient, acting_user):
     """Calling release on an item that isn't held returns ITEM_NOT_HELD."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data, a, _b, _c = await _running_queue_with_abc(
-        client, headers, guild, initiative.id
-    )
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data, a, _b, _c = await _running_queue_with_abc(client, actor)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/release/{a['id']}",
-        headers=headers,
+        actor.g(f"/queues/{queue_data['id']}/release/{a['id']}"),
+        headers=actor.headers,
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "QUEUE_ITEM_NOT_HELD"
 
 
 @pytest.mark.integration
-async def test_hold_requires_write_access(client: AsyncClient, session: AsyncSession):
+async def test_hold_requires_write_access(client: AsyncClient, acting_user):
     """Members without write permission can't hold."""
-    admin, member, guild, initiative = await _setup_with_member(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
-    member_headers = await get_guild_headers(session, guild, member)
-    queue_data, _a, _b, _c = await _running_queue_with_abc(
-        client, admin_headers, guild, initiative.id
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
+    queue_data, _a, _b, _c = await _running_queue_with_abc(client, admin)
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/hold", headers=member_headers
+        member.g(f"/queues/{queue_data['id']}/hold"), headers=member.headers
     )
     assert response.status_code == 403
 
@@ -838,45 +723,53 @@ async def test_hold_requires_write_access(client: AsyncClient, session: AsyncSes
 
 
 @pytest.mark.integration
-async def test_set_queue_grants(client: AsyncClient, session: AsyncSession):
+async def test_set_queue_grants(client: AsyncClient, acting_user):
     """Owner can set user grants on a queue via the unified grants endpoint."""
-    admin, member, guild, initiative = await _setup_with_member(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    queue_data = await _create_queue_via_api(client, admin)
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
-        headers=headers,
-        json=[{"user_id": member.id, "level": "write"}],
+        admin.g(f"/queues/{queue_data['id']}/grants"),
+        headers=admin.headers,
+        json=[{"user_id": member.user.id, "level": "write"}],
     )
 
     assert response.status_code == 200
     data = response.json()
     member_grants = [
-        g for g in data["grants"] if g["user_id"] == member.id and g["level"] == "write"
+        g
+        for g in data["grants"]
+        if g["user_id"] == member.user.id and g["level"] == "write"
     ]
     assert len(member_grants) == 1
 
 
 @pytest.mark.integration
-async def test_set_queue_role_grants(client: AsyncClient, session: AsyncSession):
+async def test_set_queue_role_grants(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Owner can set role grants on a queue via the unified grants endpoint."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
 
     # Find the member role
     result = await session.exec(
         select(InitiativeRoleModel).where(
-            InitiativeRoleModel.initiative_id == initiative.id,
+            InitiativeRoleModel.initiative_id == a.initiative.id,
             InitiativeRoleModel.name == "member",
         )
     )
     member_role = result.one()
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/grants"),
+        headers=a.headers,
         json=[{"role_id": member_role.id, "level": "read"}],
     )
 
@@ -891,62 +784,61 @@ async def test_set_queue_role_grants(client: AsyncClient, session: AsyncSession)
 
 
 @pytest.mark.integration
-async def test_member_with_read_can_view_queue(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_member_with_read_can_view_queue(client: AsyncClient, acting_user):
     """Member with read permission can view but not modify."""
-    admin, member, guild, initiative = await _setup_with_member(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(
-        client, admin_headers, guild, initiative.id
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
+    queue_data = await _create_queue_via_api(client, admin)
 
     # Grant read to member
     await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
-        headers=admin_headers,
-        json=[{"user_id": member.id, "level": "read"}],
+        admin.g(f"/queues/{queue_data['id']}/grants"),
+        headers=admin.headers,
+        json=[{"user_id": member.user.id, "level": "read"}],
     )
-
-    member_headers = await get_guild_headers(session, guild, member)
 
     # Can read
     response = await client.get(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}", headers=member_headers
+        member.g(f"/queues/{queue_data['id']}"), headers=member.headers
     )
     assert response.status_code == 200
 
     # Cannot update
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}",
-        headers=member_headers,
+        member.g(f"/queues/{queue_data['id']}"),
+        headers=member.headers,
         json={"name": "Hacked"},
     )
     assert response.status_code == 403
 
 
 @pytest.mark.integration
-async def test_member_without_permission_cannot_view(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_member_without_permission_cannot_view(client: AsyncClient, acting_user):
     """Member with no permission cannot access the queue."""
-    admin, member, guild, initiative = await _setup_with_member(session)
-    admin_headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(
-        client, admin_headers, guild, initiative.id
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
     )
+    queue_data = await _create_queue_via_api(client, admin)
     # New queues default to all-members Viewer; restrict to owner-only so a member
     # without a grant is genuinely denied.
     restrict = await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/grants",
-        headers=admin_headers,
+        admin.g(f"/queues/{queue_data['id']}/grants"),
+        headers=admin.headers,
         json=[],
     )
     assert restrict.status_code == 200
 
-    member_headers = await get_guild_headers(session, guild, member)
     response = await client.get(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}", headers=member_headers
+        member.g(f"/queues/{queue_data['id']}"), headers=member.headers
     )
     assert response.status_code == 403
 
@@ -957,26 +849,22 @@ async def test_member_without_permission_cannot_view(
 
 
 @pytest.mark.integration
-async def test_set_queue_item_tags(client: AsyncClient, session: AsyncSession):
+async def test_set_queue_item_tags(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Owner can set tags on a queue item."""
-    from app.models.tenant.tag import Tag
+    from app.testing import create_tag
 
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue_data = await _create_queue_via_api(client, headers, guild, initiative.id)
-    item_data = await _add_item_via_api(
-        client, headers, guild, queue_data["id"], "Tagged"
-    )
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue_data = await _create_queue_via_api(client, a)
+    item_data = await _add_item_via_api(client, a, queue_data["id"], "Tagged")
 
     # Create a tag
-    tag = Tag(name="Priority", guild_id=guild.id)
-    session.add(tag)
-    await session.commit()
-    await session.refresh(tag)
+    tag = await create_tag(session, a.guild, name="Priority")
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/queues/{queue_data['id']}/items/{item_data['id']}/tags",
-        headers=headers,
+        a.g(f"/queues/{queue_data['id']}/items/{item_data['id']}/tags"),
+        headers=a.headers,
         json=[tag.id],
     )
 
@@ -987,28 +875,35 @@ async def test_set_queue_item_tags(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_create_queue_with_grants(client: AsyncClient, session: AsyncSession):
+async def test_create_queue_with_grants(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Create a queue with inline role and user grants."""
-    admin, member, guild, initiative = await _setup_with_member(session)
-    headers = await get_guild_headers(session, guild, admin)
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
 
     result = await session.exec(
         select(InitiativeRoleModel).where(
-            InitiativeRoleModel.initiative_id == initiative.id,
+            InitiativeRoleModel.initiative_id == admin.initiative.id,
             InitiativeRoleModel.name == "member",
         )
     )
     member_role = result.one()
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/queues/",
-        headers=headers,
+        admin.g("/queues/"),
+        headers=admin.headers,
         json={
             "name": "With Perms",
-            "initiative_id": initiative.id,
+            "initiative_id": admin.initiative.id,
             "grants": [
                 {"role_id": member_role.id, "level": "read"},
-                {"user_id": member.id, "level": "write"},
+                {"user_id": member.user.id, "level": "write"},
             ],
         },
     )
@@ -1022,22 +917,23 @@ async def test_create_queue_with_grants(client: AsyncClient, session: AsyncSessi
     ]
     assert len(role_grants) == 1
     user_grants = [
-        g for g in data["grants"] if g["user_id"] == member.id and g["level"] == "write"
+        g
+        for g in data["grants"]
+        if g["user_id"] == member.user.id and g["level"] == "write"
     ]
     assert len(user_grants) == 1
 
 
 @pytest.mark.integration
 async def test_delete_queue_still_emits_queue_deleted(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, acting_user, monkeypatch
 ):
     """Deleting a queue must still emit ``queue_deleted``. Regression: the queue
     is soft-deleted before _emit_queue runs, so its fallback guild lookup is
     hidden by the global deleted_at IS NULL filter — the delete path must pass
     guild_id explicitly or the event is silently dropped."""
-    admin, guild, initiative = await _setup_guild_and_initiative(session)
-    headers = await get_guild_headers(session, guild, admin)
-    queue = await _create_queue_via_api(client, headers, guild, initiative.id)
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    queue = await _create_queue_via_api(client, a)
 
     from app.services import stream_authz
 
@@ -1048,8 +944,6 @@ async def test_delete_queue_still_emits_queue_deleted(
 
     monkeypatch.setattr(stream_authz.authority, "emit", _record)
 
-    resp = await client.delete(
-        f"/api/v1/g/{guild.id}/queues/{queue['id']}", headers=headers
-    )
+    resp = await client.delete(a.g(f"/queues/{queue['id']}"), headers=a.headers)
     assert resp.status_code == 204, resp.text
-    assert (guild.id, "queue", queue["id"], "queue_deleted") in emitted
+    assert (a.guild.id, "queue", queue["id"], "queue_deleted") in emitted

--- a/backend/app/api/v1/tenant_endpoints/recents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/recents_test.py
@@ -10,43 +10,29 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.testing.factories import (
+from app.models.platform.guild import GuildRole
+from app.testing import (
     create_guild,
     create_guild_membership,
-    create_initiative,
     create_project,
     create_queue,
-    create_user,
-    get_guild_headers,
 )
-
-
-async def _make_user_with_guild_and_initiative(session, email="user@example.com"):
-    user = await create_user(session, email=email)
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-    initiative = await create_initiative(session, guild, user, name="Init")
-    return user, guild, initiative
 
 
 @pytest.mark.integration
 async def test_record_and_list_recent_project(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    user, guild, initiative = await _make_user_with_guild_and_initiative(session)
-    project = await create_project(session, initiative, user, name="P1")
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, a.initiative, a.user, name="P1")
 
-    headers = await get_guild_headers(session, guild, user)
-
-    r = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
-    )
+    r = await client.post(a.g(f"/projects/{project.id}/view"), headers=a.headers)
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["entity_type"] == "project"
     assert body["entity_id"] == project.id
 
-    r = await client.get("/api/v1/recents/", headers=headers)
+    r = await client.get("/api/v1/recents/", headers=a.headers)
     assert r.status_code == 200
     items = r.json()
     assert len(items) == 1
@@ -56,23 +42,19 @@ async def test_record_and_list_recent_project(
 
 
 @pytest.mark.integration
-async def test_record_and_list_recent_queue(client: AsyncClient, session: AsyncSession):
-    user, guild, initiative = await _make_user_with_guild_and_initiative(
-        session, email="queue@example.com"
-    )
-    queue = await create_queue(session, initiative, user, name="Q1")
+async def test_record_and_list_recent_queue(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    queue = await create_queue(session, a.initiative, a.user, name="Q1")
 
-    headers = await get_guild_headers(session, guild, user)
-
-    r = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue.id}/view", headers=headers
-    )
+    r = await client.post(a.g(f"/queues/{queue.id}/view"), headers=a.headers)
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["entity_type"] == "queue"
     assert body["entity_id"] == queue.id
 
-    r = await client.get("/api/v1/recents/", headers=headers)
+    r = await client.get("/api/v1/recents/", headers=a.headers)
     assert r.status_code == 200
     items = r.json()
     assert any(
@@ -81,28 +63,22 @@ async def test_record_and_list_recent_queue(client: AsyncClient, session: AsyncS
 
 
 @pytest.mark.integration
-async def test_recents_mixed_ordering(client: AsyncClient, session: AsyncSession):
+async def test_recents_mixed_ordering(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Items from different entity types must be ordered by last_viewed_at desc."""
-    user, guild, initiative = await _make_user_with_guild_and_initiative(
-        session, email="mix@example.com"
-    )
-    project = await create_project(session, initiative, user, name="Older project")
-    queue = await create_queue(session, initiative, user, name="Newer queue")
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, a.initiative, a.user, name="Older project")
+    queue = await create_queue(session, a.initiative, a.user, name="Newer queue")
 
-    headers = await get_guild_headers(session, guild, user)
-
-    r1 = await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
-    )
+    r1 = await client.post(a.g(f"/projects/{project.id}/view"), headers=a.headers)
     assert r1.status_code == 200
     # Small delay so timestamps differ deterministically.
     await asyncio.sleep(0.05)
-    r2 = await client.post(
-        f"/api/v1/g/{guild.id}/queues/{queue.id}/view", headers=headers
-    )
+    r2 = await client.post(a.g(f"/queues/{queue.id}/view"), headers=a.headers)
     assert r2.status_code == 200
 
-    r = await client.get("/api/v1/recents/", headers=headers)
+    r = await client.get("/api/v1/recents/", headers=a.headers)
     items = r.json()
     # Newer queue must come first.
     assert items[0]["entity_type"] == "queue"
@@ -112,100 +88,89 @@ async def test_recents_mixed_ordering(client: AsyncClient, session: AsyncSession
 
 
 @pytest.mark.integration
-async def test_clear_view_removes_item(client: AsyncClient, session: AsyncSession):
-    user, guild, initiative = await _make_user_with_guild_and_initiative(
-        session, email="clear@example.com"
-    )
-    project = await create_project(session, initiative, user, name="P")
-    headers = await get_guild_headers(session, guild, user)
+async def test_clear_view_removes_item(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, a.initiative, a.user, name="P")
 
-    await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
-    )
-    r = await client.delete(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
-    )
+    await client.post(a.g(f"/projects/{project.id}/view"), headers=a.headers)
+    r = await client.delete(a.g(f"/projects/{project.id}/view"), headers=a.headers)
     assert r.status_code == 204
 
-    r = await client.get("/api/v1/recents/", headers=headers)
+    r = await client.get("/api/v1/recents/", headers=a.headers)
     assert r.json() == []
 
 
 @pytest.mark.integration
 async def test_recents_are_cross_guild_names_only(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """The tabs bar shows entities from ANY of the user's guilds, from any
     context — render metadata only, tagged with the owning guild. Another
     user never sees them."""
-    user = await create_user(session, email="multi@example.com")
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project_a = await create_project(session, a.initiative, a.user, name="A's project")
 
-    guild_a = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild_a)
-    init_a = await create_initiative(session, guild_a, user, name="A")
-    project_a = await create_project(session, init_a, user, name="A's project")
-
+    # The same user also belongs to a second guild.
     guild_b = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild_b)
+    await create_guild_membership(session, user=a.user, guild=guild_b)
+    assert guild_b.id != a.guild.id
 
-    other = await create_user(session, email="other-multi@example.com")
-    await create_guild_membership(session, user=other, guild=guild_a)
+    # A different member of guild A.
+    other = await acting_user(
+        guild_role=GuildRole.member,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
 
     # Record the view while in guild A...
-    headers = await get_guild_headers(session, guild_a, user)
-    r = await client.post(
-        f"/api/v1/g/{guild_a.id}/projects/{project_a.id}/view", headers=headers
-    )
+    r = await client.post(a.g(f"/projects/{project_a.id}/view"), headers=a.headers)
     assert r.status_code == 200
 
     # ...then enter guild B: the tab still renders (name + owning guild).
-    headers = await get_guild_headers(session, guild_b, user)
-    r = await client.get("/api/v1/recents/", headers=headers)
+    r = await client.get("/api/v1/recents/", headers=a.headers)
     assert r.status_code == 200
     items = r.json()
     assert [(i["entity_type"], i["entity_id"], i["guild_id"]) for i in items] == [
-        ("project", project_a.id, guild_a.id)
+        ("project", project_a.id, a.guild.id)
     ]
     assert items[0]["name"] == "A's project"
 
     # The list is the user's own: another member of guild A sees nothing.
-    other_headers = await get_guild_headers(session, guild_a, other)
-    r = await client.get("/api/v1/recents/", headers=other_headers)
+    r = await client.get("/api/v1/recents/", headers=other.headers)
     assert r.status_code == 200
     assert r.json() == []
 
 
 @pytest.mark.integration
 async def test_recent_tabs_limit_caps_list_and_prune(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """The user's ``recent_tabs_limit`` bounds both what's stored (prune) and
     what the tabs-bar endpoint returns."""
-    user, guild, initiative = await _make_user_with_guild_and_initiative(
-        session, email="limit@example.com"
-    )
-    headers = await get_guild_headers(session, guild, user)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     # Lower the user's recents cap to 2 via self-update.
     r = await client.patch(
-        "/api/v1/users/me", json={"recent_tabs_limit": 2}, headers=headers
+        "/api/v1/users/me", json={"recent_tabs_limit": 2}, headers=a.headers
     )
     assert r.status_code == 200, r.text
     assert r.json()["recent_tabs_limit"] == 2
 
     # Open four projects, oldest first.
     projects = [
-        await create_project(session, initiative, user, name=f"P{i}") for i in range(4)
+        await create_project(session, a.initiative, a.user, name=f"P{i}")
+        for i in range(4)
     ]
     for project in projects:
-        rv = await client.post(
-            f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
-        )
+        rv = await client.post(a.g(f"/projects/{project.id}/view"), headers=a.headers)
         assert rv.status_code == 200
         await asyncio.sleep(0.02)
 
     # Only the two most-recently-opened survive — the rest were pruned.
-    r = await client.get("/api/v1/recents/", headers=headers)
+    r = await client.get("/api/v1/recents/", headers=a.headers)
     assert r.status_code == 200
     items = r.json()
     assert [i["entity_id"] for i in items] == [projects[3].id, projects[2].id]
@@ -213,50 +178,41 @@ async def test_recent_tabs_limit_caps_list_and_prune(
 
 @pytest.mark.integration
 async def test_recent_tabs_limit_rejects_out_of_range(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """The cap is validated to [1, 100]."""
-    user, guild, _ = await _make_user_with_guild_and_initiative(
-        session, email="limit-bad@example.com"
-    )
-    headers = await get_guild_headers(session, guild, user)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
 
     r = await client.patch(
-        "/api/v1/users/me", json={"recent_tabs_limit": 0}, headers=headers
+        "/api/v1/users/me", json={"recent_tabs_limit": 0}, headers=a.headers
     )
     assert r.status_code == 422
     r = await client.patch(
-        "/api/v1/users/me", json={"recent_tabs_limit": 101}, headers=headers
+        "/api/v1/users/me", json={"recent_tabs_limit": 101}, headers=a.headers
     )
     assert r.status_code == 422
 
 
 @pytest.mark.integration
 async def test_clear_recent_is_guild_addressed(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Closing a tab works from any context via the guild path segment."""
-    user, guild, initiative = await _make_user_with_guild_and_initiative(
-        session, email="close-tab@example.com"
-    )
-    project = await create_project(session, initiative, user, name="P")
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    project = await create_project(session, a.initiative, a.user, name="P")
+
     other_guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=other_guild)
+    await create_guild_membership(session, user=a.user, guild=other_guild)
 
-    headers = await get_guild_headers(session, guild, user)
-    await client.post(
-        f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
-    )
-
-    headers = await get_guild_headers(session, other_guild, user)
+    await client.post(a.g(f"/projects/{project.id}/view"), headers=a.headers)
 
     # Close guild A's tab while in guild B — addressed by the guild path.
     r = await client.delete(
-        f"/api/v1/g/{guild.id}/recents/project/{project.id}",
-        headers=headers,
+        f"/api/v1/g/{a.guild.id}/recents/project/{project.id}",
+        headers=a.headers,
     )
     assert r.status_code == 204
 
-    r = await client.get("/api/v1/recents/", headers=headers)
+    r = await client.get("/api/v1/recents/", headers=a.headers)
     assert r.status_code == 200
     assert r.json() == []

--- a/backend/app/api/v1/tenant_endpoints/resource_grants_test.py
+++ b/backend/app/api/v1/tenant_endpoints/resource_grants_test.py
@@ -18,7 +18,7 @@ from app.testing.factories import (
     create_project,
     create_queue,
     create_user,
-    get_guild_headers,
+    get_auth_headers,
 )
 
 BULK = "/api/v1/g/{guild}/resource-grants/bulk"
@@ -43,7 +43,7 @@ async def test_bulk_applies_grants_across_many_projects(
     await create_initiative_member(session, initiative, member, role_name="member")
     p1 = await create_project(session, initiative, owner)
     p2 = await create_project(session, initiative, owner)
-    headers = await get_guild_headers(session, guild, owner)
+    headers = get_auth_headers(owner)
 
     resp = await client.put(
         BULK.format(guild=guild.id),
@@ -92,7 +92,7 @@ async def test_bulk_dispatches_across_resource_types(
     await create_initiative_member(session, initiative, member, role_name="member")
     project = await create_project(session, initiative, owner)
     queue = await create_queue(session, initiative, owner)
-    headers = await get_guild_headers(session, guild, owner)
+    headers = get_auth_headers(owner)
 
     resp = await client.put(
         BULK.format(guild=guild.id),
@@ -133,7 +133,7 @@ async def test_bulk_is_best_effort_per_item(client: AsyncClient, session: AsyncS
     initiative = await create_initiative(session, guild, owner)
     await create_initiative_member(session, initiative, member, role_name="member")
     project = await create_project(session, initiative, owner)
-    headers = await get_guild_headers(session, guild, owner)
+    headers = get_auth_headers(owner)
 
     resp = await client.put(
         BULK.format(guild=guild.id),
@@ -177,7 +177,7 @@ async def test_bulk_reports_forbidden_for_unmanageable_item(
     initiative = await create_initiative(session, guild, owner)
     await create_initiative_member(session, initiative, member, role_name="member")
     project = await create_project(session, initiative, owner)
-    member_headers = await get_guild_headers(session, guild, member)
+    member_headers = get_auth_headers(member)
 
     resp = await client.put(
         BULK.format(guild=guild.id),
@@ -196,7 +196,7 @@ async def test_bulk_reports_forbidden_for_unmanageable_item(
     assert _results_by_id(resp.json()) == {project.id: "forbidden"}
 
     # Nothing changed — the member did not self-grant write.
-    owner_headers = await get_guild_headers(session, guild, owner)
+    owner_headers = get_auth_headers(owner)
     detail = await client.get(
         f"/api/v1/g/{guild.id}/projects/{project.id}", headers=owner_headers
     )
@@ -224,7 +224,7 @@ async def test_bulk_skips_archived_project_but_applies_the_rest(
     archived.is_archived = True
     session.add(archived)
     await session.commit()
-    headers = await get_guild_headers(session, guild, owner)
+    headers = get_auth_headers(owner)
 
     resp = await client.put(
         BULK.format(guild=guild.id),
@@ -256,7 +256,7 @@ async def test_bulk_rejects_too_many_items(client: AsyncClient, session: AsyncSe
     owner = await create_user(session, email="owner@example.com")
     guild = await create_guild(session)
     await create_guild_membership(session, user=owner, guild=guild)
-    headers = await get_guild_headers(session, guild, owner)
+    headers = get_auth_headers(owner)
 
     item = {"resource_type": "project", "resource_id": 1, "grants": []}
     resp = await client.put(
@@ -273,7 +273,7 @@ async def test_bulk_rejects_empty_items(client: AsyncClient, session: AsyncSessi
     owner = await create_user(session, email="owner@example.com")
     guild = await create_guild(session)
     await create_guild_membership(session, user=owner, guild=guild)
-    headers = await get_guild_headers(session, guild, owner)
+    headers = get_auth_headers(owner)
 
     resp = await client.put(
         BULK.format(guild=guild.id), headers=headers, json={"items": []}

--- a/backend/app/api/v1/tenant_endpoints/task_statuses_test.py
+++ b/backend/app/api/v1/tenant_endpoints/task_statuses_test.py
@@ -17,7 +17,7 @@ from app.testing.factories import (
     create_initiative,
     create_project,
     create_user,
-    get_guild_headers,
+    get_auth_headers,
 )
 
 
@@ -27,7 +27,7 @@ async def _setup_project(session: AsyncSession):
     await create_guild_membership(session, user=user, guild=guild)
     initiative = await create_initiative(session, guild, user, name="Test Initiative")
     project = await create_project(session, initiative, user, name="Test Project")
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     return project, headers
 
 

--- a/backend/app/api/v1/tenant_endpoints/tasks_properties_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_properties_test.py
@@ -30,7 +30,7 @@ from app.testing import (
     create_project,
     create_property_definition,
     create_user,
-    get_guild_headers,
+    get_auth_headers,
 )
 
 
@@ -75,7 +75,7 @@ async def test_put_task_properties_sets_values(
         session, initiative, name="Score", type=PropertyType.number
     )
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     response = await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
         headers=headers,
@@ -108,7 +108,7 @@ async def test_put_task_properties_empty_clears_existing(
         session, initiative, name="Tag", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
         headers=headers,
@@ -150,7 +150,7 @@ async def test_put_task_text_rejects_non_string(
 
     response = await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        headers=get_auth_headers(user),
         json={"values": [{"property_id": defn.id, "value": 12345}]},
     )
     assert response.status_code == 400
@@ -174,7 +174,7 @@ async def test_put_task_number_accepts_numeric_string(
 
     response = await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        headers=get_auth_headers(user),
         json={"values": [{"property_id": defn.id, "value": "3.14"}]},
     )
     assert response.status_code == 200
@@ -196,7 +196,7 @@ async def test_put_task_date_accepts_iso_and_rejects_garbage(
     defn = await create_property_definition(
         session, initiative, name="D", type=PropertyType.date
     )
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
 
     ok = await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
@@ -235,7 +235,7 @@ async def test_put_task_multi_select_unknown_slug_rejected(
 
     response = await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        headers=get_auth_headers(user),
         json={"values": [{"property_id": defn.id, "value": ["a", "ghost"]}]},
     )
     assert response.status_code == 400
@@ -265,7 +265,7 @@ async def test_put_task_user_reference_non_initiative_member_rejected(
 
     response = await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        headers=get_auth_headers(user),
         json={"values": [{"property_id": defn.id, "value": outsider.id}]},
     )
     assert response.status_code == 400
@@ -298,7 +298,7 @@ async def test_put_task_properties_cross_guild_task_returns_404(
     # Send with guild A header — task belongs to guild B.
     response = await client.put(
         f"/api/v1/g/{guild_a.id}/tasks/{task_b.id}/properties",
-        headers=await get_guild_headers(session, guild_a, user),
+        headers=get_auth_headers(user),
         json={"values": []},
     )
     assert response.status_code == 404
@@ -323,7 +323,7 @@ async def test_put_task_cross_initiative_definition_rejected(
 
     response = await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task_a.id}/properties",
-        headers=await get_guild_headers(session, guild, user),
+        headers=get_auth_headers(user),
         json={"values": [{"property_id": defn_b.id, "value": "x"}]},
     )
     assert response.status_code == 404
@@ -354,7 +354,7 @@ async def test_move_task_across_initiatives_drops_property_values(
         session, init_a, name="Tag", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
         headers=headers,
@@ -391,7 +391,7 @@ async def test_duplicate_task_same_project_carries_property_values(
         session, initiative, name="Tag", type=PropertyType.text
     )
 
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
     await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task.id}/properties",
         headers=headers,
@@ -433,7 +433,7 @@ async def test_list_tasks_filter_by_property_text_eq(
     defn = await create_property_definition(
         session, initiative, name="Tag", type=PropertyType.text
     )
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
 
     await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task_match.id}/properties",
@@ -487,7 +487,7 @@ async def test_list_tasks_filter_by_property_multi_select(
             {"value": "beta", "label": "Beta"},
         ],
     )
-    headers = await get_guild_headers(session, guild, user)
+    headers = get_auth_headers(user)
 
     await client.put(
         f"/api/v1/g/{guild.id}/tasks/{task_a.id}/properties",

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -23,29 +23,9 @@ from app.models.platform.guild import GuildRole
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
+    create_project,
     create_user,
-    get_guild_headers,
 )
-
-
-async def _create_initiative(session, guild, user):
-    """Helper to create an initiative."""
-    from app.testing.factories import create_initiative as factory_create_initiative
-
-    initiative = await factory_create_initiative(
-        session, guild, user, name="Test Initiative"
-    )
-    return initiative
-
-
-async def _create_project(session, initiative, owner):
-    """Helper to create a project."""
-    from app.testing.factories import create_project as factory_create_project
-
-    project = await factory_create_project(
-        session, initiative, owner, name="Test Project"
-    )
-    return project
 
 
 async def _create_task(session, project, title="Test Task"):
@@ -70,21 +50,19 @@ async def _create_task(session, project, title="Test Task"):
 
 
 @pytest.mark.integration
-async def test_list_tasks_in_project(client: AsyncClient, session: AsyncSession):
+async def test_list_tasks_in_project(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test listing tasks filtered by project."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task1 = await _create_task(session, a.project, "Task 1")
+    task2 = await _create_task(session, a.project, "Task 2")
 
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task1 = await _create_task(session, project, "Task 1")
-    task2 = await _create_task(session, project, "Task 2")
-
-    headers = await get_guild_headers(session, guild, user)
-    conditions = json.dumps([{"field": "project_id", "op": "eq", "value": project.id}])
+    conditions = json.dumps(
+        [{"field": "project_id", "op": "eq", "value": a.project.id}]
+    )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/?conditions={conditions}", headers=headers
+        a.g(f"/tasks/?conditions={conditions}"), headers=a.headers
     )
 
     assert response.status_code == 200
@@ -96,7 +74,7 @@ async def test_list_tasks_in_project(client: AsyncClient, session: AsyncSession)
 
 @pytest.mark.integration
 async def test_list_tasks_guild_admin_sees_unjoined_project(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A guild admin sees every project's tasks, even ones they never joined.
 
@@ -106,25 +84,21 @@ async def test_list_tasks_guild_admin_sees_unjoined_project(
     full guild access. Previously ``_allowed_project_ids`` lacked a guild-admin
     branch, so the admin got "no results".
     """
-    admin = await create_user(session, email="admin@example.com")
-    owner = await create_user(session, email="owner@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(
-        session, user=admin, guild=guild, role=GuildRole.admin
+    # ``owner`` (a plain guild member) builds the initiative + project, so the
+    # admin is neither a member nor a permission holder.
+    owner = await acting_user(
+        guild_role=GuildRole.member, initiative=True, project=True
     )
-    await create_guild_membership(session, user=owner, guild=guild)
+    admin = await acting_user(guild_role=GuildRole.admin, guild=owner.guild)
 
-    # ``owner`` (not the admin) builds the initiative + project, so the admin is
-    # neither a member nor a permission holder.
-    initiative = await _create_initiative(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-    task1 = await _create_task(session, project, "Hidden Task 1")
-    task2 = await _create_task(session, project, "Hidden Task 2")
+    task1 = await _create_task(session, owner.project, "Hidden Task 1")
+    task2 = await _create_task(session, owner.project, "Hidden Task 2")
 
-    headers = await get_guild_headers(session, guild, admin)
-    conditions = json.dumps([{"field": "project_id", "op": "eq", "value": project.id}])
+    conditions = json.dumps(
+        [{"field": "project_id", "op": "eq", "value": owner.project.id}]
+    )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/?conditions={conditions}", headers=headers
+        admin.g(f"/tasks/?conditions={conditions}"), headers=admin.headers
     )
 
     assert response.status_code == 200
@@ -134,34 +108,26 @@ async def test_list_tasks_guild_admin_sees_unjoined_project(
 
 
 @pytest.mark.integration
-async def test_create_task(client: AsyncClient, session: AsyncSession):
+async def test_create_task(client: AsyncClient, session: AsyncSession, acting_user):
     """Test creating a new task."""
     from app.services.tenant import task_statuses as task_statuses_service
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
 
     # Create a task status
-    await task_statuses_service.ensure_default_statuses(session, project.id)
-    status = await task_statuses_service.get_default_status(session, project.id)
+    await task_statuses_service.ensure_default_statuses(session, a.project.id)
+    status = await task_statuses_service.get_default_status(session, a.project.id)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
         "title": "New Task",
         "description": "Task description",
-        "project_id": project.id,
+        "project_id": a.project.id,
         "task_status_id": status.id,
         "priority": "high",
     }
 
-    response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/", headers=headers, json=payload
-    )
+    response = await client.post(a.g("/tasks/"), headers=a.headers, json=payload)
 
     assert response.status_code == 201
     data = response.json()
@@ -172,33 +138,29 @@ async def test_create_task(client: AsyncClient, session: AsyncSession):
 
 @pytest.mark.integration
 async def test_create_task_requires_project_access(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that creating tasks requires project access."""
-    owner = await create_user(session, email="owner@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=outsider, guild=guild)
-
-    initiative = await _create_initiative(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
+    owner = await acting_user(
+        guild_role=GuildRole.member, initiative=True, project=True
+    )
+    # ``outsider`` is a guild member but NOT an initiative member.
+    outsider = await acting_user(guild_role=GuildRole.member, guild=owner.guild)
 
     from app.services.tenant import task_statuses as task_statuses_service
 
-    await task_statuses_service.ensure_default_statuses(session, project.id)
-    status = await task_statuses_service.get_default_status(session, project.id)
+    await task_statuses_service.ensure_default_statuses(session, owner.project.id)
+    status = await task_statuses_service.get_default_status(session, owner.project.id)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, outsider)
     payload = {
         "title": "Forbidden Task",
-        "project_id": project.id,
+        "project_id": owner.project.id,
         "task_status_id": status.id,
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/", headers=headers, json=payload
+        outsider.g("/tasks/"), headers=outsider.headers, json=payload
     )
 
     assert (
@@ -207,20 +169,12 @@ async def test_create_task_requires_project_access(
 
 
 @pytest.mark.integration
-async def test_get_task_by_id(client: AsyncClient, session: AsyncSession):
+async def test_get_task_by_id(client: AsyncClient, session: AsyncSession, acting_user):
     """Test getting a task by ID."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project)
 
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project)
-
-    headers = await get_guild_headers(session, guild, user)
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}", headers=headers
-    )
+    response = await client.get(a.g(f"/tasks/{task.id}"), headers=a.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -229,34 +183,27 @@ async def test_get_task_by_id(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_get_task_not_found(client: AsyncClient, session: AsyncSession):
+async def test_get_task_not_found(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test getting non-existent task."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
 
-    headers = await get_guild_headers(session, guild, user)
-    response = await client.get(f"/api/v1/g/{guild.id}/tasks/99999", headers=headers)
+    response = await client.get(a.g("/tasks/99999"), headers=a.headers)
 
     assert response.status_code == 404
 
 
 @pytest.mark.integration
-async def test_update_task(client: AsyncClient, session: AsyncSession):
+async def test_update_task(client: AsyncClient, session: AsyncSession, acting_user):
     """Test updating a task."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project)
 
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project)
-
-    headers = await get_guild_headers(session, guild, user)
     payload = {"title": "Updated Title", "description": "Updated description"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}", headers=headers, json=payload
+        a.g(f"/tasks/{task.id}"), headers=a.headers, json=payload
     )
 
     assert response.status_code == 200
@@ -267,24 +214,19 @@ async def test_update_task(client: AsyncClient, session: AsyncSession):
 
 @pytest.mark.integration
 async def test_update_task_without_permission_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that users without permission cannot update tasks."""
-    owner = await create_user(session, email="owner@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=outsider, guild=guild)
+    owner = await acting_user(
+        guild_role=GuildRole.member, initiative=True, project=True
+    )
+    outsider = await acting_user(guild_role=GuildRole.member, guild=owner.guild)
+    task = await _create_task(session, owner.project)
 
-    initiative = await _create_initiative(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-    task = await _create_task(session, project)
-
-    headers = await get_guild_headers(session, guild, outsider)
     payload = {"title": "Hacked Title"}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}", headers=headers, json=payload
+        outsider.g(f"/tasks/{task.id}"), headers=outsider.headers, json=payload
     )
 
     assert (
@@ -293,42 +235,29 @@ async def test_update_task_without_permission_forbidden(
 
 
 @pytest.mark.integration
-async def test_delete_task(client: AsyncClient, session: AsyncSession):
+async def test_delete_task(client: AsyncClient, session: AsyncSession, acting_user):
     """Test deleting a task."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project)
 
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project)
-
-    headers = await get_guild_headers(session, guild, user)
-    response = await client.delete(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}", headers=headers
-    )
+    response = await client.delete(a.g(f"/tasks/{task.id}"), headers=a.headers)
 
     assert response.status_code == 204
 
 
 @pytest.mark.integration
 async def test_delete_task_without_permission_forbidden(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that users without permission cannot delete tasks."""
-    owner = await create_user(session, email="owner@example.com")
-    outsider = await create_user(session, email="outsider@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=owner, guild=guild)
-    await create_guild_membership(session, user=outsider, guild=guild)
+    owner = await acting_user(
+        guild_role=GuildRole.member, initiative=True, project=True
+    )
+    outsider = await acting_user(guild_role=GuildRole.member, guild=owner.guild)
+    task = await _create_task(session, owner.project)
 
-    initiative = await _create_initiative(session, guild, owner)
-    project = await _create_project(session, initiative, owner)
-    task = await _create_task(session, project)
-
-    headers = await get_guild_headers(session, guild, outsider)
     response = await client.delete(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}", headers=headers
+        outsider.g(f"/tasks/{task.id}"), headers=outsider.headers
     )
 
     assert (
@@ -337,52 +266,41 @@ async def test_delete_task_without_permission_forbidden(
 
 
 @pytest.mark.integration
-async def test_assign_user_to_task(client: AsyncClient, session: AsyncSession):
+async def test_assign_user_to_task(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test assigning a user to a task."""
-    user = await create_user(session, email="user@example.com")
-    assignee = await create_user(session, email="assignee@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-    await create_guild_membership(session, user=assignee, guild=guild)
+    user = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    # Add assignee to the initiative as a member.
+    assignee = await acting_user(
+        guild_role=GuildRole.member,
+        guild=user.guild,
+        initiative=user.initiative,
+        initiative_role="member",
+    )
 
-    initiative = await _create_initiative(session, guild, user)
+    task = await _create_task(session, user.project)
 
-    # Add assignee to initiative
-    from app.testing.factories import create_initiative_member
-
-    await create_initiative_member(session, initiative, assignee, role_name="member")
-
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project)
-
-    headers = await get_guild_headers(session, guild, user)
-    payload = {"assignee_ids": [assignee.id]}
+    payload = {"assignee_ids": [assignee.user.id]}
 
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}", headers=headers, json=payload
+        user.g(f"/tasks/{task.id}"), headers=user.headers, json=payload
     )
 
     assert response.status_code == 200
     data = response.json()
     assignee_ids = {a["id"] for a in data["assignees"]}
-    assert assignee.id in assignee_ids
+    assert assignee.user.id in assignee_ids
 
 
 @pytest.mark.integration
 async def test_move_task_to_different_project(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test moving a task to a different project."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project1 = await _create_project(session, initiative, user)
-    project2 = await _create_project(session, initiative, user)
-    project2.name = "Project 2"
-    session.add(project2)
-    await session.commit()
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    project1 = a.project
+    project2 = await create_project(session, a.initiative, a.user, name="Project 2")
 
     task = await _create_task(session, project1)
 
@@ -392,14 +310,13 @@ async def test_move_task_to_different_project(
     target_status = await task_statuses_service.get_default_status(session, project2.id)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
         "target_project_id": project2.id,
         "target_status_id": target_status.id,
     }
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}/move", headers=headers, json=payload
+        a.g(f"/tasks/{task.id}/move"), headers=a.headers, json=payload
     )
 
     assert response.status_code == 200
@@ -408,19 +325,13 @@ async def test_move_task_to_different_project(
 
 
 @pytest.mark.integration
-async def test_duplicate_task(client: AsyncClient, session: AsyncSession):
+async def test_duplicate_task(client: AsyncClient, session: AsyncSession, acting_user):
     """Test duplicating a task."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project, "Original Task")
 
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project, "Original Task")
-
-    headers = await get_guild_headers(session, guild, user)
     response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}/duplicate", headers=headers, json={}
+        a.g(f"/tasks/{task.id}/duplicate"), headers=a.headers, json={}
     )
 
     assert response.status_code == 201
@@ -431,21 +342,15 @@ async def test_duplicate_task(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_create_subtask(client: AsyncClient, session: AsyncSession):
+async def test_create_subtask(client: AsyncClient, session: AsyncSession, acting_user):
     """Test creating a subtask."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project)
 
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project)
-
-    headers = await get_guild_headers(session, guild, user)
     payload = {"content": "Subtask content"}
 
     response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}/subtasks", headers=headers, json=payload
+        a.g(f"/tasks/{task.id}/subtasks"), headers=a.headers, json=payload
     )
 
     assert response.status_code == 201
@@ -456,17 +361,12 @@ async def test_create_subtask(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_list_subtasks(client: AsyncClient, session: AsyncSession):
+async def test_list_subtasks(client: AsyncClient, session: AsyncSession, acting_user):
     """Test listing subtasks."""
     from app.models.tenant.task import Subtask
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project)
 
     # Create some subtasks
     subtask1 = Subtask(task_id=task.id, content="Subtask 1", position=0)
@@ -475,10 +375,7 @@ async def test_list_subtasks(client: AsyncClient, session: AsyncSession):
     session.add(subtask2)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}/subtasks", headers=headers
-    )
+    response = await client.get(a.g(f"/tasks/{task.id}/subtasks"), headers=a.headers)
 
     assert response.status_code == 200
     data = response.json()
@@ -489,17 +386,14 @@ async def test_list_subtasks(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_reorder_subtasks(client: AsyncClient, session: AsyncSession):
+async def test_reorder_subtasks(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test reordering subtasks."""
     from app.models.tenant.task import Subtask
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task = await _create_task(session, project)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project)
 
     # Create subtasks
     subtask1 = Subtask(task_id=task.id, content="Subtask 1", position=0)
@@ -510,7 +404,6 @@ async def test_reorder_subtasks(client: AsyncClient, session: AsyncSession):
     await session.refresh(subtask1)
     await session.refresh(subtask2)
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
         "items": [
             {"id": subtask2.id, "position": 0},
@@ -519,8 +412,8 @@ async def test_reorder_subtasks(client: AsyncClient, session: AsyncSession):
     }
 
     response = await client.put(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}/subtasks/order",
-        headers=headers,
+        a.g(f"/tasks/{task.id}/subtasks/order"),
+        headers=a.headers,
         json=payload,
     )
 
@@ -531,21 +424,15 @@ async def test_reorder_subtasks(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_reorder_tasks(client: AsyncClient, session: AsyncSession):
+async def test_reorder_tasks(client: AsyncClient, session: AsyncSession, acting_user):
     """Test reordering tasks within a project."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task1 = await _create_task(session, a.project, "Task 1")
+    task2 = await _create_task(session, a.project, "Task 2")
+    task3 = await _create_task(session, a.project, "Task 3")
 
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task1 = await _create_task(session, project, "Task 1")
-    task2 = await _create_task(session, project, "Task 2")
-    task3 = await _create_task(session, project, "Task 3")
-
-    headers = await get_guild_headers(session, guild, user)
     payload = {
-        "project_id": project.id,
+        "project_id": a.project.id,
         "items": [
             {"id": task3.id, "task_status_id": task3.task_status_id, "position": 0},
             {"id": task1.id, "task_status_id": task1.task_status_id, "position": 1},
@@ -553,9 +440,7 @@ async def test_reorder_tasks(client: AsyncClient, session: AsyncSession):
         ],
     }
 
-    response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/reorder", headers=headers, json=payload
-    )
+    response = await client.post(a.g("/tasks/reorder"), headers=a.headers, json=payload)
 
     assert response.status_code == 200
     data = response.json()
@@ -584,18 +469,13 @@ def test_reorder_item_rejects_non_finite_position():
 
 @pytest.mark.integration
 async def test_reorder_single_task_returns_only_affected(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A reorder sends only the moved task and the response is slimmed to it."""
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task1 = await _create_task(session, project, "Task 1")
-    task2 = await _create_task(session, project, "Task 2")
-    task3 = await _create_task(session, project, "Task 3")
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task1 = await _create_task(session, a.project, "Task 1")
+    task2 = await _create_task(session, a.project, "Task 2")
+    task3 = await _create_task(session, a.project, "Task 3")
 
     # Anchor task1/task2 at 1 and 2 so task3 can drop between them.
     task1.position = 1.0
@@ -604,17 +484,14 @@ async def test_reorder_single_task_returns_only_affected(
     session.add_all([task1, task2, task3])
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
-        "project_id": project.id,
+        "project_id": a.project.id,
         "items": [
             {"id": task3.id, "task_status_id": task3.task_status_id, "position": 1.5},
         ],
     }
 
-    response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/reorder", headers=headers, json=payload
-    )
+    response = await client.post(a.g("/tasks/reorder"), headers=a.headers, json=payload)
 
     assert response.status_code == 200
     data = response.json()
@@ -625,21 +502,16 @@ async def test_reorder_single_task_returns_only_affected(
 
 @pytest.mark.integration
 async def test_reorder_rebalances_on_precision_exhaustion(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Colliding positions trigger a project-wide renumber that leaves the
     updated_at of merely-renumbered (not explicitly moved) tasks untouched."""
     from datetime import datetime
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
-    task1 = await _create_task(session, project, "Task 1")
-    task2 = await _create_task(session, project, "Task 2")
-    task3 = await _create_task(session, project, "Task 3")
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task1 = await _create_task(session, a.project, "Task 1")
+    task2 = await _create_task(session, a.project, "Task 2")
+    task3 = await _create_task(session, a.project, "Task 3")
 
     # task1/task2 sit one representable step apart, so a midpoint between them
     # rounds onto a neighbor — precision is exhausted at the drop point.
@@ -650,9 +522,8 @@ async def test_reorder_rebalances_on_precision_exhaustion(
     await session.commit()
     task2_updated_before = task2.updated_at
 
-    headers = await get_guild_headers(session, guild, user)
     payload = {
-        "project_id": project.id,
+        "project_id": a.project.id,
         # Drop task3 into the exhausted gap (its position collides with task2),
         # which is what triggers the project-wide renumber.
         "items": [
@@ -664,9 +535,7 @@ async def test_reorder_rebalances_on_precision_exhaustion(
         ],
     }
 
-    response = await client.post(
-        f"/api/v1/g/{guild.id}/tasks/reorder", headers=headers, json=payload
-    )
+    response = await client.post(a.g("/tasks/reorder"), headers=a.headers, json=payload)
 
     assert response.status_code == 200
     data = {t["id"]: t for t in response.json()}
@@ -685,58 +554,50 @@ async def test_reorder_rebalances_on_precision_exhaustion(
 
 
 @pytest.mark.integration
-async def test_task_guild_isolation(client: AsyncClient, session: AsyncSession):
+async def test_task_guild_isolation(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test that tasks are isolated by guild."""
-    user = await create_user(session, email="user@example.com")
-    guild1 = await create_guild(session, name="Guild 1")
+    # First guild (with a workspace) — the actor is admin of it.
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task1 = await _create_task(session, a.project)
+
+    # A SECOND guild for the SAME user (acting_user always makes a new user, so
+    # build the second guild membership with the raw factories reusing a.user).
     guild2 = await create_guild(session, name="Guild 2")
     await create_guild_membership(
-        session, user=user, guild=guild1, role=GuildRole.admin
+        session, user=a.user, guild=guild2, role=GuildRole.admin
     )
-    await create_guild_membership(
-        session, user=user, guild=guild2, role=GuildRole.admin
-    )
-
-    initiative1 = await _create_initiative(session, guild1, user)
-    project1 = await _create_project(session, initiative1, user)
-    task1 = await _create_task(session, project1)
 
     # Cannot access guild1 task with guild2 context
-    headers2 = await get_guild_headers(session, guild2, user)
     response2 = await client.get(
-        f"/api/v1/g/{guild2.id}/tasks/{task1.id}", headers=headers2
+        f"/api/v1/g/{guild2.id}/tasks/{task1.id}", headers=a.headers
     )
 
     assert response2.status_code == 404
 
 
 @pytest.mark.integration
-async def test_list_my_tasks(client: AsyncClient, session: AsyncSession):
+async def test_list_my_tasks(client: AsyncClient, session: AsyncSession, acting_user):
     """Test listing tasks assigned to current user."""
     from app.models.tenant.task import TaskAssignee
 
-    user = await create_user(session, email="user@example.com")
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
     other_user = await create_user(session, email="other@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-    await create_guild_membership(session, user=other_user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    await create_guild_membership(session, user=other_user, guild=a.guild)
 
     # Create tasks
-    my_task = await _create_task(session, project, "My Task")
-    other_task = await _create_task(session, project, "Other Task")
+    my_task = await _create_task(session, a.project, "My Task")
+    other_task = await _create_task(session, a.project, "Other Task")
 
     # Assign tasks
-    session.add(TaskAssignee(task_id=my_task.id, user_id=user.id))
+    session.add(TaskAssignee(task_id=my_task.id, user_id=a.user.id))
     session.add(TaskAssignee(task_id=other_task.id, user_id=other_user.id))
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
     conditions = json.dumps([{"field": "assignee_ids", "op": "in_", "value": ["me"]}])
     response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/?conditions={conditions}", headers=headers
+        a.g(f"/tasks/?conditions={conditions}"), headers=a.headers
     )
 
     assert response.status_code == 200
@@ -747,19 +608,18 @@ async def test_list_my_tasks(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
-async def test_filter_tasks_by_status(client: AsyncClient, session: AsyncSession):
+async def test_filter_tasks_by_status(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
     """Test filtering tasks by status."""
     from app.services.tenant import task_statuses as task_statuses_service
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
 
     # Create statuses
-    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    statuses = await task_statuses_service.ensure_default_statuses(
+        session, a.project.id
+    )
     todo_status = next(s for s in statuses if s.is_default)
     done_status = next(s for s in statuses if s.name == "Done")
     await session.commit()
@@ -769,30 +629,29 @@ async def test_filter_tasks_by_status(client: AsyncClient, session: AsyncSession
 
     task1 = Task(
         title="Todo Task",
-        project_id=project.id,
+        project_id=a.project.id,
         task_status_id=todo_status.id,
-        guild_id=guild.id,
+        guild_id=a.guild.id,
     )
     task2 = Task(
         title="Done Task",
-        project_id=project.id,
+        project_id=a.project.id,
         task_status_id=done_status.id,
-        guild_id=guild.id,
+        guild_id=a.guild.id,
     )
     session.add(task1)
     session.add(task2)
     await session.commit()
 
-    headers = await get_guild_headers(session, guild, user)
     conditions = json.dumps(
         [
-            {"field": "project_id", "op": "eq", "value": project.id},
+            {"field": "project_id", "op": "eq", "value": a.project.id},
             {"field": "task_status_id", "op": "in_", "value": [todo_status.id]},
         ]
     )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/?conditions={conditions}",
-        headers=headers,
+        a.g(f"/tasks/?conditions={conditions}"),
+        headers=a.headers,
     )
 
     assert response.status_code == 200
@@ -804,22 +663,19 @@ async def test_filter_tasks_by_status(client: AsyncClient, session: AsyncSession
 
 @pytest.mark.integration
 async def test_rolling_recurrence_preserves_due_time(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that completing a task with rolling recurrence preserves the original due time."""
     from datetime import datetime, timezone
     from app.models.tenant.task import Task
     from app.services.tenant import task_statuses as task_statuses_service
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
 
     # Create statuses
-    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    statuses = await task_statuses_service.ensure_default_statuses(
+        session, a.project.id
+    )
     todo_status = next(s for s in statuses if s.is_default)
     done_status = next(s for s in statuses if s.name == "Done")
     await session.commit()
@@ -834,9 +690,9 @@ async def test_rolling_recurrence_preserves_due_time(
 
     task = Task(
         title="Recurring Task",
-        project_id=project.id,
+        project_id=a.project.id,
         task_status_id=todo_status.id,
-        guild_id=guild.id,
+        guild_id=a.guild.id,
         due_date=original_due_time,
         recurrence=recurrence_data,
         recurrence_strategy="rolling",  # After completion mode
@@ -846,19 +702,20 @@ async def test_rolling_recurrence_preserves_due_time(
     await session.refresh(task)
 
     # Mark the task as done (simulating completion at a different time like 12:34)
-    headers = await get_guild_headers(session, guild, user)
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}",
-        headers=headers,
+        a.g(f"/tasks/{task.id}"),
+        headers=a.headers,
         json={"task_status_id": done_status.id},
     )
 
     assert response.status_code == 200
 
     # Fetch all tasks to find the newly created recurring task
-    conditions = json.dumps([{"field": "project_id", "op": "eq", "value": project.id}])
+    conditions = json.dumps(
+        [{"field": "project_id", "op": "eq", "value": a.project.id}]
+    )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/?conditions={conditions}", headers=headers
+        a.g(f"/tasks/?conditions={conditions}"), headers=a.headers
     )
     assert response.status_code == 200
     tasks = response.json()["items"]
@@ -880,22 +737,19 @@ async def test_rolling_recurrence_preserves_due_time(
 
 @pytest.mark.integration
 async def test_fixed_recurrence_uses_original_due_date(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that fixed recurrence strategy calculates from the original due date."""
     from datetime import datetime, timezone
     from app.models.tenant.task import Task
     from app.services.tenant import task_statuses as task_statuses_service
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
 
     # Create statuses
-    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    statuses = await task_statuses_service.ensure_default_statuses(
+        session, a.project.id
+    )
     todo_status = next(s for s in statuses if s.is_default)
     done_status = next(s for s in statuses if s.name == "Done")
     await session.commit()
@@ -910,9 +764,9 @@ async def test_fixed_recurrence_uses_original_due_date(
 
     task = Task(
         title="Fixed Recurring Task",
-        project_id=project.id,
+        project_id=a.project.id,
         task_status_id=todo_status.id,
-        guild_id=guild.id,
+        guild_id=a.guild.id,
         due_date=original_due_time,
         recurrence=recurrence_data,
         recurrence_strategy="fixed",  # Fixed mode (default)
@@ -922,19 +776,20 @@ async def test_fixed_recurrence_uses_original_due_date(
     await session.refresh(task)
 
     # Mark the task as done
-    headers = await get_guild_headers(session, guild, user)
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}",
-        headers=headers,
+        a.g(f"/tasks/{task.id}"),
+        headers=a.headers,
         json={"task_status_id": done_status.id},
     )
 
     assert response.status_code == 200
 
     # Fetch all tasks
-    conditions = json.dumps([{"field": "project_id", "op": "eq", "value": project.id}])
+    conditions = json.dumps(
+        [{"field": "project_id", "op": "eq", "value": a.project.id}]
+    )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/?conditions={conditions}", headers=headers
+        a.g(f"/tasks/?conditions={conditions}"), headers=a.headers
     )
     assert response.status_code == 200
     tasks = response.json()["items"]
@@ -954,22 +809,19 @@ async def test_fixed_recurrence_uses_original_due_date(
 
 @pytest.mark.integration
 async def test_rolling_recurrence_with_midnight_time(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
     """Test that rolling recurrence correctly preserves midnight (00:00) time."""
     from datetime import datetime, timezone
     from app.models.tenant.task import Task
     from app.services.tenant import task_statuses as task_statuses_service
 
-    user = await create_user(session, email="user@example.com")
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
 
     # Create statuses
-    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    statuses = await task_statuses_service.ensure_default_statuses(
+        session, a.project.id
+    )
     todo_status = next(s for s in statuses if s.is_default)
     done_status = next(s for s in statuses if s.name == "Done")
     await session.commit()
@@ -985,9 +837,9 @@ async def test_rolling_recurrence_with_midnight_time(
 
     task = Task(
         title="Midnight Task",
-        project_id=project.id,
+        project_id=a.project.id,
         task_status_id=todo_status.id,
-        guild_id=guild.id,
+        guild_id=a.guild.id,
         due_date=original_due_time,
         recurrence=recurrence_data,
         recurrence_strategy="rolling",
@@ -997,19 +849,20 @@ async def test_rolling_recurrence_with_midnight_time(
     await session.refresh(task)
 
     # Mark the task as done
-    headers = await get_guild_headers(session, guild, user)
     response = await client.patch(
-        f"/api/v1/g/{guild.id}/tasks/{task.id}",
-        headers=headers,
+        a.g(f"/tasks/{task.id}"),
+        headers=a.headers,
         json={"task_status_id": done_status.id},
     )
 
     assert response.status_code == 200
 
     # Fetch all tasks
-    conditions = json.dumps([{"field": "project_id", "op": "eq", "value": project.id}])
+    conditions = json.dumps(
+        [{"field": "project_id", "op": "eq", "value": a.project.id}]
+    )
     response = await client.get(
-        f"/api/v1/g/{guild.id}/tasks/?conditions={conditions}", headers=headers
+        a.g(f"/tasks/?conditions={conditions}"), headers=a.headers
     )
     assert response.status_code == 200
     tasks = response.json()["items"]
@@ -1028,6 +881,7 @@ async def test_rolling_recurrence_with_midnight_time(
 @pytest.mark.integration
 async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
     session: AsyncSession,
+    acting_user,
 ):
     """The completion-date anchor for rolling recurrence is the user's
     *local* calendar day, not the UTC day.
@@ -1042,13 +896,15 @@ async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
     from app.models.tenant.task import Task, TaskStatusCategory
     from app.services.tenant import task_statuses as task_statuses_service
 
-    user = await create_user(
-        session, email="la-user@example.com", timezone="America/Los_Angeles"
+    a = await acting_user(
+        guild_role=GuildRole.member,
+        initiative=True,
+        project=True,
+        email="la-user@example.com",
+        timezone="America/Los_Angeles",
     )
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    user = a.user
+    project = a.project
 
     statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
     todo_status = next(s for s in statuses if s.is_default)
@@ -1063,7 +919,7 @@ async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
         title="Feed frogs",
         project_id=project.id,
         task_status_id=todo_status.id,
-        guild_id=guild.id,
+        guild_id=a.guild.id,
         due_date=original_due,
         recurrence={"frequency": "daily", "interval": 3, "ends": "never"},
         recurrence_strategy="rolling",
@@ -1114,6 +970,7 @@ async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
 @pytest.mark.integration
 async def test_rolling_recurrence_spring_forward_preserves_wall_clock_time(
     session: AsyncSession,
+    acting_user,
 ):
     """When the original due time would land in the clocked-forward gap
     on a spring-forward night, rolling recurrence preserves the
@@ -1133,13 +990,15 @@ async def test_rolling_recurrence_spring_forward_preserves_wall_clock_time(
     from app.models.tenant.task import Task, TaskStatusCategory
     from app.services.tenant import task_statuses as task_statuses_service
 
-    user = await create_user(
-        session, email="dst-user@example.com", timezone="America/Los_Angeles"
+    a = await acting_user(
+        guild_role=GuildRole.member,
+        initiative=True,
+        project=True,
+        email="dst-user@example.com",
+        timezone="America/Los_Angeles",
     )
-    guild = await create_guild(session)
-    await create_guild_membership(session, user=user, guild=guild)
-    initiative = await _create_initiative(session, guild, user)
-    project = await _create_project(session, initiative, user)
+    user = a.user
+    project = a.project
 
     statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
     todo_status = next(s for s in statuses if s.is_default)
@@ -1154,7 +1013,7 @@ async def test_rolling_recurrence_spring_forward_preserves_wall_clock_time(
         title="DST gap task",
         project_id=project.id,
         task_status_id=todo_status.id,
-        guild_id=guild.id,
+        guild_id=a.guild.id,
         due_date=original_due,
         recurrence={"frequency": "daily", "interval": 1, "ends": "never"},
         recurrence_strategy="rolling",

--- a/backend/app/db/guild_migrations_test.py
+++ b/backend/app/db/guild_migrations_test.py
@@ -93,9 +93,14 @@ async def test_apply_to_all_guild_schemas_hits_every_guild(engine):
             await drop_guild_schema(conn, _GID_B)
 
 
-async def test_apply_to_all_guild_schemas_includes_public_by_default(engine):
-    """The default include_public=True also changes the legacy public copy — the
-    path every guild-scoped migration takes until public's copies are retired."""
+async def test_apply_to_all_guild_schemas_targets_template_not_public_by_default(
+    engine,
+):
+    """Post-squash contract: the default (include_public=False) applies to
+    ``guild_template`` + every ``guild_<id>`` and must NOT touch the frozen legacy
+    public copies. The template is the source provisioning reflects, so a fresh
+    guild inherits the change; public's copies are frozen/absent and are never a
+    guild-scoped migration target."""
     try:
         async with engine.begin() as conn:
             await provision_guild_schema(conn, _GID_C)
@@ -103,17 +108,22 @@ async def test_apply_to_all_guild_schemas_includes_public_by_default(engine):
             await conn.run_sync(
                 lambda c: apply_to_all_guild_schemas(
                     c, f"ALTER TABLE tags ADD COLUMN IF NOT EXISTS {_COLUMN} boolean"
-                )  # include_public defaults to True
+                )  # include_public defaults to False now
             )
         async with engine.connect() as conn:
-            assert await _tags_has_column(conn, "public")  # the default path hit public
+            # The provisioned guild schema got the change...
             assert await _tags_has_column(conn, guild_schema_name(_GID_C))
+            # ...and so did guild_template (the source new guilds are built from),
+            # which the migration 20260701_0126 created in the test DB.
+            assert await _tags_has_column(conn, "guild_template")
+            # ...but the legacy public copy is deliberately left untouched.
+            assert not await _tags_has_column(conn, "public")
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(
                 lambda c: apply_to_all_guild_schemas(
                     c, f"ALTER TABLE tags DROP COLUMN IF EXISTS {_COLUMN}"
-                )  # remove from public + every guild schema
+                )  # remove from guild_template + every guild schema
             )
             await drop_guild_schema(conn, _GID_C)
 

--- a/backend/app/db/platform_role_rls_test.py
+++ b/backend/app/db/platform_role_rls_test.py
@@ -243,26 +243,26 @@ async def test_app_settings_reseed_degrades_to_transient_for_non_owner(
 async def test_support_can_list_users_role_scoped(client, acting_user):
     """The moved ``GET /admin/users`` runs as ``platform_support`` (off the BYPASSRLS
     engine) and the cross-user read is authorized by ``users_platform_read``."""
-    user, headers = await acting_user("support")
-    resp = await client.get("/api/v1/admin/users", headers=headers)
+    a = await acting_user("support")
+    resp = await client.get("/api/v1/admin/users", headers=a.headers)
     assert resp.status_code == 200
-    assert any(u["id"] == user.id for u in resp.json())
+    assert any(u["id"] == a.user.id for u in resp.json())
 
 
 async def test_member_cannot_list_users(client, acting_user):
     """The capability gate still holds above RLS: a member lacks ``users.read``."""
-    _user, headers = await acting_user("member")
-    resp = await client.get("/api/v1/admin/users", headers=headers)
+    a = await acting_user("member")
+    resp = await client.get("/api/v1/admin/users", headers=a.headers)
     assert resp.status_code == 403
 
 
 async def test_owner_can_update_interface_settings_role_scoped(client, acting_user):
     """The moved ``PUT /settings/interface`` runs as ``platform_owner`` and the
     owner-only GRANT + ``app_settings_owner`` policy let the write through."""
-    _user, headers = await acting_user("owner")
+    a = await acting_user("owner")
     resp = await client.put(
         "/api/v1/settings/interface",
-        headers=headers,
+        headers=a.headers,
         json={"light_accent_color": "#123456", "dark_accent_color": "#654321"},
     )
     assert resp.status_code == 200
@@ -273,6 +273,6 @@ async def test_interface_settings_readable_without_write_privilege(client, actin
     """A public config read works even for a non-owner when the singleton row is
     absent: the privilege-tolerant lazy-create degrades to a transient default
     instead of faulting on the owner-only write."""
-    _user, headers = await acting_user("member")
-    resp = await client.get("/api/v1/settings/interface", headers=headers)
+    a = await acting_user("member")
+    resp = await client.get("/api/v1/settings/interface", headers=a.headers)
     assert resp.status_code == 200

--- a/backend/app/db/platform_roles_test.py
+++ b/backend/app/db/platform_roles_test.py
@@ -109,11 +109,12 @@ async def test_invalid_platform_role_rejected(session):
 
 
 async def test_acting_user_defaults_to_owner(client, acting_user):
-    """The harness mints an owner by default and the request path serves it."""
-    user, headers = await acting_user()
-    assert user.role.value == "owner"
+    """The harness mints an owner by default (no guild_role) and the request path
+    serves it."""
+    a = await acting_user()
+    assert a.user.role.value == "owner"
     # A personal-mode (UserSessionDep) endpoint runs AS platform_owner end to end.
-    resp = await client.get("/api/v1/guilds/", headers=headers)
+    resp = await client.get("/api/v1/guilds/", headers=a.headers)
     assert resp.status_code == 200
 
 
@@ -121,9 +122,9 @@ async def test_acting_user_defaults_to_owner(client, acting_user):
 async def test_acting_user_emulates_each_tier(client, acting_user, tier):
     """Any tier can be emulated; the public path serves all of them (Phase 1 keeps
     RLS unchanged, so every tier runs a personal-mode request like today)."""
-    user, headers = await acting_user(tier)
-    assert user.role.value == tier
-    resp = await client.get("/api/v1/guilds/", headers=headers)
+    a = await acting_user(tier)
+    assert a.user.role.value == tier
+    resp = await client.get("/api/v1/guilds/", headers=a.headers)
     assert resp.status_code == 200
 
 
@@ -131,10 +132,11 @@ async def test_acting_user_emulates_each_tier(client, acting_user, tier):
 async def test_acting_user_optional_guild_role(client, acting_user, g_role):
     """The optional guild dimension: the harness provisions a guild + membership,
     and the guild-path request routes through guild_<id>, authorized by it. The
-    platform tier (member) and the guild role are orthogonal."""
-    user, headers, guild = await acting_user("member", guild_role=g_role)
-    assert user.role.value == "member"
-    resp = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
+    platform tier (member) and the guild role are orthogonal — pass the tier
+    explicitly since a guild_role actor defaults to platform member."""
+    a = await acting_user("member", guild_role=g_role)
+    assert a.user.role.value == "member"
+    resp = await client.get(f"/api/v1/g/{a.guild.id}/initiatives/", headers=a.headers)
     assert resp.status_code == 200
 
 
@@ -149,10 +151,12 @@ async def test_platform_and_guild_roles_coexist(client, acting_user):
     costs the other. Uses a non-bypass platform tier (member) so the guild request
     is governed purely by the guild role, not data.bypass / is_superadmin.
     """
-    user, headers, guild = await acting_user("member", guild_role="admin")
+    a = await acting_user("member", guild_role="admin")
 
-    public_resp = await client.get("/api/v1/guilds/", headers=headers)
+    public_resp = await client.get("/api/v1/guilds/", headers=a.headers)
     assert public_resp.status_code == 200  # ran as platform_member
 
-    guild_resp = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
+    guild_resp = await client.get(
+        f"/api/v1/g/{a.guild.id}/initiatives/", headers=a.headers
+    )
     assert guild_resp.status_code == 200  # ran as guild_<id> (admin), same identity

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -75,7 +75,12 @@ async def test_provision_creates_every_guild_scoped_table(engine):
 
 
 async def test_writes_route_to_guild_schema_not_public(engine):
-    """A row inserted under the guild schema lands there, not in public."""
+    """A routed tenant write lands in the guild schema; an UNROUTED one fails.
+
+    Post-squash there is no ``public`` copy of a tenant table, so isolation is the
+    schema boundary itself: the row can only exist in ``guild_<id>``, and a write
+    with the search_path still on ``public`` fails closed (relation does not
+    exist) instead of silently leaking into a shared public copy."""
     gid = _GID_ISOLATION
     schema = guild_schema_name(gid)
     try:
@@ -95,11 +100,25 @@ async def test_writes_route_to_guild_schema_not_public(engine):
             await conn.exec_driver_sql("SET search_path TO public")
 
             in_guild = await conn.scalar(text(f'SELECT count(*) FROM "{schema}".tags'))
-            in_public = await conn.scalar(
-                text("SELECT count(*) FROM public.tags WHERE guild_id = :g"), {"g": gid}
-            )
         assert in_guild == 1, "row should be in the guild schema"
-        assert in_public == 0, "row must NOT leak into public.tags"
+
+        # The tenant table has NO public copy since the v0.53.5 squash — an
+        # unrouted (public search_path) tenant write fails closed rather than
+        # landing in a shared public table.
+        async with engine.connect() as conn:
+            public_tags = await conn.scalar(text("SELECT to_regclass('public.tags')"))
+        assert public_tags is None, "there must be NO public.tags copy post-squash"
+
+        with pytest.raises(ProgrammingError):
+            async with engine.begin() as conn:
+                await conn.exec_driver_sql("SET search_path TO public")
+                await conn.execute(
+                    text(
+                        "INSERT INTO tags (guild_id, name, color, created_at, "
+                        "updated_at) VALUES (:g, :n, '#abcdef80', now(), now())"
+                    ),
+                    {"g": gid, "n": "unrouted-tag"},
+                )
     finally:
         async with engine.begin() as conn:
             await drop_guild_schema(conn, gid)
@@ -251,12 +270,15 @@ async def test_reprovision_backfills_missing_tables_with_grants(engine):
             recreated = await conn.scalar(
                 text(f"SELECT to_regclass('{schema}.subtasks')")
             )
-            # and the role's grant reaches the back-filled table
+            # and the role's grant reaches the back-filled table. Route the
+            # search_path into the guild schema first: subtasks' initiative-member
+            # RLS policy references tasks/projects/initiative_members unqualified,
+            # and post-squash those live only in the guild schema (no public copy).
+            await conn.exec_driver_sql(f'SET search_path TO "{schema}", public')
             await conn.exec_driver_sql(f'SET ROLE "{role}"')
-            readable = await conn.scalar(
-                text(f'SELECT count(*) FROM "{schema}".subtasks')
-            )
+            readable = await conn.scalar(text("SELECT count(*) FROM subtasks"))
             await conn.exec_driver_sql("RESET ROLE")
+            await conn.exec_driver_sql("SET search_path TO public")
         assert recreated is not None, "subtasks should be back-filled"
         assert readable == 0, "role should be able to read the back-filled table"
     finally:
@@ -300,9 +322,14 @@ async def test_drop_guild_schema_is_safe_when_absent(engine):
         await drop_guild_schema(conn, _GID_DROP_ABSENT)  # must not raise
 
 
-# --- drift guard: the provisioned guild schema must equal Alembic's public ------
+# --- drift guard: the provisioned guild schema must equal guild_template --------
 
 _GID_DRIFT = 990_120
+
+# The Alembic-maintained canonical guild schema (created by migration
+# 20260701_0126 by running guild_schema.sql + guild_rls.sql). Post-squash there
+# are no tenant tables in ``public``, so the drift reference is the template.
+_TEMPLATE_SCHEMA = "guild_template"
 
 
 def _norm_default(d):
@@ -320,13 +347,15 @@ def _norm_constraint(s):
     return re.sub(r"[\s()\[\]]", "", s)
 
 
-async def test_guild_schema_matches_alembic_public(engine):
+async def test_guild_schema_matches_guild_template(engine):
     """The schema provisioning builds (by running alembic/guild/guild_schema.sql)
-    must be structurally identical to the tables Alembic builds in ``public`` —
-    same columns/types/nullability/defaults, CHECK/PK/UNIQUE, indexes (incl.
+    must be structurally identical to the ``guild_template`` schema Alembic
+    maintains (migration 20260701_0126 builds it from the same artifacts) — same
+    columns/types/nullability/defaults, CHECK/PK/UNIQUE, indexes (incl.
     opclasses), and intra-schema FK ON DELETE rules. Cross-schema FKs are
-    intentionally absent (soft refs). This fails if the artifact drifts from
-    Alembic; regenerate it with scripts/gen_guild_schema.py."""
+    intentionally absent (soft refs). Post-squash there are no tenant tables in
+    ``public``, so the template is the canonical reference. This fails if the
+    artifact drifts from Alembic; regenerate it with scripts/gen_guild_schema.py."""
     schema = guild_schema_name(_GID_DRIFT)
     try:
         async with engine.begin() as conn:
@@ -392,20 +421,44 @@ async def test_guild_schema_matches_alembic_public(engine):
 
             drift = []
             for t in sorted(GUILD_SCOPED_TABLES):
-                if await cols("public", t) != await cols(schema, t):
+                if await cols(_TEMPLATE_SCHEMA, t) != await cols(schema, t):
                     drift.append(f"columns: {t}")
-                if await cons("public", t) != await cons(schema, t):
+                if await cons(_TEMPLATE_SCHEMA, t) != await cons(schema, t):
                     drift.append(f"constraints: {t}")
-                if await intra_fks("public", t) != await intra_fks(schema, t):
+                if await intra_fks(_TEMPLATE_SCHEMA, t) != await intra_fks(schema, t):
                     drift.append(f"foreign keys: {t}")
-                if await idx("public", t) != await idx(schema, t):
+                if await idx(_TEMPLATE_SCHEMA, t) != await idx(schema, t):
                     drift.append(f"indexes: {t}")
-                if await trig("public", t) != await trig(schema, t):
+                if await trig(_TEMPLATE_SCHEMA, t) != await trig(schema, t):
                     drift.append(f"triggers: {t}")
-            assert drift == [], f"guild schema drifted from Alembic's public: {drift}"
+            assert drift == [], f"guild schema drifted from guild_template: {drift}"
     finally:
         async with engine.begin() as conn:
             await drop_guild_schema(conn, _GID_DRIFT)
+
+
+async def test_public_schema_has_no_tenant_tables(engine):
+    """Squash leak-check: on a fresh database the ``public`` schema must contain
+    NO copy of any guild-scoped (tenant) table. Post-v0.53.5-baseline, tenant
+    content lives ONLY in ``guild_<id>`` (and ``guild_template``); a stray public
+    copy would be a silent cross-tenant leak surface, so this fails closed if one
+    reappears."""
+    async with engine.connect() as conn:
+        leaked = {
+            row[0]
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT table_name FROM information_schema.tables "
+                        "WHERE table_schema = 'public' AND table_name = ANY(:t)"
+                    ),
+                    {"t": list(GUILD_SCOPED_TABLES)},
+                )
+            )
+        }
+    assert leaked == set(), (
+        f"public must hold NO tenant tables post-squash; found: {sorted(leaked)}"
+    )
 
 
 # --- back-fill sweep: heal half-states and drift for existing guilds -----------

--- a/backend/app/db/secret_key_rotation.py
+++ b/backend/app/db/secret_key_rotation.py
@@ -28,9 +28,11 @@ Runs two ways:
         # 3. restart, confirm login / SMTP / AI keys work, then UNSET PREVIOUS_SECRET_KEY
 
 Schema-per-guild: ``guild_settings`` is guild-scoped, so its live rows live in every
-``guild_<id>`` schema (plus a retained ``public`` backup copy from the conversion);
-the sweep visits both. Runs on the provisioning (superuser) engine so it reaches
-every guild schema and bypasses RLS.
+``guild_<id>`` schema; the sweep re-keys them there. The frozen ``public`` copies of
+guild tables (a read-nothing/write-nothing integrity backup on legacy deployments)
+are deliberately NOT re-keyed — a stale backup holds old secrets, not live content,
+and writing it would touch guild data on an unrouted public pathway. Runs on the
+provisioning (superuser) engine so it reaches every guild schema and bypasses RLS.
 """
 
 from __future__ import annotations
@@ -62,8 +64,12 @@ logger = logging.getLogger(__name__)
 
 # Every Fernet column EXCEPT users.email_encrypted, which is handled specially
 # because its plaintext also feeds the email_hash HMAC (the two must move together).
-# (table, column, salt). All live in ``public``; guild_settings additionally lives in
-# each guild schema (see _GUILD_SCHEMA_COLUMNS).
+# (table, column, salt). These are the SHARED ``public`` tables only. Guild-scoped
+# columns (e.g. guild_settings) are re-keyed per guild schema via
+# _GUILD_SCHEMA_COLUMNS — never through a public copy: the frozen public copies of
+# guild tables are a read-nothing/write-nothing integrity backup, so re-encrypting
+# them would be a write of guild data on an unrouted public pathway. A legacy backup
+# left under the old key is fine — it holds stale secrets, not live content.
 _PUBLIC_FERNET_COLUMNS: list[tuple[str, str, bytes]] = [
     ("users", "ai_api_key_encrypted", SALT_AI_API_KEY),
     ("users", "oidc_refresh_token_encrypted", SALT_OIDC_REFRESH_TOKEN),
@@ -71,8 +77,6 @@ _PUBLIC_FERNET_COLUMNS: list[tuple[str, str, bytes]] = [
     ("app_settings", "smtp_password_encrypted", SALT_SMTP_PASSWORD),
     ("app_settings", "ai_api_key_encrypted", SALT_AI_API_KEY),
     ("guild_invites", "invitee_email_encrypted", SALT_EMAIL),
-    # Retained public backup copy of the (now guild-scoped) guild_settings rows.
-    ("guild_settings", "ai_api_key_encrypted", SALT_AI_API_KEY),
 ]
 
 # Columns rotated once per ``guild_<id>`` schema (the live copies).
@@ -159,6 +163,16 @@ async def _rotate_fernet_column(
     UPDATE key (Fernet's random IV makes each value unique), so this needs no
     knowledge of the table's primary key."""
     result = ColumnResult(schema, table, column)
+    # Skip a guild-schema relation that isn't there yet: a guild schema can lag a
+    # migration that added a table/column, and reading a missing relation would
+    # abort the whole streamed sweep. Absent → nothing to re-key for this column.
+    if (
+        await read_conn.scalar(
+            text("SELECT to_regclass(:rel)"), {"rel": f'"{schema}"."{table}"'}
+        )
+        is None
+    ):
+        return result
     stream = await read_conn.stream(
         text(
             f'SELECT "{column}" FROM "{schema}"."{table}" WHERE "{column}" IS NOT NULL'

--- a/backend/app/db/secret_key_rotation_test.py
+++ b/backend/app/db/secret_key_rotation_test.py
@@ -205,7 +205,9 @@ async def test_dry_run_reports_but_does_not_write(engine, monkeypatch):
 
 async def test_rotate_visits_per_guild_schema_settings(engine, monkeypatch):
     """guild_settings is guild-scoped, so its live rows live in guild_<id> schemas —
-    the sweep must re-key those, not just the public copy."""
+    the sweep re-keys them there. Post-squash there is no public copy of a guild
+    table in the rotation set: guild data is re-keyed ONLY through its guild schema,
+    never an unrouted public pathway."""
     gid = None
     try:
         async with engine.begin() as conn:

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -242,21 +242,40 @@ class User(SQLModel, table=True):
 
         return decrypt_field(self.email_encrypted, SALT_EMAIL)
 
-    projects_owned: List["Project"] = Relationship(back_populates="owner")
-    tasks_assigned: List["Task"] = Relationship(
-        back_populates="assignees", link_model=TaskAssignee
+    # Relationships into GUILD-SCOPED tables carry passive_deletes="all": their
+    # rows live in per-guild schemas, so the ORM must never load or cascade
+    # them from the platform context at ``session.delete(user)`` time (the
+    # tables don't exist in ``public``). hard_delete_user cleans them
+    # explicitly, routed into each guild's schema (Phase 1).
+    projects_owned: List["Project"] = Relationship(
+        back_populates="owner",
+        sa_relationship_kwargs={"passive_deletes": "all"},
     )
+    tasks_assigned: List["Task"] = Relationship(
+        back_populates="assignees",
+        link_model=TaskAssignee,
+        sa_relationship_kwargs={"passive_deletes": "all"},
+    )
+    # No delete cascade here (unlike guild_memberships): hard_delete_user
+    # removes the guild-schema rows itself, and SQLAlchemy disallows
+    # passive_deletes="all" together with delete-orphan.
     initiative_memberships: List["InitiativeMember"] = Relationship(
         back_populates="user",
-        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+        sa_relationship_kwargs={"passive_deletes": "all"},
     )
     guild_memberships: List["GuildMembership"] = Relationship(
         back_populates="user",
         sa_relationship_kwargs={"cascade": "all, delete-orphan"},
     )
-    project_orders: List["ProjectOrder"] = Relationship(back_populates="user")
+    project_orders: List["ProjectOrder"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={"passive_deletes": "all"},
+    )
     api_keys: List["UserApiKey"] = Relationship(back_populates="user")
-    favorite_projects: List["ProjectFavorite"] = Relationship(back_populates="user")
+    favorite_projects: List["ProjectFavorite"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={"passive_deletes": "all"},
+    )
 
 
 from app.models.tenant.project import Project  # noqa: E402  # isort:skip

--- a/backend/app/services/access_grants_rls_test.py
+++ b/backend/app/services/access_grants_rls_test.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.pam_context import set_active_grant
+from app.db.schema_provisioning import guild_schema_name
 from app.db.session import set_rls_context
 from app.models.tenant.counter import CounterGroup
 from app.models.tenant.document import Document
@@ -234,17 +235,26 @@ async def test_pam_read_grant_does_not_fault_legacy_isolation_tables(
 
 @pytest.mark.integration
 async def test_no_pam_flag_sees_nothing(session: AsyncSession):
+    """An INACTIVE grant (pam_guild_id set, but neither flag) must yield no access.
+
+    Post-squash the guild's ``projects`` live only in ``guild_<id>`` and there is
+    no public copy. ``set_rls_context`` deliberately does NOT route an inactive
+    grant into the guild schema (see the "don't route inactive grants" fix), so
+    the fail-closed guarantee is at the schema/role boundary: the session stays on
+    the public path with no guild role assumed, leaving the guild's schema entirely
+    out of reach. We assert both halves — the context did not route in, and the
+    guild's content is unreachable — so "sees nothing" is proven, not weakened."""
     owner = await create_user(session, email="owner2@example.com", role=UserRole.owner)
     support = await create_user(
         session, email="support2@example.com", role=UserRole.support
     )
     guild = await create_guild(session, creator=owner)
     init = await create_initiative(session, guild, owner)
-    proj = await create_project(session, init, owner, name="Gamma")
+    await create_project(session, init, owner, name="Gamma")
 
     try:
         await _set_app_user(session)
-        # Same guild context but NO pam flag — a non-member must see nothing.
+        # Same guild id, but NO pam flag — the grant is inactive.
         await set_rls_context(
             session,
             user_id=support.id,
@@ -252,12 +262,22 @@ async def test_no_pam_flag_sees_nothing(session: AsyncSession):
             pam_read=False,
             pam_write=False,
         )
-        rows = (
+        # An inactive grant is not routed: no guild role is assumed (set_rls_context
+        # resets to the login role) and the guild schema is not on the search_path.
+        current_role = (await session.exec(text("SELECT current_user"))).scalar_one()
+        search_path = (await session.exec(text("SHOW search_path"))).scalar_one()
+        assert guild_schema_name(guild.id) not in current_role
+        assert guild_schema_name(guild.id) not in search_path
+        # Under the real (non-privileged) app_user login role — which holds no
+        # standing access to any guild schema (WITH INHERIT FALSE) — the guild's
+        # content is denied at the catalog/role boundary. There is no public copy
+        # to fall through to either, so the grantee sees nothing.
+        await _set_app_user(session)
+        with pytest.raises(Exception):
             await session.exec(
-                text("SELECT id FROM projects WHERE id = :p"), params={"p": proj.id}
+                text(f'SELECT id FROM "{guild_schema_name(guild.id)}".projects')
             )
-        ).all()
-        assert len(rows) == 0
+        await session.rollback()
     finally:
         await _reset_role(session)
 

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -164,11 +164,32 @@ async def enqueue_task_assignment_event(
 async def clear_task_assignment_queue_for_user(
     session: AsyncSession, user_id: int
 ) -> None:
+    """Clear the user's pending digest items in the CURRENTLY ROUTED guild
+    schema. Callers on the platform path (no guild route) must use
+    :func:`clear_task_assignment_queue_across_guilds` instead."""
     stmt = delete(TaskAssignmentDigestItem).where(
         TaskAssignmentDigestItem.user_id == user_id,
         TaskAssignmentDigestItem.processed_at.is_(None),
     )
     await session.exec(stmt)
+
+
+async def clear_task_assignment_queue_across_guilds(
+    session: AsyncSession, user_id: int
+) -> None:
+    """Platform-path variant: the digest queue is guild-scoped, so visit each
+    of the user's guild schemas. Leaves the session routed into the last guild
+    and the identity map expunged — the caller restores its own context.
+    Deletes are flushed, not committed; they ride the caller's transaction."""
+    from app.services import cross_guild
+
+    guild_ids = await cross_guild.member_guild_ids(session, user_id)
+
+    async def _clear(routed: AsyncSession, _gid: int) -> list:
+        await clear_task_assignment_queue_for_user(routed, user_id)
+        return []
+
+    await cross_guild.gather_across_guilds(session, user_id, guild_ids, _clear)
 
 
 async def notify_initiative_membership(

--- a/backend/app/services/oidc_sync_test.py
+++ b/backend/app/services/oidc_sync_test.py
@@ -35,6 +35,7 @@ from app.testing.factories import (
     create_project,
     create_user,
 )
+from app.testing.schema_harness import route_session_to_guild
 
 
 @pytest.mark.unit
@@ -324,6 +325,8 @@ async def test_sync_skips_orphaned_initiative_mapping(session: AsyncSession):
     result = await sync_oidc_assignments(session, user_id=user.id, claim_values={"eng"})
 
     assert result.initiatives_added == []
+    # initiative_members lives in the guild schema; route before asserting.
+    await route_session_to_guild(session, guild.id)
     members = (
         await session.exec(
             select(InitiativeMember).where(InitiativeMember.user_id == user.id)

--- a/backend/app/services/platform/guilds_test.py
+++ b/backend/app/services/platform/guilds_test.py
@@ -542,10 +542,14 @@ async def test_get_guild_retention_days_distinguishes_never_from_missing(
     auto-purge for guilds that opted out.
     """
     from app.models.tenant.guild_setting import GuildSetting
+    from app.testing import route_session_to_guild
 
     # 1. No guild_settings row at all -> default 90.
     user = await create_user(session)
     guild = await create_guild(session)  # bare factory, no settings row
+    # guild_settings is guild-scoped: its rows live only in guild_<id> post-squash,
+    # so route the session there before reading it (production callers route too).
+    await route_session_to_guild(session, guild.id)
     await session.exec(
         # double-check no setting row exists (factory shouldn't create one)
         select(GuildSetting).where(GuildSetting.guild_id == guild.id)
@@ -556,12 +560,14 @@ async def test_get_guild_retention_days_distinguishes_never_from_missing(
     setting = GuildSetting(guild_id=guild.id, retention_days=30)
     session.add(setting)
     await session.commit()
+    await route_session_to_guild(session, guild.id)
     assert (await guild_service.get_guild_retention_days(session, guild.id)) == 30
 
     # 3. Row exists with retention_days = NULL -> None ("never").
     setting.retention_days = None
     session.add(setting)
     await session.commit()
+    await route_session_to_guild(session, guild.id)
     assert (await guild_service.get_guild_retention_days(session, guild.id)) is None
 
     # Suppress unused-name warning if linters complain about the user

--- a/backend/app/services/tenant/soft_delete_test.py
+++ b/backend/app/services/tenant/soft_delete_test.py
@@ -237,11 +237,13 @@ async def test_restore_rejects_invalid_new_owner(session: AsyncSession):
 async def test_restrictive_delete_policy_exists_on_each_soft_delete_table(
     session: AsyncSession,
 ):
-    """The migration creates a RESTRICTIVE FOR DELETE policy on every
-    soft-delete-capable table that admits only sessions where
-    ``app.current_guild_role`` is ``admin`` (or superadmin). The test
-    fixture connects via the BYPASSRLS admin role so it can't exercise
-    the policy at runtime — verify by inspecting pg_policies instead."""
+    """Every soft-delete-capable table carries a RESTRICTIVE FOR DELETE policy
+    (``soft_delete_admin_purge``) that admits only a routed guild admin
+    (``app.current_guild_role = 'admin'``); a hard delete is a purge. Post-squash
+    these tables (and thus their policies) live in the per-guild schemas, not
+    ``public`` — the canonical copy is the Alembic-maintained ``guild_template``
+    schema (created by migration 20260701_0126). The BYPASSRLS admin fixture can't
+    exercise the policy at runtime, so we inspect ``pg_policies`` in the template."""
     expected = {
         "projects",
         "tasks",
@@ -257,7 +259,8 @@ async def test_restrictive_delete_policy_exists_on_each_soft_delete_table(
         text(
             "SELECT tablename, policyname, cmd, permissive "
             "FROM pg_policies "
-            "WHERE policyname LIKE '%_delete_admin_only'"
+            "WHERE schemaname = 'guild_template' "
+            "AND policyname = 'soft_delete_admin_purge'"
         )
     )
     rows = result.all()
@@ -404,7 +407,7 @@ async def test_trash_listing_dedupes_nested_comment_replies(
     from app.models.platform.guild import GuildRole
     from app.testing.factories import (
         create_guild_membership,
-        get_guild_headers,
+        get_auth_headers,
     )
 
     user = await create_user(session)
@@ -440,8 +443,9 @@ async def test_trash_listing_dedupes_nested_comment_replies(
     )
     await session.commit()
 
-    # Hit the listing endpoint and confirm only the parent appears.
-    headers = await get_guild_headers(session, guild, user)
+    # Hit the listing endpoint and confirm only the parent appears. Guild context
+    # is path-based now (/g/{guild_id}); the headers just carry auth.
+    headers = get_auth_headers(user)
     response = await client.get(f"/api/v1/g/{guild.id}/trash/", headers=headers)
     assert response.status_code == 200, response.text
     body = response.json()

--- a/backend/app/services/tenant/webhook_dispatcher_test.py
+++ b/backend/app/services/tenant/webhook_dispatcher_test.py
@@ -119,9 +119,13 @@ async def _make_subscription(
 @pytest.mark.integration
 async def test_dispatch_skips_when_no_subscribers(session):
     """No subscriptions, no work — and crucially no errors."""
+    from app.testing import route_session_to_guild
     from app.testing.factories import create_guild
 
     guild = await create_guild(session)
+    # Production callers pass a guild-routed session (webhook_subscriptions is
+    # guild-scoped); mirror that — no tenant write here routes it implicitly.
+    await route_session_to_guild(session, guild.id)
     with patch(
         "app.services.tenant.webhook_dispatcher._deliver", new=AsyncMock()
     ) as mock_deliver:

--- a/backend/app/testing/__init__.py
+++ b/backend/app/testing/__init__.py
@@ -3,44 +3,68 @@ Shared test utilities and factories.
 
 Re-exports all factory functions for convenient imports:
     from app.testing import create_user, create_guild, get_auth_headers
+
+Tenant factories are schema-native: they route the session to the target
+guild's ``guild_<id>`` schema before touching the database (see
+``schema_harness``). For raw tenant reads on a not-yet-routed session, use
+``route_session_to_guild``.
 """
 
+from app.testing.actor import Actor, make_actor
 from app.testing.factories import (
     create_calendar_event,
     create_calendar_event_property_value,
+    create_comment,
+    create_counter,
+    create_counter_group,
+    create_document,
     create_document_property_value,
     create_guild,
     create_guild_membership,
     create_initiative,
     create_initiative_member,
     create_project,
-    create_task,
     create_property_definition,
     create_queue,
     create_queue_item,
+    create_subtask,
+    create_tag,
+    create_task,
     create_task_property_value,
+    create_task_status,
+    create_upload,
     create_user,
     get_auth_headers,
     get_auth_token,
-    get_guild_headers,
 )
+from app.testing.schema_harness import route_session_to_guild
 
 __all__ = [
+    "Actor",
+    "make_actor",
     "create_calendar_event",
     "create_calendar_event_property_value",
+    "create_comment",
+    "create_counter",
+    "create_counter_group",
+    "create_document",
     "create_document_property_value",
     "create_guild",
     "create_guild_membership",
     "create_initiative",
     "create_initiative_member",
     "create_project",
-    "create_task",
     "create_property_definition",
     "create_queue",
     "create_queue_item",
+    "create_subtask",
+    "create_tag",
+    "create_task",
     "create_task_property_value",
+    "create_task_status",
+    "create_upload",
     "create_user",
     "get_auth_headers",
     "get_auth_token",
-    "get_guild_headers",
+    "route_session_to_guild",
 ]

--- a/backend/app/testing/actor.py
+++ b/backend/app/testing/actor.py
@@ -1,0 +1,130 @@
+"""The one seam for "run this test AS role X": an authenticated test identity
+with explicit platform and guild roles, plus optional initiative/project
+scaffolding.
+
+The two role dimensions are orthogonal (platform-roles design §7):
+
+* **Platform role** — the tier the public/platform request path assumes
+  (``platform_<users.role>``). Defaults to ``owner`` for public-path actors
+  (most privileged, so role-agnostic tests run unblocked) and to ``member``
+  for guild-path actors — guild access must never depend on platform tier,
+  and defaulting low makes the suite prove that continuously.
+* **Guild role** — when ``guild_role`` (or ``guild``) is given, the actor gets
+  a provisioned guild (or joins the one passed) with that ``GuildRole``;
+  requests route through ``/g/{guild_id}`` and assume ``guild_<id>``.
+
+Usage (via the ``acting_user`` fixture):
+
+    a = await acting_user()                                   # platform owner
+    a = await acting_user("support")                          # tier ceilings
+    a = await acting_user(guild_role=GuildRole.admin,
+                          initiative=True, project=True)      # full workspace
+    b = await acting_user(guild_role=GuildRole.member, guild=a.guild,
+                          initiative=a.initiative, initiative_role="member")
+    await client.get(a.g("/projects/"), headers=a.headers)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.platform.guild import Guild, GuildMembership, GuildRole
+from app.models.platform.user import User, UserRole
+from app.models.tenant.initiative import Initiative
+from app.models.tenant.project import Project
+from app.testing.factories import (
+    create_guild,
+    create_guild_membership,
+    create_initiative,
+    create_initiative_member,
+    create_project,
+    create_user,
+    get_auth_headers,
+)
+
+API = "/api/v1"
+
+
+@dataclass
+class Actor:
+    """An authenticated test identity and the workspace it acts in."""
+
+    user: User
+    headers: dict[str, str]
+    guild: Guild | None = None
+    membership: GuildMembership | None = None
+    initiative: Initiative | None = None
+    project: Project | None = None
+
+    def g(self, path: str = "/") -> str:
+        """Guild-scoped API URL: ``a.g("/projects/")`` →
+        ``/api/v1/g/<guild_id>/projects/``."""
+        assert self.guild is not None, "actor has no guild; pass guild_role="
+        return f"{API}/g/{self.guild.id}{path}"
+
+
+async def make_actor(
+    session: AsyncSession,
+    role: UserRole | str | None = None,
+    *,
+    guild_role: GuildRole | str | None = None,
+    guild: Guild | None = None,
+    initiative: Initiative | bool | None = None,
+    initiative_role: str = "project_manager",
+    project: Project | bool | None = None,
+    **overrides: Any,
+) -> Actor:
+    """Build an :class:`Actor`. See the module docstring for semantics.
+
+    ``initiative=True`` creates one with the actor as creator (built-in PM);
+    pass an existing ``Initiative`` to join it with ``initiative_role``.
+    ``project=True`` creates one owned by the actor inside the initiative;
+    pass an existing ``Project`` to reference it without any grant.
+    ``**overrides`` go to ``create_user`` (e.g. ``email=``, ``full_name=``).
+    """
+    if guild is not None and guild_role is None:
+        guild_role = GuildRole.member
+    if role is None:
+        role = UserRole.member if guild_role is not None else UserRole.owner
+    if isinstance(role, str):
+        role = UserRole(role)
+
+    user = await create_user(session, role=role, **overrides)
+    actor = Actor(user=user, headers=get_auth_headers(user))
+
+    if guild_role is None:
+        if initiative is not None or project is not None:
+            raise ValueError("initiative/project require a guild_role")
+        return actor
+
+    if isinstance(guild_role, str):
+        guild_role = GuildRole(guild_role)
+    actor.guild = guild if guild is not None else await create_guild(session)
+    actor.membership = await create_guild_membership(
+        session, user=user, guild=actor.guild, role=guild_role
+    )
+
+    if initiative is True:
+        if initiative_role != "project_manager":
+            raise ValueError(
+                "initiative=True makes the actor the creator (PM); pass an "
+                "existing initiative to join it with initiative_role="
+            )
+        actor.initiative = await create_initiative(session, actor.guild, user)
+    elif isinstance(initiative, Initiative):
+        actor.initiative = initiative
+        await create_initiative_member(
+            session, initiative, user, role_name=initiative_role
+        )
+
+    if project is True:
+        if actor.initiative is None:
+            raise ValueError("project=True requires initiative")
+        actor.project = await create_project(session, actor.initiative, user)
+    elif isinstance(project, Project):
+        actor.project = project
+
+    return actor

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -1,8 +1,16 @@
 """
 Test data factories for creating database models.
 
-This module provides factory functions for creating test instances of database models
-with sensible defaults. Each factory function can accept overrides for any field.
+This module provides factory functions for creating test instances of database
+models with sensible defaults. Each factory function can accept overrides for
+any field.
+
+Schema-per-guild: tenant models live in per-guild Postgres schemas, never in
+``public``. Every tenant factory therefore routes its session to the target
+guild's schema (``route_session_to_guild``) before reading or writing, derived
+from the parent object it receives — so factory calls are deterministic
+regardless of flush composition. Raw ``session.add()`` of tenant models in
+tests is covered by the fail-closed flush router in ``schema_harness``.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -13,7 +21,9 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.security import create_access_token, get_password_hash
 from app.models.tenant.calendar_event import CalendarEvent
-from app.models.tenant.document import Document
+from app.models.tenant.comment import Comment
+from app.models.tenant.counter import Counter, CounterGroup
+from app.models.tenant.document import Document, DocumentType
 from app.models.platform.guild import Guild, GuildMembership, GuildRole
 from app.models.tenant.initiative import Initiative, InitiativeMember
 from app.models.tenant.project import Project
@@ -26,15 +36,19 @@ from app.models.tenant.property import (
     TaskPropertyValue,
 )
 from app.models.tenant.queue import Queue, QueueItem
+from app.models.tenant.tag import Tag
 from app.models.tenant.task import (
+    Subtask,
     Task,
     TaskAssignee,
     TaskPriority,
     TaskStatus,
     TaskStatusCategory,
 )
+from app.models.tenant.upload import Upload
 from app.models.platform.user import User, UserRole, UserStatus
 from app.services.tenant.initiatives import create_builtin_roles
+from app.testing.schema_harness import route_session_to_guild
 
 
 async def create_user(
@@ -242,27 +256,6 @@ def get_auth_headers(user: User) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-async def get_guild_headers(
-    session: AsyncSession, guild: Guild, user: User
-) -> dict[str, str]:
-    """Return auth headers for ``user``.
-
-    Guild context is no longer server-held — every guild-scoped request
-    addresses its guild through the ``/g/{guild_id}`` URL path. So this no
-    longer writes any state; it's a thin wrapper over ``get_auth_headers``,
-    kept for call-site compatibility. Put the guild in the request URL:
-
-        headers = await get_guild_headers(session, test_guild, test_user)
-        await client.get(f"/api/v1/g/{test_guild.id}/initiatives/", headers=headers)
-
-    Args:
-        session: Unused (no server-held context to write).
-        guild: Unused (address the guild in the request path instead).
-        user: User to authenticate as.
-    """
-    return get_auth_headers(user)
-
-
 async def create_initiative(
     session: AsyncSession,
     guild: Guild,
@@ -286,6 +279,8 @@ async def create_initiative(
     Example:
         initiative = await create_initiative(session, guild, user, name="Test Initiative")
     """
+    await route_session_to_guild(session, guild.id)
+
     defaults = {
         "name": f"Test Initiative {datetime.now(timezone.utc).timestamp()}",
         "description": "A test initiative",
@@ -343,6 +338,8 @@ async def create_project(
     Example:
         project = await create_project(session, initiative, user, name="Test Project")
     """
+    await route_session_to_guild(session, initiative.guild_id)
+
     defaults = {
         "name": f"Test Project {datetime.now(timezone.utc).timestamp()}",
         "description": "A test project",
@@ -393,6 +390,8 @@ async def create_task(
     ``assignees=[user]`` to build a completed, assigned task (e.g. for stats).
     """
     from sqlmodel import select as _select
+
+    await route_session_to_guild(session, project.guild_id)
 
     status = (
         await session.exec(
@@ -459,6 +458,8 @@ async def create_queue(
     Returns:
         Created Queue instance
     """
+    await route_session_to_guild(session, initiative.guild_id)
+
     defaults = {
         "name": f"Test Queue {datetime.now(timezone.utc).timestamp()}",
         "description": "A test queue",
@@ -509,6 +510,8 @@ async def create_queue_item(
     Returns:
         Created QueueItem instance
     """
+    await route_session_to_guild(session, queue.guild_id)
+
     defaults = {
         "queue_id": queue.id,
         "guild_id": queue.guild_id,
@@ -550,6 +553,8 @@ async def create_initiative_member(
     """
     from app.models.tenant.initiative import InitiativeRoleModel
     from sqlmodel import select
+
+    await route_session_to_guild(session, initiative.guild_id)
 
     # Find the matching role for this initiative
     stmt = select(InitiativeRoleModel).where(
@@ -611,6 +616,8 @@ async def create_property_definition(
     Returns:
         Created PropertyDefinition instance
     """
+    await route_session_to_guild(session, initiative.guild_id)
+
     if name is None:
         name = f"Prop {datetime.now(timezone.utc).timestamp()}"
 
@@ -667,6 +674,8 @@ async def create_document_property_value(
     Returns:
         Created DocumentPropertyValue instance
     """
+    await route_session_to_guild(session, document.guild_id)
+
     row = DocumentPropertyValue(
         document_id=document.id,
         property_id=definition.id,
@@ -704,6 +713,8 @@ async def create_task_property_value(
     Returns:
         Created TaskPropertyValue instance
     """
+    await route_session_to_guild(session, task.guild_id)
+
     row = TaskPropertyValue(
         task_id=task.id,
         property_id=definition.id,
@@ -733,6 +744,8 @@ async def create_calendar_event(
     is expected to be events-enabled — callers that need to test the
     feature flag should toggle that on the passed-in ``initiative``.
     """
+    await route_session_to_guild(session, initiative.guild_id)
+
     now = datetime.now(timezone.utc)
     defaults = {
         "guild_id": initiative.guild_id,
@@ -805,6 +818,8 @@ async def create_calendar_event_property_value(
     Mirrors :func:`create_document_property_value` /
     :func:`create_task_property_value` for the event value table.
     """
+    await route_session_to_guild(session, event.guild_id)
+
     row = CalendarEventPropertyValue(
         event_id=event.id,
         property_id=definition.id,
@@ -816,3 +831,257 @@ async def create_calendar_event_property_value(
         await session.commit()
 
     return row
+
+
+async def create_document(
+    session: AsyncSession,
+    initiative: Initiative,
+    creator: User,
+    *,
+    title: str | None = None,
+    commit: bool = True,
+    **overrides: Any,
+) -> Document:
+    """Create a test document with sensible defaults.
+
+    Defaults to a ``native`` (editor) document with empty content and an
+    owner grant for ``creator``, mirroring the create endpoint's DAC setup.
+    """
+    await route_session_to_guild(session, initiative.guild_id)
+
+    defaults = {
+        "guild_id": initiative.guild_id,
+        "initiative_id": initiative.id,
+        "title": title or f"Test Document {datetime.now(timezone.utc).timestamp()}",
+        "document_type": DocumentType.native,
+        "created_by_id": creator.id,
+        "updated_by_id": creator.id,
+    }
+    document = Document(**{**defaults, **overrides})
+    session.add(document)
+
+    if commit:
+        await session.commit()
+        await session.refresh(document)
+
+        session.add(
+            ResourceGrant(
+                resource_type="document",
+                resource_id=document.id,
+                user_id=creator.id,
+                level=ResourceAccessLevel.owner,
+                guild_id=document.guild_id,
+                initiative_id=document.initiative_id,
+            )
+        )
+        await session.commit()
+
+    return document
+
+
+async def create_comment(
+    session: AsyncSession,
+    author: User,
+    *,
+    task: Task | None = None,
+    document: Document | None = None,
+    content: str = "A test comment",
+    commit: bool = True,
+    **overrides: Any,
+) -> Comment:
+    """Create a comment on exactly one of ``task`` or ``document``."""
+    if (task is None) == (document is None):
+        raise ValueError("pass exactly one of task= or document=")
+    parent = task if task is not None else document
+    await route_session_to_guild(session, parent.guild_id)
+
+    defaults = {
+        "guild_id": parent.guild_id,
+        "content": content,
+        "author_id": author.id,
+        "task_id": task.id if task else None,
+        "document_id": document.id if document else None,
+    }
+    comment = Comment(**{**defaults, **overrides})
+    session.add(comment)
+
+    if commit:
+        await session.commit()
+        await session.refresh(comment)
+
+    return comment
+
+
+async def create_tag(
+    session: AsyncSession,
+    guild: Guild,
+    *,
+    name: str | None = None,
+    commit: bool = True,
+    **overrides: Any,
+) -> Tag:
+    """Create a guild-scoped tag."""
+    await route_session_to_guild(session, guild.id)
+
+    defaults = {
+        "guild_id": guild.id,
+        "name": name or f"tag-{datetime.now(timezone.utc).timestamp()}",
+    }
+    tag = Tag(**{**defaults, **overrides})
+    session.add(tag)
+
+    if commit:
+        await session.commit()
+        await session.refresh(tag)
+
+    return tag
+
+
+async def create_subtask(
+    session: AsyncSession,
+    task: Task,
+    *,
+    content: str = "A test subtask",
+    commit: bool = True,
+    **overrides: Any,
+) -> Subtask:
+    """Create a subtask under ``task``."""
+    await route_session_to_guild(session, task.guild_id)
+
+    defaults = {
+        "guild_id": task.guild_id,
+        "task_id": task.id,
+        "content": content,
+    }
+    subtask = Subtask(**{**defaults, **overrides})
+    session.add(subtask)
+
+    if commit:
+        await session.commit()
+        await session.refresh(subtask)
+
+    return subtask
+
+
+async def create_task_status(
+    session: AsyncSession,
+    project: Project,
+    *,
+    name: str | None = None,
+    category: TaskStatusCategory = TaskStatusCategory.todo,
+    commit: bool = True,
+    **overrides: Any,
+) -> TaskStatus:
+    """Create a task status for ``project`` (does not deduplicate; use
+    ``create_task`` when you just need a task in a given category)."""
+    await route_session_to_guild(session, project.guild_id)
+
+    defaults = {
+        "guild_id": project.guild_id,
+        "project_id": project.id,
+        "name": name or category.value.replace("_", " ").title(),
+        "category": category,
+        "position": 0,
+    }
+    status = TaskStatus(**{**defaults, **overrides})
+    session.add(status)
+
+    if commit:
+        await session.commit()
+        await session.refresh(status)
+
+    return status
+
+
+async def create_counter_group(
+    session: AsyncSession,
+    initiative: Initiative,
+    creator: User,
+    *,
+    name: str | None = None,
+    commit: bool = True,
+    **overrides: Any,
+) -> CounterGroup:
+    """Create a counter group with an owner grant for ``creator``."""
+    await route_session_to_guild(session, initiative.guild_id)
+
+    defaults = {
+        "guild_id": initiative.guild_id,
+        "initiative_id": initiative.id,
+        "name": name or f"Test Counters {datetime.now(timezone.utc).timestamp()}",
+        "created_by_id": creator.id,
+    }
+    group = CounterGroup(**{**defaults, **overrides})
+    session.add(group)
+
+    if commit:
+        await session.commit()
+        await session.refresh(group)
+
+        session.add(
+            ResourceGrant(
+                resource_type="counter_group",
+                resource_id=group.id,
+                user_id=creator.id,
+                level=ResourceAccessLevel.owner,
+                guild_id=group.guild_id,
+                initiative_id=group.initiative_id,
+            )
+        )
+        await session.commit()
+
+    return group
+
+
+async def create_counter(
+    session: AsyncSession,
+    group: CounterGroup,
+    *,
+    name: str | None = None,
+    commit: bool = True,
+    **overrides: Any,
+) -> Counter:
+    """Create a counter inside ``group``."""
+    await route_session_to_guild(session, group.guild_id)
+
+    defaults = {
+        "guild_id": group.guild_id,
+        "counter_group_id": group.id,
+        "name": name or f"Counter {datetime.now(timezone.utc).timestamp()}",
+    }
+    counter = Counter(**{**defaults, **overrides})
+    session.add(counter)
+
+    if commit:
+        await session.commit()
+        await session.refresh(counter)
+
+    return counter
+
+
+async def create_upload(
+    session: AsyncSession,
+    guild: Guild,
+    uploader: User,
+    *,
+    filename: str | None = None,
+    commit: bool = True,
+    **overrides: Any,
+) -> Upload:
+    """Create an upload row (metadata only; writes no file to disk)."""
+    await route_session_to_guild(session, guild.id)
+
+    defaults = {
+        "guild_id": guild.id,
+        "uploader_user_id": uploader.id,
+        "filename": filename or f"file-{datetime.now(timezone.utc).timestamp()}.txt",
+        "size_bytes": 1,
+    }
+    upload = Upload(**{**defaults, **overrides})
+    session.add(upload)
+
+    if commit:
+        await session.commit()
+        await session.refresh(upload)
+
+    return upload

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -860,20 +860,23 @@ async def create_document(
     document = Document(**{**defaults, **overrides})
     session.add(document)
 
+    # The owner grant is part of the factory's contract in BOTH modes; with
+    # commit=False it is flushed (id available) but left uncommitted with the
+    # rest of the caller's transaction.
+    await (session.commit() if commit else session.flush())
     if commit:
-        await session.commit()
         await session.refresh(document)
-
-        session.add(
-            ResourceGrant(
-                resource_type="document",
-                resource_id=document.id,
-                user_id=creator.id,
-                level=ResourceAccessLevel.owner,
-                guild_id=document.guild_id,
-                initiative_id=document.initiative_id,
-            )
+    session.add(
+        ResourceGrant(
+            resource_type="document",
+            resource_id=document.id,
+            user_id=creator.id,
+            level=ResourceAccessLevel.owner,
+            guild_id=document.guild_id,
+            initiative_id=document.initiative_id,
         )
+    )
+    if commit:
         await session.commit()
 
     return document

--- a/backend/app/testing/infrastructure_test.py
+++ b/backend/app/testing/infrastructure_test.py
@@ -68,3 +68,69 @@ async def test_authenticated_request(client: AsyncClient, session: AsyncSession)
     data = response.json()
     assert data["email"] == "auth-test@example.com"
     assert data["id"] == user.id
+
+
+@pytest.mark.integration
+async def test_acting_user_builds_guild_workspace(client: AsyncClient, acting_user):
+    """The Actor seam provisions a guild + initiative + project and mints
+    headers that work through the real-role request path."""
+    from app.models.platform.guild import GuildRole
+    from app.models.platform.user import UserRole
+
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    # Guild-path actors default to the LOWEST platform tier: guild access
+    # must never depend on platform privileges.
+    assert a.user.role == UserRole.member
+    assert a.guild is not None and a.initiative is not None and a.project is not None
+
+    response = await client.get(a.g("/projects/"), headers=a.headers)
+    assert response.status_code == 200
+    assert any(p["id"] == a.project.id for p in response.json()["items"])
+
+    # A second actor joining the same guild/initiative at member level.
+    b = await acting_user(
+        guild_role=GuildRole.member,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    response = await client.get(b.g("/initiatives/"), headers=b.headers)
+    assert response.status_code == 200
+    assert any(i["id"] == a.initiative.id for i in response.json())
+
+
+@pytest.mark.unit
+async def test_tenant_rows_land_in_guild_schema(session: AsyncSession, acting_user):
+    """Factory-created tenant rows live in guild_<id>, not public (which no
+    longer has tenant tables since the baseline squash)."""
+    from sqlalchemy import text
+
+    a = await acting_user(guild_role="admin", initiative=True, project=True)
+    count = (
+        await session.exec(
+            text(  # type: ignore[call-overload]
+                f'SELECT count(*) FROM "guild_{a.guild.id}".projects'
+            )
+        )
+    ).scalar()
+    assert count == 1
+
+
+@pytest.mark.unit
+async def test_unrouted_tenant_write_fails_closed(session: AsyncSession, acting_user):
+    """A tenant write that carries no guild_id on an unrouted session must
+    raise the harness's explicit error, not fall through toward public."""
+    from sqlalchemy import text
+
+    from app.models.tenant.task import TaskAssignee
+
+    a = await acting_user(guild_role="admin")
+    # Un-route the session, then write a guild_id-less junction row. The
+    # router raises in before_flush, so no SQL (and no FK check) ever runs.
+    await session.exec(
+        text("SELECT set_config('search_path', 'public', false)")  # type: ignore[call-overload]
+    )
+    session.add(TaskAssignee(task_id=1, user_id=a.user.id))
+    with pytest.raises(RuntimeError, match="not routed to a guild schema"):
+        await session.commit()
+    await session.rollback()

--- a/backend/app/testing/schema_harness.py
+++ b/backend/app/testing/schema_harness.py
@@ -1,22 +1,31 @@
-"""Test-only harness: route guild-scoped ORM writes to the active guild's schema.
+"""Test-only harness: route guild-scoped ORM work to the active guild's schema.
 
 In production, ``set_rls_context`` sets ``search_path`` per request from the
 guild in the ``/g/{guild_id}`` URL path, so guild-scoped reads/writes land in
-``guild_<id>``.
-Direct-session tests (a factory + a raw session, no HTTP request) have no such
-context, so without help their guild-scoped writes would land in ``public``.
+``guild_<id>``. Direct-session tests (a factory + a raw session, no HTTP
+request) have no such context, so without help their guild-scoped statements
+would resolve against ``public`` — where, since the v0.53.5 baseline squash,
+the tenant tables **do not exist** on a fresh database.
 
-This installs a single ``before_flush`` listener on the ORM ``Session``: when a
-flush carries guild-scoped rows for exactly one guild, it points ``search_path``
-at that guild's schema before the flush SQL runs. Because ``set_config`` sets a
-session-level GUC, the routing persists to subsequent reads too — so a test that
-writes then reads the same guild sees its rows. Tables without a ``guild_id``
-column (property values, junctions) inherit the ``search_path`` already set by
-the parent write in the same guild.
+Two cooperating layers make direct sessions schema-native:
 
-Pair this with provision-on-create in the ``create_guild`` factory so the schema
-exists; an unprovisioned guild's schema is simply skipped by ``search_path`` and
-falls through to ``public`` (no error).
+1. **Explicit routing** — ``route_session_to_guild(session, guild_id)`` pins
+   the session's ``search_path`` at ``guild_<id>, public``. Every tenant
+   factory calls it from its parent object's ``guild_id`` before touching the
+   database, so factory reads *and* writes are deterministic regardless of
+   flush composition or ordering.
+2. **A fail-closed ``before_flush`` net** for raw ``session.add(...)`` in
+   tests: a flush that carries guild-scoped rows for exactly one guild is
+   routed to that guild's schema; a flush spanning two guilds, or one whose
+   tenant rows carry no ``guild_id`` while the session was never routed,
+   raises immediately with a pointer here — instead of surfacing later as a
+   cryptic ``UndefinedTableError`` from the missing public copy.
+
+Because ``set_config(..., false)`` sets a session-level GUC on the bound
+connection, routing persists across commits for the connection-bound test
+sessions (see ``conftest.session``). The request path is unaffected: its
+sessions route through ``set_rls_context`` before any tenant statement, which
+the net recognizes by inspecting the live ``search_path``.
 """
 
 from __future__ import annotations
@@ -29,24 +38,59 @@ from app.db.tenancy import GUILD_SCOPED_TABLES
 _installed = False
 
 
-def _flush_guild_ids(session: Session) -> set[int]:
-    gids: set[int] = set()
-    for obj in (*session.new, *session.dirty, *session.deleted):
-        if getattr(obj, "__tablename__", None) in GUILD_SCOPED_TABLES:
-            gid = getattr(obj, "guild_id", None)
-            if gid is not None:
-                gids.add(int(gid))
-    return gids
+async def route_session_to_guild(session, guild_id: int) -> None:
+    """Pin an AsyncSession's search_path at ``guild_<id>, public``.
+
+    Session-level (survives commits on a connection-bound session). Factories
+    call this automatically; call it directly before raw tenant-table reads on
+    a session that has not created tenant rows yet.
+    """
+    gid = int(guild_id)
+    conn = await session.connection()
+    await conn.exec_driver_sql(
+        f"SELECT set_config('search_path', 'guild_{gid}, public', false)"
+    )
+
+
+def _tenant_rows(session: Session) -> list:
+    return [
+        obj
+        for obj in (*session.new, *session.dirty, *session.deleted)
+        if getattr(obj, "__tablename__", None) in GUILD_SCOPED_TABLES
+    ]
 
 
 def _route_before_flush(session: Session, flush_context, instances) -> None:
-    gids = _flush_guild_ids(session)
-    # Only route when the flush is unambiguously about a single guild. A flush
-    # spanning multiple guilds (rare in tests) keeps whatever search_path is set.
+    rows = _tenant_rows(session)
+    if not rows:
+        return
+    gids = {
+        int(gid) for obj in rows if (gid := getattr(obj, "guild_id", None)) is not None
+    }
+    if len(gids) > 1:
+        raise RuntimeError(
+            f"Tenant flush spans multiple guilds {sorted(gids)}; tenant tables "
+            "live in per-guild schemas, so one flush can only target one guild. "
+            "Commit per guild (see app/testing/schema_harness.py)."
+        )
+    conn = session.connection()
     if len(gids) == 1:
         gid = next(iter(gids))
-        session.connection().exec_driver_sql(
+        conn.exec_driver_sql(
             f"SELECT set_config('search_path', 'guild_{gid}, public', false)"
+        )
+        return
+    # Tenant rows without a guild_id column (property values, junctions):
+    # they must inherit an existing guild route — falling through to public
+    # would hit tables that no longer exist there.
+    search_path = conn.exec_driver_sql("SHOW search_path").scalar() or ""
+    if "guild_" not in search_path:
+        names = sorted({type(obj).__name__ for obj in rows})
+        raise RuntimeError(
+            f"Tenant write for {names} carries no guild_id and the session is "
+            "not routed to a guild schema. Use the factories in app.testing, "
+            "or call route_session_to_guild(session, guild_id) first "
+            "(see app/testing/schema_harness.py)."
         )
 
 

--- a/backend/app/testing/schema_harness.py
+++ b/backend/app/testing/schema_harness.py
@@ -47,9 +47,10 @@ async def route_session_to_guild(session, guild_id: int) -> None:
     """
     gid = int(guild_id)
     conn = await session.connection()
-    await conn.exec_driver_sql(
+    result = await conn.exec_driver_sql(
         f"SELECT set_config('search_path', 'guild_{gid}, public', false)"
     )
+    result.close()
 
 
 def _tenant_rows(session: Session) -> list:
@@ -78,7 +79,7 @@ def _route_before_flush(session: Session, flush_context, instances) -> None:
         gid = next(iter(gids))
         conn.exec_driver_sql(
             f"SELECT set_config('search_path', 'guild_{gid}, public', false)"
-        )
+        ).close()
         return
     # Tenant rows without a guild_id column (property values, junctions):
     # they must inherit an existing guild route — falling through to public

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -29,6 +29,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import settings
 from app.core.rate_limit import limiter
 from app.db.session import get_admin_session, get_session
+from app.db.tenancy import SHARED_TABLES
 from app.main import app
 
 # --- Per-worker isolation (pytest-xdist) ---------------------------------------
@@ -424,14 +425,19 @@ async def session(engine) -> AsyncGenerator[AsyncSession, None]:
                     )
                 ).all()
             ]
-        # Truncate all public tables to reset state — one multi-table TRUNCATE
-        # (a single round-trip) instead of one statement per table.
+        # Truncate the SHARED (public-schema) tables to reset state — one
+        # multi-table TRUNCATE (a single round-trip) instead of one statement
+        # per table. Only shared tables exist in public since the v0.53.5
+        # baseline squash; tenant content lives in the per-test guild schemas
+        # dropped above.
         await conn.execute(text("SET session_replication_role = 'replica'"))
-        all_tables = ", ".join(
-            f'"{table.name}"' for table in SQLModel.metadata.sorted_tables
+        shared_tables = ", ".join(
+            f'"{table.name}"'
+            for table in SQLModel.metadata.sorted_tables
+            if table.name in SHARED_TABLES
         )
         await conn.execute(
-            text(f"TRUNCATE TABLE {all_tables} RESTART IDENTITY CASCADE")
+            text(f"TRUNCATE TABLE {shared_tables} RESTART IDENTITY CASCADE")
         )
         await conn.execute(text("SET session_replication_role = 'origin'"))
 
@@ -602,61 +608,28 @@ def auth_headers() -> dict[str, str]:
 
 @pytest.fixture
 async def acting_user(session):
-    """Mint an authenticated test identity with a **required platform role** and an
-    **optional guild role** — the single seam for "run this test AS role X".
+    """Mint an authenticated test identity at explicit platform/guild roles —
+    the single seam for "run this test AS role X". Returns an
+    :class:`app.testing.Actor`; see ``app/testing/actor.py`` for the full
+    semantics (role defaults, initiative/project scaffolding, ``a.g()`` URLs).
 
-    The two role dimensions are orthogonal (see the platform-roles design §7):
+        a = await acting_user()                                  # platform owner
+        a = await acting_user("support")                         # tier ceilings
+        a = await acting_user(guild_role=GuildRole.admin,
+                              initiative=True, project=True)     # workspace
+        b = await acting_user(guild_role=GuildRole.member, guild=a.guild,
+                              initiative=a.initiative, initiative_role="member")
+        await client.get(a.g("/projects/"), headers=a.headers)
 
-    * **Platform role — required, defaults to ``owner``.** The platform tier the
-      public/platform request path assumes (``platform_<users.role>`` via
-      ``get_user_session`` -> ``set_rls_context``). Omit for ``owner`` (most
-      privileged, so role-agnostic tests run unblocked); pass a lower tier
-      (``member``/``support``/…) to exercise a public-path ceiling. With the
-      real-role ``client`` fixture, the request runs AS that platform role on a real
-      ``app_user`` connection at the database — RLS enforced, like production.
-
-    * **Guild role — optional, for guild-path testing.** When ``guild_role`` is
-      given, the harness also provisions a guild (or uses ``guild=``) and adds the
-      user as a member with that ``GuildRole``; the request then routes through
-      ``/g/{guild_id}`` and assumes ``guild_<id>`` with ``current_guild_role``.
-
-    Return arity follows the dimensions requested:
-        user, headers          = await acting_user()                       # owner, public path
-        user, headers          = await acting_user("member")               # member, public path
-        user, headers, guild   = await acting_user("member",
-                                                   guild_role=GuildRole.admin)  # + guild admin
-        await client.get(f"/api/v1/g/{guild.id}/projects", headers=headers)
+    With the real-role ``client`` fixture the request runs AS the actor's
+    platform tier (public path) or guild role (``/g/{guild_id}`` path) on a
+    real ``app_user`` connection — RLS enforced, like production.
     """
-    from app.models.platform.guild import GuildRole
-    from app.models.platform.user import UserRole
-    from app.testing import (
-        create_guild,
-        create_guild_membership,
-        create_user,
-        get_auth_headers,
-    )
+    import functools
 
-    async def _make(
-        role: "UserRole | str" = UserRole.owner,
-        *,
-        guild_role: "GuildRole | str | None" = None,
-        guild=None,
-        **overrides: Any,
-    ):
-        if isinstance(role, str):
-            role = UserRole(role)
-        user = await create_user(session, role=role, **overrides)
-        headers = get_auth_headers(user)
-        if guild_role is None:
-            return user, headers
-        if isinstance(guild_role, str):
-            guild_role = GuildRole(guild_role)
-        if guild is None:
-            guild = await create_guild(session)
-        await create_guild_membership(session, user=user, guild=guild, role=guild_role)
-        return user, headers, guild
+    from app.testing.actor import make_actor
 
-    return _make
+    return functools.partial(make_actor, session)
 
 
 def create_test_user_data(**overrides: Any) -> dict[str, Any]:

--- a/frontend/src/pages/ArchivePage.tsx
+++ b/frontend/src/pages/ArchivePage.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/components/ui/card";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { useArchivedProjects, useUnarchiveProject } from "@/hooks/useProjects";
 import { guildPath } from "@/lib/guildUrl";
 import { Capability, hasCapability } from "@/lib/permissions";
@@ -22,16 +24,21 @@ export const ArchivePage = () => {
   const { t } = useTranslation("projects");
   const { user } = useAuth();
   const { activeGuildId } = useGuilds();
+  // Same shared access helper ProjectsPage uses — honors guild-admin / PAM
+  // grants, so we derive manager state from guild-scoped initiative data rather
+  // than user.initiative_roles (no longer populated on the /users/me object).
+  const { filterVisible, permissionsFor } = useInitiativeAccess();
+  const initiativesQuery = useInitiatives();
 
   // Helper to create guild-scoped paths
   const gp = (path: string) => (activeGuildId ? guildPath(activeGuildId, path) : path);
-  const managedInitiatives = useMemo(
-    () =>
-      user?.initiative_roles?.filter((assignment) => assignment.role === "project_manager") ?? [],
-    [user]
-  );
-  const canManageProjects =
-    hasCapability(user, Capability.dataBypass) || managedInitiatives.length > 0;
+  const canManageProjects = useMemo(() => {
+    if (hasCapability(user, Capability.dataBypass)) return true;
+    if (!initiativesQuery.data) return false;
+    return filterVisible(initiativesQuery.data).some(
+      (initiative) => permissionsFor(initiative).canCreateProjects
+    );
+  }, [user, initiativesQuery.data, filterVisible, permissionsFor]);
 
   const archivedProjectsQuery = useArchivedProjects();
 

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -97,12 +97,6 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   const handleRefresh = useCallback(async () => {
     await invalidateAllProjects();
   }, []);
-  const claimedManagedInitiatives = useMemo(
-    () =>
-      user?.initiative_roles?.filter((assignment) => assignment.role === "project_manager") ?? [],
-    [user]
-  );
-  const hasClaimedManagerRole = claimedManagedInitiatives.length > 0;
   const [initiativeId, setInitiativeId] = useState<string | null>(null);
   const [isComposerOpen, setIsComposerOpen] = useState(false);
   const [isImportOpen, setIsImportOpen] = useState(false);
@@ -246,11 +240,13 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
 
   const projectsQuery = useProjects();
 
-  const initiativesQuery = useInitiatives({
-    // Guild admins / PAM grantees can create across the guild even without a
-    // claimed manager role, so they must fetch initiatives too.
-    enabled: hasClaimedManagerRole || isGuildAdmin || isGrantGuild,
-  });
+  // This is a guild-scoped page and the initiatives list is cheap + cached, so
+  // fetch it unconditionally. Manager state is derived below from the payload
+  // via the shared access helper (permissionsFor(...).canCreateProjects), which
+  // already honors guild-admin / PAM grants — no need to pre-gate on a claimed
+  // manager role from user.initiative_roles (the /users/me object no longer
+  // populates that field: initiative membership is guild-schema content).
+  const initiativesQuery = useInitiatives();
   // Initiatives the user can create projects in — resolved through the shared
   // access helper so guild admins are included regardless of any membership row.
   const creatableInitiatives = useMemo(() => {

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/components/ui/card";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { useTemplateProjects, useUpdateProject } from "@/hooks/useProjects";
 import { guildPath } from "@/lib/guildUrl";
 import { Capability, hasCapability } from "@/lib/permissions";
@@ -22,16 +24,21 @@ export const TemplatesPage = () => {
   const { t } = useTranslation("projects");
   const { user } = useAuth();
   const { activeGuildId } = useGuilds();
+  // Same shared access helper ProjectsPage uses — honors guild-admin / PAM
+  // grants, so we derive manager state from guild-scoped initiative data rather
+  // than user.initiative_roles (no longer populated on the /users/me object).
+  const { filterVisible, permissionsFor } = useInitiativeAccess();
+  const initiativesQuery = useInitiatives();
 
   // Helper to create guild-scoped paths
   const gp = (path: string) => (activeGuildId ? guildPath(activeGuildId, path) : path);
-  const managedInitiatives = useMemo(
-    () =>
-      user?.initiative_roles?.filter((assignment) => assignment.role === "project_manager") ?? [],
-    [user]
-  );
-  const canManageProjects =
-    hasCapability(user, Capability.dataBypass) || managedInitiatives.length > 0;
+  const canManageProjects = useMemo(() => {
+    if (hasCapability(user, Capability.dataBypass)) return true;
+    if (!initiativesQuery.data) return false;
+    return filterVisible(initiativesQuery.data).some(
+      (initiative) => permissionsFor(initiative).canCreateProjects
+    );
+  }, [user, initiativesQuery.data, filterVisible, permissionsFor]);
 
   const templatesQuery = useTemplateProjects();
 


### PR DESCRIPTION
## Problem

The v0.53.5 baseline squash (#776) removed the public copies of the 42 tenant tables on fresh databases — which broke the test infrastructure (teardown TRUNCATEd `SQLModel.metadata` in `public`; `migrations_test` pinned the deleted `20260216_0053` revision; the flush router silently fell through to `public`) and exposed several production paths that still read/wrote guild content outside any guild context.

## Test harness (backend)

- **Schema-native factories**: every tenant factory routes its session into the target guild's schema (`route_session_to_guild`) before touching the DB. New factories (`create_document`, `create_comment`, `create_tag`, `create_subtask`, `create_task_status`, `create_counter_group`, `create_counter`, `create_upload`) replace per-file helper duplicates.
- **Fail-closed flush router**: a tenant flush that spans two guilds, or carries no `guild_id` on an unrouted session, raises immediately with a pointer to the harness — no more silent fall-through toward `public`.
- **`acting_user` → `Actor`**: the one role seam. `a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)` gives `a.user/.headers/.guild/.membership/.initiative/.project` and `a.g("/projects/")` URLs. Guild-path actors default to platform **member**, so the suite continuously proves guild access never depends on platform tier. `get_guild_headers` (a no-op legacy wrapper) is deleted.
- **Teardown** truncates only `SHARED_TABLES`; per-test guild schemas are dropped wholesale.
- **`migrations_test.py`** re-pointed at the squashed chain (`BASELINE_REVISION = 20260626_0125`), asserting shared tables in `public`, content in `guild_template`, and **no** tenant tables in `public`.
- **~60 test files migrated** off `get_guild_headers`/manual setup chains to the Actor seam; the obsolete 0115-backfill migration test removed (it imported a squashed-away migration file).

## Production fixes the new harness surfaced

All the same class — guild-scoped data touched on an unrouted (platform/public) pathway, which now hard-fails on fresh installs and silently served stale frozen copies on upgraded ones:

1. `GET/PATCH /users/me`, register, and platform admin user endpoints no longer enrich `initiative_roles` (guild-routed roster/CSV endpoints still serve it).
2. `PATCH /users/me` clears the guild-scoped task-assignment digest queue via a per-guild `cross_guild` fan-out.
3. `hard_delete_user`: `User`'s ORM relationships into tenant tables carry `passive_deletes` so `session.delete(user)` emits no tenant DML against `public` (Phase 1 already cleans each guild schema explicitly).
4. Secret-key rotation no longer re-keys the frozen `public.guild_settings` backup (frozen copies are read-nothing/write-nothing); guild schemas lagging a migration are skipped via `to_regclass` instead of aborting the sweep.

## Frontend

`ProjectsPage`/`ArchivePage`/`TemplatesPage` derive "manages some initiative" from the guild-scoped initiatives payload (shared `useInitiativeAccess` helper) instead of `user.initiative_roles` — also fixing guild admins without a membership row being wrongly excluded.

## Testing

- `cd backend && pytest app -n auto -m "not slow"` → **1364 passed, 5 failed** (the 5 are pre-existing environment-dependent SSRF tests that expect an URL-validation error but get a sandbox connection timeout; unrelated to this change).
- `cd backend && pytest alembic/migrations_test.py` → 8 passed, 1 intentional skip (irreversible head).
- `cd frontend && ./scripts/test-changed.sh` → 744 passed; `pnpm typecheck` clean.
- `ruff check` + `ruff format` clean; biome clean on touched frontend files.

No schema or env changes. UI change is behavior-identical (PM gating source swapped).