### PR TITLE
Standard Postgres actor model: no superadmin, no superuser in the app, grant-bounded system engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **No more superadmin.** The internal `is_superadmin` flag and its dead policy legs are gone. The system database role follows PostgreSQL's standard trusted-batch model — bounded by explicit, per-table grants (new tables give it nothing by default) — and background jobs and maintenance sweeps route into each guild under that guild's own scoped role.
+- **The app no longer needs a Postgres superuser.** Fresh docker-compose installs create a least-privilege `app_provisioner` role (migrations + guild provisioning only) automatically at first database init, and `DATABASE_URL` points at it from the start. Existing deployments run `backend/scripts/create-provisioner.sql` once and switch `DATABASE_URL`; staying on a superuser keeps working but logs a boot warning.
+- Faster boots on large installs: guild schemas already built by the current version are skipped by the startup sweep (set `FORCE_GUILD_BACKFILL=true` for a one-off full sweep).
+- `FIRST_SUPERUSER_*` settings are renamed `FIRST_OWNER_*` (old names still accepted).
+
+### Changed
+
 - **Database migration history squashed to a v0.53.5 baseline.** Fresh installs now build the shared schema from a single baseline plus a `guild_template` schema, and never create the legacy public copies of guild content (tasks, projects, documents, …) — guild data lives only in per-guild schemas. Existing deployments are unaffected: their frozen legacy copies are kept untouched.
 - **Upgrade note:** deployments running a version older than **v0.53.2** must upgrade to any v0.53.x release and boot it once before upgrading to this version. The app refuses to start (with instructions) if the database is older.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The app no longer needs a Postgres superuser.** Fresh docker-compose installs create a least-privilege `app_provisioner` role (migrations + guild provisioning only) automatically at first database init, and `DATABASE_URL` points at it from the start. Existing deployments run `backend/scripts/create-provisioner.sql` once and switch `DATABASE_URL`; staying on a superuser keeps working but logs a boot warning.
 - Faster boots on large installs: guild schemas already built by the current version are skipped by the startup sweep (set `FORCE_GUILD_BACKFILL=true` for a one-off full sweep).
 - `FIRST_SUPERUSER_*` settings are renamed `FIRST_OWNER_*` (old names still accepted).
-
-### Changed
-
 - **Database migration history squashed to a v0.53.5 baseline.** Fresh installs now build the shared schema from a single baseline plus a `guild_template` schema, and never create the legacy public copies of guild content (tasks, projects, documents, …) — guild data lives only in per-guild schemas. Existing deployments are unaffected: their frozen legacy copies are kept untouched.
 - **Upgrade note:** deployments running a version older than **v0.53.2** must upgrade to any v0.53.x release and boot it once before upgrading to this version. The app refuses to start (with instructions) if the database is older.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ History favors short subjects (e.g., `MVP WIP 1`), so keep the first line impera
 
 ## Security & Configuration Tips
 
-Copy `backend/.env.example`, set `DATABASE_URL`, `SECRET_KEY`, `AUTO_APPROVED_EMAIL_DOMAINS`, and optional `FIRST_SUPERUSER_*`, then run `alembic upgrade head` (or `python -m app.db.init_db`) so the schema is current and default settings/SUs are seeded. The app connects through **three Postgres logins** (see the tenancy/RLS section): `DATABASE_URL` (superuser — migrations + guild provisioning), `DATABASE_URL_APP` (`app_user`, RLS-enforced request path), and `DATABASE_URL_ADMIN` (`app_admin`, BYPASSRLS system engine); all three point at the same database. The SPA reads `VITE_API_URL`; align it with the reverse-proxy host in every environment. If enabling OIDC, ensure `APP_URL` is publicly reachable so computed callback URLs stay valid.
+Copy `backend/.env.example`, set `DATABASE_URL`, `SECRET_KEY`, `AUTO_APPROVED_EMAIL_DOMAINS`, and optional `FIRST_OWNER_*` (legacy `FIRST_SUPERUSER_*` names still accepted), then run `alembic upgrade head` (or `python -m app.db.init_db`) so the schema is current and default settings/owner are seeded. The app connects through **three Postgres logins** (see the tenancy/RLS section): `DATABASE_URL` (the provisioning role — migrations + guild provisioning; the least-privilege `app_provisioner`, NOT a superuser — fresh docker-compose installs create it via the db init script; existing installs run `backend/scripts/create-provisioner.sql` once; the app warns at boot if it detects a superuser), `DATABASE_URL_APP` (`app_user`, RLS-enforced request path), and `DATABASE_URL_ADMIN` (`app_admin`, the policy-bound system engine); all three point at the same database. The SPA reads `VITE_API_URL`; align it with the reverse-proxy host in every environment. If enabling OIDC, ensure `APP_URL` is publicly reachable so computed callback URLs stay valid.
 
 ## Tenancy, Database Architecture & RLS
 
@@ -379,8 +379,8 @@ Two rules follow from this being a **DB-layer** standard: authorization is a pro
 ### Three engines (Postgres logins) — [`session.py`](backend/app/db/session.py)
 
 - **`app_user`** (`DATABASE_URL_APP`, `LOGIN NOINHERIT`, **RLS-enforced**) — the request path. Holds *no* standing access to any guild schema; every request `SET ROLE`s into a scoped role first.
-- **`app_admin`** (`DATABASE_URL_ADMIN`, `LOGIN BYPASSRLS`) — the **only** RLS-bypassing role. System engine: startup seeding, background jobs, provisioning, and bootstrapping/lifecycle endpoints that can't run under a scoped role. No user request gets ambient BYPASSRLS.
-- **superuser** (`DATABASE_URL`, `provisioning_engine`) — privileged DDL only: migrations, `CREATE SCHEMA`/`CREATE ROLE`, guild provisioning.
+- **`app_admin`** (`DATABASE_URL_ADMIN`, `LOGIN BYPASSRLS`) — the system engine: startup seeding, background jobs, and bootstrapping/lifecycle endpoints that can't run under a scoped role. This is PostgreSQL's textbook trusted-batch actor (BYPASSRLS is the documented mechanism for administrative sweeps); its boundary is **enumerated per-table GRANTs** (migration 0129) — a new shared table gives it nothing until a migration grants it. Guild schemas require `SET ROLE guild_<id>` (which **drops** the bypass), with `guild_role='admin'` for full-authority maintenance. No *user-facing* role ever bypasses RLS.
+- **`app_provisioner`** (`DATABASE_URL`, `provisioning_engine`) — DDL only: migrations, `CREATE SCHEMA`/`CREATE ROLE`, guild provisioning. A least-privilege `NOSUPERUSER CREATEROLE` role that owns the app's objects — created by infrastructure, not app code (fresh installs: the compose `initdb` script; existing installs: `backend/scripts/create-provisioner.sql`, run once); `FORCE ROW LEVEL SECURITY` keeps even the owner policy-bound for DML. The app never holds Postgres superuser credentials — boot logs a warning if `DATABASE_URL` is a superuser/BYPASSRLS role.
 
 ### Schema-per-guild
 
@@ -395,7 +395,7 @@ Guild **content** (projects, tasks, documents, initiatives, queues, counters, ca
 - **Per-guild roles** `guild_<id>` (read/write its schema) and `guild_<id>_ro` (SELECT-only, for PAM *read* grants). Both inherit shared/`public` access from **`app_guild_base`**. The login roles are granted membership in every guild role **`WITH INHERIT FALSE`** — they can `SET ROLE` in but hold no standing access (fail-closed).
 - **Platform-tier roles** `platform_<tier>` (member/support/moderator/admin/owner, `NOLOGIN`) + a shared **`platform_base`** floor; the public/platform path assumes `platform_<users.role>`.
 - **Routing:** a **guild request** (`/g/{guild_id}/…`) → `SET ROLE guild_<id>` (or `_ro`), `search_path = guild_<id>, public`; a **public/platform request** → `SET ROLE platform_<tier>`, `search_path = public`. Each request resets to the login role (`SET ROLE none`) first, and the connection is reset on return to the pool.
-- **No standing all-guild bypass.** The `app.is_superadmin` GUC is retired from the request path; it is set only on the `app_admin` (BYPASSRLS) engine, where it's moot. A platform admin reaches a guild's data only via an explicit **break-glass** grant (below).
+- **No standing all-guild bypass for users, no superadmin.** The `app.is_superadmin` GUC and its policy legs were removed entirely (migration 0128). The only BYPASSRLS holder is the system engine (`app_admin`, the standard trusted-batch role — grant-bounded, never serving a user request as itself). A platform admin reaches a guild's data only via an explicit **break-glass** grant (below).
 
 ### Session Types (choose the right one)
 
@@ -403,7 +403,7 @@ Guild **content** (projects, tasks, documents, initiatives, queues, counters, ca
 |---|---|---|
 | `RLSSessionDep` (`get_guild_session`) | `app_user` → `SET ROLE guild_<id>`/`_ro` | Guild-scoped data under `/g/{guild_id}/…` (projects, tasks, documents, initiatives, tags, comments, task statuses, collaboration, imports). Pair with `GuildContextDep`. |
 | `UserSessionDep` (`get_user_session`) | `app_user` → `SET ROLE platform_<tier>` | Authenticated public/platform path with no guild: list/reorder/leave guilds, cross-guild "my" (`/me/*`) reads, platform reads governed by `platform_<tier>` policies. |
-| `AdminSessionDep` (`get_admin_session`) | `app_admin` (**BYPASSRLS**) | Bootstrapping where the entity doesn't exist yet (create guild, accept invite), platform user management + `access_grants` endpoints (capability-gated), background jobs, startup seeding. |
+| `AdminSessionDep` (`get_admin_session`) | `app_admin` (system engine: BYPASSRLS, grant-bounded) | Bootstrapping where the entity doesn't exist yet (create guild, accept invite), platform user management + `access_grants` endpoints (capability-gated), background jobs, startup seeding. Guild schemas only via `set_rls_context(guild_id=…)` — SET ROLE drops the bypass. |
 | `SessionDep` (`get_session`) | `app_user`, login role (no `SET ROLE`) | Unauthenticated endpoints, or handlers that call `set_rls_context()` themselves after validating. |
 
 ### Path-based guild tenancy
@@ -425,7 +425,7 @@ A user reaches a guild they don't belong to only through a **time-bound, per-gui
 
 1. **Default to `RLSSessionDep`** for any endpoint that reads/writes guild-scoped data; it requires `GuildContextDep` in the same signature (the guild comes from the `/g/{guild_id}` path).
 2. **After every `session.commit()` that is followed by a database query** (including `session.refresh()`), call `await reapply_rls_context(session)`. A commit may release the connection back to the pool; the next query could land on a connection without the `SET ROLE`/GUCs.
-3. **Use `UserSessionDep`** for authenticated cross-guild/platform reads so the request is `platform_<tier>`-scoped; reserve `AdminSessionDep` (BYPASSRLS) for bootstrapping/lifecycle/jobs that genuinely can't run under a scoped role.
+3. **Use `UserSessionDep`** for authenticated cross-guild/platform reads so the request is `platform_<tier>`-scoped; reserve `AdminSessionDep` (the system engine) for bootstrapping/lifecycle/jobs that genuinely can't run under a scoped role — and remember a new shared table needs an explicit `GRANT … TO app_admin` before the system engine can touch it.
 4. **Never use `SessionDep` for guild-scoped data** — without a `SET ROLE` it can't even see the guild schema (and shared-table reads run as the bare login role).
 5. **Gate platform endpoints on `require_capability(...)`**; never re-introduce a request-path `is_superadmin=True` (that was Phase 3's whole removal).
 6. **`set_rls_context()` uses `set_config()`** (not `SET` commands) so the assumed role and GUCs land on the same pooled connection as subsequent queries.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -139,6 +139,11 @@ S3_KMS_KEY_ID=              # optional SSE-KMS key id/ARN; blank otherwise
 S3_LOCAL_FALLBACK=false     # migration window only: serve S3 read-misses from local disk
 
 # Initial superuser
+# DATABASE_URL should be the least-privilege app_provisioner role, NOT a
+# superuser. Fresh docker-compose installs create it automatically (initdb
+# script); existing deployments run backend/scripts/create-provisioner.sql once
+# — see the deployment docs. The app warns at boot if it detects a superuser.
+
 # Becomes the platform `owner` (legacy FIRST_SUPERUSER_* names still accepted)
 FIRST_OWNER_EMAIL=admin@example.com
 FIRST_OWNER_PASSWORD=changeme

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -139,6 +139,7 @@ S3_KMS_KEY_ID=              # optional SSE-KMS key id/ARN; blank otherwise
 S3_LOCAL_FALLBACK=false     # migration window only: serve S3 read-misses from local disk
 
 # Initial superuser
-FIRST_SUPERUSER_EMAIL=admin@example.com
-FIRST_SUPERUSER_PASSWORD=changeme
-FIRST_SUPERUSER_FULL_NAME=Admin User
+# Becomes the platform `owner` (legacy FIRST_SUPERUSER_* names still accepted)
+FIRST_OWNER_EMAIL=admin@example.com
+FIRST_OWNER_PASSWORD=changeme
+FIRST_OWNER_FULL_NAME=Admin User

--- a/backend/alembic/versions/20260701_0128_retire_is_superadmin.py
+++ b/backend/alembic/versions/20260701_0128_retire_is_superadmin.py
@@ -1,0 +1,150 @@
+"""Retire the ``app.is_superadmin`` GUC: strip its dead policy legs.
+
+The GUC was retired from the request path long ago (Phase 3 of the platform
+roles work) and since then has only ever been set on the BYPASSRLS admin
+engine — where policies don't apply at all. Every ``OR is_superadmin`` leg
+below is therefore provably dead: no live, policy-bound session ever sets the
+GUC true. This migration recreates the 14 shared-table policies that still
+carry the leg, without it — a strictly-tightening, no-behavior-change edit —
+so the superadmin concept can be deleted from the codebase entirely.
+
+(The frozen legacy public copies of guild-content tables on pre-squash
+deployments keep their inert legs; they are dropped with those tables in the
+future drop release.)
+
+Revision ID: 20260701_0128
+Revises: 20260701_0127
+Create Date: 2026-07-01
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260701_0128"
+down_revision = "20260701_0127"
+branch_labels = None
+depends_on = None
+
+# NULLIF-guarded session-variable forms (see CLAUDE.md): an unset/empty GUC
+# must compare as NULL, never raise mid-policy.
+_GUILD_ID = "(NULLIF(current_setting('app.current_guild_id', true), ''))::integer"
+_USER_ID = "(NULLIF(current_setting('app.current_user_id', true), ''))::integer"
+_GUILD_ADMIN = "current_setting('app.current_guild_role', true) = 'admin'"
+_SUPERADMIN_LEG = "current_setting('app.is_superadmin', true) = 'true'"
+
+_INVITE_MEMBER = (
+    "EXISTS (SELECT 1 FROM public.guild_memberships "
+    "WHERE guild_memberships.guild_id = guild_invites.guild_id "
+    f"AND guild_memberships.user_id = {_USER_ID})"
+)
+_GUILD_MEMBER = (
+    "EXISTS (SELECT 1 FROM public.guild_memberships "
+    "WHERE guild_memberships.guild_id = guilds.id "
+    f"AND guild_memberships.user_id = {_USER_ID})"
+)
+
+# (table, policy, FOR clause, USING predicate | None, WITH CHECK predicate | None)
+# — the predicates are the existing ones minus the dead superadmin leg.
+_POLICIES: list[tuple[str, str, str, str | None, str | None]] = [
+    ("guild_invites", "guild_select", "FOR SELECT", _INVITE_MEMBER, None),
+    (
+        "guild_invites",
+        "guild_insert",
+        "FOR INSERT",
+        None,
+        f"guild_id = {_GUILD_ID}",
+    ),
+    (
+        "guild_invites",
+        "guild_update",
+        "FOR UPDATE",
+        f"guild_id = {_GUILD_ID}",
+        f"guild_id = {_GUILD_ID}",
+    ),
+    ("guild_invites", "guild_delete", "FOR DELETE", f"guild_id = {_GUILD_ID}", None),
+    (
+        "guilds",
+        "guild_select",
+        "FOR SELECT",
+        f"id = {_GUILD_ID} OR {_GUILD_MEMBER}",
+        None,
+    ),
+    ("guilds", "guild_insert", "FOR INSERT", None, f"{_USER_ID} IS NOT NULL"),
+    (
+        "guilds",
+        "guild_update",
+        "FOR UPDATE",
+        f"id = {_GUILD_ID} AND {_GUILD_ADMIN}",
+        f"id = {_GUILD_ID} AND {_GUILD_ADMIN}",
+    ),
+    (
+        "guilds",
+        "guild_delete",
+        "FOR DELETE",
+        f"id = {_GUILD_ID} AND {_GUILD_ADMIN}",
+        None,
+    ),
+    (
+        "oidc_claim_mappings",
+        "guild_isolation",
+        "",
+        f"guild_id = {_GUILD_ID}",
+        f"guild_id = {_GUILD_ID}",
+    ),
+    (
+        "guild_memberships",
+        "guild_memberships_select",
+        "FOR SELECT",
+        f"guild_id = {_GUILD_ID} OR user_id = {_USER_ID}",
+        None,
+    ),
+    (
+        "guild_memberships",
+        "guild_memberships_insert",
+        "FOR INSERT",
+        None,
+        f"guild_id = {_GUILD_ID}",
+    ),
+    (
+        "guild_memberships",
+        "guild_memberships_update",
+        "FOR UPDATE",
+        f"guild_id = {_GUILD_ID}",
+        f"guild_id = {_GUILD_ID}",
+    ),
+    (
+        "guild_memberships",
+        "guild_memberships_delete",
+        "FOR DELETE",
+        f"guild_id = {_GUILD_ID}",
+        None,
+    ),
+    (
+        "user_view_preferences",
+        "user_view_preferences_self_scope",
+        "",
+        f"user_id = {_USER_ID}",
+        f"user_id = {_USER_ID}",
+    ),
+]
+
+
+def _recreate(conn, superadmin_leg: bool) -> None:
+    for table, policy, cmd, using, check in _POLICIES:
+        conn.execute(text(f'DROP POLICY IF EXISTS "{policy}" ON public."{table}"'))
+        parts = [f'CREATE POLICY "{policy}" ON public."{table}" {cmd}'.rstrip()]
+        if using is not None:
+            leg = f" OR ({_SUPERADMIN_LEG})" if superadmin_leg else ""
+            parts.append(f"USING (({using}){leg})")
+        if check is not None:
+            leg = f" OR ({_SUPERADMIN_LEG})" if superadmin_leg else ""
+            parts.append(f"WITH CHECK (({check}){leg})")
+        conn.execute(text(" ".join(parts)))
+
+
+def upgrade() -> None:
+    _recreate(op.get_bind(), superadmin_leg=False)
+
+
+def downgrade() -> None:
+    _recreate(op.get_bind(), superadmin_leg=True)

--- a/backend/alembic/versions/20260702_0129_system_engine_grants.py
+++ b/backend/alembic/versions/20260702_0129_system_engine_grants.py
@@ -1,0 +1,103 @@
+"""Bound the system engine by enumerated table GRANTs (industry-standard model).
+
+``app_admin`` (the ``DATABASE_URL_ADMIN`` login for background jobs, startup
+seeding, and platform lifecycle endpoints) is the textbook PostgreSQL
+"trusted batch/system" actor: it keeps ``BYPASSRLS`` — the mechanism the RLS
+documentation designates for administrative sweeps — and its boundary is
+**which tables it is GRANTed**, spelled out per table below instead of the old
+chain's blanket ``GRANT ALL`` everywhere:
+
+1. **Enumerated per-table grants** — each shared table gets exactly the verb
+   set its audited call sites use (e.g. the system engine never touches
+   ``user_view_preferences``, and never UPDATEs ``notifications``).
+2. **Narrowed default privileges** — the blanket ``ALTER DEFAULT PRIVILEGES …
+   GRANT ALL ON TABLES/SEQUENCES TO app_admin`` is revoked: a new shared table
+   is born with NO system-engine access until a migration grants it.
+
+Guild schemas are unaffected: the system engine holds no standing access there
+and must ``SET ROLE guild_<id>`` (which drops BYPASSRLS), running under the
+guild's own grants and policies — with ``guild_role='admin'`` for
+full-authority maintenance (trash purge, admin endpoints).
+
+Sequence grants are left as-is: sequence access carries no row data, and
+INSERT-granted tables need their serial sequences anyway.
+
+Derived from the 2026-07-02 call-site audit (AdminSessionDep endpoints,
+AdminSessionLocal workers, startup seeding, maintenance jobs). A future
+feature that needs a new verb adds a migration widening exactly that grant.
+
+Revision ID: 20260702_0129
+Revises: 20260701_0128
+Create Date: 2026-07-02
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260702_0129"
+down_revision = "20260701_0128"
+branch_labels = None
+depends_on = None
+
+# table -> verbs the system engine's call sites use (audited).
+_SYSTEM_TABLE_GRANTS: dict[str, str | None] = {
+    "users": "SELECT, INSERT, UPDATE, DELETE",
+    "guilds": "SELECT, INSERT, UPDATE, DELETE",
+    "guild_memberships": "SELECT, INSERT, UPDATE, DELETE",
+    # invite redemption reads/creates/updates; row removal rides the FK cascade
+    "guild_invites": "SELECT, INSERT, UPDATE",
+    "access_grants": "SELECT, INSERT, UPDATE, DELETE",
+    # singleton config: seeded + updated, never deleted
+    "app_settings": "SELECT, INSERT, UPDATE",
+    # OIDC sync reads mappings; the settings endpoints manage them (system engine)
+    "oidc_claim_mappings": "SELECT, INSERT, UPDATE, DELETE",
+    # personal UI state — the system engine has no business here
+    "user_view_preferences": None,
+    "notifications": "SELECT, INSERT, DELETE",
+    "user_tokens": "SELECT, INSERT, DELETE",
+    "push_tokens": "SELECT, INSERT, DELETE",
+    "user_api_keys": "SELECT, DELETE",
+    "auto_delegation_jti_blocklist": "SELECT, INSERT",
+    # migrations-only bookkeeping (the provisioning role owns it)
+    "alembic_version": None,
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table, verbs in _SYSTEM_TABLE_GRANTS.items():
+        conn.execute(text(f'REVOKE ALL ON TABLE public."{table}" FROM app_admin'))
+        if verbs:
+            conn.execute(text(f'GRANT {verbs} ON TABLE public."{table}" TO app_admin'))
+    # Future tables get no implicit system-engine access. (Default-privilege
+    # entries are per-grantor; migrations always run as the provisioning role,
+    # the same role that created the original entry.)
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "REVOKE ALL ON TABLES FROM app_admin"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "REVOKE ALL ON SEQUENCES FROM app_admin"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO app_admin"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "GRANT ALL ON SEQUENCES TO app_admin"
+        )
+    )
+    for table in _SYSTEM_TABLE_GRANTS:
+        conn.execute(text(f'GRANT ALL ON TABLE public."{table}" TO app_admin'))

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -535,7 +535,6 @@ async def _apply_guild_session_context(
             user_id=current_user.id,
             guild_id=None,
             guild_role=None,
-            is_superadmin=False,
             pam_guild_id=guild_context.guild_id,
             pam_read=True,
             pam_write=(access_level == AccessLevel.read_write.value),
@@ -548,7 +547,7 @@ async def _apply_guild_session_context(
     set_active_role(guild_context.guild_id, guild_context.role.value)
     # No standing all-guild bypass: a guild admin sees the whole guild via the
     # ``current_guild_role='admin'`` RLS leg (and the guild role they SET into),
-    # not ``is_superadmin``. A ``data.bypass`` holder who isn't a member reaches
+    # never an ambient bypass. A ``data.bypass`` holder who isn't a member reaches
     # this guild only through a break-glass PAM grant (the ``is_pam`` branch above).
     await set_rls_context(
         session,
@@ -629,7 +628,7 @@ async def get_user_session(
     to route. Guild-addressed work uses ``get_guild_session`` instead, which
     ``SET ROLE``s into the guild role.
 
-    No standing ``is_superadmin`` bypass: a platform admin's cross-user/guild
+    No standing all-guild bypass: a platform admin's cross-user/guild
     reach on this path is authorized by the ``platform_<tier>`` RLS policies
     (Phase 2), and reaching a guild's *data* requires an explicit break-glass
     PAM grant (§7), never an ambient flag.

--- a/backend/app/api/uploads_test.py
+++ b/backend/app/api/uploads_test.py
@@ -409,7 +409,7 @@ async def test_app_admin_needs_set_role_for_guild_schema(session, role_session):
     await admin.rollback()
 
     # The production pattern (SET ROLE via set_rls_context) succeeds.
-    await set_rls_context(admin, guild_id=guild.id, is_superadmin=True)
+    await set_rls_context(admin, guild_id=guild.id)
     row = (
         await admin.exec(
             text("SELECT filename FROM uploads WHERE filename = 'grant_probe.jpg'")

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -65,7 +65,7 @@ async def list_all_users(
 
     Platform-scoped: runs on the role-scoped session (``platform_<tier>``), so the
     cross-user read is authorized by RLS (``users_platform_read``, support+) rather
-    than the BYPASSRLS admin engine. Initiative roles are guild-scoped and
+    than the system admin engine. Initiative roles are guild-scoped and
     deliberately NOT loaded here — a platform user view exposes platform data only.
     """
     from app.services.platform.users import SYSTEM_USER_EMAIL

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -637,10 +637,11 @@ async def admin_delete_initiative(
     ``guild_id`` is REQUIRED: initiatives live in per-guild schemas with
     independent id sequences, so ``initiative_id`` alone is ambiguous across
     guilds. The caller (the blocker-resolution UI) has it from the blocker
-    record. We route into that guild's schema as superadmin so the cascade
-    deletes the real rows, not the frozen ``public`` backup copies.
+    record. We route into that guild's schema as a guild admin (full authority
+    over the guild; clears the purge guard) so the cascade deletes the real
+    rows, not the frozen ``public`` backup copies.
     """
-    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
 
     initiative = await session.get(Initiative, initiative_id)
     if not initiative:
@@ -729,11 +730,11 @@ async def admin_get_initiative_members(
     """List members of any initiative (platform admin only).
 
     ``guild_id`` is required: initiatives live in per-guild schemas with
-    independent id sequences. We route into that guild's schema as superadmin
-    so the member list comes from the live data, not the frozen ``public``
-    backup.
+    independent id sequences. We route into that guild's schema as a guild
+    admin so the member list comes from the live data, not the frozen
+    ``public`` backup.
     """
-    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
 
     stmt = select(Initiative).where(Initiative.id == initiative_id)
     result = await session.exec(stmt)
@@ -780,12 +781,12 @@ async def admin_update_initiative_member_role(
     even if they're not a member. Useful for resolving "sole PM" blockers.
 
     ``guild_id`` is required (per-guild schemas; ``initiative_id`` is not unique
-    across guilds). We route into that guild's schema as superadmin.
+    across guilds). We route into that guild's schema as a guild admin.
 
     Restrictions:
     - Cannot demote the last project manager
     """
-    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
 
     # Check initiative exists
     stmt = select(Initiative).where(Initiative.id == initiative_id)

--- a/backend/app/api/v1/platform_endpoints/admin_test.py
+++ b/backend/app/api/v1/platform_endpoints/admin_test.py
@@ -241,7 +241,7 @@ async def test_admin_delete_rejects_surplus_project_transfers(
     from app.models.tenant.project import Project
     from app.db.session import set_rls_context
 
-    # Verify as a guild admin: initiative_access ignores is_superadmin, so route
+    # Verify as a guild admin: initiative_access honors only the admin leg, so route
     # with the admin role to read the (untouched) bystander project.
     await set_rls_context(session, guild_id=guild.id, guild_role="admin")
     refreshed = (

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -223,7 +223,7 @@ async def register_user(
                 # PendingRollbackError and the already-committed user + guild rows
                 # are stranded. Rollback also reverts the seed's SET ROLE (Postgres
                 # SET is transactional) so deprovision can DROP the role; this is an
-                # admin (BYPASSRLS) session, so removing the shared rows isn't filtered.
+                # system-engine session (BYPASSRLS), so removing the shared rows isn't filtered.
                 await session.rollback()
                 with _suppress(Exception):
                     await deprovision_guild(guild_id)

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -203,7 +203,6 @@ async def create_guild(
             session,
             guild_id=guild.id,
             creator=current_user,
-            is_superadmin=user_has_capability(current_user, Capability.DATA_BYPASS),
         )
         await session.commit()
     except Exception:

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -255,7 +255,7 @@ async def list_platform_guild_storage(
 
     Admin/owner (``guilds.manage``). Reads only shared ``public`` tables
     (``guilds``, ``guild_memberships``) — no guild-scoped content — so it runs on
-    the BYPASSRLS admin engine without routing into any guild schema. Member
+    the system admin engine without routing into any guild schema. Member
     counts come from a single grouped query rather than per-guild (no N+1).
     """
     guilds = (await session.exec(select(Guild).order_by(Guild.name))).all()
@@ -342,7 +342,7 @@ async def _reset_admin_session(session: AsyncSession) -> None:
 
     After routing into a guild schema the session has assumed that guild's role,
     which has no write access to shared ``public`` config tables. Reset to the
-    BYPASSRLS admin login role (``SET ROLE none``, ``search_path public``) before
+    admin login role (``SET ROLE none``, ``search_path public``) before
     writing the mapping back to ``public``.
     """
     await set_rls_context(session)
@@ -358,7 +358,7 @@ async def _lookup_guild_initiative(
 
     Routes the session into ``guild_<id>`` for the read, then resets it back to
     the neutral admin baseline so callers can write the mapping to the shared
-    ``public.oidc_claim_mappings`` table as the BYPASSRLS admin login role (the
+    ``public.oidc_claim_mappings`` table as the admin login role (the
     guild role has no write grant on config tables). ``populate_existing`` keeps
     a colliding id from another guild already in the identity map from being
     returned stale — ids are unique only within a schema.

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -334,7 +334,7 @@ async def _route_admin_to_guild(session: AsyncSession, guild_id: int) -> None:
     routed guild could otherwise be returned for a colliding id.
     """
     session.expunge_all()
-    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild_id)
 
 
 async def _reset_admin_session(session: AsyncSession) -> None:
@@ -363,7 +363,7 @@ async def _lookup_guild_initiative(
     a colliding id from another guild already in the identity map from being
     returned stale — ids are unique only within a schema.
     """
-    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild_id)
     try:
         initiative = (
             await session.exec(

--- a/backend/app/api/v1/platform_endpoints/settings_test.py
+++ b/backend/app/api/v1/platform_endpoints/settings_test.py
@@ -173,7 +173,7 @@ async def test_create_initiative_oidc_mapping_resolves_guild_scoped_data(
 
 
 # The whole OIDC claim-mapping surface reads/writes guild-scoped data through the
-# BYPASSRLS admin engine, so the ONLY thing standing between a caller and every
+# system admin engine, so the ONLY thing standing between a caller and every
 # guild's data is the owner-only ``config.manage`` capability gate. These tests
 # hard-pin that gate per endpoint so a future edit can't silently drop it and let
 # a non-owner (even a platform admin) through.

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -618,11 +618,11 @@ async def get_my_initiative_members(
     Used by the account-deletion transfer-target picker. ``guild_id`` is
     required: the initiative lives in that guild's schema (ids repeat across
     guild schemas), and the caller has it from the blocker record. We route in
-    as superadmin so the member list is read from the live guild schema (the
+    into the guild schema so the member list is read from the live data (the
     intentional cross-guild visibility the picker needs), not the frozen
     ``public`` backup.
     """
-    await set_rls_context(session, guild_id=guild_id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild_id)
 
     # Verify the current user is a member of this initiative
     membership = await initiatives_service.get_initiative_membership(

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1935,7 +1935,7 @@ async def _load_download_document(
 
     # Route into the guild through the single entry point — same resolution and
     # applied context (membership / live PAM / break-glass, then SET ROLE +
-    # active_role/grant, no is_superadmin bypass) as REST and the realtime
+    # active_role/grant, no ambient bypass) as REST and the realtime
     # sockets. Fine-grained read permission is then enforced by
     # require_document_access against the context this established.
     try:

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1923,7 +1923,7 @@ async def _load_download_document(
 
     # Guard the SET ROLE sink: if the guild schema/role isn't provisioned,
     # establish_guild_access would fault rather than 404. (The session is the
-    # BYPASSRLS admin engine, so this lookup runs regardless of context.)
+    # system admin engine (BYPASSRLS), so this lookup runs regardless of context.)
     schema_exists = (
         await session.exec(
             text("SELECT 1 FROM pg_namespace WHERE nspname = :ns"),

--- a/backend/app/core/capabilities.py
+++ b/backend/app/core/capabilities.py
@@ -47,7 +47,7 @@ class Capability(str, Enum):
     ROLES_ASSIGN = "roles.assign"
 
     # The right to self-issue a break-glass PAM grant (admin+owner only). This is
-    # NOT a standing all-guild bypass: instead of ambient ``app.is_superadmin``
+    # NOT a standing all-guild bypass: instead of an ambient superadmin flag
     # god-mode, the holder records a scoped, time-bound, audited grant in one step
     # (created + self-approved) to reach one guild's data, then routes through the
     # normal PAM path until it expires. Lower tiers reach a guild via the

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from urllib.parse import urlsplit
 
-from pydantic import EmailStr, Field, field_validator, model_validator
+from pydantic import AliasChoices, EmailStr, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Origins used by the Capacitor native mobile app (iOS and Android).
@@ -379,9 +379,25 @@ class Settings(BaseSettings):
     S3_LOCAL_FALLBACK: bool = False
     STATIC_DIR: str = "static"
 
-    FIRST_SUPERUSER_EMAIL: EmailStr | None = None
-    FIRST_SUPERUSER_PASSWORD: str | None = None
-    FIRST_SUPERUSER_FULL_NAME: str | None = None
+    # First/bootstrap user — becomes the platform `owner` tier (there is no
+    # superuser concept). The legacy FIRST_SUPERUSER_* env names are accepted
+    # as aliases so existing deployments keep working.
+    FIRST_OWNER_EMAIL: EmailStr | None = Field(
+        default=None,
+        validation_alias=AliasChoices("FIRST_OWNER_EMAIL", "FIRST_SUPERUSER_EMAIL"),
+    )
+    FIRST_OWNER_PASSWORD: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "FIRST_OWNER_PASSWORD", "FIRST_SUPERUSER_PASSWORD"
+        ),
+    )
+    FIRST_OWNER_FULL_NAME: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "FIRST_OWNER_FULL_NAME", "FIRST_SUPERUSER_FULL_NAME"
+        ),
+    )
     DISABLE_GUILD_CREATION: bool = False
     ENABLE_PUBLIC_REGISTRATION: bool = (
         True  # When False, requires invite code to register

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     DATABASE_URL_APP: (
         str  # Non-superuser connection for RLS-enforced queries (required)
     )
-    DATABASE_URL_ADMIN: str  # Admin connection with BYPASSRLS for migrations (required)
+    DATABASE_URL_ADMIN: str  # System-engine login (BYPASSRLS, grant-bounded) for jobs/seeding (required)
 
     SECRET_KEY: str
     # Optional: the *previous* SECRET_KEY, set only while rotating the encryption
@@ -399,6 +399,9 @@ class Settings(BaseSettings):
         ),
     )
     DISABLE_GUILD_CREATION: bool = False
+    # Boot back-fill normally skips guild schemas stamped with the current
+    # provisioning-artifact version; set true to force a full sweep once.
+    FORCE_GUILD_BACKFILL: bool = False
     ENABLE_PUBLIC_REGISTRATION: bool = (
         True  # When False, requires invite code to register
     )

--- a/backend/app/db/backfill_uploads_to_s3.py
+++ b/backend/app/db/backfill_uploads_to_s3.py
@@ -30,7 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 from app.core.config import settings
 from app.db import session as db_session
-from app.db.schema_provisioning import guild_schema_name
+from app.db.schema_provisioning import guild_role_name, guild_schema_name
 from app.services.storage import StorageBackend, s3_guild_storage
 
 logger = logging.getLogger(__name__)
@@ -123,7 +123,7 @@ async def backfill_uploads_to_s3(*, dry_run: bool = False) -> BackfillSummary:
     """Copy every guild's local blobs into S3. See module docstring."""
     summary = BackfillSummary()
     root = Path(settings.UPLOADS_DIR)
-    engine = db_session.provisioning_engine  # superuser: reads every guild schema
+    engine = db_session.admin_engine  # system engine; guild schemas via SET ROLE
     async with engine.connect() as conn:
         guild_ids = (
             (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
@@ -134,6 +134,12 @@ async def backfill_uploads_to_s3(*, dry_run: bool = False) -> BackfillSummary:
             guild_dir = root / f"guild_{gid}"
             if not guild_dir.is_dir():
                 continue
+            # Assume the guild's own role for the schema read (the system
+            # login holds no standing guild-schema access).
+            await conn.execute(
+                text("SELECT set_config('role', :r, false)"),
+                {"r": guild_role_name(gid)},
+            )
             meta = await _guild_upload_meta(conn, guild_schema_name(gid))
             # Always a real S3 backend, even on a dry run, so the exists() skip
             # check reflects what's already in the bucket.

--- a/backend/app/db/backfill_uploads_to_s3.py
+++ b/backend/app/db/backfill_uploads_to_s3.py
@@ -107,7 +107,13 @@ async def _guild_upload_meta(
     """filename -> (content_type, content_hash) for a guild's uploads, or {} if
     the schema/table is absent."""
     exists = (
-        await conn.execute(text("SELECT to_regclass(:t)"), {"t": f"{schema}.uploads"})
+        await conn.execute(
+            text(
+                "SELECT 1 FROM pg_tables "
+                "WHERE schemaname = :s AND tablename = 'uploads'"
+            ),
+            {"s": schema},
+        )
     ).scalar()
     if exists is None:
         return {}
@@ -125,6 +131,8 @@ async def backfill_uploads_to_s3(*, dry_run: bool = False) -> BackfillSummary:
     root = Path(settings.UPLOADS_DIR)
     engine = db_session.admin_engine  # system engine; guild schemas via SET ROLE
     async with engine.connect() as conn:
+        # Pooled connection: shed any guild role a previous checkout assumed.
+        await conn.execute(text("SELECT set_config('role', 'none', false)"))
         guild_ids = (
             (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
             .scalars()

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -21,14 +21,14 @@ from app.services.platform import guilds as guilds_service
 BASELINE_REVISION = "20260626_0125"
 
 
-async def init_superuser() -> None:
-    if not (settings.FIRST_SUPERUSER_EMAIL and settings.FIRST_SUPERUSER_PASSWORD):
+async def init_owner() -> None:
+    if not (settings.FIRST_OWNER_EMAIL and settings.FIRST_OWNER_PASSWORD):
         return
 
     async with AdminSessionLocal() as session:
         existing = await session.exec(
             select(User).where(
-                User.email_hash == hash_email(settings.FIRST_SUPERUSER_EMAIL)
+                User.email_hash == hash_email(settings.FIRST_OWNER_EMAIL)
             )
         )
         if existing.one_or_none() is not None:
@@ -36,10 +36,10 @@ async def init_superuser() -> None:
 
         # Create the first superuser (the platform owner)...
         user = User(
-            email_hash=hash_email(settings.FIRST_SUPERUSER_EMAIL),
-            email_encrypted=encrypt_field(settings.FIRST_SUPERUSER_EMAIL, SALT_EMAIL),
-            full_name=settings.FIRST_SUPERUSER_FULL_NAME,
-            hashed_password=get_password_hash(settings.FIRST_SUPERUSER_PASSWORD),
+            email_hash=hash_email(settings.FIRST_OWNER_EMAIL),
+            email_encrypted=encrypt_field(settings.FIRST_OWNER_EMAIL, SALT_EMAIL),
+            full_name=settings.FIRST_OWNER_FULL_NAME,
+            hashed_password=get_password_hash(settings.FIRST_OWNER_PASSWORD),
             role=UserRole.owner,
             email_verified=True,
         )
@@ -64,7 +64,7 @@ async def init_superuser() -> None:
             await session.commit()
         except Exception:
             # Undo the whole first-boot seed so a restart re-initializes cleanly.
-            # Otherwise the committed user makes init_superuser short-circuit on
+            # Otherwise the committed user makes init_owner short-circuit on
             # every restart, stranding the primary guild without a schema. Mirrors
             # the API/registration cleanup. Roll back FIRST (an aborted session
             # would fault the cleanup queries, and it reverts the seed's SET ROLE
@@ -160,11 +160,11 @@ async def check_pre_baseline_db() -> None:
 async def init() -> None:
     await check_pre_baseline_db()
     await run_migrations()
-    await init_superuser()
+    await init_owner()
     async with AdminSessionLocal() as session:
         # guild_settings is guild-scoped; route into the primary guild's schema so
         # the seeded settings row lands there, not in public. get_primary_guild_id
-        # provisions the guild if it has to create it (no-FIRST_SUPERUSER path).
+        # provisions the guild if it has to create it (no-FIRST_OWNER path).
         primary_id = await guilds_service.get_primary_guild_id(session)
         await set_rls_context(session, guild_id=primary_id)
         await app_settings_service.get_or_create_guild_settings(

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -68,7 +68,7 @@ async def init_owner() -> None:
             # every restart, stranding the primary guild without a schema. Mirrors
             # the API/registration cleanup. Roll back FIRST (an aborted session
             # would fault the cleanup queries, and it reverts the seed's SET ROLE
-            # so deprovision can DROP the role); this is an admin (BYPASSRLS)
+            # so deprovision can DROP the role); this is a system-engine
             # session, so the bulk DELETEs aren't RLS-filtered.
             await session.rollback()
             with suppress(Exception):

--- a/backend/app/db/init_db_test.py
+++ b/backend/app/db/init_db_test.py
@@ -16,15 +16,15 @@ from app.services.platform import guilds as guilds_service
 pytestmark = pytest.mark.database
 
 
-async def test_init_superuser_cleans_up_when_guild_seed_fails(engine, monkeypatch):
+async def test_init_owner_cleans_up_when_guild_seed_fails(engine, monkeypatch):
     """A guild-seed failure during first-boot superuser init must undo the
     already-committed user + guild.
 
-    Otherwise the committed user makes init_superuser short-circuit on every
+    Otherwise the committed user makes init_owner short-circuit on every
     subsequent restart ("already seeded"), permanently stranding the primary
     guild without a schema. The cleanup mirrors the API/registration paths.
     """
-    # init_superuser uses AdminSessionLocal (bound to the prod admin engine);
+    # init_owner uses AdminSessionLocal (bound to the prod admin engine);
     # point it (and provisioning, via the autouse harness) at the test DB.
     test_sessions = async_sessionmaker(
         engine, class_=AsyncSession, expire_on_commit=False
@@ -32,9 +32,9 @@ async def test_init_superuser_cleans_up_when_guild_seed_fails(engine, monkeypatc
     monkeypatch.setattr(init_db, "AdminSessionLocal", test_sessions)
 
     email = "init-boot-seedfail@example.com"
-    monkeypatch.setattr(settings, "FIRST_SUPERUSER_EMAIL", email)
-    monkeypatch.setattr(settings, "FIRST_SUPERUSER_PASSWORD", "securepassword123")
-    monkeypatch.setattr(settings, "FIRST_SUPERUSER_FULL_NAME", "Boot Fail")
+    monkeypatch.setattr(settings, "FIRST_OWNER_EMAIL", email)
+    monkeypatch.setattr(settings, "FIRST_OWNER_PASSWORD", "securepassword123")
+    monkeypatch.setattr(settings, "FIRST_OWNER_FULL_NAME", "Boot Fail")
 
     async def _boom(seed_session, *args, **kwargs):
         # Abort the transaction like a real failing query would, so the cleanup
@@ -47,7 +47,7 @@ async def test_init_superuser_cleans_up_when_guild_seed_fails(engine, monkeypatc
         guilds_before = len((await pre.exec(select(Guild))).all())
 
     with pytest.raises(Exception):
-        await init_db.init_superuser()
+        await init_db.init_owner()
 
     async with test_sessions() as check:
         user = (

--- a/backend/app/db/local_upload_migration.py
+++ b/backend/app/db/local_upload_migration.py
@@ -72,6 +72,8 @@ async def _build_filename_guild_map() -> dict[str, int]:
     engine = db_session.admin_engine  # system engine; guild schemas via SET ROLE
     mapping: dict[str, int] = {}
     async with engine.connect() as conn:
+        # Pooled connection: shed any guild role a previous checkout assumed.
+        await conn.execute(text("SELECT set_config('role', 'none', false)"))
         guild_ids = (
             (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
             .scalars()
@@ -79,9 +81,16 @@ async def _build_filename_guild_map() -> dict[str, int]:
         )
         for gid in guild_ids:
             schema = guild_schema_name(gid)
+            # Existence check via pg_catalog (needs no schema USAGE —
+            # to_regclass would raise: name resolution requires USAGE, and
+            # the system login holds none until it assumes the guild role).
             exists = (
                 await conn.execute(
-                    text("SELECT to_regclass(:t)"), {"t": f"{schema}.uploads"}
+                    text(
+                        "SELECT 1 FROM pg_tables "
+                        "WHERE schemaname = :s AND tablename = 'uploads'"
+                    ),
+                    {"s": schema},
                 )
             ).scalar()
             if exists is None:  # schema missing/partial — skip

--- a/backend/app/db/local_upload_migration.py
+++ b/backend/app/db/local_upload_migration.py
@@ -22,7 +22,7 @@ from sqlalchemy import text
 
 from app.core.config import settings
 from app.db import session as db_session
-from app.db.schema_provisioning import guild_schema_name
+from app.db.schema_provisioning import guild_role_name, guild_schema_name
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def relocate_flat_uploads(
 async def _build_filename_guild_map() -> dict[str, int]:
     """Map every guild's ``uploads.filename`` -> guild id (filenames are UUIDs,
     so they're globally unique and never collide across guilds)."""
-    engine = db_session.provisioning_engine  # superuser: can read every schema
+    engine = db_session.admin_engine  # system engine; guild schemas via SET ROLE
     mapping: dict[str, int] = {}
     async with engine.connect() as conn:
         guild_ids = (
@@ -86,6 +86,12 @@ async def _build_filename_guild_map() -> dict[str, int]:
             ).scalar()
             if exists is None:  # schema missing/partial — skip
                 continue
+            # Assume the guild's own role for the schema read (the system
+            # login holds no standing guild-schema access).
+            await conn.execute(
+                text("SELECT set_config('role', :r, false)"),
+                {"r": guild_role_name(gid)},
+            )
             rows = (
                 (await conn.execute(text(f'SELECT filename FROM "{schema}".uploads')))
                 .scalars()

--- a/backend/app/db/local_upload_migration_test.py
+++ b/backend/app/db/local_upload_migration_test.py
@@ -57,3 +57,39 @@ def test_legacy_flat_files_ignores_subdirs(tmp_path):
 
 def test_legacy_flat_files_missing_root(tmp_path):
     assert _legacy_flat_files(tmp_path / "nope") == []
+
+
+# --- DB-backed: the guild map builder spans guilds on one connection ----------
+
+
+async def test_build_filename_guild_map_spans_multiple_guilds(engine, session):
+    """``_build_filename_guild_map`` iterates every guild on ONE system-engine
+    connection, assuming each guild's role in turn. Guild A -> guild B directly
+    is legal (``SET ROLE`` checks the SESSION user's memberships — the login
+    role belongs to every provisioned guild role — not the current role's), so
+    a multi-guild deployment must map every guild's uploads in a single pass.
+    """
+    from sqlalchemy import text
+
+    from app.db.local_upload_migration import _build_filename_guild_map
+    from app.testing import create_guild, create_user
+
+    user = await create_user(session)
+    guild_a = await create_guild(session, creator=user)
+    guild_b = await create_guild(session, creator=user)
+
+    async with engine.begin() as conn:
+        for guild, filename in ((guild_a, "map-a.png"), (guild_b, "map-b.png")):
+            await conn.execute(
+                text(
+                    f'INSERT INTO "guild_{guild.id}".uploads '
+                    "(filename, guild_id, uploader_user_id, size_bytes, created_at) "
+                    "VALUES (:f, :g, :u, 1, now())"
+                ),
+                {"f": filename, "g": guild.id, "u": user.id},
+            )
+
+    mapping = await _build_filename_guild_map()
+
+    assert mapping["map-a.png"] == guild_a.id
+    assert mapping["map-b.png"] == guild_b.id

--- a/backend/app/db/platform_role_rls_test.py
+++ b/backend/app/db/platform_role_rls_test.py
@@ -124,7 +124,7 @@ async def _insert_grant(session, user_id: int, guild_id: int) -> None:
 
 async def test_access_grants_self_vs_admin(session):
     """A grantee sees only their own grant (``access_grants_self``); an admin sees
-    the whole queue (``access_grants_admin``). ``is_superadmin`` is retired here."""
+    the whole queue (``access_grants_admin``). There is no superadmin bypass."""
     guild = await create_guild(session)
     u1 = await create_user(session)
     u2 = await create_user(session)

--- a/backend/app/db/platform_role_rls_test.py
+++ b/backend/app/db/platform_role_rls_test.py
@@ -241,7 +241,7 @@ async def test_app_settings_reseed_degrades_to_transient_for_non_owner(
 
 
 async def test_support_can_list_users_role_scoped(client, acting_user):
-    """The moved ``GET /admin/users`` runs as ``platform_support`` (off the BYPASSRLS
+    """The moved ``GET /admin/users`` runs as ``platform_support`` (off the
     engine) and the cross-user read is authorized by ``users_platform_read``."""
     a = await acting_user("support")
     resp = await client.get("/api/v1/admin/users", headers=a.headers)

--- a/backend/app/db/platform_roles_test.py
+++ b/backend/app/db/platform_roles_test.py
@@ -149,7 +149,7 @@ async def test_platform_and_guild_roles_coexist(client, acting_user):
 
     SET ROLE is single-valued per statement, so the two never conflict and neither
     costs the other. Uses a non-bypass platform tier (member) so the guild request
-    is governed purely by the guild role, not data.bypass / is_superadmin.
+    is governed purely by the guild role, not data.bypass or any bypass flag.
     """
     a = await acting_user("member", guild_role="admin")
 

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -333,6 +333,9 @@ async def backfill_guild_schemas() -> BackfillSummary:
     # actor — FORCE RLS filters its unrouted data reads to zero rows (by
     # design). Reading data is the system engine's job (BYPASSRLS).
     async with db_session.admin_engine.connect() as conn:
+        # Pooled connection: shed any guild role a previous checkout assumed
+        # (a leaked role would RLS-filter public.guilds to zero rows).
+        await conn.execute(text("SELECT set_config('role', 'none', false)"))
         rows = (
             await conn.execute(
                 text(

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -22,8 +22,10 @@ sequential loop heals both with no extra bookkeeping.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 
 from sqlalchemy import text
@@ -101,6 +103,27 @@ GUILD_SCHEMA_SQL_PATH = (
 GUILD_RLS_SQL_PATH = (
     Path(__file__).resolve().parents[2] / "alembic" / "guild" / "guild_rls.sql"
 )
+
+# Bump when _grant_statements() changes: the provisioning stamp hashes the two
+# SQL artifacts plus this number, so a grants-only change still re-provisions
+# every guild on the next boot.
+GRANTS_VERSION = 1
+
+
+@lru_cache(maxsize=1)
+def provisioning_stamp() -> str:
+    """Schema-comment stamp identifying the provisioning artifacts' version.
+
+    A guild schema whose comment carries the current stamp was provisioned by
+    exactly these artifacts, so the boot back-fill can skip it — O(changed
+    guilds) boots instead of O(all guilds). Any artifact change (or a
+    GRANTS_VERSION bump) produces a new stamp and a one-time full sweep.
+    """
+    digest = hashlib.sha256()
+    digest.update(GUILD_SCHEMA_SQL_PATH.read_bytes())
+    digest.update(GUILD_RLS_SQL_PATH.read_bytes())
+    digest.update(str(GRANTS_VERSION).encode())
+    return f"provisioned:{digest.hexdigest()[:16]}"
 
 
 async def apply_guild_schema(conn: AsyncConnection, schema: str) -> None:
@@ -213,6 +236,11 @@ async def provision_guild_schema(conn: AsyncConnection, guild_id: int) -> str:
     await apply_guild_schema(conn, schema)  # canonical Alembic-owned table DDL
     await _exec_batch(conn, _grant_statements(schema, role, ro_role))
     await apply_guild_rls(conn, schema)  # initiative-level RLS policies
+    # Stamp the artifacts' version so the boot back-fill can skip this guild
+    # until they change (constant hex literal, safe to inline).
+    await conn.exec_driver_sql(
+        f"COMMENT ON SCHEMA \"{schema}\" IS '{provisioning_stamp()}'"
+    )
     return schema
 
 
@@ -226,8 +254,14 @@ async def drop_guild_schema(conn: AsyncConnection, guild_id: int) -> None:
     # this drop is idempotent so a retry recovers cleanly.
     await conn.exec_driver_sql("SET lock_timeout = '10s'")
     await conn.exec_driver_sql(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+    provisioning_login = make_url(settings.DATABASE_URL).username
     for role in (guild_role_name(guild_id), guild_readonly_role_name(guild_id)):
         if await _role_exists(conn, role):
+            # DROP OWNED requires the role's PRIVILEGES, not just ADMIN OPTION
+            # on it (PG16+ separates the two). The provisioning login
+            # administers every guild role, so grant itself membership first —
+            # a no-op under a superuser DATABASE_URL.
+            await conn.exec_driver_sql(f'GRANT "{role}" TO "{provisioning_login}"')
             await conn.exec_driver_sql(f'DROP OWNED BY "{role}"')  # clear grants first
             await conn.exec_driver_sql(f'DROP ROLE "{role}"')
 
@@ -270,36 +304,53 @@ class BackfillSummary:
     total: int
     provisioned: int
     failed: int
+    skipped: int = 0  # stamp matched — provisioned by the current artifacts
     failed_guild_ids: list[int] = field(default_factory=list)
 
 
 async def backfill_guild_schemas() -> BackfillSummary:
-    """Re-provision every existing guild's schema + roles on boot. Idempotent.
+    """Re-provision every guild schema the current artifacts haven't built yet.
 
-    Enumerates guild ids from the shared ``public.guilds`` table on the
-    provisioning (superuser) engine, then runs the idempotent
-    ``provision_guild`` for each. Because provisioning re-runs the canonical
-    ``guild_schema.sql`` DDL (``CREATE ... IF NOT EXISTS``) and re-applies grants,
-    this back-fills any table/column/index/grant added since a guild was first
-    provisioned and (re-)creates a schema that is missing entirely — healing both
-    the silent-drift gap and a crash that left a guild row without its schema.
+    Enumerates guild ids (and their schema-comment stamps) from the
+    provisioning engine, then runs the idempotent ``provision_guild`` for each
+    guild whose stamp doesn't match :func:`provisioning_stamp` — i.e. its
+    schema predates the current ``guild_schema.sql`` / ``guild_rls.sql`` /
+    grants version, is missing entirely, or was never stamped. Because
+    provisioning re-runs the canonical DDL (``CREATE ... IF NOT EXISTS``) and
+    re-applies grants, this back-fills any table/column/index/grant added
+    since, then re-stamps. Already-stamped guilds are skipped, so a boot with
+    unchanged artifacts is O(changed guilds), not O(all guilds) — set
+    ``FORCE_GUILD_BACKFILL=true`` to sweep everything regardless.
 
     Per-guild failures are logged with the guild id and skipped so one broken
     guild can't take down boot for the rest; ``provision_guild`` runs each guild
     in its own transaction, so a failure rolls back only that guild. Returns a
     summary for the caller to log.
     """
-    engine = db_session.provisioning_engine  # superuser
-    async with engine.connect() as conn:
-        guild_ids = (
-            (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
-            .scalars()
-            .all()
-        )
+    stamp = provisioning_stamp()
+    # Enumerate on the SYSTEM engine, not the provisioning engine: guild ids
+    # live in the RLS-forced public.guilds, and the provisioner is a pure DDL
+    # actor — FORCE RLS filters its unrouted data reads to zero rows (by
+    # design). Reading data is the system engine's job (BYPASSRLS).
+    async with db_session.admin_engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT g.id, obj_description(n.oid) "
+                    "FROM public.guilds g "
+                    "LEFT JOIN pg_namespace n ON n.nspname = 'guild_' || g.id "
+                    "ORDER BY g.id"
+                )
+            )
+        ).all()
 
     provisioned = 0
+    skipped = 0
     failed_guild_ids: list[int] = []
-    for gid in guild_ids:
+    for gid, comment in rows:
+        if comment == stamp and not settings.FORCE_GUILD_BACKFILL:
+            skipped += 1
+            continue
         try:
             await provision_guild(gid)
             provisioned += 1
@@ -308,8 +359,38 @@ async def backfill_guild_schemas() -> BackfillSummary:
             logger.exception("guild schema back-fill failed for guild %s", gid)
 
     return BackfillSummary(
-        total=len(guild_ids),
+        total=len(rows),
         provisioned=provisioned,
         failed=len(failed_guild_ids),
+        skipped=skipped,
         failed_guild_ids=failed_guild_ids,
     )
+
+
+async def warn_if_privileged_database_url() -> None:
+    """Warn when DATABASE_URL connects as a superuser (or BYPASSRLS) role.
+
+    The app never needs a Postgres superuser: migrations + guild provisioning
+    fit in the least-privilege ``app_provisioner`` role (NOSUPERUSER CREATEROLE
+    + CREATE on the database + ownership of the app's objects). Role creation
+    is an infrastructure concern, not app code: fresh docker-compose installs
+    get the role from the Postgres image's ``docker-entrypoint-initdb.d``
+    script; existing deployments run ``scripts/create-provisioner.sql`` once
+    (see the deployment docs), then point DATABASE_URL at ``app_provisioner``.
+    """
+    async with db_session.provisioning_engine.connect() as conn:
+        rolsuper, rolbypassrls = (
+            await conn.execute(
+                text(
+                    "SELECT rolsuper, rolbypassrls FROM pg_roles "
+                    "WHERE rolname = current_user"
+                )
+            )
+        ).one()
+    if rolsuper or rolbypassrls:
+        logger.warning(
+            "DATABASE_URL connects as %s role — the app does not need this. "
+            "Run backend/scripts/create-provisioner.sql once (see the "
+            "deployment docs) and point DATABASE_URL at app_provisioner.",
+            "a SUPERUSER" if rolsuper else "a BYPASSRLS",
+        )

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -489,7 +489,10 @@ async def test_backfill_provisions_a_guild_missing_its_schema(engine):
         # shared test DB, and an unrelated broken guild must not fail this test.
         assert done not in summary.failed_guild_ids
         assert missing not in summary.failed_guild_ids
-        assert summary.provisioned >= 2
+        # `missing` had no schema, so it must have been provisioned; `done` was
+        # provisioned with the current artifacts, so the stamp skips it.
+        assert summary.provisioned >= 1
+        assert summary.skipped >= 1
 
         async with engine.connect() as conn:
             tables = await conn.scalar(
@@ -512,15 +515,23 @@ async def test_backfill_provisions_a_guild_missing_its_schema(engine):
 
 async def test_backfill_repairs_a_dropped_table(engine):
     """A table missing from an already-provisioned schema (drift: a table added to
-    guild_schema.sql after the guild was made) is recreated by the back-fill."""
+    guild_schema.sql after the guild was made) is recreated by the back-fill.
+
+    In that scenario the guild's schema-comment stamp predates the current
+    artifacts, so the sweep re-provisions it (a schema stamped with the CURRENT
+    artifacts is skipped — out-of-band corruption needs FORCE_GUILD_BACKFILL)."""
     gid = _GID_BACKFILL_DRIFT
     schema = guild_schema_name(gid)
     try:
         async with engine.begin() as conn:
             await _insert_public_guild(conn, gid, "backfill-drift")
             await provision_guild_schema(conn, gid)
-            # Simulate a table that didn't exist when the schema was provisioned.
+            # Simulate a table that didn't exist when the schema was provisioned:
+            # the table is absent AND the stamp names the older artifact version.
             await conn.exec_driver_sql(f'DROP TABLE "{schema}".subtasks CASCADE')
+            await conn.exec_driver_sql(
+                f"COMMENT ON SCHEMA \"{schema}\" IS 'provisioned:pre-subtasks'"
+            )
 
         async with engine.connect() as conn:
             gone = await conn.scalar(text(f"SELECT to_regclass('{schema}.subtasks')"))

--- a/backend/app/db/secret_key_rotation.py
+++ b/backend/app/db/secret_key_rotation.py
@@ -288,6 +288,9 @@ async def rotate_secret_key(*, dry_run: bool = False) -> RotationSummary:
     # second (engine.begin()) — separate connections so an open read cursor and the
     # UPDATEs don't collide on asyncpg. The write txn commits together, resumable.
     async with engine.connect() as read_conn, engine.begin() as write_conn:
+        for conn_ in (read_conn, write_conn):
+            # Pooled connections: shed any guild role a prior checkout assumed.
+            await conn_.execute(text("SELECT set_config('role', 'none', false)"))
         summary.columns.append(
             await _rotate_user_emails(read_conn, write_conn, old_key, new_key, dry_run)
         )

--- a/backend/app/db/secret_key_rotation.py
+++ b/backend/app/db/secret_key_rotation.py
@@ -58,7 +58,7 @@ from app.core.encryption import (
     hash_email,
 )
 from app.db import session as db_session
-from app.db.schema_provisioning import guild_schema_name
+from app.db.schema_provisioning import guild_role_name, guild_schema_name
 
 logger = logging.getLogger(__name__)
 
@@ -279,7 +279,10 @@ async def rotate_secret_key(*, dry_run: bool = False) -> RotationSummary:
         )
 
     summary = RotationSummary(dry_run=dry_run)
-    engine = db_session.provisioning_engine  # superuser: all schemas, bypasses RLS
+    # System engine (policy-bound): the public half runs as app_admin under its
+    # enumerated `_system` policies; each guild schema is entered by assuming
+    # that guild's own role (app_admin holds INHERIT FALSE membership in all).
+    engine = db_session.admin_engine
 
     # Platform tables (public). Reads stream on one connection; writes commit on a
     # second (engine.begin()) — separate connections so an open read cursor and the
@@ -318,6 +321,11 @@ async def rotate_secret_key(*, dry_run: bool = False) -> RotationSummary:
                 engine.connect() as read_conn,
                 engine.begin() as write_conn,
             ):
+                for conn_ in (read_conn, write_conn):
+                    await conn_.execute(
+                        text("SELECT set_config('role', :r, false)"),
+                        {"r": guild_role_name(gid)},
+                    )
                 for table, column, salt in _GUILD_SCHEMA_COLUMNS:
                     summary.columns.append(
                         await _rotate_fernet_column(

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -15,7 +15,10 @@ from app.db import base  # noqa: F401  # ensure models are imported for Alembic
 # Primary engine: non-superuser (DATABASE_URL_APP) for RLS-enforced queries.
 engine = create_async_engine(settings.DATABASE_URL_APP, echo=False)
 
-# Admin engine: for background jobs and startup seeding (BYPASSRLS).
+# System engine: background jobs, startup seeding, platform lifecycle.
+# The textbook Postgres trusted-batch actor: BYPASSRLS, bounded by
+# enumerated per-table GRANTs (migration 0129). Guild schemas still
+# require SET ROLE guild_<id>, which drops the bypass.
 admin_engine = create_async_engine(settings.DATABASE_URL_ADMIN, echo=False)
 
 # Provisioning engine: superuser credentials (same as migrations) for privileged
@@ -60,9 +63,10 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
 
 async def get_admin_session() -> AsyncGenerator[AsyncSession, None]:
     """Get a session on the system engine (background jobs, bootstrapping,
-    platform lifecycle). The engine is policy-bound like every other: its
-    reach on shared tables comes from explicit ``TO app_admin`` policies, and
-    guild schemas require ``SET ROLE guild_<id>`` via set_rls_context()."""
+    platform lifecycle). ``app_admin`` is the standard Postgres trusted-batch
+    actor — BYPASSRLS, bounded by enumerated per-table GRANTs (0129); guild
+    schemas require ``SET ROLE guild_<id>`` (dropping the bypass) via
+    set_rls_context()."""
     async with AdminSessionLocal() as session:
         # Reset routing GUCs on the recycled connection. Without this an admin
         # session inherits whatever search_path / assumed guild role the previous

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -46,7 +46,6 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
                 "SELECT set_config('app.current_user_id', '', false), "
                 "set_config('app.current_guild_id', '', false), "
                 "set_config('app.current_guild_role', '', false), "
-                "set_config('app.is_superadmin', 'false', false), "
                 "set_config('app.pam_guild_id', '', false), "
                 "set_config('app.pam_read', 'false', false), "
                 "set_config('app.pam_write', 'false', false), "
@@ -60,7 +59,10 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def get_admin_session() -> AsyncGenerator[AsyncSession, None]:
-    """Get a session that bypasses RLS (for migrations, background jobs, etc.)."""
+    """Get a session on the system engine (background jobs, bootstrapping,
+    platform lifecycle). The engine is policy-bound like every other: its
+    reach on shared tables comes from explicit ``TO app_admin`` policies, and
+    guild schemas require ``SET ROLE guild_<id>`` via set_rls_context()."""
     async with AdminSessionLocal() as session:
         # Reset routing GUCs on the recycled connection. Without this an admin
         # session inherits whatever search_path / assumed guild role the previous
@@ -74,7 +76,6 @@ async def get_admin_session() -> AsyncGenerator[AsyncSession, None]:
                 "SELECT set_config('app.current_user_id', '', false), "
                 "set_config('app.current_guild_id', '', false), "
                 "set_config('app.current_guild_role', '', false), "
-                "set_config('app.is_superadmin', 'false', false), "
                 "set_config('app.pam_guild_id', '', false), "
                 "set_config('app.pam_read', 'false', false), "
                 "set_config('app.pam_write', 'false', false), "
@@ -90,7 +91,6 @@ async def set_rls_context(
     user_id: Optional[int] = None,
     guild_id: Optional[int] = None,
     guild_role: Optional[str] = None,
-    is_superadmin: bool = False,
     pam_guild_id: Optional[int] = None,
     pam_read: bool = False,
     pam_write: bool = False,
@@ -113,9 +113,8 @@ async def set_rls_context(
     the flag is set. ``pam_guild_id`` is deliberately separate from
     ``current_guild_id`` — the existing write policies treat a matching
     ``current_guild_id`` as proof of membership, so a grantee must leave it
-    unset and be scoped via ``pam_guild_id`` instead. PAM access is distinct
-    from ``is_superadmin`` (all-guild bypass): a grantee gets scoped access,
-    not god-mode.
+    unset and be scoped via ``pam_guild_id`` instead. A grantee gets scoped,
+    time-bound access to one guild; there is no all-guild bypass.
 
     ``platform_role`` is the caller's platform tier (``users.role``). When the
     request carries no guild context (and no active PAM grant), the public/platform
@@ -141,7 +140,6 @@ async def set_rls_context(
         "user_id": user_id,
         "guild_id": guild_id,
         "guild_role": guild_role,
-        "is_superadmin": is_superadmin,
         "pam_guild_id": pam_guild_id,
         "pam_read": pam_read,
         "pam_write": pam_write,
@@ -156,7 +154,6 @@ async def set_rls_context(
     uid = str(int(user_id)) if user_id is not None else ""
     gid = str(int(guild_id)) if guild_id is not None else ""
     grole = guild_role if guild_role is not None else ""
-    sa = "true" if is_superadmin else "false"
     pgid = str(int(pam_guild_id)) if pam_guild_id is not None else ""
     pr = "true" if pam_read else "false"
     pw = "true" if pam_write else "false"
@@ -211,7 +208,6 @@ async def set_rls_context(
             "SELECT set_config('app.current_user_id', :uid, false), "
             "set_config('app.current_guild_id', :gid, false), "
             "set_config('app.current_guild_role', :grole, false), "
-            "set_config('app.is_superadmin', :sa, false), "
             "set_config('app.pam_guild_id', :pgid, false), "
             "set_config('app.pam_read', :pr, false), "
             "set_config('app.pam_write', :pw, false), "
@@ -222,7 +218,6 @@ async def set_rls_context(
             "uid": uid,
             "gid": gid,
             "grole": grole,
-            "sa": sa,
             "pgid": pgid,
             "pr": pr,
             "pw": pw,
@@ -250,7 +245,6 @@ async def rls_session(
     user_id: int,
     guild_id: int,
     guild_role: Optional[str] = None,
-    is_superadmin: bool = False,
 ) -> AsyncGenerator[AsyncSession, None]:
     """Context manager that provides a session with RLS context set.
 
@@ -266,7 +260,6 @@ async def rls_session(
                 user_id=user_id,
                 guild_id=guild_id,
                 guild_role=guild_role,
-                is_superadmin=is_superadmin,
             )
             yield session
 

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -203,9 +203,11 @@ async def set_rls_context(
         name_fn = guild_readonly_role_name if read_only_grant else guild_role_name
         role_target = name_fn(route_guild)
 
-    # Reset to the login role first: a session already SET ROLE'd into guild A
-    # cannot SET ROLE into guild B (it isn't a member). 'none' returns to the
-    # authenticated login role, which IS a member of every provisioned guild role.
+    # Reset to the login role first. NOT because switching requires it — SET
+    # ROLE checks the SESSION user's memberships (the login role, a member of
+    # every provisioned guild role), so guild A -> guild B directly is legal —
+    # but as a defensive baseline: if the set below fails mid-way, the
+    # connection is left as the login role, never wearing a stale guild role.
     await session.exec(text("SELECT set_config('role', 'none', false)"))
     await session.exec(
         text(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,9 +65,14 @@ async def lifespan(app: FastAPI):
     # Re-run the idempotent per-guild provisioning for every guild so any
     # table/column/index/grant added to guild_schema.sql since a guild was
     # provisioned is back-filled, and any guild left without a schema (e.g. a
-    # crash mid-provision) is healed. One broken guild is logged and skipped.
-    from app.db.schema_provisioning import backfill_guild_schemas
+    # crash mid-provision) is healed. One broken guild is logged and skipped;
+    # guilds stamped with the current artifact version are skipped entirely.
+    from app.db.schema_provisioning import (
+        backfill_guild_schemas,
+        warn_if_privileged_database_url,
+    )
 
+    await warn_if_privileged_database_url()
     backfill = await backfill_guild_schemas()
     if backfill.failed:
         # WARNING so partial failure survives INFO-filtered logs (per-guild
@@ -81,8 +86,9 @@ async def lifespan(app: FastAPI):
         )
     else:
         logger.info(
-            "guild schema back-fill: %d provisioned (of %d)",
+            "guild schema back-fill: %d provisioned, %d up-to-date (of %d)",
             backfill.provisioned,
+            backfill.skipped,
             backfill.total,
         )
     # Relocate any legacy flat local uploads into per-guild dirs (guild_<id>/),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -278,7 +278,7 @@ async def serve_upload_file(
     ).first()
     if exists is None:
         raise HTTPException(status_code=404)
-    await set_rls_context(session, guild_id=int(guild_id), is_superadmin=True)
+    await set_rls_context(session, guild_id=int(guild_id))
     hit = (
         await session.exec(
             text("SELECT 1 FROM uploads WHERE filename = :fn LIMIT 1"),

--- a/backend/app/services/access_grants_rls_test.py
+++ b/backend/app/services/access_grants_rls_test.py
@@ -1,6 +1,6 @@
 """DB-level RLS isolation tests for PAM grants.
 
-The test database connects as a BYPASSRLS superuser, so these tests explicitly
+The default test connection would mask RLS, so these tests explicitly
 ``SET ROLE app_user`` (the non-privileged role the app uses at runtime) to make
 RLS + FORCE ROW LEVEL SECURITY actually apply. Without that, the policies would
 silently pass and prove nothing.

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -52,7 +52,7 @@ async def _dispatch(session: AsyncSession) -> None:
     """Drive the reminder pass with the test session. The worker's
     AdminSessionLocal (app_admin) sees the shared users table; mirror that so the
     user-list read isn't RLS-filtered (the gather inside is still member-scoped)."""
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     await _run_event_reminder_pass(session, now=datetime.now(timezone.utc))
 
 
@@ -364,7 +364,7 @@ async def test_overdue_digest_gathers_tasks_across_user_guilds(
 
     # Mirror the worker's starting context: its AdminSessionLocal (app_admin) sees
     # the shared users table; the gather inside still scopes guild data per member.
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     await _run_overdue_pass(session, now=datetime.now(timezone.utc))
 
     assert captured.get("user_id") == user.id
@@ -377,7 +377,7 @@ async def _assignment_item_in_new_guild(
     """Queue a task-assignment digest item for ``user`` in a brand-new guild."""
     # A prior call left the session in a guild-member context; reset so the new
     # guild INSERT into public.guilds isn't RLS-denied.
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     guild = await create_guild(session, creator=user)
     await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
     initiative = await create_initiative(session, guild, user, name=label)
@@ -442,7 +442,7 @@ async def test_assignment_digest_gathers_items_across_user_guilds(
         email_service, "send_task_assignment_digest_email", _capture_email
     )
 
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     await _run_assignment_digest_pass(session, now=datetime.now(timezone.utc))
 
     assert captured.get("user_id") == user.id
@@ -470,9 +470,7 @@ async def test_event_reminders_fire_across_a_users_guilds(session: AsyncSession)
         session, email="multi-reminder@example.com", event_reminder_minutes_before=15
     )
     for label in ("Alpha", "Beta"):
-        await set_rls_context(
-            session, is_superadmin=True
-        )  # permissive for the guild INSERT
+        await set_rls_context(session)  # permissive for the guild INSERT
         creator = await create_user(session, email=f"organizer-{label}@example.com")
         guild = await create_guild(session, creator=creator)
         initiative = await create_initiative(session, guild, creator, name=label)
@@ -495,6 +493,6 @@ async def test_event_reminders_fire_across_a_users_guilds(session: AsyncSession)
     await _dispatch(session)
 
     # Count across guilds: notifications are shared, so view them as superadmin.
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     reminders = await _reminders_for(session, attendee.id)
     assert len(reminders) == 2

--- a/backend/app/services/oidc_sync.py
+++ b/backend/app/services/oidc_sync.py
@@ -191,7 +191,7 @@ async def sync_oidc_assignments(
 
     for gid in relevant_guilds:
         session.expunge_all()
-        await set_rls_context(session, guild_id=gid, is_superadmin=True)
+        await set_rls_context(session, guild_id=gid, guild_role="admin")
 
         guild_inits = {iid for iid, g in initiative_guild.items() if g == gid}
         # Drop references to initiatives that no longer exist in this schema
@@ -275,7 +275,7 @@ async def sync_oidc_assignments(
     from app.services.tenant.initiatives import remove_user_from_guild_initiatives
 
     session.expunge_all()
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     stale_guild_ids = (
         await session.exec(
             select(GuildMembership.guild_id).where(
@@ -288,7 +288,7 @@ async def sync_oidc_assignments(
         if stale_gid in matched_guild_ids:
             continue
         session.expunge_all()
-        await set_rls_context(session, guild_id=stale_gid, is_superadmin=True)
+        await set_rls_context(session, guild_id=stale_gid, guild_role="admin")
         await _auto_transfer_owned_projects(
             session, user_id=user_id, guild_id=stale_gid
         )
@@ -297,7 +297,7 @@ async def sync_oidc_assignments(
         )
         await session.flush()
         session.expunge_all()
-        await set_rls_context(session, is_superadmin=True)
+        await set_rls_context(session)
         await session.exec(
             delete(GuildMembership).where(
                 GuildMembership.user_id == user_id,
@@ -307,7 +307,7 @@ async def sync_oidc_assignments(
         result.guilds_removed.append(stale_gid)
 
     session.expunge_all()
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     await session.commit()
     return result
 

--- a/backend/app/services/oidc_sync_test.py
+++ b/backend/app/services/oidc_sync_test.py
@@ -363,7 +363,7 @@ async def test_sync_nulls_orphaned_role_on_valid_initiative(session: AsyncSessio
 
     # sync resets the shared test session to public on the way out (as a real
     # admin request would); re-route to read the guild-scoped member it wrote.
-    await set_rls_context(session, guild_id=guild.id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild.id, guild_role="admin")
     members = (
         await session.exec(
             select(InitiativeMember).where(

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -303,7 +303,6 @@ async def seed_guild_content(
     *,
     guild_id: int,
     creator: User,
-    is_superadmin: bool = False,
 ) -> None:
     """Provision a new guild's schema and create its guild-scoped seed rows
     (settings + default initiative) *inside* it.
@@ -322,7 +321,6 @@ async def seed_guild_content(
         user_id=creator.id,
         guild_id=guild_id,
         guild_role=GuildRole.admin.value,
-        is_superadmin=is_superadmin,
     )
     await create_guild_settings(session, guild_id)
     await initiatives_service.ensure_default_initiative(

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -239,7 +239,7 @@ async def count_members(session: AsyncSession, *, guild_id: int) -> int:
     """Total number of members in a guild.
 
     The caller must already hold a session that can see the guild's
-    ``guild_memberships`` rows — an admin (BYPASSRLS) session, or one whose RLS
+    ``guild_memberships`` rows — a system-engine session, or one whose RLS
     context is set to this guild (``guild_id = current_guild_id``). Under a
     user-only context the ``guild_memberships_select`` policy would expose only
     the caller's own row."""

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -315,7 +315,7 @@ async def get_initiative_blocker_details(
     # Reset to the public baseline so callers' subsequent reads aren't trapped
     # in the last guild's schema.
     session.expunge_all()
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     return blockers
 
 
@@ -451,7 +451,7 @@ async def check_deletion_eligibility(
             for p in await get_owned_projects(session, user_id)
         )
     session.expunge_all()
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
 
     if sole_pm_initiatives:
         for initiative in sole_pm_initiatives:
@@ -526,7 +526,7 @@ async def _drop_user_memberships(session: AsyncSession, user_id: int) -> User:
     # Back to the public, login-role baseline for the shared-table work: the
     # membership rows themselves and the caller's PII/status writes.
     session.expunge_all()
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     memberships = (
         await session.exec(
             select(GuildMembership).where(GuildMembership.user_id == user_id)
@@ -753,7 +753,7 @@ async def transfer_owned_projects(
                 session, project.id, project_transfers[key]
             )
     session.expunge_all()
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
 
 
 async def reassign_user_content(
@@ -1054,10 +1054,10 @@ async def hard_delete_user(
         await session.flush()
 
     # Phase 2 — shared/public cleanup. Reset to the public, login-role baseline
-    # (BYPASSRLS) so these shared-table writes aren't trapped in the last guild's
-    # schema/role.
+    # so these shared-table writes aren't trapped in the last guild's
+    # schema/role (the system engine's TO app_admin policies govern them).
     session.expunge_all()
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
 
     await session.exec(delete(Notification).where(Notification.user_id == user_id))
     await session.exec(delete(UserApiKey).where(UserApiKey.user_id == user_id))

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -1055,7 +1055,7 @@ async def hard_delete_user(
 
     # Phase 2 — shared/public cleanup. Reset to the public, login-role baseline
     # so these shared-table writes aren't trapped in the last guild's
-    # schema/role (the system engine's TO app_admin policies govern them).
+    # schema/role (restoring the system engine's BYPASSRLS).
     session.expunge_all()
     await set_rls_context(session)
 

--- a/backend/app/services/platform/users_test.py
+++ b/backend/app/services/platform/users_test.py
@@ -585,7 +585,7 @@ async def test_soft_delete_removes_membership_in_guild_schema(session: AsyncSess
     await create_initiative_member(session, initiative=initiative, user=member)
 
     # Sanity: the membership exists in the guild schema before deletion.
-    await set_rls_context(session, guild_id=guild.id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild.id, guild_role="admin")
     before = (
         await session.exec(
             select(InitiativeMember).where(InitiativeMember.user_id == member.id)
@@ -597,7 +597,7 @@ async def test_soft_delete_removes_membership_in_guild_schema(session: AsyncSess
 
     # Re-route into the guild schema and confirm the row is gone THERE.
     session.expunge_all()
-    await set_rls_context(session, guild_id=guild.id, is_superadmin=True)
+    await set_rls_context(session, guild_id=guild.id, guild_role="admin")
     after = (
         await session.exec(
             select(InitiativeMember).where(InitiativeMember.user_id == member.id)
@@ -606,6 +606,6 @@ async def test_soft_delete_removes_membership_in_guild_schema(session: AsyncSess
     assert after == []
 
     # And the user row itself (shared/public) is anonymized.
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     refreshed = (await session.exec(select(User).where(User.id == member.id))).one()
     assert refreshed.status == UserStatus.anonymized

--- a/backend/app/services/tenant/soft_delete.py
+++ b/backend/app/services/tenant/soft_delete.py
@@ -309,7 +309,7 @@ async def hard_purge_entity(
 
     The caller's ``session`` must be able to clear the RESTRICTIVE FOR DELETE
     policies on these tables — either a routed **guild-admin** RLS session (the
-    interactive purge endpoint) or a BYPASSRLS ``app_admin`` session (the
+    interactive purge endpoint) or a guild-admin-routed ``app_admin`` session (the
     background auto-purge worker, which has no guild context). The caller is also
     responsible for locking the target against a concurrent restore and for
     committing.

--- a/backend/app/services/tenant/soft_delete_test.py
+++ b/backend/app/services/tenant/soft_delete_test.py
@@ -242,7 +242,7 @@ async def test_restrictive_delete_policy_exists_on_each_soft_delete_table(
     (``app.current_guild_role = 'admin'``); a hard delete is a purge. Post-squash
     these tables (and thus their policies) live in the per-guild schemas, not
     ``public`` — the canonical copy is the Alembic-maintained ``guild_template``
-    schema (created by migration 20260701_0126). The BYPASSRLS admin fixture can't
+    schema (created by migration 20260701_0126). The admin fixture can't
     exercise the policy at runtime, so we inspect ``pg_policies`` in the template."""
     expected = {
         "projects",

--- a/backend/app/services/tenant/trash_purge.py
+++ b/backend/app/services/tenant/trash_purge.py
@@ -5,7 +5,8 @@ Polled by ``background_tasks._loop_worker`` once an hour. Connects via
 schema as a guild admin (``current_guild_role='admin'``) — that admin leg clears
 the ``soft_delete_admin_purge`` RESTRICTIVE FOR DELETE guard (and the
 initiative-member policies), since SET ROLE into ``guild_<id>`` drops the
-``app_admin`` BYPASSRLS. See ``_purge_all_guilds``.
+``app_admin`` (BYPASSRLS drops on SET ROLE) and routes into each guild as a
+guild admin. See ``_purge_all_guilds``.
 
 Documents need per-row treatment because their hard-purge has to clean up
 ``Upload`` rows + filesystem blobs (both for ``file``-type docs whose Upload
@@ -95,11 +96,10 @@ async def _purge_all_guilds(session, *, now: datetime) -> None:
     guild, so it routes into each guild's schema AS A GUILD ADMIN
     (``current_guild_role='admin'``). That admin leg is what clears both the
     initiative-member policies and the ``soft_delete_admin_purge`` RESTRICTIVE
-    guard on the soft-delete tables — the system engine holds no ambient
-    bypass, so the admin context is what lets the hard deletes through. Guilds
-    are enumerated on the system engine first (its ``TO app_admin`` policy on
-    ``guilds``); each schema gets its own committed pass. Split out so tests
-    can drive it with the test session.
+    guard on the soft-delete tables — ``SET ROLE`` drops the system engine's
+    BYPASSRLS, so the admin context is what lets the hard deletes through.
+    Guilds are enumerated on the system engine first; each schema gets its
+    own committed pass. Split out so tests can drive it with the test session.
     """
     await set_rls_context(session)
     guild_ids = list(await session.exec(select(Guild.id).order_by(Guild.id.asc())))

--- a/backend/app/services/tenant/trash_purge.py
+++ b/backend/app/services/tenant/trash_purge.py
@@ -95,13 +95,13 @@ async def _purge_all_guilds(session, *, now: datetime) -> None:
     guild, so it routes into each guild's schema AS A GUILD ADMIN
     (``current_guild_role='admin'``). That admin leg is what clears both the
     initiative-member policies and the ``soft_delete_admin_purge`` RESTRICTIVE
-    guard on the soft-delete tables — routing into ``guild_<id>`` drops the
-    ``app_admin`` BYPASSRLS, so an admin context (not the retired ``is_superadmin``
-    GUC) is what lets the hard deletes through. Guilds are enumerated on the admin
-    context first; each schema gets its own committed pass. Split out so tests can
-    drive it with the test session.
+    guard on the soft-delete tables — the system engine holds no ambient
+    bypass, so the admin context is what lets the hard deletes through. Guilds
+    are enumerated on the system engine first (its ``TO app_admin`` policy on
+    ``guilds``); each schema gets its own committed pass. Split out so tests
+    can drive it with the test session.
     """
-    await set_rls_context(session, is_superadmin=True)
+    await set_rls_context(session)
     guild_ids = list(await session.exec(select(Guild.id).order_by(Guild.id.asc())))
     for guild_id in guild_ids:
         # ids collide across schemas, so clear the identity map between guilds.

--- a/backend/app/services/tenant/trash_purge_test.py
+++ b/backend/app/services/tenant/trash_purge_test.py
@@ -135,7 +135,7 @@ async def test_auto_purge_sweeps_every_guild_schema(
         await session.commit()
         targets.append((guild.id, initiative.id))
 
-    # Production runs the worker on AdminSessionLocal (app_admin, BYPASSRLS).
+    # Production runs the worker on AdminSessionLocal (app_admin, policy-bound).
     admin = await role_session("app_admin")
     await _purge_all_guilds(admin, now=datetime.now(timezone.utc))
 

--- a/backend/app/services/tenant/trash_purge_test.py
+++ b/backend/app/services/tenant/trash_purge_test.py
@@ -140,7 +140,7 @@ async def test_auto_purge_sweeps_every_guild_schema(
     await _purge_all_guilds(admin, now=datetime.now(timezone.utc))
 
     for guild_id, initiative_id in targets:
-        await set_rls_context(admin, guild_id=guild_id, is_superadmin=True)
+        await set_rls_context(admin, guild_id=guild_id, guild_role="admin")
         count = (
             await admin.exec(
                 text("SELECT COUNT(*) FROM initiatives WHERE id = :id"),
@@ -157,7 +157,7 @@ async def test_auto_purge_clears_content_table_guard(
 
     Content tables carry both the initiative-member delete policy AND the
     soft_delete_admin_purge RESTRICTIVE guard; the worker clears both by routing
-    as a guild admin. Regression: routing in as the bare ``is_superadmin`` GUC
+    as a guild admin. Regression: routing in without the admin guild-role GUC
     cleared neither, so the DELETE silently matched 0 rows."""
     from app.services.tenant.trash_purge import _purge_all_guilds
 

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -283,14 +283,19 @@ _provisioned_guild_ids: set[int] = set()
 
 
 @pytest.fixture(autouse=True)
-def _schema_test_harness(engine, monkeypatch):
+async def _schema_test_harness(engine, monkeypatch):
     """Make every test schema-per-guild aware.
 
     - Installs the before_flush router so direct-session (factory) guild-scoped
       writes land in the guild's schema, mirroring what set_rls_context does for
       the request path.
-    - Points the (superuser) provisioning engine at the test DB so create_guild /
-      the guilds endpoint provision schemas/roles on the test database.
+    - Points the provisioning engine at the test DB so create_guild / the guilds
+      endpoint provision schemas/roles on the test database.
+    - Points the system (admin) engine at the test DB **as the real app_admin
+      role**, so maintenance jobs that use ``db_session.admin_engine`` /
+      ``AdminSessionLocal`` directly (secret-key rotation, upload back-fills,
+      workers) run against test data under the real policy-bound role instead
+      of silently hitting the dev database.
     - Wraps ``provision_guild`` (the universal provisioning choke point — factory,
       guild endpoints, backfill, and conversion all route through it) to record
       which guilds got a schema this test, so teardown can skip its cleanup scan
@@ -302,6 +307,21 @@ def _schema_test_harness(engine, monkeypatch):
 
     install_guild_routing()
     monkeypatch.setattr(db_session, "provisioning_engine", engine)
+
+    test_admin_engine = create_async_engine(
+        _test_url_for_role("app_admin"), echo=False, pool_pre_ping=True
+    )
+    monkeypatch.setattr(db_session, "admin_engine", test_admin_engine)
+    monkeypatch.setattr(
+        db_session,
+        "AdminSessionLocal",
+        async_sessionmaker(
+            bind=test_admin_engine,
+            autoflush=False,
+            expire_on_commit=False,
+            class_=AsyncSession,
+        ),
+    )
 
     _provisioned_guild_ids.clear()
     _orig_provision_guild = schema_provisioning.provision_guild
@@ -315,6 +335,8 @@ def _schema_test_harness(engine, monkeypatch):
     monkeypatch.setattr(
         schema_provisioning, "provision_guild", _tracking_provision_guild
     )
+    yield
+    await test_admin_engine.dispose()
 
 
 @pytest.fixture(scope="function")
@@ -479,7 +501,8 @@ async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
     for *data setup* (factories commit, so the request connection sees the rows) and
     for the privileged teardown (TRUNCATE / DROP SCHEMA / DROP ROLE).
 
-    ``AdminSessionDep`` is overridden to a real ``app_admin`` (BYPASSRLS) session,
+    ``AdminSessionDep`` is overridden to a real ``app_admin`` (BYPASSRLS,
+    grant-bounded) session,
     mirroring the production admin engine, so bootstrapping endpoints (guild
     creation, background-job style ops) keep their intended RLS bypass instead of
     silently leaning on the superuser.

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -459,7 +459,6 @@ _REQUEST_RESET_SQL = (
     "SELECT set_config('app.current_user_id', '', false), "
     "set_config('app.current_guild_id', '', false), "
     "set_config('app.current_guild_role', '', false), "
-    "set_config('app.is_superadmin', 'false', false), "
     "set_config('app.pam_guild_id', '', false), "
     "set_config('app.pam_read', 'false', false), "
     "set_config('app.pam_write', 'false', false), "

--- a/backend/scripts/create-provisioner.sql
+++ b/backend/scripts/create-provisioner.sql
@@ -1,0 +1,121 @@
+-- One-time handover to the least-privilege provisioning role (existing installs).
+--
+-- Fresh docker-compose installs never need this — their init script creates
+-- app_provisioner at first database init. Run this ONCE on deployments that
+-- predate it, connected to the app database AS THE CURRENT DATABASE_URL ROLE
+-- (the role that has been running migrations — it owns the app's objects):
+--
+--   docker exec -i initiative-db \
+--     psql -v ON_ERROR_STOP=1 -U initiative -d initiative \
+--          -v provisioner_password='CHANGE-ME' \
+--          -f - < backend/scripts/create-provisioner.sql
+--
+-- Then set DATABASE_URL to connect as app_provisioner and restart the app.
+-- Re-running is safe (attributes, grants and ownership are re-asserted).
+--
+-- Why: the app needs CREATEROLE + CREATE on the database + ownership of its
+-- own objects for migrations and guild provisioning — never a SUPERUSER.
+-- FORCE ROW LEVEL SECURITY keeps even the object owner policy-bound for DML.
+
+\set ON_ERROR_STOP on
+
+-- 1. The role: DDL-capable, never SUPERUSER, never BYPASSRLS.
+SELECT format(
+    'CREATE ROLE app_provisioner WITH LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS PASSWORD %L',
+    :'provisioner_password'
+) WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_provisioner')
+\gexec
+SELECT format(
+    'ALTER ROLE app_provisioner WITH LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS PASSWORD %L',
+    :'provisioner_password'
+)
+\gexec
+
+-- 2. Schema creation (guild provisioning) in this database.
+SELECT format(
+    'GRANT CREATE, CONNECT ON DATABASE %I TO app_provisioner', current_database()
+)
+\gexec
+
+-- 3. Administer the app's existing cluster roles (sync login-role passwords,
+--    grant guild-role memberships, drop guild roles on deprovision). Roles the
+--    provisioner CREATES from now on carry implicit ADMIN (PG16+ CREATEROLE).
+DO $$
+DECLARE r record;
+BEGIN
+    FOR r IN
+        SELECT rolname FROM pg_roles
+        WHERE rolname IN (
+            'app_user', 'app_admin', 'app_guild_base', 'platform_base',
+            'platform_member', 'platform_support', 'platform_moderator',
+            'platform_admin', 'platform_owner'
+        )
+        OR rolname ~ '^guild_[0-9]+(_ro)?$'
+    LOOP
+        EXECUTE format('GRANT %I TO app_provisioner WITH ADMIN OPTION', r.rolname);
+    END LOOP;
+END $$;
+
+-- 4. Hand over the app's objects. Explicit catalog iteration, NOT REASSIGN
+--    OWNED (which fails for a bootstrap superuser's pinned system objects).
+--    Tables first — their owned (serial) sequences follow automatically.
+DO $$
+DECLARE r record;
+BEGIN
+    FOR r IN
+        SELECT n.nspname, c.relname FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE (n.nspname = 'public' OR n.nspname ~ '^guild_([0-9]+|template)$')
+          AND c.relkind IN ('r', 'v', 'm', 'p')
+          AND c.relowner = current_user::regrole
+    LOOP
+        EXECUTE format('ALTER TABLE %I.%I OWNER TO app_provisioner', r.nspname, r.relname);
+    END LOOP;
+    FOR r IN
+        SELECT n.nspname, c.relname FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE (n.nspname = 'public' OR n.nspname ~ '^guild_([0-9]+|template)$')
+          AND c.relkind = 'S' AND c.relowner = current_user::regrole
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_depend d WHERE d.objid = c.oid AND d.deptype = 'a'
+          )
+    LOOP
+        EXECUTE format('ALTER SEQUENCE %I.%I OWNER TO app_provisioner', r.nspname, r.relname);
+    END LOOP;
+    FOR r IN
+        SELECT p.oid::regprocedure AS sig FROM pg_proc p
+        WHERE p.pronamespace = 'public'::regnamespace
+          AND p.proowner = current_user::regrole
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_depend d WHERE d.objid = p.oid AND d.deptype = 'e'
+          )
+    LOOP
+        EXECUTE format('ALTER FUNCTION %s OWNER TO app_provisioner', r.sig);
+    END LOOP;
+    FOR r IN
+        SELECT t.typname FROM pg_type t
+        WHERE t.typnamespace = 'public'::regnamespace AND t.typtype = 'e'
+          AND t.typowner = current_user::regrole
+    LOOP
+        EXECUTE format('ALTER TYPE public.%I OWNER TO app_provisioner', r.typname);
+    END LOOP;
+    FOR r IN
+        SELECT n.nspname FROM pg_namespace n
+        WHERE n.nspname ~ '^guild_([0-9]+|template)$'
+          AND n.nspowner = current_user::regrole
+    LOOP
+        EXECUTE format('ALTER SCHEMA %I OWNER TO app_provisioner', r.nspname);
+    END LOOP;
+END $$;
+
+-- 5. Tables created by future provisioner-run migrations get the standard
+--    working grants automatically (deliberately WITHOUT app_admin — the system
+--    engine is granted per table by migrations, never implicitly).
+ALTER DEFAULT PRIVILEGES FOR ROLE app_provisioner IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES
+    TO app_user, app_guild_base, platform_base;
+ALTER DEFAULT PRIVILEGES FOR ROLE app_provisioner IN SCHEMA public
+    GRANT SELECT, USAGE ON SEQUENCES
+    TO app_user, app_guild_base, platform_base;
+
+\echo 'app_provisioner ready — point DATABASE_URL at it and restart the app.'

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,6 +9,14 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-initiative}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    configs:
+      # Runs ONCE when the database volume is first initialized: creates the
+      # least-privilege role the app uses for migrations + guild provisioning,
+      # so the app never holds Postgres superuser credentials. Existing
+      # deployments (volume already initialized) instead run
+      # backend/scripts/create-provisioner.sql once — see the deployment docs.
+      - source: initdb-provisioner
+        target: /docker-entrypoint-initdb.d/01-app-provisioner.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
@@ -33,12 +41,14 @@ services:
       # Unraid users: set PUID=99 PGID=100 for nobody:users
       # PUID: 1000
       # PGID: 1000
-      # RLS-enforced connection (app_user role, no BYPASSRLS)
+      # RLS-enforced connection (app_user role, the request path)
       DATABASE_URL_APP: postgresql+asyncpg://app_user:${APP_USER_PASSWORD:-app_user_password}@db:5432/${POSTGRES_DB:-initiative}
-      # Admin connection for migrations and background jobs (app_admin role, BYPASSRLS)
+      # System engine for background jobs and seeding (app_admin role — policy-bound, no RLS bypass)
       DATABASE_URL_ADMIN: postgresql+asyncpg://app_admin:${APP_ADMIN_PASSWORD:-app_admin_password}@db:5432/${POSTGRES_DB:-initiative}
-      # Superuser connection (used for migrations and role creation)
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-initiative}:${POSTGRES_PASSWORD:-initiative}@db:5432/${POSTGRES_DB:-initiative}
+      # Provisioning connection for migrations + guild schema/role creation.
+      # app_provisioner is least-privilege (no superuser) — created by the db
+      # init script above on fresh installs.
+      DATABASE_URL: postgresql+asyncpg://app_provisioner:${PROVISIONER_PASSWORD:-provisioner_password}@db:5432/${POSTGRES_DB:-initiative}
       # REQUIRED: generate with `openssl rand -hex 32`. The stack refuses to start without it.
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set - generate with openssl rand -hex 32}
       ACCESS_TOKEN_EXPIRE_MINUTES: 60
@@ -67,3 +77,10 @@ services:
 volumes:
   postgres_data:
     driver: local
+
+configs:
+  initdb-provisioner:
+    content: |
+      CREATE ROLE app_provisioner WITH LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS
+        PASSWORD '${PROVISIONER_PASSWORD:-provisioner_password}';
+      GRANT CREATE, CONNECT ON DATABASE "${POSTGRES_DB:-initiative}" TO app_provisioner;

--- a/frontend/scripts/generate-api.sh
+++ b/frontend/scripts/generate-api.sh
@@ -19,7 +19,24 @@ if [[ -n "$SPEC_PATH" ]]; then
 else
   API_URL="${VITE_API_URL:-http://localhost:8000/api/v1}"
   echo "Fetching OpenAPI spec from ${API_URL}/openapi.json..."
-  curl -sf "${API_URL}/openapi.json" -o "${FRONTEND_DIR}/openapi.json"
+  # The backend takes several seconds to boot (migrations + guild backfill +
+  # seeding), and editor tasks often start it in parallel with this script —
+  # retry briefly instead of losing that race.
+  fetched=0
+  for attempt in $(seq 1 20); do
+    if curl -sf "${API_URL}/openapi.json" -o "${FRONTEND_DIR}/openapi.json"; then
+      fetched=1
+      break
+    fi
+    [[ "$attempt" -eq 1 ]] && echo "Backend not responding yet; waiting (up to 30s)..."
+    sleep 1.5
+  done
+  if [[ "$fetched" -ne 1 ]]; then
+    # No running backend: fall back to exporting the spec directly from the
+    # app (no server needed) — same path CI uses.
+    echo "Backend unreachable; exporting the spec without a server..."
+    (cd "${FRONTEND_DIR}/../backend" && uv run python scripts/export_openapi.py "${FRONTEND_DIR}/openapi.json")
+  fi
 fi
 
 echo "Generating TypeScript types and React Query hooks..."

--- a/frontend/src/api/generated/admin/admin.ts
+++ b/frontend/src/api/generated/admin/admin.ts
@@ -48,7 +48,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
  *
  * Platform-scoped: runs on the role-scoped session (``platform_<tier>``), so the
  * cross-user read is authorized by RLS (``users_platform_read``, support+) rather
- * than the BYPASSRLS admin engine. Initiative roles are guild-scoped and
+ * than the system admin engine. Initiative roles are guild-scoped and
  * deliberately NOT loaded here — a platform user view exposes platform data only.
  * @summary List All Users
  */
@@ -1176,8 +1176,9 @@ export const useAdminDeleteGuildApiV1AdminGuildsGuildIdDelete = <
  * ``guild_id`` is REQUIRED: initiatives live in per-guild schemas with
  * independent id sequences, so ``initiative_id`` alone is ambiguous across
  * guilds. The caller (the blocker-resolution UI) has it from the blocker
- * record. We route into that guild's schema as superadmin so the cascade
- * deletes the real rows, not the frozen ``public`` backup copies.
+ * record. We route into that guild's schema as a guild admin (full authority
+ * over the guild; clears the purge guard) so the cascade deletes the real
+ * rows, not the frozen ``public`` backup copies.
  * @summary Admin Delete Initiative
  */
 export const adminDeleteInitiativeApiV1AdminInitiativesInitiativeIdDelete = (
@@ -1406,9 +1407,9 @@ export const useAdminUpdateGuildMemberRoleApiV1AdminGuildsGuildIdMembersUserIdRo
  * List members of any initiative (platform admin only).
  *
  * ``guild_id`` is required: initiatives live in per-guild schemas with
- * independent id sequences. We route into that guild's schema as superadmin
- * so the member list comes from the live data, not the frozen ``public``
- * backup.
+ * independent id sequences. We route into that guild's schema as a guild
+ * admin so the member list comes from the live data, not the frozen
+ * ``public`` backup.
  * @summary Admin Get Initiative Members
  */
 export const adminGetInitiativeMembersApiV1AdminInitiativesInitiativeIdMembersGet = (
@@ -1631,7 +1632,7 @@ export function useAdminGetInitiativeMembersApiV1AdminInitiativesInitiativeIdMem
  * even if they're not a member. Useful for resolving "sole PM" blockers.
  *
  * ``guild_id`` is required (per-guild schemas; ``initiative_id`` is not unique
- * across guilds). We route into that guild's schema as superadmin.
+ * across guilds). We route into that guild's schema as a guild admin.
  *
  * Restrictions:
  * - Cannot demote the last project manager

--- a/frontend/src/api/generated/settings/settings.ts
+++ b/frontend/src/api/generated/settings/settings.ts
@@ -990,7 +990,7 @@ export function useGetFcmConfigApiV1SettingsFcmConfigGet<
  *
  * Admin/owner (``guilds.manage``). Reads only shared ``public`` tables
  * (``guilds``, ``guild_memberships``) — no guild-scoped content — so it runs on
- * the BYPASSRLS admin engine without routing into any guild schema. Member
+ * the system admin engine without routing into any guild schema. Member
  * counts come from a single grouped query rather than per-guild (no N+1).
  * @summary List Platform Guild Storage
  */

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -409,7 +409,7 @@ export function useCheckDeletionEligibilityApiV1UsersMeDeletionEligibilityGet<
  * Used by the account-deletion transfer-target picker. ``guild_id`` is
  * required: the initiative lives in that guild's schema (ids repeat across
  * guild schemas), and the caller has it from the blocker record. We route in
- * as superadmin so the member list is read from the live guild schema (the
+ * into the guild schema so the member list is read from the live data (the
  * intentional cross-guild visibility the picker needs), not the frozen
  * ``public`` backup.
  * @summary Get My Initiative Members


### PR DESCRIPTION
## Problem

The app's database actors carried three legacy constructions that predate the schema-per-guild architecture:

1. **A bespoke `app.is_superadmin` GUC** with `OR is_superadmin` legs in 14 shared-table policies — provably dead (only ever set on the BYPASSRLS engine, where policies don't apply), but keeping the "superadmin" concept alive in code.
2. **A live Postgres SUPERUSER connection pool inside the app** (`DATABASE_URL` = `POSTGRES_USER`): any RCE/SQL injection anywhere in the app was a full-cluster compromise — `COPY … FROM PROGRAM` (OS command execution), every database, `ALTER SYSTEM`. Every tenant-isolation gate is irrelevant on that engine.
3. **Blanket `GRANT ALL` (including on all future tables) to the system engine** — its boundary was implicit-everything rather than a decision.

## What changed — the standard PostgreSQL actor model

| Actor | Mechanism | Boundary |
|---|---|---|
| Cluster superuser | DB-container init + operator psql only | **never in the app's environment** (boot warning if detected) |
| `app_provisioner` (`DATABASE_URL`) | the canonical owner/migrator role: object OWNER + `CREATEROLE`, `NOSUPERUSER NOBYPASSRLS` | pure DDL actor — migrations + guild schema/role provisioning; `FORCE RLS` even filters its data reads (boot backfill enumerates guilds on the system engine instead) |
| `app_user` → `guild_<id>` / `platform_<tier>` | pooled login + per-request `SET ROLE` | GRANTs + RLS, fail-closed (unchanged) |
| `app_admin` (system engine) | **BYPASSRLS — PostgreSQL's textbook trusted-batch actor** | **enumerated per-table GRANTs** (audited verb matrix; `user_view_preferences`/`alembic_version`: none) + revoked future-table default privileges. `SET ROLE` into guild schemas drops the bypass. |

### Migrations (chain after the #776 squash)

- **`20260701_0128`** — retire `is_superadmin`: recreates the 14 policies without their dead legs; the GUC, the `set_rls_context(is_superadmin=…)` parameter, and every call site are removed. Guild-routed maintenance passes `guild_role="admin"` explicitly (the established worker pattern). `init_superuser`/`FIRST_SUPERUSER_*` renamed to owner terms (legacy env names still accepted via aliases).
- **`20260702_0129`** — enumerated system-engine grants: each shared table gets exactly the verbs its audited call sites use, and `ALTER DEFAULT PRIVILEGES … GRANT ALL … TO app_admin` is revoked — a new shared table gives the system engine nothing until a migration grants it. Includes the `users_no_delete`-compatible model: user hard-deletes remain a system-engine-only operation.

### No superuser in the app

- Fresh docker-compose installs: a `docker-entrypoint-initdb.d` config (inline in `docker-compose.example.yml`) creates `app_provisioner` at first database init; `DATABASE_URL` points at it from the start — a superuser never enters the app's env.
- Existing installs: run `backend/scripts/create-provisioner.sql` once (`docker exec … psql`, same flow as the old v0.30 upgrade script), switch `DATABASE_URL`, restart. Staying on a superuser keeps working but logs a boot warning.
- Maintenance jobs that rode the superuser engine (secret-key rotation, local-upload migration, S3 upload backfill) now run on the system engine and `SET ROLE` into each guild.

### Efficiency at scale

Boot backfill is now O(changed guilds): each schema is stamped (`COMMENT ON SCHEMA … 'provisioned:<hash of guild_schema.sql + guild_rls.sql + grants version>'`) and skipped while the stamp matches (`FORCE_GUILD_BACKFILL=true` forces a sweep). Previously every boot re-provisioned every guild (~0.2s each — minutes of deploy downtime at thousands of guilds).

## Testing

```bash
# 483 tests green across the affected suites, with per-worker test DBs rebuilt
# from the new chain (baseline → 0126 → 0127 → 0128 → 0129):
pytest app/db/ app/services/platform/ app/services/notifications_test.py \
       app/services/oidc_sync_test.py app/services/tenant/trash_purge_test.py \
       app/api/v1/platform_endpoints/ -q

# End-to-end on a simulated legacy deployment:
#   alembic upgrade head (as superuser) → create-provisioner.sql →
#   guild INSERT on the system engine → backfill_guild_schemas() as
#   app_provisioner provisions the schema → second boot skips via stamp.
# Fresh-chain build verified on an empty database.

ruff check && ruff format   # clean
```

The test harness now routes `db_session.admin_engine` / `AdminSessionLocal` at the per-worker test DB **as the real `app_admin` role**, so system-engine grant gaps fail tests instead of shipping (this is how the audit's two under-grants were caught and fixed).

## Notes for review

- A strict no-BYPASSRLS variant (per-table `TO app_admin` policies) was fully built and validated first, then deliberately replaced with this grant-bounded BYPASSRLS model per the RLS docs' intended use — design history in `history/remove-superadmin-bypassrls-design.md`.
- Deploy note (dev environments): the first boot on this branch applies 0128/0129; nothing to do manually. Production hardening (provisioner switch) is opt-in via the script + boot warning.
