### PR TITLE
Enumerated grants for the request login role + catalog posture invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The database role handling requests now holds only the minimal per-table access the sign-in and account-security flows actually use, and the security posture (role attributes, per-table access, row-security configuration) is verified by automated tests on every CI run.
+
+### Changed
+
 - **No more superadmin.** The internal `is_superadmin` flag and its dead policy legs are gone. The system database role follows PostgreSQL's standard trusted-batch model — bounded by explicit, per-table grants (new tables give it nothing by default) — and background jobs and maintenance sweeps route into each guild under that guild's own scoped role.
 - **The app no longer needs a Postgres superuser.** Fresh docker-compose installs create a least-privilege `app_provisioner` role (migrations + guild provisioning only) automatically at first database init, and `DATABASE_URL` points at it from the start. Existing deployments run `backend/scripts/create-provisioner.sql` once and switch `DATABASE_URL`; staying on a superuser keeps working but logs a boot warning.
 - Faster boots on large installs: guild schemas already built by the current version are skipped by the startup sweep (set `FORCE_GUILD_BACKFILL=true` for a one-off full sweep).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The database role handling requests now holds only the minimal per-table access the sign-in and account-security flows actually use, and the security posture (role attributes, per-table access, row-security configuration) is verified by automated tests on every CI run.
-
-### Changed
-
 - **No more superadmin.** The internal `is_superadmin` flag and its dead policy legs are gone. The system database role follows PostgreSQL's standard trusted-batch model — bounded by explicit, per-table grants (new tables give it nothing by default) — and background jobs and maintenance sweeps route into each guild under that guild's own scoped role.
 - **The app no longer needs a Postgres superuser.** Fresh docker-compose installs create a least-privilege `app_provisioner` role (migrations + guild provisioning only) automatically at first database init, and `DATABASE_URL` points at it from the start. Existing deployments run `backend/scripts/create-provisioner.sql` once and switch `DATABASE_URL`; staying on a superuser keeps working but logs a boot warning.
 - Faster boots on large installs: guild schemas already built by the current version are skipped by the startup sweep (set `FORCE_GUILD_BACKFILL=true` for a one-off full sweep).

--- a/backend/alembic/versions/20260702_0130_app_user_table_grants.py
+++ b/backend/alembic/versions/20260702_0130_app_user_table_grants.py
@@ -1,0 +1,95 @@
+"""Bound the bare login role (`app_user`) by enumerated table GRANTs.
+
+Companion to 20260702_0129 (which did the same for the system engine). Every
+request starts as the ``app_user`` login role before ``SET ROLE`` assumes a
+platform tier or guild role — and the unauthenticated surface (login, password
+reset, email verification, OIDC callback, public config, invite lookup) plus
+per-request auth resolution run entirely on it. The old chain granted it
+blanket per-table DML everywhere; this reduces it to the audited verb set of
+those bare-login call sites:
+
+* auth resolution + self-service credential lifecycle: ``users`` (read/update
+  only — creation is the system engine's, deletion is nobody's),
+  ``user_tokens`` and ``user_api_keys`` (full self-service lifecycle),
+  ``auto_delegation_jti_blocklist`` (append-only replay guard);
+* pre-routing/unauthenticated reads: ``app_settings``, ``guilds``,
+  ``guild_invites``, ``guild_memberships``, and ``access_grants`` (deps
+  validate a live PAM/break-glass grant before routing) — SELECT only;
+* everything else — ``notifications``, ``push_tokens``,
+  ``oidc_claim_mappings``, ``user_view_preferences`` — is reached only through
+  ``platform_<tier>``/guild roles after routing, so the bare login role gets
+  nothing.
+
+Routed access is unaffected: ``platform_base`` / ``app_guild_base`` grants are
+their own (unchanged) layers. Sequence grants stay (INSERT-granted tables need
+their serials; sequences carry no row data). Default privileges for future
+tables are revoked, like the system engine's: a new shared table grants the
+bare login role nothing until a migration decides.
+
+Revision ID: 20260702_0130
+Revises: 20260702_0129
+Create Date: 2026-07-02
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260702_0130"
+down_revision = "20260702_0129"
+branch_labels = None
+depends_on = None
+
+# table -> verbs the bare login role's audited call sites use.
+_APP_USER_TABLE_GRANTS: dict[str, str | None] = {
+    "users": "SELECT, UPDATE",
+    "user_tokens": "SELECT, INSERT, UPDATE, DELETE",
+    "user_api_keys": "SELECT, INSERT, UPDATE, DELETE",
+    "auto_delegation_jti_blocklist": "SELECT, INSERT",
+    "app_settings": "SELECT",
+    "guilds": "SELECT",
+    "guild_invites": "SELECT",
+    "guild_memberships": "SELECT",
+    "access_grants": "SELECT",
+    "notifications": None,
+    "oidc_claim_mappings": None,
+    "push_tokens": None,
+    "user_view_preferences": None,
+    "alembic_version": None,
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table, verbs in _APP_USER_TABLE_GRANTS.items():
+        conn.execute(text(f'REVOKE ALL ON TABLE public."{table}" FROM app_user'))
+        if verbs:
+            conn.execute(text(f'GRANT {verbs} ON TABLE public."{table}" TO app_user'))
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "REVOKE ALL ON TABLES FROM app_user"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "REVOKE ALL ON SEQUENCES FROM app_user"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO app_user"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "GRANT ALL ON SEQUENCES TO app_user"
+        )
+    )
+    for table in _APP_USER_TABLE_GRANTS:
+        conn.execute(text(f'GRANT ALL ON TABLE public."{table}" TO app_user'))

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -1,0 +1,259 @@
+"""The database privilege posture, asserted as CI invariants.
+
+The actor model (see ``history/remove-superadmin-bypassrls-design.md``) is only
+as durable as the catalog state that implements it — a hotfix migration adding
+a broad ``GRANT``, a manually flipped role attribute, or a new RLS table
+without a decision would all land silently. These tests re-derive the posture
+from the live catalog on every run, the same way ``tenancy_test`` enforces
+table placement:
+
+* the app's role families never hold SUPERUSER; ``app_admin`` is the ONLY
+  BYPASSRLS holder (PostgreSQL's trusted-batch actor, grant-bounded);
+* ``app_admin``'s per-table grants equal the audited matrix of migration
+  20260702_0129 — new shared tables give the system engine nothing until a
+  migration (and this matrix) says so;
+* every RLS-enabled shared table is FORCEd (even table owners obey policies);
+* the retired ``is_superadmin`` GUC appears in no policy anywhere;
+* no app role may CREATE objects in ``public`` (search_path hijack guard);
+* login-role memberships in scoped roles are INHERIT FALSE (no standing
+  access without an explicit ``SET ROLE``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from app.core.config import settings
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+# Mirror of migration 20260702_0129's audited matrix. Deliberately duplicated
+# until the grants registry lands (issue #782 makes a registry the single
+# source and derives both the migration and this test from it).
+_APP_ADMIN_TABLE_GRANTS: dict[str, set[str] | None] = {
+    "users": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "guilds": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "guild_memberships": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "guild_invites": {"SELECT", "INSERT", "UPDATE"},
+    "access_grants": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "app_settings": {"SELECT", "INSERT", "UPDATE"},
+    "oidc_claim_mappings": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "user_view_preferences": None,
+    "notifications": {"SELECT", "INSERT", "DELETE"},
+    "user_tokens": {"SELECT", "INSERT", "DELETE"},
+    "push_tokens": {"SELECT", "INSERT", "DELETE"},
+    "user_api_keys": {"SELECT", "DELETE"},
+    "auto_delegation_jti_blocklist": {"SELECT", "INSERT"},
+    "alembic_version": None,
+}
+
+# Mirror of migration 20260702_0130's audited matrix for the BARE login role
+# (pre-routing / unauthenticated surface). Same registry-consolidation note.
+_APP_USER_TABLE_GRANTS: dict[str, set[str] | None] = {
+    "users": {"SELECT", "UPDATE"},
+    "user_tokens": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "user_api_keys": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "auto_delegation_jti_blocklist": {"SELECT", "INSERT"},
+    "app_settings": {"SELECT"},
+    "guilds": {"SELECT"},
+    "guild_invites": {"SELECT"},
+    "guild_memberships": {"SELECT"},
+    "access_grants": {"SELECT"},
+    "notifications": None,
+    "oidc_claim_mappings": None,
+    "push_tokens": None,
+    "user_view_preferences": None,
+    "alembic_version": None,
+}
+
+# Shared tables that carry (FORCEd) row-level security.
+_RLS_SHARED_TABLES = {
+    "access_grants",
+    "app_settings",
+    "guild_invites",
+    "guild_memberships",
+    "guilds",
+    "oidc_claim_mappings",
+    "user_view_preferences",
+    "users",
+}
+
+
+def _app_role_family() -> list[str]:
+    """The fixed app roles plus this worker's prefixed platform ladder."""
+    from app.db.schema_provisioning import PLATFORM_TIERS, platform_role_name
+
+    return [
+        "app_user",
+        "app_admin",
+        "app_guild_base",
+        f"{settings.PLATFORM_ROLE_PREFIX}platform_base",
+        *(platform_role_name(t) for t in PLATFORM_TIERS),
+    ]
+
+
+async def test_no_app_role_is_superuser_and_only_app_admin_bypasses_rls(engine):
+    roles = _app_role_family()
+    async with engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT rolname, rolsuper, rolbypassrls FROM pg_roles "
+                    "WHERE rolname = ANY(:r)"
+                ),
+                {"r": roles},
+            )
+        ).all()
+    found = {r[0]: (r[1], r[2]) for r in rows}
+    assert "app_user" in found and "app_admin" in found, "login roles must exist"
+    for name, (is_super, bypass) in found.items():
+        assert not is_super, f"{name} must never be SUPERUSER"
+        if name == "app_admin":
+            assert bypass, (
+                "app_admin is the designated trusted-batch actor (BYPASSRLS, "
+                "bounded by enumerated grants)"
+            )
+        else:
+            assert not bypass, f"{name} must not carry BYPASSRLS"
+
+
+async def _table_grants_for(engine, role: str) -> dict[str, set[str]]:
+    async with engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT c.relname, a.privilege_type FROM pg_class c, "
+                    "LATERAL aclexplode(c.relacl) a "
+                    "WHERE c.relnamespace = 'public'::regnamespace "
+                    "AND c.relkind = 'r' "
+                    "AND a.grantee = CAST(:role AS regrole)"
+                ),
+                {"role": role},
+            )
+        ).all()
+    live: dict[str, set[str]] = {}
+    for table, verb in rows:
+        live.setdefault(table, set()).add(verb)
+    return live
+
+
+def _assert_matrix(role: str, live: dict[str, set[str]], matrix) -> None:
+    for table, expected in matrix.items():
+        got = live.pop(table, set())
+        assert got == (expected or set()), (
+            f"{role} grants drifted on {table!r}: expected "
+            f"{sorted(expected or set())}, catalog has {sorted(got)}"
+        )
+    assert live == {}, (
+        f"shared tables with {role} grants but no matrix decision "
+        f"(add to the audited matrix / migration): {sorted(live)}"
+    )
+
+
+async def test_app_admin_grants_match_audited_matrix(engine):
+    live = await _table_grants_for(engine, "app_admin")
+    _assert_matrix("app_admin", live, _APP_ADMIN_TABLE_GRANTS)
+
+
+async def test_app_user_grants_match_audited_matrix(engine):
+    live = await _table_grants_for(engine, "app_user")
+    _assert_matrix("app_user", live, _APP_USER_TABLE_GRANTS)
+
+
+async def test_rls_shared_tables_are_forced(engine):
+    async with engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT relname, relrowsecurity, relforcerowsecurity "
+                    "FROM pg_class WHERE relnamespace = 'public'::regnamespace "
+                    "AND relkind = 'r'"
+                )
+            )
+        ).all()
+    rls_tables = {r[0] for r in rows if r[1]}
+    assert rls_tables == _RLS_SHARED_TABLES, (
+        "the set of RLS-enabled shared tables changed — decide FORCE + policies "
+        f"+ update this invariant. Diff: +{sorted(rls_tables - _RLS_SHARED_TABLES)} "
+        f"-{sorted(_RLS_SHARED_TABLES - rls_tables)}"
+    )
+    not_forced = {r[0] for r in rows if r[1] and not r[2]}
+    assert not_forced == set(), (
+        f"RLS tables must be FORCEd (owners obey policies too): {sorted(not_forced)}"
+    )
+
+
+async def test_no_policy_references_retired_superadmin_guc(engine):
+    async with engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT schemaname, tablename, policyname FROM pg_policies "
+                    "WHERE COALESCE(qual, '') LIKE '%is_superadmin%' "
+                    "OR COALESCE(with_check, '') LIKE '%is_superadmin%'"
+                )
+            )
+        ).all()
+    assert rows == [], f"policies still reference the retired GUC: {rows}"
+
+
+async def test_no_app_role_can_create_in_public(engine):
+    """A role that can CREATE in ``public`` could shadow the shared,
+    unqualified-name trigger functions/types via search_path — only the
+    provisioning (owner) role may define objects."""
+    async with engine.connect() as conn:
+        for role in _app_role_family():
+            can_create = (
+                await conn.execute(
+                    text("SELECT has_schema_privilege(:r, 'public', 'CREATE')"),
+                    {"r": role},
+                )
+            ).scalar()
+            assert not can_create, f"{role} must not CREATE in public"
+
+
+async def test_login_role_memberships_in_scoped_roles_are_inherit_false(engine):
+    """The login roles may only reach scoped (guild/platform) roles via an
+    explicit ``SET ROLE`` — a standing (INHERIT) membership would grant every
+    request ambient access to every guild."""
+    async with engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT m.rolname AS member, r.rolname AS granted, "
+                    "am.inherit_option "
+                    "FROM pg_auth_members am "
+                    "JOIN pg_roles m ON m.oid = am.member "
+                    "JOIN pg_roles r ON r.oid = am.roleid "
+                    "WHERE m.rolname IN ('app_user', 'app_admin') "
+                    "AND (r.rolname LIKE '%guild\\_%' OR r.rolname LIKE '%platform\\_%')"
+                )
+            )
+        ).all()
+    inheriting = [(m, g) for m, g, inh in rows if inh]
+    assert inheriting == [], (
+        f"login-role memberships must be INHERIT FALSE (SET ROLE only): {inheriting}"
+    )
+
+
+async def test_no_default_privileges_for_login_roles(engine):
+    """New shared tables must grant the login roles nothing until a migration
+    decides (0129/0130 revoked the blanket future-table grants). Routed access
+    for new tables comes via platform_base / app_guild_base, whose defaults
+    are deliberately kept."""
+    async with engine.connect() as conn:
+        hits = (
+            await conn.execute(
+                text(
+                    "SELECT r.rolname, d.defaclobjtype, a.privilege_type "
+                    "FROM pg_default_acl d, LATERAL aclexplode(d.defaclacl) a "
+                    "JOIN pg_roles r ON r.oid = a.grantee "
+                    "WHERE d.defaclnamespace = 'public'::regnamespace "
+                    "AND r.rolname IN ('app_admin', 'app_user')"
+                )
+            )
+        ).all()
+    assert hits == [], (
+        f"default privileges silently grant future objects to login roles: {hits}"
+    )


### PR DESCRIPTION
Companions to the actor-model work (#778), closing out the deferred item recorded in the old platform-roles migration ('narrowing app_user requires a full enumeration of that surface plus role-aware tests' — both now exist).

## Migration `20260702_0130` — the bare login role gets an audited grant matrix

Every request starts as `app_user` before `SET ROLE`, and the unauthenticated surface (login, password reset, verification, OIDC callback, public config, invite lookup) plus per-request auth resolution run entirely on it. The old chain granted it blanket per-table DML; it now holds exactly what those call sites use:

- **writes** only for self-service credential lifecycle: `users` (UPDATE only — creation is the system engine's, deletion nobody's), `user_tokens` + `user_api_keys` (full lifecycle), `auto_delegation_jti_blocklist` (append-only)
- **SELECT only** for the pre-routing reads: `app_settings`, `guilds`, `guild_invites`, `guild_memberships`, `access_grants` (deps validate live PAM/break-glass grants before routing)
- **nothing** for the rest (`notifications`, `push_tokens`, `oidc_claim_mappings`, `user_view_preferences`), and no future-table default privileges — routed access via `platform_<tier>`/guild roles is unchanged.

The role-scoped test harness caught two audit under-counts (break-glass validation reads `access_grants`; the API-key endpoints run bare) — folded into the matrix, which is the harness doing exactly its job.

## `security_invariants_test.py` — the posture as CI invariants

The privilege model is only as durable as the catalog implementing it. Following the `tenancy_test` pattern, the new suite re-derives the posture from the live catalog every run: role attributes (never SUPERUSER; only `app_admin` BYPASSRLS), both login roles' grants == their audited matrices (a new shared table without a decision fails CI), RLS tables all FORCEd, no retired-GUC references in any policy, no CREATE in `public` for app roles, INHERIT FALSE scoped memberships, no login-role default privileges.

## Testing

106 tests across invariants/auth/guilds/api-keys/break-glass/collaboration suites, with per-worker test DBs rebuilt through the new head; invariants verified to fail loudly on grant drift during development (they caught the two matrix corrections).