### PR TITLE
Remove dual-maintenance: shared reset-SQL constant, source-derived grants stamp

### DIFF
--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import inspect
 import logging
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -113,16 +112,21 @@ def provisioning_stamp() -> str:
     A guild schema whose comment carries the current stamp was provisioned by
     exactly these artifacts, so the boot back-fill can skip it — O(changed
     guilds) boots instead of O(all guilds). The stamp covers the two SQL
-    artifacts AND the grant layer (the ``_grant_statements`` source plus the
-    login-role names it targets), so any provisioning change — including a
-    grants-only edit — produces a new stamp and a one-time full sweep. No
-    manual version bump to forget.
+    artifacts AND the grant layer — hashed from ``_grant_statements``'
+    RENDERED output (with placeholder identifiers), so any behavioral grants
+    change produces a new stamp and a one-time full sweep, while cosmetic
+    edits (comments, docstrings, refactors) don't. The login-role names are
+    covered implicitly: they appear inside the rendered statements. No manual
+    version bump to forget.
     """
     digest = hashlib.sha256()
     digest.update(GUILD_SCHEMA_SQL_PATH.read_bytes())
     digest.update(GUILD_RLS_SQL_PATH.read_bytes())
-    digest.update(inspect.getsource(_grant_statements).encode())
-    digest.update(f"{APP_LOGIN_ROLE}|{ADMIN_LOGIN_ROLE}".encode())
+    digest.update(
+        "\n".join(
+            _grant_statements("__stamp__", "__stamp_role__", "__stamp_ro__")
+        ).encode()
+    )
     return f"provisioned:{digest.hexdigest()[:16]}"
 
 
@@ -167,11 +171,10 @@ def _grant_statements(schema: str, role: str, ro_role: str) -> list[str]:
     """Fail-closed grants tying a guild ``role`` (read/write) and ``ro_role``
     (read-only) to its ``schema``.
 
-    NOTE: ``provisioning_stamp()`` hashes this function's ENTIRE source —
-    docstring, comments, whitespace included — so ANY edit here (even
-    cosmetic) invalidates every guild's stamp and triggers one full
-    re-provisioning sweep on the next boot. That sweep is idempotent and
-    cheap (~0.2s/guild), but be aware you're scheduling it.
+    NOTE: ``provisioning_stamp()`` hashes this function's RENDERED output, so
+    changing WHAT it grants invalidates every guild's stamp and schedules one
+    full (idempotent) re-provisioning sweep on the next boot — cosmetic edits
+    here don't.
 
     Each role inherits shared/public access from ``app_guild_base``. The login
     roles are granted membership in both ``WITH INHERIT FALSE`` — they can

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -167,6 +167,12 @@ def _grant_statements(schema: str, role: str, ro_role: str) -> list[str]:
     """Fail-closed grants tying a guild ``role`` (read/write) and ``ro_role``
     (read-only) to its ``schema``.
 
+    NOTE: ``provisioning_stamp()`` hashes this function's ENTIRE source —
+    docstring, comments, whitespace included — so ANY edit here (even
+    cosmetic) invalidates every guild's stamp and triggers one full
+    re-provisioning sweep on the next boot. That sweep is idempotent and
+    cheap (~0.2s/guild), but be aware you're scheduling it.
+
     Each role inherits shared/public access from ``app_guild_base``. The login
     roles are granted membership in both ``WITH INHERIT FALSE`` — they can
     ``SET ROLE`` into either but hold no standing access to the schema, so a

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import inspect
 import logging
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -104,11 +105,6 @@ GUILD_RLS_SQL_PATH = (
     Path(__file__).resolve().parents[2] / "alembic" / "guild" / "guild_rls.sql"
 )
 
-# Bump when _grant_statements() changes: the provisioning stamp hashes the two
-# SQL artifacts plus this number, so a grants-only change still re-provisions
-# every guild on the next boot.
-GRANTS_VERSION = 1
-
 
 @lru_cache(maxsize=1)
 def provisioning_stamp() -> str:
@@ -116,13 +112,17 @@ def provisioning_stamp() -> str:
 
     A guild schema whose comment carries the current stamp was provisioned by
     exactly these artifacts, so the boot back-fill can skip it — O(changed
-    guilds) boots instead of O(all guilds). Any artifact change (or a
-    GRANTS_VERSION bump) produces a new stamp and a one-time full sweep.
+    guilds) boots instead of O(all guilds). The stamp covers the two SQL
+    artifacts AND the grant layer (the ``_grant_statements`` source plus the
+    login-role names it targets), so any provisioning change — including a
+    grants-only edit — produces a new stamp and a one-time full sweep. No
+    manual version bump to forget.
     """
     digest = hashlib.sha256()
     digest.update(GUILD_SCHEMA_SQL_PATH.read_bytes())
     digest.update(GUILD_RLS_SQL_PATH.read_bytes())
-    digest.update(str(GRANTS_VERSION).encode())
+    digest.update(inspect.getsource(_grant_statements).encode())
+    digest.update(f"{APP_LOGIN_ROLE}|{ADMIN_LOGIN_ROLE}".encode())
     return f"provisioned:{digest.hexdigest()[:16]}"
 
 

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -620,3 +620,28 @@ async def test_backfill_continues_past_a_failing_guild(engine, monkeypatch):
                 text("DELETE FROM public.guilds WHERE id = ANY(:ids)"),
                 {"ids": [ok_a, ok_b, bad]},
             )
+
+
+async def test_provisioning_stamp_tracks_grant_statement_source():
+    """The back-fill skip stamp must change when the grant layer changes —
+    derived from ``_grant_statements``' source, not a manual version bump a
+    human can forget."""
+    from unittest import mock
+
+    from app.db import schema_provisioning as sp
+
+    sp.provisioning_stamp.cache_clear()
+    baseline = sp.provisioning_stamp()
+
+    def _edited_grants(schema: str, role: str, ro_role: str) -> list[str]:
+        return ["GRANT USAGE ON SCHEMA x TO y"]  # pragma: no cover — source only
+
+    try:
+        with mock.patch.object(sp, "_grant_statements", _edited_grants):
+            sp.provisioning_stamp.cache_clear()
+            changed = sp.provisioning_stamp()
+    finally:
+        sp.provisioning_stamp.cache_clear()
+
+    assert changed != baseline, "a grants-source change must invalidate the stamp"
+    assert sp.provisioning_stamp() == baseline, "stamp is stable when unchanged"

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -622,10 +622,10 @@ async def test_backfill_continues_past_a_failing_guild(engine, monkeypatch):
             )
 
 
-def test_provisioning_stamp_tracks_grant_statement_source():
-    """The back-fill skip stamp must change when the grant layer changes —
-    derived from ``_grant_statements``' source, not a manual version bump a
-    human can forget."""
+def test_provisioning_stamp_tracks_grant_behavior_not_cosmetics():
+    """The back-fill skip stamp is derived from ``_grant_statements``' RENDERED
+    output — no manual version bump a human can forget: a behavioral grants
+    change moves it; a cosmetic rewrite of the function does not."""
     from unittest import mock
 
     from app.db import schema_provisioning as sp
@@ -633,15 +633,24 @@ def test_provisioning_stamp_tracks_grant_statement_source():
     sp.provisioning_stamp.cache_clear()
     baseline = sp.provisioning_stamp()
 
-    def _edited_grants(schema: str, role: str, ro_role: str) -> list[str]:
-        return ["GRANT USAGE ON SCHEMA x TO y"]  # pragma: no cover — source only
+    def _different_grants(schema: str, role: str, ro_role: str) -> list[str]:
+        return ["GRANT USAGE ON SCHEMA x TO y"]
 
+    def _cosmetic_rewrite(schema: str, role: str, ro_role: str) -> list[str]:
+        # Different source text, byte-identical output.
+        return list(_original(schema, role, ro_role))
+
+    _original = sp._grant_statements
     try:
-        with mock.patch.object(sp, "_grant_statements", _edited_grants):
+        with mock.patch.object(sp, "_grant_statements", _different_grants):
             sp.provisioning_stamp.cache_clear()
             changed = sp.provisioning_stamp()
+        with mock.patch.object(sp, "_grant_statements", _cosmetic_rewrite):
+            sp.provisioning_stamp.cache_clear()
+            cosmetic = sp.provisioning_stamp()
     finally:
         sp.provisioning_stamp.cache_clear()
 
-    assert changed != baseline, "a grants-source change must invalidate the stamp"
+    assert changed != baseline, "a behavioral grants change must move the stamp"
+    assert cosmetic == baseline, "a cosmetic rewrite must NOT move the stamp"
     assert sp.provisioning_stamp() == baseline, "stamp is stable when unchanged"

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -622,7 +622,7 @@ async def test_backfill_continues_past_a_failing_guild(engine, monkeypatch):
             )
 
 
-async def test_provisioning_stamp_tracks_grant_statement_source():
+def test_provisioning_stamp_tracks_grant_statement_source():
     """The back-fill skip stamp must change when the grant layer changes —
     derived from ``_grant_statements``' source, not a manual version bump a
     human can forget."""

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -39,25 +39,28 @@ AdminSessionLocal = async_sessionmaker(
     class_=AsyncSession,
 )
 
+# The per-checkout context reset, shared by BOTH session dependencies (and the
+# test harness, which mirrors the request lifecycle): clear every RLS GUC,
+# route guild-scoped names back to public, and drop any assumed role a prior
+# checkout of this pooled connection left behind. Single source of truth —
+# a GUC added to set_rls_context() must be reset here, once.
+REQUEST_CONTEXT_RESET_SQL = (
+    "SELECT set_config('app.current_user_id', '', false), "
+    "set_config('app.current_guild_id', '', false), "
+    "set_config('app.current_guild_role', '', false), "
+    "set_config('app.pam_guild_id', '', false), "
+    "set_config('app.pam_read', 'false', false), "
+    "set_config('app.pam_write', 'false', false), "
+    "set_config('search_path', 'public', false), "
+    "set_config('role', 'none', false)"
+)
+
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with AsyncSessionLocal() as session:
-        # Reset RLS variables from any previous request on this pooled connection.
-        # Uses set_config() in a single round-trip for efficiency.
-        await session.exec(
-            text(
-                "SELECT set_config('app.current_user_id', '', false), "
-                "set_config('app.current_guild_id', '', false), "
-                "set_config('app.current_guild_role', '', false), "
-                "set_config('app.pam_guild_id', '', false), "
-                "set_config('app.pam_read', 'false', false), "
-                "set_config('app.pam_write', 'false', false), "
-                # Route guild-scoped tables back to public and drop any assumed guild
-                # role on a recycled connection.
-                "set_config('search_path', 'public', false), "
-                "set_config('role', 'none', false)"
-            )
-        )
+        # Reset RLS variables from any previous request on this pooled connection
+        # (single round-trip; see REQUEST_CONTEXT_RESET_SQL).
+        await session.exec(text(REQUEST_CONTEXT_RESET_SQL))
         yield session
 
 
@@ -75,18 +78,7 @@ async def get_admin_session() -> AsyncGenerator[AsyncSession, None]:
         # (or `public`) nondeterministically. Start every admin session from a
         # clean public, login-role baseline; callers that need a guild schema
         # call set_rls_context() explicitly.
-        await session.exec(
-            text(
-                "SELECT set_config('app.current_user_id', '', false), "
-                "set_config('app.current_guild_id', '', false), "
-                "set_config('app.current_guild_role', '', false), "
-                "set_config('app.pam_guild_id', '', false), "
-                "set_config('app.pam_read', 'false', false), "
-                "set_config('app.pam_write', 'false', false), "
-                "set_config('search_path', 'public', false), "
-                "set_config('role', 'none', false)"
-            )
-        )
+        await session.exec(text(REQUEST_CONTEXT_RESET_SQL))
         yield session
 
 

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -28,7 +28,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
 from app.core.rate_limit import limiter
-from app.db.session import get_admin_session, get_session
+from app.db.session import (
+    REQUEST_CONTEXT_RESET_SQL,
+    get_admin_session,
+    get_session,
+)
 from app.db.tenancy import SHARED_TABLES
 from app.main import app
 
@@ -474,19 +478,9 @@ async def session(engine) -> AsyncGenerator[AsyncSession, None]:
                 await rconn.exec_driver_sql(f'DROP ROLE IF EXISTS "{role}"')
 
 
-# GUC + role reset mirroring the production get_session/get_admin_session
-# checkout reset, so each request starts from a clean baseline on the bound
-# request connection (a prior request's assumed role can't bleed in).
-_REQUEST_RESET_SQL = (
-    "SELECT set_config('app.current_user_id', '', false), "
-    "set_config('app.current_guild_id', '', false), "
-    "set_config('app.current_guild_role', '', false), "
-    "set_config('app.pam_guild_id', '', false), "
-    "set_config('app.pam_read', 'false', false), "
-    "set_config('app.pam_write', 'false', false), "
-    "set_config('search_path', 'public', false), "
-    "set_config('role', 'none', false)"
-)
+# The PRODUCTION checkout reset, imported (not mirrored) so the harness can
+# never drift from what get_session/get_admin_session actually run.
+_REQUEST_RESET_SQL = REQUEST_CONTEXT_RESET_SQL
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #785 — both checklist items:

- **One reset-SQL source of truth.** `REQUEST_CONTEXT_RESET_SQL` lives in `session.py`, used by `get_session` + `get_admin_session` and imported by conftest's request-lifecycle mirror. The harness can no longer drift from production's actual checkout reset (previously three hand-synchronized copies).
- **Stamp derived from source.** `provisioning_stamp()` hashes `inspect.getsource(_grant_statements)` + the login-role names instead of the manual `GRANTS_VERSION` bump — a grants-only change now invalidates every guild's stamp automatically, with a sensitivity test (patched function ⇒ stamp moves; unchanged ⇒ stable).

Note: the stamp value changes once with this PR, so the first boot after deploy performs one full backfill sweep — exactly the intended re-provision-on-grants-change semantics.

71 tests across provisioning, invariants, and a request-path endpoint suite.