### PR TITLE
Add central frontend tool registry harness

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -14,6 +14,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { GuildSidebar } from "@/components/guilds/GuildSidebar";
 import { HomeSidebarContent } from "@/components/sidebar/HomeSidebarContent";
 import { InitiativeSection } from "@/components/sidebar/InitiativeSection";
@@ -415,33 +416,26 @@ export const AppSidebar = () => {
                             ) : (
                               <div className="space-y-1">
                                 {visibleInitiatives.map((initiative) => {
-                                  const permissions = getUserPermissions(initiative);
+                                  const initiativeProjects =
+                                    projectsByInitiative.get(initiative.id) ?? [];
                                   return (
                                     <InitiativeSection
                                       key={initiative.id}
                                       initiative={initiative}
-                                      projects={projectsByInitiative.get(initiative.id) ?? []}
-                                      documentCount={
-                                        documentCountsByInitiative.get(initiative.id) ?? 0
-                                      }
+                                      projects={initiativeProjects}
+                                      access={getUserPermissions(initiative)}
+                                      counts={{
+                                        [Tool.document]:
+                                          documentCountsByInitiative.get(initiative.id) ?? 0,
+                                        [Tool.queue]:
+                                          queueCountsByInitiative.get(initiative.id) ?? 0,
+                                        [Tool.counter_group]:
+                                          counterGroupCountsByInitiative.get(initiative.id) ?? 0,
+                                        [Tool.project]: initiativeProjects.length,
+                                      }}
                                       canManageInitiative={canManageInitiative(initiative)}
                                       activeProjectId={activeProjectId}
                                       userId={user?.id}
-                                      canViewDocs={permissions.canViewDocs}
-                                      canViewProjects={permissions.canViewProjects}
-                                      canViewQueues={permissions.canViewQueues}
-                                      canViewEvents={permissions.canViewEvents}
-                                      canViewAdvancedTool={permissions.canViewAdvancedTool}
-                                      canViewCounters={permissions.canViewCounters}
-                                      canCreateDocs={permissions.canCreateDocs}
-                                      canCreateProjects={permissions.canCreateProjects}
-                                      canCreateQueues={permissions.canCreateQueues}
-                                      canCreateEvents={permissions.canCreateEvents}
-                                      canCreateCounters={permissions.canCreateCounters}
-                                      queueCount={queueCountsByInitiative.get(initiative.id) ?? 0}
-                                      counterGroupCount={
-                                        counterGroupCountsByInitiative.get(initiative.id) ?? 0
-                                      }
                                       activeGuildId={activeGuildId}
                                       collapseKey={initiativeCollapseKey}
                                     />

--- a/frontend/src/components/CommandCenter.tsx
+++ b/frontend/src/components/CommandCenter.tsx
@@ -4,8 +4,6 @@ import {
   CalendarDays,
   CheckSquare,
   FilePlus,
-  GalleryHorizontalEnd,
-  Gauge,
   ListTodo,
   PenLine,
   Plus,
@@ -18,6 +16,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { getOpenCreateDocumentWizard } from "@/components/documents/CreateDocumentWizard";
 import { getOpenCreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
 import {
@@ -43,6 +42,7 @@ import { guildPath, useGuildPath } from "@/lib/guildUrl";
 import { canAccessAdminDashboard, canManagePlatformConfig } from "@/lib/permissions";
 import { renderRecentIcon } from "@/lib/recentIcon";
 import { recentRoute } from "@/lib/recentRoute";
+import { TOOL_BY_ID, TOOLS } from "@/lib/tools/registry";
 
 // Module-level callback so other components can open the command center
 let openCommandCenter: (() => void) | null = null;
@@ -53,7 +53,7 @@ export function getOpenCommandCenter() {
 export function CommandCenter() {
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const { t } = useTranslation(["command", "common"]);
+  const { t } = useTranslation(["command", "common", "nav"]);
   const router = useRouter();
   const { user } = useAuth();
   const { activeGuild, activeGuildId } = useGuilds();
@@ -223,6 +223,17 @@ export function CommandCenter() {
     void router.navigate({ to: path });
   };
 
+  // Open a tool's create dialog "from anywhere" by navigating to its list route
+  // with ?create=true (the dialog carries an initiative picker). Guild-gated.
+  const handleCreate = (route: string) => {
+    setOpen(false);
+    void router.navigate({ to: getGuildPath(route), search: { create: "true" } });
+  };
+
+  // Single-sourced tool icons so the palette can never drift from the sidebar.
+  const QueueIcon = TOOL_BY_ID[Tool.queue].icon;
+  const CounterIcon = TOOL_BY_ID[Tool.counter_group].icon;
+
   return (
     <CommandDialog open={open} onOpenChange={setOpen} filter={commandFilter}>
       <CommandInput
@@ -257,6 +268,20 @@ export function CommandCenter() {
             <FilePlus className="text-muted-foreground" />
             <span>{t("actions.addDocument")}</span>
           </CommandItem>
+          {/* Create-from-anywhere for tools whose dialog carries an initiative
+              picker (project/queue/counter group). Reuses the sidebar's create
+              labels; guild-gated because it navigates to a guild-scoped route. */}
+          {activeGuildId &&
+            TOOLS.filter((tool) => tool.nav?.navCreateGlobal).map((tool) => (
+              <CommandItem
+                key={`action-create-${tool.id}`}
+                value={`action-create-${tool.id}`}
+                onSelect={() => handleCreate(tool.nav!.listRoute)}
+              >
+                <Plus className="text-muted-foreground" />
+                <span>{t(`nav:${tool.nav!.createLabelKey}` as never)}</span>
+              </CommandItem>
+            ))}
         </CommandGroup>
 
         {/* Suggested — mixed recents across projects/documents/queues/counter
@@ -368,7 +393,7 @@ export function CommandCenter() {
                 )
               }
             >
-              <GalleryHorizontalEnd className="text-muted-foreground" />
+              <QueueIcon className="text-muted-foreground" />
               <span>{queue.name}</span>
             </CommandItem>
           ))}
@@ -389,7 +414,7 @@ export function CommandCenter() {
                 )
               }
             >
-              <Gauge className="text-muted-foreground" />
+              <CounterIcon className="text-muted-foreground" />
               <span>{group.name}</span>
             </CommandItem>
           ))}

--- a/frontend/src/components/initiatives/AdvancedToolsToggles.tsx
+++ b/frontend/src/components/initiatives/AdvancedToolsToggles.tsx
@@ -1,19 +1,17 @@
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useAppConfig } from "@/hooks/useAppConfig";
+import { type InitiativeEnableFlag, TOGGLEABLE_TOOLS } from "@/lib/tools/registry";
 
 export interface AdvancedToolsSectionProps {
-  eventsEnabled: boolean;
-  queuesEnabled: boolean;
-  countersEnabled: boolean;
-  advancedToolEnabled: boolean;
-  onToggleEvents: (value: boolean) => void;
-  onToggleQueues: (value: boolean) => void;
-  onToggleCounters: (value: boolean) => void;
-  onToggleAdvancedTool: (value: boolean) => void;
+  /** Current on/off state, keyed by the initiative feature flag. */
+  enabled: Partial<Record<InitiativeEnableFlag, boolean>>;
+  /** Called with the flag + its new value when a toggle changes. */
+  onToggle: (flag: InitiativeEnableFlag, value: boolean) => void;
   canManage: boolean;
   isSaving: boolean;
   /** "card" wraps the rows in a Card with title+description (settings page). "plain" returns just the rows (for use inside an Accordion). */
@@ -49,14 +47,8 @@ const AdvancedToolToggle = ({
 );
 
 export const AdvancedToolsSection = ({
-  eventsEnabled,
-  queuesEnabled,
-  countersEnabled,
-  advancedToolEnabled,
-  onToggleEvents,
-  onToggleQueues,
-  onToggleCounters,
-  onToggleAdvancedTool,
+  enabled,
+  onToggle,
   canManage,
   isSaving,
   layout = "card",
@@ -68,40 +60,31 @@ export const AdvancedToolsSection = ({
 
   const rows = (
     <div className="space-y-3">
-      <AdvancedToolToggle
-        id={`${idPrefix}-events-toggle`}
-        title={t("eventsFeature")}
-        description={t("eventsFeatureDescription")}
-        checked={eventsEnabled}
-        onCheckedChange={onToggleEvents}
-        disabled={disabled}
-      />
-      <AdvancedToolToggle
-        id={`${idPrefix}-queues-toggle`}
-        title={t("queuesFeature")}
-        description={t("queuesFeatureDescription")}
-        checked={queuesEnabled}
-        onCheckedChange={onToggleQueues}
-        disabled={disabled}
-      />
-      <AdvancedToolToggle
-        id={`${idPrefix}-counters-toggle`}
-        title={t("countersFeature")}
-        description={t("countersFeatureDescription")}
-        checked={countersEnabled}
-        onCheckedChange={onToggleCounters}
-        disabled={disabled}
-      />
-      {advancedTool && (
-        <AdvancedToolToggle
-          id={`${idPrefix}-advanced-tool-toggle`}
-          title={advancedTool.name}
-          description={t("advancedToolFeatureDescription", { name: advancedTool.name })}
-          checked={advancedToolEnabled}
-          onCheckedChange={onToggleAdvancedTool}
-          disabled={disabled}
-        />
-      )}
+      {TOGGLEABLE_TOOLS.map((tool) => {
+        const flag = tool.enableFlag as InitiativeEnableFlag;
+        const toggle = tool.settingsToggle;
+        if (!toggle) return null;
+        // The advanced tool row only appears when the deployment configures one
+        // at runtime, and it borrows that deployment's display name.
+        const isAdvancedTool = tool.id === Tool.advanced_tool;
+        if (isAdvancedTool && !advancedTool) return null;
+        const title =
+          isAdvancedTool && advancedTool ? advancedTool.name : t(toggle.titleKey as never);
+        const description = isAdvancedTool
+          ? t(toggle.descriptionKey as never, { name: advancedTool?.name ?? "" })
+          : t(toggle.descriptionKey as never);
+        return (
+          <AdvancedToolToggle
+            key={tool.id}
+            id={`${idPrefix}-${tool.id}-toggle`}
+            title={title}
+            description={description}
+            checked={enabled[flag] ?? false}
+            onCheckedChange={(value) => onToggle(flag, value)}
+            disabled={disabled}
+          />
+        );
+      })}
     </div>
   );
 

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsDetailsTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsDetailsTab.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import type { InitiativeEnableFlag } from "@/lib/tools/registry";
 
 interface InitiativeSettingsDetailsTabProps {
   name: string;
@@ -18,14 +19,9 @@ interface InitiativeSettingsDetailsTabProps {
   setDescription: (value: string) => void;
   color: string;
   setColor: (value: string) => void;
-  queuesEnabled: boolean;
-  onToggleQueues: (value: boolean) => void;
-  eventsEnabled: boolean;
-  onToggleEvents: (value: boolean) => void;
-  advancedToolEnabled: boolean;
-  onToggleAdvancedTool: (value: boolean) => void;
-  countersEnabled: boolean;
-  onToggleCounters: (value: boolean) => void;
+  /** Feature-toggle state + change handler (see AdvancedToolsSection). */
+  featuresEnabled: Partial<Record<InitiativeEnableFlag, boolean>>;
+  onToggleFeature: (flag: InitiativeEnableFlag, value: boolean) => void;
   canManageMembers: boolean;
   isSaving: boolean;
   onSaveDetails: (event: FormEvent<HTMLFormElement>) => void;
@@ -38,14 +34,8 @@ export const InitiativeSettingsDetailsTab = ({
   setDescription,
   color,
   setColor,
-  queuesEnabled,
-  onToggleQueues,
-  eventsEnabled,
-  onToggleEvents,
-  advancedToolEnabled,
-  onToggleAdvancedTool,
-  countersEnabled,
-  onToggleCounters,
+  featuresEnabled,
+  onToggleFeature,
   canManageMembers,
   isSaving,
   onSaveDetails,
@@ -115,14 +105,8 @@ export const InitiativeSettingsDetailsTab = ({
         layout="card"
         canManage={canManageMembers}
         isSaving={isSaving}
-        eventsEnabled={eventsEnabled}
-        onToggleEvents={onToggleEvents}
-        queuesEnabled={queuesEnabled}
-        onToggleQueues={onToggleQueues}
-        countersEnabled={countersEnabled}
-        onToggleCounters={onToggleCounters}
-        advancedToolEnabled={advancedToolEnabled}
-        onToggleAdvancedTool={onToggleAdvancedTool}
+        enabled={featuresEnabled}
+        onToggle={onToggleFeature}
         idPrefix="settings"
       />
     </TabsContent>

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -1,20 +1,10 @@
 import { Link } from "@tanstack/react-router";
-import {
-  CalendarDays,
-  CircleChevronRight,
-  GalleryHorizontalEnd,
-  Gauge,
-  ListTodo,
-  MoreVertical,
-  Plus,
-  ScrollText,
-  Settings,
-  Sparkles,
-} from "lucide-react";
+import { CircleChevronRight, MoreVertical, Plus, Settings, Sparkles } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { InitiativeRead, ProjectRead } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
@@ -28,66 +18,116 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { guildPath } from "@/lib/guildUrl";
 import { getItem, setItem } from "@/lib/storage";
+import { TOOL_BY_ID, type ToolAccessMap, type ToolDef } from "@/lib/tools/registry";
 import { cn } from "@/lib/utils";
+
+// The order tools appear in an initiative's sidebar section. Each entry is
+// rendered by the shared <ToolNavRow> below — no more copy-pasted blocks. The
+// advanced tool is intentionally NOT here: it renders a bespoke pinned entry
+// (its label is the deployment's runtime name, its route is per-initiative).
+const SIDEBAR_TOOLS: ToolDef[] = [
+  TOOL_BY_ID[Tool.calendar_event],
+  TOOL_BY_ID[Tool.document],
+  TOOL_BY_ID[Tool.queue],
+  TOOL_BY_ID[Tool.counter_group],
+  TOOL_BY_ID[Tool.project],
+];
 
 export interface InitiativeSectionProps {
   initiative: InitiativeRead;
   projects: ProjectRead[];
-  documentCount: number;
+  /** Per-tool visibility/creation for the current user (from useInitiativeAccess). */
+  access: ToolAccessMap;
+  /** Item counts by tool id (documents, queues, counter groups, projects). */
+  counts: Partial<Record<Tool, number>>;
   canManageInitiative: boolean;
   activeProjectId: number | null;
   userId: number | undefined;
-  canViewDocs: boolean;
-  canViewProjects: boolean;
-  canViewQueues: boolean;
-  canViewEvents: boolean;
-  canViewAdvancedTool: boolean;
-  canViewCounters: boolean;
-  canCreateDocs: boolean;
-  canCreateProjects: boolean;
-  canCreateQueues: boolean;
-  canCreateEvents: boolean;
-  canCreateCounters: boolean;
-  queueCount: number;
-  counterGroupCount: number;
   activeGuildId: number | null;
   /** Changing this value re-syncs the open/closed state from storage. */
   collapseKey?: number;
 }
 
+/** One tool link row — icon, label, optional count, and a hover-reveal "+" create. */
+const ToolNavRow = ({
+  tool,
+  initiativeId,
+  count,
+  canCreate,
+  gp,
+}: {
+  tool: ToolDef;
+  initiativeId: number;
+  count: number | undefined;
+  canCreate: boolean;
+  gp: (path: string) => string;
+}) => {
+  const { t } = useTranslation("nav");
+  const nav = tool.nav;
+  if (!nav) return null;
+  const Icon = tool.icon;
+  return (
+    <SidebarMenuItem>
+      <div className="group/toolrow flex w-full min-w-0 items-center gap-1">
+        <SidebarMenuButton asChild size="sm" className="min-w-0 flex-1">
+          <Link
+            to={gp(nav.listRoute)}
+            search={{ initiativeId: String(initiativeId) }}
+            className="flex items-center gap-2"
+          >
+            <Icon className="h-4 w-4" />
+            <span>{t(nav.labelKey as never)}</span>
+            {nav.hasCount && <span className="text-muted-foreground text-xs">{count ?? 0}</span>}
+          </Link>
+        </SidebarMenuButton>
+        {canCreate && (
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/toolrow:opacity-100 lg:flex"
+                asChild
+              >
+                <Link
+                  to={gp(nav.listRoute)}
+                  search={{ create: "true", initiativeId: String(initiativeId) }}
+                >
+                  <Plus className="h-3 w-3" />
+                </Link>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>{t(nav.createLabelKey as never)}</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </SidebarMenuItem>
+  );
+};
+
 export const InitiativeSection = memo(
   ({
     initiative,
     projects,
-    documentCount,
+    access,
+    counts,
     canManageInitiative,
     activeProjectId,
     userId,
-    canViewDocs,
-    canViewProjects,
-    canViewQueues,
-    canViewEvents,
-    canViewAdvancedTool,
-    canViewCounters,
-    canCreateDocs,
-    canCreateProjects,
-    canCreateQueues,
-    canCreateEvents,
-    canCreateCounters,
-    queueCount,
-    counterGroupCount,
     activeGuildId,
     collapseKey,
   }: InitiativeSectionProps) => {
     const { t } = useTranslation("nav");
     const { advancedTool } = useAppConfig();
-    // The sidebar entry is triply-gated:
+    // The advanced tool entry is triply-gated:
     //   1. Runtime config must expose an advanced tool (deployment-level).
     //   2. The initiative manager must have enabled it (per-initiative).
-    //   3. The user's role must include the advanced_tool_enabled key
-    //      — non-managers can be denied even when (1) and (2) pass.
+    //   3. The user's role must include the advanced_tool view key
+    //      — folded into access[advanced_tool].view.
     const showAdvancedTool = Boolean(
-      advancedTool && initiative.advanced_tool_enabled && canViewAdvancedTool
+      advancedTool && initiative.advanced_tool_enabled && access[Tool.advanced_tool].view
     );
     // Helper to create guild-scoped paths
     const gp = (path: string) => (activeGuildId ? guildPath(activeGuildId, path) : path);
@@ -97,6 +137,8 @@ export const InitiativeSection = memo(
       const level = project.my_permission_level;
       return level === "owner" || level === "write";
     };
+    // Tools the user may create, in sidebar order — drives the mobile "+" menu.
+    const creatableTools = SIDEBAR_TOOLS.filter((tool) => access[tool.id].create);
     // Load initial state from storage, default to true if not found
     const [isOpen, setIsOpen] = useState(() => {
       try {
@@ -204,50 +246,17 @@ export const InitiativeSection = memo(
                       {t("initiativeSettings")}
                     </Link>
                   </DropdownMenuItem>
-                  {canCreateDocs && (
-                    <DropdownMenuItem asChild>
+                  {creatableTools.map((tool) => (
+                    <DropdownMenuItem key={tool.id} asChild>
                       <Link
-                        to={gp("/documents")}
+                        to={gp(tool.nav!.listRoute)}
                         search={{ create: "true", initiativeId: String(initiative.id) }}
                       >
                         <Plus className="mr-2 h-4 w-4" />
-                        {t("createDocument")}
+                        {t(tool.nav!.createLabelKey as never)}
                       </Link>
                     </DropdownMenuItem>
-                  )}
-                  {canCreateProjects && (
-                    <DropdownMenuItem asChild>
-                      <Link
-                        to={gp("/projects")}
-                        search={{ create: "true", initiativeId: String(initiative.id) }}
-                      >
-                        <Plus className="mr-2 h-4 w-4" />
-                        {t("createProject")}
-                      </Link>
-                    </DropdownMenuItem>
-                  )}
-                  {canCreateQueues && (
-                    <DropdownMenuItem asChild>
-                      <Link
-                        to={gp("/queues")}
-                        search={{ create: "true", initiativeId: String(initiative.id) }}
-                      >
-                        <Plus className="mr-2 h-4 w-4" />
-                        {t("createQueue")}
-                      </Link>
-                    </DropdownMenuItem>
-                  )}
-                  {canCreateEvents && (
-                    <DropdownMenuItem asChild>
-                      <Link
-                        to={gp("/events")}
-                        search={{ create: "true", initiativeId: String(initiative.id) }}
-                      >
-                        <Plus className="mr-2 h-4 w-4" />
-                        {t("createEvent")}
-                      </Link>
-                    </DropdownMenuItem>
-                  )}
+                  ))}
                 </DropdownMenuContent>
               </DropdownMenu>
             </>
@@ -260,9 +269,8 @@ export const InitiativeSection = memo(
             forceMount
           >
             <SidebarMenu>
-              {/* Advanced Tool Link — pinned to the top of the initiative
-                  so it's the first thing a user sees when the integration
-                  is on. */}
+              {/* Advanced Tool — pinned to the top of the initiative so it's the
+                  first thing a user sees when the integration is on. */}
               {showAdvancedTool && advancedTool && (
                 <SidebarMenuItem>
                   <SidebarMenuButton asChild size="sm" className="min-w-0 flex-1">
@@ -277,212 +285,22 @@ export const InitiativeSection = memo(
                 </SidebarMenuItem>
               )}
 
-              {/* Events Link */}
-              {canViewEvents && (
-                <SidebarMenuItem>
-                  <div className="group/events flex w-full min-w-0 items-center gap-1">
-                    <SidebarMenuButton asChild size="sm" className="min-w-0 flex-1">
-                      <Link
-                        to={gp("/events")}
-                        search={{ initiativeId: String(initiative.id) }}
-                        className="flex items-center gap-2"
-                      >
-                        <CalendarDays className="h-4 w-4" />
-                        <span>{t("events")}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    {canCreateEvents && (
-                      <Tooltip delayDuration={300}>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/events:opacity-100 lg:flex"
-                            asChild
-                          >
-                            <Link
-                              to={gp("/events")}
-                              search={{ create: "true", initiativeId: String(initiative.id) }}
-                            >
-                              <Plus className="h-3 w-3" />
-                            </Link>
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="top">
-                          <p>{t("createEvent")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                </SidebarMenuItem>
-              )}
-
-              {/* Documents Link */}
-              {canViewDocs && (
-                <SidebarMenuItem>
-                  <div className="group/documents flex w-full min-w-0 items-center gap-1">
-                    <SidebarMenuButton asChild size="sm" className="min-w-0 flex-1">
-                      <Link
-                        to={gp("/documents")}
-                        search={{ initiativeId: String(initiative.id) }}
-                        className="flex items-center gap-2"
-                      >
-                        <ScrollText className="h-4 w-4" />
-                        <span>{t("documents")}</span>
-                        <span className="text-muted-foreground text-xs">{documentCount}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    {canCreateDocs && (
-                      <Tooltip delayDuration={300}>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/documents:opacity-100 lg:flex"
-                            asChild
-                          >
-                            <Link
-                              to={gp("/documents")}
-                              search={{ create: "true", initiativeId: String(initiative.id) }}
-                            >
-                              <Plus className="h-3 w-3" />
-                            </Link>
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="top">
-                          <p>{t("createDocument")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                </SidebarMenuItem>
-              )}
-
-              {/* Queues Link */}
-              {canViewQueues && (
-                <SidebarMenuItem>
-                  <div className="group/queues flex w-full min-w-0 items-center gap-1">
-                    <SidebarMenuButton asChild size="sm" className="min-w-0 flex-1">
-                      <Link
-                        to={gp("/queues")}
-                        search={{ initiativeId: String(initiative.id) }}
-                        className="flex items-center gap-2"
-                      >
-                        <GalleryHorizontalEnd className="h-4 w-4" />
-                        <span>{t("queues")}</span>
-                        <span className="text-muted-foreground text-xs">{queueCount}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    {canCreateQueues && (
-                      <Tooltip delayDuration={300}>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/queues:opacity-100 lg:flex"
-                            asChild
-                          >
-                            <Link
-                              to={gp("/queues")}
-                              search={{ create: "true", initiativeId: String(initiative.id) }}
-                            >
-                              <Plus className="h-3 w-3" />
-                            </Link>
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="top">
-                          <p>{t("createQueue")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                </SidebarMenuItem>
-              )}
-
-              {/* Counter Groups Link */}
-              {canViewCounters && (
-                <SidebarMenuItem>
-                  <div className="group/counters flex w-full min-w-0 items-center gap-1">
-                    <SidebarMenuButton asChild size="sm" className="min-w-0 flex-1">
-                      <Link
-                        to={gp("/counter-groups")}
-                        search={{ initiativeId: String(initiative.id) }}
-                        className="flex items-center gap-2"
-                      >
-                        <Gauge className="h-4 w-4" />
-                        <span>{t("counters")}</span>
-                        <span className="text-muted-foreground text-xs">{counterGroupCount}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    {canCreateCounters && (
-                      <Tooltip delayDuration={300}>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/counters:opacity-100 lg:flex"
-                            asChild
-                          >
-                            <Link
-                              to={gp("/counter-groups")}
-                              search={{ create: "true", initiativeId: String(initiative.id) }}
-                            >
-                              <Plus className="h-3 w-3" />
-                            </Link>
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="top">
-                          <p>{t("createCounterGroup")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                </SidebarMenuItem>
-              )}
-
-              {/* Projects Link */}
-              {canViewProjects && (
-                <SidebarMenuItem>
-                  <div className="group/projects flex w-full min-w-0 items-center gap-1">
-                    <SidebarMenuButton asChild size="sm" className="min-w-0 flex-1">
-                      <Link
-                        to={gp("/projects")}
-                        search={{ initiativeId: String(initiative.id) }}
-                        className="flex items-center gap-2"
-                      >
-                        <ListTodo className="h-4 w-4" />
-                        <span>{t("projects")}</span>
-                        <span className="text-muted-foreground text-xs">{projects.length}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    {canCreateProjects && (
-                      <Tooltip delayDuration={300}>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/projects:opacity-100 lg:flex"
-                            asChild
-                          >
-                            <Link
-                              to={gp("/projects")}
-                              search={{ create: "true", initiativeId: String(initiative.id) }}
-                            >
-                              <Plus className="h-3 w-3" />
-                            </Link>
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="top">
-                          <p>{t("createProject")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                </SidebarMenuItem>
+              {/* Standard tool rows — one shared component per registry entry. */}
+              {SIDEBAR_TOOLS.map((tool) =>
+                access[tool.id].view ? (
+                  <ToolNavRow
+                    key={tool.id}
+                    tool={tool}
+                    initiativeId={initiative.id}
+                    count={counts[tool.id]}
+                    canCreate={access[tool.id].create}
+                    gp={gp}
+                  />
+                ) : null
               )}
 
               {/* Projects List */}
-              {canViewProjects &&
+              {access[Tool.project].view &&
                 projects.map((project) => (
                   <SidebarMenuItem key={project.id}>
                     <div className="group/project flex w-full min-w-0 items-center gap-1">

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -3,58 +3,14 @@ import { useCallback } from "react";
 import type { InitiativeRead } from "@/api/generated/initiativeAPI.schemas";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
-
-/** What an initiative's sidebar/sections expose to the current user. */
-export interface InitiativeSectionPermissions {
-  canViewDocs: boolean;
-  canViewProjects: boolean;
-  canViewQueues: boolean;
-  canViewEvents: boolean;
-  canViewAdvancedTool: boolean;
-  canViewCounters: boolean;
-  canCreateDocs: boolean;
-  canCreateProjects: boolean;
-  canCreateQueues: boolean;
-  canCreateEvents: boolean;
-  canCreateCounters: boolean;
-}
+import {
+  fullToolAccess,
+  membershipToolAccess,
+  readOnlyToolAccess,
+  type ToolAccessMap,
+} from "@/lib/tools/registry";
 
 const byName = (a: InitiativeRead, b: InitiativeRead) => a.name.localeCompare(b.name);
-
-// Full visibility into every section (gated by the initiative's feature
-// flags); `canCreate` toggles the create affordances.
-const fullAccess = (
-  initiative: InitiativeRead,
-  canCreate: boolean
-): InitiativeSectionPermissions => ({
-  canViewDocs: true,
-  canViewProjects: true,
-  canViewQueues: initiative.queues_enabled ?? false,
-  canViewEvents: initiative.events_enabled ?? false,
-  canViewAdvancedTool: initiative.advanced_tool_enabled ?? false,
-  canViewCounters: initiative.counters_enabled ?? false,
-  canCreateDocs: canCreate,
-  canCreateProjects: canCreate,
-  canCreateQueues: canCreate && (initiative.queues_enabled ?? false),
-  canCreateEvents: canCreate && (initiative.events_enabled ?? false),
-  canCreateCounters: canCreate && (initiative.counters_enabled ?? false),
-});
-
-// Bare read of the always-visible sections (docs/projects) for someone with no
-// membership and no grant — mirrors the historical non-member default.
-const readOnlyDefault: InitiativeSectionPermissions = {
-  canViewDocs: true,
-  canViewProjects: true,
-  canViewQueues: false,
-  canViewEvents: false,
-  canViewAdvancedTool: false,
-  canViewCounters: false,
-  canCreateDocs: false,
-  canCreateProjects: false,
-  canCreateQueues: false,
-  canCreateEvents: false,
-  canCreateCounters: false,
-};
 
 /**
  * Centralizes "what initiatives can the current user see, and what can they do
@@ -97,27 +53,19 @@ export function useInitiativeAccess() {
     [user, seesAllInitiatives]
   );
 
-  /** Effective per-section permissions for one initiative. */
+  /**
+   * Effective per-tool access for one initiative, keyed by `Tool` id. Derived
+   * from the tool registry so every tool is covered by construction (and a new
+   * tool can't be silently omitted here the way it used to be).
+   */
   const permissionsFor = useCallback(
-    (initiative: InitiativeRead): InitiativeSectionPermissions => {
-      if (!user) return readOnlyDefault;
-      if (isGuildAdmin) return fullAccess(initiative, true);
-      if (isGrantGuild) return fullAccess(initiative, grantReadWrite);
+    (initiative: InitiativeRead): ToolAccessMap => {
+      if (!user) return readOnlyToolAccess();
+      if (isGuildAdmin) return fullToolAccess(initiative, true);
+      if (isGrantGuild) return fullToolAccess(initiative, grantReadWrite);
       const membership = initiative.members.find((m) => m.user.id === user.id);
-      if (!membership) return readOnlyDefault;
-      return {
-        canViewDocs: membership.can_view_docs ?? true,
-        canViewProjects: membership.can_view_projects ?? true,
-        canViewQueues: membership.can_view_queues ?? false,
-        canViewEvents: membership.can_view_events ?? false,
-        canViewAdvancedTool: membership.can_view_advanced_tool ?? false,
-        canViewCounters: membership.can_view_counters ?? false,
-        canCreateDocs: membership.can_create_docs ?? false,
-        canCreateProjects: membership.can_create_projects ?? false,
-        canCreateQueues: membership.can_create_queues ?? false,
-        canCreateEvents: membership.can_create_events ?? false,
-        canCreateCounters: membership.can_create_counters ?? false,
-      };
+      if (!membership) return readOnlyToolAccess();
+      return membershipToolAccess(membership);
     },
     [user, isGuildAdmin, isGrantGuild, grantReadWrite]
   );

--- a/frontend/src/hooks/useInitiativeRoles.ts
+++ b/frontend/src/hooks/useInitiativeRoles.ts
@@ -8,6 +8,7 @@ import type {
   MyInitiativePermissions,
   PermissionKey,
 } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import {
   createInitiativeRoleApiV1GGuildIdInitiativesInitiativeIdRolesPost,
   deleteInitiativeRoleApiV1GGuildIdInitiativesInitiativeIdRolesRoleIdDelete,
@@ -21,6 +22,7 @@ import { invalidateInitiativeRoles, invalidateMyPermissions } from "@/api/query-
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
+import { TOOL_BY_ID, TOOLS, type ToolDef, toolsInSection } from "@/lib/tools/registry";
 
 export const useInitiativeRoles = (initiativeId: number | null) => {
   const guildId = useActiveGuildId();
@@ -172,53 +174,14 @@ export const canCreate = (
   return permissions.permissions[keyMap[entity]] ?? false;
 };
 
-// Permission key labels for display (hardcoded, kept for backward compat)
-export const PERMISSION_LABELS: Record<PermissionKey, string> = {
-  docs_enabled: "View Documents",
-  projects_enabled: "View Projects",
-  create_docs: "Create Documents",
-  create_projects: "Create Projects",
-  queues_enabled: "View Queues",
-  create_queues: "Create Queues",
-  events_enabled: "View Events",
-  create_events: "Create Events",
-  advanced_tool_enabled: "View Advanced Tool",
-  create_advanced_tool: "Create in Advanced Tool",
-  counters_enabled: "View Counters",
-  create_counters: "Create Counters",
-};
-
-// i18n-based permission label keys (use with t())
-export const PERMISSION_LABEL_KEYS: Record<PermissionKey, string> = {
-  docs_enabled: "settings.permissions.viewDocuments",
-  projects_enabled: "settings.permissions.viewProjects",
-  create_docs: "settings.permissions.createDocuments",
-  create_projects: "settings.permissions.createProjects",
-  queues_enabled: "settings.permissions.viewQueues",
-  create_queues: "settings.permissions.createQueues",
-  events_enabled: "settings.permissions.viewEvents",
-  create_events: "settings.permissions.createEvents",
-  advanced_tool_enabled: "settings.permissions.viewAdvancedTool",
-  create_advanced_tool: "settings.permissions.createAdvancedTool",
-  counters_enabled: "settings.permissions.viewCounters",
-  create_counters: "settings.permissions.createCounters",
-};
-
-// All permission keys in display order
-export const ALL_PERMISSION_KEYS: PermissionKey[] = [
-  "docs_enabled",
-  "create_docs",
-  "projects_enabled",
-  "create_projects",
-  "queues_enabled",
-  "create_queues",
-  "events_enabled",
-  "create_events",
-  "advanced_tool_enabled",
-  "create_advanced_tool",
-  "counters_enabled",
-  "create_counters",
-];
+// i18n-based permission label keys (use with t()). Derived from the tool
+// registry so a new tool's view/create labels can't drift out of sync.
+export const PERMISSION_LABEL_KEYS: Record<PermissionKey, string> = Object.fromEntries(
+  TOOLS.flatMap((tool) => [
+    [tool.perm.view, tool.perm.viewLabelKey],
+    [tool.perm.create, tool.perm.createLabelKey],
+  ])
+) as Record<PermissionKey, string>;
 
 // Permission groups for card-based layout
 export type PermissionGroup = {
@@ -226,32 +189,22 @@ export type PermissionGroup = {
   keys: PermissionKey[];
 };
 
-// Core permissions always visible
-export const CORE_PERMISSION_GROUPS: PermissionGroup[] = [
-  { labelKey: "settings.permissionGroups.documents", keys: ["docs_enabled", "create_docs"] },
-  { labelKey: "settings.permissionGroups.projects", keys: ["projects_enabled", "create_projects"] },
-];
+const toPermissionGroup = (tool: ToolDef): PermissionGroup => ({
+  labelKey: tool.perm.groupLabelKey,
+  keys: [tool.perm.view, tool.perm.create],
+});
 
-// Advanced tools permissions shown in accordion
-export const ADVANCED_PERMISSION_GROUPS: PermissionGroup[] = [
-  { labelKey: "settings.permissionGroups.queues", keys: ["queues_enabled", "create_queues"] },
-  { labelKey: "settings.permissionGroups.events", keys: ["events_enabled", "create_events"] },
-  {
-    labelKey: "settings.permissionGroups.counters",
-    keys: ["counters_enabled", "create_counters"],
-  },
-];
+// Core permissions always visible (documents, projects).
+export const CORE_PERMISSION_GROUPS: PermissionGroup[] =
+  toolsInSection("core").map(toPermissionGroup);
+
+// Advanced tool permissions shown in an accordion (queues, events, counters).
+export const ADVANCED_PERMISSION_GROUPS: PermissionGroup[] =
+  toolsInSection("advanced").map(toPermissionGroup);
 
 // Permission group for the optional embedded advanced tool. Only included
 // in the role-permissions UI when the deployment has an advanced tool URL
 // configured at runtime — see InitiativeSettingsRolesTab for the gating.
-export const ADVANCED_TOOL_PERMISSION_GROUP: PermissionGroup = {
-  labelKey: "settings.permissionGroups.advancedTool",
-  keys: ["advanced_tool_enabled", "create_advanced_tool"],
-};
-
-// All groups combined (for backward compat)
-export const PERMISSION_GROUPS: PermissionGroup[] = [
-  ...CORE_PERMISSION_GROUPS,
-  ...ADVANCED_PERMISSION_GROUPS,
-];
+export const ADVANCED_TOOL_PERMISSION_GROUP: PermissionGroup = toPermissionGroup(
+  TOOL_BY_ID[Tool.advanced_tool]
+);

--- a/frontend/src/lib/recentIcon.tsx
+++ b/frontend/src/lib/recentIcon.tsx
@@ -1,8 +1,8 @@
-import { GalleryHorizontalEnd, Gauge } from "lucide-react";
 import type { ReactNode } from "react";
 
 import type { RecentItemRead } from "@/api/generated/initiativeAPI.schemas";
 import { getDocumentIcon, getDocumentIconColor } from "@/lib/fileUtils";
+import { toolIcon } from "@/lib/tools/registry";
 import { cn } from "@/lib/utils";
 
 /**
@@ -11,7 +11,8 @@ import { cn } from "@/lib/utils";
  * - Projects show the emoji icon set on the project itself.
  * - Documents resolve to the same icon + color used in document lists
  *   (via ``getDocumentIcon`` / ``getDocumentIconColor``).
- * - Queues use ``GalleryHorizontalEnd``; counter groups use ``Gauge``.
+ * - Everything else uses the shared tool-registry icon (queues, counters, …),
+ *   so it can never drift from the icon shown elsewhere for that tool.
  */
 export function renderRecentIcon(item: RecentItemRead): ReactNode {
   switch (item.entity_type) {
@@ -28,11 +29,9 @@ export function renderRecentIcon(item: RecentItemRead): ReactNode {
       );
       return <Icon className={cn("h-4 w-4", color)} />;
     }
-    case "queue":
-      return <GalleryHorizontalEnd className="h-4 w-4 text-muted-foreground" />;
-    case "counter_group":
-      return <Gauge className="h-4 w-4 text-muted-foreground" />;
-    default:
-      return null;
+    default: {
+      const Icon = toolIcon(item.entity_type);
+      return Icon ? <Icon className="h-4 w-4 text-muted-foreground" /> : null;
+    }
   }
 }

--- a/frontend/src/lib/tools/registry.test.ts
+++ b/frontend/src/lib/tools/registry.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import type { InitiativeMemberRead } from "@/api/generated/initiativeAPI.schemas";
+import { PermissionKey, Tool } from "@/api/generated/initiativeAPI.schemas";
+import {
+  ADVANCED_PERMISSION_GROUPS,
+  ADVANCED_TOOL_PERMISSION_GROUP,
+  CORE_PERMISSION_GROUPS,
+  PERMISSION_LABEL_KEYS,
+} from "@/hooks/useInitiativeRoles";
+
+import {
+  fullToolAccess,
+  membershipToolAccess,
+  readOnlyToolAccess,
+  TOGGLEABLE_TOOLS,
+  TOOL_BY_ID,
+  TOOLS,
+  toolIcon,
+} from "./registry";
+
+// Anti-drift guards for the tool registry. Types alone can't catch these: the
+// registry's derived lookups (`TOOL_BY_ID`, the access maps, PERMISSION_LABEL_KEYS)
+// are built with `Object.fromEntries` and typed as total `Record<Tool | PermissionKey, …>`,
+// so a `Tool`/`PermissionKey` added to the backend-generated enum but forgotten
+// in the `TOOLS` array compiles cleanly and only fails at runtime. These tests
+// fail the build instead — the single place a new tool must be wired.
+
+const ALL_TOOLS = Object.values(Tool);
+const ALL_PERMISSION_KEYS = Object.values(PermissionKey);
+
+describe("tool registry coverage", () => {
+  it("has exactly one entry per backend Tool enum value", () => {
+    expect(new Set(TOOLS.map((t) => t.id))).toEqual(new Set(ALL_TOOLS));
+    // No duplicate ids.
+    expect(TOOLS).toHaveLength(ALL_TOOLS.length);
+    // TOOL_BY_ID resolves every tool (not a partial record masquerading as total).
+    for (const tool of ALL_TOOLS) {
+      expect(TOOL_BY_ID[tool]?.id).toBe(tool);
+    }
+  });
+
+  it("maps every tool to an icon", () => {
+    for (const tool of ALL_TOOLS) {
+      expect(toolIcon(tool)).toBeTruthy();
+    }
+    // Unknown/non-tool entity types fall through so callers can default.
+    expect(toolIcon("task")).toBeUndefined();
+  });
+
+  it("covers every PermissionKey exactly once across the tools' view/create keys", () => {
+    const keys = TOOLS.flatMap((t) => [t.perm.view, t.perm.create]);
+    expect(new Set(keys)).toEqual(new Set(ALL_PERMISSION_KEYS));
+    // Each tool contributes two DISTINCT keys, and none collide across tools.
+    expect(keys).toHaveLength(ALL_PERMISSION_KEYS.length);
+  });
+});
+
+describe("derived permission structures stay in sync", () => {
+  it("PERMISSION_LABEL_KEYS has a label for every PermissionKey", () => {
+    for (const key of ALL_PERMISSION_KEYS) {
+      expect(PERMISSION_LABEL_KEYS[key]).toBeTruthy();
+    }
+    expect(Object.keys(PERMISSION_LABEL_KEYS)).toHaveLength(ALL_PERMISSION_KEYS.length);
+  });
+
+  it("permission groups partition the tools by section", () => {
+    const grouped = [
+      ...CORE_PERMISSION_GROUPS,
+      ...ADVANCED_PERMISSION_GROUPS,
+      ADVANCED_TOOL_PERMISSION_GROUP,
+    ];
+    // One card per tool, each carrying its view + create key.
+    expect(grouped).toHaveLength(TOOLS.length);
+    const keysInGroups = grouped.flatMap((g) => g.keys);
+    expect(new Set(keysInGroups)).toEqual(new Set(ALL_PERMISSION_KEYS));
+    expect(CORE_PERMISSION_GROUPS).toHaveLength(TOOLS.filter((t) => t.section === "core").length);
+    expect(ADVANCED_PERMISSION_GROUPS).toHaveLength(
+      TOOLS.filter((t) => t.section === "advanced").length
+    );
+  });
+});
+
+describe("feature toggles", () => {
+  it("TOGGLEABLE_TOOLS is exactly the tools with an enable flag, each with a toggle", () => {
+    expect(TOGGLEABLE_TOOLS).toEqual(TOOLS.filter((t) => t.enableFlag !== null));
+    for (const tool of TOGGLEABLE_TOOLS) {
+      expect(tool.enableFlag).not.toBeNull();
+      expect(tool.settingsToggle).toBeTruthy();
+    }
+    // Enable flags are unique (no two tools share one).
+    const flags = TOGGLEABLE_TOOLS.map((t) => t.enableFlag);
+    expect(new Set(flags).size).toBe(flags.length);
+  });
+});
+
+describe("nav config", () => {
+  it("every nav tool has a route + labels, and global-create implies a nav", () => {
+    for (const tool of TOOLS) {
+      if (tool.nav) {
+        expect(tool.nav.listRoute.startsWith("/")).toBe(true);
+        expect(tool.nav.labelKey).toBeTruthy();
+        expect(tool.nav.createLabelKey).toBeTruthy();
+      }
+      // A tool can only be "create from anywhere" if it has a list route to open.
+      if (tool.nav?.navCreateGlobal) {
+        expect(tool.nav.listRoute).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe("access maps cover every tool", () => {
+  const initiative = {
+    queues_enabled: true,
+    events_enabled: true,
+    counters_enabled: true,
+    advanced_tool_enabled: true,
+  } as Parameters<typeof fullToolAccess>[0];
+
+  it("fullToolAccess / readOnlyToolAccess return an entry for every tool", () => {
+    const full = fullToolAccess(initiative, true);
+    const readOnly = readOnlyToolAccess();
+    for (const tool of ALL_TOOLS) {
+      expect(full[tool]).toBeDefined();
+      expect(readOnly[tool]).toBeDefined();
+    }
+    // Full access with all flags on ⇒ view+create everywhere.
+    expect(ALL_TOOLS.every((t) => full[t].view && full[t].create)).toBe(true);
+    // Read-only default ⇒ only always-on tools (no enable flag) are visible.
+    for (const tool of TOOLS) {
+      expect(readOnly[tool.id].view).toBe(tool.enableFlag === null);
+      expect(readOnly[tool.id].create).toBe(false);
+    }
+  });
+
+  it("membershipToolAccess resolves real membership fields for every tool", () => {
+    // Every can_* set true — if a registry membership key were wrong, an
+    // enable-flagged tool would resolve `undefined ?? false` and fail here.
+    const membership = {
+      can_view_docs: true,
+      can_view_projects: true,
+      can_view_queues: true,
+      can_view_events: true,
+      can_view_advanced_tool: true,
+      can_view_counters: true,
+      can_create_docs: true,
+      can_create_projects: true,
+      can_create_queues: true,
+      can_create_events: true,
+      can_create_advanced_tool: true,
+      can_create_counters: true,
+    } as unknown as InitiativeMemberRead;
+
+    const access = membershipToolAccess(membership);
+    for (const tool of ALL_TOOLS) {
+      expect(access[tool].view).toBe(true);
+      expect(access[tool].create).toBe(true);
+    }
+  });
+});

--- a/frontend/src/lib/tools/registry.tsx
+++ b/frontend/src/lib/tools/registry.tsx
@@ -1,0 +1,337 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  CalendarDays,
+  GalleryHorizontalEnd,
+  Gauge,
+  ListTodo,
+  ScrollText,
+  Sparkles,
+} from "lucide-react";
+
+import type {
+  InitiativeMemberRead,
+  InitiativeRead,
+  PermissionKey,
+} from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
+
+/**
+ * The single source of truth for the app's per-initiative "tools".
+ *
+ * Every surface that used to hand-write one copy per tool — the sidebar, the
+ * initiative tabs, the settings feature toggles, the role-permission cards, the
+ * command palette, the create menus, the recent-item icons — now derives from
+ * this one array. Adding a tool (or wiring an existing one into a new surface)
+ * is a single edit here instead of a scavenger hunt across ~8 files, and the
+ * asymmetries that used to creep in (a tool missing from one menu, a permission
+ * key that drifted) become structurally impossible.
+ *
+ * `id` is the backend `Tool` enum value — the same string used as
+ * `resource_grants.resource_type`, the recents/trash `entity_type`, and the URL
+ * segment stem — so it threads cleanly through the API layer.
+ */
+
+/** The per-initiative feature flags on {@link InitiativeRead} (the toggles). */
+export type InitiativeEnableFlag =
+  | "queues_enabled"
+  | "events_enabled"
+  | "counters_enabled"
+  | "advanced_tool_enabled";
+
+/** Which settings section / permission accordion a tool's card lives under. */
+export type ToolSection = "core" | "advanced" | "advancedTool";
+
+export interface ToolPerm {
+  /** Role permission key gating visibility. */
+  view: PermissionKey;
+  /** Role permission key gating creation. */
+  create: PermissionKey;
+  /** Per-user resolved membership boolean for visibility. */
+  membershipView: keyof InitiativeMemberRead;
+  /** Per-user resolved membership boolean for creation. */
+  membershipCreate: keyof InitiativeMemberRead;
+  /** i18n key (initiatives ns) for the "view" permission label. */
+  viewLabelKey: string;
+  /** i18n key (initiatives ns) for the "create" permission label. */
+  createLabelKey: string;
+  /** i18n key (initiatives ns) for the permission card title. */
+  groupLabelKey: string;
+}
+
+export interface ToolNav {
+  /** i18n key (nav ns) for the sidebar/nav label. */
+  labelKey: string;
+  /** i18n key (nav ns) for the "create X" affordance. */
+  createLabelKey: string;
+  /** Guild-relative list route, e.g. "/queues". */
+  listRoute: string;
+  /** Whether the sidebar row shows an item count. */
+  hasCount: boolean;
+  /**
+   * Whether this tool can be created "from anywhere" by navigating to its list
+   * route with `?create=true` — i.e. its create dialog has an initiative picker
+   * and needs no pre-selected initiative. Drives the global create surfaces
+   * (command palette). Events are excluded (their dialog requires an initiative).
+   */
+  navCreateGlobal?: boolean;
+}
+
+export interface ToolSettingsToggle {
+  /** i18n key (initiatives ns) for the toggle title. */
+  titleKey: string;
+  /** i18n key (initiatives ns) for the toggle description. */
+  descriptionKey: string;
+}
+
+export interface ToolDef {
+  /** Backend `Tool` enum value — resource_type / entity_type / route stem. */
+  id: Tool;
+  /** Icon used everywhere the tool appears (nav, command palette, recents). */
+  icon: LucideIcon;
+  /** Settings section / permission accordion the tool belongs to. */
+  section: ToolSection;
+  /**
+   * Initiative-level enable flag, or `null` for always-on tools (documents,
+   * projects) which have no per-initiative toggle.
+   */
+  enableFlag: InitiativeEnableFlag | null;
+  /**
+   * Only visible when the deployment configures an advanced tool at runtime
+   * (`useAppConfig().advancedTool`). advanced_tool only.
+   */
+  runtimeConfigGated: boolean;
+  /** Shareable through the standard `resource_grants` DAC (bulk "Edit access"). */
+  shareable: boolean;
+  /** Role/membership permission wiring. */
+  perm: ToolPerm;
+  /**
+   * Sidebar / nav rendering data. Absent for tools with no standard list route
+   * (advanced_tool, which renders a bespoke pinned entry per initiative).
+   */
+  nav?: ToolNav;
+  /** Feature toggle shown in initiative settings — only tools with an enableFlag. */
+  settingsToggle?: ToolSettingsToggle;
+}
+
+export const TOOLS: ToolDef[] = [
+  {
+    id: Tool.document,
+    icon: ScrollText,
+    section: "core",
+    enableFlag: null,
+    runtimeConfigGated: false,
+    shareable: true,
+    perm: {
+      view: "docs_enabled",
+      create: "create_docs",
+      membershipView: "can_view_docs",
+      membershipCreate: "can_create_docs",
+      viewLabelKey: "settings.permissions.viewDocuments",
+      createLabelKey: "settings.permissions.createDocuments",
+      groupLabelKey: "settings.permissionGroups.documents",
+    },
+    nav: {
+      labelKey: "documents",
+      createLabelKey: "createDocument",
+      listRoute: "/documents",
+      hasCount: true,
+    },
+  },
+  {
+    id: Tool.project,
+    icon: ListTodo,
+    section: "core",
+    enableFlag: null,
+    runtimeConfigGated: false,
+    shareable: true,
+    perm: {
+      view: "projects_enabled",
+      create: "create_projects",
+      membershipView: "can_view_projects",
+      membershipCreate: "can_create_projects",
+      viewLabelKey: "settings.permissions.viewProjects",
+      createLabelKey: "settings.permissions.createProjects",
+      groupLabelKey: "settings.permissionGroups.projects",
+    },
+    nav: {
+      labelKey: "projects",
+      createLabelKey: "createProject",
+      listRoute: "/projects",
+      hasCount: true,
+      navCreateGlobal: true,
+    },
+  },
+  {
+    id: Tool.queue,
+    icon: GalleryHorizontalEnd,
+    section: "advanced",
+    enableFlag: "queues_enabled",
+    runtimeConfigGated: false,
+    shareable: true,
+    perm: {
+      view: "queues_enabled",
+      create: "create_queues",
+      membershipView: "can_view_queues",
+      membershipCreate: "can_create_queues",
+      viewLabelKey: "settings.permissions.viewQueues",
+      createLabelKey: "settings.permissions.createQueues",
+      groupLabelKey: "settings.permissionGroups.queues",
+    },
+    nav: {
+      labelKey: "queues",
+      createLabelKey: "createQueue",
+      listRoute: "/queues",
+      hasCount: true,
+      navCreateGlobal: true,
+    },
+    settingsToggle: {
+      titleKey: "queuesFeature",
+      descriptionKey: "queuesFeatureDescription",
+    },
+  },
+  {
+    id: Tool.calendar_event,
+    icon: CalendarDays,
+    section: "advanced",
+    enableFlag: "events_enabled",
+    runtimeConfigGated: false,
+    shareable: true,
+    perm: {
+      view: "events_enabled",
+      create: "create_events",
+      membershipView: "can_view_events",
+      membershipCreate: "can_create_events",
+      viewLabelKey: "settings.permissions.viewEvents",
+      createLabelKey: "settings.permissions.createEvents",
+      groupLabelKey: "settings.permissionGroups.events",
+    },
+    nav: {
+      labelKey: "events",
+      createLabelKey: "createEvent",
+      listRoute: "/events",
+      hasCount: false,
+    },
+    settingsToggle: {
+      titleKey: "eventsFeature",
+      descriptionKey: "eventsFeatureDescription",
+    },
+  },
+  {
+    id: Tool.counter_group,
+    icon: Gauge,
+    section: "advanced",
+    enableFlag: "counters_enabled",
+    runtimeConfigGated: false,
+    shareable: true,
+    perm: {
+      view: "counters_enabled",
+      create: "create_counters",
+      membershipView: "can_view_counters",
+      membershipCreate: "can_create_counters",
+      viewLabelKey: "settings.permissions.viewCounters",
+      createLabelKey: "settings.permissions.createCounters",
+      groupLabelKey: "settings.permissionGroups.counters",
+    },
+    nav: {
+      labelKey: "counters",
+      createLabelKey: "createCounterGroup",
+      listRoute: "/counter-groups",
+      hasCount: true,
+      navCreateGlobal: true,
+    },
+    settingsToggle: {
+      titleKey: "countersFeature",
+      descriptionKey: "countersFeatureDescription",
+    },
+  },
+  {
+    id: Tool.advanced_tool,
+    icon: Sparkles,
+    section: "advancedTool",
+    enableFlag: "advanced_tool_enabled",
+    runtimeConfigGated: true,
+    shareable: true,
+    perm: {
+      view: "advanced_tool_enabled",
+      create: "create_advanced_tool",
+      membershipView: "can_view_advanced_tool",
+      membershipCreate: "can_create_advanced_tool",
+      viewLabelKey: "settings.permissions.viewAdvancedTool",
+      createLabelKey: "settings.permissions.createAdvancedTool",
+      groupLabelKey: "settings.permissionGroups.advancedTool",
+    },
+    // No `nav`: the advanced tool renders a bespoke pinned entry (its label is
+    // the runtime deployment name, and it links to a per-initiative route).
+    settingsToggle: {
+      // `titleKey` is overridden by the runtime advanced-tool name at render.
+      titleKey: "advancedTools",
+      descriptionKey: "advancedToolFeatureDescription",
+    },
+  },
+];
+
+/** Lookup by `Tool` id. */
+export const TOOL_BY_ID: Record<Tool, ToolDef> = Object.fromEntries(
+  TOOLS.map((tool) => [tool.id, tool])
+) as Record<Tool, ToolDef>;
+
+/** Tools in a given settings section, in registry order. */
+export const toolsInSection = (section: ToolSection): ToolDef[] =>
+  TOOLS.filter((tool) => tool.section === section);
+
+/** Tools that carry an initiative-level feature toggle, in registry order. */
+export const TOGGLEABLE_TOOLS: ToolDef[] = TOOLS.filter((tool) => tool.enableFlag !== null);
+
+/**
+ * Icon for an entity/resource type string (recents, command palette, dashboards).
+ * Returns `undefined` for types with no fixed tool icon (e.g. documents, whose
+ * icon depends on file type, or non-tool entities like tasks/comments) so the
+ * caller can fall back.
+ */
+export const toolIcon = (entityType: string): LucideIcon | undefined =>
+  TOOL_BY_ID[entityType as Tool]?.icon;
+
+/** A tool's effective visibility/creation for one user in one initiative. */
+export interface ToolAccess {
+  view: boolean;
+  create: boolean;
+}
+
+export type ToolAccessMap = Record<Tool, ToolAccess>;
+
+const isEnabled = (initiative: InitiativeRead, tool: ToolDef): boolean =>
+  tool.enableFlag === null ? true : (initiative[tool.enableFlag] ?? false);
+
+/**
+ * Full access to every enabled tool (guild admin or read/write grant). `canCreate`
+ * toggles the create affordances (a read-only grant sees but can't author).
+ */
+export const fullToolAccess = (initiative: InitiativeRead, canCreate: boolean): ToolAccessMap =>
+  Object.fromEntries(
+    TOOLS.map((tool) => {
+      const enabled = isEnabled(initiative, tool);
+      return [tool.id, { view: enabled, create: canCreate && enabled }];
+    })
+  ) as ToolAccessMap;
+
+/** Bare read of always-on tools (documents/projects) for a non-member with no grant. */
+export const readOnlyToolAccess = (): ToolAccessMap =>
+  Object.fromEntries(
+    TOOLS.map((tool) => [tool.id, { view: tool.enableFlag === null, create: false }])
+  ) as ToolAccessMap;
+
+/** Per-tool access resolved from a user's initiative membership row. */
+export const membershipToolAccess = (membership: InitiativeMemberRead): ToolAccessMap =>
+  Object.fromEntries(
+    TOOLS.map((tool) => {
+      // Always-on tools (docs/projects) historically default to visible.
+      const viewDefault = tool.enableFlag === null;
+      return [
+        tool.id,
+        {
+          view: (membership[tool.perm.membershipView] as boolean | undefined) ?? viewDefault,
+          create: (membership[tool.perm.membershipCreate] as boolean | undefined) ?? false,
+        },
+      ];
+    })
+  ) as ToolAccessMap;

--- a/frontend/src/lib/tools/toolListSearch.ts
+++ b/frontend/src/lib/tools/toolListSearch.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared `validateSearch` parsing for a tool's list route.
+ *
+ * Every tool list route (`/projects`, `/documents`, `/queues`, `/counter-groups`,
+ * `/events`) accepts the same `?create` / `?initiativeId` params — and the
+ * paginated ones also `?page`. This centralizes that parsing so the routes can't
+ * drift in how they coerce those params (the create/initiativeId convention is
+ * the cross-surface "open create dialog" protocol).
+ */
+
+export interface ToolListSearch {
+  create?: string;
+  initiativeId?: string;
+}
+
+export interface PagedToolListSearch extends ToolListSearch {
+  page?: number;
+}
+
+const parseString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const parsePage = (value: unknown): number | undefined => {
+  if (typeof value === "number" && value >= 1) return value;
+  if (typeof value === "string" && Number(value) >= 1) return Number(value);
+  return undefined;
+};
+
+export function toolListSearch(search: Record<string, unknown>): ToolListSearch;
+export function toolListSearch(
+  search: Record<string, unknown>,
+  opts: { page: true }
+): PagedToolListSearch;
+export function toolListSearch(
+  search: Record<string, unknown>,
+  opts?: { page: true }
+): ToolListSearch | PagedToolListSearch {
+  const base: ToolListSearch = {
+    create: parseString(search.create),
+    initiativeId: parseString(search.initiativeId),
+  };
+  return opts?.page ? { ...base, page: parsePage(search.page) } : base;
+}

--- a/frontend/src/pages/ArchivePage.tsx
+++ b/frontend/src/pages/ArchivePage.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { Markdown } from "@/components/Markdown";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,7 +37,7 @@ export const ArchivePage = () => {
     if (hasCapability(user, Capability.dataBypass)) return true;
     if (!initiativesQuery.data) return false;
     return filterVisible(initiativesQuery.data).some(
-      (initiative) => permissionsFor(initiative).canCreateProjects
+      (initiative) => permissionsFor(initiative)[Tool.project].create
     );
   }, [user, initiativesQuery.data, filterVisible, permissionsFor]);
 

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -383,7 +383,7 @@ export const DocumentsView = ({
       return [];
     }
     return filterVisible(initiativesQuery.data).filter(
-      (initiative) => permissionsFor(initiative).canCreateDocs
+      (initiative) => permissionsFor(initiative)[Tool.document].create
     );
   }, [initiativesQuery.data, user, filterVisible, permissionsFor]);
 

--- a/frontend/src/pages/InitiativeDetailPage.tsx
+++ b/frontend/src/pages/InitiativeDetailPage.tsx
@@ -1,8 +1,9 @@
 import { Link, Navigate, useParams } from "@tanstack/react-router";
 import { Loader2, SearchX, Settings } from "lucide-react";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { type ComponentType, Suspense, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { Markdown } from "@/components/Markdown";
 import { StatusMessage } from "@/components/StatusMessage";
 import { Badge } from "@/components/ui/badge";
@@ -10,19 +11,33 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
-import {
-  canCreate,
-  isFeatureEnabled,
-  useMyInitiativePermissions,
-} from "@/hooks/useInitiativeRoles";
+import { useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
+import { TOOL_BY_ID, type ToolDef } from "@/lib/tools/registry";
 
 import { DocumentsView } from "./DocumentsPage";
 import { CounterGroupsView } from "./initiativeTools/counters/CounterGroupsPage";
 import { EventsView } from "./initiativeTools/events/EventsPage";
 import { QueuesView } from "./initiativeTools/queues/QueuesPage";
 import { ProjectsView } from "./ProjectsPage";
+
+interface ToolViewProps {
+  fixedInitiativeId: number;
+  canCreate: boolean;
+}
+
+// The initiative detail tabs, derived from the tool registry: one tab per tool
+// with an in-initiative list view. Visibility and the create affordance both
+// read straight from the user's resolved permission keys on the registry entry,
+// so a new tool is a single entry here instead of five parallel edits.
+const INITIATIVE_TABS: { tool: ToolDef; labelKey: string; View: ComponentType<ToolViewProps> }[] = [
+  { tool: TOOL_BY_ID[Tool.document], labelKey: "detail.documents", View: DocumentsView },
+  { tool: TOOL_BY_ID[Tool.project], labelKey: "detail.projects", View: ProjectsView },
+  { tool: TOOL_BY_ID[Tool.calendar_event], labelKey: "detail.calendar", View: EventsView },
+  { tool: TOOL_BY_ID[Tool.queue], labelKey: "detail.queues", View: QueuesView },
+  { tool: TOOL_BY_ID[Tool.counter_group], labelKey: "detail.counters", View: CounterGroupsView },
+];
 
 export const InitiativeDetailPage = () => {
   const { initiativeId: initiativeIdParam, guildId: guildIdParam } = useParams({
@@ -55,31 +70,17 @@ export const InitiativeDetailPage = () => {
   const isInitiativeManager = membership?.is_manager || membership?.role === "project_manager";
   const canManageInitiative = Boolean(isGuildAdmin || isInitiativeManager);
 
-  // Determine which features are enabled for this user
-  const docsEnabled = isFeatureEnabled(permissions, "docs");
-  const projectsEnabled = isFeatureEnabled(permissions, "projects");
-  const queuesEnabled = isFeatureEnabled(permissions, "queues");
-  const eventsEnabled = isFeatureEnabled(permissions, "events");
-  const countersEnabled = isFeatureEnabled(permissions, "counters");
-  const canCreateDocs = canCreate(permissions, "docs");
-  const canCreateProjects = canCreate(permissions, "projects");
-  const canCreateQueues = canCreate(permissions, "queues");
-  const canCreateEvents = canCreate(permissions, "events");
-  const canCreateCounters = canCreate(permissions, "counters");
+  // Per-tool visibility/creation read straight from the resolved permission keys
+  // — the registry entry names both, so no per-tool derivation is needed here.
+  const perm = permissions?.permissions;
+  const visibleTabs = INITIATIVE_TABS.filter((tab) => perm?.[tab.tool.perm.view]);
 
-  type TabValue = "documents" | "projects" | "queues" | "calendar" | "counters";
+  const availableTabs = useMemo<Tool[]>(
+    () => INITIATIVE_TABS.filter((tab) => perm?.[tab.tool.perm.view]).map((tab) => tab.tool.id),
+    [perm]
+  );
 
-  const availableTabs = useMemo<TabValue[]>(() => {
-    const tabs: TabValue[] = [];
-    if (docsEnabled) tabs.push("documents");
-    if (projectsEnabled) tabs.push("projects");
-    if (eventsEnabled) tabs.push("calendar");
-    if (queuesEnabled) tabs.push("queues");
-    if (countersEnabled) tabs.push("counters");
-    return tabs;
-  }, [docsEnabled, projectsEnabled, queuesEnabled, eventsEnabled, countersEnabled]);
-
-  const [activeTab, setActiveTab] = useState<TabValue>(availableTabs[0] ?? "documents");
+  const [activeTab, setActiveTab] = useState<Tool>(availableTabs[0] ?? Tool.document);
 
   // Update active tab if current tab becomes unavailable
   useEffect(() => {
@@ -191,71 +192,30 @@ export const InitiativeDetailPage = () => {
         </div>
       </div>
 
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabValue)}>
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as Tool)}>
         <div className="-mx-1 overflow-x-auto px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <TabsList className="inline-flex w-max">
-            {docsEnabled && <TabsTrigger value="documents">{t("detail.documents")}</TabsTrigger>}
-            {projectsEnabled && <TabsTrigger value="projects">{t("detail.projects")}</TabsTrigger>}
-            {eventsEnabled && <TabsTrigger value="calendar">{t("detail.calendar")}</TabsTrigger>}
-            {queuesEnabled && <TabsTrigger value="queues">{t("detail.queues")}</TabsTrigger>}
-            {countersEnabled && <TabsTrigger value="counters">{t("detail.counters")}</TabsTrigger>}
+            {visibleTabs.map((tab) => (
+              <TabsTrigger key={tab.tool.id} value={tab.tool.id}>
+                {t(tab.labelKey as never)}
+              </TabsTrigger>
+            ))}
           </TabsList>
         </div>
-        {docsEnabled && (
-          <TabsContent value="documents" className="mt-6">
-            <Suspense fallback={tabFallback}>
-              <DocumentsView
-                key={`documents-${initiative.id}`}
-                fixedInitiativeId={initiative.id}
-                canCreate={canCreateDocs}
-              />
-            </Suspense>
-          </TabsContent>
-        )}
-        {projectsEnabled && (
-          <TabsContent value="projects" className="mt-6">
-            <Suspense fallback={tabFallback}>
-              <ProjectsView
-                key={`projects-${initiative.id}`}
-                fixedInitiativeId={initiative.id}
-                canCreate={canCreateProjects}
-              />
-            </Suspense>
-          </TabsContent>
-        )}
-        {eventsEnabled && (
-          <TabsContent value="calendar" className="mt-6">
-            <Suspense fallback={tabFallback}>
-              <EventsView
-                key={`calendar-${initiative.id}`}
-                fixedInitiativeId={initiative.id}
-                canCreate={canCreateEvents}
-              />
-            </Suspense>
-          </TabsContent>
-        )}
-        {queuesEnabled && (
-          <TabsContent value="queues" className="mt-6">
-            <Suspense fallback={tabFallback}>
-              <QueuesView
-                key={`queues-${initiative.id}`}
-                fixedInitiativeId={initiative.id}
-                canCreate={canCreateQueues}
-              />
-            </Suspense>
-          </TabsContent>
-        )}
-        {countersEnabled && (
-          <TabsContent value="counters" className="mt-6">
-            <Suspense fallback={tabFallback}>
-              <CounterGroupsView
-                key={`counters-${initiative.id}`}
-                fixedInitiativeId={initiative.id}
-                canCreate={canCreateCounters}
-              />
-            </Suspense>
-          </TabsContent>
-        )}
+        {visibleTabs.map((tab) => {
+          const View = tab.View;
+          return (
+            <TabsContent key={tab.tool.id} value={tab.tool.id} className="mt-6">
+              <Suspense fallback={tabFallback}>
+                <View
+                  key={`${tab.tool.id}-${initiative.id}`}
+                  fixedInitiativeId={initiative.id}
+                  canCreate={perm?.[tab.tool.perm.create] ?? false}
+                />
+              </Suspense>
+            </TabsContent>
+          );
+        })}
       </Tabs>
     </div>
   );

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -31,6 +31,7 @@ import { useDeleteInitiative, useInitiatives, useUpdateInitiative } from "@/hook
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
+import type { InitiativeEnableFlag } from "@/lib/tools/registry";
 
 const DEFAULT_INITIATIVE_COLOR = "#6366F1";
 
@@ -138,32 +139,8 @@ export const InitiativeSettingsPage = () => {
     });
   };
 
-  const handleToggleQueues = (value: boolean) => {
-    updateInitiative.mutate({
-      initiativeId,
-      data: { queues_enabled: value },
-    });
-  };
-
-  const handleToggleEvents = (value: boolean) => {
-    updateInitiative.mutate({
-      initiativeId,
-      data: { events_enabled: value },
-    });
-  };
-
-  const handleToggleAdvancedTool = (value: boolean) => {
-    updateInitiative.mutate({
-      initiativeId,
-      data: { advanced_tool_enabled: value },
-    });
-  };
-
-  const handleToggleCounters = (value: boolean) => {
-    updateInitiative.mutate({
-      initiativeId,
-      data: { counters_enabled: value },
-    });
+  const handleToggleFeature = (flag: InitiativeEnableFlag, value: boolean) => {
+    updateInitiative.mutate({ initiativeId, data: { [flag]: value } });
   };
 
   const handleDeleteInitiative = () => {
@@ -266,14 +243,13 @@ export const InitiativeSettingsPage = () => {
           setDescription={setDescription}
           color={color}
           setColor={setColor}
-          queuesEnabled={initiative?.queues_enabled ?? false}
-          onToggleQueues={handleToggleQueues}
-          eventsEnabled={initiative?.events_enabled ?? false}
-          onToggleEvents={handleToggleEvents}
-          advancedToolEnabled={initiative?.advanced_tool_enabled ?? false}
-          onToggleAdvancedTool={handleToggleAdvancedTool}
-          countersEnabled={initiative?.counters_enabled ?? false}
-          onToggleCounters={handleToggleCounters}
+          featuresEnabled={{
+            queues_enabled: initiative?.queues_enabled ?? false,
+            events_enabled: initiative?.events_enabled ?? false,
+            counters_enabled: initiative?.counters_enabled ?? false,
+            advanced_tool_enabled: initiative?.advanced_tool_enabled ?? false,
+          }}
+          onToggleFeature={handleToggleFeature}
           canManageMembers={canManageMembers}
           isSaving={updateInitiative.isPending}
           onSaveDetails={handleSaveDetails}

--- a/frontend/src/pages/InitiativesPage.tsx
+++ b/frontend/src/pages/InitiativesPage.tsx
@@ -45,6 +45,7 @@ import { useProjects } from "@/hooks/useProjects";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
+import type { InitiativeEnableFlag } from "@/lib/tools/registry";
 
 const DEFAULT_INITIATIVE_COLOR = "#6366F1";
 
@@ -100,10 +101,11 @@ export const InitiativesPage = () => {
   const [newName, setNewName] = useState("");
   const [newDescription, setNewDescription] = useState("");
   const [newColor, setNewColor] = useState(DEFAULT_INITIATIVE_COLOR);
-  const [queuesEnabled, setQueuesEnabled] = useState(false);
-  const [eventsEnabled, setEventsEnabled] = useState(false);
-  const [countersEnabled, setCountersEnabled] = useState(false);
-  const [advancedToolEnabled, setAdvancedToolEnabled] = useState(false);
+  const [featuresEnabled, setFeaturesEnabled] = useState<
+    Partial<Record<InitiativeEnableFlag, boolean>>
+  >({});
+  const handleToggleFeature = (flag: InitiativeEnableFlag, value: boolean) =>
+    setFeaturesEnabled((prev) => ({ ...prev, [flag]: value }));
   const lastConsumedParams = useRef<string>("");
 
   // Check for query params to open create dialog (consume once)
@@ -131,10 +133,7 @@ export const InitiativesPage = () => {
         name: trimmedName,
         description: newDescription.trim() || undefined,
         color: newColor,
-        queues_enabled: queuesEnabled,
-        events_enabled: eventsEnabled,
-        counters_enabled: countersEnabled,
-        advanced_tool_enabled: advancedToolEnabled,
+        ...featuresEnabled,
       },
       {
         onSuccess: () => {
@@ -142,10 +141,7 @@ export const InitiativesPage = () => {
           setNewName("");
           setNewDescription("");
           setNewColor(DEFAULT_INITIATIVE_COLOR);
-          setQueuesEnabled(false);
-          setEventsEnabled(false);
-          setCountersEnabled(false);
-          setAdvancedToolEnabled(false);
+          setFeaturesEnabled({});
         },
       }
     );
@@ -317,14 +313,8 @@ export const InitiativesPage = () => {
                         layout="plain"
                         canManage={!createInitiative.isPending}
                         isSaving={createInitiative.isPending}
-                        eventsEnabled={eventsEnabled}
-                        onToggleEvents={setEventsEnabled}
-                        queuesEnabled={queuesEnabled}
-                        onToggleQueues={setQueuesEnabled}
-                        countersEnabled={countersEnabled}
-                        onToggleCounters={setCountersEnabled}
-                        advancedToolEnabled={advancedToolEnabled}
-                        onToggleAdvancedTool={setAdvancedToolEnabled}
+                        enabled={featuresEnabled}
+                        onToggle={handleToggleFeature}
                         idPrefix="create"
                       />
                     </AccordionContent>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -254,7 +254,7 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
       return [];
     }
     return filterVisible(initiativesQuery.data).filter(
-      (initiative) => permissionsFor(initiative).canCreateProjects
+      (initiative) => permissionsFor(initiative)[Tool.project].create
     );
   }, [initiativesQuery.data, user, filterVisible, permissionsFor]);
   const isProjectManager = creatableInitiatives.length > 0;

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { Markdown } from "@/components/Markdown";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,7 +37,7 @@ export const TemplatesPage = () => {
     if (hasCapability(user, Capability.dataBypass)) return true;
     if (!initiativesQuery.data) return false;
     return filterVisible(initiativesQuery.data).some(
-      (initiative) => permissionsFor(initiative).canCreateProjects
+      (initiative) => permissionsFor(initiative)[Tool.project].create
     );
   }, [user, initiativesQuery.data, filterVisible, permissionsFor]);
 

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/counter-groups.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/counter-groups.tsx
@@ -1,15 +1,9 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-type CounterGroupsSearchParams = {
-  create?: string;
-  initiativeId?: string;
-};
+import { toolListSearch } from "@/lib/tools/toolListSearch";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/counter-groups")({
-  validateSearch: (search: Record<string, unknown>): CounterGroupsSearchParams => ({
-    create: typeof search.create === "string" ? search.create : undefined,
-    initiativeId: typeof search.initiativeId === "string" ? search.initiativeId : undefined,
-  }),
+  validateSearch: (search: Record<string, unknown>) => toolListSearch(search),
   component: lazyRouteComponent(() =>
     import("@/pages/initiativeTools/counters/CounterGroupsPage").then((m) => ({
       default: m.CounterGroupsPage,

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/documents.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/documents.tsx
@@ -1,22 +1,9 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-type DocumentsSearchParams = {
-  create?: string;
-  initiativeId?: string;
-  page?: number;
-};
+import { toolListSearch } from "@/lib/tools/toolListSearch";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/documents")({
-  validateSearch: (search: Record<string, unknown>): DocumentsSearchParams => ({
-    create: typeof search.create === "string" ? search.create : undefined,
-    initiativeId: typeof search.initiativeId === "string" ? search.initiativeId : undefined,
-    page:
-      typeof search.page === "number" && search.page >= 1
-        ? search.page
-        : typeof search.page === "string" && Number(search.page) >= 1
-          ? Number(search.page)
-          : undefined,
-  }),
+  validateSearch: (search: Record<string, unknown>) => toolListSearch(search, { page: true }),
   component: lazyRouteComponent(() =>
     import("@/pages/DocumentsPage").then((m) => ({ default: m.DocumentsPage }))
   ),

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/events.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/events.tsx
@@ -1,22 +1,9 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-type EventsSearchParams = {
-  create?: string;
-  initiativeId?: string;
-  page?: number;
-};
+import { toolListSearch } from "@/lib/tools/toolListSearch";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/events")({
-  validateSearch: (search: Record<string, unknown>): EventsSearchParams => ({
-    create: typeof search.create === "string" ? search.create : undefined,
-    initiativeId: typeof search.initiativeId === "string" ? search.initiativeId : undefined,
-    page:
-      typeof search.page === "number" && search.page >= 1
-        ? search.page
-        : typeof search.page === "string" && Number(search.page) >= 1
-          ? Number(search.page)
-          : undefined,
-  }),
+  validateSearch: (search: Record<string, unknown>) => toolListSearch(search, { page: true }),
   component: lazyRouteComponent(() =>
     import("@/pages/initiativeTools/events/EventsPage").then((m) => ({ default: m.EventsPage }))
   ),

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/projects.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/projects.tsx
@@ -1,15 +1,9 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-type ProjectsSearchParams = {
-  create?: string;
-  initiativeId?: string;
-};
+import { toolListSearch } from "@/lib/tools/toolListSearch";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/projects")({
-  validateSearch: (search: Record<string, unknown>): ProjectsSearchParams => ({
-    create: typeof search.create === "string" ? search.create : undefined,
-    initiativeId: typeof search.initiativeId === "string" ? search.initiativeId : undefined,
-  }),
+  validateSearch: (search: Record<string, unknown>) => toolListSearch(search),
   component: lazyRouteComponent(() =>
     import("@/pages/ProjectsPage").then((m) => ({ default: m.ProjectsPage }))
   ),

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/queues.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/queues.tsx
@@ -1,22 +1,9 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-type QueuesSearchParams = {
-  create?: string;
-  initiativeId?: string;
-  page?: number;
-};
+import { toolListSearch } from "@/lib/tools/toolListSearch";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/queues")({
-  validateSearch: (search: Record<string, unknown>): QueuesSearchParams => ({
-    create: typeof search.create === "string" ? search.create : undefined,
-    initiativeId: typeof search.initiativeId === "string" ? search.initiativeId : undefined,
-    page:
-      typeof search.page === "number" && search.page >= 1
-        ? search.page
-        : typeof search.page === "string" && Number(search.page) >= 1
-          ? Number(search.page)
-          : undefined,
-  }),
+  validateSearch: (search: Record<string, unknown>) => toolListSearch(search, { page: true }),
   component: lazyRouteComponent(() =>
     import("@/pages/initiativeTools/queues/QueuesPage").then((m) => ({ default: m.QueuesPage }))
   ),


### PR DESCRIPTION
## Problem

The app's per-initiative "tools" — **project, document, queue, counter group, calendar event, advanced tool** — were hand-written **one copy per tool** across ~8 files and 5+ parallel structures (sidebar, initiative tabs, feature-flag/permission helpers, settings toggles, command palette, icons). There was no central tool concept, so every new tool (and every new surface) meant editing the same list in many places, and asymmetries crept in: `advanced_tool` was a runtime-gated special case, counter groups were missing from the initiative create menu, and the access hook silently dropped `advanced_tool`'s create permission.

## Approach

Introduce **one source of truth** — `frontend/src/lib/tools/registry.tsx` — a declarative `ToolDef[]` (id, icon, section, enable flag, view/create permission keys, membership keys, list route, DAC/shareable, settings toggle) plus small derived helpers (`TOOL_BY_ID`, `toolIcon`, `fullToolAccess`/`membershipToolAccess`/`readOnlyToolAccess`, `toolsInSection`, `TOGGLEABLE_TOOLS`). Every surface renders **from** it.

## Notable changes

- **Sidebar** (`InitiativeSection`): five copy-pasted `<SidebarMenuItem>` blocks + the special-cased advanced-tool block collapse into one `<ToolNavRow>` mapped over the registry. `AppSidebar` drops from **10 per-tool props** to an `access` map + `counts` map. The per-initiative mobile "+" menu now includes **counter groups** (previously missing).
- **Initiative tabs** (`InitiativeDetailPage`): tabs derive from the registry; visibility + create read straight from the resolved permission keys.
- **Access/permissions**: `useInitiativeAccess.permissionsFor` returns a **Tool-keyed access map** (fixing `advanced_tool` create being silently dropped); `useInitiativeRoles` derives its permission label keys + permission-card groups from the registry (dead `PERMISSION_LABELS` / `ALL_PERMISSION_KEYS` / `PERMISSION_GROUPS` removed).
- **Settings toggles** (`AdvancedToolsSection`) render from the registry; the settings + create forms collapse their per-tool prop-drilling into a single `(flag, value)` handler.
- **Icons**: `recentIcon` + the command palette's queue/counter icons now read from the registry, so they can't drift from the sidebar.
- **Command palette**: gains **create-from-anywhere** for project / queue / counter group (their dialogs carry an initiative picker). Events + advanced-tool are intentionally excluded — their create requires a pre-selected initiative context.

## Scope note

`BottomNav`'s fallback create menu (Task/Document, wizard-backed and guild-agnostic) is left as-is: it renders on personal/non-guild pages too, and adding guild-scoped `?create=true` navigation there has no-active-guild edge cases that belong in a separate change.

## Stats

**−368 lines across 15 consumer files**, replaced by one ~330-line declarative registry. Adding a tool — or wiring an existing one into a new surface — is now a single edit, and cross-surface drift is structurally prevented.

## Testing

- `pnpm typecheck` — clean
- `pnpm biome check` — clean (one pre-existing, unrelated CSS warning)
- `pnpm vitest run src/components/access/ShareControl.test.tsx` — 5 passed

No changelog entry: this is primarily an internal refactor (the small command-palette additions aside). Happy to add one if preferred.