### PR TITLE
Derive tool naming and surfaces from the Tool enum (backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Calendar events now appear in the recent-items tabs bar, like projects, documents, queues, and counter groups.
+
+### Changed
+
+- **Canonical tool naming across the API (breaking, pre-v1).** Every per-tool name now derives from one canonical tool enum: initiative master switches (`events_enabled` → `calendar_events_enabled`, `counters_enabled` → `counter_groups_enabled`, `advanced_tool_enabled` → `advanced_tools_enabled`), role permission keys (`docs_enabled`/`create_docs` → `documents_enabled`/`create_documents`, `create_events` → `create_calendar_events`, `create_counters` → `create_counter_groups`, `create_advanced_tool` → `create_advanced_tools`), and the per-member permission flags (`can_view_docs` → `can_view_documents`, `can_view_events` → `can_view_calendar_events`, `can_view_counters` → `can_view_counter_groups`, `can_view_advanced_tool` → `can_view_advanced_tools`, plus the matching `can_create_*`). A guild migration renames the columns and rewrites stored permission keys; no compatibility shims. The advanced-tool embed handoff now reads `advanced_tools_enabled` and the `create_advanced_tools` claim — external embed backends must follow the rename.
+- Permission keys, initiative switch fields, membership permission flags, and recents entity types are now all derived from the tool enum in code (with CI drift tests), so adding a tool wires every backend surface automatically.
+
 ### Fixed
 
 - Trashed counter groups and counters now auto-purge after their retention window, like every other trashed item — previously they lingered in the database indefinitely once past retention.

--- a/backend/alembic/versions/20260704_0128_canonical_tool_naming.py
+++ b/backend/alembic/versions/20260704_0128_canonical_tool_naming.py
@@ -1,0 +1,173 @@
+"""canonical tool naming
+
+Rename every per-tool name to the stem derived from the canonical ``Tool``
+enum (``{plural}_enabled`` / ``create_{plural}`` / ``can_view_{plural}``):
+
+- ``initiatives`` master-switch columns: ``events_enabled`` →
+  ``calendar_events_enabled``, ``advanced_tool_enabled`` →
+  ``advanced_tools_enabled``, ``counters_enabled`` → ``counter_groups_enabled``.
+- ``initiative_role_permissions.permission_key`` values rewritten to the new
+  ``PermissionKey`` spellings (stored strings, part of the composite PK; the
+  mapping is injective so no conflicts are possible).
+- ``recent_views`` CHECK constraint extended with ``calendar_event`` (recents
+  now cover calendar events).
+
+Pre-v1 breaking rename — no compatibility shims, downgrade restores the old
+names exactly.
+"""
+
+from alembic import op
+
+from app.db.guild_migrations import run_for_each_guild_schema
+
+revision = "20260704_0128"
+down_revision = "20260704_0127"
+branch_labels = None
+depends_on = None
+
+
+_COLUMN_RENAMES = [
+    ("events_enabled", "calendar_events_enabled"),
+    ("advanced_tool_enabled", "advanced_tools_enabled"),
+    ("counters_enabled", "counter_groups_enabled"),
+]
+
+_PERMISSION_KEY_RENAMES = [
+    ("docs_enabled", "documents_enabled"),
+    ("create_docs", "create_documents"),
+    ("events_enabled", "calendar_events_enabled"),
+    ("create_events", "create_calendar_events"),
+    ("advanced_tool_enabled", "advanced_tools_enabled"),
+    ("create_advanced_tool", "create_advanced_tools"),
+    ("counters_enabled", "counter_groups_enabled"),
+    ("create_counters", "create_counter_groups"),
+]
+
+_OLD_RECENT_TYPES = (
+    "'project'::text, 'document'::text, 'queue'::text, 'counter_group'::text"
+)
+_NEW_RECENT_TYPES = _OLD_RECENT_TYPES + ", 'calendar_event'::text"
+
+_OLD_PERMISSION_KEYS = [
+    "docs_enabled",
+    "projects_enabled",
+    "create_docs",
+    "create_projects",
+    "queues_enabled",
+    "create_queues",
+    "events_enabled",
+    "create_events",
+    "advanced_tool_enabled",
+    "create_advanced_tool",
+    "counters_enabled",
+    "create_counters",
+]
+_NEW_PERMISSION_KEYS = [
+    dict(_PERMISSION_KEY_RENAMES).get(key, key) for key in _OLD_PERMISSION_KEYS
+]
+
+
+def _rewrite_permission_keys(renames: list[tuple[str, str]]) -> None:
+    cases = " ".join(
+        f"WHEN permission_key = '{old}' THEN '{new}'" for old, new in renames
+    )
+    olds = ", ".join(f"'{old}'" for old, _new in renames)
+    op.execute(
+        f"UPDATE initiative_role_permissions "
+        f"SET permission_key = CASE {cases} ELSE permission_key END "
+        f"WHERE permission_key IN ({olds})"
+    )
+
+
+def _swap_permission_key_check(keys: list[str]) -> None:
+    values = ", ".join(f"'{key}'" for key in keys)
+    op.execute(
+        "ALTER TABLE initiative_role_permissions "
+        "DROP CONSTRAINT IF EXISTS ck_initiative_role_permissions_permission_key"
+    )
+    op.execute(
+        "ALTER TABLE initiative_role_permissions "
+        "ADD CONSTRAINT ck_initiative_role_permissions_permission_key "
+        f"CHECK (permission_key::text = ANY (ARRAY[{values}]::text[]))"
+    )
+
+
+def _swap_recent_check(types: str) -> None:
+    op.execute(
+        "ALTER TABLE recent_views DROP CONSTRAINT IF EXISTS ck_recent_views_entity_type"
+    )
+    op.execute(
+        "ALTER TABLE recent_views ADD CONSTRAINT ck_recent_views_entity_type "
+        f"CHECK (entity_type = ANY (ARRAY[{types}]))"
+    )
+
+
+def _recent_views_trigger_fn(entity_tables: list[tuple[str, str]]) -> str:
+    """Render public.fn_recent_views_set_guild_id with one CASE arm per
+    recentable entity type (the trigger denormalizes guild_id from the entity's
+    own table; a type with no arm makes every INSERT fail with
+    CaseNotFoundError)."""
+    arms = "\n".join(
+        f"""                    WHEN '{etype}' THEN
+                        SELECT guild_id INTO NEW.guild_id FROM {table}
+                        WHERE id = NEW.entity_id;"""
+        for etype, table in entity_tables
+    )
+    return f"""
+        CREATE OR REPLACE FUNCTION public.fn_recent_views_set_guild_id() RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF NEW.guild_id IS NULL OR (TG_OP = 'UPDATE' AND (
+                OLD.entity_type IS DISTINCT FROM NEW.entity_type
+                OR OLD.entity_id IS DISTINCT FROM NEW.entity_id
+            )) THEN
+                CASE NEW.entity_type
+{arms}
+                END CASE;
+            END IF;
+            RETURN NEW;
+        END;
+        $$
+    """
+
+
+_OLD_ENTITY_TABLES = [
+    ("project", "projects"),
+    ("document", "documents"),
+    ("queue", "queues"),
+    ("counter_group", "counter_groups"),
+]
+_NEW_ENTITY_TABLES = _OLD_ENTITY_TABLES + [("calendar_event", "calendar_events")]
+
+
+def upgrade() -> None:
+    # Shared public-schema trigger function: one replacement, not per guild.
+    op.execute(_recent_views_trigger_fn(_NEW_ENTITY_TABLES))
+    run_for_each_guild_schema(op.get_bind(), _apply_upgrade)
+
+
+def _apply_upgrade() -> None:
+    for old, new in _COLUMN_RENAMES:
+        op.alter_column("initiatives", old, new_column_name=new)
+    # Constraint first (widened), then the data rewrite, then re-pin to the
+    # new values only.
+    _swap_permission_key_check(_OLD_PERMISSION_KEYS + _NEW_PERMISSION_KEYS)
+    _rewrite_permission_keys(_PERMISSION_KEY_RENAMES)
+    _swap_permission_key_check(_NEW_PERMISSION_KEYS)
+    _swap_recent_check(_NEW_RECENT_TYPES)
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_downgrade)
+    op.execute(_recent_views_trigger_fn(_OLD_ENTITY_TABLES))
+
+
+def _apply_downgrade() -> None:
+    op.execute("DELETE FROM recent_views WHERE entity_type = 'calendar_event'")
+    _swap_recent_check(_OLD_RECENT_TYPES)
+    _swap_permission_key_check(_OLD_PERMISSION_KEYS + _NEW_PERMISSION_KEYS)
+    _rewrite_permission_keys([(new, old) for old, new in _PERMISSION_KEY_RENAMES])
+    _swap_permission_key_check(_OLD_PERMISSION_KEYS)
+    for old, new in _COLUMN_RENAMES:
+        op.alter_column("initiatives", new, new_column_name=old)

--- a/backend/app/api/resource_access.py
+++ b/backend/app/api/resource_access.py
@@ -79,7 +79,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.queue: ResourceAccessConfig(
         dac_kind=Tool.queue,
-        feature_attr="queues_enabled",
+        feature_attr=Tool.queue.view_permission,
         feature_disabled_msg=QueueMessages.FEATURE_DISABLED,
         loader=queues_service.get_queue,
         path_param="queue_id",
@@ -87,7 +87,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.counter_group: ResourceAccessConfig(
         dac_kind=Tool.counter_group,
-        feature_attr="counters_enabled",
+        feature_attr=Tool.counter_group.view_permission,
         feature_disabled_msg=CounterMessages.FEATURE_DISABLED,
         grant_cannot_manage_msg=CounterMessages.GRANT_CANNOT_MANAGE,
         loader=counters_service.get_counter_group,
@@ -96,7 +96,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.calendar_event: ResourceAccessConfig(
         dac_kind=Tool.calendar_event,
-        feature_attr="events_enabled",
+        feature_attr=Tool.calendar_event.view_permission,
         feature_disabled_msg=CalendarEventMessages.FEATURE_DISABLED,
         grant_cannot_manage_msg=CalendarEventMessages.GRANT_CANNOT_MANAGE_MEMBERS,
         loader=calendar_events_service.get_event,
@@ -108,7 +108,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
         # Only checked for initiative-scoped rows; a guild-wide advanced tool has
         # no initiative, so authorize() skips the feature gate (it's admin-only
         # by RLS instead).
-        feature_attr="advanced_tool_enabled",
+        feature_attr=Tool.advanced_tool.view_permission,
         feature_disabled_msg=AdvancedToolMessages.NOT_ENABLED,
         grant_cannot_manage_msg=AdvancedToolMessages.GRANT_CANNOT_MANAGE_MEMBERS,
         loader=advanced_tool_service.get_advanced_tool,

--- a/backend/app/api/v1/tenant_endpoints/advanced_tool.py
+++ b/backend/app/api/v1/tenant_endpoints/advanced_tool.py
@@ -6,7 +6,7 @@ its ``data`` blob is what the service runs. Authorization goes through the share
 ``resource_access`` enforcement path.
 
 Scope: ``initiative_id`` set → an initiative-scoped tool (needs
-``advanced_tool_enabled`` + the create permission, shared via ``resource_grants``).
+``advanced_tools_enabled`` + the create permission, shared via ``resource_grants``).
 ``initiative_id`` NULL → **guild-wide**, which only a guild admin may create, and
 which is admin-only by RLS (no per-user grants).
 """
@@ -81,7 +81,7 @@ async def list_advanced_tools(
 
     if initiative_id is not None:
         initiative = await session.get(Initiative, initiative_id)
-        if initiative and not initiative.advanced_tool_enabled:
+        if initiative and not initiative.advanced_tools_enabled:
             return AdvancedToolListResponse(
                 items=[], total_count=0, page=page, page_size=page_size, has_next=False
             )
@@ -95,7 +95,7 @@ async def list_advanced_tools(
                 AdvancedTool.initiative_id.is_(None),
                 AdvancedTool.initiative_id.in_(
                     select(Initiative.id).where(
-                        Initiative.advanced_tool_enabled == True  # noqa: E712
+                        Initiative.advanced_tools_enabled == True  # noqa: E712
                     )
                 ),
             )
@@ -199,7 +199,7 @@ async def create_advanced_tool(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=InitiativeMessages.NOT_FOUND,
             )
-        if not initiative.advanced_tool_enabled:
+        if not initiative.advanced_tools_enabled:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=AdvancedToolMessages.NOT_ENABLED,
@@ -209,7 +209,7 @@ async def create_advanced_tool(
                 session,
                 initiative_id=initiative.id,
                 user=current_user,
-                permission_key=PermissionKey.create_advanced_tool,
+                permission_key=PermissionKey.create_advanced_tools,
             )
             if not has_perm:
                 raise HTTPException(

--- a/backend/app/api/v1/tenant_endpoints/advanced_tool_test.py
+++ b/backend/app/api/v1/tenant_endpoints/advanced_tool_test.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.integration
 async def _enable_advanced_tool(session: AsyncSession, initiative) -> None:
     await route_session_to_guild(session, initiative.guild_id)
     init = await session.get(Initiative, initiative.id)
-    init.advanced_tool_enabled = True
+    init.advanced_tools_enabled = True
     session.add(init)
     await session.commit()
 

--- a/backend/app/api/v1/tenant_endpoints/calendar_events.py
+++ b/backend/app/api/v1/tenant_endpoints/calendar_events.py
@@ -1,7 +1,7 @@
 """Calendar event endpoints — CRUD, attendees, tags, and documents.
 
 Initiative-scoped calendar events. Creation is gated at the initiative level
-(events_enabled + create_events); per-event access is the unified resource-grant
+(calendar_events_enabled + create_calendar_events); per-event access is the unified resource-grant
 DAC (``resource_grants`` + ``PUT /{id}/grants``), like the other resources.
 """
 
@@ -60,6 +60,8 @@ from app.services.cross_guild import gather_across_guilds, member_guild_ids
 from app.services.tenant import ical_service
 from app.services import notifications as notifications_service
 from app.services.tenant import properties as properties_service
+from app.services.tenant import recent_views as recent_views_service
+from app.schemas.tenant.recent_view import RecentViewWrite
 from app.services import rls as rls_service
 
 router = APIRouter()
@@ -136,7 +138,7 @@ async def _get_event_or_404(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=CalendarEventMessages.NOT_FOUND,
         )
-    # Feature gate + per-event DAC. Writes additionally gate on create_events in
+    # Feature gate + per-event DAC. Writes additionally gate on create_calendar_events in
     # the handler, so read access here is sufficient.
     resource_access.authorize(
         Tool.calendar_event, event, user, access=access, guild_role=guild_context.role
@@ -211,7 +213,7 @@ async def list_my_calendar_events(
 
     def _fetch(guild_session, guild_id):  # type: ignore[no-untyped-def]
         conditions = [
-            Initiative.events_enabled == True,  # noqa: E712
+            Initiative.calendar_events_enabled == True,  # noqa: E712
         ]
         if start_after is not None:
             conditions.append(CalendarEvent.start_at >= start_after)
@@ -293,7 +295,7 @@ async def export_calendar_events_ics(
     else:
         conditions.append(
             CalendarEvent.initiative_id.in_(
-                select(Initiative.id).where(Initiative.events_enabled == True)  # noqa: E712
+                select(Initiative.id).where(Initiative.calendar_events_enabled == True)  # noqa: E712
             )
         )
     if start_after is not None:
@@ -338,7 +340,7 @@ async def export_my_calendar_events_ics(
 
     def _fetch(guild_session, guild_id):  # type: ignore[no-untyped-def]
         conditions = [
-            Initiative.events_enabled == True,  # noqa: E712
+            Initiative.calendar_events_enabled == True,  # noqa: E712
         ]
         if start_after is not None:
             conditions.append(CalendarEvent.start_at >= start_after)
@@ -409,7 +411,7 @@ async def import_ical_events(
         initiative,
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
 
     try:
@@ -467,7 +469,7 @@ async def list_calendar_events(
 
     if initiative_id is not None:
         initiative = await session.get(Initiative, initiative_id)
-        if initiative and not initiative.events_enabled:
+        if initiative and not initiative.calendar_events_enabled:
             return CalendarEventListResponse(
                 items=[],
                 total_count=0,
@@ -479,7 +481,7 @@ async def list_calendar_events(
     else:
         conditions.append(
             CalendarEvent.initiative_id.in_(
-                select(Initiative.id).where(Initiative.events_enabled == True)  # noqa: E712
+                select(Initiative.id).where(Initiative.calendar_events_enabled == True)  # noqa: E712
             )
         )
 
@@ -579,9 +581,9 @@ async def create_calendar_event(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> CalendarEventRead:
-    """Create a calendar event. Requires create_events permission."""
+    """Create a calendar event. Requires create_calendar_events permission."""
     initiative = await _get_initiative_for_event(session, event_in.initiative_id)
-    if not initiative.events_enabled:
+    if not initiative.calendar_events_enabled:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=CalendarEventMessages.FEATURE_DISABLED,
@@ -591,7 +593,7 @@ async def create_calendar_event(
         initiative,
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
 
     recurrence_json = None
@@ -688,14 +690,14 @@ async def update_calendar_event(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> CalendarEventRead:
-    """Update a calendar event. Requires create_events permission on the initiative."""
+    """Update a calendar event. Requires create_calendar_events permission on the initiative."""
     event = await _get_event_or_404(session, event_id, current_user, guild_context)
     await _check_initiative_permission(
         session,
         await _get_initiative_for_event(session, event.initiative_id),
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
 
     # Snapshot fields that drive the "updated"/"rescheduled" notification before
@@ -782,7 +784,7 @@ async def delete_calendar_event(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> None:
-    """Soft-delete a calendar event. Requires create_events permission or guild admin."""
+    """Soft-delete a calendar event. Requires create_calendar_events permission or guild admin."""
     from app.services.platform import guilds as guilds_service
     from app.services.tenant.soft_delete import soft_delete_entity
 
@@ -792,7 +794,7 @@ async def delete_calendar_event(
         await _get_initiative_for_event(session, event.initiative_id),
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
     retention_days = await guilds_service.get_guild_retention_days(
         session, guild_context.guild_id
@@ -834,14 +836,14 @@ async def set_attendees(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> CalendarEventRead:
-    """Set attendees. Requires create_events permission."""
+    """Set attendees. Requires create_calendar_events permission."""
     event = await _get_event_or_404(session, event_id, current_user, guild_context)
     await _check_initiative_permission(
         session,
         await _get_initiative_for_event(session, event.initiative_id),
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
     old_ids = {a.user_id for a in event.attendees}
     await events_service.set_event_attendees(
@@ -927,7 +929,7 @@ async def set_tags(
         await _get_initiative_for_event(session, event.initiative_id),
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
     await events_service.set_event_tags(session, event, tag_ids, guild_context.guild_id)
     await session.commit()
@@ -949,7 +951,7 @@ async def set_documents(
         await _get_initiative_for_event(session, event.initiative_id),
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
     await events_service.set_event_documents(
         session,
@@ -979,7 +981,7 @@ async def set_event_properties(
     """Replace-all set of property values on an event.
 
     Mirrors the tasks/documents shape: any initiative member with
-    ``create_events`` (or guild admin) can attach values; cross-initiative
+    ``create_calendar_events`` (or guild admin) can attach values; cross-initiative
     definitions return 404 DEFINITION_NOT_FOUND via the service layer.
     """
     event = await _get_event_or_404(session, event_id, current_user, guild_context)
@@ -988,7 +990,7 @@ async def set_event_properties(
         await _get_initiative_for_event(session, event.initiative_id),
         current_user,
         guild_context,
-        PermissionKey.create_events,
+        PermissionKey.create_calendar_events,
     )
     await properties_service.set_event_property_values(
         session, event, payload.values, initiative_id=event.initiative_id
@@ -1020,3 +1022,51 @@ async def set_calendar_event_grants(
     )
     hydrated = await _refetch_event(session, event_id)
     return serialize_calendar_event(hydrated, user_id=current_user.id)
+
+
+# ---------------------------------------------------------------------------
+# Recent-view tracking (powers the layout header tabs bar)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{event_id}/view", response_model=RecentViewWrite)
+async def record_calendar_event_view(
+    event_id: int,
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> RecentViewWrite:
+    event = await _get_event_or_404(
+        session, event_id, current_user, guild_context, access="read"
+    )
+    record = await recent_views_service.record_view(
+        session,
+        user_id=current_user.id,
+        entity_type="calendar_event",
+        entity_id=event.id,
+        persist=not guild_context.is_pam,
+        limit=current_user.recent_tabs_limit,
+    )
+    return RecentViewWrite(
+        entity_type="calendar_event",
+        entity_id=event.id,
+        last_viewed_at=record.last_viewed_at,
+    )
+
+
+@router.delete("/{event_id}/view", status_code=status.HTTP_204_NO_CONTENT)
+async def clear_calendar_event_view(
+    event_id: int,
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> None:
+    event = await _get_event_or_404(
+        session, event_id, current_user, guild_context, access="read"
+    )
+    await recent_views_service.clear_view(
+        session,
+        user_id=current_user.id,
+        entity_type="calendar_event",
+        entity_id=event.id,
+    )

--- a/backend/app/api/v1/tenant_endpoints/calendar_events_test.py
+++ b/backend/app/api/v1/tenant_endpoints/calendar_events_test.py
@@ -37,7 +37,7 @@ async def _notifications_for(
 
 async def _enable_events(session: AsyncSession, initiative):
     """Toggle the events feature flag on and persist it."""
-    initiative.events_enabled = True
+    initiative.calendar_events_enabled = True
     session.add(initiative)
     await session.commit()
     await session.refresh(initiative)

--- a/backend/app/api/v1/tenant_endpoints/counters.py
+++ b/backend/app/api/v1/tenant_endpoints/counters.py
@@ -232,7 +232,7 @@ async def list_counter_groups(
 
     if initiative_id is not None:
         initiative = await session.get(Initiative, initiative_id)
-        if initiative and not initiative.counters_enabled:
+        if initiative and not initiative.counter_groups_enabled:
             return CounterGroupListResponse(
                 items=[],
                 total_count=0,
@@ -244,7 +244,7 @@ async def list_counter_groups(
     else:
         conditions.append(
             CounterGroup.initiative_id.in_(
-                select(Initiative.id).where(Initiative.counters_enabled == True)  # noqa: E712
+                select(Initiative.id).where(Initiative.counter_groups_enabled == True)  # noqa: E712
             )
         )
 
@@ -320,7 +320,7 @@ async def create_counter_group(
     initiative = await _get_initiative_for_counter_group(
         session, group_in.initiative_id
     )
-    if not initiative.counters_enabled:
+    if not initiative.counter_groups_enabled:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=CounterMessages.FEATURE_DISABLED,
@@ -330,7 +330,7 @@ async def create_counter_group(
         initiative,
         current_user,
         guild_context,
-        PermissionKey.create_counters,
+        PermissionKey.create_counter_groups,
     )
 
     group = CounterGroup(
@@ -935,7 +935,7 @@ async def websocket_counter_group(
         # Mirror the feature gate enforced on every HTTP endpoint via
         # _get_counter_group_with_access — don't stream events for a group
         # whose initiative has counters disabled.
-        if group.initiative and not group.initiative.counters_enabled:
+        if group.initiative and not group.initiative.counter_groups_enabled:
             logger.warning(f"Counter WS: counters disabled for group {group_id}")
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
             return

--- a/backend/app/api/v1/tenant_endpoints/counters_test.py
+++ b/backend/app/api/v1/tenant_endpoints/counters_test.py
@@ -113,7 +113,7 @@ async def test_feature_disabled_blocks_creation(
     client: AsyncClient, session: AsyncSession, acting_user
 ):
     a = await acting_user(guild_role=GuildRole.admin, initiative=True)
-    a.initiative.counters_enabled = False
+    a.initiative.counter_groups_enabled = False
     await session.commit()
 
     response = await client.post(

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -191,7 +191,7 @@ async def _require_initiative_access(
         user: User to check
         guild_role: User's guild role (admins bypass checks)
         require_manager: If True, require manager-level role (legacy, use permission_key instead)
-        permission_key: Specific permission to check (e.g., PermissionKey.create_docs)
+        permission_key: Specific permission to check (e.g., PermissionKey.create_documents)
     """
     if rls_service.is_guild_admin(guild_role):
         return
@@ -839,7 +839,7 @@ async def create_document(
         initiative_id=initiative.id,
         user=current_user,
         guild_role=guild_context.role,
-        permission_key=PermissionKey.create_docs,
+        permission_key=PermissionKey.create_documents,
     )
     title = document_in.title.strip()
     if not title:
@@ -945,7 +945,7 @@ async def upload_document_file(
         initiative_id=initiative.id,
         user=current_user,
         guild_role=guild_context.role,
-        permission_key=PermissionKey.create_docs,
+        permission_key=PermissionKey.create_documents,
     )
     title = title.strip()
     if not title:
@@ -1570,13 +1570,13 @@ async def copy_document(
         initiative_id=payload.target_initiative_id,
         guild_id=guild_context.guild_id,
     )
-    # Also require create_docs permission in target initiative
+    # Also require create_documents permission in target initiative
     await _require_initiative_access(
         session,
         initiative_id=target_initiative.id,
         user=current_user,
         guild_role=guild_context.role,
-        permission_key=PermissionKey.create_docs,
+        permission_key=PermissionKey.create_documents,
     )
     title = (payload.title or document.title).strip()
     if not title:

--- a/backend/app/api/v1/tenant_endpoints/documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_test.py
@@ -258,7 +258,7 @@ async def test_copy_template_with_read_only_access(
 ):
     """A user with only read on a template can still copy it into a new document."""
     template_owner = await acting_user(guild_role=GuildRole.admin, initiative=True)
-    # Reader needs create_docs in the target initiative; PM role grants it by default.
+    # Reader needs create_documents in the target initiative; PM role grants it by default.
     reader = await acting_user(
         guild_role=GuildRole.member,
         guild=template_owner.guild,

--- a/backend/app/api/v1/tenant_endpoints/events_properties_test.py
+++ b/backend/app/api/v1/tenant_endpoints/events_properties_test.py
@@ -33,7 +33,7 @@ from app.testing import (
 
 async def _enable_events(session: AsyncSession, initiative):
     """Toggle the events feature flag on and persist it."""
-    initiative.events_enabled = True
+    initiative.calendar_events_enabled = True
     session.add(initiative)
     await session.commit()
     await session.refresh(initiative)

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -21,6 +21,7 @@ from app.core.messages import (
 )
 from app.core.security import create_advanced_tool_handoff_token
 from app.core.config import settings
+from app.core.tools import CORE_TOOLS, TOGGLEABLE_TOOLS, Tool
 from app.models.platform.access_grant import AccessLevel
 from app.models.tenant.document import Document
 from app.models.tenant.project import Project
@@ -269,10 +270,12 @@ async def create_initiative(
         name=initiative_in.name,
         description=initiative_in.description,
         guild_id=guild_id,
-        queues_enabled=initiative_in.queues_enabled,
-        events_enabled=initiative_in.events_enabled,
-        advanced_tool_enabled=initiative_in.advanced_tool_enabled,
-        counters_enabled=initiative_in.counters_enabled,
+        # One master switch per toggleable tool, derived — a new Tool member
+        # flows through without touching this endpoint.
+        **{
+            t.view_permission: getattr(initiative_in, t.view_permission)
+            for t in TOGGLEABLE_TOOLS
+        },
     )
     if initiative_in.color:
         initiative.color = initiative_in.color
@@ -627,6 +630,11 @@ async def get_my_initiative_permissions(
         initiative_id, session, guild_context.guild_id
     )
 
+    # Whether a tool is available in this initiative at all: core tools always,
+    # toggleable tools per their master switch.
+    def tool_available(t: Tool) -> bool:
+        return t in CORE_TOOLS or bool(getattr(initiative, t.view_permission))
+
     # Guild admins have all permissions
     if rls_service.is_guild_admin(guild_context.role):
         return MyInitiativePermissions(
@@ -634,20 +642,11 @@ async def get_my_initiative_permissions(
             # Guild admins view/edit everything regardless of sharing.
             override_share_restrictions=True,
             permissions={
-                "docs_enabled": True,
-                "projects_enabled": True,
-                "create_docs": True,
-                "create_projects": True,
-                "queues_enabled": initiative.queues_enabled,
-                "create_queues": initiative.queues_enabled,
-                "events_enabled": initiative.events_enabled,
-                "create_events": initiative.events_enabled,
-                "advanced_tool_enabled": initiative.advanced_tool_enabled,
-                "create_advanced_tool": initiative.advanced_tool_enabled,
-                "counters_enabled": initiative.counters_enabled,
-                "create_counters": initiative.counters_enabled,
+                PermissionKey(key): tool_available(t)
+                for t in Tool
+                for key in (t.view_permission, t.create_permission)
             },
-            advanced_tool_enabled=initiative.advanced_tool_enabled,
+            advanced_tools_enabled=initiative.advanced_tools_enabled,
         )
 
     # PAM grantee: time-bound, guild-wide access with no membership row. They
@@ -662,20 +661,13 @@ async def get_my_initiative_permissions(
         return MyInitiativePermissions(
             is_manager=False,
             permissions={
-                "docs_enabled": True,
-                "projects_enabled": True,
-                "create_docs": can_write,
-                "create_projects": can_write,
-                "queues_enabled": initiative.queues_enabled,
-                "create_queues": initiative.queues_enabled and can_write,
-                "events_enabled": initiative.events_enabled,
-                "create_events": initiative.events_enabled and can_write,
-                "advanced_tool_enabled": initiative.advanced_tool_enabled,
-                "create_advanced_tool": initiative.advanced_tool_enabled and can_write,
-                "counters_enabled": initiative.counters_enabled,
-                "create_counters": initiative.counters_enabled and can_write,
+                **{PermissionKey(t.view_permission): tool_available(t) for t in Tool},
+                **{
+                    PermissionKey(t.create_permission): tool_available(t) and can_write
+                    for t in Tool
+                },
             },
-            advanced_tool_enabled=initiative.advanced_tool_enabled,
+            advanced_tools_enabled=initiative.advanced_tools_enabled,
         )
 
     membership = await initiatives_service.get_initiative_membership_with_role(
@@ -697,28 +689,14 @@ async def get_my_initiative_permissions(
         perm.permission_key: perm.enabled for perm in (role.permissions or [])
     }
 
-    # Initiative-level master switch overrides role-level queue permissions
-    if not initiative.queues_enabled:
-        permissions[PermissionKey.queues_enabled] = False
-        permissions[PermissionKey.create_queues] = False
-
-    # Initiative-level master switch overrides role-level event permissions
-    if not initiative.events_enabled:
-        permissions[PermissionKey.events_enabled] = False
-        permissions[PermissionKey.create_events] = False
-
-    # Same pattern for advanced tool: master switch overrides per-role keys
-    # so members of an initiative whose toggle is off never see the panel
+    # Initiative-level master switches override role-level permissions, so
+    # members of an initiative whose toggle is off never see the tool
     # regardless of what their role permits.
-    if not initiative.advanced_tool_enabled:
-        permissions[PermissionKey.advanced_tool_enabled] = False
-        permissions[PermissionKey.create_advanced_tool] = False
-    advanced_tool_enabled = initiative.advanced_tool_enabled
-
-    # Initiative-level master switch overrides role-level counters permissions
-    if not initiative.counters_enabled:
-        permissions[PermissionKey.counters_enabled] = False
-        permissions[PermissionKey.create_counters] = False
+    for t in TOGGLEABLE_TOOLS:
+        if not tool_available(t):
+            permissions[PermissionKey(t.view_permission)] = False
+            permissions[PermissionKey(t.create_permission)] = False
+    advanced_tools_enabled = initiative.advanced_tools_enabled
 
     return MyInitiativePermissions(
         role_id=role.id,
@@ -727,7 +705,7 @@ async def get_my_initiative_permissions(
         is_manager=role.is_manager,
         override_share_restrictions=role.override_share_restrictions,
         permissions=permissions,
-        advanced_tool_enabled=advanced_tool_enabled,
+        advanced_tools_enabled=advanced_tools_enabled,
     )
 
 
@@ -754,15 +732,15 @@ async def create_advanced_tool_handoff(
       1. The deployment must have ADVANCED_TOOL_URL configured.
       2. The initiative must exist in the active guild.
       3. The user must be a guild admin OR an initiative member.
-      4. The initiative must have advanced_tool_enabled=true.
+      4. The initiative must have advanced_tools_enabled=true.
       5. The user's initiative role must include the
-         ``advanced_tool_enabled`` permission key. Guild admins and
+         ``advanced_tools_enabled`` permission key. Guild admins and
          initiative managers bypass step 5 since they're trusted by
          construction.
 
     The returned token has audience=initiative:advanced-tool and a 60s
     expiry. The SPA passes it via postMessage (never URL/query string).
-    The ``can_create`` claim forwards the create_advanced_tool permission
+    The ``can_create`` claim forwards the create_advanced_tools permission
     so the proprietary backend can hide create UI for view-only members.
     """
     if not settings.ADVANCED_TOOL_URL:
@@ -778,7 +756,7 @@ async def create_advanced_tool_handoff(
     # Master switch: per-initiative toggle owned by an initiative manager.
     # If off, even a guild admin can't open the panel — the data plane on
     # the proprietary side may not even know this initiative exists yet.
-    if not initiative.advanced_tool_enabled:
+    if not initiative.advanced_tools_enabled:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=AdvancedToolMessages.NOT_ENABLED,
@@ -807,12 +785,12 @@ async def create_advanced_tool_handoff(
     if not is_manager and role_ref:
         for perm in role_ref.permissions or []:
             if (
-                perm.permission_key == PermissionKey.advanced_tool_enabled
+                perm.permission_key == PermissionKey.advanced_tools_enabled
                 and perm.enabled
             ):
                 can_view = True
             elif (
-                perm.permission_key == PermissionKey.create_advanced_tool
+                perm.permission_key == PermissionKey.create_advanced_tools
                 and perm.enabled
             ):
                 can_create = True

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -702,8 +702,8 @@ async def test_initiative_guild_isolation(
 #   1. ADVANCED_TOOL_URL configured
 #   2. Initiative exists in the active guild
 #   3. User is guild admin OR initiative member
-#   4. initiative.advanced_tool_enabled = true
-#   5. User's role grants advanced_tool_enabled (managers bypass)
+#   4. initiative.advanced_tools_enabled = true
+#   5. User's role grants advanced_tools_enabled (managers bypass)
 # ---------------------------------------------------------------------------
 
 
@@ -720,7 +720,7 @@ async def test_advanced_tool_handoff_returns_404_when_url_unset(
 
     admin = await acting_user(guild_role=GuildRole.admin)
     initiative = await create_initiative(
-        session, admin.guild, admin.user, name="Init", advanced_tool_enabled=True
+        session, admin.guild, admin.user, name="Init", advanced_tools_enabled=True
     )
 
     response = await client.post(
@@ -745,7 +745,7 @@ async def test_advanced_tool_handoff_returns_403_when_master_switch_off(
 
     admin = await acting_user(guild_role=GuildRole.admin)
     initiative = await create_initiative(
-        session, admin.guild, admin.user, name="Init", advanced_tool_enabled=False
+        session, admin.guild, admin.user, name="Init", advanced_tools_enabled=False
     )
 
     response = await client.post(
@@ -771,7 +771,7 @@ async def test_advanced_tool_handoff_returns_403_for_non_member(
     admin = await acting_user(guild_role=GuildRole.admin)
     outsider = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
     initiative = await create_initiative(
-        session, admin.guild, admin.user, name="Init", advanced_tool_enabled=True
+        session, admin.guild, admin.user, name="Init", advanced_tools_enabled=True
     )
 
     response = await client.post(
@@ -787,7 +787,7 @@ async def test_advanced_tool_handoff_returns_403_when_role_lacks_view_permission
     client: AsyncClient, session: AsyncSession, acting_user, monkeypatch
 ):
     """An initiative member whose role does NOT grant
-    ``advanced_tool_enabled`` must be refused. The default ``member``
+    ``advanced_tools_enabled`` must be refused. The default ``member``
     role is exactly this case — view permission is opt-in per role.
     Without this gate, role-level access control would be a no-op."""
     from app.core.config import settings as app_settings
@@ -799,10 +799,10 @@ async def test_advanced_tool_handoff_returns_403_when_role_lacks_view_permission
     pm = await acting_user(
         guild_role=GuildRole.member, initiative=True, email="pm@example.com"
     )
-    pm.initiative.advanced_tool_enabled = True
+    pm.initiative.advanced_tools_enabled = True
     session.add(pm.initiative)
     await session.commit()
-    # member joins with the default member role (advanced_tool_enabled=False)
+    # member joins with the default member role (advanced_tools_enabled=False)
     member = await acting_user(
         guild_role=GuildRole.member,
         guild=pm.guild,
@@ -835,7 +835,7 @@ async def test_advanced_tool_handoff_succeeds_for_initiative_manager(
 
     pm = await acting_user(guild_role=GuildRole.member, email="pm@example.com")
     initiative = await create_initiative(
-        session, pm.guild, pm.user, name="Init", advanced_tool_enabled=True
+        session, pm.guild, pm.user, name="Init", advanced_tools_enabled=True
     )
 
     response = await client.post(
@@ -890,7 +890,7 @@ async def test_advanced_tool_handoff_can_create_false_for_view_only_role(
     pm = await acting_user(
         guild_role=GuildRole.member, initiative=True, email="pm@example.com"
     )
-    pm.initiative.advanced_tool_enabled = True
+    pm.initiative.advanced_tools_enabled = True
     session.add(pm.initiative)
     await session.commit()
 
@@ -908,7 +908,7 @@ async def test_advanced_tool_handoff_can_create_false_for_view_only_role(
             select(InitiativeRolePermission).where(
                 InitiativeRolePermission.initiative_role_id == member_role.id,
                 InitiativeRolePermission.permission_key
-                == PermissionKey.advanced_tool_enabled,
+                == PermissionKey.advanced_tools_enabled,
             )
         )
     ).one()
@@ -961,7 +961,7 @@ async def test_advanced_tool_handoff_succeeds_for_guild_admin_non_member(
         guild_role=GuildRole.member, guild=admin.guild, email="pm@example.com"
     )
     initiative = await create_initiative(
-        session, admin.guild, pm.user, name="Init", advanced_tool_enabled=True
+        session, admin.guild, pm.user, name="Init", advanced_tools_enabled=True
     )
     # Admin is intentionally NOT added as an initiative member
 

--- a/backend/app/api/v1/tenant_endpoints/recents.py
+++ b/backend/app/api/v1/tenant_endpoints/recents.py
@@ -28,6 +28,8 @@ from app.api.deps import (
     get_current_active_user,
     get_guild_membership,
 )
+from app.core.tools import Tool
+from app.models.tenant.calendar_event import CalendarEvent
 from app.models.tenant.counter import CounterGroup
 from app.models.tenant.document import Document
 from app.models.platform.guild import GuildMembership, GuildRole
@@ -125,6 +127,21 @@ async def _enrich_recent_rows(
         )
         result = await session.exec(stmt)
         counter_group_map = {g.id: g for g in result.all()}
+
+    event_map: Dict[int, CalendarEvent] = {}
+    if event_ids := ids_by_type.get("calendar_event"):
+        stmt = (
+            select(CalendarEvent)
+            .where(CalendarEvent.id.in_(event_ids))
+            .options(
+                selectinload(CalendarEvent.grants).selectinload(ResourceGrant.role),
+                selectinload(CalendarEvent.initiative).selectinload(
+                    Initiative.memberships
+                ),
+            )
+        )
+        result = await session.exec(stmt)
+        event_map = {e.id: e for e in result.all()}
 
     guild_role = GuildRole.admin if is_guild_admin else None
 
@@ -225,6 +242,31 @@ async def _enrich_recent_rows(
                     entity_id=group.id,
                     guild_id=group.guild_id,
                     name=group.name,
+                    last_viewed_at=row.last_viewed_at,
+                )
+            )
+        elif row.entity_type == "calendar_event":
+            event = event_map.get(row.entity_id)
+            if event is None:
+                continue
+            if not is_guild_admin:
+                try:
+                    permissions_service.require_access(
+                        permissions_service.DAC_RESOURCES[Tool.calendar_event],
+                        event,
+                        current_user,
+                        access="read",
+                    )
+                except HTTPException:
+                    # Permission denied — drop the row but let unexpected
+                    # errors bubble up.
+                    continue
+            items.append(
+                RecentItemRead.model_construct(
+                    entity_type="calendar_event",
+                    entity_id=event.id,
+                    guild_id=event.guild_id,
+                    name=event.title,
                     last_viewed_at=row.last_viewed_at,
                 )
             )

--- a/backend/app/api/v1/tenant_endpoints/recents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/recents_test.py
@@ -12,6 +12,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
 from app.testing import (
+    create_calendar_event,
     create_guild,
     create_guild_membership,
     create_project,
@@ -216,3 +217,35 @@ async def test_clear_recent_is_guild_addressed(
     r = await client.get("/api/v1/recents/", headers=a.headers)
     assert r.status_code == 200
     assert r.json() == []
+
+
+@pytest.mark.integration
+async def test_record_and_list_recent_calendar_event(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    a.initiative.calendar_events_enabled = True
+    session.add(a.initiative)
+    await session.commit()
+    event = await create_calendar_event(session, a.initiative, a.user, title="E1")
+
+    r = await client.post(a.g(f"/calendar-events/{event.id}/view"), headers=a.headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["entity_type"] == "calendar_event"
+    assert body["entity_id"] == event.id
+
+    r = await client.get("/api/v1/recents/", headers=a.headers)
+    assert r.status_code == 200
+    items = r.json()
+    assert any(
+        i["entity_type"] == "calendar_event"
+        and i["entity_id"] == event.id
+        and i["name"] == "E1"
+        for i in items
+    )
+
+    r = await client.delete(a.g(f"/calendar-events/{event.id}/view"), headers=a.headers)
+    assert r.status_code == 204
+    r = await client.get("/api/v1/recents/", headers=a.headers)
+    assert all(i["entity_type"] != "calendar_event" for i in r.json())

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -237,7 +237,7 @@ def create_advanced_tool_handoff_token(
         "is_manager": is_manager,
         "scope": scope,
         # Forwarded so the proprietary backend can hide create UI for
-        # members whose role doesn't grant create_advanced_tool. View
+        # members whose role doesn't grant create_advanced_tools. View
         # access is implied by the fact that we issued this token at all.
         "can_create": can_create,
     }

--- a/backend/app/core/tools.py
+++ b/backend/app/core/tools.py
@@ -20,7 +20,40 @@ class Tool(str, Enum):
     calendar_event = "calendar_event"
     advanced_tool = "advanced_tool"
 
+    @property
+    def plural(self) -> str:
+        """Pluralized stem — the table-ish spelling every derived name uses
+        (``counter_group`` → ``counter_groups``)."""
+        return f"{self.value}s"
 
-# The tool string values as a set — the accepted ``resource_grants.resource_type``
-# values, derived from the enum (single source of truth).
-TOOL_TYPES = frozenset(t.value for t in Tool)
+    @property
+    def view_permission(self) -> str:
+        """The role ``PermissionKey`` value gating viewing this tool. For
+        toggleable tools it is also the initiative master-switch column."""
+        return f"{self.plural}_enabled"
+
+    @property
+    def create_permission(self) -> str:
+        """The role ``PermissionKey`` value gating creating this tool."""
+        return f"create_{self.plural}"
+
+    @property
+    def member_view_field(self) -> str:
+        """``InitiativeMemberRead`` computed view flag for this tool."""
+        return f"can_view_{self.plural}"
+
+    @property
+    def member_create_field(self) -> str:
+        """``InitiativeMemberRead`` computed create flag for this tool."""
+        return f"can_create_{self.plural}"
+
+
+# Core tools are always on: no ``*_enabled`` master switch on the initiative and
+# view defaults to True. Every other tool is opt-in per initiative via its
+# ``{plural}_enabled`` column.
+CORE_TOOLS = frozenset({Tool.project, Tool.document})
+TOGGLEABLE_TOOLS = tuple(t for t in Tool if t not in CORE_TOOLS)
+
+# Tools that appear in the recent-items bar. The advanced tool is deliberately
+# absent: it has no per-entity detail route to return to.
+RECENTABLE_TOOLS = tuple(t for t in Tool if t is not Tool.advanced_tool)

--- a/backend/app/core/tools_test.py
+++ b/backend/app/core/tools_test.py
@@ -8,12 +8,17 @@ here. This is the "confirm all tools have similar surface coverage" guarantee,
 kept honest against the actual sources rather than a re-declared list.
 """
 
-from app.core.tools import TOOL_TYPES, Tool
+from app.core.tools import Tool
 
 
-def test_resource_types_are_exactly_the_tools():
-    # Every tool is a shareable resource_type, and nothing else is.
-    assert TOOL_TYPES == frozenset(t.value for t in Tool)
+def test_resource_grant_schema_takes_the_tool_enum():
+    # resource_grants rows and schemas are typed by the Tool enum itself — no
+    # parallel string list anywhere.
+    from app.models.tenant.resource_grant import ResourceGrant
+    from app.schemas.tenant.resource_grant import ResourceGrantBulkItem
+
+    assert ResourceGrant.model_fields["resource_type"].annotation is Tool
+    assert ResourceGrantBulkItem.model_fields["resource_type"].annotation is Tool
 
 
 def test_dac_registries_cover_every_tool():
@@ -45,3 +50,73 @@ def test_trash_listing_covers_every_soft_delete_model():
 
     listed = {model for model, _name_field in ENTITY_REGISTRY.values()}
     assert set(SOFT_DELETE_MODELS) <= listed
+
+
+def test_permission_keys_are_exactly_the_derived_tool_pairs():
+    # Every tool has a `{plural}_enabled` + `create_{plural}` PermissionKey pair
+    # spelled exactly as the Tool enum derives it, and nothing else exists. A new
+    # tool that forgets its keys — or a key that drifts from the canonical stem —
+    # fails here.
+    from app.models.tenant.initiative import (
+        BUILTIN_ROLE_PERMISSIONS,
+        DEFAULT_PERMISSION_VALUES,
+        PermissionKey,
+    )
+
+    derived = {t.view_permission for t in Tool} | {t.create_permission for t in Tool}
+    assert {k.value for k in PermissionKey} == derived
+    assert set(DEFAULT_PERMISSION_VALUES) == set(PermissionKey)
+    for role_permissions in BUILTIN_ROLE_PERMISSIONS.values():
+        assert set(role_permissions) == set(PermissionKey)
+
+
+def test_initiative_master_switches_are_exactly_the_toggleable_tools():
+    # Every non-core tool has an initiative-level `{plural}_enabled` master
+    # switch (model column + read/create/update schema fields); core tools are
+    # always-on and must NOT grow one.
+    from app.core.tools import CORE_TOOLS, TOGGLEABLE_TOOLS
+    from app.models.tenant.initiative import Initiative
+    from app.schemas.tenant.initiative import InitiativeBase, InitiativeUpdate
+
+    switches = {t.view_permission for t in TOGGLEABLE_TOOLS}
+    model_fields = set(Initiative.model_fields)
+    schema_fields = set(InitiativeBase.model_fields)
+    update_fields = set(InitiativeUpdate.model_fields)
+    assert switches <= model_fields
+    assert switches <= schema_fields
+    assert switches <= update_fields
+    for core in CORE_TOOLS:
+        assert core.view_permission not in model_fields
+        assert core.view_permission not in schema_fields
+
+
+def test_member_read_flags_are_exactly_the_derived_tool_pairs():
+    # InitiativeMemberRead carries one can_view/can_create pair per tool, spelled
+    # exactly as the Tool enum derives them.
+    from app.schemas.tenant.initiative import InitiativeMemberRead
+
+    fields = set(InitiativeMemberRead.model_fields)
+    for t in Tool:
+        assert t.member_view_field in fields
+        assert t.member_create_field in fields
+    flag_fields = {f for f in fields if f.startswith(("can_view_", "can_create_"))}
+    derived = {t.member_view_field for t in Tool} | {
+        t.member_create_field for t in Tool
+    }
+    assert flag_fields == derived
+
+
+def test_recent_entity_types_agree_across_surfaces():
+    # The model's allowed set, the schema enum, and the RLS path registry all
+    # derive from RECENTABLE_TOOLS — assert they agree and stay within the Tool
+    # enum (this also guards someone re-declaring one of them by hand).
+    from app.core.tools import RECENTABLE_TOOLS
+    from app.db.initiative_rls import RECENT_ENTITY_TABLES
+    from app.models.tenant.recent_view import RECENT_ENTITY_TYPES
+    from app.schemas.tenant.recent_view import RecentEntityType
+
+    derived = {t.value for t in RECENTABLE_TOOLS}
+    assert set(RECENT_ENTITY_TYPES) == derived
+    assert set(RECENT_ENTITY_TABLES) == derived
+    assert {e.value for e in RecentEntityType} == derived
+    assert derived <= {t.value for t in Tool}

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 from typing import Callable
 
+from app.core.tools import RECENTABLE_TOOLS
+
 # The request-GUC user id, NULLIF-guarded so an unset/PAM context yields NULL
 # (no membership) rather than faulting the cast for every row.
 _UID = "(NULLIF(current_setting('app.current_user_id'::text, true), ''::text))::integer"
@@ -102,15 +104,11 @@ def comments_path() -> PathBuilder:
 
 # recent_views is polymorphic over (entity_type, entity_id). Every entity it can
 # point at is an initiative-scoped table with a direct initiative_id, so the path
-# is a per-type EXISTS join. Keyed by the entity_type string the app stores; a
-# test (test_recent_views_path_covers_entity_types) asserts this stays in sync
-# with app.models.recent_view.RECENT_ENTITY_TYPES.
-RECENT_ENTITY_TABLES: dict[str, str] = {
-    "project": "projects",
-    "document": "documents",
-    "queue": "queues",
-    "counter_group": "counter_groups",
-}
+# is a per-type EXISTS join. Derived from the canonical Tool enum: entity_type is
+# the tool's string value, its table is the pluralized stem. (RECENTABLE_TOOLS
+# excludes the advanced tool — recents never point at one, and CHECK-constraint
+# enforcement on the table matches.)
+RECENT_ENTITY_TABLES: dict[str, str] = {t.value: t.plural for t in RECENTABLE_TOOLS}
 
 
 def recent_views_path() -> PathBuilder:

--- a/backend/app/models/tenant/calendar_event.py
+++ b/backend/app/models/tenant/calendar_event.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class CalendarEvent(SoftDeleteMixin, table=True):
     """Initiative-scoped calendar event (Google Calendar-like).
 
-    Access today: initiative members (events_enabled) read, the create_events role
+    Access today: initiative members (calendar_events_enabled) read, the create_calendar_events role
     permission writes. Per-event DAC arrives with the resource_grants repoint.
     """
 

--- a/backend/app/models/tenant/initiative.py
+++ b/backend/app/models/tenant/initiative.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
 )
 from sqlmodel import Field, Relationship, SQLModel
 
+from app.core.tools import CORE_TOOLS, TOGGLEABLE_TOOLS, Tool
 from app.models.tenant._mixins import SoftDeleteMixin
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -32,76 +33,35 @@ class InitiativeRole(str, Enum):
     member = "member"
 
 
-# Permission keys for role-based access control
-class PermissionKey(str, Enum):
-    docs_enabled = "docs_enabled"
-    projects_enabled = "projects_enabled"
-    create_docs = "create_docs"
-    create_projects = "create_projects"
-    queues_enabled = "queues_enabled"
-    create_queues = "create_queues"
-    events_enabled = "events_enabled"
-    create_events = "create_events"
-    advanced_tool_enabled = "advanced_tool_enabled"
-    create_advanced_tool = "create_advanced_tool"
-    counters_enabled = "counters_enabled"
-    create_counters = "create_counters"
+# Permission keys for role-based access control — fully derived from the Tool
+# enum: one `{plural}_enabled` + `create_{plural}` pair per tool
+# (documents_enabled, create_documents, …, counter_groups_enabled,
+# create_counter_groups). A new Tool member gets its keys automatically; only
+# the DB CHECK constraint on initiative_role_permissions still needs a guild
+# migration to accept the new values.
+PermissionKey = Enum(
+    "PermissionKey",
+    [(name, name) for t in Tool for name in (t.view_permission, t.create_permission)],
+    type=str,
+)
 
 
-# Fallback values when a permission is not explicitly set on a role.
-# Feature visibility defaults to True (permissive), creation defaults to False (restrictive).
-# When adding new permission keys, add an entry here to define the fallback behavior.
+# Fallback values when a permission is not explicitly set on a role, derived
+# from the tool classification: viewing a core (always-on) tool defaults to
+# True, viewing an opt-in tool defaults to False (its initiative master switch
+# gates availability, and within that only managers see it unless a custom
+# role grants it), and creation is always False (restrictive).
 DEFAULT_PERMISSION_VALUES: dict["PermissionKey", bool] = {
-    PermissionKey.docs_enabled: True,
-    PermissionKey.projects_enabled: True,
-    PermissionKey.create_docs: False,
-    PermissionKey.create_projects: False,
-    PermissionKey.queues_enabled: False,
-    PermissionKey.create_queues: False,
-    PermissionKey.events_enabled: False,
-    PermissionKey.create_events: False,
-    # The advanced tool is opt-in by default — the master switch on the
-    # initiative gates whether it's available at all, and within that,
-    # only managers can view/create unless a custom role grants it.
-    PermissionKey.advanced_tool_enabled: False,
-    PermissionKey.create_advanced_tool: False,
-    # Counters is an advanced tool — opt-in by default like queues/events,
-    # gated by the initiative master switch.
-    PermissionKey.counters_enabled: False,
-    PermissionKey.create_counters: False,
+    **{PermissionKey(t.view_permission): t in CORE_TOOLS for t in Tool},
+    **{PermissionKey(t.create_permission): False for t in Tool},
 }
 
 
-# Default permission sets for built-in roles
+# Default permission sets for built-in roles: managers get everything, members
+# get view-only on the core (always-on) tools.
 BUILTIN_ROLE_PERMISSIONS = {
-    "project_manager": {
-        PermissionKey.docs_enabled: True,
-        PermissionKey.projects_enabled: True,
-        PermissionKey.create_docs: True,
-        PermissionKey.create_projects: True,
-        PermissionKey.queues_enabled: True,
-        PermissionKey.create_queues: True,
-        PermissionKey.events_enabled: True,
-        PermissionKey.create_events: True,
-        PermissionKey.advanced_tool_enabled: True,
-        PermissionKey.create_advanced_tool: True,
-        PermissionKey.counters_enabled: True,
-        PermissionKey.create_counters: True,
-    },
-    "member": {
-        PermissionKey.docs_enabled: True,
-        PermissionKey.projects_enabled: True,
-        PermissionKey.create_docs: False,
-        PermissionKey.create_projects: False,
-        PermissionKey.queues_enabled: False,
-        PermissionKey.create_queues: False,
-        PermissionKey.events_enabled: False,
-        PermissionKey.create_events: False,
-        PermissionKey.advanced_tool_enabled: False,
-        PermissionKey.create_advanced_tool: False,
-        PermissionKey.counters_enabled: False,
-        PermissionKey.create_counters: False,
-    },
+    "project_manager": {key: True for key in PermissionKey},
+    "member": dict(DEFAULT_PERMISSION_VALUES),
 }
 
 
@@ -203,7 +163,29 @@ class InitiativeMember(SQLModel, table=True):
     role_ref: Optional["InitiativeRoleModel"] = Relationship(back_populates="members")
 
 
-class Initiative(SoftDeleteMixin, table=True):
+# One `{tool.plural}_enabled` master-switch column per toggleable Tool —
+# derived from the Tool enum, so a new opt-in tool grows its column here
+# automatically. The actual DDL still ships as a guild migration (and the
+# provisioning drift tests catch a model/schema mismatch).
+_InitiativeToolSwitchColumns = type(
+    "_InitiativeToolSwitchColumns",
+    (SQLModel,),
+    {
+        "__module__": __name__,
+        "__annotations__": {t.view_permission: bool for t in TOGGLEABLE_TOOLS},
+        **{
+            t.view_permission: Field(
+                default=False,
+                nullable=False,
+                sa_column_kwargs={"server_default": "false"},
+            )
+            for t in TOGGLEABLE_TOOLS
+        },
+    },
+)
+
+
+class Initiative(_InitiativeToolSwitchColumns, SoftDeleteMixin, table=True):
     __tablename__ = "initiatives"
 
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -219,22 +201,6 @@ class Initiative(SoftDeleteMixin, table=True):
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
     is_archived: bool = Field(
-        default=False,
-        sa_column=Column(Boolean, nullable=False, server_default="false"),
-    )
-    queues_enabled: bool = Field(
-        default=False,
-        sa_column=Column(Boolean, nullable=False, server_default="false"),
-    )
-    events_enabled: bool = Field(
-        default=False,
-        sa_column=Column(Boolean, nullable=False, server_default="false"),
-    )
-    advanced_tool_enabled: bool = Field(
-        default=False,
-        sa_column=Column(Boolean, nullable=False, server_default="false"),
-    )
-    counters_enabled: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )

--- a/backend/app/models/tenant/recent_view.py
+++ b/backend/app/models/tenant/recent_view.py
@@ -4,15 +4,14 @@ from typing import Optional
 from sqlalchemy import Column, DateTime, Text
 from sqlmodel import Field, SQLModel
 
+from app.core.tools import RECENTABLE_TOOLS
 
-# Allowed values mirror the CHECK constraint on the table. Keep in sync with
-# migration ``20260523_0088_create_recent_views.py``.
-RECENT_ENTITY_TYPES: tuple[str, ...] = (
-    "project",
-    "document",
-    "queue",
-    "counter_group",
-)
+
+# Allowed values, derived from the canonical Tool enum. They mirror the CHECK
+# constraint on the table (baseline + migration
+# ``20260704_0128_canonical_tool_naming.py``) — a new recentable tool needs a
+# guild migration extending that constraint.
+RECENT_ENTITY_TYPES: tuple[str, ...] = tuple(t.value for t in RECENTABLE_TOOLS)
 
 
 class RecentView(SQLModel, table=True):

--- a/backend/app/models/tenant/resource_grant.py
+++ b/backend/app/models/tenant/resource_grant.py
@@ -34,7 +34,7 @@ from sqlalchemy import (
 )
 from sqlmodel import Field, Relationship, SQLModel
 
-from app.core.tools import TOOL_TYPES, Tool  # noqa: F401  (Tool re-exported)
+from app.core.tools import Tool  # noqa: F401  (re-exported for grant callers)
 
 if TYPE_CHECKING:  # pragma: no cover
     from app.models.tenant.initiative import InitiativeRoleModel
@@ -45,12 +45,6 @@ class ResourceAccessLevel(str, Enum):
     owner = "owner"
     write = "write"
     read = "read"
-
-
-# A resource_grants row's ``resource_type`` is one of the app-wide tool kinds. The
-# canonical enum lives in ``app.core.tools`` (it's an app-wide concept, not a
-# grants-only one); re-exported here for callers near the grant model.
-RESOURCE_TYPES = TOOL_TYPES
 
 
 class ResourceGrant(SQLModel, table=True):
@@ -93,7 +87,8 @@ class ResourceGrant(SQLModel, table=True):
     # resource's delete path, inert if orphaned.
     # Indexed by the COMPOSITE partial indexes below (ix_resource_grants_resource
     # etc.), owned by migration history — not per-column, so no index=True here.
-    resource_type: str = Field(sa_column=Column(String(length=32), nullable=False))
+    # Typed as the canonical Tool enum (stored as its string value).
+    resource_type: Tool = Field(sa_column=Column(String(length=32), nullable=False))
     resource_id: int = Field(sa_column=Column(Integer, nullable=False))
     user_id: Optional[int] = Field(
         default=None,

--- a/backend/app/schemas/tenant/advanced_tool.py
+++ b/backend/app/schemas/tenant/advanced_tool.py
@@ -28,7 +28,7 @@ class AdvancedToolBase(SanitizedBaseModel):
 
 class AdvancedToolCreate(AdvancedToolBase):
     # None → guild-wide (admin-only). Set → initiative-scoped (needs
-    # advanced_tool_enabled + the create permission, like other tools).
+    # advanced_tools_enabled + the create permission, like other tools).
     initiative_id: Optional[int] = None
     # Initial sharing for an initiative-scoped tool (ignored for guild-wide ones —
     # those are admin-only and can't hold grants). Defaults to Viewer for all

--- a/backend/app/schemas/tenant/initiative.py
+++ b/backend/app/schemas/tenant/initiative.py
@@ -1,42 +1,55 @@
 from datetime import datetime
 from typing import Dict, List, Optional, TYPE_CHECKING
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, create_model
 
+from app.core.tools import CORE_TOOLS, TOGGLEABLE_TOOLS, Tool
 from app.schemas.base import RichTextStr, SanitizedBaseModel
 
 from app.models.tenant.initiative import InitiativeRole, PermissionKey
 from app.schemas.platform.user import UserPublic
 
 if TYPE_CHECKING:  # pragma: no cover
-    from app.models.tenant.initiative import Initiative, InitiativeRoleModel
+    from app.models.tenant.initiative import (
+        Initiative,
+        InitiativeMember,
+        InitiativeRoleModel,
+    )
 
 
 HEX_COLOR_PATTERN = r"^#(?:[0-9a-fA-F]{3}){1,2}$"
 
 
-class InitiativeBase(SanitizedBaseModel):
+# Derived bases: one `{tool.plural}_enabled` master-switch field per
+# toggleable Tool. A new Tool member grows these schemas automatically (the
+# SQLModel column itself is still declared on the Initiative model — real DDL
+# stays explicit, pinned by its migration and the drift test).
+_InitiativeToolSwitches = create_model(
+    "_InitiativeToolSwitches",
+    __base__=SanitizedBaseModel,
+    **{t.view_permission: (bool, False) for t in TOGGLEABLE_TOOLS},
+)
+_InitiativeToolSwitchesPatch = create_model(
+    "_InitiativeToolSwitchesPatch",
+    __base__=SanitizedBaseModel,
+    **{t.view_permission: (Optional[bool], None) for t in TOGGLEABLE_TOOLS},
+)
+
+
+class InitiativeBase(_InitiativeToolSwitches):
     name: str
     description: Optional[RichTextStr] = None
     color: Optional[str] = Field(default=None, pattern=HEX_COLOR_PATTERN)
-    queues_enabled: bool = False
-    events_enabled: bool = False
-    advanced_tool_enabled: bool = False
-    counters_enabled: bool = False
 
 
 class InitiativeCreate(InitiativeBase):
     pass
 
 
-class InitiativeUpdate(SanitizedBaseModel):
+class InitiativeUpdate(_InitiativeToolSwitchesPatch):
     name: Optional[str] = None
     description: Optional[RichTextStr] = None
     color: Optional[str] = Field(default=None, pattern=HEX_COLOR_PATTERN)
-    queues_enabled: Optional[bool] = None
-    events_enabled: Optional[bool] = None
-    advanced_tool_enabled: Optional[bool] = None
-    counters_enabled: Optional[bool] = None
     is_archived: Optional[bool] = None
 
 
@@ -131,7 +144,7 @@ class MyInitiativePermissions(SanitizedBaseModel):
     # Flat initiative-level master switch for the optional embedded
     # advanced tool. Mirrored here so the proprietary embed backend can
     # gate access in a single permissions call.
-    advanced_tool_enabled: bool = False
+    advanced_tools_enabled: bool = False
 
 
 # Member schemas - updated to work with role_id
@@ -155,7 +168,17 @@ class InitiativeMemberUpdate(SanitizedBaseModel):
     role_id: int
 
 
-class InitiativeMemberRead(SanitizedBaseModel):
+# Derived: one `can_view_{tool.plural}` / `can_create_{tool.plural}` pair per
+# Tool, for UI filtering. View defaults True only for core tools.
+_MemberToolFlags = create_model(
+    "_MemberToolFlags",
+    __base__=SanitizedBaseModel,
+    **{t.member_view_field: (bool, t in CORE_TOOLS) for t in Tool},
+    **{t.member_create_field: (bool, False) for t in Tool},
+)
+
+
+class InitiativeMemberRead(_MemberToolFlags):
     """Member info including their role."""
 
     model_config = ConfigDict(
@@ -171,19 +194,6 @@ class InitiativeMemberRead(SanitizedBaseModel):
     # Legacy field for backward compatibility
     role: InitiativeRole = InitiativeRole.member
     oidc_managed: bool = False
-    # Permission flags for UI filtering
-    can_view_docs: bool = True
-    can_view_projects: bool = True
-    can_view_queues: bool = False
-    can_view_events: bool = False
-    can_view_advanced_tool: bool = False
-    can_view_counters: bool = False
-    can_create_docs: bool = False
-    can_create_projects: bool = False
-    can_create_queues: bool = False
-    can_create_events: bool = False
-    can_create_advanced_tool: bool = False
-    can_create_counters: bool = False
 
 
 class InitiativeRead(InitiativeBase):
@@ -221,13 +231,42 @@ def serialize_role(
     )
 
 
+def member_tool_flags(
+    initiative: "Initiative", membership: "InitiativeMember"
+) -> dict[str, bool]:
+    """Effective per-tool view/create flags for one membership.
+
+    Derived per Tool from one rule instead of a hand-rolled branch per tool:
+    defaults (view core tools only) → manager gets everything → otherwise the
+    role's `{plural}_enabled` / `create_{plural}` permissions → the
+    initiative's master switch force-disables toggleable tools it turned off.
+    """
+    role_ref = getattr(membership, "role_ref", None)
+    is_manager = role_ref.is_manager if role_ref else False
+    flags = {
+        **{t.member_view_field: t in CORE_TOOLS for t in Tool},
+        **{t.member_create_field: False for t in Tool},
+    }
+    if is_manager:
+        flags = {name: True for name in flags}
+    elif role_ref:
+        # getattr to avoid lazy loading
+        role_permissions = getattr(role_ref, "permissions", None) or []
+        enabled_by_key = {p.permission_key: p.enabled for p in role_permissions}
+        for t in Tool:
+            view = enabled_by_key.get(PermissionKey(t.view_permission))
+            if view is not None:
+                flags[t.member_view_field] = view
+            if enabled_by_key.get(PermissionKey(t.create_permission)):
+                flags[t.member_create_field] = True
+    for t in TOGGLEABLE_TOOLS:
+        if not getattr(initiative, t.view_permission, False):
+            flags[t.member_view_field] = False
+            flags[t.member_create_field] = False
+    return flags
+
+
 def serialize_initiative(initiative: "Initiative") -> InitiativeRead:
-    initiative_queues_enabled = getattr(initiative, "queues_enabled", False)
-    initiative_events_enabled = getattr(initiative, "events_enabled", False)
-    initiative_advanced_tool_enabled = getattr(
-        initiative, "advanced_tool_enabled", False
-    )
-    initiative_counters_enabled = getattr(initiative, "counters_enabled", False)
     members: List[InitiativeMemberRead] = []
     for membership in getattr(initiative, "memberships", []) or []:
         if membership.user is None:
@@ -235,95 +274,6 @@ def serialize_initiative(initiative: "Initiative") -> InitiativeRead:
         # Get role info from role_ref if available
         role_ref = getattr(membership, "role_ref", None)
         role_name = role_ref.name if role_ref else None
-        role_display_name = role_ref.display_name if role_ref else None
-        is_manager = role_ref.is_manager if role_ref else False
-
-        # Compute permissions from role
-        can_view_docs = True
-        can_view_projects = True
-        can_view_queues = False
-        can_view_events = False
-        can_view_advanced_tool = False
-        can_view_counters = False
-        can_create_docs = False
-        can_create_projects = False
-        can_create_queues = False
-        can_create_events = False
-        can_create_advanced_tool = False
-        can_create_counters = False
-        if is_manager:
-            # Managers have all permissions
-            can_create_docs = True
-            can_create_projects = True
-            can_view_queues = True
-            can_create_queues = True
-            can_view_events = True
-            can_create_events = True
-            can_view_advanced_tool = True
-            can_create_advanced_tool = True
-            can_view_counters = True
-            can_create_counters = True
-        elif role_ref:
-            # Check role permissions (use getattr to avoid lazy loading)
-            role_permissions = getattr(role_ref, "permissions", None) or []
-            for perm in role_permissions:
-                if perm.permission_key == PermissionKey.docs_enabled:
-                    can_view_docs = perm.enabled
-                elif perm.permission_key == PermissionKey.projects_enabled:
-                    can_view_projects = perm.enabled
-                elif perm.permission_key == PermissionKey.queues_enabled:
-                    can_view_queues = perm.enabled
-                elif perm.permission_key == PermissionKey.create_docs and perm.enabled:
-                    can_create_docs = True
-                elif (
-                    perm.permission_key == PermissionKey.create_projects
-                    and perm.enabled
-                ):
-                    can_create_projects = True
-                elif (
-                    perm.permission_key == PermissionKey.create_queues and perm.enabled
-                ):
-                    can_create_queues = True
-                elif perm.permission_key == PermissionKey.events_enabled:
-                    can_view_events = perm.enabled
-                elif (
-                    perm.permission_key == PermissionKey.create_events and perm.enabled
-                ):
-                    can_create_events = True
-                elif perm.permission_key == PermissionKey.advanced_tool_enabled:
-                    can_view_advanced_tool = perm.enabled
-                elif (
-                    perm.permission_key == PermissionKey.create_advanced_tool
-                    and perm.enabled
-                ):
-                    can_create_advanced_tool = True
-                elif perm.permission_key == PermissionKey.counters_enabled:
-                    can_view_counters = perm.enabled
-                elif (
-                    perm.permission_key == PermissionKey.create_counters
-                    and perm.enabled
-                ):
-                    can_create_counters = True
-
-        # Initiative-level master switch overrides role-level queue permissions
-        if not initiative_queues_enabled:
-            can_view_queues = False
-            can_create_queues = False
-
-        # Initiative-level master switch overrides role-level event permissions
-        if not initiative_events_enabled:
-            can_view_events = False
-            can_create_events = False
-
-        # Initiative-level master switch overrides role-level advanced tool perms
-        if not initiative_advanced_tool_enabled:
-            can_view_advanced_tool = False
-            can_create_advanced_tool = False
-
-        # Initiative-level master switch overrides role-level counter perms
-        if not initiative_counters_enabled:
-            can_view_counters = False
-            can_create_counters = False
 
         # Determine legacy role for backward compatibility
         legacy_role = (
@@ -337,23 +287,12 @@ def serialize_initiative(initiative: "Initiative") -> InitiativeRead:
                 user=UserPublic.model_validate(membership.user),
                 role_id=membership.role_id,
                 role_name=role_name,
-                role_display_name=role_display_name,
-                is_manager=is_manager,
+                role_display_name=role_ref.display_name if role_ref else None,
+                is_manager=role_ref.is_manager if role_ref else False,
                 joined_at=membership.joined_at,
                 role=legacy_role,
                 oidc_managed=membership.oidc_managed,
-                can_view_docs=can_view_docs,
-                can_view_projects=can_view_projects,
-                can_view_queues=can_view_queues,
-                can_view_events=can_view_events,
-                can_view_advanced_tool=can_view_advanced_tool,
-                can_view_counters=can_view_counters,
-                can_create_docs=can_create_docs,
-                can_create_projects=can_create_projects,
-                can_create_queues=can_create_queues,
-                can_create_events=can_create_events,
-                can_create_advanced_tool=can_create_advanced_tool,
-                can_create_counters=can_create_counters,
+                **member_tool_flags(initiative, membership),
             )
         )
     return InitiativeRead(
@@ -364,11 +303,11 @@ def serialize_initiative(initiative: "Initiative") -> InitiativeRead:
         color=initiative.color,
         is_default=initiative.is_default,
         is_archived=getattr(initiative, "is_archived", False),
-        queues_enabled=initiative_queues_enabled,
-        events_enabled=initiative_events_enabled,
-        advanced_tool_enabled=initiative_advanced_tool_enabled,
-        counters_enabled=initiative_counters_enabled,
         created_at=initiative.created_at,
         updated_at=initiative.updated_at,
         members=members,
+        **{
+            t.view_permission: getattr(initiative, t.view_permission, False)
+            for t in TOGGLEABLE_TOOLS
+        },
     )

--- a/backend/app/schemas/tenant/recent_view.py
+++ b/backend/app/schemas/tenant/recent_view.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, Optional
+from enum import Enum
+from typing import Optional
 
 from pydantic import ConfigDict
 
+from app.core.tools import RECENTABLE_TOOLS
 from app.schemas.base import SanitizedBaseModel
 
 
-RecentEntityType = Literal["project", "document", "queue", "counter_group"]
+# Derived from the canonical Tool enum — the recentable tools' string values,
+# as a str enum so FastAPI validates path params and OpenAPI lists the values.
+RecentEntityType = Enum(
+    "RecentEntityType", [(t.value, t.value) for t in RECENTABLE_TOOLS], type=str
+)
 
 
 class RecentViewWrite(SanitizedBaseModel):

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -59,7 +59,7 @@ async def _dispatch(session: AsyncSession) -> None:
 async def _events_initiative(session: AsyncSession, creator):
     guild = await create_guild(session)
     initiative = await create_initiative(session, guild, creator, name="Reminders")
-    initiative.events_enabled = True
+    initiative.calendar_events_enabled = True
     session.add(initiative)
     await session.commit()
     await session.refresh(initiative)
@@ -474,7 +474,7 @@ async def test_event_reminders_fire_across_a_users_guilds(session: AsyncSession)
         creator = await create_user(session, email=f"organizer-{label}@example.com")
         guild = await create_guild(session, creator=creator)
         initiative = await create_initiative(session, guild, creator, name=label)
-        initiative.events_enabled = True
+        initiative.calendar_events_enabled = True
         session.add(initiative)
         await session.commit()
         await session.refresh(initiative)

--- a/backend/app/services/rls.py
+++ b/backend/app/services/rls.py
@@ -187,7 +187,7 @@ async def check_initiative_permission(
         session: Database session
         initiative_id: ID of the initiative
         user: User to check permissions for
-        permission_key: Permission to check (e.g., PermissionKey.create_docs)
+        permission_key: Permission to check (e.g., PermissionKey.create_documents)
 
     Returns:
         True if user has the permission, False otherwise
@@ -279,28 +279,3 @@ async def override_sharing_initiative_ids(
         )
     )
     return set((await session.exec(stmt)).all())
-
-
-async def has_feature_access(
-    session: AsyncSession,
-    *,
-    initiative_id: int,
-    user: User,
-    feature: str,
-) -> bool:
-    """Check if user can see a feature (docs or projects).
-
-    Args:
-        feature: Either "docs" or "projects"
-    """
-    perm_key = (
-        PermissionKey.docs_enabled
-        if feature == "docs"
-        else PermissionKey.projects_enabled
-    )
-    return await check_initiative_permission(
-        session,
-        initiative_id=initiative_id,
-        user=user,
-        permission_key=perm_key,
-    )

--- a/backend/app/services/rls_test.py
+++ b/backend/app/services/rls_test.py
@@ -4,7 +4,7 @@ Tests cover:
 - Guild-level access checks (is_guild_admin, require_guild_admin)
 - Guild membership lookups (get_guild_membership, require_guild_membership)
 - Initiative manager checks (is_initiative_manager, assert_initiative_manager)
-- Initiative permission checks (check_initiative_permission, has_feature_access)
+- Initiative permission checks (check_initiative_permission)
 """
 
 import pytest
@@ -18,7 +18,6 @@ from app.models.platform.user import UserRole
 from app.services.rls import (
     check_initiative_permission,
     get_guild_membership,
-    has_feature_access,
     is_guild_admin,
     is_initiative_manager,
     assert_initiative_manager,
@@ -241,7 +240,7 @@ async def test_check_initiative_permission_manager_has_all(session: AsyncSession
         session,
         initiative_id=initiative.id,
         user=user,
-        permission_key=PermissionKey.create_docs,
+        permission_key=PermissionKey.create_documents,
     )
 
     assert result is True
@@ -262,12 +261,12 @@ async def test_check_initiative_permission_member_explicit_enabled(
     await create_guild_membership(session, user=member, guild=guild)
     await create_initiative_member(session, initiative, member, role_name="member")
 
-    # The member role has docs_enabled=True and projects_enabled=True by default
+    # The member role has documents_enabled=True and projects_enabled=True by default
     result = await check_initiative_permission(
         session,
         initiative_id=initiative.id,
         user=member,
-        permission_key=PermissionKey.docs_enabled,
+        permission_key=PermissionKey.documents_enabled,
     )
 
     assert result is True
@@ -288,12 +287,12 @@ async def test_check_initiative_permission_member_explicit_disabled(
     await create_guild_membership(session, user=member, guild=guild)
     await create_initiative_member(session, initiative, member, role_name="member")
 
-    # The member role has create_docs=False and create_projects=False by default
+    # The member role has create_documents=False and create_projects=False by default
     result = await check_initiative_permission(
         session,
         initiative_id=initiative.id,
         user=member,
-        permission_key=PermissionKey.create_docs,
+        permission_key=PermissionKey.create_documents,
     )
 
     assert result is False
@@ -344,7 +343,7 @@ async def test_check_initiative_permission_non_member(session: AsyncSession):
         session,
         initiative_id=initiative.id,
         user=outsider,
-        permission_key=PermissionKey.docs_enabled,
+        permission_key=PermissionKey.documents_enabled,
     )
 
     assert result is False
@@ -353,37 +352,3 @@ async def test_check_initiative_permission_non_member(session: AsyncSession):
 # ---------------------------------------------------------------------------
 # Feature access helper (async / service)
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.service
-async def test_has_feature_access_docs(session: AsyncSession):
-    user = await create_user(session)
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user)
-
-    result = await has_feature_access(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        feature="docs",
-    )
-
-    assert result is True
-
-
-@pytest.mark.service
-async def test_has_feature_access_projects(session: AsyncSession):
-    user = await create_user(session)
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
-    initiative = await create_initiative(session, guild, user)
-
-    result = await has_feature_access(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        feature="projects",
-    )
-
-    assert result is True

--- a/backend/app/services/tenant/calendar_events.py
+++ b/backend/app/services/tenant/calendar_events.py
@@ -1,6 +1,6 @@
 """Calendar event service layer — business logic for CRUD and attachments.
 
-Access control is at the initiative level (events_enabled + create_events
+Access control is at the initiative level (calendar_events_enabled + create_calendar_events
 permission keys). No per-event DAC — any initiative member with the right
 role permission can view/create/edit events.
 """

--- a/backend/app/services/tenant/comments.py
+++ b/backend/app/services/tenant/comments.py
@@ -20,7 +20,7 @@ from app.models.tenant.project import Project
 from app.models.tenant.task import Task
 from app.models.platform.user import User
 from app.services.tenant import documents as documents_service
-from app.services.tenant import initiatives as initiatives_service
+from app.services import rls as rls_service
 from app.services import notifications
 from app.services import permissions as permissions_service
 from app.services.mention_parser import (
@@ -539,7 +539,7 @@ async def delete_comment(
     is_guild_admin = guild_role == GuildRole.admin
     is_initiative_manager = False
     if not is_author and not is_guild_admin and initiative_id is not None:
-        is_initiative_manager = await initiatives_service.is_initiative_manager(
+        is_initiative_manager = await rls_service.is_initiative_manager(
             session,
             initiative_id=initiative_id,
             user=user,

--- a/backend/app/services/tenant/initiatives.py
+++ b/backend/app/services/tenant/initiatives.py
@@ -22,13 +22,6 @@ from app.models.tenant.initiative import (
 from app.models.platform.user import User
 from app.schemas.platform.user import UserInitiativeRole
 
-# Backward compatibility — these security functions moved to rls.py
-from app.services.rls import (  # noqa: F401
-    is_initiative_manager,
-    assert_initiative_manager,
-    check_initiative_permission,
-    has_feature_access,
-)
 
 DEFAULT_INITIATIVE_NAME = "Default Initiative"
 DEFAULT_INITIATIVE_COLOR = "#2563eb"

--- a/backend/app/services/tenant/recent_views.py
+++ b/backend/app/services/tenant/recent_views.py
@@ -8,16 +8,16 @@ queues, and counter groups.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Iterable, Literal, Sequence
+from typing import Iterable, Sequence
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.tenant.recent_view import RecentView
+from app.schemas.tenant.recent_view import RecentEntityType
 
-
-RecentEntityType = Literal["project", "document", "queue", "counter_group"]
+__all__ = ["RecentEntityType"]  # re-export for existing importers
 
 # Per-user cap on entries kept/displayed, across all entity types. The user's
 # ``recent_tabs_limit`` (Interface settings) drives the actual value; these

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -286,7 +286,7 @@ async def create_initiative(
         "description": "A test initiative",
         "guild_id": guild.id,
         "queues_enabled": True,
-        "counters_enabled": True,
+        "counter_groups_enabled": True,
     }
 
     initiative_data = {**defaults, **overrides}

--- a/frontend/src/__tests__/factories/initiative.factory.ts
+++ b/frontend/src/__tests__/factories/initiative.factory.ts
@@ -21,9 +21,9 @@ export function buildInitiativeMember(
     is_manager: false,
     oidc_managed: false,
     joined_at: "2026-01-15T00:00:00.000Z",
-    can_view_docs: true,
+    can_view_documents: true,
     can_view_projects: true,
-    can_create_docs: false,
+    can_create_documents: false,
     can_create_projects: false,
     ...overrides,
   };

--- a/frontend/src/__tests__/helpers/handlers/initiative.handlers.ts
+++ b/frontend/src/__tests__/helpers/handlers/initiative.handlers.ts
@@ -20,9 +20,9 @@ export const initiativeHandlers = [
       role_display_name: "Project Manager",
       is_manager: true,
       permissions: {
-        docs_enabled: true,
+        documents_enabled: true,
         projects_enabled: true,
-        create_docs: true,
+        create_documents: true,
         create_projects: true,
       },
     });

--- a/frontend/src/api/generated/calendar-events/calendar-events.ts
+++ b/frontend/src/api/generated/calendar-events/calendar-events.ts
@@ -36,6 +36,7 @@ import type {
   ListCalendarEventsApiV1GGuildIdCalendarEventsGetParams,
   ListMyCalendarEventsApiV1MeCalendarEventsGetParams,
   PropertyValuesSetRequest,
+  RecentViewWrite,
   ResourceGrantSchema,
 } from "../initiativeAPI.schemas";
 
@@ -601,7 +602,7 @@ export function useListCalendarEventsApiV1GGuildIdCalendarEventsGet<
 }
 
 /**
- * Create a calendar event. Requires create_events permission.
+ * Create a calendar event. Requires create_calendar_events permission.
  * @summary Create Calendar Event
  */
 export const createCalendarEventApiV1GGuildIdCalendarEventsPost = (
@@ -873,7 +874,7 @@ export function useReadCalendarEventApiV1GGuildIdCalendarEventsEventIdGet<
 }
 
 /**
- * Update a calendar event. Requires create_events permission on the initiative.
+ * Update a calendar event. Requires create_calendar_events permission on the initiative.
  * @summary Update Calendar Event
  */
 export const updateCalendarEventApiV1GGuildIdCalendarEventsEventIdPatch = (
@@ -973,7 +974,7 @@ export const useUpdateCalendarEventApiV1GGuildIdCalendarEventsEventIdPatch = <
   );
 };
 /**
- * Soft-delete a calendar event. Requires create_events permission or guild admin.
+ * Soft-delete a calendar event. Requires create_calendar_events permission or guild admin.
  * @summary Delete Calendar Event
  */
 export const deleteCalendarEventApiV1GGuildIdCalendarEventsEventIdDelete = (
@@ -1064,7 +1065,7 @@ export const useDeleteCalendarEventApiV1GGuildIdCalendarEventsEventIdDelete = <
   );
 };
 /**
- * Set attendees. Requires create_events permission.
+ * Set attendees. Requires create_calendar_events permission.
  * @summary Set Attendees
  */
 export const setAttendeesApiV1GGuildIdCalendarEventsEventIdAttendeesPut = (
@@ -1461,7 +1462,7 @@ export const useSetDocumentsApiV1GGuildIdCalendarEventsEventIdDocumentsPut = <
  * Replace-all set of property values on an event.
  *
  * Mirrors the tasks/documents shape: any initiative member with
- * ``create_events`` (or guild admin) can attach values; cross-initiative
+ * ``create_calendar_events`` (or guild admin) can attach values; cross-initiative
  * definitions return 404 DEFINITION_NOT_FOUND via the service layer.
  * @summary Set Event Properties
  */
@@ -1662,6 +1663,192 @@ export const useSetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPu
 > => {
   return useMutation(
     getSetCalendarEventGrantsApiV1GGuildIdCalendarEventsEventIdGrantsPutMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * @summary Record Calendar Event View
+ */
+export const recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost = (
+  guildId: number,
+  eventId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<RecentViewWrite>(
+    { url: `/api/v1/g/${guildId}/calendar-events/${eventId}/view`, method: "POST", signal },
+    options
+  );
+};
+
+export const getRecordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost>>,
+    TError,
+    { guildId: number; eventId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost>>,
+  TError,
+  { guildId: number; eventId: number },
+  TContext
+> => {
+  const mutationKey = ["recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost>>,
+    { guildId: number; eventId: number }
+  > = (props) => {
+    const { guildId, eventId } = props ?? {};
+
+    return recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost(
+      guildId,
+      eventId,
+      requestOptions
+    );
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RecordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPostMutationResult =
+  NonNullable<
+    Awaited<ReturnType<typeof recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost>>
+  >;
+
+export type RecordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Record Calendar Event View
+ */
+export const useRecordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost>>,
+      TError,
+      { guildId: number; eventId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost>>,
+  TError,
+  { guildId: number; eventId: number },
+  TContext
+> => {
+  return useMutation(
+    getRecordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * @summary Clear Calendar Event View
+ */
+export const clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete = (
+  guildId: number,
+  eventId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<void>(
+    { url: `/api/v1/g/${guildId}/calendar-events/${eventId}/view`, method: "DELETE", signal },
+    options
+  );
+};
+
+export const getClearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDeleteMutationOptions =
+  <TError = ErrorType<HTTPValidationError>, TContext = unknown>(options?: {
+    mutation?: UseMutationOptions<
+      Awaited<
+        ReturnType<typeof clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete>
+      >,
+      TError,
+      { guildId: number; eventId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }): UseMutationOptions<
+    Awaited<ReturnType<typeof clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete>>,
+    TError,
+    { guildId: number; eventId: number },
+    TContext
+  > => {
+    const mutationKey = ["clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete"];
+    const { mutation: mutationOptions, request: requestOptions } = options
+      ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+        ? options
+        : { ...options, mutation: { ...options.mutation, mutationKey } }
+      : { mutation: { mutationKey }, request: undefined };
+
+    const mutationFn: MutationFunction<
+      Awaited<
+        ReturnType<typeof clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete>
+      >,
+      { guildId: number; eventId: number }
+    > = (props) => {
+      const { guildId, eventId } = props ?? {};
+
+      return clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete(
+        guildId,
+        eventId,
+        requestOptions
+      );
+    };
+
+    return { mutationFn, ...mutationOptions };
+  };
+
+export type ClearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDeleteMutationResult =
+  NonNullable<
+    Awaited<ReturnType<typeof clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete>>
+  >;
+
+export type ClearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDeleteMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Clear Calendar Event View
+ */
+export const useClearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<
+        ReturnType<typeof clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete>
+      >,
+      TError,
+      { guildId: number; eventId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof clearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDelete>>,
+  TError,
+  { guildId: number; eventId: number },
+  TContext
+> => {
+  return useMutation(
+    getClearCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewDeleteMutationOptions(options),
     queryClient
   );
 };

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -998,6 +998,18 @@ export interface DocumentFileVersionRead {
  * Member info including their role.
  */
 export interface InitiativeMemberRead {
+  can_view_projects: boolean;
+  can_view_documents: boolean;
+  can_view_queues: boolean;
+  can_view_counter_groups: boolean;
+  can_view_calendar_events: boolean;
+  can_view_advanced_tools: boolean;
+  can_create_projects: boolean;
+  can_create_documents: boolean;
+  can_create_queues: boolean;
+  can_create_counter_groups: boolean;
+  can_create_calendar_events: boolean;
+  can_create_advanced_tools: boolean;
   user: UserPublic;
   role_id: number | null;
   role_name: string | null;
@@ -1006,28 +1018,16 @@ export interface InitiativeMemberRead {
   joined_at: string;
   role: InitiativeRole;
   oidc_managed: boolean;
-  can_view_docs: boolean;
-  can_view_projects: boolean;
-  can_view_queues: boolean;
-  can_view_events: boolean;
-  can_view_advanced_tool: boolean;
-  can_view_counters: boolean;
-  can_create_docs: boolean;
-  can_create_projects: boolean;
-  can_create_queues: boolean;
-  can_create_events: boolean;
-  can_create_advanced_tool: boolean;
-  can_create_counters: boolean;
 }
 
 export interface InitiativeRead {
+  queues_enabled: boolean;
+  counter_groups_enabled: boolean;
+  calendar_events_enabled: boolean;
+  advanced_tools_enabled: boolean;
   name: string;
   description: string | null;
   color: string | null;
-  queues_enabled: boolean;
-  events_enabled: boolean;
-  advanced_tool_enabled: boolean;
-  counters_enabled: boolean;
   id: number;
   guild_id: number;
   is_default: boolean;
@@ -1460,13 +1460,13 @@ export interface ImportResult {
 }
 
 export interface InitiativeCreate {
+  queues_enabled?: boolean;
+  counter_groups_enabled?: boolean;
+  calendar_events_enabled?: boolean;
+  advanced_tools_enabled?: boolean;
   name: string;
   description?: string | null;
   color?: string | null;
-  queues_enabled?: boolean;
-  events_enabled?: boolean;
-  advanced_tool_enabled?: boolean;
-  counters_enabled?: boolean;
 }
 
 /**
@@ -1487,18 +1487,18 @@ export interface InitiativeMemberUpdate {
 export type PermissionKey = (typeof PermissionKey)[keyof typeof PermissionKey];
 
 export const PermissionKey = {
-  docs_enabled: "docs_enabled",
   projects_enabled: "projects_enabled",
-  create_docs: "create_docs",
   create_projects: "create_projects",
+  documents_enabled: "documents_enabled",
+  create_documents: "create_documents",
   queues_enabled: "queues_enabled",
   create_queues: "create_queues",
-  events_enabled: "events_enabled",
-  create_events: "create_events",
-  advanced_tool_enabled: "advanced_tool_enabled",
-  create_advanced_tool: "create_advanced_tool",
-  counters_enabled: "counters_enabled",
-  create_counters: "create_counters",
+  counter_groups_enabled: "counter_groups_enabled",
+  create_counter_groups: "create_counter_groups",
+  calendar_events_enabled: "calendar_events_enabled",
+  create_calendar_events: "create_calendar_events",
+  advanced_tools_enabled: "advanced_tools_enabled",
+  create_advanced_tools: "create_advanced_tools",
 } as const;
 
 /**
@@ -1545,13 +1545,13 @@ export interface InitiativeRoleUpdate {
 }
 
 export interface InitiativeUpdate {
+  queues_enabled?: boolean | null;
+  counter_groups_enabled?: boolean | null;
+  calendar_events_enabled?: boolean | null;
+  advanced_tools_enabled?: boolean | null;
   name?: string | null;
   description?: string | null;
   color?: string | null;
-  queues_enabled?: boolean | null;
-  events_enabled?: boolean | null;
-  advanced_tool_enabled?: boolean | null;
-  counters_enabled?: boolean | null;
   is_archived?: boolean | null;
 }
 
@@ -1631,7 +1631,7 @@ export interface MyInitiativePermissions {
   is_manager: boolean;
   override_share_restrictions: boolean;
   permissions: Partial<Record<PermissionKey, boolean>>;
-  advanced_tool_enabled: boolean;
+  advanced_tools_enabled: boolean;
 }
 
 export interface NotificationCountResponse {
@@ -2376,14 +2376,14 @@ export interface RecentActivityEntry {
   project_name?: string | null;
 }
 
-export type RecentItemReadEntityType =
-  (typeof RecentItemReadEntityType)[keyof typeof RecentItemReadEntityType];
+export type RecentEntityType = (typeof RecentEntityType)[keyof typeof RecentEntityType];
 
-export const RecentItemReadEntityType = {
+export const RecentEntityType = {
   project: "project",
   document: "document",
   queue: "queue",
   counter_group: "counter_group",
+  calendar_event: "calendar_event",
 } as const;
 
 /**
@@ -2393,7 +2393,7 @@ export const RecentItemReadEntityType = {
  * icon and link without an N+1 fetch per entity type.
  */
 export interface RecentItemRead {
-  entity_type: RecentItemReadEntityType;
+  entity_type: RecentEntityType;
   entity_id: number;
   guild_id: number;
   name: string;
@@ -2404,21 +2404,11 @@ export interface RecentItemRead {
   original_filename: string | null;
 }
 
-export type RecentViewWriteEntityType =
-  (typeof RecentViewWriteEntityType)[keyof typeof RecentViewWriteEntityType];
-
-export const RecentViewWriteEntityType = {
-  project: "project",
-  document: "document",
-  queue: "queue",
-  counter_group: "counter_group",
-} as const;
-
 /**
  * Response body for POST .../{id}/view, common across entity types.
  */
 export interface RecentViewWrite {
-  entity_type: RecentViewWriteEntityType;
+  entity_type: RecentEntityType;
   entity_id: number;
   last_viewed_at: string;
 }

--- a/frontend/src/api/generated/initiatives/initiatives.ts
+++ b/frontend/src/api/generated/initiatives/initiatives.ts
@@ -1485,15 +1485,15 @@ export function useGetMyInitiativePermissionsApiV1GGuildIdInitiativesInitiativeI
  *   1. The deployment must have ADVANCED_TOOL_URL configured.
  *   2. The initiative must exist in the active guild.
  *   3. The user must be a guild admin OR an initiative member.
- *   4. The initiative must have advanced_tool_enabled=true.
+ *   4. The initiative must have advanced_tools_enabled=true.
  *   5. The user's initiative role must include the
- *      ``advanced_tool_enabled`` permission key. Guild admins and
+ *      ``advanced_tools_enabled`` permission key. Guild admins and
  *      initiative managers bypass step 5 since they're trusted by
  *      construction.
  *
  * The returned token has audience=initiative:advanced-tool and a 60s
  * expiry. The SPA passes it via postMessage (never URL/query string).
- * The ``can_create`` claim forwards the create_advanced_tool permission
+ * The ``can_create`` claim forwards the create_advanced_tools permission
  * so the proprietary backend can hide create UI for view-only members.
  * @summary Create Advanced Tool Handoff
  */

--- a/frontend/src/api/generated/recents/recents.ts
+++ b/frontend/src/api/generated/recents/recents.ts
@@ -20,7 +20,11 @@ import type {
   UseQueryResult,
 } from "@tanstack/react-query";
 
-import type { HTTPValidationError, RecentItemRead } from "../initiativeAPI.schemas";
+import type {
+  HTTPValidationError,
+  RecentEntityType,
+  RecentItemRead,
+} from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
 import type { ErrorType } from "../../mutator";
@@ -161,7 +165,7 @@ export function useListRecentsApiV1RecentsGet<
  */
 export const clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete = (
   guildId: number,
-  entityType: "project" | "document" | "queue" | "counter_group",
+  entityType: RecentEntityType,
   entityId: number,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
@@ -179,22 +183,14 @@ export const getClearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDeleteMutationO
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete>>,
     TError,
-    {
-      guildId: number;
-      entityType: "project" | "document" | "queue" | "counter_group";
-      entityId: number;
-    },
+    { guildId: number; entityType: RecentEntityType; entityId: number },
     TContext
   >;
   request?: SecondParameter<typeof apiMutator>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete>>,
   TError,
-  {
-    guildId: number;
-    entityType: "project" | "document" | "queue" | "counter_group";
-    entityId: number;
-  },
+  { guildId: number; entityType: RecentEntityType; entityId: number },
   TContext
 > => {
   const mutationKey = ["clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete"];
@@ -206,11 +202,7 @@ export const getClearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDeleteMutationO
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete>>,
-    {
-      guildId: number;
-      entityType: "project" | "document" | "queue" | "counter_group";
-      entityId: number;
-    }
+    { guildId: number; entityType: RecentEntityType; entityId: number }
   > = (props) => {
     const { guildId, entityType, entityId } = props ?? {};
 
@@ -243,11 +235,7 @@ export const useClearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete>>,
       TError,
-      {
-        guildId: number;
-        entityType: "project" | "document" | "queue" | "counter_group";
-        entityId: number;
-      },
+      { guildId: number; entityType: RecentEntityType; entityId: number },
       TContext
     >;
     request?: SecondParameter<typeof apiMutator>;
@@ -256,11 +244,7 @@ export const useClearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof clearRecentApiV1GGuildIdRecentsEntityTypeEntityIdDelete>>,
   TError,
-  {
-    guildId: number;
-    entityType: "project" | "document" | "queue" | "counter_group";
-    entityId: number;
-  },
+  { guildId: number; entityType: RecentEntityType; entityId: number },
   TContext
 > => {
   return useMutation(

--- a/frontend/src/components/initiativeTools/events/ICalImportDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/ICalImportDialog.tsx
@@ -84,7 +84,7 @@ export const ICalImportDialog = ({
     if (!user) return [];
     return (initiativesQuery.data ?? []).filter(
       (init) =>
-        init.events_enabled &&
+        init.calendar_events_enabled &&
         init.members.some((m) => m.user.id === user.id && m.role === "project_manager")
     );
   }, [initiativesQuery.data, user]);

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -84,10 +84,10 @@ export const InitiativeSection = memo(
     // The sidebar entry is triply-gated:
     //   1. Runtime config must expose an advanced tool (deployment-level).
     //   2. The initiative manager must have enabled it (per-initiative).
-    //   3. The user's role must include the advanced_tool_enabled key
+    //   3. The user's role must include the advanced_tools_enabled key
     //      — non-managers can be denied even when (1) and (2) pass.
     const showAdvancedTool = Boolean(
-      advancedTool && initiative.advanced_tool_enabled && canViewAdvancedTool
+      advancedTool && initiative.advanced_tools_enabled && canViewAdvancedTool
     );
     // Helper to create guild-scoped paths
     const gp = (path: string) => (activeGuildId ? guildPath(activeGuildId, path) : path);

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -30,14 +30,14 @@ const fullAccess = (
   canViewDocs: true,
   canViewProjects: true,
   canViewQueues: initiative.queues_enabled ?? false,
-  canViewEvents: initiative.events_enabled ?? false,
-  canViewAdvancedTool: initiative.advanced_tool_enabled ?? false,
-  canViewCounters: initiative.counters_enabled ?? false,
+  canViewEvents: initiative.calendar_events_enabled ?? false,
+  canViewAdvancedTool: initiative.advanced_tools_enabled ?? false,
+  canViewCounters: initiative.counter_groups_enabled ?? false,
   canCreateDocs: canCreate,
   canCreateProjects: canCreate,
   canCreateQueues: canCreate && (initiative.queues_enabled ?? false),
-  canCreateEvents: canCreate && (initiative.events_enabled ?? false),
-  canCreateCounters: canCreate && (initiative.counters_enabled ?? false),
+  canCreateEvents: canCreate && (initiative.calendar_events_enabled ?? false),
+  canCreateCounters: canCreate && (initiative.counter_groups_enabled ?? false),
 });
 
 // Bare read of the always-visible sections (docs/projects) for someone with no
@@ -106,17 +106,17 @@ export function useInitiativeAccess() {
       const membership = initiative.members.find((m) => m.user.id === user.id);
       if (!membership) return readOnlyDefault;
       return {
-        canViewDocs: membership.can_view_docs ?? true,
+        canViewDocs: membership.can_view_documents ?? true,
         canViewProjects: membership.can_view_projects ?? true,
         canViewQueues: membership.can_view_queues ?? false,
-        canViewEvents: membership.can_view_events ?? false,
-        canViewAdvancedTool: membership.can_view_advanced_tool ?? false,
-        canViewCounters: membership.can_view_counters ?? false,
-        canCreateDocs: membership.can_create_docs ?? false,
+        canViewEvents: membership.can_view_calendar_events ?? false,
+        canViewAdvancedTool: membership.can_view_advanced_tools ?? false,
+        canViewCounters: membership.can_view_counter_groups ?? false,
+        canCreateDocs: membership.can_create_documents ?? false,
         canCreateProjects: membership.can_create_projects ?? false,
         canCreateQueues: membership.can_create_queues ?? false,
-        canCreateEvents: membership.can_create_events ?? false,
-        canCreateCounters: membership.can_create_counters ?? false,
+        canCreateEvents: membership.can_create_calendar_events ?? false,
+        canCreateCounters: membership.can_create_counter_groups ?? false,
       };
     },
     [user, isGuildAdmin, isGrantGuild, grantReadWrite]

--- a/frontend/src/hooks/useInitiativeRoles.ts
+++ b/frontend/src/hooks/useInitiativeRoles.ts
@@ -146,11 +146,11 @@ export const isFeatureEnabled = (
 ): boolean => {
   if (!permissions) return false;
   const keyMap: Record<typeof feature, PermissionKey> = {
-    docs: "docs_enabled",
+    docs: "documents_enabled",
     projects: "projects_enabled",
     queues: "queues_enabled",
-    events: "events_enabled",
-    counters: "counters_enabled",
+    events: "calendar_events_enabled",
+    counters: "counter_groups_enabled",
   };
   return permissions.permissions[keyMap[feature]] ?? false;
 };
@@ -163,61 +163,61 @@ export const canCreate = (
 ): boolean => {
   if (!permissions) return false;
   const keyMap: Record<typeof entity, PermissionKey> = {
-    docs: "create_docs",
+    docs: "create_documents",
     projects: "create_projects",
     queues: "create_queues",
-    events: "create_events",
-    counters: "create_counters",
+    events: "create_calendar_events",
+    counters: "create_counter_groups",
   };
   return permissions.permissions[keyMap[entity]] ?? false;
 };
 
 // Permission key labels for display (hardcoded, kept for backward compat)
 export const PERMISSION_LABELS: Record<PermissionKey, string> = {
-  docs_enabled: "View Documents",
+  documents_enabled: "View Documents",
   projects_enabled: "View Projects",
-  create_docs: "Create Documents",
+  create_documents: "Create Documents",
   create_projects: "Create Projects",
   queues_enabled: "View Queues",
   create_queues: "Create Queues",
-  events_enabled: "View Events",
-  create_events: "Create Events",
-  advanced_tool_enabled: "View Advanced Tool",
-  create_advanced_tool: "Create in Advanced Tool",
-  counters_enabled: "View Counters",
-  create_counters: "Create Counters",
+  calendar_events_enabled: "View Events",
+  create_calendar_events: "Create Events",
+  advanced_tools_enabled: "View Advanced Tool",
+  create_advanced_tools: "Create in Advanced Tool",
+  counter_groups_enabled: "View Counters",
+  create_counter_groups: "Create Counters",
 };
 
 // i18n-based permission label keys (use with t())
 export const PERMISSION_LABEL_KEYS: Record<PermissionKey, string> = {
-  docs_enabled: "settings.permissions.viewDocuments",
+  documents_enabled: "settings.permissions.viewDocuments",
   projects_enabled: "settings.permissions.viewProjects",
-  create_docs: "settings.permissions.createDocuments",
+  create_documents: "settings.permissions.createDocuments",
   create_projects: "settings.permissions.createProjects",
   queues_enabled: "settings.permissions.viewQueues",
   create_queues: "settings.permissions.createQueues",
-  events_enabled: "settings.permissions.viewEvents",
-  create_events: "settings.permissions.createEvents",
-  advanced_tool_enabled: "settings.permissions.viewAdvancedTool",
-  create_advanced_tool: "settings.permissions.createAdvancedTool",
-  counters_enabled: "settings.permissions.viewCounters",
-  create_counters: "settings.permissions.createCounters",
+  calendar_events_enabled: "settings.permissions.viewEvents",
+  create_calendar_events: "settings.permissions.createEvents",
+  advanced_tools_enabled: "settings.permissions.viewAdvancedTool",
+  create_advanced_tools: "settings.permissions.createAdvancedTool",
+  counter_groups_enabled: "settings.permissions.viewCounters",
+  create_counter_groups: "settings.permissions.createCounters",
 };
 
 // All permission keys in display order
 export const ALL_PERMISSION_KEYS: PermissionKey[] = [
-  "docs_enabled",
-  "create_docs",
+  "documents_enabled",
+  "create_documents",
   "projects_enabled",
   "create_projects",
   "queues_enabled",
   "create_queues",
-  "events_enabled",
-  "create_events",
-  "advanced_tool_enabled",
-  "create_advanced_tool",
-  "counters_enabled",
-  "create_counters",
+  "calendar_events_enabled",
+  "create_calendar_events",
+  "advanced_tools_enabled",
+  "create_advanced_tools",
+  "counter_groups_enabled",
+  "create_counter_groups",
 ];
 
 // Permission groups for card-based layout
@@ -228,17 +228,23 @@ export type PermissionGroup = {
 
 // Core permissions always visible
 export const CORE_PERMISSION_GROUPS: PermissionGroup[] = [
-  { labelKey: "settings.permissionGroups.documents", keys: ["docs_enabled", "create_docs"] },
+  {
+    labelKey: "settings.permissionGroups.documents",
+    keys: ["documents_enabled", "create_documents"],
+  },
   { labelKey: "settings.permissionGroups.projects", keys: ["projects_enabled", "create_projects"] },
 ];
 
 // Advanced tools permissions shown in accordion
 export const ADVANCED_PERMISSION_GROUPS: PermissionGroup[] = [
   { labelKey: "settings.permissionGroups.queues", keys: ["queues_enabled", "create_queues"] },
-  { labelKey: "settings.permissionGroups.events", keys: ["events_enabled", "create_events"] },
+  {
+    labelKey: "settings.permissionGroups.events",
+    keys: ["calendar_events_enabled", "create_calendar_events"],
+  },
   {
     labelKey: "settings.permissionGroups.counters",
-    keys: ["counters_enabled", "create_counters"],
+    keys: ["counter_groups_enabled", "create_counter_groups"],
   },
 ];
 
@@ -247,7 +253,7 @@ export const ADVANCED_PERMISSION_GROUPS: PermissionGroup[] = [
 // configured at runtime — see InitiativeSettingsRolesTab for the gating.
 export const ADVANCED_TOOL_PERMISSION_GROUP: PermissionGroup = {
   labelKey: "settings.permissionGroups.advancedTool",
-  keys: ["advanced_tool_enabled", "create_advanced_tool"],
+  keys: ["advanced_tools_enabled", "create_advanced_tools"],
 };
 
 // All groups combined (for backward compat)

--- a/frontend/src/hooks/useInitiatives.ts
+++ b/frontend/src/hooks/useInitiatives.ts
@@ -112,9 +112,9 @@ export const useCreateInitiative = (
       description?: string;
       color?: string;
       queues_enabled?: boolean;
-      events_enabled?: boolean;
-      counters_enabled?: boolean;
-      advanced_tool_enabled?: boolean;
+      calendar_events_enabled?: boolean;
+      counter_groups_enabled?: boolean;
+      advanced_tools_enabled?: boolean;
     }
   >
 ) => {
@@ -129,9 +129,9 @@ export const useCreateInitiative = (
       description?: string;
       color?: string;
       queues_enabled?: boolean;
-      events_enabled?: boolean;
-      counters_enabled?: boolean;
-      advanced_tool_enabled?: boolean;
+      calendar_events_enabled?: boolean;
+      counter_groups_enabled?: boolean;
+      advanced_tools_enabled?: boolean;
     }) => {
       return createInitiativeApiV1GGuildIdInitiativesPost(
         guildId,

--- a/frontend/src/hooks/useRecents.ts
+++ b/frontend/src/hooks/useRecents.ts
@@ -1,5 +1,6 @@
 import { type UseQueryOptions, useMutation, useQuery } from "@tanstack/react-query";
 
+import { recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost } from "@/api/generated/calendar-events/calendar-events";
 import { recordCounterGroupViewApiV1GGuildIdCounterGroupsGroupIdViewPost } from "@/api/generated/counters/counters";
 import { recordDocumentViewApiV1GGuildIdDocumentsDocumentIdViewPost } from "@/api/generated/documents/documents";
 import type { RecentItemRead } from "@/api/generated/initiativeAPI.schemas";
@@ -37,6 +38,7 @@ const recorders: Record<RecentEntityType, (guildId: number, id: number) => Promi
   document: recordDocumentViewApiV1GGuildIdDocumentsDocumentIdViewPost,
   queue: recordQueueViewApiV1GGuildIdQueuesQueueIdViewPost,
   counter_group: recordCounterGroupViewApiV1GGuildIdCounterGroupsGroupIdViewPost,
+  calendar_event: recordCalendarEventViewApiV1GGuildIdCalendarEventsEventIdViewPost,
 };
 
 /**

--- a/frontend/src/lib/recentRoute.ts
+++ b/frontend/src/lib/recentRoute.ts
@@ -13,6 +13,7 @@ const SEGMENT_BY_TYPE: Record<RecentItemRead["entity_type"], string> = {
   document: "documents",
   queue: "queues",
   counter_group: "counter-groups",
+  calendar_event: "events",
 };
 
 /**
@@ -43,6 +44,7 @@ export function getActiveRecentKey(pathname: string): RecentKey | null {
     { entityType: "document", re: /^\/g\/(\d+)\/documents\/(\d+)/ },
     { entityType: "queue", re: /^\/g\/(\d+)\/queues\/(\d+)/ },
     { entityType: "counter_group", re: /^\/g\/(\d+)\/counter-groups\/(\d+)/ },
+    { entityType: "calendar_event", re: /^\/g\/(\d+)\/events\/(\d+)/ },
   ];
 
   for (const { entityType, re } of patterns) {

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -415,13 +415,13 @@ export const DocumentDetailPage = () => {
     if (!document?.initiative || !user) {
       return false;
     }
-    // Check if user has create_docs permission via their role
+    // Check if user has create_documents permission via their role
     const membership = document.initiative.members?.find((m) => m.user?.id === user.id);
     if (!membership) {
       return false;
     }
-    // can_create_docs is populated from the initiative membership role
-    return membership.can_create_docs ?? false;
+    // can_create_documents is populated from the initiative membership role
+    return membership.can_create_documents ?? false;
   }, [document?.initiative, user]);
 
   // Wikilink navigation handler

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -436,7 +436,7 @@ export const DocumentsView = ({
     if (!membership) {
       return true; // Not a member, let the backend handle access control
     }
-    return membership.can_view_docs !== false;
+    return membership.can_view_documents !== false;
   }, [
     lockedInitiativeId,
     filteredInitiativeId,
@@ -549,7 +549,7 @@ export const DocumentsView = ({
       const membership = initiative.members.find((m) => m.user.id === user.id);
       // If not a member, include it (backend will handle access control)
       if (!membership) return true;
-      return membership.can_view_docs !== false;
+      return membership.can_view_documents !== false;
     });
   }, [initiativesQuery.data, user, isGuildAdmin, isGrantGuild]);
   const lockedInitiative = lockedInitiativeId

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -148,21 +148,21 @@ export const InitiativeSettingsPage = () => {
   const handleToggleEvents = (value: boolean) => {
     updateInitiative.mutate({
       initiativeId,
-      data: { events_enabled: value },
+      data: { calendar_events_enabled: value },
     });
   };
 
   const handleToggleAdvancedTool = (value: boolean) => {
     updateInitiative.mutate({
       initiativeId,
-      data: { advanced_tool_enabled: value },
+      data: { advanced_tools_enabled: value },
     });
   };
 
   const handleToggleCounters = (value: boolean) => {
     updateInitiative.mutate({
       initiativeId,
-      data: { counters_enabled: value },
+      data: { counter_groups_enabled: value },
     });
   };
 
@@ -268,11 +268,11 @@ export const InitiativeSettingsPage = () => {
           setColor={setColor}
           queuesEnabled={initiative?.queues_enabled ?? false}
           onToggleQueues={handleToggleQueues}
-          eventsEnabled={initiative?.events_enabled ?? false}
+          eventsEnabled={initiative?.calendar_events_enabled ?? false}
           onToggleEvents={handleToggleEvents}
-          advancedToolEnabled={initiative?.advanced_tool_enabled ?? false}
+          advancedToolEnabled={initiative?.advanced_tools_enabled ?? false}
           onToggleAdvancedTool={handleToggleAdvancedTool}
-          countersEnabled={initiative?.counters_enabled ?? false}
+          countersEnabled={initiative?.counter_groups_enabled ?? false}
           onToggleCounters={handleToggleCounters}
           canManageMembers={canManageMembers}
           isSaving={updateInitiative.isPending}

--- a/frontend/src/pages/InitiativesPage.tsx
+++ b/frontend/src/pages/InitiativesPage.tsx
@@ -132,9 +132,9 @@ export const InitiativesPage = () => {
         description: newDescription.trim() || undefined,
         color: newColor,
         queues_enabled: queuesEnabled,
-        events_enabled: eventsEnabled,
-        counters_enabled: countersEnabled,
-        advanced_tool_enabled: advancedToolEnabled,
+        calendar_events_enabled: eventsEnabled,
+        counter_groups_enabled: countersEnabled,
+        advanced_tools_enabled: advancedToolEnabled,
       },
       {
         onSuccess: () => {

--- a/frontend/src/pages/initiativeTools/AdvancedToolPage.tsx
+++ b/frontend/src/pages/initiativeTools/AdvancedToolPage.tsx
@@ -22,7 +22,7 @@ import { useGuildPath } from "@/lib/guildUrl";
  *      `advanced_tool` block (otherwise the route renders an empty state).
  *   2. Backend handoff already verifies: AUTOMATIONS_URL configured,
  *      initiative exists in active guild, user is guild admin or initiative
- *      member, advanced_tool_enabled=true.
+ *      member, advanced_tools_enabled=true.
  *   3. The handoff token is delivered to the iframe via postMessage *only*
  *      to the iframe's expected origin. We never put it in the URL.
  *   4. Inbound postMessage handlers verify event.origin against the same
@@ -241,7 +241,7 @@ export const AdvancedToolPage = () => {
     );
   }
 
-  if (!initiative.advanced_tool_enabled) {
+  if (!initiative.advanced_tools_enabled) {
     return (
       <Card>
         <CardHeader>

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -91,7 +91,7 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
   });
   const initiativesQuery = useInitiatives();
   const initiatives = useMemo(
-    () => (initiativesQuery.data ?? []).filter((init) => init.counters_enabled),
+    () => (initiativesQuery.data ?? []).filter((init) => init.counter_groups_enabled),
     [initiativesQuery.data]
   );
   const initiativeNameMap = useMemo(() => {


### PR DESCRIPTION
## Problem

Per-tool names were spelled differently on every surface (`counter_group` / `counters` / `counter-groups`; `calendar_event` / `events`; `document` / `docs`), and each backend surface re-declared its own per-tool list by hand — permission keys, initiative switch columns, membership flags, DAC feature gates, recents types, the recents trigger. Adding a tool meant finding all of them; forgetting one silently drifted (calendar events were missing from recents entirely).

## Changes

**Canonical naming, derived everywhere** (backend half of the tool-registry refactor; frontend registry lands as a follow-up PR):

- `Tool` enum grows derivation helpers (`plural`, `view_permission`, `create_permission`, `member_view_field`, `member_create_field`) plus `CORE_TOOLS` / `TOGGLEABLE_TOOLS` / `RECENTABLE_TOOLS` classifications.
- `PermissionKey` is now **generated** from the Tool enum (one `{plural}_enabled` + `create_{plural}` pair per tool); defaults and built-in role permissions derive too.
- Initiative master-switch columns, `InitiativeBase`/`InitiativeUpdate` schema fields, and `InitiativeMemberRead` `can_view_*`/`can_create_*` flags are generated from the enum (dynamic SQLModel mixin / `create_model`).
- `serialize_initiative`'s 130-line per-tool elif chain replaced by one `member_tool_flags` loop; `/my-permissions` blocks and `create_initiative` kwargs loop over tools.
- `ResourceGrant.resource_type` is typed as `Tool`; the parallel `TOOL_TYPES` / `RESOURCE_TYPES` string sets are gone.
- Dead `has_feature_access` wrapper and the rls-compat re-exports in the initiatives service removed (single real caller repointed to `rls`).
- **Renames** (breaking, pre-v1, no shims): `events_*` → `calendar_events_*`, `counters_*` → `counter_groups_*`, `docs_*` → `documents_*`, `advanced_tool_enabled`/`create_advanced_tool` → `advanced_tools_enabled`/`create_advanced_tools`, and the matching `can_view_*`/`can_create_*` member flags.
- **Calendar events join recents**: new `POST/DELETE /calendar-events/{id}/view`, enrichment in `/api/v1/recents`, RLS path leg, CHECK constraint + trigger arm.

## Schema / env updates

- Guild migration `20260704_0128`: renames the three initiative columns, rewrites stored `initiative_role_permissions.permission_key` values (constraint widened → data rewrite → re-pinned), extends the `recent_views` CHECK, and replaces the shared `public.fn_recent_views_set_guild_id` trigger function with a `calendar_event` arm.
- ⚠️ **External embed backend contract**: `MyInitiativePermissions.advanced_tools_enabled` (was `advanced_tool_enabled`) and the handoff JWT's `create_advanced_tools` claim (was `create_advanced_tool`) — the proprietary embed service must be updated in lockstep.
- Frontend: regenerated Orval types + mechanical field renames only (registry refactor, route/i18n renames, and new surfaces come in the follow-up frontend PR). Calendar events already record/appear in the recents bar.

## Drift tests

`app/core/tools_test.py` now asserts: PermissionKey == derived pairs, initiative switches == toggleable tools (and core tools have none), member flags == derived pairs, recents types agree across model/schema/RLS registry, and resource grants are Tool-typed — on top of the existing DAC/purge/trash coverage.

## Testing

```
cd backend && pytest app/core/tools_test.py app/services/ app/api/v1/tenant_endpoints/{initiatives,calendar_events,recents,documents,queues,counters,advanced_tool,events_properties}_test.py app/db/{tenancy,schema_provisioning,guild_rls}_test.py
cd backend && ruff check app && ruff format app
cd frontend && pnpm typecheck && pnpm lint && ./scripts/test-changed.sh   # 744 tests
```
All passing (fresh test DBs, migration exercised by the conftest fixture).