### PR TITLE
Fix calendar attendee picker, All Documents filter, PAM refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calendar events and the advanced tool now appear in the command palette (⌘K) — events are searchable like other tools; the advanced tool gets one jump entry per enabled initiative.
 - Initiative pages have an advanced-tools tab listing the initiative's advanced tools, with the standard Select → Edit access bulk-sharing flow (creation still happens in the connected automation service, and the UI says so).
 - Counter groups can now be created from the mobile initiative menu, matching the other tools.
+- Hard-purging an advanced tool (manual trash purge or the retention worker) now notifies the connected automation backend so its scheduling mirror is deleted too — including tools swept away by an initiative purge. Configured via `ADVANCED_TOOL_BACKEND_URL` + `ADVANCED_TOOL_PURGE_SECRET` (HMAC-signed, best-effort; unset on the default OSS image). Soft delete and archive stay pull-based — the automation side discovers them by syncing.
 
 ### Changed
 
@@ -24,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trashed counter groups and counters now auto-purge after their retention window, like every other trashed item — previously they lingered in the database indefinitely once past retention.
 - Restoring an item from the trash now refreshes the relevant list pages immediately — the restore invalidation used cache keys that didn't match the app's real query keys, so restored items only reappeared after a manual reload.
+- The calendar event attendee picker no longer comes up empty. It now lists the initiative members who can access the event.
+- Clearing the initiative filter (e.g. clicking "All Documents") now resets to every document without a manual refresh.
+- Break-glass / PAM access now shows the granted guild in the switcher immediately, instead of requiring a page reload before the guild becomes reachable.
 
 ## [0.54.0] - 2026-07-03
 

--- a/backend/app/api/v1/tenant_endpoints/trash.py
+++ b/backend/app/api/v1/tenant_endpoints/trash.py
@@ -50,6 +50,10 @@ from app.schemas.tenant.trash import (
     TrashItem,
     TrashListResponse,
 )
+from app.services.tenant.advanced_tool_notify import (
+    drain_purged_advanced_tools,
+    notify_purged_advanced_tools,
+)
 from app.services.platform import guilds as guilds_service
 from app.services.tenant.soft_delete import (
     RestoreResult,
@@ -391,4 +395,7 @@ async def purge_trash_entity(
     )
     await hard_purge_entity(session, entity)
     await session.commit()
+    # Post-commit: hard purges must also delete the advanced tool's
+    # scheduling mirror on the external backend (best-effort).
+    await notify_purged_advanced_tools(drain_purged_advanced_tools(session))
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -441,6 +441,17 @@ class Settings(BaseSettings):
     ADVANCED_TOOL_NAME: str | None = None
     ADVANCED_TOOL_URL: str | None = None
 
+    # Server-to-server link to the advanced tool's own backend. When a
+    # guild HARD-purges an advanced tool (manual trash purge or the
+    # retention worker), we notify that backend so its scheduling mirror
+    # is deleted too — a purge must not leave a live schedule pointing at
+    # nothing. ``ADVANCED_TOOL_BACKEND_URL`` is the service's API base
+    # (e.g. http://auto:9002/api/v1); ``ADVANCED_TOOL_PURGE_SECRET`` signs
+    # the notification (HMAC-SHA256, same envelope as webhook dispatch).
+    # Either unset -> notifications are skipped silently (default OSS image).
+    ADVANCED_TOOL_BACKEND_URL: str | None = None
+    ADVANCED_TOOL_PURGE_SECRET: str | None = None
+
     # Optional captcha gate on the public registration endpoint to push
     # back on bot signups. ``CAPTCHA_PROVIDER`` selects the vendor —
     # ``"hcaptcha"`` / ``"turnstile"`` / ``"recaptcha"`` — and the SPA

--- a/backend/app/services/tenant/advanced_tool_notify.py
+++ b/backend/app/services/tenant/advanced_tool_notify.py
@@ -1,0 +1,111 @@
+"""Purge notifications to the advanced tool's backend.
+
+The advanced tool service (initiative-auto) keeps a scheduling mirror per
+``advanced_tools`` row. Soft delete and archive need no push — the mirror
+discovers them by reading our API (404 → hidden, times preserved). A HARD
+purge is different: the row is gone forever, so the mirror must be deleted
+too, and only we know the purge happened. Hence this one outbound call.
+
+Mechanics:
+
+* Pairs are QUEUED on ``session.info`` while ``hard_purge_entity`` walks
+  its doomed rows, and DRAINED by the caller **after commit** — notifying
+  before commit could delete a mirror for a purge that then rolls back.
+* Delivery is best-effort: the purge itself must never fail or roll back
+  because the tool's backend is down. A missed notification leaves an
+  orphaned mirror whose next sync sees our 404 and hides it — safe, just
+  untidy.
+* The envelope reuses the webhook dispatch signature format
+  (``sha256=<hex>`` over ``{timestamp}.{body}``) with the dedicated
+  ``ADVANCED_TOOL_PURGE_SECRET``, so the receiving side verifies it the
+  same way it verifies event deliveries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_SESSION_INFO_KEY = "purged_advanced_tools"
+_TIMEOUT_SECONDS = 5.0
+
+
+def queue_purged_advanced_tool(
+    session: Any, *, guild_id: int, advanced_tool_id: int
+) -> None:
+    """Record a purged (guild_id, advanced_tool_id) pair on the session,
+    to be drained after the purge transaction commits."""
+    session.info.setdefault(_SESSION_INFO_KEY, []).append((guild_id, advanced_tool_id))
+
+
+def drain_purged_advanced_tools(session: Any) -> list[tuple[int, int]]:
+    """Take (and clear) the queued pairs. Call after commit."""
+    return session.info.pop(_SESSION_INFO_KEY, [])
+
+
+def _sign(secret: str, timestamp: str, body: bytes) -> str:
+    mac = hmac.new(secret.encode("utf-8"), digestmod=hashlib.sha256)
+    mac.update(timestamp.encode("utf-8"))
+    mac.update(b".")
+    mac.update(body)
+    return f"sha256={mac.hexdigest()}"
+
+
+async def notify_purged_advanced_tools(pairs: list[tuple[int, int]]) -> None:
+    """Tell the advanced tool's backend these rows are gone forever.
+
+    No-op when the server-to-server link isn't configured. Failures are
+    logged, never raised — see module docstring for why that is safe.
+    """
+    if not pairs:
+        return
+    if (
+        not settings.ADVANCED_TOOL_BACKEND_URL
+        or not settings.ADVANCED_TOOL_PURGE_SECRET
+    ):
+        return
+
+    base = settings.ADVANCED_TOOL_BACKEND_URL.rstrip("/")
+    async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+        for guild_id, advanced_tool_id in pairs:
+            body = json.dumps(
+                {"guild_id": guild_id, "advanced_tool_id": advanced_tool_id}
+            ).encode("utf-8")
+            timestamp = str(int(time.time()))
+            headers = {
+                "Content-Type": "application/json",
+                "X-Initiative-Timestamp": timestamp,
+                "X-Initiative-Signature": _sign(
+                    settings.ADVANCED_TOOL_PURGE_SECRET, timestamp, body
+                ),
+            }
+            try:
+                response = await client.post(
+                    f"{base}/automations/purged", content=body, headers=headers
+                )
+                if response.status_code >= 400:
+                    logger.warning(
+                        "advanced-tool purge notification rejected "
+                        "(guild=%s tool=%s): %s %s",
+                        guild_id,
+                        advanced_tool_id,
+                        response.status_code,
+                        response.text[:200],
+                    )
+            except httpx.HTTPError as exc:
+                logger.warning(
+                    "advanced-tool purge notification failed (guild=%s tool=%s): %s",
+                    guild_id,
+                    advanced_tool_id,
+                    exc,
+                )

--- a/backend/app/services/tenant/advanced_tool_notify_test.py
+++ b/backend/app/services/tenant/advanced_tool_notify_test.py
@@ -1,0 +1,101 @@
+"""Tests for the advanced-tool purge notification pipeline.
+
+The contract under test: a HARD purge of an advanced tool queues a
+(guild_id, advanced_tool_id) pair on the session, the drain hands it
+over exactly once, and the outbound envelope is signed the way the
+receiving service verifies it (``sha256=<hex>`` over
+``{timestamp}.{body}`` with the shared secret). Soft deletes must queue
+nothing — the mirror discovers those by syncing against our API.
+"""
+
+import hashlib
+import hmac
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.tenant.advanced_tool import AdvancedTool
+from app.services.tenant.advanced_tool_notify import (
+    _sign,
+    drain_purged_advanced_tools,
+    notify_purged_advanced_tools,
+    queue_purged_advanced_tool,
+)
+from app.services.tenant.soft_delete import (
+    hard_purge_entity,
+    soft_delete_entity,
+)
+from app.testing import create_guild, create_user, route_session_to_guild
+
+
+async def _make_tool(session: AsyncSession) -> AdvancedTool:
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    await route_session_to_guild(session, guild.id)
+    tool = AdvancedTool(guild_id=guild.id, name="Nightly export", created_by_id=user.id)
+    session.add(tool)
+    await session.commit()
+    await session.refresh(tool)
+    return tool
+
+
+@pytest.mark.unit
+def test_signature_matches_the_receivers_scheme():
+    secret, timestamp, body = "s3cret", "1720000000", b'{"guild_id":1}'
+    mac = hmac.new(secret.encode(), digestmod=hashlib.sha256)
+    mac.update(b"1720000000.")
+    mac.update(body)
+    assert _sign(secret, timestamp, body) == f"sha256={mac.hexdigest()}"
+
+
+@pytest.mark.service
+async def test_hard_purge_queues_the_pair(session: AsyncSession):
+    tool = await _make_tool(session)
+    guild_id, tool_id = tool.guild_id, tool.id
+
+    await hard_purge_entity(session, tool)
+    await session.commit()
+
+    assert drain_purged_advanced_tools(session) == [(guild_id, tool_id)]
+    # Drained exactly once.
+    assert drain_purged_advanced_tools(session) == []
+
+
+@pytest.mark.service
+async def test_soft_delete_queues_nothing(session: AsyncSession):
+    tool = await _make_tool(session)
+
+    await soft_delete_entity(
+        session, tool, deleted_by_user_id=tool.created_by_id, retention_days=30
+    )
+    await session.commit()
+
+    assert drain_purged_advanced_tools(session) == []
+
+
+@pytest.mark.service
+async def test_notify_is_a_noop_without_config(monkeypatch):
+    """Unconfigured deployments (default OSS image) must not attempt any
+    HTTP call — notify returns before touching the network."""
+    from app.services.tenant import advanced_tool_notify as module
+
+    monkeypatch.setattr(module.settings, "ADVANCED_TOOL_BACKEND_URL", None)
+    monkeypatch.setattr(module.settings, "ADVANCED_TOOL_PURGE_SECRET", None)
+
+    class Boom:
+        def __call__(self, *a, **k):
+            raise AssertionError("no HTTP client should be constructed")
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", Boom())
+    await notify_purged_advanced_tools([(1, 2)])
+
+
+@pytest.mark.unit
+def test_queue_and_drain_accumulate_in_order():
+    class FakeSession:
+        info: dict = {}
+
+    fake = FakeSession()
+    queue_purged_advanced_tool(fake, guild_id=1, advanced_tool_id=10)
+    queue_purged_advanced_tool(fake, guild_id=1, advanced_tool_id=11)
+    assert drain_purged_advanced_tools(fake) == [(1, 10), (1, 11)]

--- a/backend/app/services/tenant/soft_delete.py
+++ b/backend/app/services/tenant/soft_delete.py
@@ -33,6 +33,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.db.soft_delete_filter import select_including_deleted
 from app.models.tenant._mixins import SoftDeleteMixin
+from app.models.tenant.advanced_tool import AdvancedTool
 from app.models.tenant.calendar_event import CalendarEvent
 from app.models.tenant.comment import Comment
 from app.models.tenant.document import Document
@@ -322,6 +323,7 @@ async def hard_purge_entity(
     disk and ``Upload`` rows pinned only by the doomed documents are also
     removed.
     """
+    from app.services.tenant.advanced_tool_notify import queue_purged_advanced_tool
     from app.services.attachments import purge_document_uploads
 
     descendants = await _gather_descendants(session, entity)
@@ -330,6 +332,26 @@ async def hard_purge_entity(
     doomed_documents = [d for d in all_doomed if isinstance(d, Document)]
     if doomed_documents:
         await purge_document_uploads(session, doomed_documents)
+
+    # A hard purge must also delete the advanced tool's scheduling mirror on
+    # the external backend (soft delete/archive need no push — the mirror sees
+    # our 404 on sync). Queue the pairs now, notify AFTER the caller commits.
+    # Initiative purges need explicit enumeration: advanced_tools hangs off
+    # the DB-level ON DELETE CASCADE, not the CASCADE_CHILDREN walk, so the
+    # doomed rows never appear in ``all_doomed``.
+    doomed_tools: list[AdvancedTool] = [
+        d for d in all_doomed if isinstance(d, AdvancedTool)
+    ]
+    doomed_initiatives = [d for d in all_doomed if isinstance(d, Initiative)]
+    for initiative in doomed_initiatives:
+        cascade_stmt = select_including_deleted(AdvancedTool).where(
+            AdvancedTool.initiative_id == initiative.id
+        )
+        doomed_tools.extend((await session.exec(cascade_stmt)).all())
+    for tool in doomed_tools:
+        queue_purged_advanced_tool(
+            session, guild_id=tool.guild_id, advanced_tool_id=tool.id
+        )
 
     # Reverse so we delete leaves before parents — needed because most FKs
     # in this codebase don't use DB-level ON DELETE CASCADE.

--- a/backend/app/services/tenant/trash_purge.py
+++ b/backend/app/services/tenant/trash_purge.py
@@ -40,6 +40,10 @@ from app.models.tenant.project import Project
 from app.models.tenant.queue import Queue, QueueItem
 from app.models.tenant.tag import Tag
 from app.models.tenant.task import Task
+from app.services.tenant.advanced_tool_notify import (
+    drain_purged_advanced_tools,
+    notify_purged_advanced_tools,
+)
 from app.services.tenant.soft_delete import hard_purge_entity
 
 
@@ -117,6 +121,10 @@ async def _purge_all_guilds(session, *, now: datetime) -> None:
         await set_rls_context(session, guild_id=guild_id, guild_role="admin")
         await _run_purge_pass(session, now=now)
         await session.commit()
+        # Post-commit: tell the advanced tool's backend about hard-purged
+        # tools so their scheduling mirrors are deleted too. Best-effort —
+        # a failure logs and the next mirror sync hides the orphan anyway.
+        await notify_purged_advanced_tools(drain_purged_advanced_tools(session))
 
 
 async def process_trash_purges() -> None:

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -40,7 +40,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/hooks/useAuth";
 import { useCreateCalendarEvent } from "@/hooks/useCalendarEvents";
-import { useInitiativeMembers } from "@/hooks/useInitiatives";
+import { useInitiative } from "@/hooks/useInitiatives";
 import type { DialogProps } from "@/types/dialog";
 
 import {
@@ -87,8 +87,32 @@ export const CreateEventDialog = ({
     { all_initiative_members: true, level: "read" },
   ]);
 
-  // Fetch initiative members for attendee picker
-  const { data: members } = useInitiativeMembers(initiativeId);
+  // Attendee candidates: initiative members who can access this event via its
+  // grants — mirrors how task assignees are derived from a project's grants
+  // (ProjectDetailPage.userOptions), but scoped to the initiative's members
+  // rather than all guild users. Any grant level qualifies (attending only needs
+  // view access, unlike a task assignee who needs write). The initiative is read
+  // via get_initiative (the same source ShareControl uses), which honors the
+  // guild-admin override — so the picker is no longer empty for a non-member
+  // admin, and the default all-members grant surfaces the whole initiative.
+  const { data: initiative } = useInitiative(initiativeId);
+  const members = useMemo(() => {
+    const initiativeMembers = initiative?.members ?? [];
+    if (grants.some((g) => g.all_initiative_members)) {
+      return initiativeMembers.map((m) => m.user);
+    }
+    const grantedUserIds = new Set(
+      grants.filter((g) => g.user_id != null).map((g) => g.user_id as number)
+    );
+    const grantedRoleIds = new Set(
+      grants.filter((g) => g.role_id != null).map((g) => g.role_id as number)
+    );
+    return initiativeMembers
+      .filter(
+        (m) => grantedUserIds.has(m.user.id) || (m.role_id != null && grantedRoleIds.has(m.role_id))
+      )
+      .map((m) => m.user);
+  }, [initiative?.members, grants]);
 
   const memberItems = useMemo(() => {
     return (members ?? [])

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -100,15 +100,20 @@ export const DocumentsView = ({
   const prevGuildIdRef = useRef<number | null>(activeGuildId);
   const isClosingCreateDialog = useRef(false);
 
-  // Check for query params to filter by initiative (consume once)
+  // Sync the initiative filter to the URL's ?initiativeId. A specific id filters
+  // to it; clearing the param — e.g. clicking "All Documents" from an
+  // initiative-scoped view — resets to ALL. Tracking lastConsumedParams lets the
+  // filter dropdown override the selection without the URL re-pinning it, while
+  // still resetting on real navigation. Without the reset the filter stayed
+  // pinned to the initiative we arrived from, so All Documents showed only that
+  // initiative's docs until a manual refresh.
   useEffect(() => {
+    if (lockedInitiativeId) return;
     const urlInitiativeId = searchParams.initiativeId;
     const paramKey = urlInitiativeId || "";
-
-    if (urlInitiativeId && !lockedInitiativeId && paramKey !== lastConsumedParams.current) {
-      lastConsumedParams.current = paramKey;
-      setInitiativeFilter(urlInitiativeId);
-    }
+    if (paramKey === lastConsumedParams.current) return;
+    lastConsumedParams.current = paramKey;
+    setInitiativeFilter(urlInitiativeId || INITIATIVE_FILTER_ALL);
   }, [searchParams, lockedInitiativeId]);
   const [searchQuery, setSearchQuery] = useState("");
   const [filtersOpen, setFiltersOpen] = useState(getDefaultDocumentFiltersVisibility);

--- a/frontend/src/pages/SettingsAccessGrantsPage.tsx
+++ b/frontend/src/pages/SettingsAccessGrantsPage.tsx
@@ -31,6 +31,7 @@ import {
   useRevokeAccessGrant,
 } from "@/hooks/useAccessGrants";
 import { useAuth } from "@/hooks/useAuth";
+import { useGuilds } from "@/hooks/useGuilds";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { Capability, hasCapability } from "@/lib/permissions";
@@ -146,6 +147,7 @@ const BREAK_GLASS_DURATIONS_MINUTES = [60, 120, 240];
 // read-only by default, short-lived, and recorded as an audited grant.
 const BreakGlassSection = () => {
   const { t } = useTranslation(["settings", "common"]);
+  const { refreshGuilds } = useGuilds();
   const [guildId, setGuildId] = useState("");
   const [level, setLevel] = useState("read");
   const [duration, setDuration] = useState("60");
@@ -158,6 +160,11 @@ const BreakGlassSection = () => {
       setReason("");
       setLevel("read");
       setDuration("60");
+      // A break-glass grant is live immediately. The guild switcher and the
+      // /g/{id} route guard read from the GuildProvider's context list (not
+      // React Query), so refresh it here — otherwise the newly-reachable guild
+      // doesn't appear until a manual reload.
+      void refreshGuilds();
     },
     onError: (err) => toast.error(getErrorMessage(err, "settings:accessGrants.breakGlass.error")),
   });

--- a/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
@@ -55,7 +55,7 @@ import {
   useSetEventTags,
   useUpdateCalendarEvent,
 } from "@/hooks/useCalendarEvents";
-import { useInitiativeMembers } from "@/hooks/useInitiatives";
+import { useInitiative } from "@/hooks/useInitiatives";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
 
@@ -86,8 +86,32 @@ export function EventSettingsPage() {
   // the PropertyList. The list's debounced save handles persistence.
   const [pendingProperties, setPendingProperties] = useState<PropertyDefinitionRead[]>([]);
 
-  // Fetch initiative members
-  const { data: members } = useInitiativeMembers(event?.initiative_id ?? null);
+  // Attendee candidates: initiative members who can access this event via its
+  // grants — mirrors task-assignee derivation (ProjectDetailPage.userOptions)
+  // but scoped to the initiative's members rather than all guild users. Any
+  // grant level qualifies (attending needs only view access). The initiative is
+  // read via get_initiative (the same source ShareControl uses), which honors
+  // the guild-admin override — the /members endpoint 403'd for a non-member
+  // admin and left the picker empty.
+  const { data: initiative } = useInitiative(event?.initiative_id ?? null);
+  const members = useMemo(() => {
+    const initiativeMembers = initiative?.members ?? [];
+    const grants = event?.grants ?? [];
+    if (grants.some((g) => g.all_initiative_members)) {
+      return initiativeMembers.map((m) => m.user);
+    }
+    const grantedUserIds = new Set(
+      grants.filter((g) => g.user_id != null).map((g) => g.user_id as number)
+    );
+    const grantedRoleIds = new Set(
+      grants.filter((g) => g.role_id != null).map((g) => g.role_id as number)
+    );
+    return initiativeMembers
+      .filter(
+        (m) => grantedUserIds.has(m.user.id) || (m.role_id != null && grantedRoleIds.has(m.role_id))
+      )
+      .map((m) => m.user);
+  }, [initiative?.members, event?.grants]);
 
   const memberItems = useMemo(() => {
     return (members ?? [])


### PR DESCRIPTION
## Problem

Three UI bugs plus a backend cleanup gap:

1. **Calendar event attendee picker came up empty** — even the PM wasn't selectable. The picker read from the `/initiatives/{id}/members` endpoint, which returns 403 for a guild admin who isn't an initiative member, so it loaded nobody.
2. **"All Documents" page stayed stale** — opening it from an initiative's document view left the list pinned to that one initiative until a manual browser refresh.
3. **Break-glass / PAM grant didn't refresh the UI** — after self-issuing a grant, the newly-reachable guild didn't appear in the switcher (and its `/g/{id}` route guard failed) until a full reload.
4. **Advanced-tool hard-purge left a dangling external schedule** — purging an advanced tool didn't tell the external automation backend, so its scheduling mirror kept pointing at nothing.

## Changes

**Frontend**
- **Attendee picker** (`CreateEventDialog`, `EventSettingsPage`): derive candidates from the initiative's members that the event's **sharing grants** cover — initiative-scoped, mirroring how task assignees are derived from a project's grants (`ProjectDetailPage.userOptions`). Any grant level qualifies (attending only needs view access). The initiative is read via `useInitiative` — the same source the dialog's own `ShareControl` uses, served by `get_initiative` which honors the guild-admin override — so the picker is no longer empty. Admins still only appear if they've actually joined the initiative.
- **All Documents** (`DocumentsPage`): reset the initiative filter to ALL when the `?initiativeId` URL param is cleared, so navigating to "All Documents" from an initiative view no longer stays stale.
- **PAM refresh** (`SettingsAccessGrantsPage`): call `refreshGuilds()` after a break-glass grant so the granted guild appears in the switcher immediately.

**Backend**
- **Advanced-tool purge notification**: hard-purging an advanced tool (manual purge or the retention worker) now notifies the external advanced-tool backend (HMAC-signed, same envelope as webhook dispatch) so its scheduling mirror is deleted too. New optional settings `ADVANCED_TOOL_BACKEND_URL` / `ADVANCED_TOOL_PURGE_SECRET` (both unset → skipped silently, default OSS image).

## Testing

- `pnpm exec tsc --noEmit` — 0 errors.
- `pnpm exec biome check` on the changed frontend files — clean.
- Backend: `advanced_tool_notify_test.py` added alongside the new service.

_No backend API/schema changes to the calendar or members endpoints — the attendee fix is entirely client-side._