### PR TITLE
Fix notifications after 0.54 login-role narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Notifications work again.** The 0.54.0 least-privilege database refactor revoked the bare login role's access to the `notifications` and `push_tokens` tables, but the notification and push-token endpoints still ran on that role — every request failed, so the bell showed no notifications (the backlog looked cleared; it was never deleted and reappears with this fix), nothing could be marked read, and mobile push registration failed. These endpoints now run on the authenticated platform path like the rest of the API.
+- **Notifications work again.** The 0.54.0 least-privilege database refactor revoked the bare login role's access to the `notifications` and `push_tokens` tables, but the notification and push-token endpoints still ran on that role — every request failed, so the bell showed no notifications (the backlog looked cleared; it was never deleted and reappears with this fix), nothing could be marked read, and mobile push registration failed. These endpoints now run on the authenticated platform path like the rest of the API, and unregistering a push token is scoped to the calling user's own tokens.
 - Permanently purging a document (manual trash purge or the retention worker) now unresolves wikilinks pointing at it in every other document — including trashed ones — instead of leaving links that reference a document that no longer exists.
 - Expired sign-in and verification tokens are now cleaned up automatically by an hourly background sweep; previously expired rows accumulated indefinitely.
 - Deleted (anonymized) users now display consistently as "Deleted user" everywhere; several screens previously showed a raw email or "Anonymous".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Notifications work again.** The 0.54.0 least-privilege database refactor revoked the bare login role's access to the `notifications` and `push_tokens` tables, but the notification and push-token endpoints still ran on that role — every request failed, so the bell showed no notifications (the backlog looked cleared; it was never deleted and reappears with this fix), nothing could be marked read, and mobile push registration failed. These endpoints now run on the authenticated platform path like the rest of the API.
 - Permanently purging a document (manual trash purge or the retention worker) now unresolves wikilinks pointing at it in every other document — including trashed ones — instead of leaving links that reference a document that no longer exists.
 - Expired sign-in and verification tokens are now cleaned up automatically by an hourly background sweep; previously expired rows accumulated indefinitely.
 - Deleted (anonymized) users now display consistently as "Deleted user" everywhere; several screens previously showed a raw email or "Anonymous".

--- a/backend/app/api/v1/platform_endpoints/notifications.py
+++ b/backend/app/api/v1/platform_endpoints/notifications.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from app.api.deps import SessionDep, get_current_active_user
+from app.api.deps import UserSessionDep, get_current_active_user
 from app.models.platform.user import User
 from app.schemas.platform.notification import (
     NotificationCountResponse,
@@ -15,7 +15,7 @@ router = APIRouter()
 
 @router.get("/", response_model=NotificationListResponse)
 async def list_notifications(
-    session: SessionDep,
+    session: UserSessionDep,
     current_user: User = Depends(get_current_active_user),
     limit: int = Query(default=20, ge=1, le=100),
 ) -> NotificationListResponse:
@@ -31,7 +31,7 @@ async def list_notifications(
 
 @router.get("/unread-count", response_model=NotificationCountResponse)
 async def unread_notifications_count(
-    session: SessionDep,
+    session: UserSessionDep,
     current_user: User = Depends(get_current_active_user),
 ) -> NotificationCountResponse:
     count = await notifications_service.unread_count(session, user_id=current_user.id)
@@ -41,7 +41,7 @@ async def unread_notifications_count(
 @router.post("/{notification_id}/read", response_model=NotificationRead)
 async def mark_notification_read(
     notification_id: int,
-    session: SessionDep,
+    session: UserSessionDep,
     current_user: User = Depends(get_current_active_user),
 ) -> NotificationRead:
     notification = await notifications_service.mark_notification_read(
@@ -56,7 +56,7 @@ async def mark_notification_read(
 
 @router.post("/read-all", response_model=NotificationCountResponse)
 async def mark_all_notifications_read(
-    session: SessionDep,
+    session: UserSessionDep,
     current_user: User = Depends(get_current_active_user),
 ) -> NotificationCountResponse:
     await notifications_service.mark_all_notifications_read(

--- a/backend/app/api/v1/platform_endpoints/notifications_test.py
+++ b/backend/app/api/v1/platform_endpoints/notifications_test.py
@@ -1,0 +1,99 @@
+"""Integration tests for /api/v1/notifications.
+
+These run through the real-role ``client`` (bare ``app_user`` login +
+``SET ROLE platform_<tier>``), guarding the 0.54.0 regression where the
+endpoints ran as the de-granted bare login role and every request failed
+with ``permission denied for table notifications``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.platform.notification import NotificationType
+from app.services.platform import user_notifications
+from app.testing.factories import create_user, get_auth_headers
+
+
+async def _seed_notification(session: AsyncSession, user_id: int) -> int:
+    notification = await user_notifications.create_notification(
+        session,
+        user_id=user_id,
+        notification_type=NotificationType.task_assignment,
+        data={"task_title": "Ship it"},
+    )
+    await session.commit()
+    return notification.id
+
+
+@pytest.mark.integration
+async def test_list_notifications(client: AsyncClient, session: AsyncSession):
+    user = await create_user(session)
+    await _seed_notification(session, user.id)
+
+    response = await client.get(
+        "/api/v1/notifications/", headers=get_auth_headers(user)
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["unread_count"] == 1
+    assert len(body["notifications"]) == 1
+    assert body["notifications"][0]["type"] == "task_assignment"
+
+
+@pytest.mark.integration
+async def test_unread_count(client: AsyncClient, session: AsyncSession):
+    user = await create_user(session)
+    await _seed_notification(session, user.id)
+
+    response = await client.get(
+        "/api/v1/notifications/unread-count", headers=get_auth_headers(user)
+    )
+    assert response.status_code == 200
+    assert response.json() == {"unread_count": 1}
+
+
+@pytest.mark.integration
+async def test_mark_notification_read(client: AsyncClient, session: AsyncSession):
+    user = await create_user(session)
+    notification_id = await _seed_notification(session, user.id)
+    headers = get_auth_headers(user)
+
+    response = await client.post(
+        f"/api/v1/notifications/{notification_id}/read", headers=headers
+    )
+    assert response.status_code == 200
+    assert response.json()["read_at"] is not None
+
+    count_resp = await client.get("/api/v1/notifications/unread-count", headers=headers)
+    assert count_resp.json() == {"unread_count": 0}
+
+
+@pytest.mark.integration
+async def test_mark_all_notifications_read(client: AsyncClient, session: AsyncSession):
+    user = await create_user(session)
+    await _seed_notification(session, user.id)
+    await _seed_notification(session, user.id)
+
+    response = await client.post(
+        "/api/v1/notifications/read-all", headers=get_auth_headers(user)
+    )
+    assert response.status_code == 200
+    assert response.json() == {"unread_count": 0}
+
+
+@pytest.mark.integration
+async def test_cannot_read_other_users_notification(
+    client: AsyncClient, session: AsyncSession
+):
+    owner = await create_user(session)
+    other = await create_user(session)
+    notification_id = await _seed_notification(session, owner.id)
+
+    response = await client.post(
+        f"/api/v1/notifications/{notification_id}/read",
+        headers=get_auth_headers(other),
+    )
+    assert response.status_code == 404

--- a/backend/app/api/v1/platform_endpoints/notifications_test.py
+++ b/backend/app/api/v1/platform_endpoints/notifications_test.py
@@ -25,6 +25,7 @@ async def _seed_notification(session: AsyncSession, user_id: int) -> int:
         data={"task_title": "Ship it"},
     )
     await session.commit()
+    assert notification.id is not None
     return notification.id
 
 

--- a/backend/app/api/v1/platform_endpoints/push.py
+++ b/backend/app/api/v1/platform_endpoints/push.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
-from app.api.deps import SessionDep, get_current_active_user
+from app.api.deps import UserSessionDep, get_current_active_user
 from app.models.platform.user import User
 from app.schemas.platform.push import (
     PushTokenRegisterRequest,
@@ -18,7 +18,7 @@ CurrentUser = Annotated[User, Depends(get_current_active_user)]
 
 @router.post("/register", response_model=PushTokenResponse)
 async def register_push_token(
-    session: SessionDep,
+    session: UserSessionDep,
     current_user: CurrentUser,
     request: PushTokenRegisterRequest,
 ) -> PushTokenResponse:
@@ -39,7 +39,7 @@ async def register_push_token(
 
 @router.delete("/unregister", response_model=PushTokenResponse)
 async def unregister_push_token(
-    session: SessionDep,
+    session: UserSessionDep,
     current_user: CurrentUser,
     request: PushTokenUnregisterRequest,
 ) -> PushTokenResponse:

--- a/backend/app/api/v1/platform_endpoints/push.py
+++ b/backend/app/api/v1/platform_endpoints/push.py
@@ -48,5 +48,7 @@ async def unregister_push_token(
     This endpoint removes a push token from the database. The device will
     no longer receive push notifications.
     """
-    await push_tokens.delete_push_token(session, push_token=request.push_token)
+    await push_tokens.delete_push_token(
+        session, user_id=current_user.id, push_token=request.push_token
+    )
     return PushTokenResponse(status="unregistered")

--- a/backend/app/api/v1/platform_endpoints/push_test.py
+++ b/backend/app/api/v1/platform_endpoints/push_test.py
@@ -1,0 +1,40 @@
+"""Integration tests for /api/v1/push token registration.
+
+These run through the real-role ``client`` (bare ``app_user`` login +
+``SET ROLE platform_<tier>``), guarding the 0.54.0 regression where the
+endpoints ran as the de-granted bare login role and failed with
+``permission denied for table push_tokens``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.testing.factories import create_user, get_auth_headers
+
+
+@pytest.mark.integration
+async def test_register_and_unregister_push_token(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session)
+    headers = get_auth_headers(user)
+
+    register = await client.post(
+        "/api/v1/push/register",
+        headers=headers,
+        json={"push_token": "test-push-token-abc", "platform": "android"},
+    )
+    assert register.status_code == 200
+    assert register.json() == {"status": "registered"}
+
+    unregister = await client.request(
+        "DELETE",
+        "/api/v1/push/unregister",
+        headers=headers,
+        json={"push_token": "test-push-token-abc"},
+    )
+    assert unregister.status_code == 200
+    assert unregister.json() == {"status": "unregistered"}

--- a/backend/app/api/v1/platform_endpoints/push_test.py
+++ b/backend/app/api/v1/platform_endpoints/push_test.py
@@ -12,6 +12,7 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.services.platform import push_tokens as push_tokens_service
 from app.testing.factories import create_user, get_auth_headers
 
 
@@ -38,3 +39,33 @@ async def test_register_and_unregister_push_token(
     )
     assert unregister.status_code == 200
     assert unregister.json() == {"status": "unregistered"}
+
+
+@pytest.mark.integration
+async def test_unregister_cannot_delete_other_users_token(
+    client: AsyncClient, session: AsyncSession
+):
+    owner = await create_user(session)
+    attacker = await create_user(session)
+    token_value = "owner-push-token-xyz"
+
+    register = await client.post(
+        "/api/v1/push/register",
+        headers=get_auth_headers(owner),
+        json={"push_token": token_value, "platform": "ios"},
+    )
+    assert register.status_code == 200
+
+    # A different authenticated user who learned the token value must not be
+    # able to silence the owner's device.
+    await client.request(
+        "DELETE",
+        "/api/v1/push/unregister",
+        headers=get_auth_headers(attacker),
+        json={"push_token": token_value},
+    )
+
+    remaining = await push_tokens_service.get_push_tokens_for_user(
+        session, user_id=owner.id
+    )
+    assert [t.push_token for t in remaining] == [token_value]

--- a/backend/app/services/platform/push_notifications.py
+++ b/backend/app/services/platform/push_notifications.py
@@ -237,7 +237,9 @@ async def send_push_to_user(
     # Delete invalid tokens
     for invalid_token in tokens_to_delete:
         logger.info(f"Deleting invalid push token: {invalid_token[:20]}...")
-        await push_tokens.delete_push_token(session, push_token=invalid_token)
+        await push_tokens.delete_push_token(
+            session, user_id=user_id, push_token=invalid_token
+        )
 
     logger.info(
         f"Sent push notification to {successful}/{len(tokens)} devices "

--- a/backend/app/services/platform/push_tokens.py
+++ b/backend/app/services/platform/push_tokens.py
@@ -67,13 +67,19 @@ async def get_push_tokens_for_user(
 async def delete_push_token(
     session: AsyncSession,
     *,
+    user_id: int,
     push_token: str,
 ) -> bool:
-    """Remove a push token (on unregister or invalid token error).
+    """Remove one of ``user_id``'s push tokens (on unregister or invalid
+    token error). Scoped to the owner so a leaked token value can't be used
+    to silence another user's devices.
 
     Returns True if a token was deleted, False otherwise.
     """
-    stmt = delete(PushToken).where(PushToken.push_token == push_token)
+    stmt = delete(PushToken).where(
+        PushToken.user_id == user_id,
+        PushToken.push_token == push_token,
+    )
     result = await session.exec(stmt)
     await session.commit()
     return result.rowcount > 0  # type: ignore


### PR DESCRIPTION
## Problem

Since v0.54.0, in-app notifications stopped entirely: the bell showed nothing (looking like the backlog had been cleared), unread counts were gone, nothing could be marked read, and mobile push-token registration failed.

Root cause: the 0.54.0 grant matrices (migration `20260702_0126`, registry `app/db/system_grants.py`) revoked the bare `app_user` login role's access to `public.notifications` and `public.push_tokens` (`None` in `SHARED_TABLE_APP_USER_GRANTS`) — but `/api/v1/notifications` and `/api/v1/push` still used bare `SessionDep` (no `SET ROLE`), so every request died with `permission denied for table notifications` / `push_tokens`.

**No data was lost** — the backlog rows were never deleted, only unreadable; they reappear with this fix.

## Changes

- `notifications.py` and `push.py` platform endpoints now use `UserSessionDep` (authenticated platform path, `SET ROLE platform_<tier>`). `platform_base` holds the needed grants on both fresh installs (baseline ACLs) and upgraded ones (broad grants + default privileges from the platform-roles migration), so no migration is needed.
- New real-role integration tests for both routers (`notifications_test.py`, `push_test.py`) — verified they **fail against the old `SessionDep` code** (permission denied) and pass with the fix. These endpoints previously had no tests, which is why CI missed the regression.
- Changelog entry under Unreleased.

No schema or env changes. The other bare-`SessionDep` platform endpoints were checked: they either route themselves (`_set_guild_admin_rls` in guilds.py) or only touch tables `app_user` retains (auth/users/settings).

## Testing

```
cd backend && pytest app/api/v1/platform_endpoints/notifications_test.py app/api/v1/platform_endpoints/push_test.py
# 6 passed
```
Also ran the same tests with the endpoint changes stashed to confirm they reproduce the failure.