### PR TITLE
Add guild_template model drift gate

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -20,7 +20,7 @@ if str(BASE_DIR) not in sys.path:
 
 from app.core.config import settings  # noqa: E402
 from app.db import base  # noqa: F401,E402  # ensure models are imported
-from app.db.tenancy import GUILD_SCOPED_TABLES  # noqa: E402
+from app.db.migration_filters import make_include_object  # noqa: E402
 
 config = context.config
 
@@ -48,50 +48,10 @@ GUILD_AUTOGEN = "guild" in context.get_x_argument(as_dictionary=True)
 config.attributes["guild_autogen"] = GUILD_AUTOGEN
 
 
-def _include_object(obj, name, type_, reflected, compare_to):
-    """Keep each autogenerate mode on its own tables — and, in guild mode, on
-    its own OBJECT KINDS.
-
-    Default mode compares shared/public tables only: guild-content tables live
-    in the per-guild schemas, so without the filter autogenerate would try to
-    CREATE them in ``public`` on a fresh database (the model metadata still
-    declares them for the ORM) or DROP/ALTER the frozen legacy copies on a
-    pre-squash database.
-
-    Guild mode (``-x guild``) inverts the table filter (guild-content tables
-    only, compared against ``guild_template``) and additionally scopes WHAT
-    autogenerate manages, mirroring the established division of labor:
-
-    * models own **tables + columns** — that's what guild autogen diffs;
-    * the artifacts own the dressing — FKs keep their PG-authored names and
-      deliberately omit cross-schema references, partial/GIN indexes carry
-      opclasses reflection loses (preserving them is WHY provisioning
-      reflects pg catalogs — see app.db.guild_ddl), and CHECKs come from
-      pg_get_constraintdef — so
-      constraint/index objects that exist only on one side are not diffs to
-      emit. Metadata-declared indexes/uniques missing from the template are
-      still created (a real model change); reflected-only ones are never
-      dropped.
-    * ``guild_id`` columns are trigger-populated and DDL-owned (NOT NULL in
-      the schema, Optional in models) — their nullability is not a diff.
-    """
-    if type_ == "table":
-        return (name in GUILD_SCOPED_TABLES) == GUILD_AUTOGEN
-
-    table = getattr(obj, "table", None)  # indexes/constraints/columns
-    in_guild_tables = table is not None and table.name in GUILD_SCOPED_TABLES
-    if not GUILD_AUTOGEN:
-        return not in_guild_tables
-    if table is not None and not in_guild_tables:
-        return False
-
-    if type_ == "foreign_key_constraint":
-        return False  # wholly artifact-owned (names + cross-schema omissions)
-    if type_ in ("index", "unique_constraint", "check_constraint"):
-        return not reflected or compare_to is not None  # never drop artifact-owned
-    if type_ == "column" and name == "guild_id":
-        return False  # trigger-populated; DDL owns its NOT NULL
-    return True
+# What each autogenerate mode manages lives in app.db.migration_filters
+# (shared with the model drift test, so CI proves models match the migrated
+# schemas through the exact filter autogenerate uses).
+_include_object = make_include_object(GUILD_AUTOGEN)
 
 
 def _process_revision_directives(context, revision, directives):

--- a/backend/alembic/versions/20260626_0125_baseline.py
+++ b/backend/alembic/versions/20260626_0125_baseline.py
@@ -113,8 +113,7 @@ def _executor_holds_bypassrls(connection) -> bool:
     are the database bootstrap's responsibility, never this migration's."""
     result = connection.execute(
         text(
-            "SELECT rolsuper OR rolbypassrls FROM pg_roles"
-            " WHERE rolname = current_user"
+            "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user"
         )
     )
     row = result.fetchone()

--- a/backend/app/db/migration_filters.py
+++ b/backend/app/db/migration_filters.py
@@ -1,0 +1,67 @@
+"""The autogenerate object filter shared by Alembic and the drift test.
+
+``alembic/env.py`` builds its ``include_object`` hook from here, and
+``app/db/model_drift_test.py`` runs ``compare_metadata`` through the same
+filter — one source of truth for what each autogenerate mode manages, so the
+drift test proves exactly what ``alembic revision --autogenerate`` would see.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from app.db.tenancy import GUILD_SCOPED_TABLES
+
+IncludeObject = Callable[[object, str, str, bool, object], bool]
+
+
+def make_include_object(guild_autogen: bool) -> IncludeObject:
+    """Build the ``include_object`` hook for one autogenerate mode.
+
+    Keeps each mode on its own tables — and, in guild mode, on its own OBJECT
+    KINDS.
+
+    Default mode compares shared/public tables only: guild-content tables live
+    in the per-guild schemas, so without the filter autogenerate would try to
+    CREATE them in ``public`` on a fresh database (the model metadata still
+    declares them for the ORM) or DROP/ALTER the frozen legacy copies on a
+    pre-squash database.
+
+    Guild mode (``-x guild``) inverts the table filter (guild-content tables
+    only, compared against ``guild_template``) and additionally scopes WHAT
+    autogenerate manages, mirroring the established division of labor:
+
+    * models own **tables + columns** — that's what guild autogen diffs;
+    * the artifacts own the dressing — FKs keep their PG-authored names and
+      deliberately omit cross-schema references, partial/GIN indexes carry
+      opclasses reflection loses (preserving them is WHY provisioning
+      reflects pg catalogs — see app.db.guild_ddl), and CHECKs come from
+      pg_get_constraintdef — so
+      constraint/index objects that exist only on one side are not diffs to
+      emit. Metadata-declared indexes/uniques missing from the template are
+      still created (a real model change); reflected-only ones are never
+      dropped.
+    * ``guild_id`` columns are trigger-populated and DDL-owned (NOT NULL in
+      the schema, Optional in models) — their nullability is not a diff.
+    """
+
+    def include_object(obj, name, type_, reflected, compare_to) -> bool:
+        if type_ == "table":
+            return (name in GUILD_SCOPED_TABLES) == guild_autogen
+
+        table = getattr(obj, "table", None)  # indexes/constraints/columns
+        in_guild_tables = table is not None and table.name in GUILD_SCOPED_TABLES
+        if not guild_autogen:
+            return not in_guild_tables
+        if table is not None and not in_guild_tables:
+            return False
+
+        if type_ == "foreign_key_constraint":
+            return False  # wholly artifact-owned (names + cross-schema omissions)
+        if type_ in ("index", "unique_constraint", "check_constraint"):
+            return not reflected or compare_to is not None  # never drop artifact-owned
+        if type_ == "column" and name == "guild_id":
+            return False  # trigger-populated; DDL owns its NOT NULL
+        return True
+
+    return include_object

--- a/backend/app/db/model_drift_test.py
+++ b/backend/app/db/model_drift_test.py
@@ -1,0 +1,64 @@
+"""Drift gate: SQLModel models must match the migrated database schemas.
+
+The frozen baseline seeds are write-once and every schema change flows through
+a migration, so the one seam that CAN drift is models ↔ the Alembic-maintained
+schemas: a model change merged without ``scripts/gen_guild_migration.py`` (guild
+content) or ``alembic revision --autogenerate`` (shared/public) leaves the ORM
+disagreeing with every deployed database. A missing column fails loudly at
+runtime, but index / type / constraint drift is silent.
+
+This test runs Alembic's own comparison (``compare_metadata``) against the
+migrated test database through the exact ``include_object`` filter
+``alembic/env.py`` uses (shared via ``app.db.migration_filters``) and requires
+an empty diff — the database twin of the ``check-generated-types`` CI gate: if
+you changed a model, you must have generated the migration.
+
+Scope: guild mode only. The ``public`` schema carries known benign drift that
+predates this gate (index names left behind by the admin_api_keys →
+user_api_keys rename, FK ``ondelete`` behaviors that exist only in migrations,
+``ix_access_grants_user_guild`` undeclared in models) — a public-mode gate
+needs that cleanup migration first, tracked separately rather than baselined
+here as a tolerance list.
+"""
+
+import pytest
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from sqlalchemy import text
+from sqlmodel import SQLModel
+
+from app.db import base  # noqa: F401 — register every model on SQLModel.metadata
+from app.db.migration_filters import make_include_object
+
+
+def _model_diffs(sync_conn, guild_autogen: bool) -> list:
+    ctx = MigrationContext.configure(
+        sync_conn,
+        opts={
+            "compare_type": True,
+            "include_object": make_include_object(guild_autogen),
+            "target_metadata": SQLModel.metadata,
+        },
+    )
+    return compare_metadata(ctx, SQLModel.metadata)
+
+
+def _render(diffs: list) -> str:
+    return "\n".join(f"  {diff}" for diff in diffs)
+
+
+@pytest.mark.database
+async def test_models_match_guild_template(engine):
+    """Guild-content models == the migrated ``guild_template`` (the schema every
+    guild is provisioned from). A diff means a model changed without running
+    ``python scripts/gen_guild_migration.py "desc"``."""
+    async with engine.connect() as conn:
+        # Mirror env.py's guild mode: guild_template first on the search_path
+        # becomes the default schema the (schema-less) metadata compares against.
+        await conn.execute(text("SET search_path TO guild_template, public"))
+        diffs = await conn.run_sync(_model_diffs, True)
+    assert not diffs, (
+        "SQLModel models have drifted from guild_template — generate the guild "
+        "migration with: cd backend && python scripts/gen_guild_migration.py "
+        f'"desc". Autogenerate sees:\n{_render(diffs)}'
+    )

--- a/backend/app/db/model_drift_test.py
+++ b/backend/app/db/model_drift_test.py
@@ -37,7 +37,6 @@ def _model_diffs(sync_conn, guild_autogen: bool) -> list:
         opts={
             "compare_type": True,
             "include_object": make_include_object(guild_autogen),
-            "target_metadata": SQLModel.metadata,
         },
     )
     return compare_metadata(ctx, SQLModel.metadata)
@@ -54,8 +53,10 @@ async def test_models_match_guild_template(engine):
     ``python scripts/gen_guild_migration.py "desc"``."""
     async with engine.connect() as conn:
         # Mirror env.py's guild mode: guild_template first on the search_path
-        # becomes the default schema the (schema-less) metadata compares against.
-        await conn.execute(text("SET search_path TO guild_template, public"))
+        # becomes the default schema the (schema-less) metadata compares
+        # against. SET LOCAL, so it dies with this transaction instead of
+        # riding the pooled connection into another test.
+        await conn.execute(text("SET LOCAL search_path TO guild_template, public"))
         diffs = await conn.run_sync(_model_diffs, True)
     assert not diffs, (
         "SQLModel models have drifted from guild_template — generate the guild "


### PR DESCRIPTION
## Problem

Analysis of #788 (see discussion there): the frozen `guild_template_0125.sql` baseline seed is the industry-standard mechanism and cannot drift (write-once, executed once per database lifetime; both 0125 and the 0126 reconciler read it as immutable records). The seam that CAN drift is **models ↔ the live `guild_template`**: a model change merged without `scripts/gen_guild_migration.py` leaves the ORM disagreeing with every guild schema. Missing columns fail tests loudly, but index/type/constraint drift is silent — there was no DB equivalent of the `check-generated-types` CI gate.

## Changes

- **`backend/app/db/migration_filters.py`** (new): the autogenerate `include_object` filter, extracted from `alembic/env.py` as `make_include_object(guild_autogen)` — one source of truth shared by Alembic and the drift test.
- **`backend/alembic/env.py`**: imports the shared filter; behavior unchanged (both autogen modes use the identical logic).
- **`backend/app/db/model_drift_test.py`** (new): runs Alembic's `compare_metadata` against the migrated test DB with `search_path = guild_template, public` through the exact filter autogenerate uses, and asserts an **empty diff**. A model change without its guild migration now fails CI with the offending ops and the `gen_guild_migration.py` command in the message.
- Whitespace-only `ruff format` normalization in `20260626_0125_baseline.py`.

Scope is guild mode only: running the same comparison in public mode surfaced pre-existing benign drift in `public` (index names from the `admin_api_keys` → `user_api_keys` rename, migration-only FK `ondelete`, `ix_access_grants_user_guild` undeclared) — cleanup + public gate tracked in #811 rather than baselining a tolerance list here.

## Schema / env updates

None. No migrations, no new tables, no env changes.

## Testing

```
cd backend && pytest app/db/model_drift_test.py app/db/guild_migrations_test.py  # 4 passed
cd backend && ruff check app alembic && ruff format app alembic
```

Related: #788 (recommend closing as wrong-direction or re-scoping to this gate — the frozen seed stays, per the analysis in the issue discussion).