### PR TITLE
Widen ty gate to full default rule set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,14 +149,13 @@ jobs:
           uv run ruff format --check app
 
       - name: Type-check with ty
-        # Scoped gate: only ty's `invalid-return-type` rule is enforced (every
-        # other rule is ignored), mirroring the old Pyright `reportReturnType`
-        # gate — fails on return-type regressions without drowning in the
-        # SQLModel/ORM-expression false positives ty reports by default.
+        # Full default rule set; the only exclusions are the SQLModel/ORM
+        # false-positive rules disabled in backend/pyproject.toml
+        # ([tool.ty.rules]), which is the single source of truth for the gate.
         if: steps.changes.outputs.skip != 'true'
         run: |
           cd backend
-          uv run ty check app --ignore all --error invalid-return-type
+          uv run ty check app
 
 
       - name: Start PgBouncer (transaction mode)

--- a/backend/app/api/resource_access.py
+++ b/backend/app/api/resource_access.py
@@ -178,6 +178,7 @@ async def load_authorized(
 ) -> Any:
     """Load by id (RLS scopes to the guild) → 404 if absent, then authorize."""
     cfg = RESOURCE_ACCESS[kind]
+    assert cfg.loader is not None, f"RESOURCE_ACCESS[{kind}] has no loader"
     row = await cfg.loader(session, resource_id)
     if row is None:
         raise HTTPException(

--- a/backend/app/api/resource_access.py
+++ b/backend/app/api/resource_access.py
@@ -178,7 +178,10 @@ async def load_authorized(
 ) -> Any:
     """Load by id (RLS scopes to the guild) → 404 if absent, then authorize."""
     cfg = RESOURCE_ACCESS[kind]
-    assert cfg.loader is not None, f"RESOURCE_ACCESS[{kind}] has no loader"
+    if cfg.loader is None:
+        # Config bug, not a request error: this entry is feature-gate only and
+        # can't be loaded by id. Fail loudly rather than call None.
+        raise RuntimeError(f"RESOURCE_ACCESS[{kind}] has no loader")
     row = await cfg.loader(session, resource_id)
     if row is None:
         raise HTTPException(

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -287,7 +287,7 @@ async def update_users_me(
     response: Response,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> User:
-    update_data = user_in.dict(exclude_unset=True)
+    update_data = user_in.model_dump(exclude_unset=True)
     if not update_data:
         return current_user
 
@@ -473,7 +473,7 @@ async def update_user(
             status_code=status.HTTP_404_NOT_FOUND, detail=AuthMessages.USER_NOT_FOUND
         )
 
-    update_data = user_in.dict(exclude_unset=True)
+    update_data = user_in.model_dump(exclude_unset=True)
     # Platform role changes are not allowed via this endpoint - use /admin/users/{id}/platform-role
     if "role" in update_data:
         raise HTTPException(

--- a/backend/app/api/v1/tenant_endpoints/advanced_tool_test.py
+++ b/backend/app/api/v1/tenant_endpoints/advanced_tool_test.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.integration
 async def _enable_advanced_tool(session: AsyncSession, initiative) -> None:
     await route_session_to_guild(session, initiative.guild_id)
     init = await session.get(Initiative, initiative.id)
+    assert init is not None
     init.advanced_tools_enabled = True
     session.add(init)
     await session.commit()

--- a/backend/app/api/v1/tenant_endpoints/comments.py
+++ b/backend/app/api/v1/tenant_endpoints/comments.py
@@ -177,7 +177,7 @@ async def recent_comments(
     if task_ids:
         task_result = await session.exec(select(Task).where(Task.id.in_(task_ids)))
         for task in task_result.all():
-            tasks_by_id[task.id] = task
+            tasks_by_id[task.id] = task  # ty: ignore[invalid-assignment] — persisted row, id is set
 
         project_ids = {t.project_id for t in tasks_by_id.values()}
         if project_ids:
@@ -185,14 +185,14 @@ async def recent_comments(
                 select(Project).where(Project.id.in_(project_ids))
             )
             for proj in proj_result.all():
-                projects_by_id[proj.id] = proj
+                projects_by_id[proj.id] = proj  # ty: ignore[invalid-assignment] — persisted row, id is set
 
     if doc_ids:
         doc_result = await session.exec(
             select(Document).where(Document.id.in_(doc_ids))
         )
         for doc in doc_result.all():
-            docs_by_id[doc.id] = doc
+            docs_by_id[doc.id] = doc  # ty: ignore[invalid-assignment] — persisted row, id is set
 
     entries: List[RecentActivityEntry] = []
     for comment in comments:

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1189,7 +1189,7 @@ async def upload_document_version(
     document.file_content_type = mime_type
     document.file_size = len(contents)
     document.original_filename = file.filename
-    document.updated_by_id = current_user.id
+    document.updated_by_id = current_user.id  # ty: ignore[invalid-assignment] — persisted row, id is set
     document.updated_at = datetime.now(timezone.utc)
     if mime_type and mime_type.startswith("image/"):
         document.featured_image_url = file_url
@@ -1310,7 +1310,7 @@ async def delete_document_version(
             document.file_content_type = promoted.file_content_type
             document.file_size = promoted.file_size
             document.original_filename = promoted.original_filename
-            document.updated_by_id = current_user.id
+            document.updated_by_id = current_user.id  # ty: ignore[invalid-assignment] — persisted row, id is set
             document.updated_at = datetime.now(timezone.utc)
             # Keep featured image coherent when it referenced the deleted blob.
             if document.featured_image_url == deleted_url:
@@ -1459,7 +1459,7 @@ async def update_document(
 
     if updated:
         document.updated_at = datetime.now(timezone.utc)
-        document.updated_by_id = current_user.id
+        document.updated_by_id = current_user.id  # ty: ignore[invalid-assignment] — persisted row, id is set
         session.add(document)
         # Sync wikilinks if content was updated
         if content_updated:

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -1513,9 +1513,7 @@ async def project_activity_feed(
             )
         )
     next_page = page + 1 if has_next else None
-    return ProjectActivityResponse(
-        items=entries, next_page=next_page, project_id=project.id
-    )
+    return ProjectActivityResponse(items=entries, next_page=next_page)
 
 
 @router.get("/{project_id}", response_model=ProjectRead)
@@ -1556,7 +1554,7 @@ async def update_project(
     )
     _ensure_not_archived(project)
 
-    update_data = project_in.dict(exclude_unset=True)
+    update_data = project_in.model_dump(exclude_unset=True)
     pinned_sentinel = object()
     pinned_value = update_data.pop("pinned", pinned_sentinel)
     if pinned_value is not pinned_sentinel:

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -424,7 +424,7 @@ async def _rebalance_if_needed(
         if task.position != new_position:
             task.position = new_position
             session.add(task)
-            changed[task.id] = new_position
+            changed[task.id] = new_position  # ty: ignore[invalid-assignment] — persisted row, id is set
     return changed
 
 
@@ -1524,7 +1524,7 @@ async def create_task(
             session, project.id
         )
 
-    task_data = task_in.dict(exclude={"assignee_ids", "task_status_id"})
+    task_data = task_in.model_dump(exclude={"assignee_ids", "task_status_id"})
 
     # Serialize recurrence to JSON if present
     if task_data.get("recurrence") is not None:
@@ -1624,7 +1624,7 @@ async def update_task(
         access="write",
     )
 
-    update_data = task_in.dict(exclude_unset=True)
+    update_data = task_in.model_dump(exclude_unset=True)
     assignee_ids = update_data.pop("assignee_ids", None)
     previous_status_category = task.task_status.category if task.task_status else None
     new_status_id = update_data.pop("task_status_id", None)
@@ -1640,7 +1640,7 @@ async def update_task(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=TaskMessages.STATUS_NOT_FOUND,
             )
-        task.task_status_id = selected_status.id
+        task.task_status_id = selected_status.id  # ty: ignore[invalid-assignment] — persisted row, id is set
         task.task_status = selected_status
 
     for field, value in update_data.items():
@@ -1751,8 +1751,8 @@ async def move_task(
     now = datetime.now(timezone.utc)
     source_project_id = task.project_id
     source_initiative_id = task.project.initiative_id if task.project else None
-    task.project_id = target_project.id
-    task.task_status_id = default_status.id
+    task.project_id = target_project.id  # ty: ignore[invalid-assignment] — persisted row, id is set
+    task.task_status_id = default_status.id  # ty: ignore[invalid-assignment] — persisted row, id is set
     task.task_status = default_status
     task.position = 0
     task.updated_at = now
@@ -2036,7 +2036,7 @@ async def reorder_tasks(
                         detail=TaskMessages.STATUS_NOT_FOUND,
                     )
                 status_cache[item.task_status_id] = status_obj
-            task.task_status_id = status_obj.id
+            task.task_status_id = status_obj.id  # ty: ignore[invalid-assignment] — persisted row, id is set
             task.task_status = status_obj
 
         task.position = item.position

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -936,7 +936,7 @@ async def test_rolling_recurrence_uses_user_timezone_for_completion_date(
     # Simulate the user completing the task at ~9pm Los Angeles on the
     # same Sunday (2026-05-03). In UTC that's 04:00 Monday 2026-05-04.
     completion_now = datetime(2026, 5, 4, 4, 0, 0, tzinfo=timezone.utc)
-    task.task_status_id = done_status.id
+    task.task_status_id = done_status.id  # ty: ignore[invalid-assignment] — persisted row, id is set
     task.task_status = done_status
 
     advanced = await _advance_recurrence_if_needed(
@@ -1033,7 +1033,7 @@ async def test_rolling_recurrence_spring_forward_preserves_wall_clock_time(
     # Mar 9 at 02:30 PDT, which is a valid local time and matches
     # the user's "every day at 2:30 AM" intent.
     completion_now = datetime(2026, 3, 8, 18, 0, 0, tzinfo=timezone.utc)
-    task.task_status_id = done_status.id
+    task.task_status_id = done_status.id  # ty: ignore[invalid-assignment] — persisted row, id is set
     task.task_status = done_status
 
     advanced = await _advance_recurrence_if_needed(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -641,7 +641,9 @@ class Settings(BaseSettings):
 # Use caching to avoid re-reading the env file over and over
 # (FastAPI startup imports Config many times).
 def get_settings() -> Settings:
-    return Settings()
+    # Required fields (DATABASE_URL_*, SECRET_KEY) are loaded from the
+    # environment by pydantic-settings, which ty can't see.
+    return Settings()  # ty: ignore[missing-argument]
 
 
 settings = get_settings()

--- a/backend/app/core/email_i18n.py
+++ b/backend/app/core/email_i18n.py
@@ -58,10 +58,10 @@ def _lookup(key: str, locale: str, namespace: str, count: int | None) -> str | N
 def _resolve_key(data: dict, key: str) -> str | None:
     """Walk dot-separated key through nested dict."""
     parts = key.split(".")
-    current: dict | str = data
+    current: dict | str | None = data
     for part in parts:
         if isinstance(current, dict):
-            current = current.get(part)  # type: ignore[assignment]
+            current = current.get(part)
             if current is None:
                 return None
         else:

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -222,7 +222,7 @@ def _build_tables(sync_conn) -> list[str]:
                 t.constraints.discard(con)
         for col in t.columns:
             if hasattr(col.type, "create_type"):
-                col.type.create_type = False
+                col.type.create_type = False  # ty: ignore[invalid-assignment]
         out.append(
             str(
                 CreateTable(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -421,7 +421,7 @@ def custom_openapi() -> dict:
 # without the ``_inject_query_schemas`` upgrades, which then leaks into the frontend
 # type generation (conditions/sorting collapse back to ``string``). The SPA catch-all
 # registered later is ``include_in_schema=False``, so the spec is already complete here.
-app.openapi = custom_openapi
+app.openapi = custom_openapi  # ty: ignore[invalid-assignment]
 
 if settings.ENABLE_MCP:
     # Build the route-backed MCP server from the fully-routed app and mount it at

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -86,7 +86,7 @@ async def _hsts_for(app_url: str) -> str | None:
     """
     hsts_value = (
         "max-age=63072000; includeSubDomains"
-        if Settings(APP_URL=app_url).app_url_is_https
+        if Settings(APP_URL=app_url).app_url_is_https  # ty: ignore[missing-argument]
         else None
     )
     probe = FastAPI()
@@ -174,7 +174,7 @@ def test_docs_routes_return_404_when_disabled() -> None:
     a custom route, registered only when enabled), and with docs disabled that
     route is never added, so ``openapi_url`` is ``None`` too.
     """
-    cfg = Settings(ENABLE_API_DOCS=False)
+    cfg = Settings(ENABLE_API_DOCS=False)  # ty: ignore[missing-argument]
     disabled = FastAPI(
         docs_url=None,
         openapi_url=(f"{cfg.API_V1_STR}/openapi.json" if cfg.ENABLE_API_DOCS else None),

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -46,11 +46,12 @@ class User(SQLModel, table=True):
     full_name: Optional[str] = Field(default=None)
     hashed_password: str
     role: UserRole = Field(
+        default=UserRole.member,
         sa_column=Column(
             SQLEnum(UserRole, name="user_role"),
             nullable=False,
             server_default=UserRole.member.value,
-        )
+        ),
     )
     status: UserStatus = Field(
         default=UserStatus.active,

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -24,7 +24,7 @@ from app.services.platform import app_settings as app_settings_service
 try:  # premailer inlines our <style> rules so they survive Gmail/Outlook stripping <style>
     from premailer import transform as _premailer_transform
 except Exception:  # pragma: no cover - optional dependency guard
-    _premailer_transform = None
+    _premailer_transform = None  # ty: ignore[invalid-assignment]
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -95,44 +95,69 @@ async def _reminders_for(session: AsyncSession, user_id: int) -> list[Notificati
     return list(result.all())
 
 
+def _unsaved_event(
+    *, title: str, start_at: datetime, end_at: datetime, all_day: bool
+) -> CalendarEvent:
+    """In-memory event for the pure-unit formatting tests (never persisted)."""
+    return CalendarEvent(
+        guild_id=1,
+        initiative_id=1,
+        created_by_id=1,
+        title=title,
+        start_at=start_at,
+        end_at=end_at,
+        all_day=all_day,
+    )
+
+
+def _unsaved_user(tz: str) -> User:
+    """In-memory recipient for the pure-unit formatting tests (never persisted)."""
+    return User(
+        email_hash="x",
+        email_encrypted="x",
+        hashed_password="x",
+        timezone=tz,
+    )
+
+
 @pytest.mark.unit
 def test_format_event_when_localizes_to_recipient_timezone():
     """A timed event renders in the recipient's IANA timezone with its abbrev."""
-    event = CalendarEvent(
+    event = _unsaved_event(
         title="Sync",
         start_at=datetime(2026, 7, 1, 21, 30, tzinfo=timezone.utc),
         end_at=datetime(2026, 7, 1, 22, 30, tzinfo=timezone.utc),
         all_day=False,
     )
-    la = User(timezone="America/Los_Angeles")
+    la = _unsaved_user("America/Los_Angeles")
     assert _format_event_when(event, la) == "Wed, Jul 1, 2026 at 2:30 PM PDT"
 
-    utc_user = User(timezone="UTC")
+    utc_user = _unsaved_user("UTC")
     assert _format_event_when(event, utc_user) == "Wed, Jul 1, 2026 at 9:30 PM UTC"
 
 
 @pytest.mark.unit
 def test_format_event_when_all_day_omits_time_and_zone():
     """All-day events show just the date, regardless of recipient timezone."""
-    event = CalendarEvent(
+    event = _unsaved_event(
         title="Holiday",
         start_at=datetime(2026, 7, 1, 0, 0, tzinfo=timezone.utc),
         end_at=datetime(2026, 7, 1, 23, 59, tzinfo=timezone.utc),
         all_day=True,
     )
-    assert _format_event_when(event, User(timezone="Asia/Tokyo")) == "Wed, Jul 1, 2026"
+    assert _format_event_when(event, _unsaved_user("Asia/Tokyo")) == "Wed, Jul 1, 2026"
 
 
 @pytest.mark.unit
 def test_format_event_when_falls_back_on_bad_timezone():
     """An unrecognized timezone string falls back to UTC instead of raising."""
-    event = CalendarEvent(
+    event = _unsaved_event(
         title="Sync",
         start_at=datetime(2026, 7, 1, 21, 30, tzinfo=timezone.utc),
         end_at=datetime(2026, 7, 1, 22, 30, tzinfo=timezone.utc),
         all_day=False,
     )
-    assert _format_event_when(event, User(timezone="Not/AZone")) == (
+    assert _format_event_when(event, _unsaved_user("Not/AZone")) == (
         "Wed, Jul 1, 2026 at 9:30 PM UTC"
     )
 

--- a/backend/app/services/platform/push_notifications.py
+++ b/backend/app/services/platform/push_notifications.py
@@ -84,19 +84,18 @@ async def _send_to_fcm(
         return (False, False)
 
     # Build FCM message
-    message = {
-        "message": {
-            "token": token,
-            "notification": {
-                "title": title,
-                "body": body,
-            },
-        }
+    fcm_message: dict[str, Any] = {
+        "token": token,
+        "notification": {
+            "title": title,
+            "body": body,
+        },
     }
+    message = {"message": fcm_message}
 
     # Add Android-specific configuration for notification channels
     if notification_type:
-        message["message"]["android"] = {
+        fcm_message["android"] = {
             "notification": {
                 "channel_id": notification_type,  # Maps to Android channel ID
             }
@@ -104,7 +103,7 @@ async def _send_to_fcm(
 
     # Add data payload if provided (convert all values to strings)
     if data:
-        message["message"]["data"] = {k: str(v) for k, v in data.items()}
+        fcm_message["data"] = {k: str(v) for k, v in data.items()}
 
     # Send to FCM
     url = FCM_API_URL.format(project_id=settings.FCM_PROJECT_ID)

--- a/backend/app/services/platform/push_tokens.py
+++ b/backend/app/services/platform/push_tokens.py
@@ -82,7 +82,7 @@ async def delete_push_token(
     )
     result = await session.exec(stmt)
     await session.commit()
-    return result.rowcount > 0  # type: ignore
+    return result.rowcount > 0
 
 
 async def update_last_used(

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List
+
+if TYPE_CHECKING:
+    from app.schemas.platform.user import ProjectBasic, UserPublic
 
 from sqlalchemy import func, update
 from sqlmodel import select, delete
@@ -344,7 +347,7 @@ async def fetch_pm_candidates(
     *,
     initiative_id: int,
     excluded_user_id: int,
-) -> List["UserPublic"]:  # noqa: F821 — forward ref to avoid circular import
+) -> List["UserPublic"]:
     """Active project-manager candidates for ``initiative_id``, with
     ``excluded_user_id`` filtered out.
 
@@ -384,7 +387,7 @@ async def check_deletion_eligibility(
     user_id: int,
     *,
     admin_context: bool = False,
-) -> tuple[bool, List[str], List[str], List["ProjectBasic"]]:  # noqa: F821
+) -> tuple[bool, List[str], List[str], List["ProjectBasic"]]:
     """
     Check if user can be deleted.
     Returns: (can_delete, blockers, warnings, owned_projects)

--- a/backend/app/services/tenant/advanced_tool.py
+++ b/backend/app/services/tenant/advanced_tool.py
@@ -10,7 +10,7 @@ legs, which is the intended admin-only behavior.
 
 from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 

--- a/backend/app/services/tenant/calendar_events.py
+++ b/backend/app/services/tenant/calendar_events.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete as sa_delete
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 

--- a/backend/app/services/tenant/collaboration.py
+++ b/backend/app/services/tenant/collaboration.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Optional, Set
 
 from fastapi import WebSocket
 from pycrdt import Doc
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import select
 
 from app.models.tenant.document import Document

--- a/backend/app/services/tenant/counters.py
+++ b/backend/app/services/tenant/counters.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 

--- a/backend/app/services/tenant/documents.py
+++ b/backend/app/services/tenant/documents.py
@@ -298,7 +298,8 @@ async def duplicate_document(
         new_to_source = {new: old for old, new in replacements.items()}
         if featured_image_url and featured_image_url != source.featured_image_url:
             new_urls.append(featured_image_url)
-            new_to_source[featured_image_url] = source.featured_image_url
+            if source.featured_image_url:
+                new_to_source[featured_image_url] = source.featured_image_url
         source_meta = await attachments_service.get_upload_metadata_for_urls(
             session, list(new_to_source.values())
         )

--- a/backend/app/services/tenant/import_service.py
+++ b/backend/app/services/tenant/import_service.py
@@ -7,7 +7,7 @@ import re
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.tenant.task import Task, TaskPriority, Subtask
 from app.schemas.tenant.import_data import (

--- a/backend/app/services/tenant/project_export.py
+++ b/backend/app/services/tenant/project_export.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
@@ -103,7 +103,7 @@ async def build_project_export(
             pd = pv.property_definition
             if pd is None:
                 continue
-            referenced_property_ids[pd.id] = _PropDefSnapshot(
+            referenced_property_ids[pd.id] = _PropDefSnapshot(  # ty: ignore[invalid-assignment] — persisted row, id is set
                 name=pd.name,
                 type=pd.type,
                 position=pd.position,

--- a/backend/app/services/tenant/project_import.py
+++ b/backend/app/services/tenant/project_import.py
@@ -23,7 +23,7 @@ from datetime import date, datetime
 from typing import Any
 
 from fastapi import HTTPException, status
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import select
 
 from app.core.messages import ProjectExportMessages
@@ -140,7 +140,7 @@ async def import_project(
         )
         session.add(status_row)
         await session.flush()
-        status_name_to_id[s.name] = status_row.id
+        status_name_to_id[s.name] = status_row.id  # ty: ignore[invalid-assignment] — persisted row, id is set
         if s.is_default and default_status_id is None:
             default_status_id = status_row.id
     if default_status_id is None:
@@ -185,7 +185,7 @@ async def import_project(
             and match_existing.type == pd.type
             and _options_compatible(pd.type, match_existing.options, pd.options)
         ):
-            prop_key_to_id[(pd.name, pd.type)] = match_existing.id
+            prop_key_to_id[(pd.name, pd.type)] = match_existing.id  # ty: ignore[invalid-assignment] — persisted row, id is set
             property_match_count += 1
             continue
         # Name collision with a different type *or* an incompatible
@@ -210,7 +210,7 @@ async def import_project(
         )
         session.add(new_def)
         await session.flush()
-        prop_key_to_id[(pd.name, pd.type)] = new_def.id
+        prop_key_to_id[(pd.name, pd.type)] = new_def.id  # ty: ignore[invalid-assignment] — persisted row, id is set
         # Track for subsequent collision-renames within this import
         existing_props[target_name] = new_def
         property_create_count += 1
@@ -364,7 +364,7 @@ async def _load_initiative_member_emails(
         .where(InitiativeMember.initiative_id == initiative_id)
     )
     users = (await session.exec(stmt)).all()
-    return {user.email: user.id for user in users if user.email}
+    return {user.email: user.id for user in users if user.email}  # ty: ignore[invalid-return-type] — persisted rows, ids are set
 
 
 async def _load_initiative_properties(

--- a/backend/app/services/tenant/queues.py
+++ b/backend/app/services/tenant/queues.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete as sa_delete
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 

--- a/backend/app/services/tenant/stats_service.py
+++ b/backend/app/services/tenant/stats_service.py
@@ -7,7 +7,7 @@ from typing import List, Literal, Optional, Set
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy import case, func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.tenant.initiative import Initiative
 from app.models.tenant.project import Project

--- a/backend/app/services/tenant/task_statuses.py
+++ b/backend/app/services/tenant/task_statuses.py
@@ -133,5 +133,5 @@ async def clone_statuses(
         )
         session.add(clone)
         await session.flush()
-        mapping[source_status.id] = clone.id
+        mapping[source_status.id] = clone.id  # ty: ignore[invalid-assignment] — persisted row, id is set
     return mapping

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,3 +47,29 @@ dev = [
 [tool.uv]
 # Application, not a distributable package — sync dependencies only, never build/install the project itself.
 package = false
+
+[tool.ty.rules]
+# Full default rule set is enforced (CI runs a bare `uv run ty check app`).
+# Only the rules below are off, because SQLModel models don't use Mapped[]
+# column annotations: class-level attribute access types as the plain Python
+# value (int, datetime, ...), so every ORM expression — Model.field == x,
+# .in_()/.is_()/.desc(), selectinload(Model.rel), session.exec(...) — is a
+# structural false positive ty cannot see through (confirmed unchanged on the
+# latest ty release).
+invalid-argument-type = "ignore"
+unresolved-attribute = "ignore"
+no-matching-overload = "ignore"
+# Same root cause through operators: `Model.col < value` in a .where()/case()
+# types as a plain-value comparison (e.g. `datetime | None < datetime`), and
+# arithmetic on a persisted row's primary key hits the `int | None` id typing.
+unsupported-operator = "ignore"
+
+[[tool.ty.overrides]]
+# SQLModel declares `model_config: SQLModelConfig`, so the standard pydantic
+# `model_config = ConfigDict(...)` idiom used across the models is flagged as
+# an invalid assignment. Model-directory-only carve-out; the rule stays on
+# everywhere else.
+include = ["app/models/**"]
+
+[tool.ty.overrides.rules]
+invalid-assignment = "ignore"


### PR DESCRIPTION
## Problem

The ty type-check gate in CI was scoped to a single rule (`--ignore all --error invalid-return-type`), so every other rule — including ones that catch real bugs — was unenforced.

## Changes

- **`backend/pyproject.toml`**: new `[tool.ty.rules]` section is now the single source of truth for the gate. The full default rule set is enforced; only the SQLModel/ORM structural false-positive rules are off (`invalid-argument-type`, `unresolved-attribute`, `no-matching-overload`, `unsupported-operator` — SQLModel doesn't use `Mapped[]`, so column expressions type as plain values; confirmed unchanged on the latest ty release), plus a models-only `invalid-assignment` carve-out for SQLModel's `model_config` typing.
- **CI** now runs a bare `uv run ty check app`.
- Fixed the ~60 real diagnostics the wider gate surfaced, including:
  - deprecated `.dict()` → `.model_dump()` (5 sites)
  - `UserPublic`/`ProjectBasic` forward refs resolved via `TYPE_CHECKING` imports
  - dead `project_id` argument to `ProjectActivityResponse` removed (schema has no such field — pydantic silently dropped it)
  - `load_authorized` asserts its config has a loader instead of calling a possibly-`None` callable
  - `User.role` gets a Python-side `default=UserRole.member` matching its existing `server_default` (no DDL change)
  - nine tenant services annotated with sqlmodel's `AsyncSession` instead of sqlalchemy's (they call `.exec()`, which only exists on the subclass they actually receive)
  - duplicate-document featured-image metadata map no longer stores a `None` source URL
  - targeted `ty: ignore` markers where the pattern is deliberate (pydantic-settings env loading, FastAPI custom-openapi assignment, persisted-row id assignments)

No schema or env changes.

## Testing

```
cd backend && uv run ty check app        # All checks passed!
cd backend && uv run ruff check app && uv run ruff format app
cd backend && pytest app/core/email_i18n_test.py app/services/notifications_test.py app/main_test.py app/services/platform/users_test.py                       # 52 passed
cd backend && pytest app/api/v1/tenant_endpoints/projects_test.py app/api/v1/platform_endpoints/users_test.py app/api/v1/tenant_endpoints/tasks_test.py        # 101 passed
cd backend && pytest app/api/v1/platform_endpoints/auth_test.py app/api/v1/tenant_endpoints/advanced_tool_test.py app/services/tenant/comments_test.py app/api/v1/tenant_endpoints/documents_test.py  # 78 passed
```