### PR TITLE
Add guild lifecycle status with suspension enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Platform admins can now set a per-guild user limit from the admin dashboard's Guilds tab (default unlimited). Each guild shows its current headcount against the cap (e.g. `3/unlimited` or `3/10`), and the limit is editable inline. When a guild is at its limit, joining via an invite, signing up with an invite, or a guild admin creating a member is refused; existing members are never removed, and lowering a cap below the current headcount only blocks new joins. SSO/OIDC auto-provisioning is exempt.
+- Guilds now carry an operator-set lifecycle status (`active` / `read_only` / `suspended`) for billing/moderation holds — backend enforcement only in this release (no management UI yet). Under `read_only`, members keep reading content but writes are denied at the database role level; under `suspended`, members lose all access and the guild disappears from their guild list, while guild **admins** keep the guild listed and retain full settings access (billing, data ownership, danger zone). New members can't join a non-active guild. Trash auto-purge pauses for non-active guilds so a hold never keeps destroying data. Time-bound PAM/break-glass access grants deliberately override the status, so operators can always reach a guild they suspended. The status is reversible, never touches stored data, and is not disclosed to members.
 
 ## [0.54.2] - 2026-07-04
 

--- a/backend/alembic/versions/20260705_0130_add_guild_status.py
+++ b/backend/alembic/versions/20260705_0130_add_guild_status.py
@@ -1,0 +1,45 @@
+"""add guilds.status + guilds.status_changed_at
+
+Operator-set guild lifecycle status on the shared ``public.guilds`` table:
+``active`` (default) / ``read_only`` (content writes denied at the Postgres
+role level) / ``suspended`` (soft delete — members lose content access).
+Stored as a CHECK-constrained string, mirroring the ``access_grants`` pattern.
+Enforcement happens in the guild-access resolver (which Postgres role a
+request assumes), so no RLS policy changes here; PAM/break-glass grants are
+deliberately unaffected by the status.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260705_0130"
+down_revision = "20260705_0129"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guilds",
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="active",
+        ),
+    )
+    op.add_column(
+        "guilds",
+        sa.Column("status_changed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_guilds_status",
+        "guilds",
+        "status IN ('active', 'read_only', 'suspended')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_guilds_status", "guilds", type_="check")
+    op.drop_column("guilds", "status_changed_at")
+    op.drop_column("guilds", "status")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -23,7 +23,7 @@ from app.core.security import (
 from app.db.session import get_session, set_rls_context
 from app.models.platform.access_grant import AccessGrant, AccessLevel
 from app.models.platform.api_key import UserApiKey
-from app.models.platform.guild import Guild, GuildMembership, GuildRole
+from app.models.platform.guild import Guild, GuildMembership, GuildRole, GuildStatus
 from app.models.platform.user import User, UserRole, UserStatus
 from app.schemas.platform.token import TokenPayload
 from app.services.platform import access_grants as access_grants_service
@@ -312,6 +312,11 @@ class GuildContext:
     # + guild-admin RLS context), unlike a regular PAM grant which stays scoped
     # to content read/write. Still grant-gated: no live grant, no reach.
     break_glass: bool = False
+    # True when the guild is in ``read_only`` status and access is via real
+    # membership: the session is routed into the SELECT-only ``guild_<id>_ro``
+    # Postgres role so content writes are denied at the role level. Never set
+    # on the grant branches — PAM/break-glass override the guild status.
+    content_read_only: bool = False
 
     @property
     def guild_id(self) -> int:
@@ -420,7 +425,22 @@ async def _load_guild_context(
             guild=guild, membership=synthetic, grant=grant, break_glass=break_glass
         )
     guild = await guilds_service.get_guild(session, guild_id=guild_id)
-    return GuildContext(guild=guild, membership=membership)
+    # Guild lifecycle status gates REAL MEMBERS ONLY — the grant branch above
+    # deliberately never consults it (PAM/break-glass behave exactly as against
+    # an active guild, so suspending a guild can never lock operators out).
+    # This resolver is the one layer where a grantee is still distinguishable
+    # from a member: at the DB layer break-glass is byte-identical to a real
+    # guild admin, so the status check cannot live in RLS. ``suspended`` fails
+    # closed with the generic access-denied code (the status is not disclosed
+    # to members); ``read_only`` keeps membership but routes the session into
+    # the SELECT-only guild role (see _apply_guild_session_context).
+    if guild.status == GuildStatus.suspended.value:
+        raise GuildAccessError()
+    return GuildContext(
+        guild=guild,
+        membership=membership,
+        content_read_only=(guild.status == GuildStatus.read_only.value),
+    )
 
 
 async def get_guild_membership(
@@ -554,6 +574,11 @@ async def _apply_guild_session_context(
         user_id=current_user.id,
         guild_id=guild_context.guild_id,
         guild_role=guild_context.role.value,
+        # Guild in read_only status: keep the full membership GUCs (so the
+        # initiative-member and admin RLS legs evaluate normally) but assume
+        # the SELECT-only guild_<id>_ro Postgres role — content writes are
+        # denied by Postgres, not app code.
+        read_only=guild_context.content_read_only,
     )
     # Precompute the initiatives where this member holds "Full access" so the
     # sync DAC checks can apply the gate-4 override without an async query. Runs

--- a/backend/app/api/guild_suspension_test.py
+++ b/backend/app/api/guild_suspension_test.py
@@ -312,7 +312,12 @@ async def test_scoped_read_write_grant_edits_suspended_guild(
 
 
 async def _invite_for(session: AsyncSession, guild: Guild, code: str) -> GuildInvite:
-    invite = GuildInvite(code=code, guild_id=guild.id, max_uses=5)
+    invite = GuildInvite(
+        code=code,
+        guild_id=guild.id,
+        created_by_user_id=guild.created_by_user_id,
+        max_uses=5,
+    )
     session.add(invite)
     await session.commit()
     return invite

--- a/backend/app/api/guild_suspension_test.py
+++ b/backend/app/api/guild_suspension_test.py
@@ -1,0 +1,349 @@
+"""Access-matrix tests for guild lifecycle status (suspension).
+
+The matrix under test (see history/guild-suspension-design.md):
+
+- ``read_only``: members keep content READS but writes are denied at the
+  Postgres role level (routed into ``guild_<id>_ro``); initiative isolation
+  still holds.
+- ``suspended``: members lose all content access (generic 403 — the status is
+  never disclosed) and the guild vanishes from their guild list. Guild ADMINS
+  keep the guild listed and keep the settings surface writable.
+- PAM/break-glass grants override the status entirely: a grantee behaves
+  byte-identically against a suspended guild and an active one.
+- Joins (invite redemption) are refused for any non-active guild, reported as
+  an ordinary expired invite.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import GuildMessages
+from app.models.platform.access_grant import AccessGrant
+from app.models.platform.guild import Guild, GuildInvite, GuildRole, GuildStatus
+from app.models.platform.user import UserRole
+from app.services.tenant import task_statuses as task_statuses_service
+from app.testing import (
+    create_guild,
+    create_initiative,
+    create_task,
+    create_user,
+    get_auth_headers,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def _set_status(session: AsyncSession, guild: Guild, status: GuildStatus):
+    """Flip a guild's lifecycle status the way the (future) operator endpoint
+    will: status + timestamp on the shared row."""
+    guild.status = status.value
+    guild.status_changed_at = datetime.now(timezone.utc)
+    session.add(guild)
+    await session.commit()
+
+
+async def _live_grant(
+    session: AsyncSession, *, user, guild, level: str = "read"
+) -> AccessGrant:
+    """An approved, unexpired PAM grant (the access_grants_test pattern)."""
+    now = datetime.now(timezone.utc)
+    grant = AccessGrant(
+        user_id=user.id,
+        guild_id=guild.id,
+        access_level=level,
+        status="approved",
+        reason="ticket",
+        requested_duration_minutes=60,
+        requested_by_id=user.id,
+        approved_by_id=user.id,
+        decided_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    session.add(grant)
+    await session.commit()
+    return grant
+
+
+# ---------------------------------------------------------------------------
+# suspended: members and admins lose content
+# ---------------------------------------------------------------------------
+
+
+async def test_member_gets_generic_403_on_suspended_guild(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A member's content requests fail closed with the same generic code a
+    non-member gets — the lifecycle status is never disclosed."""
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+
+    resp = await client.get(a.g("/initiatives/"), headers=a.headers)
+    assert resp.status_code == 200
+
+    await _set_status(session, a.guild, GuildStatus.suspended)
+
+    resp = await client.get(a.g("/initiatives/"), headers=a.headers)
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == GuildMessages.GUILD_ACCESS_DENIED
+
+
+async def test_admin_suspended_content_blocked_settings_writable(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A guild ADMIN of a suspended guild loses content like anyone else but
+    keeps the settings surface fully writable (billing / data ownership)."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _set_status(session, a.guild, GuildStatus.suspended)
+
+    # Content: blocked, generic code.
+    resp = await client.get(a.g("/initiatives/"), headers=a.headers)
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == GuildMessages.GUILD_ACCESS_DENIED
+
+    # Settings: still writable (this endpoint gates on real guild-admin
+    # membership, deliberately outside the content choke point).
+    resp = await client.patch(
+        f"/api/v1/guilds/{a.guild.id}",
+        headers=a.headers,
+        json={"name": "Still Ours"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "Still Ours"
+
+
+async def test_suspended_guild_hidden_from_members_listed_for_admins(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The guild list drops a suspended guild for members but keeps it for
+    guild admins (they need to navigate to settings). No status field is
+    serialized either way."""
+    admin = await acting_user(guild_role=GuildRole.admin)
+    member = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
+    await _set_status(session, admin.guild, GuildStatus.suspended)
+
+    resp = await client.get("/api/v1/guilds/", headers=member.headers)
+    assert resp.status_code == 200
+    assert admin.guild.id not in [g["id"] for g in resp.json()]
+
+    resp = await client.get("/api/v1/guilds/", headers=admin.headers)
+    assert resp.status_code == 200
+    listed = [g for g in resp.json() if g["id"] == admin.guild.id]
+    assert listed, "admin must still see the suspended guild"
+    assert "status" not in listed[0], "lifecycle status must not be serialized"
+
+
+async def test_establish_guild_access_refuses_suspended(
+    session: AsyncSession, acting_user
+):
+    """The WS/keepalive entry point shares the resolver, so a suspended guild
+    refuses the socket path identically (GuildAccessError → 1008)."""
+    from app.api.deps import GuildAccessError, establish_guild_access
+
+    a = await acting_user(guild_role=GuildRole.member)
+    await _set_status(session, a.guild, GuildStatus.suspended)
+
+    with pytest.raises(GuildAccessError):
+        await establish_guild_access(session, a.user, a.guild.id)
+
+
+# ---------------------------------------------------------------------------
+# read_only: reads survive, writes die in Postgres
+# ---------------------------------------------------------------------------
+
+
+async def test_read_only_member_reads_but_writes_denied_at_role_level(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Under ``read_only`` a member still reads content (initiative RLS legs
+    intact) but an INSERT dies in Postgres (``guild_<id>_ro`` has no write
+    privileges) and surfaces as the generic 403."""
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    await task_statuses_service.ensure_default_statuses(session, a.project.id)
+    status = await task_statuses_service.get_default_status(session, a.project.id)
+    await session.commit()
+
+    await _set_status(session, a.guild, GuildStatus.read_only)
+
+    # Reads: fine.
+    resp = await client.get(a.g("/initiatives/"), headers=a.headers)
+    assert resp.status_code == 200
+    assert any(i["id"] == a.initiative.id for i in resp.json())
+
+    # Writes: denied by the role, mapped to the generic 403.
+    resp = await client.post(
+        a.g("/tasks/"),
+        headers=a.headers,
+        json={
+            "title": "frozen",
+            "project_id": a.project.id,
+            "task_status_id": status.id,
+        },
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"] == GuildMessages.GUILD_ACCESS_DENIED
+
+
+async def test_read_only_keeps_initiative_isolation(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The read-only route keeps the membership GUCs, so gate 2 (initiative
+    isolation) still filters: a member sees only their own initiatives."""
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    b = await acting_user(guild_role=GuildRole.member, guild=a.guild, initiative=True)
+    await _set_status(session, a.guild, GuildStatus.read_only)
+
+    resp = await client.get(a.g("/initiatives/"), headers=a.headers)
+    assert resp.status_code == 200
+    ids = [i["id"] for i in resp.json()]
+    assert a.initiative.id in ids
+    assert b.initiative.id not in ids
+
+
+async def test_read_only_admin_settings_still_writable(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Settings stay writable for guild admins under read_only too."""
+    a = await acting_user(guild_role=GuildRole.admin)
+    await _set_status(session, a.guild, GuildStatus.read_only)
+
+    resp = await client.patch(
+        f"/api/v1/guilds/{a.guild.id}",
+        headers=a.headers,
+        json={"description": "billing sorted soon"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# PAM / break-glass: the override
+# ---------------------------------------------------------------------------
+
+
+async def test_break_glass_full_admin_on_suspended_guild(
+    client: AsyncClient, session: AsyncSession
+):
+    """A break-glass holder behaves as a full guild admin against a SUSPENDED
+    guild — reads and writes — exactly as against an active one. This is the
+    requirement that suspension can never lock operators out."""
+    owner = await create_user(session, role=UserRole.owner)
+    guild = await create_guild(session, creator=owner)
+    initiative = await create_initiative(session, guild, owner, name="Frozen Wing")
+    await _set_status(session, guild, GuildStatus.suspended)
+
+    platform_admin = await create_user(session, role=UserRole.admin)
+    headers = get_auth_headers(platform_admin)
+    resp = await client.post(
+        "/api/v1/access-grants/break-glass",
+        json={
+            "guild_id": guild.id,
+            "reason": "billing hold review",
+            "access_level": "read_write",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    # Read.
+    resp = await client.get(f"/api/v1/g/{guild.id}/initiatives/", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert any(i["name"] == "Frozen Wing" for i in resp.json())
+
+    # Write (full admin: edits guild content).
+    resp = await client.patch(
+        f"/api/v1/g/{guild.id}/initiatives/{initiative.id}",
+        headers=headers,
+        json={"description": "reviewed under break-glass"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_scoped_read_grant_reads_suspended_guild(
+    client: AsyncClient, session: AsyncSession
+):
+    """A scoped PAM read grant (support's request→approve flow) still reads a
+    suspended guild — the resolver's grant branch never consults the status."""
+    owner = await create_user(session, role=UserRole.owner)
+    guild = await create_guild(session, creator=owner)
+    await create_initiative(session, guild, owner, name="Held Wing")
+    await _set_status(session, guild, GuildStatus.suspended)
+
+    support = await create_user(session, role=UserRole.support)
+    await _live_grant(session, user=support, guild=guild, level="read")
+
+    resp = await client.get(
+        f"/api/v1/g/{guild.id}/initiatives/", headers=get_auth_headers(support)
+    )
+    assert resp.status_code == 200, resp.text
+    assert any(i["name"] == "Held Wing" for i in resp.json())
+
+
+async def test_scoped_read_write_grant_edits_suspended_guild(
+    client: AsyncClient, session: AsyncSession
+):
+    """A scoped read_write grant held by a NON-bypass user keeps its
+    edit-existing power against a suspended guild (routed via pam_write, so
+    neither the suspension gate nor the read-only role applies)."""
+    owner = await create_user(session, role=UserRole.owner)
+    guild = await create_guild(session, creator=owner)
+    initiative = await create_initiative(session, guild, owner)
+    from app.testing import create_project
+
+    project = await create_project(session, initiative, owner)
+    task = await create_task(session, project, title="held task")
+    await _set_status(session, guild, GuildStatus.suspended)
+
+    support = await create_user(session, role=UserRole.support)
+    await _live_grant(session, user=support, guild=guild, level="read_write")
+
+    resp = await client.patch(
+        f"/api/v1/g/{guild.id}/tasks/{task.id}",
+        headers=get_auth_headers(support),
+        json={"title": "edited under grant"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["title"] == "edited under grant"
+
+
+# ---------------------------------------------------------------------------
+# joins are frozen
+# ---------------------------------------------------------------------------
+
+
+async def _invite_for(session: AsyncSession, guild: Guild, code: str) -> GuildInvite:
+    invite = GuildInvite(code=code, guild_id=guild.id, max_uses=5)
+    session.add(invite)
+    await session.commit()
+    return invite
+
+
+@pytest.mark.parametrize(
+    "status", [GuildStatus.read_only, GuildStatus.suspended], ids=lambda s: s.value
+)
+async def test_invite_redemption_refused_on_non_active_guild(
+    client: AsyncClient, session: AsyncSession, acting_user, status
+):
+    """Joining a non-active guild is refused, reported as a plain expired
+    invite (never the guild's lifecycle status)."""
+    admin = await acting_user(guild_role=GuildRole.admin)
+    invite = await _invite_for(session, admin.guild, f"frozen-{status.value}")
+    await _set_status(session, admin.guild, status)
+
+    joiner = await acting_user()
+    resp = await client.post(
+        "/api/v1/guilds/invite/accept",
+        headers=joiner.headers,
+        json={"code": invite.code},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == GuildMessages.INVITE_EXPIRED_OR_USED
+
+    # The describe endpoint reports it like any expired code.
+    resp = await client.get(
+        f"/api/v1/guilds/invite/{invite.code}", headers=joiner.headers
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_valid"] is False
+    assert body["reason"] == GuildMessages.INVITE_EXPIRED

--- a/backend/app/api/uploads_test.py
+++ b/backend/app/api/uploads_test.py
@@ -416,3 +416,61 @@ async def test_app_admin_needs_set_role_for_guild_schema(session, role_session):
         )
     ).first()
     assert row is not None
+
+
+@pytest.mark.integration
+async def test_upload_suspended_guild_member_404_grant_still_served(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """A member of a SUSPENDED guild can no longer fetch its uploads (404, the
+    route's fail-closed shape), while a live PAM grant still serves — the
+    uploads path mirrors the resolver's member-only status gate."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.platform.access_grant import AccessGrant
+    from app.models.platform.guild import GuildStatus
+    from app.models.tenant.upload import Upload
+
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    _stage_upload(guild.id, "suspended_guild.txt")
+    session.add(
+        Upload(
+            filename="suspended_guild.txt",
+            guild_id=guild.id,
+            uploader_user_id=user.id,
+            size_bytes=5,
+        )
+    )
+    guild.status = GuildStatus.suspended.value
+    await session.commit()
+
+    resp = await client.get(
+        f"/uploads/{guild.id}/suspended_guild.txt", headers=get_auth_headers(user)
+    )
+    assert resp.status_code == 404, "member must not read a suspended guild's blobs"
+
+    # A scoped PAM read grantee is unaffected (PAM overrides suspension).
+    grantee = await create_user(session, role="support")
+    now = datetime.now(timezone.utc)
+    session.add(
+        AccessGrant(
+            user_id=grantee.id,
+            guild_id=guild.id,
+            access_level="read",
+            status="approved",
+            reason="ticket",
+            requested_duration_minutes=60,
+            requested_by_id=grantee.id,
+            approved_by_id=user.id,
+            decided_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+    )
+    await session.commit()
+
+    resp = await client.get(
+        f"/uploads/{guild.id}/suspended_guild.txt", headers=get_auth_headers(grantee)
+    )
+    assert resp.status_code == 200, resp.text

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -137,6 +137,7 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
     pam_read = bool(params.get("pam_read"))
     pam_write = bool(params.get("pam_write"))
     platform_role = params.get("platform_role")
+    read_only = bool(params.get("read_only"))
 
     # Route guild-scoped tables to the active guild's schema AND assume that
     # guild's role. The login role has no standing access to any guild schema
@@ -166,10 +167,17 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
         )
     else:
         sp = f"{guild_schema_name(route_guild)}, public"
-        # A pure read grant (read, not write, no full membership) assumes the
-        # read-only role so writes to the schema are denied at the role level.
+        # Assume the SELECT-only guild_<id>_ro role — writes to the schema are
+        # denied at the role level — for either:
+        # - a pure read grant (read, not write, no full membership), or
+        # - a real member of a guild in ``read_only`` status (the membership
+        #   GUCs stay set so the member/admin RLS legs read normally).
         read_only_grant = guild_id is None and pam_read and not pam_write
-        name_fn = guild_readonly_role_name if read_only_grant else guild_role_name
+        name_fn = (
+            guild_readonly_role_name
+            if (read_only_grant or read_only)
+            else guild_role_name
+        )
         role_target = name_fn(route_guild)
 
     return {
@@ -225,6 +233,7 @@ async def set_rls_context(
     pam_read: bool = False,
     pam_write: bool = False,
     platform_role: Optional[str] = None,
+    read_only: bool = False,
 ) -> None:
     """Set PostgreSQL context for RLS policy evaluation — transaction-local.
 
@@ -246,6 +255,13 @@ async def set_rls_context(
     ``current_guild_id`` as proof of membership, so a grantee must leave it
     unset and be scoped via ``pam_guild_id`` instead. A grantee gets scoped,
     time-bound access to one guild; there is no all-guild bypass.
+
+    ``read_only`` routes a REAL MEMBER into the SELECT-only ``guild_<id>_ro``
+    role while keeping the full membership GUCs — used when the guild is in
+    ``read_only`` lifecycle status, so content writes die at the Postgres role
+    level while reads (and the member/admin RLS legs) behave normally. It is
+    independent of the PAM read-grant routing, which derives the same role
+    from ``pam_read``/``pam_write``.
 
     ``platform_role`` is the caller's platform tier (``users.role``). When the
     request carries no guild context (and no active PAM grant), the public/platform
@@ -277,6 +293,7 @@ async def set_rls_context(
         "pam_read": pam_read,
         "pam_write": pam_write,
         "platform_role": platform_role,
+        "read_only": read_only,
     }
     session.info[_RLS_ESTABLISHED_INFO_KEY] = time.monotonic()
 

--- a/backend/app/db/session_routing_test.py
+++ b/backend/app/db/session_routing_test.py
@@ -1,0 +1,69 @@
+"""Unit tests for the role-routing decision in ``_render_context_bind_params``.
+
+The pure function is the single place that decides which Postgres role a
+request assumes; these pin the ``read_only`` (guild lifecycle status) leg
+against the pre-existing PAM read-grant leg.
+"""
+
+import pytest
+
+from app.db.schema_provisioning import guild_readonly_role_name, guild_role_name
+from app.db.session import _render_context_bind_params
+
+pytestmark = pytest.mark.unit
+
+
+def _params(**overrides):
+    base = {
+        "user_id": 7,
+        "guild_id": None,
+        "guild_role": None,
+        "pam_guild_id": None,
+        "pam_read": False,
+        "pam_write": False,
+        "platform_role": None,
+        "read_only": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_member_routes_to_full_guild_role():
+    bind = _render_context_bind_params(_params(guild_id=3, guild_role="member"))
+    assert bind["role"] == guild_role_name(3)
+    assert bind["gid"] == "3"
+
+
+def test_read_only_member_routes_to_ro_role_keeping_membership_gucs():
+    """A member of a read_only guild assumes the SELECT-only role while the
+    membership GUCs stay set — writes die in Postgres, reads (and the
+    member/admin RLS legs) behave normally."""
+    bind = _render_context_bind_params(
+        _params(guild_id=3, guild_role="member", read_only=True)
+    )
+    assert bind["role"] == guild_readonly_role_name(3)
+    assert bind["gid"] == "3"
+    assert bind["grole"] == "member"
+
+
+def test_read_only_admin_also_routes_to_ro_role():
+    bind = _render_context_bind_params(
+        _params(guild_id=3, guild_role="admin", read_only=True)
+    )
+    assert bind["role"] == guild_readonly_role_name(3)
+    assert bind["grole"] == "admin"
+
+
+def test_pam_read_grant_still_routes_to_ro_role():
+    bind = _render_context_bind_params(_params(pam_guild_id=3, pam_read=True))
+    assert bind["role"] == guild_readonly_role_name(3)
+    assert bind["gid"] == ""
+
+
+def test_pam_write_grant_keeps_full_role_regardless_of_read_only_flag():
+    """The read_only flag is a membership-path concept; the PAM write route is
+    untouched (grants override the guild status)."""
+    bind = _render_context_bind_params(
+        _params(pam_guild_id=3, pam_read=True, pam_write=True)
+    )
+    assert bind["role"] == guild_role_name(3)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,10 +16,12 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
+from sqlalchemy.exc import DBAPIError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_upload_user
 from app.api.v1.api import api_router
+from app.core.messages import GuildMessages
 from app.core.rate_limit import limiter
 from app.core.config import settings
 from app.core.version import __version__
@@ -187,6 +189,44 @@ async def validation_exception_handler(
     )
 
 
+_INSUFFICIENT_PRIVILEGE_SQLSTATE = "42501"
+
+
+def _dbapi_sqlstate(exc: DBAPIError) -> str | None:
+    """Best-effort SQLSTATE off a wrapped DBAPI error (asyncpg adapter nests
+    the real exception one level down as ``orig.__cause__``)."""
+    orig = getattr(exc, "orig", None)
+    for candidate in (orig, getattr(orig, "__cause__", None)):
+        code = getattr(candidate, "sqlstate", None) or getattr(
+            candidate, "pgcode", None
+        )
+        if code:
+            return code
+    return None
+
+
+@app.exception_handler(DBAPIError)
+async def insufficient_privilege_handler(
+    request: Request, exc: DBAPIError
+) -> JSONResponse:
+    """Map Postgres ``insufficient_privilege`` (42501) to a generic 403.
+
+    Denials enforced at the role layer — e.g. a write attempted while routed
+    into the SELECT-only ``guild_<id>_ro`` role (PAM read grants, guilds in
+    ``read_only`` status) — surface as asyncpg errors, not app-layer checks.
+    They ARE authorization denials, so answer 403 with the same generic code
+    the resolver uses; deliberately no status-specific detail (a member of a
+    read-only-suspended guild learns nothing about why). Everything else
+    re-raises to the default 500 path.
+    """
+    if _dbapi_sqlstate(exc) == _INSUFFICIENT_PRIVILEGE_SQLSTATE:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={"detail": GuildMessages.GUILD_ACCESS_DENIED},
+        )
+    raise exc
+
+
 # Computed once — Settings are fixed for the process lifetime (pentest MED-001).
 _CONTENT_SECURITY_POLICY = settings.content_security_policy
 
@@ -257,6 +297,7 @@ async def serve_upload_file(
     # is never read.
     from app.db.session import set_rls_context
     from app.db.schema_provisioning import guild_schema_name
+    from app.models.platform.guild import GuildStatus
     from app.services.platform import access_grants as access_grants_service
     from app.services.platform import guilds as guilds_service
 
@@ -268,6 +309,14 @@ async def serve_upload_file(
             session, user_id=current_user.id, guild_id=guild_id
         )
         if grant is None:
+            raise HTTPException(status_code=404)
+    else:
+        # A suspended guild is unreadable to its members (mirrors the resolver
+        # gate in deps._load_guild_context; this route resolves access inline).
+        # The grant branch above deliberately skips the status — PAM overrides
+        # suspension. read_only needs nothing here: serving a file is a read.
+        guild = await guilds_service.get_guild(session, guild_id=guild_id)
+        if guild.status == GuildStatus.suspended.value:
             raise HTTPException(status_code=404)
 
     # The admin login role has NO table grants on a guild schema, so SET ROLE

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -218,8 +218,19 @@ async def insufficient_privilege_handler(
     the resolver uses; deliberately no status-specific detail (a member of a
     read-only-suspended guild learns nothing about why). Everything else
     re-raises to the default 500 path.
+
+    Always logged server-side: 42501 is expected only on the read-only-role
+    write paths, so any other occurrence (a missing SET ROLE, a revoked table
+    grant, a misconfigured login role) must be findable in the logs — the
+    client body is deliberately too generic to debug from.
     """
     if _dbapi_sqlstate(exc) == _INSUFFICIENT_PRIVILEGE_SQLSTATE:
+        logger.warning(
+            "insufficient_privilege mapped to 403: %s %s orig=%s",
+            request.method,
+            request.url.path,
+            getattr(exc, "orig", exc),
+        )
         return JSONResponse(
             status_code=status.HTTP_403_FORBIDDEN,
             content={"detail": GuildMessages.GUILD_ACCESS_DENIED},

--- a/backend/app/models/platform/guild.py
+++ b/backend/app/models/platform/guild.py
@@ -12,6 +12,27 @@ if TYPE_CHECKING:  # pragma: no cover
     from app.models.tenant.guild_setting import GuildSetting
 
 
+class GuildStatus(str, Enum):
+    """Operator-set lifecycle status of a guild (platform `guilds.manage`).
+
+    - ``active``: normal operation.
+    - ``read_only``: members keep read access to content but writes are denied
+      at the Postgres role level (routed into ``guild_<id>_ro``).
+    - ``suspended``: soft delete — members lose all content access and the
+      guild vanishes from their guild list. Guild admins keep the settings
+      surface (billing / data ownership / danger zone) under every status.
+
+    PAM/break-glass grants deliberately override all of this: a grantee
+    behaves exactly as against an active guild (the resolver's grant branch
+    never consults the status), so suspending a guild can never lock the
+    platform operators out. The status is not serialized to guild members.
+    """
+
+    active = "active"
+    read_only = "read_only"
+    suspended = "suspended"
+
+
 class Guild(SQLModel, table=True):
     __tablename__ = "guilds"
     __allow_unmapped__ = True
@@ -39,6 +60,18 @@ class Guild(SQLModel, table=True):
     # Max number of members allowed in this guild. NULL = unlimited (default).
     max_users: Optional[int] = Field(
         default=None, sa_column=Column(Integer, nullable=True)
+    )
+    # Lifecycle status (see GuildStatus). Stored as a plain string with a CHECK
+    # constraint (the access_grants pattern) rather than a Postgres enum.
+    status: str = Field(
+        default=GuildStatus.active.value,
+        sa_column=Column(
+            String(16), nullable=False, server_default=GuildStatus.active.value
+        ),
+    )
+    # When the status last changed; NULL until the first operator change.
+    status_changed_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
 
     members: List["GuildMembership"] = Relationship(

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -11,7 +11,13 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.messages import GuildMessages
-from app.models.platform.guild import Guild, GuildInvite, GuildMembership, GuildRole
+from app.models.platform.guild import (
+    Guild,
+    GuildInvite,
+    GuildMembership,
+    GuildRole,
+    GuildStatus,
+)
 from app.models.tenant.guild_setting import GuildSetting
 from app.models.platform.user import User
 
@@ -259,6 +265,16 @@ async def list_memberships(
 
     out: list[tuple[Guild, GuildMembership, int | None, int]] = []
     for guild, membership in pairs:
+        # A suspended guild disappears from its members' guild list; guild
+        # ADMINS keep the entry so they can still reach the settings surface
+        # (billing / data ownership / danger zone stay theirs under any
+        # status). No status is serialized either way — the row is simply
+        # absent for members.
+        if (
+            guild.status == GuildStatus.suspended.value
+            and membership.role != GuildRole.admin
+        ):
+            continue
         await set_rls_context(session, user_id=user_id, guild_id=guild.id)
         row = (
             await session.exec(
@@ -555,6 +571,12 @@ async def redeem_invite_for_user(
         raise GuildInviteError(GuildMessages.INVITE_NOT_FOUND)
     if not invite_is_active(invite):
         raise GuildInviteError(GuildMessages.INVITE_EXPIRED_OR_USED)
+    # A non-active guild is frozen: no new members while read_only or
+    # suspended. Reported as an ordinary expired invite — the guild's
+    # lifecycle status is deliberately not disclosed.
+    target_guild = await get_guild(session, guild_id=invite.guild_id)
+    if target_guild.status != GuildStatus.active.value:
+        raise GuildInviteError(GuildMessages.INVITE_EXPIRED_OR_USED)
 
     # Email binding. ``invitee_email`` is advisory-when-absent: an invite with no
     # bound address (``invitee_email_encrypted`` is NULL) is a shareable link and
@@ -589,6 +611,10 @@ async def describe_invite_code(
     if not invite:
         return None, None, False, GuildMessages.INVITE_NOT_FOUND
     guild = await get_guild(session, guild_id=invite.guild_id)
+    # A non-active guild accepts no new members; report the invite as plain
+    # expired (never the guild's lifecycle status).
+    if guild.status != GuildStatus.active.value:
+        return invite, guild, False, GuildMessages.INVITE_EXPIRED
     if invite_is_active(invite):
         return invite, guild, True, None
 

--- a/backend/app/services/tenant/trash_purge.py
+++ b/backend/app/services/tenant/trash_purge.py
@@ -34,7 +34,7 @@ from app.models.tenant.calendar_event import CalendarEvent
 from app.models.tenant.comment import Comment
 from app.models.tenant.counter import Counter, CounterGroup
 from app.models.tenant.document import Document
-from app.models.platform.guild import Guild
+from app.models.platform.guild import Guild, GuildStatus
 from app.models.tenant.initiative import Initiative
 from app.models.tenant.project import Project
 from app.models.tenant.queue import Queue, QueueItem
@@ -114,7 +114,17 @@ async def _purge_all_guilds(session, *, now: datetime) -> None:
     own committed pass. Split out so tests can drive it with the test session.
     """
     await set_rls_context(session)
-    guild_ids = list(await session.exec(select(Guild.id).order_by(Guild.id.asc())))
+    # Only ACTIVE guilds are purged. A read_only or suspended guild is frozen —
+    # a nonpayment/moderation hold must not keep destroying trashed data while
+    # it is unresolved (data ownership / legal). Retention resumes (with the
+    # original purge_at stamps) when the guild returns to active.
+    guild_ids = list(
+        await session.exec(
+            select(Guild.id)
+            .where(Guild.status == GuildStatus.active.value)
+            .order_by(Guild.id.asc())
+        )
+    )
     for guild_id in guild_ids:
         # ids collide across schemas, so clear the identity map between guilds.
         session.expunge_all()

--- a/backend/app/services/tenant/trash_purge_test.py
+++ b/backend/app/services/tenant/trash_purge_test.py
@@ -191,3 +191,62 @@ async def test_auto_purge_clears_content_table_guard(
         )
     ).scalar_one()
     assert count == 0, "trashed project was not hard-purged by the worker"
+
+
+async def test_auto_purge_skips_non_active_guilds(session: AsyncSession, role_session):
+    """A guild in ``read_only``/``suspended`` status is frozen: the worker must
+    not keep destroying its trashed rows while a billing/moderation hold is
+    unresolved. Purging resumes (original ``purge_at`` stamps) once the guild
+    returns to active."""
+    from app.models.platform.guild import GuildStatus
+    from app.services.tenant.trash_purge import _purge_all_guilds
+
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    initiative = await create_initiative(session, guild, user)
+
+    await soft_delete_entity(
+        session, initiative, deleted_by_user_id=user.id, retention_days=1
+    )
+    await session.commit()
+    refreshed = (
+        await session.exec(
+            select_including_deleted(Initiative).where(Initiative.id == initiative.id)
+        )
+    ).one()
+    refreshed.purge_at = datetime.now(timezone.utc) - timedelta(days=2)
+    session.add(refreshed)
+
+    guild.status = GuildStatus.suspended.value
+    session.add(guild)
+    await session.commit()
+    initiative_id = initiative.id
+
+    admin = await role_session("app_admin")
+    await _purge_all_guilds(admin, now=datetime.now(timezone.utc))
+
+    from app.db.session import set_rls_context
+
+    await set_rls_context(admin, guild_id=guild.id, guild_role="admin")
+    count = (
+        await admin.exec(
+            text("SELECT COUNT(*) FROM initiatives WHERE id = :id"),
+            params={"id": initiative_id},
+        )
+    ).scalar_one()
+    assert count == 1, "suspended guild's trash must NOT be purged"
+
+    # Back to active: the same due row is swept on the next pass.
+    guild.status = GuildStatus.active.value
+    session.add(guild)
+    await session.commit()
+
+    await _purge_all_guilds(admin, now=datetime.now(timezone.utc))
+    await set_rls_context(admin, guild_id=guild.id, guild_role="admin")
+    count = (
+        await admin.exec(
+            text("SELECT COUNT(*) FROM initiatives WHERE id = :id"),
+            params={"id": initiative_id},
+        )
+    ).scalar_one()
+    assert count == 0, "reactivated guild's due trash must purge again"


### PR DESCRIPTION
## Problem

Platform operators need a reversible way to restrict a guild without deleting it (billing enforcement, moderation, legal holds). Today a guild is binary: fully live, or hard-deleted with its schema dropped. This PR adds the enforcement core of the guild-suspension design (PR 1 of 3 — see `history/guild-suspension-design.md` for the approved design and access matrix).

## What changes

New `guilds.status` column (`active` / `read_only` / `suspended`) + `status_changed_at` on shared `public.guilds`, enforced by **which Postgres role a request assumes**, not app-layer checks:

- **`suspended` (soft delete):** real members — guild admins included — fail closed at the guild-access resolver (`_load_guild_context`) with the generic `GUILD_ACCESS_DENIED`; no role is ever assumed. The guild disappears from members' guild lists; guild **admins** keep the entry and the settings surface stays fully writable (billing / data ownership / danger zone — those endpoints gate on real guild-admin membership outside the content choke point, by design).
- **`read_only`:** members keep their membership GUCs (initiative RLS legs intact) but are routed into the existing SELECT-only `guild_<id>_ro` role — writes are denied **by Postgres** and surface as a generic 403 via a new SQLSTATE-42501 exception mapping.
- **PAM/break-glass override:** the resolver's grant branch never consults the status, so grants behave byte-identically against a suspended guild — suspending a guild can never lock operators out.
- **Joins frozen:** invite redeem/describe against a non-active guild reports a plain expired invite (no status leak).
- **Uploads path** (parallel inline resolver in `main.py`) mirrors the member-only suspended gate; the grant fallback is untouched.
- **Trash auto-purge skips non-active guilds** — a billing/legal hold must not keep destroying trashed data; purging resumes on reactivation.

Not in this PR (per the staged plan): the operator API/UI to set the status (nothing serializes it yet — `GuildRead` unchanged), and the guild `support` role. Those are PRs 2–3.

## Schema/env updates

- Alembic migration `20260705_0130`: adds `guilds.status` (CHECK-constrained, default `active`) + `guilds.status_changed_at` to the shared `public.guilds` table. No RLS/DDL changes, no new tables, no env changes.

## Testing

- `backend/app/api/guild_suspension_test.py` — the access matrix end-to-end through the real-role client: member/admin × read_only/suspended × content read/write/settings; break-glass and scoped read/read_write grants against a suspended guild; suspended guild hidden from member list, kept for admins (and no `status` field serialized); WS entry point (`establish_guild_access`) refusal; invite redeem/describe refusals for both non-active statuses.
- `backend/app/db/session_routing_test.py` — unit-pins the role-routing decision (`read_only` member → `guild_<id>_ro` with membership GUCs kept; PAM legs unchanged).
- Purge-skip test in `trash_purge_test.py` (frozen guild not purged; purges after reactivation) and a suspended-guild uploads test in `uploads_test.py`.

Commands run:
```
cd backend && ruff format app && ruff check app
pytest app/api/guild_suspension_test.py app/db/session_routing_test.py \
       app/services/tenant/trash_purge_test.py app/api/uploads_test.py \
       app/db/model_drift_test.py app/db/tenancy_test.py \
       app/api/v1/platform_endpoints/break_glass_test.py \
       app/api/v1/platform_endpoints/access_grants_test.py \
       app/api/v1/platform_endpoints/guilds_test.py
```
All passing (93 tests across the targeted files).