### PR TITLE
Scope operator guild deletion to blocker resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Platform admins can now set a per-guild lifecycle status (`active` / `read_only` / `suspended`) from the admin dashboard's Guilds tab, for billing/moderation holds — with a confirmation prompt before suspending. Under `read_only`, members keep reading content but writes are denied at the database role level; under `suspended`, members lose all access and the guild disappears from their guild list, while guild **admins** keep the guild listed and retain full settings access (billing, data ownership, danger zone). New members can't join a non-active guild. Trash auto-purge pauses for non-active guilds so a hold never keeps destroying data. Time-bound PAM/break-glass access grants deliberately override the status, so operators can always reach a guild they suspended. Guild admins see a notice in guild settings pointing them to the platform operator, and operators acting through an access grant see the status in their temporary-access banner — but ordinary members are never told. The status is reversible and never touches stored data.
 - Time-bound support/moderator access grants now act as a first-class, **database-enforced** `support` guild role instead of masquerading as a member. A read grant is read-only; a read_write grant can edit content and guild settings but is hard-blocked at the Postgres role level from managing guild/initiative membership, roles, or sharing permissions (a dedicated per-guild `support` role, not app-layer checks alone). Break-glass admin access is unchanged — full guild admin for its window. `support` is never an assignable stored membership role.
 
+### Changed
+
+- Operator guild deletion is now scoped to resolving a user-deletion blocker: the platform "delete this guild" action (offered when deleting a user who is a guild's sole admin) only deletes a guild that user actually solely admins, instead of accepting any guild id. Guild admins can always delete their own guild as before; operators reach a live guild's deletion through its own danger zone via a break-glass grant.
+
 ## [0.54.2] - 2026-07-04
 
 ### Fixed

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -576,12 +576,35 @@ async def admin_delete_guild(
     guild_id: int,
     session: AdminSessionDep,
     _current_user: GuildsManageDep,
+    blocked_user_id: Annotated[
+        int,
+        Query(
+            description=(
+                "The user being deleted, for whom this guild must be a "
+                "last-admin blocker. The delete is refused otherwise."
+            )
+        ),
+    ],
 ) -> Response:
-    """Delete a guild (platform admin only).
+    """Delete a guild that blocks a user's deletion (platform operator).
 
-    This allows platform admins to delete any guild, even if they're not a member.
-    All initiatives, projects, tasks, and memberships within the guild will be deleted.
+    Scoped to blocker resolution — NOT a general "delete any guild" tool: the
+    guild must be one ``blocked_user_id`` is the SOLE admin of (so deleting that
+    user would orphan it). Any other guild is refused; an operator reaches a live
+    guild's own deletion only by breaking glass into its danger zone. This
+    endpoint backs the "delete the blocking guild" option in the user-deletion
+    dialog, gated on ``guilds.manage``.
     """
+    if not await users_service.is_last_admin_of_guild(
+        session, guild_id, blocked_user_id, for_update=True
+    ):
+        # Either the user isn't the guild's sole admin (not a real blocker), or
+        # the guild doesn't exist / they aren't in it — all refused identically.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=AdminMessages.GUILD_NOT_A_DELETION_BLOCKER,
+        )
+
     stmt = select(Guild).where(Guild.id == guild_id)
     result = await session.exec(stmt)
     guild = result.one_or_none()

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -600,6 +600,10 @@ async def admin_delete_guild(
     ):
         # Either the user isn't the guild's sole admin (not a real blocker), or
         # the guild doesn't exist / they aren't in it — all refused identically.
+        # ``for_update`` narrows the race against a concurrent demotion of an
+        # existing admin; it can't lock a not-yet-existing row, so a brand-new
+        # concurrent admin INSERT is a theoretical window (see the service
+        # docstring) — negligible here, and the cascade removes that row anyway.
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=AdminMessages.GUILD_NOT_A_DELETION_BLOCKER,

--- a/backend/app/api/v1/platform_endpoints/admin_test.py
+++ b/backend/app/api/v1/platform_endpoints/admin_test.py
@@ -360,3 +360,88 @@ async def test_demote_admin_uses_for_update_path_without_postgres_error(
 
     refreshed = (await session.exec(select(User).where(User.id == target.id))).one()
     assert refreshed.role == UserRole.member
+
+
+@pytest.mark.integration
+async def test_admin_delete_guild_requires_sole_admin_blocker(
+    client: AsyncClient, session: AsyncSession
+):
+    """Operator guild deletion is scoped to blocker resolution: it succeeds only
+    when the named user is the guild's SOLE admin (deleting them would orphan
+    it). A guild with another admin is not a blocker → refused."""
+    from sqlmodel import select
+
+    from app.core.messages import AdminMessages
+    from app.models.platform.guild import Guild, GuildRole
+    from app.testing.factories import create_guild, create_guild_membership
+
+    operator = await create_user(
+        session, email="op-del-guild@example.com", role=UserRole.owner
+    )
+    target = await create_user(session, email="sole-admin@example.com")
+    guild = await create_guild(session, creator=target)
+    await create_guild_membership(
+        session, user=target, guild=guild, role=GuildRole.admin
+    )
+
+    # Another admin exists → the guild is NOT orphaned by deleting target → 403.
+    coadmin = await create_user(session, email="co-admin@example.com")
+    await create_guild_membership(
+        session, user=coadmin, guild=guild, role=GuildRole.admin
+    )
+    resp = await client.delete(
+        f"/api/v1/admin/guilds/{guild.id}?blocked_user_id={target.id}",
+        headers=get_auth_headers(operator),
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"] == AdminMessages.GUILD_NOT_A_DELETION_BLOCKER
+    still_there = (
+        await session.exec(select(Guild).where(Guild.id == guild.id))
+    ).one_or_none()
+    assert still_there is not None, "a non-blocker guild must not be deleted"
+
+
+@pytest.mark.integration
+async def test_admin_delete_guild_deletes_genuine_blocker(
+    client: AsyncClient, session: AsyncSession
+):
+    """When the user is the guild's sole admin, the operator can delete it to
+    resolve the user-deletion blocker."""
+    from sqlmodel import select
+
+    from app.models.platform.guild import Guild, GuildRole
+    from app.testing.factories import create_guild, create_guild_membership
+
+    operator = await create_user(
+        session, email="op-del-guild2@example.com", role=UserRole.owner
+    )
+    target = await create_user(session, email="sole-admin2@example.com")
+    guild = await create_guild(session, creator=target)
+    await create_guild_membership(
+        session, user=target, guild=guild, role=GuildRole.admin
+    )
+
+    resp = await client.delete(
+        f"/api/v1/admin/guilds/{guild.id}?blocked_user_id={target.id}",
+        headers=get_auth_headers(operator),
+    )
+    assert resp.status_code == 204, resp.text
+    gone = (await session.exec(select(Guild).where(Guild.id == guild.id))).one_or_none()
+    assert gone is None, "the sole-admin blocker guild should be deleted"
+
+
+@pytest.mark.integration
+async def test_admin_delete_guild_requires_blocked_user_id(
+    client: AsyncClient, session: AsyncSession
+):
+    """The blocked_user_id query param is required — no bare 'delete any guild'."""
+    from app.testing.factories import create_guild
+
+    operator = await create_user(
+        session, email="op-del-guild3@example.com", role=UserRole.owner
+    )
+    guild = await create_guild(session, creator=operator)
+    resp = await client.delete(
+        f"/api/v1/admin/guilds/{guild.id}", headers=get_auth_headers(operator)
+    )
+    assert resp.status_code == 422

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -270,6 +270,10 @@ class AdminMessages:
     USER_CANNOT_BE_DELETED = "ADMIN_USER_CANNOT_BE_DELETED"
     PROJECT_TRANSFERS_REQUIRED = "ADMIN_PROJECT_TRANSFERS_REQUIRED"
     GUILD_NOT_FOUND = "ADMIN_GUILD_NOT_FOUND"
+    # Operator guild deletion is scoped to resolving a user-deletion blocker:
+    # the guild must be one the named user is the SOLE admin of. Any other guild
+    # is refused (operators reach a live guild only via a break-glass grant).
+    GUILD_NOT_A_DELETION_BLOCKER = "ADMIN_GUILD_NOT_A_DELETION_BLOCKER"
     USER_NOT_IN_GUILD = "ADMIN_USER_NOT_IN_GUILD"
     CANNOT_DEMOTE_LAST_GUILD_ADMIN = "ADMIN_CANNOT_DEMOTE_LAST_GUILD_ADMIN"
     INITIATIVE_NOT_FOUND = "ADMIN_INITIATIVE_NOT_FOUND"

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -69,7 +69,19 @@ async def is_last_admin_of_guild(
         session: Database session
         guild_id: Guild ID to check
         user_id: User ID to check
-        for_update: If True, lock rows to prevent race conditions during demotion
+        for_update: If True, lock the existing admin membership rows so a
+            concurrent demotion/removal of a *current* admin can't race this
+            check within the same transaction.
+
+    Concurrency caveat: ``for_update`` locks only the admin rows that already
+    exist. It does NOT prevent a concurrent transaction from INSERTing a
+    brand-new admin membership (a phantom — Postgres row locks aren't predicate
+    locks outside SERIALIZABLE). So a caller relying on a True result to gate a
+    follow-up mutation has a narrow window where a second admin could appear
+    just after the check. Harmless for the current callers (demote-last-admin
+    guards, and the blocker-scoped guild delete, which cascades that new row
+    away anyway); a caller needing a hard guarantee should take a per-guild
+    advisory lock that all admin-mutation paths also honor.
     """
     # Check if user is an admin of this guild
     if for_update:

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -193,6 +193,7 @@
   "ADMIN_USER_CANNOT_BE_DELETED": "Der Benutzer kann nicht gelöscht werden",
   "ADMIN_PROJECT_TRANSFERS_REQUIRED": "Projektübertragungen sind für eine endgültige Löschung erforderlich, wenn der Benutzer Projekte besitzt",
   "ADMIN_GUILD_NOT_FOUND": "Gilde nicht gefunden",
+  "ADMIN_GUILD_NOT_A_DELETION_BLOCKER": "Diese Gilde kann hier nur gelöscht werden, wenn der Benutzer ihr einziger Administrator ist. Aktualisiere und versuche es erneut.",
   "ADMIN_USER_NOT_IN_GUILD": "Benutzer in der Gilde nicht gefunden",
   "ADMIN_CANNOT_DEMOTE_LAST_GUILD_ADMIN": "Der letzte Gildenadministrator kann nicht herabgestuft werden",
   "ADMIN_INITIATIVE_NOT_FOUND": "Initiative nicht gefunden",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -193,6 +193,7 @@
   "ADMIN_USER_CANNOT_BE_DELETED": "User cannot be deleted",
   "ADMIN_PROJECT_TRANSFERS_REQUIRED": "Project transfers required for hard delete when user owns projects",
   "ADMIN_GUILD_NOT_FOUND": "Guild not found",
+  "ADMIN_GUILD_NOT_A_DELETION_BLOCKER": "This guild can only be deleted here if the user is its sole admin. Refresh and try again.",
   "ADMIN_USER_NOT_IN_GUILD": "User not found in guild",
   "ADMIN_CANNOT_DEMOTE_LAST_GUILD_ADMIN": "Cannot demote the last guild admin",
   "ADMIN_INITIATIVE_NOT_FOUND": "Initiative not found",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -191,6 +191,7 @@
   "ADMIN_USER_CANNOT_BE_DELETED": "El usuario no puede ser eliminado",
   "ADMIN_PROJECT_TRANSFERS_REQUIRED": "Se requieren transferencias de proyecto para la eliminación definitiva cuando el usuario es propietario de proyectos",
   "ADMIN_GUILD_NOT_FOUND": "Gremio no encontrado",
+  "ADMIN_GUILD_NOT_A_DELETION_BLOCKER": "Este gremio solo se puede eliminar aquí si el usuario es su único administrador. Actualiza e inténtalo de nuevo.",
   "ADMIN_USER_NOT_IN_GUILD": "Usuario no encontrado en el gremio",
   "ADMIN_CANNOT_DEMOTE_LAST_GUILD_ADMIN": "No se puede degradar al último administrador del gremio",
   "ADMIN_INITIATIVE_NOT_FOUND": "Iniciativa no encontrada",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -191,6 +191,7 @@
   "ADMIN_USER_CANNOT_BE_DELETED": "L'utilisateur ne peut pas être supprimé",
   "ADMIN_PROJECT_TRANSFERS_REQUIRED": "Des transferts de projets sont requis pour la suppression définitive lorsque l'utilisateur possède des projets",
   "ADMIN_GUILD_NOT_FOUND": "Groupe introuvable",
+  "ADMIN_GUILD_NOT_A_DELETION_BLOCKER": "Ce groupe ne peut être supprimé ici que si l'utilisateur en est le seul administrateur. Actualisez et réessayez.",
   "ADMIN_USER_NOT_IN_GUILD": "Utilisateur introuvable dans le groupe",
   "ADMIN_CANNOT_DEMOTE_LAST_GUILD_ADMIN": "Impossible de rétrograder le dernier administrateur du groupe",
   "ADMIN_INITIATIVE_NOT_FOUND": "Initiative introuvable",

--- a/frontend/src/api/generated/admin/admin.ts
+++ b/frontend/src/api/generated/admin/admin.ts
@@ -22,6 +22,7 @@ import type {
 
 import type {
   AccountDeletionResponse,
+  AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams,
   AdminDeleteInitiativeApiV1AdminInitiativesInitiativeIdDeleteParams,
   AdminDeletionEligibilityResponse,
   AdminGetInitiativeMembersApiV1AdminInitiativesInitiativeIdMembersGetParams,
@@ -1070,19 +1071,24 @@ export const useDeleteUserApiV1AdminUsersUserIdDelete = <
   return useMutation(getDeleteUserApiV1AdminUsersUserIdDeleteMutationOptions(options), queryClient);
 };
 /**
- * Delete a guild (platform admin only).
+ * Delete a guild that blocks a user's deletion (platform operator).
  *
- * This allows platform admins to delete any guild, even if they're not a member.
- * All initiatives, projects, tasks, and memberships within the guild will be deleted.
+ * Scoped to blocker resolution — NOT a general "delete any guild" tool: the
+ * guild must be one ``blocked_user_id`` is the SOLE admin of (so deleting that
+ * user would orphan it). Any other guild is refused; an operator reaches a live
+ * guild's own deletion only by breaking glass into its danger zone. This
+ * endpoint backs the "delete the blocking guild" option in the user-deletion
+ * dialog, gated on ``guilds.manage``.
  * @summary Admin Delete Guild
  */
 export const adminDeleteGuildApiV1AdminGuildsGuildIdDelete = (
   guildId: number,
+  params: AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
   return apiMutator<void>(
-    { url: `/api/v1/admin/guilds/${guildId}`, method: "DELETE", signal },
+    { url: `/api/v1/admin/guilds/${guildId}`, method: "DELETE", params, signal },
     options
   );
 };
@@ -1094,14 +1100,14 @@ export const getAdminDeleteGuildApiV1AdminGuildsGuildIdDeleteMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof adminDeleteGuildApiV1AdminGuildsGuildIdDelete>>,
     TError,
-    { guildId: number },
+    { guildId: number; params: AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams },
     TContext
   >;
   request?: SecondParameter<typeof apiMutator>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof adminDeleteGuildApiV1AdminGuildsGuildIdDelete>>,
   TError,
-  { guildId: number },
+  { guildId: number; params: AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams },
   TContext
 > => {
   const mutationKey = ["adminDeleteGuildApiV1AdminGuildsGuildIdDelete"];
@@ -1113,11 +1119,11 @@ export const getAdminDeleteGuildApiV1AdminGuildsGuildIdDeleteMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof adminDeleteGuildApiV1AdminGuildsGuildIdDelete>>,
-    { guildId: number }
+    { guildId: number; params: AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams }
   > = (props) => {
-    const { guildId } = props ?? {};
+    const { guildId, params } = props ?? {};
 
-    return adminDeleteGuildApiV1AdminGuildsGuildIdDelete(guildId, requestOptions);
+    return adminDeleteGuildApiV1AdminGuildsGuildIdDelete(guildId, params, requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
@@ -1141,7 +1147,7 @@ export const useAdminDeleteGuildApiV1AdminGuildsGuildIdDelete = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof adminDeleteGuildApiV1AdminGuildsGuildIdDelete>>,
       TError,
-      { guildId: number },
+      { guildId: number; params: AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams },
       TContext
     >;
     request?: SecondParameter<typeof apiMutator>;
@@ -1150,7 +1156,7 @@ export const useAdminDeleteGuildApiV1AdminGuildsGuildIdDelete = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof adminDeleteGuildApiV1AdminGuildsGuildIdDelete>>,
   TError,
-  { guildId: number },
+  { guildId: number; params: AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams },
   TContext
 > => {
   return useMutation(

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3670,6 +3670,13 @@ export type ExportPlatformUsersCsvApiV1AdminUsersExportCsvGetParams = {
   user_id?: number[] | null;
 };
 
+export type AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams = {
+  /**
+   * The user being deleted, for whom this guild must be a last-admin blocker. The delete is refused otherwise.
+   */
+  blocked_user_id: number;
+};
+
 export type AdminDeleteInitiativeApiV1AdminInitiativesInitiativeIdDeleteParams = {
   guild_id: number;
 };

--- a/frontend/src/components/admin/AdminDeleteUserDialog.tsx
+++ b/frontend/src/components/admin/AdminDeleteUserDialog.tsx
@@ -320,7 +320,9 @@ export function AdminDeleteUserDialog({
 
   const handleDeleteGuild = (guildId: number) => {
     setIsResolvingBlocker(true);
-    deleteGuild.mutate(guildId);
+    // The guild is a blocker because targetUser is its sole admin — the backend
+    // re-verifies that before deleting (scoped to blocker resolution).
+    deleteGuild.mutate({ guildId, blockedUserId: targetUser.id });
   };
 
   const handleDeleteInitiative = (initiativeId: number, guildId: number) => {

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -145,14 +145,19 @@ export const useAdminPromoteGuildMember = (
   });
 };
 
-/** Delete a guild (admin only). */
-export const useAdminDeleteGuild = (options?: MutationOpts<void, number>) => {
+/** Delete a guild that blocks a user's deletion (operator blocker resolution).
+ * The guild must be one `blockedUserId` is the sole admin of. */
+export const useAdminDeleteGuild = (
+  options?: MutationOpts<void, { guildId: number; blockedUserId: number }>
+) => {
   const { onSuccess, onError, onSettled, ...rest } = options ?? {};
 
   return useMutation({
     ...rest,
-    mutationFn: async (guildId: number) => {
-      await adminDeleteGuildApiV1AdminGuildsGuildIdDelete(guildId);
+    mutationFn: async ({ guildId, blockedUserId }: { guildId: number; blockedUserId: number }) => {
+      await adminDeleteGuildApiV1AdminGuildsGuildIdDelete(guildId, {
+        blocked_user_id: blockedUserId,
+      });
     },
     onSuccess: (...args) => {
       void invalidateAdminUsers();


### PR DESCRIPTION
## Problem

Phase 3b was meant to "keep deletion break-glass based" by removing the standing `DELETE /admin/guilds/{id}`. But that endpoint is **not** a casual "delete any guild" tool — its only use is [`AdminDeleteUserDialog`](frontend/src/components/admin/AdminDeleteUserDialog.tsx): resolving an **orphaned-guild blocker** when deleting a *user* who is a guild's sole admin. Removing it would break user deletion, and there is **no** casual operator delete-any-guild UI (the admin Guilds tab only has caps + the suspend/status control). Per the decision (keep it, scope it to blocker-only), this **tightens** the endpoint rather than removing it.

## What changes

- `admin_delete_guild` now requires a `blocked_user_id` query param and verifies that user is the guild's **sole admin** (`is_last_admin_of_guild`, `FOR UPDATE`) before deleting. Any other guild → `403 ADMIN_GUILD_NOT_A_DELETION_BLOCKER`. So an operator can no longer delete an arbitrary healthy guild through it — only one genuinely orphaned by the user being deleted. Also closes a TOCTOU: if a co-admin was added since the eligibility check, the delete is refused.
- Frontend: the user-deletion dialog passes the target user's id; `useAdminDeleteGuild` + Orval types updated; `errors.json` (en/de/es/fr).

Unchanged: guild admins delete their own guild via the danger zone as before; operators reach a live guild's deletion only by **breaking glass** into it. No `public.guilds` RLS migration — this is app-layer scoping of an existing system-engine endpoint, and break-glass already satisfies the guild-delete admin RLS leg.

## Testing

- `admin_test.py`: sole-admin blocker → deletes (204, row gone); guild with a co-admin → 403 `ADMIN_GUILD_NOT_A_DELETION_BLOCKER` (row survives); missing `blocked_user_id` → 422. Full `admin_test.py` + `users_test.py` green (52).
- `pnpm typecheck`, ruff, biome all clean.

## Scope note

This completes Phase 3. The design doc's "remove the standing endpoint + `public.guilds` PAM policy legs + `_ensure_guild_admin` grant branch" is intentionally **not** implemented — the premise (a casual standing delete) didn't match the code; the break-glass intent is met by the absence of any casual-delete surface plus this blocker-scoping. (Was briefly stacked on #817, now merged, so this targets dev directly.)