### PR TITLE
Scrub invite email on user erasure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Platform admins can now set a per-guild user limit from the admin dashboard's Guilds tab (default unlimited). Each guild shows its current headcount against the cap (e.g. `3/unlimited` or `3/10`), and the limit is editable inline. When a guild is at its limit, joining via an invite, signing up with an invite, or a guild admin creating a member is refused; existing members are never removed, and lowering a cap below the current headcount only blocks new joins. SSO/OIDC auto-provisioning is exempt.
-- Platform admins can now set a per-guild lifecycle status (`active` / `read_only` / `suspended`) from the admin dashboard's Guilds tab, for billing/moderation holds — with a confirmation prompt before suspending. Under `read_only`, members keep reading content but writes are denied at the database role level; under `suspended`, members lose all access and the guild disappears from their guild list, while guild **admins** keep the guild listed and retain full settings access (billing, data ownership, danger zone). New members can't join a non-active guild. Trash auto-purge pauses for non-active guilds so a hold never keeps destroying data. Time-bound PAM/break-glass access grants deliberately override the status, so operators can always reach a guild they suspended. Guild admins see a notice in guild settings pointing them to the platform operator, and operators acting through an access grant see the status in their temporary-access banner — but ordinary members are never told. The status is reversible and never touches stored data.
-- Time-bound support/moderator access grants now act as a first-class, **database-enforced** `support` guild role instead of masquerading as a member. A read grant is read-only; a read_write grant can edit content and guild settings but is hard-blocked at the Postgres role level from managing guild/initiative membership, roles, or sharing permissions (a dedicated per-guild `support` role, not app-layer checks alone). Break-glass admin access is unchanged — full guild admin for its window. `support` is never an assignable stored membership role.
+- Platform admins can set a per-guild user limit (default unlimited) from the admin dashboard's Guilds tab; at the cap, new joins/invites are refused while existing members stay, and SSO auto-provisioning is exempt.
+- Platform admins can set a per-guild lifecycle status (`active` / `read_only` / `suspended`) for billing/moderation holds — `read_only` blocks writes, `suspended` hides the guild from members while its admins keep full settings access. Non-active guilds pause trash auto-purge and block new joins; operators can still reach them via a break-glass grant. Reversible, never touches stored data.
+- Time-bound support/moderator access grants now act as a database-enforced `support` guild role: read grants are read-only, read_write grants can edit content/settings but are blocked from managing membership, roles, or sharing. Break-glass admin access is unchanged.
 
 ### Changed
 
-- Operator guild deletion is now scoped to resolving a user-deletion blocker: the platform "delete this guild" action (offered when deleting a user who is a guild's sole admin) only deletes a guild that user actually solely admins, instead of accepting any guild id. Guild admins can always delete their own guild as before; operators reach a live guild's deletion through its own danger zone via a break-glass grant.
+- Operator "delete this guild" (offered when deleting a guild's sole admin) is now scoped to that user's solely-admined guild instead of accepting any guild id; guild admins still delete their own guild as before.
+
+### Fixed
+
+- Anonymizing or deleting a user now scrubs their email out of any guild invite addressed to them (invite addresses are stored reversibly encrypted, so a lingering invite kept a recoverable copy); the invite is neutralized so this can't turn it into an open shareable link.
 
 ## [0.54.2] - 2026-07-04
 

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -564,6 +564,45 @@ async def deactivate_user(session: AsyncSession, user_id: int) -> None:
     await session.commit()
 
 
+async def _scrub_invites_addressed_to(
+    session: AsyncSession, *, email_hash: str
+) -> None:
+    """Erase a user's email from any guild invite addressed to them.
+
+    ``GuildInvite.invitee_email_encrypted`` holds the invited person's address
+    as *reversible* Fernet ciphertext, so a lingering (unexpired or already
+    consumed) invite is a recoverable PII trace that survives user erasure —
+    the one gap that otherwise makes anonymize/hard-delete not airtight.
+
+    Fernet output is non-deterministic (the same address encrypts differently
+    every time), so there is no indexed equality lookup: we load every bound
+    invite and compare the decrypted address the same way redemption does
+    (via ``hash_email``, matching the ``users.email_hash`` normalization).
+
+    A match is NULLed (removing the PII) *and* neutralised (``max_uses = 0``, so
+    ``invite_is_active`` returns False). Nulling alone is not enough: an invite
+    with no bound address is treated as an open shareable link, so a
+    still-active single-recipient invite would degrade into one anyone with the
+    code could redeem. The system engine (``app_admin``) holds UPDATE but
+    deliberately not DELETE on ``guild_invites`` (row removal rides the guild
+    FK cascade — see ``SHARED_TABLE_SYSTEM_GRANTS``), so this scrubs the row in
+    place rather than deleting it.
+    """
+    from app.models.platform.guild import GuildInvite
+
+    bound_invites = (
+        await session.exec(
+            select(GuildInvite).where(GuildInvite.invitee_email_encrypted.is_not(None))
+        )
+    ).all()
+    for invite in bound_invites:
+        bound_email = invite.invitee_email  # decrypts invitee_email_encrypted
+        if bound_email and hash_email(bound_email) == email_hash:
+            invite.invitee_email_encrypted = None
+            invite.max_uses = 0
+            session.add(invite)
+
+
 async def soft_delete_user(session: AsyncSession, user_id: int) -> None:
     """Soft-delete (anonymize) a user account.
 
@@ -603,6 +642,10 @@ async def soft_delete_user(session: AsyncSession, user_id: int) -> None:
     await set_rls_context(session)
 
     user = await _drop_user_memberships(session, user_id)
+
+    # Capture the real email hash before it's overwritten with the sentinel
+    # below — it's how we find guild invites bound to this person's address.
+    original_email_hash = user.email_hash
 
     user.status = UserStatus.anonymized
     user.token_version += 1
@@ -657,6 +700,13 @@ async def soft_delete_user(session: AsyncSession, user_id: int) -> None:
     await session.exec(delete(UserApiKey).where(UserApiKey.user_id == user_id))
     await session.exec(delete(UserToken).where(UserToken.user_id == user_id))
     await session.exec(delete(PushToken).where(PushToken.user_id == user_id))
+
+    # Scrub the user's address out of any guild invite bound to it. Without
+    # this, an unexpired/lingering invite keeps a recoverable copy of the very
+    # email this erasure was meant to remove. Runs in the same public,
+    # ``app_admin`` context as the auth-artifact deletes above.
+    if original_email_hash:
+        await _scrub_invites_addressed_to(session, email_hash=original_email_hash)
 
     # Single commit: membership removal + PII wipe + auth-artifact
     # revocation either all succeed or all roll back together.
@@ -1107,6 +1157,14 @@ async def hard_delete_user(
     # GuildMemberships cascade-delete via the User relationship. InitiativeMembers
     # were already removed per guild above.
     user = (await session.exec(select(User).where(User.id == user_id))).one()
+
+    # Scrub the user's address out of any guild invite bound to it before the
+    # row goes — a bound invite otherwise keeps a recoverable copy of the email
+    # (the ``created_by_user_id`` NULLing above only covers invites this user
+    # *sent*, not ones addressed *to* them).
+    if user.email_hash:
+        await _scrub_invites_addressed_to(session, email_hash=user.email_hash)
+
     await session.delete(user)
 
     await session.commit()

--- a/backend/app/services/platform/users_test.py
+++ b/backend/app/services/platform/users_test.py
@@ -335,6 +335,132 @@ async def test_soft_delete_user_anonymizes_pii(session: AsyncSession):
 
 @pytest.mark.unit
 @pytest.mark.service
+async def test_soft_delete_user_scrubs_addressed_invites(session: AsyncSession):
+    """Anonymizing a user must erase their address from any guild invite bound
+    to it — a lingering invite otherwise keeps a reversible copy of the very
+    email the erasure was meant to remove. The matched invite is also
+    neutralised so nulling its bound address can't demote a single-recipient
+    invite into an open shareable link. Invites for other people, and unbound
+    (shareable-link) invites, are left untouched."""
+    from app.models.platform.guild import GuildInvite
+    from app.services.platform import guilds as guild_service
+
+    victim = await create_user(session, email="scrubme@example.com")
+    admin = await create_user(session, email="inviteadmin@example.com")
+    guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=victim, guild=guild, role=GuildRole.member
+    )
+
+    # Active invite addressed to the victim — the recoverable PII trace.
+    victim_invite = await guild_service.create_guild_invite(
+        session,
+        guild_id=guild.id,
+        created_by_user_id=admin.id,
+        invitee_email="scrubme@example.com",
+        max_uses=1,
+        expires_at=None,
+    )
+    # Invite for someone else — must be untouched.
+    other_invite = await guild_service.create_guild_invite(
+        session,
+        guild_id=guild.id,
+        created_by_user_id=admin.id,
+        invitee_email="keep@example.com",
+        max_uses=1,
+        expires_at=None,
+    )
+    # Unbound shareable link (no address) — must be untouched.
+    open_invite = await guild_service.create_guild_invite(
+        session,
+        guild_id=guild.id,
+        created_by_user_id=admin.id,
+        invitee_email=None,
+        max_uses=5,
+        expires_at=None,
+    )
+    victim_invite_id = victim_invite.id
+    other_invite_id = other_invite.id
+    open_invite_id = open_invite.id
+
+    # Sanity: the victim's invite is active/bound before erasure.
+    assert guild_service.invite_is_active(victim_invite) is True
+
+    await user_service.soft_delete_user(session, victim.id)
+    session.expunge_all()
+
+    scrubbed = (
+        await session.exec(
+            select(GuildInvite).where(GuildInvite.id == victim_invite_id)
+        )
+    ).one()
+    # Address erased, and the invite neutralised so it can't act as an open link.
+    assert scrubbed.invitee_email_encrypted is None
+    assert scrubbed.invitee_email is None
+    assert scrubbed.max_uses == 0
+    assert guild_service.invite_is_active(scrubbed) is False
+
+    # Someone else's invite is untouched.
+    other_after = (
+        await session.exec(select(GuildInvite).where(GuildInvite.id == other_invite_id))
+    ).one()
+    assert other_after.invitee_email == "keep@example.com"
+    assert other_after.max_uses == 1
+
+    # Unbound shareable-link invites are untouched.
+    open_after = (
+        await session.exec(select(GuildInvite).where(GuildInvite.id == open_invite_id))
+    ).one()
+    assert open_after.invitee_email is None
+    assert open_after.max_uses == 5
+
+
+@pytest.mark.integration
+@pytest.mark.service
+async def test_hard_delete_user_scrubs_addressed_invites(session: AsyncSession):
+    """Hard delete has the same residual-PII gap: an invite addressed to the
+    removed user keeps a reversible copy of their email. The invitee address
+    must be scrubbed — distinct from the ``created_by_user_id`` NULLing, which
+    only covers invites the user *sent* (here the inviter is a different
+    admin, so only the invitee-scrub can clear it)."""
+    from app.models.platform.guild import GuildInvite
+    from app.services.platform import guilds as guild_service
+
+    victim = await create_user(session, email="hardscrub@example.com")
+    admin = await create_user(session, email="hardadmin@example.com")
+    guild = await create_guild(session, creator=admin)
+    await create_guild_membership(
+        session, user=victim, guild=guild, role=GuildRole.member
+    )
+
+    invite = await guild_service.create_guild_invite(
+        session,
+        guild_id=guild.id,
+        created_by_user_id=admin.id,
+        invitee_email="hardscrub@example.com",
+        max_uses=1,
+        expires_at=None,
+    )
+    invite_id = invite.id
+    victim_id = victim.id
+
+    await user_service.hard_delete_user(session, victim_id, {})
+    session.expunge_all()
+
+    # User row is gone...
+    assert (
+        await session.exec(select(User).where(User.id == victim_id))
+    ).one_or_none() is None
+    # ...and no invite retains their recoverable address.
+    scrubbed = (
+        await session.exec(select(GuildInvite).where(GuildInvite.id == invite_id))
+    ).one()
+    assert scrubbed.invitee_email_encrypted is None
+    assert scrubbed.invitee_email is None
+
+
+@pytest.mark.unit
+@pytest.mark.service
 async def test_users_table_has_rls_delete_deny_policy(session: AsyncSession):
     """The migration must enable RLS on `users` and install the
     ``users_no_delete`` restrictive policy that blocks DELETE for any

--- a/backend/app/services/platform/users_test.py
+++ b/backend/app/services/platform/users_test.py
@@ -457,6 +457,10 @@ async def test_hard_delete_user_scrubs_addressed_invites(session: AsyncSession):
     ).one()
     assert scrubbed.invitee_email_encrypted is None
     assert scrubbed.invitee_email is None
+    # ...and it's neutralised so nulling the bound address can't leave it as an
+    # open shareable link.
+    assert scrubbed.max_uses == 0
+    assert guild_service.invite_is_active(scrubbed) is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

`soft_delete_user` (anonymize) and `hard_delete_user` wipe the `users` row, revoke auth artifacts, and scrub the display name out of content — but neither touches `GuildInvite.invitee_email_encrypted`, the invited person's email stored as **reversible** Fernet ciphertext.

Result: after "erasing" a user, any lingering invite addressed to their email (unexpired *or* already consumed) still holds a recoverable copy of the very address the erasure was meant to remove — a residual PII trace that survives right-to-be-forgotten.

## Changes

- **`_scrub_invites_addressed_to()`** (new shared helper) — loads every bound invite and matches the decrypted address the same way redemption does (`hash_email`, matching `users.email_hash` normalization). Fernet ciphertext is non-deterministic, so there's no indexed equality lookup; the scan is fine for these rare admin-erasure paths.
- Wired into **both** `soft_delete_user` (capturing the real email hash before it's overwritten with the sentinel) and `hard_delete_user` (the existing `created_by_user_id` NULLing only covers invites the user *sent*, not ones addressed *to* them).

### Two design decisions

- **Neutralize, don't just null.** An invite with a NULL address is treated as an open shareable link, so nulling alone would silently demote a single-recipient invite into one anyone with the code could redeem. The scrub also sets `max_uses = 0` so `invite_is_active` returns False.
- **UPDATE, not DELETE.** The system engine (`app_admin`) deliberately holds no DELETE on `guild_invites` — the `SHARED_TABLE_SYSTEM_GRANTS` registry comment notes "row removal rides the FK cascade." Scrubbing in place fits the existing least-privilege grants, so **no migration / grant change is needed**.

## Tests

- `test_soft_delete_user_scrubs_addressed_invites` — victim's invite is scrubbed + inactive; another user's invite and an unbound shareable-link invite are left untouched.
- `test_hard_delete_user_scrubs_addressed_invites` — invite addressed to a hard-deleted user (sent by a *different* admin, so only the invitee-scrub can clear it) is scrubbed.

## Testing performed

```
cd backend && pytest app/services/platform/users_test.py -k "scrubs_addressed_invites or anonymizes_pii"   # 3 passed
ruff check app/services/platform/users.py app/services/platform/users_test.py                              # clean
```

## Notes

- No schema/env changes.
- Not included: the report's optional "purge consumed/expired invites generally" — that's a separate periodic-hygiene job, not part of the erasure guarantee.