### PR TITLE
Add auth provider + federated identity tables

### DIFF
--- a/backend/alembic/versions/20260705_0131_create_auth_identity_tables.py
+++ b/backend/alembic/versions/20260705_0131_create_auth_identity_tables.py
@@ -1,0 +1,150 @@
+"""create auth provider registry + federated identity tables
+
+Phase-0 foundation for the login rewrite (history/auth-detailed-design.md):
+two secret-free ``public`` tables. Additive only — nothing reads or writes them
+yet, so there is no behaviour change and no dual-verify window needed.
+
+Role security follows the least-privilege posture, NOT a blanket copy of an
+existing table:
+
+* ``auth_providers`` — like ``oidc_claim_mappings``: RLS ENABLE+FORCE with NO
+  permissive policy, granted only to ``app_admin``. The request path never reads
+  provider config directly (login + CRUD run on the system engine), so
+  guild-scoped provider metadata cannot leak cross-tenant.
+* ``federated_identities`` — own-row ``_self`` policy; ``app_admin`` does the
+  writes (login resolve/create, link/unlink — a takeover surface); the platform
+  request path gets SELECT for the "your sign-in methods" view. No guild-role
+  grant (identity is account-level, never touched from a guild schema).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260705_0131"
+down_revision = "20260705_0130"
+branch_labels = None
+depends_on = None
+
+
+def _platform(role: str) -> str:
+    """Prefixed platform-tier role name (empty prefix in prod/dev)."""
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_{role}"
+
+
+def _run(statements: list[str]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_providers",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=128), nullable=False),
+        sa.Column("kind", sa.String(length=16), server_default="oidc", nullable=False),
+        sa.Column(
+            "enabled", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column("guild_id", sa.Integer(), nullable=True),
+        sa.Column("issuer", sa.Text(), nullable=True),
+        sa.Column("client_id", sa.Text(), nullable=True),
+        sa.Column("scopes", sa.Text(), nullable=True),
+        sa.Column("role_claim_path", sa.Text(), nullable=True),
+        sa.Column("connection_claim", sa.String(length=64), nullable=True),
+        sa.Column(
+            "allow_jit", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+        sa.Column("icon", sa.String(length=64), nullable=True),
+        sa.Column("button_style", sa.String(length=32), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("guild_id", "slug", name="uq_auth_providers_guild_slug"),
+        sa.CheckConstraint(
+            "kind IN ('oidc', 'oauth2', 'broker')", name="ck_auth_providers_kind"
+        ),
+    )
+    op.create_index("ix_auth_providers_guild_id", "auth_providers", ["guild_id"])
+    # Operator-global slugs (guild_id IS NULL — not covered by the composite
+    # unique above, since NULLs compare distinct) must be unique too.
+    op.create_index(
+        "uq_auth_providers_global_slug",
+        "auth_providers",
+        ["slug"],
+        unique=True,
+        postgresql_where=sa.text("guild_id IS NULL"),
+    )
+
+    op.create_table(
+        "federated_identities",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("provider_id", sa.Integer(), nullable=False),
+        sa.Column("subject", sa.Text(), nullable=False),
+        sa.Column(
+            "email_verified",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["provider_id"], ["auth_providers.id"], ondelete="CASCADE"
+        ),
+        sa.UniqueConstraint(
+            "provider_id", "subject", name="uq_federated_identities_provider_subject"
+        ),
+    )
+    op.create_index(
+        "ix_federated_identities_user_id", "federated_identities", ["user_id"]
+    )
+    op.create_index(
+        "ix_federated_identities_provider_id", "federated_identities", ["provider_id"]
+    )
+
+    base = _platform("base")
+    _self = "(user_id = (NULLIF(current_setting('app.current_user_id', true), ''))::integer)"
+
+    # NOTE: the public schema has default privileges that GRANT platform_base +
+    # app_guild_base full DML on EVERY new public table. So a new shared table is
+    # request-path-writable unless we explicitly REVOKE — RLS alone would be the
+    # only guard. We revoke to get grant-layer denial too (defense in depth).
+    _run(
+        [
+            # --- auth_providers: system-engine (app_admin) only ---
+            "ALTER TABLE public.auth_providers ENABLE ROW LEVEL SECURITY",
+            "ALTER TABLE public.auth_providers FORCE ROW LEVEL SECURITY",
+            # Strip the schema-default DML: nothing on the request path may read
+            # provider config (login + CRUD run on app_admin). Permission-denied at
+            # the grant layer AND no permissive RLS policy => guild-scoped SSO
+            # metadata can never leak cross-tenant.
+            f'REVOKE ALL ON TABLE public.auth_providers FROM app_guild_base, "{base}"',
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.auth_providers TO app_admin",
+            "GRANT ALL ON SEQUENCE public.auth_providers_id_seq TO app_admin",
+            # --- federated_identities: own-row reads; writes via the system engine ---
+            "ALTER TABLE public.federated_identities ENABLE ROW LEVEL SECURITY",
+            "ALTER TABLE public.federated_identities FORCE ROW LEVEL SECURITY",
+            (
+                "CREATE POLICY federated_identities_self ON public.federated_identities "
+                f"USING {_self} WITH CHECK {_self}"
+            ),
+            # Identity is account-level (never touched from a guild schema) and
+            # link/unlink is a takeover surface (system engine only). Drop the
+            # default DML to a clean slate, then re-grant only the platform request
+            # path SELECT for the own-row "your sign-in methods" read.
+            f'REVOKE ALL ON TABLE public.federated_identities FROM app_guild_base, "{base}"',
+            f'GRANT SELECT ON TABLE public.federated_identities TO "{base}"',
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.federated_identities TO app_admin",
+            "GRANT ALL ON SEQUENCE public.federated_identities_id_seq TO app_admin",
+        ]
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS public.federated_identities CASCADE")
+    op.execute("DROP TABLE IF EXISTS public.auth_providers CASCADE")

--- a/backend/app/db/auth_identity_rls_test.py
+++ b/backend/app/db/auth_identity_rls_test.py
@@ -1,0 +1,121 @@
+"""RLS / role-security tests for the auth identity foundation.
+
+Locks in two deliberate least-privilege decisions (see the migration
+20260705_0131 and history/auth-detailed-design.md §6):
+
+* ``federated_identities`` is **own-row** on the request path — a platform tier
+  sees only its own links, and there is NO admin-read-all policy (platform user
+  management runs on the system engine, not the request path).
+* ``auth_providers`` carries **no permissive policy and no request-path grant**,
+  so the request role cannot read provider config at all — guild-scoped SSO
+  metadata can never leak cross-tenant. Only ``app_admin`` (BYPASSRLS) reaches it.
+
+Style mirrors ``platform_role_rls_test``: the ``session`` fixture connects as the
+superuser, but ``SET ROLE platform_<tier>`` drops to a non-superuser role so RLS
+and table GRANTs are enforced exactly like the production request path.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.schema_provisioning import platform_role_name
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def _assume(session, tier: str, user_id: int) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('app.current_user_id', :uid, false), "
+            "set_config('role', :role, false)"
+        ),
+        params={"uid": str(user_id), "role": platform_role_name(tier)},
+    )
+
+
+async def _reset(session) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('role', 'none', false), "
+            "set_config('app.current_user_id', '', false)"
+        )
+    )
+
+
+async def _make_provider(session, slug: str) -> int:
+    return (
+        await session.exec(
+            text(
+                "INSERT INTO auth_providers "
+                "(slug, display_name, kind, enabled, allow_jit, created_at, updated_at) "
+                "VALUES (:s, :s, 'oidc', true, true, now(), now()) RETURNING id"
+            ),
+            params={"s": slug},
+        )
+    ).scalar_one()
+
+
+async def _link(session, user_id: int, provider_id: int, subject: str) -> None:
+    await session.exec(
+        text(
+            "INSERT INTO federated_identities "
+            "(user_id, provider_id, subject, email_verified, created_at) "
+            "VALUES (:u, :p, :sub, true, now())"
+        ),
+        params={"u": user_id, "p": provider_id, "sub": subject},
+    )
+
+
+async def test_federated_identity_is_own_row_on_request_path(session):
+    provider = await _make_provider(session, "acme")
+    u1 = await create_user(session)
+    u2 = await create_user(session)
+    await _link(session, u1.id, provider, "sub-1")
+    await _link(session, u2.id, provider, "sub-2")
+
+    await _assume(session, "member", u1.id)
+    rows = {
+        r[0]
+        for r in (
+            await session.exec(text("SELECT user_id FROM federated_identities"))
+        ).fetchall()
+    }
+    await _reset(session)
+    assert rows == {u1.id}, "a member must see only their own federated identities"
+
+
+async def test_no_platform_tier_reads_all_identities(session):
+    """No admin-read-all policy: even platform_admin sees only its own links on
+    the request path — cross-user identity reads run on the system engine."""
+    provider = await _make_provider(session, "acme2")
+    u1 = await create_user(session)
+    u2 = await create_user(session)
+    await _link(session, u1.id, provider, "sub-a")
+    await _link(session, u2.id, provider, "sub-b")
+
+    await _assume(session, "admin", u1.id)
+    rows = {
+        r[0]
+        for r in (
+            await session.exec(text("SELECT user_id FROM federated_identities"))
+        ).fetchall()
+    }
+    await _reset(session)
+    assert rows == {u1.id}, (
+        "platform_admin must not read-all identities via the request path"
+    )
+
+
+async def test_auth_providers_unreadable_on_request_path(session):
+    """No permissive policy + no request-path grant: the request role cannot read
+    provider config at all, so guild-scoped SSO metadata can't leak cross-tenant."""
+    await _make_provider(session, "acme3")
+    u1 = await create_user(session)
+
+    await _assume(session, "owner", u1.id)
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(text("SELECT id FROM auth_providers"))
+    await _reset(session)

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -46,6 +46,8 @@ from app.models.tenant.counter import (
 from app.models.tenant.upload import Upload
 from app.models.platform.user_view_preference import UserViewPreference
 from app.models.platform.access_grant import AccessGrant
+from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.user_token import UserToken
 from app.models.platform.push_token import PushToken
 from app.models.platform.auto_delegation_jti import AutoDelegationJti
@@ -57,6 +59,8 @@ from app.models.tenant.advanced_tool import AdvancedTool
 __all__ = [
     "User",
     "AccessGrant",
+    "AuthProvider",
+    "FederatedIdentity",
     "ResourceGrant",
     "AdvancedTool",
     "Project",

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -36,6 +36,8 @@ pytestmark = [pytest.mark.integration, pytest.mark.database]
 _RLS_SHARED_TABLES = {
     "access_grants",
     "app_settings",
+    "auth_providers",
+    "federated_identities",
     "guild_invites",
     "guild_memberships",
     "guilds",

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -73,6 +73,15 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     "app_settings": frozenset({"SELECT", "INSERT", "UPDATE"}),
     # OIDC sync reads mappings; the settings endpoints manage them
     "oidc_claim_mappings": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # login provider registry (successor to app_settings.oidc_*): fully managed
+    # on the system engine — login reads + provider CRUD via AdminSessionDep with
+    # capability/ownership checks (as access_grants). Like oidc_claim_mappings, it
+    # carries NO permissive RLS policy, so the request path can't read guild-scoped
+    # provider config (no cross-tenant metadata leak).
+    "auth_providers": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # identity linking — resolved/created at login (pre-auth, by subject); link/
+    # unlink go through the system engine (linking is an account-takeover surface)
+    "federated_identities": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # personal UI state — the system engine has no business here
     "user_view_preferences": None,
     "notifications": frozenset({"SELECT", "INSERT", "DELETE"}),
@@ -98,6 +107,12 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     "guild_invites": frozenset({"SELECT"}),
     "guild_memberships": frozenset({"SELECT"}),
     "access_grants": frozenset({"SELECT"}),
+    # provider reads for the login page go via the system engine (AdminSessionDep),
+    # not the bare login role — so guild-scoped provider config never leaks here
+    "auth_providers": None,
+    # own-row identity links are read on the authenticated (platform_<tier>)
+    # path, not the bare pre-routing role
+    "federated_identities": None,
     "notifications": None,
     "oidc_claim_mappings": None,
     "push_tokens": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -68,6 +68,10 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # Consumed pre-membership / pre-routing
         "guild_invites",  # looked up by token before the user is a member
         "oidc_claim_mappings",  # SSO auto-join rules, read across all guilds at login
+        # Auth/login foundation — one user's identities span guilds; provider
+        # registry is read pre-routing at login.
+        "auth_providers",  # login provider registry (operator-global or guild-scoped)
+        "federated_identities",  # (provider, subject) -> user links
         # Platform-wide
         "app_settings",  # OIDC / SMTP / branding config
         "access_grants",  # PAM — inherently cross-guild (request -> approve -> scoped)

--- a/backend/app/models/platform/auth_provider.py
+++ b/backend/app/models/platform/auth_provider.py
@@ -1,0 +1,120 @@
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlmodel import Field, Index, SQLModel
+
+
+class AuthProviderKind(str, Enum):
+    """Which relying-party flow an auth provider speaks.
+
+    ``oidc`` — a standards-compliant OpenID Connect provider (discovery + PKCE).
+    ``oauth2`` — a plain OAuth2 provider without OIDC discovery (e.g. GitHub).
+    ``broker`` — a federation broker that fronts many upstream IdPs (cloud);
+    carries a ``connection_claim`` naming the tenant it authenticated.
+    """
+
+    oidc = "oidc"
+    oauth2 = "oauth2"
+    broker = "broker"
+
+
+# Mirror the CHECK constraint declared in the migration. Keep in sync with
+# ``20260705_0131_create_auth_identity_tables.py``.
+AUTH_PROVIDER_KINDS: tuple[str, ...] = tuple(k.value for k in AuthProviderKind)
+
+
+class AuthProvider(SQLModel, table=True):
+    """A configured identity source Initiative acts as a relying party to.
+
+    Replaces the single ``app_settings.oidc_*`` config with a registry that can
+    hold many providers. ``guild_id IS NULL`` is an **operator-global** provider
+    (platform-level login); a set ``guild_id`` is a **guild-scoped** enterprise
+    IdP (only used when ``ENTERPRISE_GUILD_SSO`` is on).
+
+    Metadata only — the client *secret* lives in a separate, ``app_admin``-only
+    companion table added with the OIDC-login phase; nothing here is sensitive
+    (``issuer``/``client_id`` are public in OIDC).
+    """
+
+    __tablename__ = "auth_providers"
+    __table_args__ = (
+        # Guild-scoped slugs are unique within their guild.
+        UniqueConstraint("guild_id", "slug", name="uq_auth_providers_guild_slug"),
+        # Operator-global slugs (guild_id IS NULL, which the composite above does
+        # not constrain) must also be unique — a partial unique index.
+        Index(
+            "uq_auth_providers_global_slug",
+            "slug",
+            unique=True,
+            postgresql_where=text("guild_id IS NULL"),
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    slug: str = Field(sa_column=Column(String(64), nullable=False))
+    display_name: str = Field(sa_column=Column(String(128), nullable=False))
+    kind: str = Field(
+        sa_column=Column(
+            String(16), nullable=False, server_default=AuthProviderKind.oidc.value
+        )
+    )
+    enabled: bool = Field(
+        sa_column=Column(Boolean, nullable=False, server_default=text("false"))
+    )
+
+    # NULL = operator-global (platform-level); set = guild-scoped enterprise IdP.
+    guild_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer, nullable=True, index=True
+        ),  # FK declared in the migration (ON DELETE CASCADE)
+    )
+
+    # OIDC / OAuth2 discovery + client identity (non-secret).
+    issuer: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    client_id: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+    scopes: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    role_claim_path: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+
+    # Broker only: the claim carrying the upstream tenant id (e.g. organization_id).
+    connection_claim: Optional[str] = Field(
+        default=None, sa_column=Column(String(64), nullable=True)
+    )
+
+    # Just-in-time provisioning of unknown users on first login.
+    allow_jit: bool = Field(
+        sa_column=Column(Boolean, nullable=False, server_default=text("true"))
+    )
+
+    # Login-button rendering.
+    icon: Optional[str] = Field(
+        default=None, sa_column=Column(String(64), nullable=True)
+    )
+    button_style: Optional[str] = Field(
+        default=None, sa_column=Column(String(32), nullable=True)
+    )
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/app/models/platform/auth_provider.py
+++ b/backend/app/models/platform/auth_provider.py
@@ -116,5 +116,12 @@ class AuthProvider(SQLModel, table=True):
     )
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        sa_column=Column(DateTime(timezone=True), nullable=False),
+        # onupdate (Python-side, no DDL) so provider CRUD in Phase 1 bumps this
+        # automatically — the codebase otherwise sets updated_at in the service,
+        # which a future endpoint could forget.
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            onupdate=lambda: datetime.now(timezone.utc),
+        ),
     )

--- a/backend/app/models/platform/federated_identity.py
+++ b/backend/app/models/platform/federated_identity.py
@@ -13,9 +13,12 @@ class FederatedIdentity(SQLModel, table=True):
     One user may have many linked identities (a work SSO, a personal passkey
     provider, …); the user row stays Initiative's system of record.
 
-    Own-row RLS: a user sees/manages only their own links; platform admins/owners
-    manage all (for support). The IdP refresh token (for group re-sync) is *not*
-    stored here yet — it arrives, encrypted, with the OIDC-login phase.
+    Own-row RLS: a user sees/manages only their own links on the request path —
+    there is **no** admin-read-all policy. Cross-user identity management (support)
+    runs on the system engine (``app_admin``), never a platform-tier request role,
+    so a support UI must not assume request-path access here. The IdP refresh token
+    (for group re-sync) is *not* stored here yet — it arrives, encrypted, with the
+    OIDC-login phase.
     """
 
     __tablename__ = "federated_identities"

--- a/backend/app/models/platform/federated_identity.py
+++ b/backend/app/models/platform/federated_identity.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, Text, UniqueConstraint, text
+from sqlmodel import Field, SQLModel
+
+
+class FederatedIdentity(SQLModel, table=True):
+    """A link between one global Initiative user and one external identity.
+
+    Identity is keyed on ``(provider_id, subject)`` — the IdP ``sub`` — never on
+    email, so trusting multiple providers can't collide into account takeover.
+    One user may have many linked identities (a work SSO, a personal passkey
+    provider, …); the user row stays Initiative's system of record.
+
+    Own-row RLS: a user sees/manages only their own links; platform admins/owners
+    manage all (for support). The IdP refresh token (for group re-sync) is *not*
+    stored here yet — it arrives, encrypted, with the OIDC-login phase.
+    """
+
+    __tablename__ = "federated_identities"
+    __table_args__ = (
+        UniqueConstraint(
+            "provider_id", "subject", name="uq_federated_identities_provider_subject"
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    # FKs declared in the migration (both ON DELETE CASCADE).
+    user_id: int = Field(sa_column=Column(Integer, nullable=False, index=True))
+    provider_id: int = Field(sa_column=Column(Integer, nullable=False, index=True))
+
+    # The IdP-asserted subject identifier — the stable join key.
+    subject: str = Field(sa_column=Column(Text, nullable=False))
+
+    # Whether the IdP asserted a verified email at link time (a snapshot used for
+    # the linking-safety check, not a join key). The email itself is not stored
+    # here — identity is resolved by (provider, subject).
+    email_verified: bool = Field(
+        sa_column=Column(Boolean, nullable=False, server_default=text("false"))
+    )
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    last_login_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )


### PR DESCRIPTION
## Problem
The login rewrite (Phase 0 foundation) needs a place to hold multiple auth providers and the links between a global user and their external identities. Today auth config is a single `app_settings.oidc_*` singleton and OIDC identities are linked by email on the `users` row.

## What this adds
Two **secret-free**, purely **additive** `public` tables. Nothing reads or writes them yet, so there is **no behaviour change** and nothing to break — it just lands the schema the rest of Phase 0 builds on.

- **`auth_providers`** — the login provider registry (successor to `app_settings.oidc_*`). `guild_id IS NULL` = operator-global (platform-level); a set `guild_id` = a guild-scoped enterprise IdP. Metadata only (no client secret — that lands in an `app_admin`-only companion table with the OIDC-login phase).
- **`federated_identities`** — `(provider_id, subject)` → user links, keyed on the IdP subject, **not** email.

## Role security (deliberate, not a blanket copy)
The `public` schema default-grants `platform_base` + `app_guild_base` **full DML on every new table**, so a new shared table is request-path-writable unless explicitly revoked (RLS would be the only guard).

- **`auth_providers`** REVOKEs both default grants → **system-engine (`app_admin`) only**. The request path can't read provider config at all (grant-layer *and* RLS denial), so guild-scoped SSO metadata can't leak cross-tenant.
- **`federated_identities`** is **own-row** (a platform tier sees only its own links); writes go via the system engine (linking is an account-takeover surface); no guild-role grant.

## Notable
- Registered in `tenancy.SHARED_TABLES` + both `system_grants.py` registries (completeness + drift CI enforced).
- Extended the `security_invariants_test` FORCE-RLS set; added `auth_identity_rls_test.py` locking in the two security decisions above.
- **Schema:** new migration `20260705_0131` (additive; clean downgrade).

## Testing
```
cd backend && pytest app/db/            # 210 passed
ruff check app && ruff format app
```