### PR TITLE
Add auth_sessions session/refresh store table

### DIFF
--- a/backend/alembic/versions/20260706_0132_create_auth_sessions.py
+++ b/backend/alembic/versions/20260706_0132_create_auth_sessions.py
@@ -1,0 +1,89 @@
+"""create auth_sessions (session / rotating-refresh store)
+
+Phase-0 foundation for the login rewrite (history/auth-detailed-design.md §2.3,
+§3): the server-side session that backs the stateless access JWT and makes the
+refresh side revocable. Additive only — nothing reads or writes it yet.
+
+uuid PK (the JWT ``sid``): non-enumerable, no hot sequence, and one row per login
+so a monotonic int would leak the login count. Because it is a uuid, there is no
+``_id_seq`` to grant.
+
+app_admin-only. Session validation is a pre-auth lookup by refresh-token hash (the
+user is unknown until it resolves), so it can't run under own-row RLS — it runs on
+the system engine, like access_grants. The public schema default-grants
+platform_base + app_guild_base full DML on every new table, so we REVOKE both:
+the request path can't touch sessions (esp. the refresh-token hash) at all.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260706_0132"
+down_revision = "20260705_0131"
+branch_labels = None
+depends_on = None
+
+
+def _platform(role: str) -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_{role}"
+
+
+def _run(statements: list[str]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_sessions",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("refresh_token_hash", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "satisfied_providers",
+            sa.ARRAY(sa.Integer()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+        sa.Column(
+            "amr", sa.ARRAY(sa.Text()), server_default=sa.text("'{}'"), nullable=False
+        ),
+        sa.Column("parent_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("user_agent", sa.Text(), nullable=True),
+        sa.Column("ip", sa.Text(), nullable=True),
+        sa.Column("device_name", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "refresh_token_hash", name="uq_auth_sessions_refresh_token_hash"
+        ),
+    )
+    op.create_index("ix_auth_sessions_user_id", "auth_sessions", ["user_id"])
+    op.create_index("ix_auth_sessions_expires_at", "auth_sessions", ["expires_at"])
+
+    base = _platform("base")
+    _run(
+        [
+            "ALTER TABLE public.auth_sessions ENABLE ROW LEVEL SECURITY",
+            "ALTER TABLE public.auth_sessions FORCE ROW LEVEL SECURITY",
+            # Strip the schema-default DML: all session ops (validate/rotate/revoke,
+            # and "list my sessions") run on the system engine; the request path
+            # never touches sessions, so the refresh-token hash can't leak.
+            f'REVOKE ALL ON TABLE public.auth_sessions FROM app_guild_base, "{base}"',
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.auth_sessions TO app_admin",
+        ]
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS public.auth_sessions CASCADE")

--- a/backend/alembic/versions/20260706_0132_create_auth_sessions.py
+++ b/backend/alembic/versions/20260706_0132_create_auth_sessions.py
@@ -17,6 +17,7 @@ the request path can't touch sessions (esp. the refresh-token hash) at all.
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 from app.core.config import settings
 
@@ -61,11 +62,18 @@ def upgrade() -> None:
         sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("user_agent", sa.Text(), nullable=True),
-        sa.Column("ip", sa.Text(), nullable=True),
+        sa.Column("ip", postgresql.INET(), nullable=True),
         sa.Column("device_name", sa.Text(), nullable=True),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.UniqueConstraint(
             "refresh_token_hash", name="uq_auth_sessions_refresh_token_hash"
+        ),
+        # A session can't be its own rotation parent (a self-loop would hang the
+        # theft-detection chain walk); longer cycles can't form as the chain is
+        # strictly backward in time.
+        sa.CheckConstraint(
+            "parent_id IS NULL OR parent_id <> id",
+            name="ck_auth_sessions_parent_not_self",
         ),
     )
     op.create_index("ix_auth_sessions_user_id", "auth_sessions", ["user_id"])

--- a/backend/app/db/auth_sessions_rls_test.py
+++ b/backend/app/db/auth_sessions_rls_test.py
@@ -1,0 +1,69 @@
+"""RLS / role-security test for the auth_sessions store.
+
+Locks in the app_admin-only wall (migration 20260706_0132): the request path
+cannot touch sessions at all, so the refresh-token hash never leaks. Session
+validation is a pre-auth lookup by hash (user unknown) and so runs on the system
+engine — there is deliberately no own-row request-path access.
+
+Style mirrors ``platform_role_rls_test``: SET ROLE platform_<tier> drops to a
+non-superuser role so RLS + table GRANTs are enforced like the request path.
+"""
+
+import hashlib
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.schema_provisioning import platform_role_name
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def _assume(session, tier: str, user_id: int) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('app.current_user_id', :uid, false), "
+            "set_config('role', :role, false)"
+        ),
+        params={"uid": str(user_id), "role": platform_role_name(tier)},
+    )
+
+
+async def _reset(session) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('role', 'none', false), "
+            "set_config('app.current_user_id', '', false)"
+        )
+    )
+
+
+async def _make_session_row(session, user_id: int, token: str) -> None:
+    await session.exec(
+        text(
+            "INSERT INTO auth_sessions "
+            "(user_id, refresh_token_hash, expires_at, created_at) "
+            "VALUES (:u, :h, now() + interval '1 day', now())"
+        ),
+        params={"u": user_id, "h": hashlib.sha256(token.encode()).digest()},
+    )
+
+
+async def test_auth_sessions_unreadable_on_request_path(session):
+    """No request-path grant: even the highest platform tier is denied at the
+    grant layer, so the refresh-token hash can never be read off the request path.
+    The superuser setup session (like the system engine) still sees the row."""
+    u1 = await create_user(session)
+    await _make_session_row(session, u1.id, "refresh-token-1")
+
+    # Positive control: the privileged path sees the session it just wrote.
+    seen = (await session.exec(text("SELECT count(*) FROM auth_sessions"))).scalar_one()
+    assert seen >= 1
+
+    await _assume(session, "owner", u1.id)
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(text("SELECT id FROM auth_sessions"))
+    await _reset(session)

--- a/backend/app/db/auth_sessions_rls_test.py
+++ b/backend/app/db/auth_sessions_rls_test.py
@@ -10,6 +10,7 @@ non-superuser role so RLS + table GRANTs are enforced like the request path.
 """
 
 import hashlib
+import uuid
 
 import pytest
 from sqlalchemy import text
@@ -67,3 +68,24 @@ async def test_auth_sessions_unreadable_on_request_path(session):
         async with session.begin_nested():
             await session.exec(text("SELECT id FROM auth_sessions"))
     await _reset(session)
+
+
+async def test_session_cannot_be_its_own_rotation_parent(session):
+    """ck_auth_sessions_parent_not_self: a row whose parent_id equals its own id
+    is rejected — a self-loop would hang the theft-detection chain walk."""
+    u1 = await create_user(session)
+    sid = uuid.uuid4()
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(
+                text(
+                    "INSERT INTO auth_sessions "
+                    "(id, user_id, refresh_token_hash, parent_id, expires_at, created_at) "
+                    "VALUES (:sid, :u, :h, :sid, now() + interval '1 day', now())"
+                ),
+                params={
+                    "sid": sid,
+                    "u": u1.id,
+                    "h": hashlib.sha256(b"self-parent").digest(),
+                },
+            )

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -47,6 +47,7 @@ from app.models.tenant.upload import Upload
 from app.models.platform.user_view_preference import UserViewPreference
 from app.models.platform.access_grant import AccessGrant
 from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.auth_session import AuthSession
 from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.user_token import UserToken
 from app.models.platform.push_token import PushToken
@@ -60,6 +61,7 @@ __all__ = [
     "User",
     "AccessGrant",
     "AuthProvider",
+    "AuthSession",
     "FederatedIdentity",
     "ResourceGrant",
     "AdvancedTool",

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -37,6 +37,7 @@ _RLS_SHARED_TABLES = {
     "access_grants",
     "app_settings",
     "auth_providers",
+    "auth_sessions",
     "federated_identities",
     "guild_invites",
     "guild_memberships",

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -82,6 +82,9 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     # identity linking — resolved/created at login (pre-auth, by subject); link/
     # unlink go through the system engine (linking is an account-takeover surface)
     "federated_identities": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # session/refresh store — validated pre-auth by refresh-token hash (user
+    # unknown), so all session ops run on the system engine; request path revoked
+    "auth_sessions": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # personal UI state — the system engine has no business here
     "user_view_preferences": None,
     "notifications": frozenset({"SELECT", "INSERT", "DELETE"}),
@@ -113,6 +116,8 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # own-row identity links are read on the authenticated (platform_<tier>)
     # path, not the bare pre-routing role
     "federated_identities": None,
+    # sessions are system-engine-only; the bare login role never touches them
+    "auth_sessions": None,
     "notifications": None,
     "oidc_claim_mappings": None,
     "push_tokens": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -72,6 +72,7 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # registry is read pre-routing at login.
         "auth_providers",  # login provider registry (operator-global or guild-scoped)
         "federated_identities",  # (provider, subject) -> user links
+        "auth_sessions",  # session/refresh store (JWT sid = row id); app_admin-only
         # Platform-wide
         "app_settings",  # OIDC / SMTP / branding config
         "access_grants",  # PAM — inherently cross-guild (request -> approve -> scoped)

--- a/backend/app/models/platform/auth_session.py
+++ b/backend/app/models/platform/auth_session.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from sqlalchemy import (
     ARRAY,
+    CheckConstraint,
     Column,
     DateTime,
     Integer,
@@ -13,6 +14,7 @@ from sqlalchemy import (
     Uuid,
     text,
 )
+from sqlalchemy.dialects.postgresql import INET
 from sqlmodel import Field, Index, SQLModel
 
 
@@ -38,6 +40,14 @@ class AuthSession(SQLModel, table=True):
     __table_args__ = (
         UniqueConstraint(
             "refresh_token_hash", name="uq_auth_sessions_refresh_token_hash"
+        ),
+        # A row can't be its own rotation parent — a self-loop would hang the
+        # theft-detection chain walk. Longer cycles can't form: the chain is
+        # strictly backward in time (a new row's fresh uuid can't already be a
+        # parent_id), so direct self-reference is the only reachable loop.
+        CheckConstraint(
+            "parent_id IS NULL OR parent_id <> id",
+            name="ck_auth_sessions_parent_not_self",
         ),
         Index("ix_auth_sessions_user_id", "user_id"),
         # Supports the background expiry sweep (GC of past-expiry sessions).
@@ -94,7 +104,9 @@ class AuthSession(SQLModel, table=True):
     user_agent: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)
     )
-    ip: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    # INET (not text): canonical normalisation + subnet queries; NULL when unknown.
+    # Rejects a raw X-Forwarded-For list, forcing the service to store one client IP.
+    ip: Optional[str] = Field(default=None, sa_column=Column(INET, nullable=True))
     device_name: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)
     )

--- a/backend/app/models/platform/auth_session.py
+++ b/backend/app/models/platform/auth_session.py
@@ -1,0 +1,100 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    ARRAY,
+    Column,
+    DateTime,
+    Integer,
+    LargeBinary,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    text,
+)
+from sqlmodel import Field, Index, SQLModel
+
+
+class AuthSession(SQLModel, table=True):
+    """A server-side session backing one login — the rotating-refresh anchor.
+
+    The access JWT is stateless (verified locally, no per-request DB hit); this
+    row is what makes the refresh side revocable. ``id`` is the JWT ``sid`` — a
+    uuid, so it is non-enumerable and leaks no session count. ``satisfied_providers``
+    / ``amr`` record which providers/factors this session authenticated against,
+    mirrored into the access token so the per-guild auth-policy gate and step-up
+    read them locally without a lookup.
+
+    **app_admin-only.** Session validation is a pre-auth lookup *by refresh-token
+    hash* (the user is unknown until it resolves), so it structurally cannot run
+    under own-row RLS — it runs on the system engine, exactly like access_grants.
+    "List/revoke my sessions" also runs on the system engine (``AdminSessionDep``)
+    filtered by the authenticated user, so the refresh-token hash never crosses the
+    request path. The schema-default request-path DML is REVOKEd in the migration.
+    """
+
+    __tablename__ = "auth_sessions"
+    __table_args__ = (
+        UniqueConstraint(
+            "refresh_token_hash", name="uq_auth_sessions_refresh_token_hash"
+        ),
+        Index("ix_auth_sessions_user_id", "user_id"),
+        # Supports the background expiry sweep (GC of past-expiry sessions).
+        Index("ix_auth_sessions_expires_at", "expires_at"),
+    )
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(
+            Uuid, primary_key=True, server_default=text("gen_random_uuid()")
+        ),
+    )
+    # FK declared in the migration (ON DELETE CASCADE).
+    user_id: int = Field(sa_column=Column(Integer, nullable=False))
+
+    # SHA-256 of the raw refresh token — deterministic so a presented token maps
+    # to one session by index lookup. The raw token is never stored.
+    refresh_token_hash: bytes = Field(sa_column=Column(LargeBinary, nullable=False))
+
+    # Providers/factors this session satisfied — drives the guild auth-policy gate
+    # and step-up; mirrored into the access JWT so the check stays local.
+    satisfied_providers: list[int] = Field(
+        default_factory=list,
+        sa_column=Column(ARRAY(Integer), nullable=False, server_default=text("'{}'")),
+    )
+    amr: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(ARRAY(Text), nullable=False, server_default=text("'{}'")),
+    )
+
+    # Rotation chain: each refresh mints a new row pointing at the one it replaced;
+    # reuse of an already-rotated token revokes the whole chain (theft detection).
+    # Plain uuid, app-managed — no self-FK.
+    parent_id: Optional[uuid.UUID] = Field(
+        default=None, sa_column=Column(Uuid, nullable=True)
+    )
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    last_used_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    # Set by the service to now + REFRESH_TTL at creation (no default here).
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False)
+    )
+    revoked_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+
+    # Audit / "your active sessions" UX.
+    user_agent: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+    ip: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    device_name: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )


### PR DESCRIPTION
## Problem
The login rewrite's session model (Phase 0, PR #2 of the series after #820) needs a server-side session row: the access JWT is stateless (verified locally, no per-request DB hit), so the **refresh** side is what makes a login revocable. There is no such table today (JWT is stateless + non-expiring device tokens).

## What this adds
One **additive** `public` table, `auth_sessions`. Nothing reads or writes it yet — no behaviour change.

- **uuid PK** = the JWT `sid`. Deliberately not a bigint: it's embedded in every token, grows one row per login, so a monotonic int would leak the login count and hand out enumerable session ids. uuid → non-enumerable, no hot sequence, and **no `_id_seq` to grant**.
- `satisfied_providers` (`int[]`) + `amr` (`text[]`) — which providers/factors the session authenticated against; to be mirrored into the access token so the per-guild auth-policy gate + step-up stay a local check.
- `refresh_token_hash` (`bytea`, unique) — SHA-256 of the raw refresh token; the raw token is never stored. Deterministic hash so a presented token maps to one session by index lookup.
- `parent_id` (`uuid`) — single-use rotation chain (reuse of a rotated token ⇒ revoke the chain).
- Plus timestamps + `user_agent`/`ip`/`device_name` for the "your active sessions" UX.

## Role security — `app_admin`-only (same wall as `auth_providers`)
Session validation is a **pre-auth lookup by refresh-token hash** — the user is unknown until it resolves — so it structurally **cannot** run under own-row RLS; it runs on the system engine, exactly like `access_grants`. The public schema default-grants `platform_base` + `app_guild_base` full DML on every new table, so the migration **REVOKEs** both: the request path can't touch sessions (esp. the refresh hash) at all. "List/revoke my sessions" runs on `AdminSessionDep` filtered by the authenticated user.

## Notable
- Registered in `tenancy.SHARED_TABLES` + both `system_grants.py` registries; extended the FORCE-RLS invariant set; added `auth_sessions_rls_test.py` proving the request-path wall.
- **Schema:** migration `20260706_0132` (additive; clean downgrade). Verified live column types are native `uuid` / `bytea` / `int[]` / `text[]`.

## Testing
```
cd backend && pytest app/db/         # 211 passed
ruff check app && ruff format app
```