### PR TITLE
Add auth session service (create/rotate/revoke)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -154,6 +154,16 @@ class Settings(BaseSettings):
     ALGORITHM: str = "HS256"
     COOKIE_NAME: str = "session_token"
 
+    # New login model (auth rewrite, Phase 0 — history/auth-detailed-design.md §3).
+    # The access token is short-lived + stateless: verified locally with no
+    # per-request DB read (the 10k+ win), so a leak is stale within one TTL. The
+    # refresh token is long, opaque, rotating, and revocable via ``auth_sessions``.
+    # These are deliberately separate from the legacy ``ACCESS_TOKEN_EXPIRE_MINUTES``
+    # (the current long-lived session JWT) — the two models coexist during the
+    # dual-verify cutover window.
+    AUTH_ACCESS_TTL_MINUTES: int = 15
+    AUTH_REFRESH_TTL_DAYS: int = 30
+
     @field_validator("SECRET_KEY")
     @classmethod
     def _validate_secret_key(cls, value: str) -> str:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -69,6 +69,61 @@ def create_access_token(
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# New login model — stateless access token (auth rewrite, Phase 0)
+#
+# A short-lived JWT that names both the user AND the server-side session
+# (``auth_sessions.id``) that backs it, plus the auth methods/providers that
+# session satisfied. It is verified locally (no per-request DB hit — the 10k+
+# win) and made revocable by its paired refresh token, whose rotation lives in
+# ``app.services.auth.sessions``. Its distinct ``aud`` keeps it from being
+# confused with the legacy session JWT, the upload token, or the handoff token
+# during the dual-verify cutover window (verification lands with the endpoint).
+# ──────────────────────────────────────────────────────────────────────────
+
+# Audience/issuer that mark a token as a new-model access credential. The
+# session-JWT verification path (added with ``/auth/refresh``) MUST check both,
+# and the upload/handoff paths already reject anything carrying this audience.
+AUTH_ACCESS_AUDIENCE = "initiative:access"
+AUTH_TOKEN_ISSUER = "initiative"
+
+
+def mint_access_token(
+    *,
+    user_id: int,
+    token_version: int,
+    session_id: uuid.UUID,
+    amr: list[str],
+    satisfied_providers: list[int],
+    expires_in: timedelta | None = None,
+    now: datetime | None = None,
+) -> tuple[str, int]:
+    """Mint a short-lived, stateless access token for one session.
+
+    Claims (history/auth-detailed-design.md §3.1): ``sub`` (user id), ``sid``
+    (the ``auth_sessions`` row), ``ver`` (``users.token_version`` — coarse "sign
+    out everywhere"), ``amr`` (auth methods satisfied), ``sat`` (satisfied-auth
+    provider ids → the per-guild auth-policy gate), plus ``iss``/``aud``/
+    ``iat``/``exp``. Returns ``(token, expires_in_seconds)`` so the caller can
+    schedule a refresh before it lapses.
+    """
+    issued = now or datetime.now(timezone.utc)
+    ttl = expires_in or timedelta(minutes=settings.AUTH_ACCESS_TTL_MINUTES)
+    payload: dict[str, Any] = {
+        "sub": str(user_id),
+        "sid": str(session_id),
+        "ver": token_version,
+        "amr": amr,
+        "sat": satisfied_providers,
+        "iss": AUTH_TOKEN_ISSUER,
+        "aud": AUTH_ACCESS_AUDIENCE,
+        "iat": int(issued.timestamp()),
+        "exp": issued + ttl,
+    }
+    token = jwt.encode(payload, settings.jwt_signing_key, algorithm=settings.ALGORITHM)
+    return token, int(ttl.total_seconds())
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # Scoped upload tokens
 #
 # Native (Capacitor) WebViews can't attach an Authorization header or send the

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -8,6 +8,7 @@ The HTTP-level gating is covered separately in the endpoint tests.
 from __future__ import annotations
 
 import time
+import uuid
 
 import jwt
 import pytest
@@ -17,15 +18,19 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from datetime import timedelta
 
 from app.core import security
+from app.core.config import settings
 from app.core.security import (
     ADVANCED_TOOL_AUDIENCE,
     ADVANCED_TOOL_HANDOFF_LIFETIME,
+    AUTH_ACCESS_AUDIENCE,
+    AUTH_TOKEN_ISSUER,
     UPLOAD_TOKEN_AUDIENCE,
     UPLOAD_TOKEN_LIFETIME,
     UPLOAD_TOKEN_SCOPE,
     UploadTokenError,
     create_advanced_tool_handoff_token,
     create_upload_token,
+    mint_access_token,
     verify_upload_token,
 )
 
@@ -309,3 +314,73 @@ def test_verify_upload_token_rejects_wrong_audience():
     )
     with pytest.raises(UploadTokenError):
         verify_upload_token(handoff)
+
+
+# ── New-model access token (auth rewrite, Phase 0) ─────────────────────────
+
+
+@pytest.mark.unit
+def test_mint_access_token_carries_session_claims():
+    """The access token names the user, the backing session, and the auth
+    context (amr/sat) that the guild-policy gate reads locally."""
+    sid = uuid.uuid4()
+    token, seconds = mint_access_token(
+        user_id=42,
+        token_version=3,
+        session_id=sid,
+        amr=["pwd", "otp"],
+        satisfied_providers=[7, 9],
+    )
+
+    assert isinstance(token, str) and token.count(".") == 2
+    assert seconds == settings.AUTH_ACCESS_TTL_MINUTES * 60
+
+    payload = _decode_unverified(token)
+    assert payload["sub"] == "42"
+    assert payload["sid"] == str(sid)
+    assert payload["ver"] == 3
+    assert payload["amr"] == ["pwd", "otp"]
+    assert payload["sat"] == [7, 9]
+    assert payload["iss"] == AUTH_TOKEN_ISSUER
+    assert payload["aud"] == AUTH_ACCESS_AUDIENCE
+
+
+@pytest.mark.unit
+def test_mint_access_token_exp_matches_advertised_seconds():
+    """``exp`` must equal ``iat`` + the returned seconds — the SPA schedules its
+    refresh off that number, so drift would refresh late (or never)."""
+    sid = uuid.uuid4()
+    token, seconds = mint_access_token(
+        user_id=1,
+        token_version=0,
+        session_id=sid,
+        amr=["pwd"],
+        satisfied_providers=[],
+    )
+
+    payload = _decode_unverified(token)
+    assert payload["exp"] - payload["iat"] == seconds
+
+
+@pytest.mark.unit
+def test_mint_access_token_is_verifiable_with_expected_audience():
+    """A round-trip decode with the audience the verification path will require
+    must succeed — signature + aud + iss all line up."""
+    sid = uuid.uuid4()
+    token, _ = mint_access_token(
+        user_id=5,
+        token_version=1,
+        session_id=sid,
+        amr=["pwd"],
+        satisfied_providers=[],
+    )
+
+    payload = jwt.decode(
+        token,
+        settings.jwt_signing_key,
+        algorithms=[settings.ALGORITHM],
+        audience=AUTH_ACCESS_AUDIENCE,
+        issuer=AUTH_TOKEN_ISSUER,
+        options={"require": ["exp", "iat", "sub", "sid", "aud", "iss"]},
+    )
+    assert payload["sub"] == "5"

--- a/backend/app/services/auth/__init__.py
+++ b/backend/app/services/auth/__init__.py
@@ -1,0 +1,25 @@
+"""Auth service package for the login rewrite (history/auth-detailed-design.md).
+
+Phase 0 lands the session lifecycle here; the ``IdentityProvider`` seam and the
+per-provider implementations slot in alongside it in later slices.
+"""
+
+from app.services.auth.sessions import (
+    IssuedSession,
+    RefreshError,
+    create_session,
+    revoke_all_for_user,
+    revoke_chain,
+    revoke_session,
+    rotate_session,
+)
+
+__all__ = [
+    "IssuedSession",
+    "RefreshError",
+    "create_session",
+    "rotate_session",
+    "revoke_session",
+    "revoke_chain",
+    "revoke_all_for_user",
+]

--- a/backend/app/services/auth/__init__.py
+++ b/backend/app/services/auth/__init__.py
@@ -6,7 +6,8 @@ per-provider implementations slot in alongside it in later slices.
 
 from app.services.auth.sessions import (
     IssuedSession,
-    RefreshError,
+    RefreshOutcome,
+    RotationResult,
     create_session,
     revoke_all_for_user,
     revoke_chain,
@@ -16,7 +17,8 @@ from app.services.auth.sessions import (
 
 __all__ = [
     "IssuedSession",
-    "RefreshError",
+    "RefreshOutcome",
+    "RotationResult",
     "create_session",
     "rotate_session",
     "revoke_session",

--- a/backend/app/services/auth/sessions.py
+++ b/backend/app/services/auth/sessions.py
@@ -1,0 +1,291 @@
+"""Server-side session lifecycle for the new login model (auth rewrite, Phase 0).
+
+This is the substrate that makes the stateless access token revocable
+(history/auth-detailed-design.md §3.2–§3.3). One ``auth_sessions`` row = one
+login; each ``/auth/refresh`` **rotates** it — mints a fresh row pointing at the
+one it replaces (``parent_id`` chain) and single-use-revokes the old one. Reuse
+of an already-spent refresh token is treated as **theft** and kills the whole
+chain, including its still-live tail.
+
+**Runs on the system engine (``app_admin``).** Session validation is a pre-auth
+lookup *by refresh-token hash* — the user is unknown until it resolves — so it
+structurally cannot run under own-row RLS. The request path holds no grant on
+``auth_sessions`` at all (migration 20260706_0132); these functions take the
+admin session, like ``services.platform.access_grants``.
+
+Nothing calls this yet — the ``/auth/refresh`` endpoint + dual-verify wiring land
+in the next slice. This PR is the tested logic layer only (additive-first).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.models.platform.auth_session import AuthSession
+
+__all__ = [
+    "IssuedSession",
+    "RefreshError",
+    "create_session",
+    "rotate_session",
+    "revoke_session",
+    "revoke_chain",
+    "revoke_all_for_user",
+]
+
+# 256 bits of entropy — infeasible to guess, so the hash (not a slow KDF) is the
+# only thing that needs storing.
+_REFRESH_TOKEN_BYTES = 32
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _generate_refresh_token() -> str:
+    """A fresh opaque refresh token (URL-safe, never persisted in the clear)."""
+    return secrets.token_urlsafe(_REFRESH_TOKEN_BYTES)
+
+
+def _hash_refresh_token(raw: str) -> bytes:
+    """SHA-256 of the raw token — *deterministic* so a presented token maps to
+    exactly one session by an indexed lookup. The token is 256-bit random, so a
+    plain fast hash is safe here (a salted/slow KDF would defeat the O(1) lookup
+    that ``uq_auth_sessions_refresh_token_hash`` exists to serve). The raw token
+    is returned to the client once and never stored."""
+    return hashlib.sha256(raw.encode("utf-8")).digest()
+
+
+@dataclass(frozen=True)
+class IssuedSession:
+    """A newly created/rotated session plus its raw refresh token.
+
+    ``refresh_token`` is the *only* time the raw token exists — hand it to the
+    client (cookie / secure storage) and drop it; only its hash is persisted.
+    """
+
+    session: AuthSession
+    refresh_token: str
+
+
+class RefreshError(Exception):
+    """A presented refresh token could not be rotated. ``code`` is machine-
+    readable so the endpoint maps it to an HTTP status + localized message."""
+
+    UNKNOWN = "unknown_refresh_token"
+    EXPIRED = "refresh_token_expired"
+    REUSED = "refresh_token_reused"
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+# Revoke every session in a token's rotation chain, in both directions, given any
+# member id. On reuse the live continuation is a *descendant* of the replayed
+# node (ancestors are already revoked), but we walk both ways for defense in
+# depth. The graph is a strict in-tree — ``parent_id`` always points at an older,
+# pre-existing row, and ``ck_auth_sessions_parent_not_self`` blocks the only
+# reachable self-loop — so the recursion terminates.
+_REVOKE_CHAIN_SQL = text(
+    """
+    WITH RECURSIVE
+    ancestors AS (
+        SELECT id, parent_id FROM auth_sessions WHERE id = :sid
+        UNION
+        SELECT s.id, s.parent_id
+        FROM auth_sessions s JOIN ancestors a ON s.id = a.parent_id
+    ),
+    descendants AS (
+        SELECT id, parent_id FROM auth_sessions WHERE id = :sid
+        UNION
+        SELECT s.id, s.parent_id
+        FROM auth_sessions s JOIN descendants d ON s.parent_id = d.id
+    )
+    UPDATE auth_sessions SET revoked_at = :now
+    WHERE revoked_at IS NULL
+      AND id IN (SELECT id FROM ancestors UNION SELECT id FROM descendants)
+    """
+)
+
+
+async def create_session(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    amr: list[str],
+    satisfied_providers: list[int],
+    user_agent: str | None = None,
+    ip: str | None = None,
+    device_name: str | None = None,
+    refresh_ttl: timedelta | None = None,
+    now: datetime | None = None,
+) -> IssuedSession:
+    """Open a new session for ``user_id`` and mint its first refresh token.
+
+    ``amr`` / ``satisfied_providers`` record which factors/providers this login
+    satisfied — they are mirrored into the access token so the per-guild
+    auth-policy gate and step-up read them locally.
+    """
+    issued = now or _now()
+    ttl = refresh_ttl or timedelta(days=settings.AUTH_REFRESH_TTL_DAYS)
+    raw = _generate_refresh_token()
+    row = AuthSession(
+        user_id=user_id,
+        refresh_token_hash=_hash_refresh_token(raw),
+        amr=list(amr),
+        satisfied_providers=list(satisfied_providers),
+        created_at=issued,
+        expires_at=issued + ttl,
+        user_agent=user_agent,
+        ip=ip,
+        device_name=device_name,
+    )
+    session.add(row)
+    await session.flush()
+    return IssuedSession(session=row, refresh_token=raw)
+
+
+async def rotate_session(
+    session: AsyncSession,
+    *,
+    raw_refresh_token: str,
+    amr: list[str] | None = None,
+    satisfied_providers: list[int] | None = None,
+    user_agent: str | None = None,
+    ip: str | None = None,
+    device_name: str | None = None,
+    refresh_ttl: timedelta | None = None,
+    now: datetime | None = None,
+) -> IssuedSession:
+    """Single-use rotate: spend the presented refresh token, mint its successor.
+
+    Carries ``amr``/``satisfied_providers`` (and device metadata) forward from the
+    parent unless overridden — a step-up rotation passes the widened set.
+
+    Raises :class:`RefreshError`:
+    - ``UNKNOWN`` — no session matches the token.
+    - ``EXPIRED`` — the refresh window has lapsed (benign; log back in).
+    - ``REUSED`` — the token was already spent ⇒ **theft**. The whole chain has
+      been revoked on ``session``; the caller **must commit that** (do not roll
+      back) before surfacing the 401, or the theft response is lost.
+    """
+    issued = now or _now()
+    ttl = refresh_ttl or timedelta(days=settings.AUTH_REFRESH_TTL_DAYS)
+    presented_hash = _hash_refresh_token(raw_refresh_token)
+
+    row = (
+        await session.exec(
+            select(AuthSession).where(AuthSession.refresh_token_hash == presented_hash)
+        )
+    ).one_or_none()
+    if row is None:
+        raise RefreshError(RefreshError.UNKNOWN)
+
+    # Already spent (rotated or explicitly revoked) ⇒ replay of a dead token.
+    if row.revoked_at is not None:
+        await revoke_chain(session, session_id=row.id, now=issued)
+        raise RefreshError(RefreshError.REUSED)
+
+    if row.expires_at <= issued:
+        raise RefreshError(RefreshError.EXPIRED)
+
+    # Atomic single-use claim: only one caller can flip revoked_at NULL→now, so
+    # two concurrent refreshes with the same token can't both mint a child.
+    claimed = (
+        await session.exec(
+            text(
+                "UPDATE auth_sessions SET revoked_at = :now, last_used_at = :now "
+                "WHERE id = :id AND revoked_at IS NULL RETURNING id"
+            ),
+            params={"now": issued, "id": row.id},
+        )
+    ).first()
+    if claimed is None:
+        # Lost the race to a concurrent rotation — same danger as a replay.
+        await revoke_chain(session, session_id=row.id, now=issued)
+        raise RefreshError(RefreshError.REUSED)
+    # Keep the in-session parent honest (the raw UPDATE bypassed the ORM).
+    await session.refresh(row)
+
+    raw = _generate_refresh_token()
+    child = AuthSession(
+        user_id=row.user_id,
+        refresh_token_hash=_hash_refresh_token(raw),
+        amr=list(amr) if amr is not None else list(row.amr),
+        satisfied_providers=(
+            list(satisfied_providers)
+            if satisfied_providers is not None
+            else list(row.satisfied_providers)
+        ),
+        parent_id=row.id,
+        created_at=issued,
+        expires_at=issued + ttl,
+        user_agent=user_agent if user_agent is not None else row.user_agent,
+        ip=ip if ip is not None else row.ip,
+        device_name=device_name if device_name is not None else row.device_name,
+    )
+    session.add(child)
+    await session.flush()
+    return IssuedSession(session=child, refresh_token=raw)
+
+
+async def revoke_session(
+    session: AsyncSession,
+    *,
+    session_id: uuid.UUID,
+    now: datetime | None = None,
+) -> int:
+    """Revoke one session (logout, unlink, disable MFA). Its access token still
+    expires within the short TTL. Returns the number of rows revoked (0 if it was
+    already revoked/absent)."""
+    result = await session.exec(
+        text(
+            "UPDATE auth_sessions SET revoked_at = :now "
+            "WHERE id = :id AND revoked_at IS NULL"
+        ),
+        params={"now": now or _now(), "id": session_id},
+    )
+    return result.rowcount
+
+
+async def revoke_chain(
+    session: AsyncSession,
+    *,
+    session_id: uuid.UUID,
+    now: datetime | None = None,
+) -> int:
+    """Revoke every still-live session in ``session_id``'s rotation chain (theft
+    response, or unlink-provider cleanup). Returns the number of rows revoked."""
+    result = await session.exec(
+        _REVOKE_CHAIN_SQL, params={"sid": session_id, "now": now or _now()}
+    )
+    return result.rowcount
+
+
+async def revoke_all_for_user(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    now: datetime | None = None,
+) -> int:
+    """Revoke all of a user's live sessions — the refresh-side of "sign out
+    everywhere" (paired with the ``users.token_version`` bump that invalidates
+    outstanding access tokens). Returns the number of rows revoked."""
+    result = await session.exec(
+        text(
+            "UPDATE auth_sessions SET revoked_at = :now "
+            "WHERE user_id = :uid AND revoked_at IS NULL"
+        ),
+        params={"now": now or _now(), "uid": user_id},
+    )
+    return result.rowcount

--- a/backend/app/services/auth/sessions.py
+++ b/backend/app/services/auth/sessions.py
@@ -24,6 +24,7 @@ import secrets
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 
 from sqlalchemy import text
 from sqlmodel import select
@@ -34,7 +35,8 @@ from app.models.platform.auth_session import AuthSession
 
 __all__ = [
     "IssuedSession",
-    "RefreshError",
+    "RefreshOutcome",
+    "RotationResult",
     "create_session",
     "rotate_session",
     "revoke_session",
@@ -77,17 +79,34 @@ class IssuedSession:
     refresh_token: str
 
 
-class RefreshError(Exception):
-    """A presented refresh token could not be rotated. ``code`` is machine-
-    readable so the endpoint maps it to an HTTP status + localized message."""
+class RefreshOutcome(str, Enum):
+    """The result of a rotation attempt. The string values double as machine-
+    readable codes the endpoint maps to an HTTP status + localized message."""
 
+    ROTATED = "rotated"
     UNKNOWN = "unknown_refresh_token"
     EXPIRED = "refresh_token_expired"
     REUSED = "refresh_token_reused"
 
-    def __init__(self, code: str):
-        self.code = code
-        super().__init__(code)
+
+@dataclass(frozen=True)
+class RotationResult:
+    """Outcome of :func:`rotate_session`.
+
+    ``rotate_session`` **returns** this rather than raising, deliberately: on
+    ``REUSED`` it has written a theft-revocation to the caller's session, and an
+    exception there would let a conventional ``try/commit … except/rollback``
+    handler silently discard that security response. Returning keeps the outcome
+    on the caller's normal control flow — a single commit persists whichever
+    write happened (the rotation on ``ROTATED``, the chain kill on ``REUSED``).
+    """
+
+    outcome: RefreshOutcome
+    issued: IssuedSession | None = None  # present iff ``outcome is ROTATED``
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome is RefreshOutcome.ROTATED
 
 
 # Revoke every session in a token's rotation chain, in both directions, given any
@@ -166,18 +185,22 @@ async def rotate_session(
     device_name: str | None = None,
     refresh_ttl: timedelta | None = None,
     now: datetime | None = None,
-) -> IssuedSession:
+) -> RotationResult:
     """Single-use rotate: spend the presented refresh token, mint its successor.
 
     Carries ``amr``/``satisfied_providers`` (and device metadata) forward from the
     parent unless overridden — a step-up rotation passes the widened set.
 
-    Raises :class:`RefreshError`:
-    - ``UNKNOWN`` — no session matches the token.
-    - ``EXPIRED`` — the refresh window has lapsed (benign; log back in).
-    - ``REUSED`` — the token was already spent ⇒ **theft**. The whole chain has
-      been revoked on ``session``; the caller **must commit that** (do not roll
-      back) before surfacing the 401, or the theft response is lost.
+    **Returns** a :class:`RotationResult` (never raises for a bad token) —
+    ``ROTATED`` carries the new :class:`IssuedSession`; ``UNKNOWN``/``EXPIRED``/
+    ``REUSED`` are rejections. On ``REUSED`` the whole chain has been revoked on
+    ``session`` (theft response). Returning rather than raising is the point: the
+    caller commits on its normal path, so one commit durably persists whichever
+    write occurred and a rollback-on-exception handler can't drop the chain kill.
+
+    **Caller contract:** commit ``session`` before acting on the outcome —
+    ``rotate → commit → branch`` — so both the rotation and the theft-revocation
+    are persisted regardless of how the request ends.
     """
     issued = now or _now()
     ttl = refresh_ttl or timedelta(days=settings.AUTH_REFRESH_TTL_DAYS)
@@ -189,15 +212,15 @@ async def rotate_session(
         )
     ).one_or_none()
     if row is None:
-        raise RefreshError(RefreshError.UNKNOWN)
+        return RotationResult(RefreshOutcome.UNKNOWN)
 
     # Already spent (rotated or explicitly revoked) ⇒ replay of a dead token.
     if row.revoked_at is not None:
         await revoke_chain(session, session_id=row.id, now=issued)
-        raise RefreshError(RefreshError.REUSED)
+        return RotationResult(RefreshOutcome.REUSED)
 
     if row.expires_at <= issued:
-        raise RefreshError(RefreshError.EXPIRED)
+        return RotationResult(RefreshOutcome.EXPIRED)
 
     # Atomic single-use claim: only one caller can flip revoked_at NULL→now, so
     # two concurrent refreshes with the same token can't both mint a child.
@@ -213,7 +236,7 @@ async def rotate_session(
     if claimed is None:
         # Lost the race to a concurrent rotation — same danger as a replay.
         await revoke_chain(session, session_id=row.id, now=issued)
-        raise RefreshError(RefreshError.REUSED)
+        return RotationResult(RefreshOutcome.REUSED)
     # Keep the in-session parent honest (the raw UPDATE bypassed the ORM).
     await session.refresh(row)
 
@@ -236,7 +259,10 @@ async def rotate_session(
     )
     session.add(child)
     await session.flush()
-    return IssuedSession(session=child, refresh_token=raw)
+    return RotationResult(
+        RefreshOutcome.ROTATED,
+        issued=IssuedSession(session=child, refresh_token=raw),
+    )
 
 
 async def revoke_session(

--- a/backend/app/services/auth/sessions_test.py
+++ b/backend/app/services/auth/sessions_test.py
@@ -16,7 +16,7 @@ import pytest
 
 from app.models.platform.auth_session import AuthSession
 from app.services.auth import sessions as session_service
-from app.services.auth.sessions import RefreshError
+from app.services.auth.sessions import RefreshOutcome
 from app.testing import create_user
 
 pytestmark = [pytest.mark.integration, pytest.mark.database]
@@ -27,6 +27,15 @@ def _at(*, days: int = 0, minutes: int = 0) -> datetime:
     without ``datetime.now`` (and without the frozen-time helpers)."""
     base = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
     return base + timedelta(days=days, minutes=minutes)
+
+
+async def _rotate_ok(session, raw, when, **kwargs):
+    """Rotate, assert it succeeded, and return the resulting IssuedSession."""
+    result = await session_service.rotate_session(
+        session, raw_refresh_token=raw, now=when, **kwargs
+    )
+    assert result.ok, f"expected ROTATED, got {result.outcome}"
+    return result.issued
 
 
 async def test_create_session_persists_hash_and_returns_raw(session):
@@ -68,9 +77,7 @@ async def test_rotate_spends_parent_and_carries_context(session):
         now=_at(),
     )
 
-    second = await session_service.rotate_session(
-        session, raw_refresh_token=first.refresh_token, now=_at(minutes=5)
-    )
+    second = await _rotate_ok(session, first.refresh_token, _at(minutes=5))
 
     assert second.refresh_token != first.refresh_token
     assert second.session.id != first.session.id
@@ -94,27 +101,27 @@ async def test_rotate_can_widen_amr_and_providers(session):
         session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
     )
 
-    second = await session_service.rotate_session(
+    second = await _rotate_ok(
         session,
-        raw_refresh_token=first.refresh_token,
+        first.refresh_token,
+        _at(minutes=1),
         amr=["pwd", "otp"],
         satisfied_providers=[9],
-        now=_at(minutes=1),
     )
 
     assert second.session.amr == ["pwd", "otp"]
     assert second.session.satisfied_providers == [9]
 
 
-async def test_rotate_unknown_token_raises(session):
-    with pytest.raises(RefreshError) as exc:
-        await session_service.rotate_session(
-            session, raw_refresh_token="never-issued", now=_at()
-        )
-    assert exc.value.code == RefreshError.UNKNOWN
+async def test_rotate_unknown_token_returns_unknown(session):
+    result = await session_service.rotate_session(
+        session, raw_refresh_token="never-issued", now=_at()
+    )
+    assert result.outcome is RefreshOutcome.UNKNOWN
+    assert result.issued is None
 
 
-async def test_rotate_expired_token_raises(session):
+async def test_rotate_expired_token_returns_expired(session):
     user = await create_user(session)
     issued = await session_service.create_session(
         session,
@@ -125,11 +132,10 @@ async def test_rotate_expired_token_raises(session):
         now=_at(),
     )
 
-    with pytest.raises(RefreshError) as exc:
-        await session_service.rotate_session(
-            session, raw_refresh_token=issued.refresh_token, now=_at(minutes=11)
-        )
-    assert exc.value.code == RefreshError.EXPIRED
+    result = await session_service.rotate_session(
+        session, raw_refresh_token=issued.refresh_token, now=_at(minutes=11)
+    )
+    assert result.outcome is RefreshOutcome.EXPIRED
 
 
 async def test_reuse_of_spent_token_revokes_whole_chain(session):
@@ -139,19 +145,15 @@ async def test_reuse_of_spent_token_revokes_whole_chain(session):
     r1 = await session_service.create_session(
         session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
     )
-    r2 = await session_service.rotate_session(
-        session, raw_refresh_token=r1.refresh_token, now=_at(minutes=1)
-    )
-    r3 = await session_service.rotate_session(
-        session, raw_refresh_token=r2.refresh_token, now=_at(minutes=2)
-    )
+    r2 = await _rotate_ok(session, r1.refresh_token, _at(minutes=1))
+    r3 = await _rotate_ok(session, r2.refresh_token, _at(minutes=2))
 
     # Attacker replays r1's (long-spent) token.
-    with pytest.raises(RefreshError) as exc:
-        await session_service.rotate_session(
-            session, raw_refresh_token=r1.refresh_token, now=_at(minutes=3)
-        )
-    assert exc.value.code == RefreshError.REUSED
+    result = await session_service.rotate_session(
+        session, raw_refresh_token=r1.refresh_token, now=_at(minutes=3)
+    )
+    assert result.outcome is RefreshOutcome.REUSED
+    assert result.issued is None
 
     # The live tail (r3) is now revoked — the attacker gained nothing and the
     # real user is forced to re-authenticate.
@@ -190,11 +192,10 @@ async def test_revoked_session_cannot_rotate(session):
         session, session_id=issued.session.id, now=_at(minutes=1)
     )
 
-    with pytest.raises(RefreshError) as exc:
-        await session_service.rotate_session(
-            session, raw_refresh_token=issued.refresh_token, now=_at(minutes=2)
-        )
-    assert exc.value.code == RefreshError.REUSED
+    result = await session_service.rotate_session(
+        session, raw_refresh_token=issued.refresh_token, now=_at(minutes=2)
+    )
+    assert result.outcome is RefreshOutcome.REUSED
 
 
 async def test_revoke_all_for_user_scoped_to_that_user(session):
@@ -228,12 +229,8 @@ async def test_revoke_chain_from_any_member_revokes_all(session):
     r1 = await session_service.create_session(
         session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
     )
-    r2 = await session_service.rotate_session(
-        session, raw_refresh_token=r1.refresh_token, now=_at(minutes=1)
-    )
-    r3 = await session_service.rotate_session(
-        session, raw_refresh_token=r2.refresh_token, now=_at(minutes=2)
-    )
+    r2 = await _rotate_ok(session, r1.refresh_token, _at(minutes=1))
+    r3 = await _rotate_ok(session, r2.refresh_token, _at(minutes=2))
     # r2 is already revoked (it rotated); re-run from r2 to prove reachability
     # both up (r1) and down (r3). r1/r2 stay revoked, r3 gets revoked.
     revoked = await session_service.revoke_chain(

--- a/backend/app/services/auth/sessions_test.py
+++ b/backend/app/services/auth/sessions_test.py
@@ -1,0 +1,253 @@
+"""Logic tests for the session lifecycle (create / rotate / revoke).
+
+Exercises the real ``auth_sessions`` table on the setup (privileged) session —
+the role-security wall (request path can't touch the table) is proven separately
+in ``app.db.auth_sessions_rls_test``. These focus on the rotation + theft-
+detection behaviour the refresh endpoint will depend on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.platform.auth_session import AuthSession
+from app.services.auth import sessions as session_service
+from app.services.auth.sessions import RefreshError
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+def _at(*, days: int = 0, minutes: int = 0) -> datetime:
+    """A fixed instant offset from a stable base — keeps TTL math deterministic
+    without ``datetime.now`` (and without the frozen-time helpers)."""
+    base = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+    return base + timedelta(days=days, minutes=minutes)
+
+
+async def test_create_session_persists_hash_and_returns_raw(session):
+    user = await create_user(session)
+    issued = await session_service.create_session(
+        session,
+        user_id=user.id,
+        amr=["pwd"],
+        satisfied_providers=[7],
+        user_agent="pytest",
+        ip="203.0.113.9",
+        now=_at(),
+    )
+
+    # The raw token is returned once; only its SHA-256 is stored.
+    assert issued.refresh_token
+    stored = await session.get(AuthSession, issued.session.id)
+    assert stored is not None
+    assert (
+        stored.refresh_token_hash
+        == hashlib.sha256(issued.refresh_token.encode()).digest()
+    )
+    assert stored.amr == ["pwd"]
+    assert stored.satisfied_providers == [7]
+    assert stored.revoked_at is None
+    assert stored.parent_id is None
+    assert stored.expires_at == _at(days=30)
+    assert str(stored.ip) == "203.0.113.9"
+
+
+async def test_rotate_spends_parent_and_carries_context(session):
+    user = await create_user(session)
+    first = await session_service.create_session(
+        session,
+        user_id=user.id,
+        amr=["oidc:acme"],
+        satisfied_providers=[3],
+        device_name="Pixel",
+        now=_at(),
+    )
+
+    second = await session_service.rotate_session(
+        session, raw_refresh_token=first.refresh_token, now=_at(minutes=5)
+    )
+
+    assert second.refresh_token != first.refresh_token
+    assert second.session.id != first.session.id
+    assert second.session.parent_id == first.session.id
+    # amr / providers / device carry forward when not overridden.
+    assert second.session.amr == ["oidc:acme"]
+    assert second.session.satisfied_providers == [3]
+    assert second.session.device_name == "Pixel"
+    # Sliding window: the child expires 30d from the rotation, not from creation.
+    assert second.session.expires_at == _at(days=30, minutes=5)
+
+    await session.refresh(first.session)
+    assert first.session.revoked_at == _at(minutes=5)
+    assert first.session.last_used_at == _at(minutes=5)
+
+
+async def test_rotate_can_widen_amr_and_providers(session):
+    """A step-up rotation replaces the satisfied set instead of carrying it."""
+    user = await create_user(session)
+    first = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+
+    second = await session_service.rotate_session(
+        session,
+        raw_refresh_token=first.refresh_token,
+        amr=["pwd", "otp"],
+        satisfied_providers=[9],
+        now=_at(minutes=1),
+    )
+
+    assert second.session.amr == ["pwd", "otp"]
+    assert second.session.satisfied_providers == [9]
+
+
+async def test_rotate_unknown_token_raises(session):
+    with pytest.raises(RefreshError) as exc:
+        await session_service.rotate_session(
+            session, raw_refresh_token="never-issued", now=_at()
+        )
+    assert exc.value.code == RefreshError.UNKNOWN
+
+
+async def test_rotate_expired_token_raises(session):
+    user = await create_user(session)
+    issued = await session_service.create_session(
+        session,
+        user_id=user.id,
+        amr=["pwd"],
+        satisfied_providers=[],
+        refresh_ttl=timedelta(minutes=10),
+        now=_at(),
+    )
+
+    with pytest.raises(RefreshError) as exc:
+        await session_service.rotate_session(
+            session, raw_refresh_token=issued.refresh_token, now=_at(minutes=11)
+        )
+    assert exc.value.code == RefreshError.EXPIRED
+
+
+async def test_reuse_of_spent_token_revokes_whole_chain(session):
+    """Theft detection: replaying an already-rotated token kills the entire
+    chain — including the live tail the legitimate client is still using."""
+    user = await create_user(session)
+    r1 = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+    r2 = await session_service.rotate_session(
+        session, raw_refresh_token=r1.refresh_token, now=_at(minutes=1)
+    )
+    r3 = await session_service.rotate_session(
+        session, raw_refresh_token=r2.refresh_token, now=_at(minutes=2)
+    )
+
+    # Attacker replays r1's (long-spent) token.
+    with pytest.raises(RefreshError) as exc:
+        await session_service.rotate_session(
+            session, raw_refresh_token=r1.refresh_token, now=_at(minutes=3)
+        )
+    assert exc.value.code == RefreshError.REUSED
+
+    # The live tail (r3) is now revoked — the attacker gained nothing and the
+    # real user is forced to re-authenticate.
+    for issued in (r1, r2, r3):
+        await session.refresh(issued.session)
+        assert issued.session.revoked_at is not None
+
+
+async def test_revoke_session_is_idempotent(session):
+    user = await create_user(session)
+    issued = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+
+    revoked = await session_service.revoke_session(
+        session, session_id=issued.session.id, now=_at(minutes=1)
+    )
+    assert revoked == 1
+
+    # Already revoked ⇒ no-op.
+    again = await session_service.revoke_session(
+        session, session_id=issued.session.id, now=_at(minutes=2)
+    )
+    assert again == 0
+
+    await session.refresh(issued.session)
+    assert issued.session.revoked_at == _at(minutes=1)
+
+
+async def test_revoked_session_cannot_rotate(session):
+    user = await create_user(session)
+    issued = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+    await session_service.revoke_session(
+        session, session_id=issued.session.id, now=_at(minutes=1)
+    )
+
+    with pytest.raises(RefreshError) as exc:
+        await session_service.rotate_session(
+            session, raw_refresh_token=issued.refresh_token, now=_at(minutes=2)
+        )
+    assert exc.value.code == RefreshError.REUSED
+
+
+async def test_revoke_all_for_user_scoped_to_that_user(session):
+    user = await create_user(session)
+    other = await create_user(session)
+    a = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+    b = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+    c = await session_service.create_session(
+        session, user_id=other.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+
+    revoked = await session_service.revoke_all_for_user(
+        session, user_id=user.id, now=_at(minutes=1)
+    )
+    assert revoked == 2
+
+    for issued in (a, b):
+        await session.refresh(issued.session)
+        assert issued.session.revoked_at == _at(minutes=1)
+    await session.refresh(c.session)
+    assert c.session.revoked_at is None
+
+
+async def test_revoke_chain_from_any_member_revokes_all(session):
+    """Given a middle node, the whole chain (ancestors + descendants) is revoked."""
+    user = await create_user(session)
+    r1 = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=_at()
+    )
+    r2 = await session_service.rotate_session(
+        session, raw_refresh_token=r1.refresh_token, now=_at(minutes=1)
+    )
+    r3 = await session_service.rotate_session(
+        session, raw_refresh_token=r2.refresh_token, now=_at(minutes=2)
+    )
+    # r2 is already revoked (it rotated); re-run from r2 to prove reachability
+    # both up (r1) and down (r3). r1/r2 stay revoked, r3 gets revoked.
+    revoked = await session_service.revoke_chain(
+        session, session_id=r2.session.id, now=_at(minutes=3)
+    )
+    assert revoked == 1  # only r3 was still live
+
+    for issued in (r1, r2, r3):
+        await session.refresh(issued.session)
+        assert issued.session.revoked_at is not None
+
+
+async def test_revoke_chain_missing_id_is_noop(session):
+    revoked = await session_service.revoke_chain(
+        session, session_id=uuid.uuid4(), now=_at()
+    )
+    assert revoked == 0


### PR DESCRIPTION
## Problem

PR #3 of the login rewrite (Phase 0, `history/auth-detailed-design.md` §3). PRs #820/#821 landed the `auth_providers`, `federated_identities`, and `auth_sessions` tables with no reader yet. This adds the **logic layer** that operates on `auth_sessions`: the session/token service the `/auth/refresh` endpoint will call.

Still **additive-only** — nothing is wired into the live auth path. The `/auth/refresh` endpoint + dual-verify token acceptance (the risky live-path piece, with the no-lockout tests) is the next slice.

## Notable changes

**`app/services/auth/` (new package)** — `sessions.py`:
- `create_session(...)` → opens one `auth_sessions` row and mints its first opaque refresh token (returned raw once; only its SHA-256 is stored).
- `rotate_session(raw_refresh_token, ...)` → **single-use rotation**: mints a successor row (`parent_id` chain), carrying `amr`/`satisfied_providers`/device forward (a step-up passes a widened set). The parent is claimed with an **atomic conditional `UPDATE ... WHERE revoked_at IS NULL RETURNING`**, so two concurrent refreshes with the same token can't both mint a child.
- **Theft detection** — presenting an already-spent token revokes the *entire* chain (ancestors + descendants via a recursive CTE), including the live tail. `RefreshError.REUSED` is raised **after** the revocation is written; the caller must commit (documented).
- `revoke_session` / `revoke_chain` / `revoke_all_for_user` (the refresh-side of "sign out everywhere"), all returning affected-row counts.

**`app/core/security.py`** — `mint_access_token(...)`: the short-lived, stateless access JWT carrying `sub`/`sid`/`ver`/`amr`/`sat` with a distinct `aud`/`iss` (`initiative:access`) so it can't be confused with the legacy session JWT, upload, or handoff tokens during cutover.

**`app/core/config.py`** — `AUTH_ACCESS_TTL_MINUTES` (15) + `AUTH_REFRESH_TTL_DAYS` (30), separate from the legacy `ACCESS_TOKEN_EXPIRE_MINUTES` so both models coexist.

## Security

Runs on the **system engine (`app_admin`)**: session validation is a pre-auth lookup *by refresh-token hash* (user unknown until it resolves), so it structurally can't run under own-row RLS — the request path holds no grant on `auth_sessions` at all (migration 20260706_0132, proven in `auth_sessions_rls_test`). Refresh tokens are 256-bit random, stored only as a deterministic SHA-256 (fast hash is safe + needed for the indexed lookup); the raw token is never persisted. Self-parent loops are blocked by `ck_auth_sessions_parent_not_self`, and the chain graph is a strict in-tree so the recursive revoke terminates.

## Schema / env

No schema change. New env knobs `AUTH_ACCESS_TTL_MINUTES` / `AUTH_REFRESH_TTL_DAYS` (both defaulted).

## Testing

`cd backend && pytest app/services/auth/sessions_test.py app/core/security_test.py` — **28 passed**. Covers: create/persist-hash, rotation + context carry-forward, step-up widening, unknown/expired/reused rejection, whole-chain theft revocation, idempotent + user-scoped revoke, and access-token claim/exp/round-trip. `ruff check` + `ruff format` clean.