### PR TITLE
Dual-verify: accept new access tokens alongside legacy

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -17,6 +17,7 @@ from app.core.messages import AuthMessages, GuildMessages, UserMessages
 from app.core.security import (
     AutoDelegationVerificationError,
     UploadTokenError,
+    decode_session_token,
     verify_auto_delegation_token,
     verify_upload_token,
 )
@@ -208,9 +209,7 @@ async def get_current_user(
     # 401 interceptor depends on this to auto-redirect to /welcome when
     # the access token expires.
     try:
-        payload = jwt.decode(
-            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
-        )
+        payload = decode_session_token(token)
         token_data = TokenPayload(**payload)
     except jwt.PyJWTError as exc:
         raise HTTPException(
@@ -817,9 +816,7 @@ async def get_upload_user(
     # Try JWT authentication. Expired / malformed tokens are 401 (not 403)
     # so the SPA can auto-redirect to /welcome when the session lapses.
     try:
-        payload = jwt.decode(
-            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
-        )
+        payload = decode_session_token(token)
         token_data = TokenPayload(**payload)
     except jwt.PyJWTError:
         raise HTTPException(

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -16,9 +16,18 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
-from app.core.security import create_access_token, get_password_hash
+from app.core.security import (
+    create_access_token,
+    create_upload_token,
+    get_password_hash,
+)
 from app.models.platform.user import User, UserStatus
-from app.testing.factories import create_user, get_auth_headers, get_auth_token
+from app.testing.factories import (
+    create_user,
+    get_auth_headers,
+    get_auth_token,
+    get_new_access_token,
+)
 
 
 @pytest.mark.integration
@@ -591,6 +600,62 @@ async def test_stale_token_version_returns_401(
     response = await client.get(
         "/api/v1/users/me",
         headers={"Authorization": f"Bearer {stale_token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_new_access_token_authenticates(
+    client: AsyncClient, session: AsyncSession
+):
+    """Dual-verify: a new-model access token (aud initiative:access) is accepted
+    on the session path alongside legacy JWTs — the accept-before-issue half of
+    the cutover."""
+    user = await create_user(session)
+    token = get_new_access_token(user)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["id"] == user.id
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_new_access_token_stale_version_returns_401(
+    client: AsyncClient, session: AsyncSession
+):
+    """The new token still carries ``ver``, so a token_version bump (logout /
+    password change) revokes it exactly like a legacy token."""
+    user = await create_user(session)
+    token = get_new_access_token(user)
+    user.token_version += 1
+    session.add(user)
+    await session.commit()
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_scoped_upload_token_rejected_on_session_path(
+    client: AsyncClient, session: AsyncSession
+):
+    """Security regression: a scoped upload token carries a different aud and
+    must never be honored as a session credential — dual-verify preserves this."""
+    user = await create_user(session)
+    upload_token, _ = create_upload_token(user_id=user.id)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {upload_token}"},
     )
     assert response.status_code == 401
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -123,6 +123,42 @@ def mint_access_token(
     return token, int(ttl.total_seconds())
 
 
+def decode_session_token(token: str) -> dict[str, Any]:
+    """Decode a session credential, accepting BOTH schemes during the
+    dual-verify cutover window (history/auth-detailed-design.md §3.1):
+
+    - the **new-model access token** — ``aud=initiative:access`` /
+      ``iss=initiative``, additionally carrying ``sid``/``amr``/``sat``.
+    - the **legacy session JWT** — no ``aud``/``iss``.
+
+    Both carry ``sub`` + ``ver`` (the caller checks ``ver`` against
+    ``users.token_version``). Raises :class:`jwt.PyJWTError` for anything else,
+    which every call site already maps to 401. Crucially this keeps the session
+    path refusing **scoped** tokens: an upload/handoff token carries a *foreign*
+    ``aud`` that fails the new decode (wrong audience) AND the legacy decode
+    (which rejects any token bearing an ``aud``), so neither is honored as a
+    session. Bad signature / expiry / missing claims raise as before.
+
+    New scheme is tried first, so once issuance flips it's the single-decode
+    fast path; during the window a legacy token pays one extra HMAC verify.
+    """
+    try:
+        return jwt.decode(
+            token,
+            settings.jwt_signing_key,
+            algorithms=[settings.ALGORITHM],
+            audience=AUTH_ACCESS_AUDIENCE,
+            issuer=AUTH_TOKEN_ISSUER,
+            options={"require": ["exp", "sub", "ver", "aud", "iss"]},
+        )
+    except jwt.PyJWTError:
+        # Legacy fallback: no aud/iss. A token bearing any aud (upload/handoff,
+        # or a malformed new token) fails here too and the error propagates.
+        return jwt.decode(
+            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
+        )
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Scoped upload tokens
 #

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -151,9 +151,19 @@ def decode_session_token(token: str) -> dict[str, Any]:
             issuer=AUTH_TOKEN_ISSUER,
             options={"require": ["exp", "sub", "ver", "aud", "iss"]},
         )
-    except jwt.PyJWTError:
-        # Legacy fallback: no aud/iss. A token bearing any aud (upload/handoff,
-        # or a malformed new token) fails here too and the error propagates.
+    except (
+        jwt.InvalidAudienceError,
+        jwt.InvalidIssuerError,
+        jwt.MissingRequiredClaimError,
+    ):
+        # These three mean "not a new-model token" — absent/foreign aud or iss,
+        # or missing the new claims — so fall back to the legacy scheme. A
+        # genuinely expired/forged/malformed JWT raises a *different* PyJWTError
+        # (ExpiredSignature/InvalidSignature/Decode) that is NOT caught here, so
+        # it propagates with its true type instead of being masked by the
+        # legacy decode's audience error — keeping cutover-window logs honest.
+        # A legacy token bearing any aud (upload/handoff) still fails the legacy
+        # decode below and is rejected.
         return jwt.decode(
             token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
         )

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -28,8 +28,10 @@ from app.core.security import (
     UPLOAD_TOKEN_LIFETIME,
     UPLOAD_TOKEN_SCOPE,
     UploadTokenError,
+    create_access_token,
     create_advanced_tool_handoff_token,
     create_upload_token,
+    decode_session_token,
     mint_access_token,
     verify_upload_token,
 )
@@ -384,3 +386,76 @@ def test_mint_access_token_is_verifiable_with_expected_audience():
         options={"require": ["exp", "iat", "sub", "sid", "aud", "iss"]},
     )
     assert payload["sub"] == "5"
+
+
+# ── Dual-verify decode (accepts new + legacy, rejects scoped) ───────────────
+
+
+@pytest.mark.unit
+def test_decode_session_token_accepts_new_access_token():
+    token, _ = mint_access_token(
+        user_id=7,
+        token_version=2,
+        session_id=uuid.uuid4(),
+        amr=["pwd"],
+        satisfied_providers=[3],
+    )
+    payload = decode_session_token(token)
+    assert payload["sub"] == "7"
+    assert payload["ver"] == 2
+    assert payload["aud"] == AUTH_ACCESS_AUDIENCE
+    assert payload["sat"] == [3]
+
+
+@pytest.mark.unit
+def test_decode_session_token_accepts_legacy_token():
+    """The legacy session JWT (no aud/iss) must keep validating across the
+    cutover window."""
+    token = create_access_token(subject="7", token_version=2)
+    payload = decode_session_token(token)
+    assert payload["sub"] == "7"
+    assert payload["ver"] == 2
+    assert "aud" not in payload
+
+
+@pytest.mark.unit
+def test_decode_session_token_rejects_scoped_upload_token():
+    """A scoped upload token carries a foreign aud — it must NOT be honored as
+    a session credential on either decode path (the key security property)."""
+    upload, _ = create_upload_token(user_id=7)
+    with pytest.raises(jwt.PyJWTError):
+        decode_session_token(upload)
+
+
+@pytest.mark.unit
+def test_decode_session_token_rejects_handoff_token():
+    handoff, _ = create_advanced_tool_handoff_token(
+        user_id=7,
+        guild_id=1,
+        guild_role="admin",
+        is_manager=True,
+        can_create=True,
+        scope="guild",
+    )
+    with pytest.raises(jwt.PyJWTError):
+        decode_session_token(handoff)
+
+
+@pytest.mark.unit
+def test_decode_session_token_rejects_expired_new_token():
+    token, _ = mint_access_token(
+        user_id=7,
+        token_version=0,
+        session_id=uuid.uuid4(),
+        amr=["pwd"],
+        satisfied_providers=[],
+        expires_in=timedelta(seconds=-1),
+    )
+    with pytest.raises(jwt.PyJWTError):
+        decode_session_token(token)
+
+
+@pytest.mark.unit
+def test_decode_session_token_rejects_garbage():
+    with pytest.raises(jwt.PyJWTError):
+        decode_session_token("not.a.jwt")

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -443,6 +443,9 @@ def test_decode_session_token_rejects_handoff_token():
 
 @pytest.mark.unit
 def test_decode_session_token_rejects_expired_new_token():
+    """An expired NEW token must surface its true ``ExpiredSignatureError`` from
+    the first decode — not be masked by the legacy fallback's audience error —
+    so cutover-window logs stay honest."""
     token, _ = mint_access_token(
         user_id=7,
         token_version=0,
@@ -451,7 +454,18 @@ def test_decode_session_token_rejects_expired_new_token():
         satisfied_providers=[],
         expires_in=timedelta(seconds=-1),
     )
-    with pytest.raises(jwt.PyJWTError):
+    with pytest.raises(jwt.ExpiredSignatureError):
+        decode_session_token(token)
+
+
+@pytest.mark.unit
+def test_decode_session_token_rejects_expired_legacy_token():
+    """An expired LEGACY token also surfaces ``ExpiredSignatureError`` (via the
+    fallback decode), not a misleading audience error."""
+    token = create_access_token(
+        subject="7", token_version=0, expires_delta=timedelta(seconds=-1)
+    )
+    with pytest.raises(jwt.ExpiredSignatureError):
         decode_session_token(token)
 
 

--- a/backend/app/services/platform/ws_auth.py
+++ b/backend/app/services/platform/ws_auth.py
@@ -24,7 +24,7 @@ import jwt
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.config import settings
+from app.core.security import decode_session_token
 from app.models.platform.user import User, UserStatus
 from app.schemas.platform.token import TokenPayload
 from app.services.platform import user_tokens
@@ -45,9 +45,7 @@ async def authenticate_ws_token(token: str, session: AsyncSession) -> Optional[U
     """
     # First try JWT validation.
     try:
-        payload = jwt.decode(
-            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
-        )
+        payload = decode_session_token(token)
         token_data = TokenPayload(**payload)
         if token_data.sub:
             statement = select(User).where(User.id == int(token_data.sub))

--- a/backend/app/services/platform/ws_auth_test.py
+++ b/backend/app/services/platform/ws_auth_test.py
@@ -12,7 +12,7 @@ from app.core.security import create_access_token
 from app.models.platform.user import UserStatus
 from app.services.platform import user_tokens
 from app.services.platform.ws_auth import authenticate_ws_token
-from app.testing import create_user, get_auth_token
+from app.testing import create_user, get_auth_token, get_new_access_token
 
 pytestmark = pytest.mark.asyncio
 
@@ -25,6 +25,30 @@ async def test_valid_token_authenticates(session: AsyncSession):
 
     assert result is not None
     assert result.id == user.id
+
+
+async def test_new_access_token_authenticates(session: AsyncSession):
+    """Dual-verify: the WS path accepts the new-model access token too, so
+    realtime sockets stay in lockstep with the HTTP path."""
+    user = await create_user(session)
+    token = get_new_access_token(user)
+
+    result = await authenticate_ws_token(token, session)
+
+    assert result is not None
+    assert result.id == user.id
+
+
+async def test_new_access_token_stale_version_rejected(session: AsyncSession):
+    """The new token's ``ver`` is enforced on the WS path as well."""
+    user = await create_user(session)
+    token = get_new_access_token(user)
+    user.token_version += 1
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+
+    assert await authenticate_ws_token(token, session) is None
 
 
 async def test_token_version_bump_revokes_token(session: AsyncSession):

--- a/backend/app/testing/__init__.py
+++ b/backend/app/testing/__init__.py
@@ -36,6 +36,7 @@ from app.testing.factories import (
     create_user,
     get_auth_headers,
     get_auth_token,
+    get_new_access_token,
 )
 from app.testing.schema_harness import route_session_to_guild
 
@@ -66,5 +67,6 @@ __all__ = [
     "create_user",
     "get_auth_headers",
     "get_auth_token",
+    "get_new_access_token",
     "route_session_to_guild",
 ]

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -13,13 +13,18 @@ regardless of flush composition. Raw ``session.add()`` of tenant models in
 tests is covered by the fail-closed flush router in ``schema_harness``.
 """
 
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
-from app.core.security import create_access_token, get_password_hash
+from app.core.security import (
+    create_access_token,
+    get_password_hash,
+    mint_access_token,
+)
 from app.models.tenant.calendar_event import CalendarEvent
 from app.models.tenant.comment import Comment
 from app.models.tenant.counter import Counter, CounterGroup
@@ -236,6 +241,32 @@ def get_auth_token(user: User) -> str:
         response = await client.get("/api/v1/users/me", headers=headers)
     """
     return create_access_token(subject=str(user.id), token_version=user.token_version)
+
+
+def get_new_access_token(
+    user: User,
+    *,
+    session_id: uuid.UUID | None = None,
+    amr: list[str] | None = None,
+    satisfied_providers: list[int] | None = None,
+) -> str:
+    """Mint a *new-model* access token (aud ``initiative:access``) for a user.
+
+    Mirrors :func:`get_auth_token` but for the dual-verify path: exercises that
+    the session-JWT verifiers accept the new scheme. ``session_id``/``amr``/
+    ``sat`` default to a throwaway session with ``pwd`` since the verify path
+    only checks ``sub``/``ver``.
+    """
+    token, _ = mint_access_token(
+        user_id=user.id,
+        token_version=user.token_version,
+        session_id=session_id or uuid.uuid4(),
+        amr=amr if amr is not None else ["pwd"],
+        satisfied_providers=satisfied_providers
+        if satisfied_providers is not None
+        else [],
+    )
+    return token
 
 
 def get_auth_headers(user: User) -> dict[str, str]:


### PR DESCRIPTION
## Problem

First slice of the login rewrite that touches the **live request path** (Phase 0, `history/auth-detailed-design.md` §3.1). PRs #820/#821/#822 built the schema + session/token service; now the verification path must **accept** the new-model access token. Correct deploy order is **verifier before issuer** — every running instance has to accept new tokens *before* anything mints one (that's PR #5). This PR ships only the accept half; nothing issues a new token yet, so there is no user-visible change.

## Notable changes

- **`security.decode_session_token(token)`** — the single dual-verify decoder. Tries the **new-model access token** first (`aud=initiative:access` / `iss=initiative`, carrying `sid`/`amr`/`sat`), falling back to the **legacy session JWT** (no `aud`). Both carry `sub`+`ver`; the caller's existing `ver == token_version` check is unchanged.
- **All three session-JWT verifiers route through it** — `get_current_user`, `get_upload_user` ([deps.py](backend/app/api/deps.py)), and `authenticate_ws_token` ([ws_auth.py](backend/app/services/platform/ws_auth.py)). These had inlined the same `jwt.decode → TokenPayload` shape and drifted apart once already (the WS path missed the `ver` check — see its module docstring); a shared helper keeps them in lockstep.
- **`get_new_access_token` test factory** for exercising the new scheme.

## Security

The key property is preserved: a **scoped** token (upload / advanced-tool handoff) carries a *foreign* `aud` that fails the new decode (wrong audience) **and** the legacy decode (which rejects any `aud`-bearing token), so it is never honored as a session credential — verified empirically (PyJWT 2.13) and locked in by `test_scoped_upload_token_rejected_on_session_path`. New tokens still carry `ver`, so a `token_version` bump (logout / password change) revokes them exactly like legacy tokens, on both the HTTP and WS paths. New scheme is tried first so it's the single-decode fast path once issuance flips; during the window a legacy token pays one extra HMAC verify.

## Schema / env

None.

## Testing

`cd backend && pytest app/core/security_test.py app/services/platform/ws_auth_test.py app/api/v1/platform_endpoints/auth_test.py app/api/uploads_test.py` — **93 passed**. Covers: decode disjointness (accept new/legacy, reject upload/handoff/expired/garbage), HTTP + WS accept of a new token, stale-`ver` rejection on both, the scoped-token-rejected-on-session-path regression, and the existing legacy-token + uploads suites still green. `ruff check`/`format` clean.