### PR TITLE
Add /auth/refresh + issue refresh cookie at login

### DIFF
--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -2,6 +2,7 @@ import base64
 from datetime import datetime, timezone
 import hashlib
 import hmac
+import ipaddress
 import logging
 import secrets
 import time
@@ -20,7 +21,7 @@ from app.api.deps import SessionDep, get_current_active_user, get_current_user_o
 from app.db.session import get_admin_session
 from app.core.config import settings
 from sqlmodel.ext.asyncio.session import AsyncSession
-from app.core.rate_limit import limiter
+from app.core.rate_limit import get_real_client_ip, limiter
 from app.core.encryption import (
     decrypt_field,
     encrypt_field,
@@ -35,6 +36,7 @@ from app.core.security import (
     create_access_token,
     create_upload_token,
     get_password_hash,
+    mint_access_token,
     password_needs_rehash,
     verify_password,
 )
@@ -54,6 +56,8 @@ from app.schemas.platform.auth import (
 )
 from app.schemas.platform.user import UserCreate, UserRead
 from app.db.session import AdminSessionLocal
+from app.services.auth import sessions as session_service
+from app.services.auth.sessions import RefreshOutcome
 from app.services.platform import app_settings as app_settings_service
 from app.services import email as email_service
 from app.services.platform import user_tokens
@@ -68,6 +72,58 @@ STATE_TTL_SECONDS = 600
 _OIDC_METADATA_TTL_SECONDS = 300  # 5 minutes
 _oidc_metadata_cache: dict[str, tuple[dict[str, Any], float]] = {}
 logger = logging.getLogger(__name__)
+
+# The refresh cookie is scoped to the auth routes so it never rides along on
+# ordinary API requests — it is only presented to /auth/refresh and /auth/logout.
+REFRESH_COOKIE_PATH = f"{settings.API_V1_STR}/auth"
+
+
+def _client_ip(request: Request) -> str | None:
+    """The client IP as a value the INET ``auth_sessions.ip`` column accepts, or
+    ``None`` when it isn't a parseable address (e.g. the ``testclient`` peer).
+    Guards the login/refresh path from faulting on a non-IP host string."""
+    try:
+        ipaddress.ip_address(get_real_client_ip(request))
+    except ValueError:
+        return None
+    return get_real_client_ip(request)
+
+
+def _set_session_cookie(response: Response, token: str, *, max_age: int) -> None:
+    """Set the session-auth cookie (read by ``get_current_user``). During the
+    cutover this holds a legacy JWT at login and a new-model access token after
+    the first refresh — the verifier accepts either."""
+    response.set_cookie(
+        key=settings.COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite="lax",
+        secure=settings.cookie_secure,
+        max_age=max_age,
+        path="/",
+    )
+
+
+def _set_refresh_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=settings.REFRESH_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite="lax",
+        secure=settings.cookie_secure,
+        max_age=settings.AUTH_REFRESH_TTL_DAYS * 86400,
+        path=REFRESH_COOKIE_PATH,
+    )
+
+
+def _clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=settings.REFRESH_COOKIE_NAME,
+        path=REFRESH_COOKIE_PATH,
+        httponly=True,
+        secure=settings.cookie_secure,
+        samesite="lax",
+    )
 
 
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
@@ -285,6 +341,7 @@ async def login_access_token(
     request: Request,
     response: Response,
     session: SessionDep,
+    admin_session: AdminSessionDep,
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Token:
     normalized_email = form_data.username.lower().strip()
@@ -323,15 +380,99 @@ async def login_access_token(
     access_token = create_access_token(
         subject=str(user.id), token_version=user.token_version
     )
-    response.set_cookie(
-        key=settings.COOKIE_NAME,
-        value=access_token,
-        httponly=True,
-        samesite="lax",
-        secure=settings.cookie_secure,
-        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-        path="/",
+    _set_session_cookie(
+        response, access_token, max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
     )
+
+    # Additively establish a server-side session + rotating refresh cookie (the
+    # new login model, history/auth-detailed-design.md §3). The legacy session
+    # cookie above is untouched, so existing clients are unaffected; the refresh
+    # cookie only matters once a client calls /auth/refresh. Session writes run
+    # on the system engine (auth_sessions is app_admin-only).
+    issued = await session_service.create_session(
+        admin_session,
+        user_id=user.id,
+        amr=["pwd"],
+        satisfied_providers=[],
+        user_agent=request.headers.get("user-agent"),
+        ip=_client_ip(request),
+    )
+    await admin_session.commit()
+    _set_refresh_cookie(response, issued.refresh_token)
+
+    return Token(access_token=access_token)
+
+
+@router.post("/refresh", response_model=Token)
+@limiter.limit("60/minute")
+async def refresh_access_token(
+    request: Request,
+    response: Response,
+    admin_session: AdminSessionDep,
+) -> Token:
+    """Rotate the refresh cookie → a fresh short-lived access token + new refresh.
+
+    Single-use rotation with theft detection lives in the session service; this
+    endpoint is the ``rotate → commit → branch`` caller (see
+    ``services.auth.sessions``). Reuse of a spent token revokes the whole chain,
+    but the client is always told the same generic thing — never that a replay
+    was detected. Runs on the system engine: validation is a pre-auth lookup by
+    refresh-token hash.
+    """
+    raw = request.cookies.get(settings.REFRESH_COOKIE_NAME)
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.NOT_AUTHENTICATED,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    result = await session_service.rotate_session(
+        admin_session,
+        raw_refresh_token=raw,
+        user_agent=request.headers.get("user-agent"),
+        ip=_client_ip(request),
+    )
+    # Commit BEFORE branching: one commit persists the rotation (ROTATED) or the
+    # theft-revocation (REUSED), so a rejection can't leave the chain kill
+    # uncommitted (see RotationResult).
+    await admin_session.commit()
+
+    if not result.ok:
+        if result.outcome is RefreshOutcome.REUSED:
+            logger.warning("Refresh token replay detected; revoked session chain")
+        _clear_refresh_cookie(response)
+        response.delete_cookie(key=settings.COOKIE_NAME, path="/")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.INVALID_REFRESH_TOKEN,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    issued = result.issued
+    user = await admin_session.get(User, issued.session.user_id)
+    if user is None or user.status != UserStatus.active:
+        # The account was deactivated/removed after the session was minted — kill
+        # the fresh session too rather than hand back a usable token.
+        await session_service.revoke_chain(admin_session, session_id=issued.session.id)
+        await admin_session.commit()
+        _clear_refresh_cookie(response)
+        response.delete_cookie(key=settings.COOKIE_NAME, path="/")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AuthMessages.INVALID_REFRESH_TOKEN,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    access_token, access_max_age = mint_access_token(
+        user_id=user.id,
+        token_version=user.token_version,
+        session_id=issued.session.id,
+        amr=issued.session.amr,
+        satisfied_providers=issued.session.satisfied_providers,
+    )
+    _set_session_cookie(response, access_token, max_age=access_max_age)
+    _set_refresh_cookie(response, issued.refresh_token)
     return Token(access_token=access_token)
 
 
@@ -340,6 +481,7 @@ async def logout(
     request: Request,
     response: Response,
     session: SessionDep,
+    admin_session: AdminSessionDep,
     current_user: Annotated[User | None, Depends(get_current_user_optional)] = None,
 ) -> None:
     # Note: `session` and `get_current_user_optional` must resolve to the
@@ -352,6 +494,9 @@ async def logout(
     # a cached cookie could keep authenticating until natural expiry.
     # In tests it worked by accident because conftest aliases both deps
     # to the same fixture session.
+    # (``admin_session`` is a SEPARATE, deliberate session used only to revoke
+    # auth_sessions — which the request-path role can't touch — never for the
+    # token_version bump above.)
     if current_user is not None:
         current_user.token_version += 1
         auth_header = request.headers.get("Authorization", "")
@@ -365,6 +510,14 @@ async def logout(
                 session.add(device_token)
         session.add(current_user)
         await session.commit()
+        # Kill the refresh side too: the token_version bump invalidates
+        # outstanding *access* tokens, but a leaked refresh token would otherwise
+        # keep rotating (and mint tokens at the new version). "Logout = sign out
+        # everywhere", matching the global token_version bump.
+        await session_service.revoke_all_for_user(
+            admin_session, user_id=current_user.id
+        )
+        await admin_session.commit()
     response.delete_cookie(
         key=settings.COOKIE_NAME,
         path="/",
@@ -372,6 +525,7 @@ async def logout(
         secure=settings.cookie_secure,
         samesite="lax",
     )
+    _clear_refresh_cookie(response)
 
 
 @router.post("/upload-token", response_model=UploadTokenResponse)

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -11,7 +11,7 @@ from urllib.parse import urlencode, urlsplit
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
@@ -124,6 +124,24 @@ def _clear_refresh_cookie(response: Response) -> None:
         secure=settings.cookie_secure,
         samesite="lax",
     )
+
+
+def _refresh_rejected(detail: str) -> JSONResponse:
+    """A 401 for a failed refresh that also clears the stale auth cookies.
+
+    The clearing must ride on the *returned* response: mutating the injected
+    ``Response`` and then ``raise``-ing an ``HTTPException`` drops the Set-Cookie
+    headers (FastAPI builds a fresh response for the exception), so the browser
+    would keep resending a dead refresh token. Returning the response directly is
+    the only way the delete-cookie headers reach the client."""
+    response = JSONResponse(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        content={"detail": detail},
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    _clear_refresh_cookie(response)
+    response.delete_cookie(key=settings.COOKIE_NAME, path="/")
+    return response
 
 
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
@@ -389,16 +407,25 @@ async def login_access_token(
     # cookie above is untouched, so existing clients are unaffected; the refresh
     # cookie only matters once a client calls /auth/refresh. Session writes run
     # on the system engine (auth_sessions is app_admin-only).
-    issued = await session_service.create_session(
-        admin_session,
-        user_id=user.id,
-        amr=["pwd"],
-        satisfied_providers=[],
-        user_agent=request.headers.get("user-agent"),
-        ip=_client_ip(request),
-    )
-    await admin_session.commit()
-    _set_refresh_cookie(response, issued.refresh_token)
+    #
+    # Best-effort: this is additive and not yet load-bearing, so a transient DB
+    # error establishing the session must NOT turn a successful password auth
+    # into a 500 (same rule as the hash-upgrade above) — legacy clients that
+    # never touch the refresh cookie would otherwise be broken by it.
+    try:
+        issued = await session_service.create_session(
+            admin_session,
+            user_id=user.id,
+            amr=["pwd"],
+            satisfied_providers=[],
+            user_agent=request.headers.get("user-agent"),
+            ip=_client_ip(request),
+        )
+        await admin_session.commit()
+        _set_refresh_cookie(response, issued.refresh_token)
+    except Exception:
+        await admin_session.rollback()
+        logger.exception("Failed to establish refresh session for user %s", user.id)
 
     return Token(access_token=access_token)
 
@@ -409,7 +436,7 @@ async def refresh_access_token(
     request: Request,
     response: Response,
     admin_session: AdminSessionDep,
-) -> Token:
+) -> Token | JSONResponse:
     """Rotate the refresh cookie → a fresh short-lived access token + new refresh.
 
     Single-use rotation with theft detection lives in the session service; this
@@ -441,13 +468,7 @@ async def refresh_access_token(
     if not result.ok:
         if result.outcome is RefreshOutcome.REUSED:
             logger.warning("Refresh token replay detected; revoked session chain")
-        _clear_refresh_cookie(response)
-        response.delete_cookie(key=settings.COOKIE_NAME, path="/")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=AuthMessages.INVALID_REFRESH_TOKEN,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        return _refresh_rejected(AuthMessages.INVALID_REFRESH_TOKEN)
 
     issued = result.issued
     user = await admin_session.get(User, issued.session.user_id)
@@ -456,13 +477,7 @@ async def refresh_access_token(
         # the fresh session too rather than hand back a usable token.
         await session_service.revoke_chain(admin_session, session_id=issued.session.id)
         await admin_session.commit()
-        _clear_refresh_cookie(response)
-        response.delete_cookie(key=settings.COOKIE_NAME, path="/")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=AuthMessages.INVALID_REFRESH_TOKEN,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        return _refresh_rejected(AuthMessages.INVALID_REFRESH_TOKEN)
 
     access_token, access_max_age = mint_access_token(
         user_id=user.id,

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -1161,7 +1161,10 @@ async def request_password_reset(
 @router.post("/password/reset", response_model=VerificationSendResponse)
 @limiter.limit("5/15minutes")
 async def reset_password(
-    request: Request, payload: PasswordResetSubmit, session: SessionDep
+    request: Request,
+    payload: PasswordResetSubmit,
+    session: SessionDep,
+    admin_session: AdminSessionDep,
 ) -> VerificationSendResponse:
     # Run the policy first so an invalid candidate doesn't burn the
     # reset token; ``consume_token`` is one-shot.
@@ -1184,9 +1187,11 @@ async def reset_password(
             status_code=status.HTTP_404_NOT_FOUND, detail=AuthMessages.USER_NOT_FOUND
         )
     user.hashed_password = get_password_hash(payload.password)
-    # Bump token_version and revoke active device tokens so a stale
-    # JWT/device token can't survive the reset.
-    await user_tokens.revoke_user_sessions(session, user=user)
+    # Bump token_version and revoke device tokens / API keys / refresh sessions
+    # so no stale credential (JWT, device token, or captured refresh) survives.
+    await user_tokens.revoke_user_sessions(
+        session, user=user, admin_session=admin_session
+    )
     if not user.email_verified:
         user.email_verified = True
     user.updated_at = datetime.now(timezone.utc)

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -1332,3 +1332,126 @@ async def test_register_rolls_back_when_guild_seed_fails(
     assert users == [], "user row must be rolled back when guild seeding fails"
     guilds = (await session.exec(select(Guild))).all()
     assert guilds == [], "guild row must be rolled back when guild seeding fails"
+
+
+# --- New login model: refresh issuance + rotation ------------------------
+
+
+async def _make_login_user(
+    session: AsyncSession,
+    email: str = "refresh@example.com",
+    password: str = "testpassword123",
+) -> tuple[User, str]:
+    user = User(
+        email_hash=hash_email(email),
+        email_encrypted=encrypt_field(email, SALT_EMAIL),
+        full_name="Refresh User",
+        hashed_password=get_password_hash(password),
+        status=UserStatus.active,
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    return user, password
+
+
+async def _login(client: AsyncClient, email: str, password: str):
+    return await client.post(
+        "/api/v1/auth/token", data={"username": email, "password": password}
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_login_sets_refresh_cookie(client: AsyncClient, session: AsyncSession):
+    """Login additively issues a rotating refresh cookie (the legacy session
+    cookie is still set too — this is additive-first)."""
+    _, password = await _make_login_user(session, "cookie@example.com")
+    resp = await _login(client, "cookie@example.com", password)
+
+    assert resp.status_code == 200
+    assert resp.cookies.get("refresh_token")
+    assert resp.cookies.get("session_token")  # legacy cookie unchanged
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_refresh_rotates_and_new_token_authenticates(
+    client: AsyncClient, session: AsyncSession
+):
+    """The refresh cookie rotates into a fresh access token that authenticates."""
+    _, password = await _make_login_user(session, "rot@example.com")
+    await _login(client, "rot@example.com", password)
+
+    resp = await client.post("/api/v1/auth/refresh")
+    assert resp.status_code == 200
+    access_token = resp.json()["access_token"]
+    assert resp.cookies.get("refresh_token")  # a new (rotated) refresh was set
+
+    me = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert me.status_code == 200
+    assert me.json()["email"] == "rot@example.com"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_refresh_without_cookie_returns_401(client: AsyncClient):
+    resp = await client.post("/api/v1/auth/refresh")
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "NOT_AUTHENTICATED"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_refresh_with_invalid_cookie_returns_401(client: AsyncClient):
+    client.cookies.set("refresh_token", "not-a-real-token", path="/api/v1/auth")
+    resp = await client.post("/api/v1/auth/refresh")
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "INVALID_REFRESH_TOKEN"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_reused_refresh_token_returns_401(
+    client: AsyncClient, session: AsyncSession
+):
+    """Endpoint-level theft detection: replaying a spent refresh token is 401
+    (and the service revokes the chain — covered in the service tests)."""
+    _, password = await _make_login_user(session, "reuse@example.com")
+    login = await _login(client, "reuse@example.com", password)
+    first_refresh = login.cookies.get("refresh_token")
+
+    # Spend it once (jar rotates to the new token).
+    ok = await client.post("/api/v1/auth/refresh")
+    assert ok.status_code == 200
+
+    # Replay the original (now spent) token.
+    client.cookies.clear()
+    client.cookies.set("refresh_token", first_refresh, path="/api/v1/auth")
+    replay = await client.post("/api/v1/auth/refresh")
+    assert replay.status_code == 401
+    assert replay.json()["detail"] == "INVALID_REFRESH_TOKEN"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_logout_revokes_refresh_session(
+    client: AsyncClient, session: AsyncSession
+):
+    """Logout revokes the refresh session, so a captured refresh token can't
+    rotate afterward — closing the gap where token_version only killed the
+    access side."""
+    _, password = await _make_login_user(session, "lo@example.com")
+    login = await _login(client, "lo@example.com", password)
+    captured = login.cookies.get("refresh_token")
+
+    logout = await client.post("/api/v1/auth/logout")
+    assert logout.status_code == 204
+
+    client.cookies.clear()
+    client.cookies.set("refresh_token", captured, path="/api/v1/auth")
+    resp = await client.post("/api/v1/auth/refresh")
+    assert resp.status_code == 401

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -1411,6 +1411,13 @@ async def test_refresh_with_invalid_cookie_returns_401(client: AsyncClient):
     resp = await client.post("/api/v1/auth/refresh")
     assert resp.status_code == 401
     assert resp.json()["detail"] == "INVALID_REFRESH_TOKEN"
+    # The rejection must actually clear the stale cookie so the browser stops
+    # resending it — the delete header has to ride on the returned response, not
+    # a raised exception (FastAPI drops the injected response's cookies on raise).
+    set_cookies = resp.headers.get_list("set-cookie")
+    assert any("refresh_token=" in c and "Max-Age=0" in c for c in set_cookies), (
+        set_cookies
+    )
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -1455,3 +1455,28 @@ async def test_logout_revokes_refresh_session(
     client.cookies.set("refresh_token", captured, path="/api/v1/auth")
     resp = await client.post("/api/v1/auth/refresh")
     assert resp.status_code == 401
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_password_change_revokes_refresh_session(
+    client: AsyncClient, session: AsyncSession
+):
+    """A credential change must invalidate refresh sessions too — otherwise a
+    captured refresh token keeps minting valid access tokens (at the new
+    token_version) right past the password change."""
+    _, password = await _make_login_user(session, "pwchange@example.com")
+    login = await _login(client, "pwchange@example.com", password)
+    captured = login.cookies.get("refresh_token")
+
+    change = await client.patch(
+        "/api/v1/users/me",
+        json={"password": "newpassword456", "current_password": password},
+    )
+    assert change.status_code == 200
+
+    # The refresh token captured before the change can no longer rotate.
+    client.cookies.clear()
+    client.cookies.set("refresh_token", captured, path="/api/v1/auth")
+    replay = await client.post("/api/v1/auth/refresh")
+    assert replay.status_code == 401

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -289,6 +289,7 @@ async def create_user(
 async def update_users_me(
     user_in: UserSelfUpdate,
     session: UserSessionDep,
+    admin_session: AdminSessionDep,
     response: Response,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> User:
@@ -339,9 +340,11 @@ async def update_users_me(
                 )
         await enforce_password_policy(password)
         current_user.hashed_password = get_password_hash(password)
-        # Bump token_version and revoke active device tokens + API keys so a
-        # stale JWT/device token/API key can't survive the password change.
-        await user_tokens_service.revoke_user_sessions(session, user=current_user)
+        # Bump token_version and revoke device tokens + API keys + refresh
+        # sessions so no stale credential can survive the password change.
+        await user_tokens_service.revoke_user_sessions(
+            session, user=current_user, admin_session=admin_session
+        )
         # ...but keep THIS session alive. The version bump above invalidates the
         # caller's own token too, so re-issue the session cookie with the new
         # version: every *other* session/device still dies, while the user who
@@ -453,6 +456,7 @@ async def update_user(
     user_id: int,
     user_in: UserUpdate,
     session: SessionDep,
+    admin_session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildAdminContext,
 ) -> User:
@@ -489,10 +493,12 @@ async def update_user(
         await enforce_password_policy(password)
         user.hashed_password = get_password_hash(password)
         # Resetting a compromised account must invalidate the attacker's
-        # outstanding sessions: bump token_version (kills unexpired JWTs)
-        # and revoke active device tokens, mirroring the self-service and
-        # forgot-password reset paths.
-        await user_tokens_service.revoke_user_sessions(session, user=user)
+        # outstanding sessions: bump token_version (kills unexpired JWTs) and
+        # revoke device tokens / API keys / refresh sessions, mirroring the
+        # self-service and forgot-password reset paths.
+        await user_tokens_service.revoke_user_sessions(
+            session, user=user, admin_session=admin_session
+        )
     if "avatar_base64" in update_data:
         user.avatar_base64 = update_data.pop("avatar_base64")
         if user.avatar_base64:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -153,6 +153,10 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     ALGORITHM: str = "HS256"
     COOKIE_NAME: str = "session_token"
+    # New login model: the rotating refresh token rides in its own HttpOnly
+    # cookie, path-scoped to the auth routes (sent only on refresh/logout, never
+    # on ordinary API calls — smaller exposure than the session cookie).
+    REFRESH_COOKIE_NAME: str = "refresh_token"
 
     # New login model (auth rewrite, Phase 0 — history/auth-detailed-design.md §3).
     # The access token is short-lived + stateless: verified locally with no

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -24,6 +24,9 @@ class AuthMessages:
     USER_NOT_FOUND = "USER_NOT_FOUND"
     INSUFFICIENT_PRIVILEGES = "INSUFFICIENT_PRIVILEGES"
     INVALID_TOKEN = "INVALID_TOKEN"
+    # Generic refresh rejection: unknown / expired / reused all map here so the
+    # client learns only "re-authenticate", never that a replay was detected.
+    INVALID_REFRESH_TOKEN = "INVALID_REFRESH_TOKEN"
     INVALID_OR_EXPIRED_TOKEN = "INVALID_OR_EXPIRED_TOKEN"
     SMTP_NOT_CONFIGURED = "SMTP_NOT_CONFIGURED"
     CAPTCHA_REQUIRED = "CAPTCHA_REQUIRED"

--- a/backend/app/services/platform/user_tokens.py
+++ b/backend/app/services/platform/user_tokens.py
@@ -8,6 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.user import User
 from app.models.platform.user_token import UserToken, UserTokenPurpose
+from app.services.auth import sessions as session_service
 from app.services.platform import api_keys as api_keys_service
 
 
@@ -256,18 +257,30 @@ async def revoke_user_sessions(
     session: AsyncSession,
     *,
     user: User,
+    admin_session: AsyncSession,
 ) -> None:
     """Invalidate every outstanding session for ``user`` after a credential
     change.
 
     Bumps ``token_version`` (which the JWT/WS authenticators compare against,
     invalidating any still-unexpired access token), bulk-revokes the user's
-    active ``device_auth`` tokens, and deactivates their API keys (a leaked PAT
-    must not survive a compromise response). Shared by the self-service password
-    change, the forgot-password reset, and the admin password reset so the
-    three paths can't drift. Does not commit — the caller owns the transaction
-    and is responsible for ``session.add(user)``/``commit``.
+    active ``device_auth`` tokens, deactivates their API keys (a leaked PAT must
+    not survive a compromise response), and revokes their rotating **refresh
+    sessions** — without which a captured refresh token would keep minting valid
+    access tokens *at the new ``token_version``* right past the reset. Shared by
+    the self-service password change, the forgot-password reset, and the admin
+    password reset so the three paths can't drift.
+
+    Two sessions by design: the caller's ``session`` carries the request-path
+    writes (``token_version``, device tokens, API keys) and the caller commits
+    it; ``admin_session`` is the system engine, the only role that may touch the
+    ``app_admin``-only ``auth_sessions`` table. The refresh-session revocation is
+    committed here (on ``admin_session``) so it can't be forgotten by a caller —
+    revoking sessions ahead of a password write that later fails just logs the
+    user out, which is the fail-safe direction.
     """
     user.token_version += 1
     await revoke_active_device_tokens(session, user_id=user.id)
     await api_keys_service.deactivate_user_api_keys(session, user_id=user.id)
+    await session_service.revoke_all_for_user(admin_session, user_id=user.id)
+    await admin_session.commit()

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -19,6 +19,7 @@
   "NOT_AUTHENTICATED": "Nicht authentifiziert",
   "INVALID_DEVICE_TOKEN": "Ungültiges Geräte-Token",
   "COULD_NOT_VALIDATE_CREDENTIALS": "Anmeldedaten konnten nicht validiert werden",
+  "INVALID_REFRESH_TOKEN": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.",
   "INVALID_TOKEN_PAYLOAD": "Ungültige Token-Nutzlast",
   "USER_NOT_FOUND": "Benutzer nicht gefunden",
   "INSUFFICIENT_PRIVILEGES": "Unzureichende Berechtigungen",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -13,6 +13,7 @@
   "NOT_AUTHENTICATED": "Not authenticated",
   "INVALID_DEVICE_TOKEN": "Invalid device token",
   "COULD_NOT_VALIDATE_CREDENTIALS": "Could not validate credentials",
+  "INVALID_REFRESH_TOKEN": "Your session has expired. Please sign in again.",
   "INVALID_TOKEN_PAYLOAD": "Invalid token payload",
   "USER_NOT_FOUND": "User not found",
   "INSUFFICIENT_PRIVILEGES": "Insufficient privileges",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -19,6 +19,7 @@
   "NOT_AUTHENTICATED": "No autenticado",
   "INVALID_DEVICE_TOKEN": "Token de dispositivo no válido",
   "COULD_NOT_VALIDATE_CREDENTIALS": "No se pudieron validar las credenciales",
+  "INVALID_REFRESH_TOKEN": "Tu sesión ha expirado. Por favor, inicia sesión de nuevo.",
   "INVALID_TOKEN_PAYLOAD": "Contenido del token no válido",
   "USER_NOT_FOUND": "Usuario no encontrado",
   "INSUFFICIENT_PRIVILEGES": "Privilegios insuficientes",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -19,6 +19,7 @@
   "NOT_AUTHENTICATED": "Non authentifié",
   "INVALID_DEVICE_TOKEN": "Jeton d'appareil invalide",
   "COULD_NOT_VALIDATE_CREDENTIALS": "Impossible de valider les identifiants",
+  "INVALID_REFRESH_TOKEN": "Votre session a expiré. Veuillez vous reconnecter.",
   "INVALID_TOKEN_PAYLOAD": "Charge utile du jeton invalide",
   "USER_NOT_FOUND": "Utilisateur introuvable",
   "INSUFFICIENT_PRIVILEGES": "Privilèges insuffisants",

--- a/frontend/src/api/generated/auth/auth.ts
+++ b/frontend/src/api/generated/auth/auth.ts
@@ -388,6 +388,92 @@ export const useLoginAccessTokenApiV1AuthTokenPost = <
   return useMutation(getLoginAccessTokenApiV1AuthTokenPostMutationOptions(options), queryClient);
 };
 /**
+ * Rotate the refresh cookie → a fresh short-lived access token + new refresh.
+ *
+ * Single-use rotation with theft detection lives in the session service; this
+ * endpoint is the ``rotate → commit → branch`` caller (see
+ * ``services.auth.sessions``). Reuse of a spent token revokes the whole chain,
+ * but the client is always told the same generic thing — never that a replay
+ * was detected. Runs on the system engine: validation is a pre-auth lookup by
+ * refresh-token hash.
+ * @summary Refresh Access Token
+ */
+export const refreshAccessTokenApiV1AuthRefreshPost = (
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<Token>({ url: `/api/v1/auth/refresh`, method: "POST", signal }, options);
+};
+
+export const getRefreshAccessTokenApiV1AuthRefreshPostMutationOptions = <
+  TError = ErrorType<unknown>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof refreshAccessTokenApiV1AuthRefreshPost>>,
+    TError,
+    void,
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof refreshAccessTokenApiV1AuthRefreshPost>>,
+  TError,
+  void,
+  TContext
+> => {
+  const mutationKey = ["refreshAccessTokenApiV1AuthRefreshPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof refreshAccessTokenApiV1AuthRefreshPost>>,
+    void
+  > = () => {
+    return refreshAccessTokenApiV1AuthRefreshPost(requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RefreshAccessTokenApiV1AuthRefreshPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof refreshAccessTokenApiV1AuthRefreshPost>>
+>;
+
+export type RefreshAccessTokenApiV1AuthRefreshPostMutationError = ErrorType<unknown>;
+
+/**
+ * @summary Refresh Access Token
+ */
+export const useRefreshAccessTokenApiV1AuthRefreshPost = <
+  TError = ErrorType<unknown>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof refreshAccessTokenApiV1AuthRefreshPost>>,
+      TError,
+      void,
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof refreshAccessTokenApiV1AuthRefreshPost>>,
+  TError,
+  void,
+  TContext
+> => {
+  return useMutation(
+    getRefreshAccessTokenApiV1AuthRefreshPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
  * @summary Logout
  */
 export const logoutApiV1AuthLogoutPost = (


### PR DESCRIPTION
## Problem

The **issuer half** of the login rewrite (Phase 0, `history/auth-detailed-design.md` §3) — the counterpart to #823's dual-verify. Now that every instance *accepts* the new-model access token, this ships what *mints* one: a server-side session at login and a `POST /auth/refresh` that rotates it.

**Additive-first.** The legacy `session_token` cookie and its behavior are untouched, so existing web/native clients keep working exactly as before. The new refresh cookie only comes into play once a client calls `/auth/refresh` — a later frontend PR wires the SPA's auto-refresh-on-401.

## Notable changes

- **Password login** additively creates an `auth_session` (`amr=["pwd"]`) and sets a **path-scoped** (`/api/v1/auth`) HttpOnly/SameSite=Lax refresh cookie, alongside the unchanged legacy cookie. Session writes run on the system engine (`auth_sessions` is `app_admin`-only).
- **`POST /auth/refresh`** rotates the refresh cookie → a fresh short-lived access token (new-model, already accepted by dual-verify) + a rotated refresh, following the `rotate → commit → branch` contract from #822. It commits **before** branching so a rejection can't leave the theft-revocation uncommitted.
- **Logout** now also `revoke_all_for_user` and clears the refresh cookie — the `token_version` bump only killed the *access* side, so a leaked refresh token could otherwise keep rotating (and mint tokens at the new version). "Logout = sign out everywhere."
- Client IP stored via `get_real_client_ip`, guarded to a parseable address for the INET column (so the `testclient` peer / bogus hosts don't fault the write).
- Regenerated the Orval client (adds the `/auth/refresh` hook, +86 lines, additive).

## Security

- Refresh rejection is **generic**: unknown / expired / reused all return `INVALID_REFRESH_TOKEN` — the client never learns a replay was detected. A replay is logged server-side (`warning`) and revokes the whole chain (service layer).
- Refresh cookie is path-scoped to the auth routes, so it isn't sent on ordinary API requests (smaller exposure than the session cookie).
- A deactivated/removed account can't rotate: after rotation the endpoint re-checks `status == active` and revokes the fresh session otherwise.
- OIDC-callback issuance is **deferred** to a follow-up (OIDC is being restructured in Phase 1); OIDC logins simply have no refresh session yet, and logout's `revoke_all_for_user` is a harmless no-op for them.

## Schema / env

New config `REFRESH_COOKIE_NAME` (defaulted). New error code `INVALID_REFRESH_TOKEN` added to `messages.py` and all four locales (en/de/es/fr).

## Testing

`cd backend && pytest app/api/v1/platform_endpoints/auth_test.py app/services/auth app/services/platform/ws_auth_test.py` — **71 passed**. New endpoint tests: login-sets-refresh-cookie (legacy cookie intact), rotate-then-authenticate-on-/users/me, missing-cookie 401, invalid-cookie 401, reuse 401, and logout-revokes-session. `ruff check`/`format` clean; Orval output regenerated + biome-formatted.