### PR TITLE
Backfill platform OIDC into provider registry + identities

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -108,6 +108,20 @@ async def lifespan(app: FastAPI):
     await maybe_rotate_at_startup()
     async with AdminSessionLocal() as session:
         await app_settings_service.ensure_defaults(session)
+    # Migrate the single platform OIDC config into the provider registry +
+    # identity links (operator-global; idempotent, self-healing). Runs after
+    # ensure_defaults so the settings singleton exists. Additive — the legacy
+    # app_settings.oidc_* / users.oidc_sub stay as the fallback path.
+    from app.services.auth.oidc_backfill import backfill_oidc_identity
+
+    oidc = await backfill_oidc_identity()
+    if oidc.provider_created or oidc.identities_linked:
+        logger.info(
+            "OIDC identity back-fill: provider %s, %d identities linked (of %d)",
+            "created" if oidc.provider_created else "existing",
+            oidc.identities_linked,
+            oidc.oidc_users,
+        )
     app.state.notification_tasks = background_tasks_service.start_background_tasks()
 
     try:

--- a/backend/app/services/auth/oidc_backfill.py
+++ b/backend/app/services/auth/oidc_backfill.py
@@ -1,0 +1,142 @@
+"""Boot backfill: migrate the single platform OIDC config into the provider
+registry + identity link table (history/auth-detailed-design.md §6.5, §11).
+
+Runs on the **app_admin (BYPASSRLS) engine** because both the source
+(``users``) and target (``federated_identities``) are FORCE ROW LEVEL SECURITY
+— a policy-bound provisioning role would silently migrate 0/partial rows, the
+data-loss trap we've hit before. Idempotent and self-healing: re-running once
+the operator-global provider exists and every ``oidc_sub`` is linked is a no-op,
+so it lives in ``lifespan`` and reconciles on every boot (like
+``backfill_guild_schemas``).
+
+The migrated provider is deliberately **operator-global** (``guild_id IS NULL``)
+— today's OIDC is platform-level and must stay that way. ``app_settings.oidc_*``
+and ``users.oidc_sub`` are left intact as the fallback; they are dropped only in
+Phase 4 after the new path is proven.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlmodel import select
+
+from app.db import session as db_session
+from app.models.platform.app_setting import AppSetting
+from app.models.platform.auth_provider import AuthProvider, AuthProviderKind
+
+logger = logging.getLogger(__name__)
+
+# Fixed slug for the one migrated platform provider: stable so re-runs find the
+# existing row (idempotent) and so the legacy ``/auth/oidc/*`` alias keeps
+# resolving once endpoints are generalized.
+PLATFORM_OIDC_SLUG = "oidc"
+
+
+@dataclass
+class OidcBackfillSummary:
+    """One-line boot log for the OIDC identity backfill."""
+
+    provider_created: bool = False
+    identities_linked: int = 0
+    oidc_users: int = 0
+    skipped_reason: str | None = None
+
+
+async def backfill_oidc_identity() -> OidcBackfillSummary:
+    """Migrate ``app_settings.oidc_*`` → one operator-global ``auth_providers``
+    row and link every ``users.oidc_sub`` into ``federated_identities``.
+
+    Never raises: a failure is logged and returned as a skipped summary so a
+    transient DB error can't take down boot (OIDC users keep the fallback path).
+    """
+    try:
+        async with db_session.AdminSessionLocal() as session:
+            return await _run(session)
+    except Exception:
+        logger.exception("OIDC identity back-fill failed; leaving legacy path intact")
+        return OidcBackfillSummary(skipped_reason="error")
+
+
+async def _run(session) -> OidcBackfillSummary:
+    settings_row = (await session.exec(select(AppSetting))).first()
+    # Fresh install or OIDC never configured → nothing to migrate.
+    if (
+        settings_row is None
+        or not settings_row.oidc_issuer
+        or not settings_row.oidc_client_id
+    ):
+        return OidcBackfillSummary(skipped_reason="oidc_not_configured")
+
+    # 1. The one operator-global (guild_id IS NULL) provider row.
+    provider = (
+        await session.exec(
+            select(AuthProvider).where(
+                AuthProvider.slug == PLATFORM_OIDC_SLUG,
+                AuthProvider.guild_id.is_(None),
+            )
+        )
+    ).first()
+    provider_created = provider is None
+    if provider is None:
+        scopes = settings_row.oidc_scopes or []
+        provider = AuthProvider(
+            slug=PLATFORM_OIDC_SLUG,
+            display_name=settings_row.oidc_provider_name or "SSO",
+            kind=AuthProviderKind.oidc.value,
+            enabled=bool(settings_row.oidc_enabled),
+            guild_id=None,  # operator-global: platform-level login
+            issuer=settings_row.oidc_issuer,
+            client_id=settings_row.oidc_client_id,
+            scopes=" ".join(scopes) if scopes else None,
+            role_claim_path=settings_row.oidc_role_claim_path,
+            allow_jit=True,  # today's flow JIT-provisions unknown OIDC users
+        )
+        session.add(provider)
+        await session.flush()
+
+    # 2. Link every existing oidc_sub to that provider. Bulk INSERT … SELECT with
+    #    ON CONFLICT so re-runs don't duplicate and a partly-migrated state heals.
+    oidc_users = (
+        await session.exec(
+            text("SELECT count(*) FROM users WHERE oidc_sub IS NOT NULL")
+        )
+    ).scalar_one()
+
+    result = await session.exec(
+        text(
+            "INSERT INTO federated_identities "
+            "(user_id, provider_id, subject, email_verified, created_at) "
+            "SELECT id, :pid, oidc_sub, true, now() FROM users "
+            "WHERE oidc_sub IS NOT NULL "
+            "ON CONFLICT (provider_id, subject) DO NOTHING"
+        ),
+        params={"pid": provider.id},
+    )
+    inserted = result.rowcount
+    await session.commit()
+
+    # Row-count sanity: every oidc user should now be linked (freshly inserted or
+    # already present). A shortfall means duplicate subjects collided — surface it.
+    linked_total = (
+        await session.exec(
+            text("SELECT count(*) FROM federated_identities WHERE provider_id = :pid"),
+            params={"pid": provider.id},
+        )
+    ).scalar_one()
+    if linked_total < oidc_users:
+        logger.warning(
+            "OIDC identity back-fill: %d oidc users but only %d linked to "
+            "provider %d — investigate duplicate subjects",
+            oidc_users,
+            linked_total,
+            provider.id,
+        )
+
+    return OidcBackfillSummary(
+        provider_created=provider_created,
+        identities_linked=inserted,
+        oidc_users=oidc_users,
+    )

--- a/backend/app/services/auth/oidc_backfill_test.py
+++ b/backend/app/services/auth/oidc_backfill_test.py
@@ -1,0 +1,114 @@
+"""Tests for the platform-OIDC → provider-registry/identity boot backfill.
+
+The backfill runs on its own ``AdminSessionLocal`` (app_admin) connection, so
+setup is committed via the ``session`` fixture first (cross-connection reads are
+READ COMMITTED) and assertions read back through it afterward.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import select
+
+from app.models.platform.app_setting import AppSetting
+from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.federated_identity import FederatedIdentity
+from app.services.auth.oidc_backfill import backfill_oidc_identity
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def _configure_oidc(session, *, enabled: bool = True, issuer: str | None = None):
+    row = (await session.exec(select(AppSetting))).first()
+    if row is None:
+        row = AppSetting()
+        session.add(row)
+    row.oidc_enabled = enabled
+    row.oidc_issuer = "https://idp.example.com" if issuer is None else issuer
+    row.oidc_client_id = "client-123"
+    row.oidc_provider_name = "Okta"
+    row.oidc_scopes = ["openid", "email"]
+    row.oidc_role_claim_path = "roles"
+    await session.commit()
+    return row
+
+
+async def test_backfill_creates_operator_global_provider_and_links(session):
+    await _configure_oidc(session)
+    u1 = await create_user(session, oidc_sub="sub-alice")
+    u2 = await create_user(session, oidc_sub="sub-bob")
+    await create_user(session)  # no oidc_sub — must NOT be linked
+
+    summary = await backfill_oidc_identity()
+
+    assert summary.provider_created is True
+    assert summary.identities_linked == 2
+    assert summary.oidc_users == 2
+
+    provider = (
+        await session.exec(select(AuthProvider).where(AuthProvider.slug == "oidc"))
+    ).one()
+    # The migrated provider MUST stay platform-level (operator-global).
+    assert provider.guild_id is None
+    assert provider.kind == "oidc"
+    assert provider.issuer == "https://idp.example.com"
+    assert provider.client_id == "client-123"
+    assert provider.scopes == "openid email"
+    assert provider.enabled is True
+
+    links = (
+        await session.exec(
+            select(FederatedIdentity).where(
+                FederatedIdentity.provider_id == provider.id
+            )
+        )
+    ).all()
+    assert {link.subject for link in links} == {"sub-alice", "sub-bob"}
+    assert {link.user_id for link in links} == {u1.id, u2.id}
+
+
+async def test_backfill_is_idempotent(session):
+    await _configure_oidc(session)
+    await create_user(session, oidc_sub="sub-1")
+
+    first = await backfill_oidc_identity()
+    second = await backfill_oidc_identity()
+
+    assert first.provider_created is True
+    assert second.provider_created is False
+    assert second.identities_linked == 0  # already linked → ON CONFLICT DO NOTHING
+
+    providers = (
+        await session.exec(select(AuthProvider).where(AuthProvider.slug == "oidc"))
+    ).all()
+    assert len(providers) == 1
+    links = (await session.exec(select(FederatedIdentity))).all()
+    assert len(links) == 1
+
+
+async def test_backfill_disabled_oidc_still_migrates_config(session):
+    """A disabled-but-configured provider is still migrated (enabled=false), so
+    an operator who toggles it back on keeps their linked identities."""
+    await _configure_oidc(session, enabled=False)
+    await create_user(session, oidc_sub="sub-x")
+
+    summary = await backfill_oidc_identity()
+
+    assert summary.provider_created is True
+    provider = (
+        await session.exec(select(AuthProvider).where(AuthProvider.slug == "oidc"))
+    ).one()
+    assert provider.enabled is False
+
+
+async def test_backfill_noop_when_oidc_unconfigured(session):
+    # No issuer configured; a stray oidc_sub must not link to a phantom provider.
+    await _configure_oidc(session, issuer="")
+    await create_user(session, oidc_sub="orphan")
+
+    summary = await backfill_oidc_identity()
+
+    assert summary.skipped_reason == "oidc_not_configured"
+    assert (await session.exec(select(AuthProvider))).all() == []
+    assert (await session.exec(select(FederatedIdentity))).all() == []


### PR DESCRIPTION
## Problem

Phase 0 tail / Phase 1 foundation (`history/auth-detailed-design.md` §6.5, §11). The provider registry (`auth_providers`) and identity table (`federated_identities`) exist but hold no data. This migrates the single platform OIDC config (`app_settings.oidc_*` + `users.oidc_sub`) into them so the upcoming `OidcProvider` seam and multi-provider endpoints have something to read.

**Current OIDC is platform-level and stays that way:** the migrated provider is **operator-global** (`auth_providers.guild_id IS NULL`). No guild-scoped OIDC is created.

## Approach — boot task via `app_admin`, not an in-migration DML

Both the source (`users`) and target (`federated_identities`) are `FORCE ROW LEVEL SECURITY`, so a plain Alembic migration (running as the least-privilege provisioning role) is policy-bound — the silent 0/partial-rows data-loss trap. The design calls for running the backfill "via the `app_admin` BYPASSRLS engine with row-count assertions."

So this is an **idempotent boot task** (`backfill_oidc_identity`) run in `lifespan` on `AdminSessionLocal`, mirroring `backfill_guild_schemas`:
- RLS-safe by construction (BYPASSRLS), no `FORCE`-toggling and thus no mid-migration RLS-hole risk that an in-migration approach would carry.
- Idempotent + self-healing — re-running once the provider exists and every `oidc_sub` is linked is a no-op, so it reconciles on every boot.
- Ships in the release image and runs on deploy.
- Never raises: a failure logs and leaves the legacy path fully intact.

## What it does

1. Reads the `app_settings` singleton. If OIDC was never configured (no issuer/client_id) → no-op.
2. Creates **one** operator-global `auth_providers` row (`guild_id=NULL`, `kind=oidc`, `enabled` = current toggle, issuer/client_id/scopes/role_claim_path copied). Fixed slug `oidc` so re-runs find it.
3. Bulk-links every `users.oidc_sub` into `federated_identities` (`INSERT … SELECT … ON CONFLICT (provider_id, subject) DO NOTHING`).
4. Row-count sanity check: warns if fewer identities linked than oidc users (duplicate-subject signal).

## Additive / no user-visible change

`app_settings.oidc_*`, `users.oidc_sub`, and the encrypted client secret are **left intact as the fallback** — the live OIDC login still reads them. The new rows are dormant until the `OidcProvider` seam consumes them (next PR). Removal is Phase 4, after the new path is proven. No secret companion table needed yet (secret stays in `app_settings`).

## Schema / env

None — both tables already exist; this is data only. No Alembic migration.

## Testing

`cd backend && pytest app/services/auth/oidc_backfill_test.py` — **4 passed**: creates the operator-global provider + links (asserts `guild_id IS NULL`, the platform-level invariant, and that non-OIDC users aren't linked); idempotent (second run is a no-op, no dupes); disabled-but-configured still migrates; unconfigured is a clean no-op. `ruff check`/`format` clean.