### PR TITLE
Add auth_provider_secrets (app_admin-only secret store)

### DIFF
--- a/backend/alembic/versions/20260706_0133_create_auth_provider_secrets.py
+++ b/backend/alembic/versions/20260706_0133_create_auth_provider_secrets.py
@@ -1,0 +1,64 @@
+"""create auth_provider_secrets (app_admin-only client-secret store)
+
+Splits the provider client secret out of ``auth_providers`` into an
+**app_admin-only** companion (history/auth-detailed-design.md §6.2): the
+request-path (``platform_<tier>``) roles hold *no* grant on secret material, so
+even an over-broad query or an injection on the authenticated path cannot
+exfiltrate a client secret. Metadata (issuer, client_id — public in OIDC) stays
+on ``auth_providers``; only the secret is here.
+
+1:1 with the provider (``provider_id`` PK, FK ``ON DELETE CASCADE``). The public
+schema default-grants platform_base + app_guild_base full DML on every new
+table, so we REVOKE both. Additive only — nothing reads or writes it yet; the
+OidcProvider phase backfills it (verbatim ciphertext, same Fernet salt) + reads
+it on the system engine.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260706_0133"
+down_revision = "20260706_0132"
+branch_labels = None
+depends_on = None
+
+
+def _platform(role: str) -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_{role}"
+
+
+def _run(statements: list[str]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_provider_secrets",
+        sa.Column("provider_id", sa.Integer(), primary_key=True),
+        sa.Column("client_secret_encrypted", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["provider_id"], ["auth_providers.id"], ondelete="CASCADE"
+        ),
+    )
+
+    base = _platform("base")
+    _run(
+        [
+            "ALTER TABLE public.auth_provider_secrets ENABLE ROW LEVEL SECURITY",
+            "ALTER TABLE public.auth_provider_secrets FORCE ROW LEVEL SECURITY",
+            # Strip the schema-default DML: the client secret is read/written only
+            # by the system engine (provider CRUD via AdminSessionDep + config.manage),
+            # never on the request path — so a request-role query can't reach it.
+            f'REVOKE ALL ON TABLE public.auth_provider_secrets FROM app_guild_base, "{base}"',
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.auth_provider_secrets TO app_admin",
+        ]
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS public.auth_provider_secrets CASCADE")

--- a/backend/app/db/auth_provider_secrets_rls_test.py
+++ b/backend/app/db/auth_provider_secrets_rls_test.py
@@ -1,0 +1,81 @@
+"""Role-security test for the auth_provider_secrets store.
+
+Locks in the app_admin-only wall (migration 20260706_0133): the request path
+holds no grant on the table, so a client secret can never be read off an
+authenticated (``platform_<tier>``) request — even the highest tier is denied at
+the grant layer. Secret reads/writes run only on the system engine (provider CRUD
+via ``AdminSessionDep`` + ``config.manage``).
+
+Style mirrors ``auth_sessions_rls_test``: SET ROLE platform_<tier> drops to a
+non-superuser role so table GRANTs are enforced like the request path.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.schema_provisioning import platform_role_name
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def _assume(session, tier: str, user_id: int) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('app.current_user_id', :uid, false), "
+            "set_config('role', :role, false)"
+        ),
+        params={"uid": str(user_id), "role": platform_role_name(tier)},
+    )
+
+
+async def _reset(session) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('role', 'none', false), "
+            "set_config('app.current_user_id', '', false)"
+        )
+    )
+
+
+async def _make_secret_row(session) -> None:
+    provider_id = (
+        await session.exec(
+            text(
+                "INSERT INTO auth_providers "
+                "(slug, display_name, kind, enabled, allow_jit, created_at, updated_at) "
+                "VALUES ('oidc', 'SSO', 'oidc', true, true, now(), now()) RETURNING id"
+            )
+        )
+    ).scalar_one()
+    await session.exec(
+        text(
+            "INSERT INTO auth_provider_secrets "
+            "(provider_id, client_secret_encrypted, created_at, updated_at) "
+            "VALUES (:pid, 'ciphertext', now(), now())"
+        ),
+        params={"pid": provider_id},
+    )
+
+
+async def test_auth_provider_secrets_unreadable_on_request_path(session):
+    """No request-path grant: even the highest platform tier is denied at the
+    grant layer, so a client secret can never be read off the request path. The
+    superuser setup session (like the system engine) still sees the row."""
+    u1 = await create_user(session)
+    await _make_secret_row(session)
+
+    # Positive control: the privileged path sees the secret it just wrote.
+    seen = (
+        await session.exec(text("SELECT count(*) FROM auth_provider_secrets"))
+    ).scalar_one()
+    assert seen >= 1
+
+    await _assume(session, "owner", u1.id)
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(
+                text("SELECT client_secret_encrypted FROM auth_provider_secrets")
+            )
+    await _reset(session)

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -47,6 +47,7 @@ from app.models.tenant.upload import Upload
 from app.models.platform.user_view_preference import UserViewPreference
 from app.models.platform.access_grant import AccessGrant
 from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.auth_provider_secret import AuthProviderSecret
 from app.models.platform.auth_session import AuthSession
 from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.user_token import UserToken
@@ -61,6 +62,7 @@ __all__ = [
     "User",
     "AccessGrant",
     "AuthProvider",
+    "AuthProviderSecret",
     "AuthSession",
     "FederatedIdentity",
     "ResourceGrant",

--- a/backend/app/db/secret_key_rotation.py
+++ b/backend/app/db/secret_key_rotation.py
@@ -74,6 +74,11 @@ _PUBLIC_FERNET_COLUMNS: list[tuple[str, str, bytes]] = [
     ("users", "ai_api_key_encrypted", SALT_AI_API_KEY),
     ("users", "oidc_refresh_token_encrypted", SALT_OIDC_REFRESH_TOKEN),
     ("app_settings", "oidc_client_secret_encrypted", SALT_OIDC_CLIENT_SECRET),
+    # Successor home for the OIDC client secret (same salt → ciphertext moves
+    # verbatim). Both rows are rotated during the transition; app_settings is
+    # dropped in Phase 4. Currently always NULL until the OidcProvider phase
+    # backfills it — rotating a NULL column is a harmless no-op.
+    ("auth_provider_secrets", "client_secret_encrypted", SALT_OIDC_CLIENT_SECRET),
     ("app_settings", "smtp_password_encrypted", SALT_SMTP_PASSWORD),
     ("app_settings", "ai_api_key_encrypted", SALT_AI_API_KEY),
     ("guild_invites", "invitee_email_encrypted", SALT_EMAIL),

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -36,6 +36,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.database]
 _RLS_SHARED_TABLES = {
     "access_grants",
     "app_settings",
+    "auth_provider_secrets",
     "auth_providers",
     "auth_sessions",
     "federated_identities",

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -79,6 +79,10 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     # carries NO permissive RLS policy, so the request path can't read guild-scoped
     # provider config (no cross-tenant metadata leak).
     "auth_providers": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # provider client secret — read/written only by the system engine (provider
+    # CRUD via AdminSessionDep + config.manage); the request path has no grant, so
+    # a secret can't be exfiltrated by an over-broad authenticated-path query
+    "auth_provider_secrets": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # identity linking — resolved/created at login (pre-auth, by subject); link/
     # unlink go through the system engine (linking is an account-takeover surface)
     "federated_identities": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
@@ -113,6 +117,8 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # provider reads for the login page go via the system engine (AdminSessionDep),
     # not the bare login role — so guild-scoped provider config never leaks here
     "auth_providers": None,
+    # client secrets are system-engine-only; no request role ever reads them
+    "auth_provider_secrets": None,
     # own-row identity links are read on the authenticated (platform_<tier>)
     # path, not the bare pre-routing role
     "federated_identities": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -71,6 +71,7 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # Auth/login foundation — one user's identities span guilds; provider
         # registry is read pre-routing at login.
         "auth_providers",  # login provider registry (operator-global or guild-scoped)
+        "auth_provider_secrets",  # provider client secret; app_admin-only companion
         "federated_identities",  # (provider, subject) -> user links
         "auth_sessions",  # session/refresh store (JWT sid = row id); app_admin-only
         # Platform-wide

--- a/backend/app/models/platform/auth_provider_secret.py
+++ b/backend/app/models/platform/auth_provider_secret.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, Integer, Text
+from sqlmodel import Field, SQLModel
+
+
+class AuthProviderSecret(SQLModel, table=True):
+    """The client secret for one auth provider — kept OUT of ``auth_providers``.
+
+    Split into this **app_admin-only** companion (history/auth-detailed-design.md
+    §6.2) so the request-path (``platform_<tier>``) roles hold *no* grant on secret
+    material: even an over-broad query or an injection on the authenticated path
+    cannot exfiltrate a client secret. Provider metadata (``issuer``/``client_id``
+    — public in OIDC) stays on ``auth_providers``; only the secret lives here.
+
+    1:1 with the provider — ``provider_id`` is the PK and an FK to
+    ``auth_providers.id`` (``ON DELETE CASCADE``, declared in the migration).
+    ``client_secret_encrypted`` is Fernet-encrypted at rest with
+    ``SALT_OIDC_CLIENT_SECRET`` (registered in the secret-key rotation registry);
+    it is ``NULL`` for public / PKCE-only providers with no secret.
+    """
+
+    __tablename__ = "auth_provider_secrets"
+
+    # PK + FK to auth_providers (ON DELETE CASCADE declared in the migration).
+    provider_id: int = Field(sa_column=Column(Integer, primary_key=True))
+
+    client_secret_encrypted: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        # onupdate (Python-side, no DDL) so secret rotation via the provider-CRUD
+        # service bumps this without the endpoint having to remember.
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            onupdate=lambda: datetime.now(timezone.utc),
+        ),
+    )


### PR DESCRIPTION
## Problem

Phase 1 prerequisite for the `OidcProvider` seam (`history/auth-detailed-design.md` §6.2). The provider registry (`auth_providers`, #820) is deliberately **secret-free** — issuer/client_id are public in OIDC, but the client *secret* must be walled off. This adds the `app_admin`-only companion table that holds it, so `OidcProvider` can read secrets from the registry instead of `app_settings`.

Same additive-first cadence as #821 (a dormant table lands before the logic that uses it): nothing reads or writes it yet — the secret **backfill + read** ride with the `OidcProvider` PR.

## Notable changes

- **`auth_provider_secrets`** — 1:1 with the provider (`provider_id` PK + FK to `auth_providers.id` `ON DELETE CASCADE`), one nullable `client_secret_encrypted` column (`NULL` for public/PKCE-only providers).
- Model + migration `20260706_0133`, `SHARED_TABLES`, both `system_grants` matrices, `_RLS_SHARED_TABLES`, and the secret-key rotation registry all updated together (CI enforces each).

## Security

The whole point is that **secret material is unreachable from any request path**:
- `ENABLE` + `FORCE ROW LEVEL SECURITY`, the schema-default base-role DML `REVOKE`d, and only `app_admin` granted `SELECT/INSERT/UPDATE/DELETE`. So even an over-broad query or an injection on the authenticated (`platform_<tier>`) path **cannot exfiltrate** a client secret — reads/writes run only on the system engine (provider CRUD via `AdminSessionDep` + `config.manage`). Same wall as `auth_sessions`/`access_grants`.
- A regression test (`auth_provider_secrets_rls_test`) asserts even `platform_owner` is denied at the grant layer.
- Fernet at rest with `SALT_OIDC_CLIENT_SECRET` — **the same salt as `app_settings.oidc_client_secret_encrypted`**, so the `OidcProvider` phase moves the ciphertext **verbatim** (no decrypt/re-encrypt). Registered in `_PUBLIC_FERNET_COLUMNS` now (a harmless no-op while `NULL`) so a key rotation can't orphan the secret once it's populated.

## Schema / env

New shared table `auth_provider_secrets` (migration `0133`, head). No env changes. `app_admin`-only — no request-path grant.

## Testing

`cd backend && pytest app/db/auth_provider_secrets_rls_test.py app/db/security_invariants_test.py app/db/system_grants_test.py app/db/tenancy_test.py app/db/secret_key_rotation_test.py` — **31 passed** (RLS wall, live-catalog grant/FORCE invariants, registry completeness, tenancy classification, and rotation with the new column). `ruff check`/`format` clean.