### PR TITLE
Backfill OIDC client secret into secret store

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -115,12 +115,14 @@ async def lifespan(app: FastAPI):
     from app.services.auth.oidc_backfill import backfill_oidc_identity
 
     oidc = await backfill_oidc_identity()
-    if oidc.provider_created or oidc.identities_linked:
+    if oidc.provider_created or oidc.identities_linked or oidc.secret_migrated:
         logger.info(
-            "OIDC identity back-fill: provider %s, %d identities linked (of %d)",
+            "OIDC identity back-fill: provider %s, %d identities linked (of %d), "
+            "secret %s",
             "created" if oidc.provider_created else "existing",
             oidc.identities_linked,
             oidc.oidc_users,
+            "migrated" if oidc.secret_migrated else "unchanged",
         )
     app.state.notification_tasks = background_tasks_service.start_background_tasks()
 

--- a/backend/app/services/auth/oidc_backfill.py
+++ b/backend/app/services/auth/oidc_backfill.py
@@ -13,6 +13,13 @@ The migrated provider is deliberately **operator-global** (``guild_id IS NULL``)
 — today's OIDC is platform-level and must stay that way. ``app_settings.oidc_*``
 and ``users.oidc_sub`` are left intact as the fallback; they are dropped only in
 Phase 4 after the new path is proven.
+
+The client secret rides along into the app_admin-only ``auth_provider_secrets``
+companion (migration 0133): both columns use the same Fernet salt
+(``SALT_OIDC_CLIENT_SECRET``), so the ciphertext moves **verbatim** — no
+decrypt/re-encrypt. Like the provider row it is **create-once** (``ON CONFLICT
+DO NOTHING``); a later secret rotation in ``app_settings`` is reconciled at
+cutover, not re-copied every boot.
 """
 
 from __future__ import annotations
@@ -42,6 +49,7 @@ class OidcBackfillSummary:
     provider_created: bool = False
     identities_linked: int = 0
     oidc_users: int = 0
+    secret_migrated: bool = False
     skipped_reason: str | None = None
 
 
@@ -116,6 +124,29 @@ async def _run(session) -> OidcBackfillSummary:
         params={"pid": provider.id},
     )
     inserted = result.rowcount
+
+    # 3. Migrate the client secret verbatim into the app_admin-only companion
+    #    (auth_provider_secrets, migration 0133). Same Fernet salt on both
+    #    columns, so the ciphertext moves as-is. Guarded on a secret actually
+    #    being set — a public / PKCE-only provider gets no secret row. Create-once
+    #    (ON CONFLICT DO NOTHING): idempotent, self-healing, and concurrency-safe;
+    #    a rotated secret is reconciled at cutover, not re-copied here.
+    secret_migrated = False
+    if settings_row.oidc_client_secret_encrypted:
+        secret_result = await session.exec(
+            text(
+                "INSERT INTO auth_provider_secrets "
+                "(provider_id, client_secret_encrypted, created_at, updated_at) "
+                "VALUES (:pid, :ct, now(), now()) "
+                "ON CONFLICT (provider_id) DO NOTHING"
+            ),
+            params={
+                "pid": provider.id,
+                "ct": settings_row.oidc_client_secret_encrypted,
+            },
+        )
+        secret_migrated = bool(secret_result.rowcount)
+
     await session.commit()
 
     # Row-count sanity: every oidc user should now be linked (freshly inserted or
@@ -139,4 +170,5 @@ async def _run(session) -> OidcBackfillSummary:
         provider_created=provider_created,
         identities_linked=inserted,
         oidc_users=oidc_users,
+        secret_migrated=secret_migrated,
     )

--- a/backend/app/services/auth/oidc_backfill_test.py
+++ b/backend/app/services/auth/oidc_backfill_test.py
@@ -10,8 +10,14 @@ from __future__ import annotations
 import pytest
 from sqlmodel import select
 
+from app.core.encryption import (
+    SALT_OIDC_CLIENT_SECRET,
+    decrypt_field,
+    encrypt_field,
+)
 from app.models.platform.app_setting import AppSetting
 from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.auth_provider_secret import AuthProviderSecret
 from app.models.platform.federated_identity import FederatedIdentity
 from app.services.auth.oidc_backfill import backfill_oidc_identity
 from app.testing import create_user
@@ -19,7 +25,13 @@ from app.testing import create_user
 pytestmark = [pytest.mark.integration, pytest.mark.database]
 
 
-async def _configure_oidc(session, *, enabled: bool = True, issuer: str | None = None):
+async def _configure_oidc(
+    session,
+    *,
+    enabled: bool = True,
+    issuer: str | None = None,
+    client_secret_ciphertext: str | None = None,
+):
     row = (await session.exec(select(AppSetting))).first()
     if row is None:
         row = AppSetting()
@@ -30,6 +42,7 @@ async def _configure_oidc(session, *, enabled: bool = True, issuer: str | None =
     row.oidc_provider_name = "Okta"
     row.oidc_scopes = ["openid", "email"]
     row.oidc_role_claim_path = "roles"
+    row.oidc_client_secret_encrypted = client_secret_ciphertext
     await session.commit()
     return row
 
@@ -69,15 +82,18 @@ async def test_backfill_creates_operator_global_provider_and_links(session):
 
 
 async def test_backfill_is_idempotent(session):
-    await _configure_oidc(session)
+    ciphertext = encrypt_field("s3cr3t-value", SALT_OIDC_CLIENT_SECRET)
+    await _configure_oidc(session, client_secret_ciphertext=ciphertext)
     await create_user(session, oidc_sub="sub-1")
 
     first = await backfill_oidc_identity()
     second = await backfill_oidc_identity()
 
     assert first.provider_created is True
+    assert first.secret_migrated is True
     assert second.provider_created is False
     assert second.identities_linked == 0  # already linked → ON CONFLICT DO NOTHING
+    assert second.secret_migrated is False  # secret already present → no re-copy
 
     providers = (
         await session.exec(select(AuthProvider).where(AuthProvider.slug == "oidc"))
@@ -85,6 +101,49 @@ async def test_backfill_is_idempotent(session):
     assert len(providers) == 1
     links = (await session.exec(select(FederatedIdentity))).all()
     assert len(links) == 1
+    # Exactly one secret row, ciphertext unchanged across the re-run.
+    secrets = (await session.exec(select(AuthProviderSecret))).all()
+    assert len(secrets) == 1
+    assert secrets[0].client_secret_encrypted == ciphertext
+
+
+async def test_backfill_migrates_client_secret_verbatim(session):
+    """The client secret lands in the app_admin-only companion, ciphertext moved
+    as-is (same Fernet salt) and still decrypting to the original plaintext."""
+    ciphertext = encrypt_field("s3cr3t-value", SALT_OIDC_CLIENT_SECRET)
+    await _configure_oidc(session, client_secret_ciphertext=ciphertext)
+
+    summary = await backfill_oidc_identity()
+    assert summary.secret_migrated is True
+
+    provider = (
+        await session.exec(select(AuthProvider).where(AuthProvider.slug == "oidc"))
+    ).one()
+    secret = (
+        await session.exec(
+            select(AuthProviderSecret).where(
+                AuthProviderSecret.provider_id == provider.id
+            )
+        )
+    ).one()
+    # Verbatim: the exact ciphertext string, no decrypt/re-encrypt round trip.
+    assert secret.client_secret_encrypted == ciphertext
+    # And it still decrypts to the original plaintext under the shared salt.
+    assert (
+        decrypt_field(secret.client_secret_encrypted, SALT_OIDC_CLIENT_SECRET)
+        == "s3cr3t-value"
+    )
+
+
+async def test_backfill_no_secret_row_when_no_client_secret(session):
+    """A public / PKCE-only provider (no configured secret) gets a provider row
+    but no secret row — the read path treats a missing row as 'no secret'."""
+    await _configure_oidc(session, client_secret_ciphertext=None)
+
+    summary = await backfill_oidc_identity()
+    assert summary.provider_created is True
+    assert summary.secret_migrated is False
+    assert (await session.exec(select(AuthProviderSecret))).all() == []
 
 
 async def test_backfill_disabled_oidc_still_migrates_config(session):


### PR DESCRIPTION
## Problem

#826 landed the `auth_provider_secrets` table (app_admin-only client-secret store) but left it **empty**. The upcoming `OidcProvider` reads its client secret from that store, not from `app_settings` — so the migrated operator-global provider needs its secret moved there first.

## Change

Extend the boot backfill (`backfill_oidc_identity`, added in #825) with one more step: copy `app_settings.oidc_client_secret_encrypted` → `auth_provider_secrets.client_secret_encrypted`.

- **Verbatim ciphertext** — both columns use the same Fernet salt (`SALT_OIDC_CLIENT_SECRET`), so the encrypted string moves as-is; no decrypt/re-encrypt, no plaintext ever materialized.
- **Create-once** (`INSERT … ON CONFLICT (provider_id) DO NOTHING`) — idempotent, self-healing, concurrency-safe. A later secret rotation in `app_settings` is **not** re-copied here; that's the one-time config reconcile deferred to the cutover PR (matches the create-once provider seed from #825).
- **Guarded on a secret existing** — a public / PKCE-only provider (no configured secret) gets its provider row but **no** secret row; the read path treats a missing row as "no secret."
- Runs on the same **app_admin (BYPASSRLS)** connection as the rest of the backfill (the target is FORCE-RLS, app_admin-only).
- Boot log now reports `secret migrated|unchanged`.

No registry/schema change — table, RLS, and grants all landed in #826. No user-visible change (Phase-0 infrastructure, additive; `app_settings.oidc_*` stays as the fallback until Phase 4).

## Tests

`app/services/auth/oidc_backfill_test.py`:
- **verbatim** — the exact ciphertext string lands in the companion and still decrypts to the original plaintext under the shared salt.
- **create-once / idempotent** — re-run reports `secret_migrated=False`, exactly one secret row, ciphertext unchanged.
- **no secret configured** — provider row created, no secret row.

`cd backend && pytest app/services/auth/oidc_backfill_test.py` → 6 passed. `ruff check` + `ruff format` clean.

## Next

The `IdentityProvider` seam + `OidcProvider` (discovery, PKCE, nonce, JWKS id_token verification, `(provider, subject)` identity resolution) — which consumes this backfilled secret.