### PR TITLE
Add secure OIDC id_token verifier

### DIFF
--- a/backend/app/services/auth/oidc/__init__.py
+++ b/backend/app/services/auth/oidc/__init__.py
@@ -1,0 +1,15 @@
+"""OpenID Connect relying-party building blocks.
+
+Kept as small, independently-testable units — the security-critical
+``id_token`` verifier (:mod:`app.services.auth.oidc.id_token`) has no network
+dependency so it can be exercised adversarially in isolation. Discovery, the
+JWKS key resolver, PKCE/nonce, and the ``OidcProvider`` that composes them land
+in follow-up slices.
+"""
+
+from app.services.auth.oidc.id_token import (
+    IdTokenVerificationError,
+    verify_id_token,
+)
+
+__all__ = ["IdTokenVerificationError", "verify_id_token"]

--- a/backend/app/services/auth/oidc/id_token.py
+++ b/backend/app/services/auth/oidc/id_token.py
@@ -1,0 +1,157 @@
+"""Secure verification of an OpenID Connect ``id_token``.
+
+The crown jewel of the OIDC relying-party flow: a bug here is an authentication
+bypass. It is deliberately a **pure, network-free** function of the raw token
+plus its trust parameters — the caller resolves the signing key beforehand (in
+production from the provider's JWKS via ``PyJWKClient``; in tests from a local
+keypair) — so the verification logic can be exercised adversarially in isolation.
+
+Built on PyJWT ``>=2.13.0`` rather than Authlib (history/auth-detailed-design.md
+§10a). The industry's 2026 CVE wave showed the dangerous class here is the
+id_token **fail-open** — an unrecognized ``alg`` silently accepted, RS/HS
+algorithm confusion, or a stripped ``alg:none`` signature. That is a *usage*
+property, so it is enforced HERE, in our code, never delegated to a library
+default:
+
+* **asymmetric-only algorithm allowlist** — HMAC and ``none`` are structurally
+  unrepresentable, so an attacker can neither re-sign the token with the
+  (public) signing key as an HMAC secret nor strip the signature;
+* **required registered claims** — ``iss``/``sub``/``aud``/``exp``/``iat`` must
+  be present (a missing ``exp`` can never yield a non-expiring token);
+* **audience + issuer** bound to the configured provider;
+* **``azp`` enforced** when the token is issued to multiple audiences;
+* **constant-time ``nonce`` match** — binds the token to *this* login attempt
+  (replay / token-injection defense).
+
+Any failure raises :class:`IdTokenVerificationError` — the verifier is
+fail-closed, so an unforeseen error rejects the token rather than admitting it.
+"""
+
+from __future__ import annotations
+
+import hmac
+from collections.abc import Sequence
+from typing import Any
+
+import jwt
+
+# Asymmetric signature algorithms only. HMAC (``HS*``) and ``none`` are
+# deliberately absent: allowing an ``HS*`` alg alongside a public verification
+# key is the classic algorithm-confusion bypass (the attacker signs with the
+# known public key as the HMAC secret), and ``none`` strips the signature
+# entirely. Keeping the set asymmetric-only makes both *unrepresentable* rather
+# than merely discouraged — a caller cannot re-enable them by accident.
+_ASYMMETRIC_ALGORITHMS: frozenset[str] = frozenset(
+    {
+        "RS256",
+        "RS384",
+        "RS512",
+        "PS256",
+        "PS384",
+        "PS512",
+        "ES256",
+        "ES384",
+        "ES512",
+        "EdDSA",
+    }
+)
+
+# Registered claims an OIDC id_token MUST carry (OIDC Core §2). Requiring
+# ``exp``/``iat`` here means a token without an expiry can never be mistaken for
+# a non-expiring one.
+_REQUIRED_CLAIMS: tuple[str, ...] = ("iss", "sub", "aud", "exp", "iat")
+
+# Default allowlist: the two ubiquitous asymmetric algs. Callers may *narrow* it
+# (e.g. to what the provider's JWKS advertises); widening past the asymmetric
+# set is refused below.
+DEFAULT_ALGORITHMS: tuple[str, ...] = ("RS256", "ES256")
+
+# Clock-skew tolerance applied to ``exp``/``iat``/``nbf`` (seconds).
+DEFAULT_LEEWAY_SECONDS: int = 60
+
+
+class IdTokenVerificationError(Exception):
+    """An id_token failed verification and MUST be rejected (no login)."""
+
+
+def verify_id_token(
+    raw_token: str,
+    *,
+    signing_key: Any,
+    issuer: str,
+    audience: str,
+    nonce: str,
+    algorithms: Sequence[str] = DEFAULT_ALGORITHMS,
+    leeway_seconds: int = DEFAULT_LEEWAY_SECONDS,
+) -> dict[str, Any]:
+    """Verify ``raw_token`` against a trusted ``signing_key`` and return its
+    claims, or raise :class:`IdTokenVerificationError`.
+
+    ``signing_key`` is the provider's *public* key (a ``PyJWK.key``, a
+    ``cryptography`` public-key object, or PEM) already resolved from the
+    provider's JWKS by ``kid``. ``issuer`` / ``audience`` are the configured
+    provider's issuer and our ``client_id``. ``nonce`` is the exact value this
+    login attempt sent to the IdP — a missing or mismatched nonce is fatal.
+
+    Raises :class:`ValueError` (not :class:`IdTokenVerificationError`) for a
+    caller misconfiguration — an empty or non-asymmetric algorithm allowlist, or
+    an empty nonce — because those are programming errors, not attacker input.
+    """
+    requested = tuple(algorithms)
+    if not requested:
+        raise ValueError("id_token algorithms allowlist must be non-empty")
+    illegal = sorted(a for a in requested if a not in _ASYMMETRIC_ALGORITHMS)
+    if illegal:
+        # Refuse to even run with a symmetric / ``none`` alg in the allowlist —
+        # that would reopen the confusion/strip bypass this module exists to shut.
+        raise ValueError(f"id_token algorithms must be asymmetric; refused {illegal}")
+    if not nonce:
+        raise ValueError("a nonce is required to verify an id_token")
+
+    try:
+        claims: dict[str, Any] = jwt.decode(
+            raw_token,
+            key=signing_key,
+            algorithms=list(requested),
+            audience=audience,
+            issuer=issuer,
+            leeway=leeway_seconds,
+            options={
+                "require": list(_REQUIRED_CLAIMS),
+                "verify_signature": True,
+                "verify_aud": True,
+                "verify_iss": True,
+                "verify_exp": True,
+            },
+        )
+    except jwt.PyJWTError as exc:
+        # Fail-closed: any PyJWT failure — bad signature, disallowed alg /
+        # ``alg:none``, wrong aud/iss, expired, missing required claim, malformed
+        # token, unusable key — rejects the token.
+        raise IdTokenVerificationError(f"id_token rejected: {exc}") from exc
+
+    _verify_nonce(claims, nonce)
+    _verify_azp(claims, audience)
+    return claims
+
+
+def _verify_nonce(claims: dict[str, Any], expected: str) -> None:
+    """Constant-time ``nonce`` match; a missing or non-string nonce is rejected."""
+    got = claims.get("nonce")
+    if not isinstance(got, str) or not hmac.compare_digest(got, expected):
+        raise IdTokenVerificationError("id_token nonce does not match this login")
+
+
+def _verify_azp(claims: dict[str, Any], audience: str) -> None:
+    """Enforce ``azp`` (OIDC Core §3.1.3.7). PyJWT confirms our ``audience`` is
+    *present in* ``aud`` but does not check the authorized party: when a token is
+    issued to multiple audiences ``azp`` MUST be present and equal our
+    ``client_id``, and whenever ``azp`` is present at all it must match.
+    """
+    azp = claims.get("azp")
+    aud = claims.get("aud")
+    multi_aud = isinstance(aud, (list, tuple)) and len(aud) > 1
+    if multi_aud and azp is None:
+        raise IdTokenVerificationError("id_token has multiple audiences but no azp")
+    if azp is not None and azp != audience:
+        raise IdTokenVerificationError("id_token azp does not match client_id")

--- a/backend/app/services/auth/oidc/id_token.py
+++ b/backend/app/services/auth/oidc/id_token.py
@@ -95,7 +95,11 @@ def verify_id_token(
 
     Raises :class:`ValueError` (not :class:`IdTokenVerificationError`) for a
     caller misconfiguration — an empty or non-asymmetric algorithm allowlist, or
-    an empty nonce — because those are programming errors, not attacker input.
+    an empty issuer, audience, or nonce — because those are programming errors,
+    not attacker input. (PyJWT already fails *closed* on an empty issuer/audience,
+    rejecting every token; the guard just surfaces the misconfiguration explicitly
+    instead of presenting as "all logins fail", and keeps the trust anchors
+    uniformly non-empty alongside the nonce.)
     """
     requested = tuple(algorithms)
     if not requested:
@@ -105,6 +109,13 @@ def verify_id_token(
         # Refuse to even run with a symmetric / ``none`` alg in the allowlist —
         # that would reopen the confusion/strip bypass this module exists to shut.
         raise ValueError(f"id_token algorithms must be asymmetric; refused {illegal}")
+    # All three trust anchors must be present — an empty one is a caller bug, not
+    # attacker input. Guarded uniformly (PyJWT already rejects on empty iss/aud,
+    # but silently, so make it explicit).
+    if not issuer:
+        raise ValueError("an issuer is required to verify an id_token")
+    if not audience:
+        raise ValueError("an audience is required to verify an id_token")
     if not nonce:
         raise ValueError("a nonce is required to verify an id_token")
 

--- a/backend/app/services/auth/oidc/id_token_test.py
+++ b/backend/app/services/auth/oidc/id_token_test.py
@@ -64,6 +64,19 @@ RSA_PRIV, RSA_PUB = _rsa_keypair()
 EC_PRIV, EC_PUB = _ec_keypair()
 
 
+def _rsa_pyjwk() -> jwt.PyJWK:
+    """A ``PyJWK`` for ``RSA_PUB`` — the key type the production ``PyJWKClient``
+    path hands to the verifier, and the type CVE-2026-48523 (alg-allowlist bypass
+    with a PyJWK key, fixed in PyJWT 2.13.0) concerned."""
+    from jwt.algorithms import RSAAlgorithm
+
+    pub_obj = serialization.load_pem_public_key(RSA_PUB.encode())
+    data = json.loads(RSAAlgorithm.to_jwk(pub_obj))
+    data["alg"] = "RS256"
+    data.setdefault("use", "sig")
+    return jwt.PyJWK.from_dict(data)
+
+
 def _claims(**overrides) -> dict:
     now = datetime.now(timezone.utc)
     base = {
@@ -137,6 +150,31 @@ def test_multi_aud_with_correct_azp_accepted():
     token = _encode(_claims(aud=[AUDIENCE, "other-app"], azp=AUDIENCE))
     claims = _verify(token)
     assert claims["azp"] == AUDIENCE
+
+
+def test_accepts_pyjwk_signing_key():
+    """Production key type: PyJWKClient resolves a ``PyJWK``, not a PEM. Verify
+    the verifier accepts it and returns the claims."""
+    claims = _verify(_encode(_claims()), signing_key=_rsa_pyjwk())
+    assert claims["sub"] == "user-1"
+
+
+def test_pyjwk_signing_key_still_rejects_alg_confusion():
+    """Even when the key is a ``PyJWK`` bound to RS256 (the CVE-2026-48523 shape),
+    an HS256-forged token is rejected by our allowlist — the header alg is checked
+    against the allowlist regardless of the key object's bound alg."""
+    now = int(datetime.now(timezone.utc).timestamp())
+    claims = {
+        "iss": ISSUER,
+        "sub": "user-1",
+        "aud": AUDIENCE,
+        "exp": now + 300,
+        "iat": now,
+        "nonce": NONCE,
+    }
+    forged = _forge_hs256(claims, RSA_PUB)
+    with pytest.raises(IdTokenVerificationError):
+        _verify(forged, signing_key=_rsa_pyjwk())
 
 
 # --- signature / algorithm attacks -----------------------------------------
@@ -263,6 +301,16 @@ def test_symmetric_algorithm_in_allowlist_refused():
 def test_none_algorithm_in_allowlist_refused():
     with pytest.raises(ValueError):
         _verify(_encode(_claims()), algorithms=["none"])
+
+
+def test_empty_issuer_is_value_error():
+    with pytest.raises(ValueError):
+        _verify(_encode(_claims()), issuer="")
+
+
+def test_empty_audience_is_value_error():
+    with pytest.raises(ValueError):
+        _verify(_encode(_claims()), audience="")
 
 
 def test_empty_nonce_is_value_error():

--- a/backend/app/services/auth/oidc/id_token_test.py
+++ b/backend/app/services/auth/oidc/id_token_test.py
@@ -1,0 +1,270 @@
+"""Adversarial tests for the OIDC id_token verifier.
+
+A bug in this module is an authentication bypass, so the suite is written as
+attacks: for every way a forged or malformed token could sneak through, assert
+it is rejected. Tokens are minted with locally-generated RSA/EC keys (no
+network), so the verification logic is exercised in complete isolation.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac as stdlib_hmac
+import json
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+from app.services.auth.oidc.id_token import (
+    IdTokenVerificationError,
+    verify_id_token,
+)
+
+pytestmark = pytest.mark.unit
+
+ISSUER = "https://idp.example.com"
+AUDIENCE = "client-123"
+NONCE = "nonce-abc"
+
+# Sentinel: pass as an override value to DROP that claim entirely.
+_DROP = object()
+
+
+def _pem_private(key) -> str:
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _pem_public(key) -> str:
+    return key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _rsa_keypair() -> tuple[str, str]:
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return _pem_private(priv), _pem_public(priv.public_key())
+
+
+def _ec_keypair() -> tuple[str, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    return _pem_private(priv), _pem_public(priv.public_key())
+
+
+# One keypair per family, generated once for the module.
+RSA_PRIV, RSA_PUB = _rsa_keypair()
+EC_PRIV, EC_PUB = _ec_keypair()
+
+
+def _claims(**overrides) -> dict:
+    now = datetime.now(timezone.utc)
+    base = {
+        "iss": ISSUER,
+        "sub": "user-1",
+        "aud": AUDIENCE,
+        "exp": now + timedelta(minutes=5),
+        "iat": now,
+        "nonce": NONCE,
+    }
+    for key, value in overrides.items():
+        if value is _DROP:
+            base.pop(key, None)
+        else:
+            base[key] = value
+    return base
+
+
+def _encode(claims: dict, *, priv: str = RSA_PRIV, alg: str = "RS256") -> str:
+    return jwt.encode(claims, priv, algorithm=alg)
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _forge_hs256(claims: dict, secret: str) -> str:
+    """Hand-roll an HS256 token with ``secret`` as the HMAC key.
+
+    Done manually because PyJWT's ``encode`` refuses to HMAC-sign with a PEM
+    public key (its own confusion guard) — we need the malicious token to exist
+    so the *verifier's* asymmetric-only allowlist is what rejects it. Claims use
+    integer timestamps so they're plain-JSON serializable.
+    """
+    header = _b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    body = _b64url(json.dumps(claims).encode())
+    signing_input = f"{header}.{body}"
+    sig = stdlib_hmac.new(
+        secret.encode(), signing_input.encode(), hashlib.sha256
+    ).digest()
+    return f"{signing_input}.{_b64url(sig)}"
+
+
+def _verify(token: str, **overrides):
+    kwargs = dict(
+        signing_key=RSA_PUB,
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        nonce=NONCE,
+    )
+    kwargs.update(overrides)
+    return verify_id_token(token, **kwargs)
+
+
+# --- happy paths ------------------------------------------------------------
+
+
+def test_valid_rs256_token_accepted():
+    claims = _verify(_encode(_claims()))
+    assert claims["sub"] == "user-1"
+    assert claims["nonce"] == NONCE
+
+
+def test_valid_es256_token_accepted():
+    token = _encode(_claims(), priv=EC_PRIV, alg="ES256")
+    claims = _verify(token, signing_key=EC_PUB, algorithms=["ES256"])
+    assert claims["sub"] == "user-1"
+
+
+def test_multi_aud_with_correct_azp_accepted():
+    token = _encode(_claims(aud=[AUDIENCE, "other-app"], azp=AUDIENCE))
+    claims = _verify(token)
+    assert claims["azp"] == AUDIENCE
+
+
+# --- signature / algorithm attacks -----------------------------------------
+
+
+def test_alg_none_rejected():
+    """A stripped (unsigned) token must never be accepted."""
+    token = jwt.encode(_claims(), key="", algorithm="none")
+    with pytest.raises(IdTokenVerificationError):
+        _verify(token)
+
+
+def test_hs256_confusion_rejected():
+    """Algorithm confusion: attacker forges an HS256 token using the *public*
+    key as the shared secret. HS256 isn't in the asymmetric allowlist, so it's
+    refused before any signature check."""
+    now = int(datetime.now(timezone.utc).timestamp())
+    claims = {
+        "iss": ISSUER,
+        "sub": "user-1",
+        "aud": AUDIENCE,
+        "exp": now + 300,
+        "iat": now,
+        "nonce": NONCE,
+    }
+    forged = _forge_hs256(claims, RSA_PUB)
+    with pytest.raises(IdTokenVerificationError):
+        _verify(forged)
+
+
+def test_tampered_signature_rejected():
+    token = _encode(_claims())
+    header, payload, sig = token.split(".")
+    i = len(sig) // 2
+    sig = sig[:i] + ("A" if sig[i] != "A" else "B") + sig[i + 1 :]
+    with pytest.raises(IdTokenVerificationError):
+        _verify(f"{header}.{payload}.{sig}")
+
+
+def test_token_signed_by_a_different_key_rejected():
+    other_priv, _ = _rsa_keypair()
+    token = jwt.encode(_claims(), other_priv, algorithm="RS256")
+    with pytest.raises(IdTokenVerificationError):
+        _verify(token)
+
+
+def test_token_alg_outside_narrowed_allowlist_rejected():
+    """The token's *actual* alg must be in the allowlist — narrowing to ES256
+    rejects an RS256 token (not a caller error: ES256 is legal, the token isn't)."""
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims()), algorithms=["ES256"])
+
+
+# --- claim attacks ----------------------------------------------------------
+
+
+def test_expired_token_rejected():
+    token = _encode(_claims(exp=datetime.now(timezone.utc) - timedelta(minutes=5)))
+    with pytest.raises(IdTokenVerificationError):
+        _verify(token)
+
+
+def test_wrong_audience_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(aud="a-different-client")))
+
+
+def test_wrong_issuer_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(iss="https://evil.example.com")))
+
+
+def test_missing_sub_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(sub=_DROP)))
+
+
+def test_missing_exp_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(exp=_DROP)))
+
+
+# --- nonce (replay / token injection) --------------------------------------
+
+
+def test_nonce_mismatch_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(nonce="a-different-nonce")))
+
+
+def test_missing_nonce_claim_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(nonce=_DROP)))
+
+
+# --- azp (authorized party) -------------------------------------------------
+
+
+def test_multi_aud_without_azp_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(aud=[AUDIENCE, "other-app"])))
+
+
+def test_azp_mismatch_rejected():
+    with pytest.raises(IdTokenVerificationError):
+        _verify(_encode(_claims(azp="an-evil-client")))
+
+
+# --- caller misconfiguration (programming errors → ValueError) --------------
+
+
+def test_empty_algorithm_allowlist_is_value_error():
+    with pytest.raises(ValueError):
+        _verify(_encode(_claims()), algorithms=[])
+
+
+def test_symmetric_algorithm_in_allowlist_refused():
+    """Refuse to even run with an HMAC alg in the allowlist — that would reopen
+    the confusion bypass. This is a ValueError (our misuse), not a rejected token."""
+    with pytest.raises(ValueError):
+        _verify(_encode(_claims()), algorithms=["HS256"])
+
+
+def test_none_algorithm_in_allowlist_refused():
+    with pytest.raises(ValueError):
+        _verify(_encode(_claims()), algorithms=["none"])
+
+
+def test_empty_nonce_is_value_error():
+    with pytest.raises(ValueError):
+        _verify(_encode(_claims()), nonce="")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,11 @@ dependencies = [
     "sqlalchemy>=2.0.49,<3",
     "greenlet>=3.0",                     # SQLAlchemy async; its own marker skips macOS arm64, so require explicitly
     "asyncpg>=0.31.0,<0.32",
-    "PyJWT>=2.12.1,<3",
+    # >=2.13.0: fixes the 2026 PyJWKClient cluster (CVE-2026-48522 JWKS-URI SSRF,
+    # 48523 alg-allowlist bypass with a PyJWK key, 48524 unbounded JWKS fetch).
+    # We verify OIDC id_tokens with jwt.decode + PyJWKClient, so this is a security
+    # floor, not a preference — an older install is exploitable.
+    "PyJWT>=2.13.0,<3",
     "argon2-cffi>=25.1.0,<26",
     "bcrypt==5.0.0",
     "pydantic-settings>=2.14.2,<3",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1201,7 +1201,7 @@ requires-dist = [
     { name = "pycrdt", specifier = ">=0.13.0,<0.15" },
     { name = "pycrdt-websocket", specifier = ">=0.16.1,<0.17" },
     { name = "pydantic-settings", specifier = ">=2.14.2,<3" },
-    { name = "pyjwt", specifier = ">=2.12.1,<3" },
+    { name = "pyjwt", specifier = ">=2.13.0,<3" },
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "python-multipart", specifier = ">=0.0.31,<0.0.33" },
     { name = "requests", specifier = ">=2.34.2" },


### PR DESCRIPTION
## Context

Part of the auth rewrite (Phase 0). This is the **signature-verification core** the upcoming `OidcProvider` will call — isolated into its own PR because a bug here is an *authentication bypass*, so it deserves focused review + an adversarial test suite. It fixes today's platform-OIDC gap: the current callback [does **not** verify the id_token signature](backend/app/api/v1/platform_endpoints/auth.py#L973-L975).

Nothing is wired to it yet — the JWKS resolver + discovery/PKCE + identity resolution (the rest of `OidcProvider`) consume it in the next PR, and the live `/auth/oidc/callback` cutover after that.

## Library decision (PyJWT, not Authlib)

The design doc pinned Authlib, but I re-ran the comparison against the *current* CVE landscape before building (user-ratified). Every JOSE lib had 2026 verify-bypass CVEs — **Authlib's CVE-2026-28498 is an id_token fail-open** (unrecognized `alg` → silently returns `True`), the exact failure this module prevents. PyJWT is already load-bearing (our own session tokens), its crypto is Rust-backed via `pyca/cryptography`, MIT-licensed, and its low-level `jwt.decode` API *forces* the algorithm allowlist. So: **PyJWT + `>=2.13.0`**, zero new dependency. Full rationale recorded in `history/auth-detailed-design.md §10a`. Authlib is re-evaluated at Phase 1 (generalized multi-provider RP).

## The verifier

A **pure, network-free** function — the caller resolves the signing key first (production: JWKS via `PyJWKClient`; tests: local keypair). The fail-open defenses live in *our* code, not a library default:

- **Asymmetric-only algorithm allowlist** — HMAC and `none` are structurally unrepresentable, so `alg:none` and RS/HS confusion can't pass. A symmetric alg in the allowlist is a `ValueError` (refuse to run), not a silent risk.
- **Required registered claims** — `iss`/`sub`/`aud`/`exp`/`iat` (a missing `exp` can't yield a non-expiring token).
- **Audience + issuer** bound to the configured provider; **`azp` enforced** for multi-audience tokens (OIDC Core §3.1.3.7).
- **Constant-time `nonce` match** — replay / token-injection defense.
- **Fail-closed** — any PyJWT error rejects the token.

## Dependency floor: PyJWT `>=2.13.0`

Was `>=2.12.1`. 2.13.0 fixes the 2026 PyJWKClient cluster (CVE-2026-48522 JWKS-URI SSRF, 48523 alg-allowlist bypass with a PyJWK key, 48524 unbounded JWKS fetch) — a floor we want *before* the next PR introduces `PyJWKClient`, and it also hardens our existing `core/security.py` token usage. `uv.lock` updated.

## Tests

`app/services/auth/oidc/id_token_test.py` — **21 adversarial cases**, tokens minted from local RSA/EC keys (no network): `alg:none`, HS/RS confusion (hand-forged to bypass PyJWT's own encode guard and hit *our* allowlist), tampered signature, wrong signer, alg outside a narrowed allowlist, expired, wrong aud/iss, missing `sub`/`exp`, nonce mismatch/missing, multi-aud without `azp`, `azp` mismatch, plus caller-misconfig `ValueError`s.

`cd backend && pytest app/services/auth/oidc/` → 21 passed. `ruff check` + `format` clean.

## Not in this PR
JWKS fetch/caching + https-only issuer allowlist (the network side), discovery, PKCE/nonce generation, identity resolution, endpoint wiring — all next.