### PR TITLE
Add JWKS signing-key resolver

### DIFF
--- a/backend/app/services/auth/oidc/__init__.py
+++ b/backend/app/services/auth/oidc/__init__.py
@@ -1,15 +1,19 @@
 """OpenID Connect relying-party building blocks.
 
-Kept as small, independently-testable units — the security-critical
-``id_token`` verifier (:mod:`app.services.auth.oidc.id_token`) has no network
-dependency so it can be exercised adversarially in isolation. Discovery, the
-JWKS key resolver, PKCE/nonce, and the ``OidcProvider`` that composes them land
-in follow-up slices.
+Small, independently-testable units — the id_token verifier and the JWKS key
+resolver so far; discovery, PKCE/nonce, and the ``OidcProvider`` that composes
+them land in follow-up slices.
 """
 
 from app.services.auth.oidc.id_token import (
     IdTokenVerificationError,
     verify_id_token,
 )
+from app.services.auth.oidc.jwks import JwksResolutionError, JwksResolver
 
-__all__ = ["IdTokenVerificationError", "verify_id_token"]
+__all__ = [
+    "IdTokenVerificationError",
+    "JwksResolutionError",
+    "JwksResolver",
+    "verify_id_token",
+]

--- a/backend/app/services/auth/oidc/id_token.py
+++ b/backend/app/services/auth/oidc/id_token.py
@@ -1,30 +1,21 @@
-"""Secure verification of an OpenID Connect ``id_token``.
+"""Verify an OpenID Connect ``id_token``.
 
-The crown jewel of the OIDC relying-party flow: a bug here is an authentication
-bypass. It is deliberately a **pure, network-free** function of the raw token
-plus its trust parameters — the caller resolves the signing key beforehand (in
-production from the provider's JWKS via ``PyJWKClient``; in tests from a local
-keypair) — so the verification logic can be exercised adversarially in isolation.
+A pure, network-free function of the raw token and its trust parameters — the
+caller resolves the signing key first (production: the provider's JWKS; tests: a
+local keypair) — so it can be tested in isolation.
 
-Built on PyJWT ``>=2.13.0`` rather than Authlib (history/auth-detailed-design.md
-§10a). The industry's 2026 CVE wave showed the dangerous class here is the
-id_token **fail-open** — an unrecognized ``alg`` silently accepted, RS/HS
-algorithm confusion, or a stripped ``alg:none`` signature. That is a *usage*
-property, so it is enforced HERE, in our code, never delegated to a library
-default:
+Verification is strict, and the rules are enforced here rather than left to
+library defaults:
 
-* **asymmetric-only algorithm allowlist** — HMAC and ``none`` are structurally
-  unrepresentable, so an attacker can neither re-sign the token with the
-  (public) signing key as an HMAC secret nor strip the signature;
-* **required registered claims** — ``iss``/``sub``/``aud``/``exp``/``iat`` must
-  be present (a missing ``exp`` can never yield a non-expiring token);
+* **asymmetric-only algorithm allowlist** (``RS*``/``PS*``/``ES*``/``EdDSA``);
+  HMAC and ``none`` are not accepted;
+* **required registered claims** ``iss``/``sub``/``aud``/``exp``/``iat``;
 * **audience + issuer** bound to the configured provider;
-* **``azp`` enforced** when the token is issued to multiple audiences;
-* **constant-time ``nonce`` match** — binds the token to *this* login attempt
-  (replay / token-injection defense).
+* **``azp`` checked** for multi-audience tokens;
+* **constant-time ``nonce`` match**.
 
-Any failure raises :class:`IdTokenVerificationError` — the verifier is
-fail-closed, so an unforeseen error rejects the token rather than admitting it.
+Any failure raises :class:`IdTokenVerificationError` — fail-closed. Built on
+PyJWT; see the auth design doc for the rationale.
 """
 
 from __future__ import annotations
@@ -35,12 +26,8 @@ from typing import Any
 
 import jwt
 
-# Asymmetric signature algorithms only. HMAC (``HS*``) and ``none`` are
-# deliberately absent: allowing an ``HS*`` alg alongside a public verification
-# key is the classic algorithm-confusion bypass (the attacker signs with the
-# known public key as the HMAC secret), and ``none`` strips the signature
-# entirely. Keeping the set asymmetric-only makes both *unrepresentable* rather
-# than merely discouraged — a caller cannot re-enable them by accident.
+# Asymmetric signature algorithms only. HMAC (``HS*``) and ``none`` are excluded
+# by construction so they can't be selected — not merely discouraged.
 _ASYMMETRIC_ALGORITHMS: frozenset[str] = frozenset(
     {
         "RS256",
@@ -95,23 +82,17 @@ def verify_id_token(
 
     Raises :class:`ValueError` (not :class:`IdTokenVerificationError`) for a
     caller misconfiguration — an empty or non-asymmetric algorithm allowlist, or
-    an empty issuer, audience, or nonce — because those are programming errors,
-    not attacker input. (PyJWT already fails *closed* on an empty issuer/audience,
-    rejecting every token; the guard just surfaces the misconfiguration explicitly
-    instead of presenting as "all logins fail", and keeps the trust anchors
-    uniformly non-empty alongside the nonce.)
+    an empty issuer, audience, or nonce — since those are programming errors.
     """
     requested = tuple(algorithms)
     if not requested:
         raise ValueError("id_token algorithms allowlist must be non-empty")
     illegal = sorted(a for a in requested if a not in _ASYMMETRIC_ALGORITHMS)
     if illegal:
-        # Refuse to even run with a symmetric / ``none`` alg in the allowlist —
-        # that would reopen the confusion/strip bypass this module exists to shut.
+        # The allowlist is asymmetric by contract — refuse a symmetric/``none`` alg.
         raise ValueError(f"id_token algorithms must be asymmetric; refused {illegal}")
-    # All three trust anchors must be present — an empty one is a caller bug, not
-    # attacker input. Guarded uniformly (PyJWT already rejects on empty iss/aud,
-    # but silently, so make it explicit).
+    # All three trust anchors must be non-empty (PyJWT rejects empty iss/aud too,
+    # but silently — surface it as an explicit caller error).
     if not issuer:
         raise ValueError("an issuer is required to verify an id_token")
     if not audience:
@@ -136,9 +117,7 @@ def verify_id_token(
             },
         )
     except jwt.PyJWTError as exc:
-        # Fail-closed: any PyJWT failure — bad signature, disallowed alg /
-        # ``alg:none``, wrong aud/iss, expired, missing required claim, malformed
-        # token, unusable key — rejects the token.
+        # Fail-closed: any PyJWT failure rejects the token.
         raise IdTokenVerificationError(f"id_token rejected: {exc}") from exc
 
     _verify_nonce(claims, nonce)

--- a/backend/app/services/auth/oidc/jwks.py
+++ b/backend/app/services/auth/oidc/jwks.py
@@ -19,6 +19,7 @@ See the auth design doc for the rationale.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from collections.abc import Callable
@@ -71,6 +72,7 @@ class JwksResolver:
         self._max_bytes = max_response_bytes
         self._client_factory = client_factory or self._default_client_factory
         self._cache: dict[str, _CachedKeySet] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
 
     def _default_client_factory(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(timeout=self._timeout)
@@ -92,11 +94,11 @@ class JwksResolver:
 
         key_set = await self._get_key_set(jwks_uri)
         key = _select_key(key_set, kid)
-        if key is None and self._may_refetch(jwks_uri):
-            # kid absent from the cached set — keys may have rotated. One
-            # rate-limited refetch, then give up (bounds outbound fetches).
-            key_set = await self._fetch_and_cache(jwks_uri)
-            key = _select_key(key_set, kid)
+        if key is None and kid is not None:
+            # A specific kid isn't in the cached set — keys may have rotated. One
+            # rate-limited refetch, then give up. (A no-kid token that didn't
+            # resolve is ambiguous, not stale, so refetching wouldn't help.)
+            key = _select_key(await self._refetch(jwks_uri), kid)
         if key is None:
             raise JwksResolutionError(
                 f"no signing key for kid={kid!r} in JWKS at {jwks_uri}"
@@ -105,16 +107,27 @@ class JwksResolver:
 
     async def _get_key_set(self, jwks_uri: str) -> jwt.PyJWKSet:
         cached = self._cache.get(jwks_uri)
-        if cached is not None:
-            if (time.monotonic() - cached.fetched_at) < self._cache_ttl:
+        if cached is not None and self._fresh(cached):
+            return cached.key_set
+        async with self._lock_for(jwks_uri):
+            # Double-check: another coroutine may have fetched while we waited, so
+            # concurrent cold-cache callers make a single outbound fetch.
+            cached = self._cache.get(jwks_uri)
+            if cached is not None and self._fresh(cached):
                 return cached.key_set
-        return await self._fetch_and_cache(jwks_uri)
+            return await self._fetch_and_cache(jwks_uri)
 
-    def _may_refetch(self, jwks_uri: str) -> bool:
-        cached = self._cache.get(jwks_uri)
-        if cached is None:
-            return True
-        return (time.monotonic() - cached.fetched_at) >= self._min_refetch_interval
+    async def _refetch(self, jwks_uri: str) -> jwt.PyJWKSet:
+        """Lock-guarded, rate-limited refetch for a rotated ``kid``. Returns the
+        current cached set unchanged when a refetch isn't due yet (or another
+        coroutine just refreshed it)."""
+        async with self._lock_for(jwks_uri):
+            cached = self._cache.get(jwks_uri)
+            if cached is not None:
+                age = time.monotonic() - cached.fetched_at
+                if age < self._min_refetch_interval:
+                    return cached.key_set
+            return await self._fetch_and_cache(jwks_uri)
 
     async def _fetch_and_cache(self, jwks_uri: str) -> jwt.PyJWKSet:
         key_set = await self._fetch(jwks_uri)
@@ -122,6 +135,17 @@ class JwksResolver:
             key_set=key_set, fetched_at=time.monotonic()
         )
         return key_set
+
+    def _fresh(self, cached: _CachedKeySet) -> bool:
+        return (time.monotonic() - cached.fetched_at) < self._cache_ttl
+
+    def _lock_for(self, jwks_uri: str) -> asyncio.Lock:
+        # setdefault is atomic under the GIL, so concurrent callers converge on a
+        # single lock per URI (a briefly-created extra Lock is harmless).
+        lock = self._locks.get(jwks_uri)
+        if lock is None:
+            lock = self._locks.setdefault(jwks_uri, asyncio.Lock())
+        return lock
 
     async def _fetch(self, jwks_uri: str) -> jwt.PyJWKSet:
         _require_https(jwks_uri)

--- a/backend/app/services/auth/oidc/jwks.py
+++ b/backend/app/services/auth/oidc/jwks.py
@@ -1,0 +1,163 @@
+"""Resolve an OIDC provider's signing key from its JWKS.
+
+Given a trusted ``jwks_uri`` and a raw token, fetch the provider's JSON Web Key
+Set and return the ``PyJWK`` whose ``kid`` matches the token header, for the
+verifier (:mod:`app.services.auth.oidc.id_token`) to check the signature against.
+
+Fetched with httpx (async) rather than PyJWT's blocking ``PyJWKClient``, so the
+request is controlled directly:
+
+* the ``jwks_uri`` must be ``https`` (rejected before any request otherwise);
+* the response body is read under a fixed size cap;
+* the key set is cached (TTL); an unknown ``kid`` triggers at most one refetch
+  per interval.
+
+Parsing uses PyJWT (``PyJWKSet``); the fetch does not. Any failure raises
+:class:`JwksResolutionError` — fail-closed, so an unresolved key blocks login.
+See the auth design doc for the rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+import httpx
+import jwt
+
+DEFAULT_CACHE_TTL_SECONDS: float = 300.0
+DEFAULT_MIN_REFETCH_INTERVAL_SECONDS: float = 10.0
+DEFAULT_HTTP_TIMEOUT_SECONDS: float = 10.0
+# A JWKS is a few KiB; 512 KiB is generous headroom.
+DEFAULT_MAX_RESPONSE_BYTES: int = 512 * 1024
+
+ClientFactory = Callable[[], httpx.AsyncClient]
+
+
+class JwksResolutionError(Exception):
+    """The provider's signing key could not be resolved; verification must not
+    proceed (fail-closed)."""
+
+
+@dataclass
+class _CachedKeySet:
+    key_set: jwt.PyJWKSet
+    fetched_at: float  # monotonic clock
+
+
+class JwksResolver:
+    """Fetches + caches provider JWKS and resolves a token's signing key.
+
+    Hold one instance per process (the cache is shared across requests). The
+    network client is built per fetch via ``client_factory`` so tests can inject
+    an ``httpx.MockTransport`` without patching globals.
+    """
+
+    def __init__(
+        self,
+        *,
+        cache_ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        min_refetch_interval_seconds: float = DEFAULT_MIN_REFETCH_INTERVAL_SECONDS,
+        http_timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+        client_factory: ClientFactory | None = None,
+    ) -> None:
+        self._cache_ttl = cache_ttl_seconds
+        self._min_refetch_interval = min_refetch_interval_seconds
+        self._timeout = http_timeout_seconds
+        self._max_bytes = max_response_bytes
+        self._client_factory = client_factory or self._default_client_factory
+        self._cache: dict[str, _CachedKeySet] = {}
+
+    def _default_client_factory(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self._timeout)
+
+    async def resolve_signing_key(self, raw_token: str, *, jwks_uri: str) -> jwt.PyJWK:
+        """Return the ``PyJWK`` for ``raw_token``'s ``kid`` from the JWKS at
+        ``jwks_uri`` (fetching/caching as needed), or raise
+        :class:`JwksResolutionError`.
+
+        The ``kid`` is read from the token's *unverified* header — it only
+        selects which key to check against; authenticity comes from the
+        signature check, not the header.
+        """
+        try:
+            header = jwt.get_unverified_header(raw_token)
+        except jwt.PyJWTError as exc:
+            raise JwksResolutionError(f"unreadable token header: {exc}") from exc
+        kid = header.get("kid")
+
+        key_set = await self._get_key_set(jwks_uri)
+        key = _select_key(key_set, kid)
+        if key is None and self._may_refetch(jwks_uri):
+            # kid absent from the cached set — keys may have rotated. One
+            # rate-limited refetch, then give up (bounds outbound fetches).
+            key_set = await self._fetch_and_cache(jwks_uri)
+            key = _select_key(key_set, kid)
+        if key is None:
+            raise JwksResolutionError(
+                f"no signing key for kid={kid!r} in JWKS at {jwks_uri}"
+            )
+        return key
+
+    async def _get_key_set(self, jwks_uri: str) -> jwt.PyJWKSet:
+        cached = self._cache.get(jwks_uri)
+        if cached is not None:
+            if (time.monotonic() - cached.fetched_at) < self._cache_ttl:
+                return cached.key_set
+        return await self._fetch_and_cache(jwks_uri)
+
+    def _may_refetch(self, jwks_uri: str) -> bool:
+        cached = self._cache.get(jwks_uri)
+        if cached is None:
+            return True
+        return (time.monotonic() - cached.fetched_at) >= self._min_refetch_interval
+
+    async def _fetch_and_cache(self, jwks_uri: str) -> jwt.PyJWKSet:
+        key_set = await self._fetch(jwks_uri)
+        self._cache[jwks_uri] = _CachedKeySet(
+            key_set=key_set, fetched_at=time.monotonic()
+        )
+        return key_set
+
+    async def _fetch(self, jwks_uri: str) -> jwt.PyJWKSet:
+        _require_https(jwks_uri)
+        try:
+            async with self._client_factory() as client:
+                async with client.stream("GET", jwks_uri) as resp:
+                    resp.raise_for_status()
+                    body = bytearray()
+                    async for chunk in resp.aiter_bytes():
+                        body.extend(chunk)
+                        if len(body) > self._max_bytes:
+                            raise JwksResolutionError(
+                                f"JWKS at {jwks_uri} exceeds the "
+                                f"{self._max_bytes}-byte cap"
+                            )
+        except httpx.HTTPError as exc:
+            raise JwksResolutionError(
+                f"JWKS fetch failed for {jwks_uri}: {exc}"
+            ) from exc
+        try:
+            return jwt.PyJWKSet.from_dict(json.loads(body))
+        except (ValueError, jwt.PyJWTError) as exc:
+            raise JwksResolutionError(f"invalid JWKS at {jwks_uri}: {exc}") from exc
+
+
+def _require_https(jwks_uri: str) -> None:
+    # urlsplit lowercases the scheme, so ``HTTP`` etc. are covered; a missing host
+    # (``https://``) is refused too.
+    parts = urlsplit(jwks_uri)
+    if parts.scheme != "https" or not parts.netloc:
+        raise JwksResolutionError(f"refusing non-https JWKS URI: {jwks_uri!r}")
+
+
+def _select_key(key_set: jwt.PyJWKSet, kid: str | None) -> jwt.PyJWK | None:
+    keys = key_set.keys
+    if kid is not None:
+        return next((k for k in keys if k.key_id == kid), None)
+    # No kid in the token: only unambiguous when the set has exactly one key.
+    return keys[0] if len(keys) == 1 else None

--- a/backend/app/services/auth/oidc/jwks_test.py
+++ b/backend/app/services/auth/oidc/jwks_test.py
@@ -1,0 +1,268 @@
+"""Tests for the JWKS signing-key resolver.
+
+Outbound fetches are stubbed with ``httpx.MockTransport`` (injected via
+``client_factory`` — no global patching, no real network), so key selection,
+caching, the rate-limited refetch, and the https/size guards are all exercised
+in isolation. The happy path composes with the id_token verifier to prove the
+two halves fit.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+from app.services.auth.oidc.id_token import verify_id_token
+from app.services.auth.oidc.jwks import JwksResolver, JwksResolutionError
+
+pytestmark = pytest.mark.unit
+
+JWKS_URI = "https://idp.example.com/jwks"
+ISSUER = "https://idp.example.com"
+AUDIENCE = "client-123"
+NONCE = "nonce-abc"
+
+# Two RSA keys, generated once; tests assign them kids as needed.
+RSA1 = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+RSA2 = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _pem_private(priv) -> str:
+    return priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _jwk(priv, *, kid: str, extra: dict | None = None) -> dict:
+    data = json.loads(RSAAlgorithm.to_jwk(priv.public_key()))
+    data.update({"kid": kid, "alg": "RS256", "use": "sig"})
+    if extra:
+        data.update(extra)
+    return data
+
+
+def _jwks(*entries: dict) -> dict:
+    return {"keys": list(entries)}
+
+
+def _sign(priv, *, kid: str | None = None, **claim_overrides) -> str:
+    now = datetime.now(timezone.utc)
+    claims = {
+        "iss": ISSUER,
+        "sub": "user-1",
+        "aud": AUDIENCE,
+        "exp": now + timedelta(minutes=5),
+        "iat": now,
+        "nonce": NONCE,
+    }
+    claims.update(claim_overrides)
+    headers = {"kid": kid} if kid is not None else None
+    return jwt.encode(claims, _pem_private(priv), algorithm="RS256", headers=headers)
+
+
+class _Endpoint:
+    """A MockTransport handler that counts calls and can change its response."""
+
+    def __init__(self, response):
+        self.calls = 0
+        self._response = response
+
+    def set_response(self, response) -> None:
+        self._response = response
+
+    def factory(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.calls += 1
+            resp = self._response
+            return resp(request) if callable(resp) else resp
+
+        return lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _json_response(payload: dict) -> httpx.Response:
+    return httpx.Response(200, json=payload)
+
+
+# --- resolution + composition ----------------------------------------------
+
+
+async def test_resolves_kid_and_verifies_end_to_end():
+    """The resolved key verifies the token — resolver + verifier compose."""
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid="k1")
+
+    key = await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+    assert key.key_id == "k1"
+    claims = verify_id_token(
+        token, signing_key=key, issuer=ISSUER, audience=AUDIENCE, nonce=NONCE
+    )
+    assert claims["sub"] == "user-1"
+
+
+async def test_selects_correct_key_among_many():
+    endpoint = _Endpoint(
+        _json_response(_jwks(_jwk(RSA1, kid="k1"), _jwk(RSA2, kid="k2")))
+    )
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA2, kid="k2")
+
+    key = await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+    # Resolved k2's key: it verifies the RSA2-signed token.
+    verify_id_token(
+        token, signing_key=key, issuer=ISSUER, audience=AUDIENCE, nonce=NONCE
+    )
+    assert key.key_id == "k2"
+
+
+async def test_no_kid_uses_sole_key():
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid=None)  # no kid header
+
+    key = await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+    assert key.key_id == "k1"
+
+
+async def test_no_kid_with_multiple_keys_is_ambiguous():
+    endpoint = _Endpoint(
+        _json_response(_jwks(_jwk(RSA1, kid="k1"), _jwk(RSA2, kid="k2")))
+    )
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid=None)
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+
+
+async def test_unknown_kid_raises():
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid="does-not-exist")
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+
+
+# --- SSRF: https-only guard -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "http://idp.example.com/jwks",
+        "file:///etc/passwd",
+        "data:application/json,{}",
+        "ftp://idp.example.com/jwks",
+        "https://",  # no host
+    ],
+)
+async def test_non_https_uri_refused_without_fetching(uri):
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid="k1")
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(token, jwks_uri=uri)
+    assert endpoint.calls == 0  # refused before any request
+
+
+# --- caching + rate-limited refetch ----------------------------------------
+
+
+async def test_key_set_is_cached_within_ttl():
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid="k1")
+
+    await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+    await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+    assert endpoint.calls == 1  # second resolve served from cache
+
+
+async def test_unknown_kid_triggers_one_refetch_when_allowed():
+    """A rotated key (new kid) is picked up by exactly one refetch."""
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    # min_refetch_interval=0 → the refetch is permitted immediately.
+    resolver = JwksResolver(
+        client_factory=endpoint.factory(), min_refetch_interval_seconds=0
+    )
+    # Prime the cache with the k1-only set.
+    await resolver.resolve_signing_key(_sign(RSA1, kid="k1"), jwks_uri=JWKS_URI)
+    assert endpoint.calls == 1
+
+    # Provider rotates in k2; a k2 token misses the cache then refetches.
+    endpoint.set_response(
+        _json_response(_jwks(_jwk(RSA1, kid="k1"), _jwk(RSA2, kid="k2")))
+    )
+    key = await resolver.resolve_signing_key(_sign(RSA2, kid="k2"), jwks_uri=JWKS_URI)
+    assert key.key_id == "k2"
+    assert endpoint.calls == 2
+
+
+async def test_unknown_kid_refetch_is_rate_limited():
+    """With a fresh cache and a long refetch interval, an unknown kid does NOT
+    refetch — the amplification guard (a flood of random kids can't hammer the
+    JWKS endpoint)."""
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(
+        client_factory=endpoint.factory(),
+        min_refetch_interval_seconds=3600,
+    )
+    await resolver.resolve_signing_key(_sign(RSA1, kid="k1"), jwks_uri=JWKS_URI)
+    assert endpoint.calls == 1
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(
+            _sign(RSA2, kid="flood-kid"), jwks_uri=JWKS_URI
+        )
+    assert endpoint.calls == 1  # no extra fetch
+
+
+# --- hostile / broken endpoints --------------------------------------------
+
+
+async def test_response_size_cap_enforced():
+    padded = _jwks(_jwk(RSA1, kid="k1", extra={"junk": "x" * 5000}))
+    endpoint = _Endpoint(_json_response(padded))
+    resolver = JwksResolver(client_factory=endpoint.factory(), max_response_bytes=256)
+    token = _sign(RSA1, kid="k1")
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+
+
+async def test_http_error_raises_resolution_error():
+    endpoint = _Endpoint(httpx.Response(500, text="down"))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid="k1")
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+
+
+async def test_invalid_jwks_body_raises():
+    endpoint = _Endpoint(httpx.Response(200, text="not json"))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid="k1")
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
+
+
+async def test_malformed_token_header_raises():
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key("not-a-jwt", jwks_uri=JWKS_URI)
+    assert endpoint.calls == 0  # bail before fetching

--- a/backend/app/services/auth/oidc/jwks_test.py
+++ b/backend/app/services/auth/oidc/jwks_test.py
@@ -9,6 +9,7 @@ two halves fit.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 
@@ -144,6 +145,20 @@ async def test_no_kid_with_multiple_keys_is_ambiguous():
         await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
 
 
+async def test_no_kid_ambiguous_does_not_refetch():
+    """An unresolved no-kid token is ambiguous, not stale — no refetch, even
+    when the rate limit would allow one."""
+    endpoint = _Endpoint(
+        _json_response(_jwks(_jwk(RSA1, kid="k1"), _jwk(RSA2, kid="k2")))
+    )
+    resolver = JwksResolver(
+        client_factory=endpoint.factory(), min_refetch_interval_seconds=0
+    )
+    with pytest.raises(JwksResolutionError):
+        await resolver.resolve_signing_key(_sign(RSA1, kid=None), jwks_uri=JWKS_URI)
+    assert endpoint.calls == 1  # the initial fetch only, no spurious refetch
+
+
 async def test_unknown_kid_raises():
     endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
     resolver = JwksResolver(client_factory=endpoint.factory())
@@ -187,6 +202,20 @@ async def test_key_set_is_cached_within_ttl():
     await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
     await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
     assert endpoint.calls == 1  # second resolve served from cache
+
+
+async def test_concurrent_cold_resolves_make_one_fetch():
+    """A burst of concurrent resolves against a cold cache collapses to a single
+    outbound fetch (per-URI lock + double-check), not one per caller."""
+    endpoint = _Endpoint(_json_response(_jwks(_jwk(RSA1, kid="k1"))))
+    resolver = JwksResolver(client_factory=endpoint.factory())
+    token = _sign(RSA1, kid="k1")
+
+    keys = await asyncio.gather(
+        *(resolver.resolve_signing_key(token, jwks_uri=JWKS_URI) for _ in range(8))
+    )
+    assert all(k.key_id == "k1" for k in keys)
+    assert endpoint.calls == 1
 
 
 async def test_unknown_kid_triggers_one_refetch_when_allowed():


### PR DESCRIPTION
## Context

Part of the auth rewrite (Phase 0). The key-fetching half of trustworthy id_token verification — pairs with the verifier from #828. Together: resolve the provider's signing key, then verify the token against it. Still **dormant** (not wired to any endpoint); the `OidcProvider` that composes discovery → PKCE/nonce → resolver → verifier → identity resolution comes next.

## What it does

`JwksResolver.resolve_signing_key(token, jwks_uri=…)` returns the `PyJWK` whose `kid` matches the token header, fetching/caching the provider's JWKS as needed.

Fetched with **httpx (async)** rather than PyJWT's `PyJWKClient`, which is synchronous (it would block the event loop) and does its own fetch. Owning the request lets us control it directly:

- **https-only** `jwks_uri` — rejected before any request is made.
- **Response size cap** — body read under a fixed byte limit.
- **TTL cache + rate-limited refetch** — an unknown `kid` (rotated keys) triggers at most one refetch per interval.
- **Fail-closed** — any failure raises `JwksResolutionError`, so an unresolved key blocks login.

PyJWT is used only to parse the key set (`PyJWKSet`); the network fetch is ours. Hardening rationale lives in the auth design doc, not the source.

## Tests

`app/services/auth/oidc/jwks_test.py` — 17 tests via `httpx.MockTransport` (no network): correct `kid` selection, no-`kid` (sole key vs ambiguous), the https-only guard (asserts no fetch attempted), within-TTL caching, one-shot refetch on rotation, refetch rate-limiting, response size cap, HTTP/parse errors, malformed token header. The happy path composes with `verify_id_token` end to end.

`cd backend && pytest app/services/auth/oidc/` → 42 passed. `ruff` clean.

## Also here

Trimmed the `id_token` module docstrings/comments (from #828) to state behavior factually and keep the CVE/threat-model rationale in the design doc rather than shipped OSS source. Docstring-only; no logic change.

## Not in this PR
Discovery (`.well-known` metadata), PKCE/state/nonce generation, `OidcProvider.begin/complete`, identity resolution — next slice.