### PR TITLE
Add OIDC provider discovery

### DIFF
--- a/backend/app/services/auth/oidc/__init__.py
+++ b/backend/app/services/auth/oidc/__init__.py
@@ -1,10 +1,15 @@
 """OpenID Connect relying-party building blocks.
 
-Small, independently-testable units — the id_token verifier and the JWKS key
-resolver so far; discovery, PKCE/nonce, and the ``OidcProvider`` that composes
-them land in follow-up slices.
+Small, independently-testable units — discovery, the id_token verifier, and the
+JWKS key resolver so far; PKCE/nonce and the ``OidcProvider`` that composes them
+land in follow-up slices.
 """
 
+from app.services.auth.oidc.discovery import (
+    DiscoveryError,
+    OidcDiscovery,
+    OidcMetadata,
+)
 from app.services.auth.oidc.id_token import (
     IdTokenVerificationError,
     verify_id_token,
@@ -12,8 +17,11 @@ from app.services.auth.oidc.id_token import (
 from app.services.auth.oidc.jwks import JwksResolutionError, JwksResolver
 
 __all__ = [
+    "DiscoveryError",
     "IdTokenVerificationError",
     "JwksResolutionError",
     "JwksResolver",
+    "OidcDiscovery",
+    "OidcMetadata",
     "verify_id_token",
 ]

--- a/backend/app/services/auth/oidc/_http.py
+++ b/backend/app/services/auth/oidc/_http.py
@@ -1,0 +1,70 @@
+"""Shared HTTPS JSON fetch for the OIDC client (discovery + JWKS).
+
+One place for the network hardening both fetchers need — https-only, a fixed
+response size cap, a timeout — so it is written and audited once rather than
+copied. Callers add their own caching and wrap :class:`OidcHttpError` in a
+domain-specific error.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+ClientFactory = Callable[[], httpx.AsyncClient]
+
+DEFAULT_HTTP_TIMEOUT_SECONDS: float = 10.0
+# A discovery doc / JWKS is a few KiB; 512 KiB is generous headroom.
+DEFAULT_MAX_RESPONSE_BYTES: int = 512 * 1024
+
+
+class OidcHttpError(Exception):
+    """An OIDC HTTPS fetch failed — non-https URL, transport/status error,
+    oversized body, or invalid JSON. Callers wrap it in their own error."""
+
+
+def require_https(url: str) -> None:
+    # urlsplit lowercases the scheme, so ``HTTP`` etc. are covered; a missing host
+    # (``https://``) is refused too.
+    parts = urlsplit(url)
+    if parts.scheme != "https" or not parts.netloc:
+        raise OidcHttpError(f"refusing non-https URL: {url!r}")
+
+
+async def fetch_json(
+    url: str,
+    *,
+    client_factory: ClientFactory | None = None,
+    timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+    max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+) -> Any:
+    """GET ``url`` and return its parsed JSON, enforcing https and a response
+    size cap. Raises :class:`OidcHttpError` on any failure (fail-closed).
+
+    ``client_factory`` builds the ``httpx.AsyncClient`` per call (tests inject a
+    ``MockTransport``); it defaults to a timeout-configured client.
+    """
+    require_https(url)
+    factory = client_factory or (lambda: httpx.AsyncClient(timeout=timeout_seconds))
+    try:
+        async with factory() as client:
+            async with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                body = bytearray()
+                async for chunk in resp.aiter_bytes():
+                    body.extend(chunk)
+                    if len(body) > max_response_bytes:
+                        raise OidcHttpError(
+                            f"response from {url} exceeds the "
+                            f"{max_response_bytes}-byte cap"
+                        )
+    except httpx.HTTPError as exc:
+        raise OidcHttpError(f"fetch failed for {url}: {exc}") from exc
+    try:
+        return json.loads(body)
+    except ValueError as exc:
+        raise OidcHttpError(f"invalid JSON from {url}: {exc}") from exc

--- a/backend/app/services/auth/oidc/_http.py
+++ b/backend/app/services/auth/oidc/_http.py
@@ -50,20 +50,26 @@ async def fetch_json(
     """
     require_https(url)
     factory = client_factory or (lambda: httpx.AsyncClient(timeout=timeout_seconds))
+    body = bytearray()
+    # The cap is flagged and raised AFTER the stream context exits: raising inside
+    # it would leave our exception exposed to replacement by a teardown error from
+    # the abandoned body (the transport may fault when we stop reading mid-stream).
+    over_cap = False
     try:
         async with factory() as client:
             async with client.stream("GET", url) as resp:
                 resp.raise_for_status()
-                body = bytearray()
                 async for chunk in resp.aiter_bytes():
                     body.extend(chunk)
                     if len(body) > max_response_bytes:
-                        raise OidcHttpError(
-                            f"response from {url} exceeds the "
-                            f"{max_response_bytes}-byte cap"
-                        )
+                        over_cap = True
+                        break
     except httpx.HTTPError as exc:
         raise OidcHttpError(f"fetch failed for {url}: {exc}") from exc
+    if over_cap:
+        raise OidcHttpError(
+            f"response from {url} exceeds the {max_response_bytes}-byte cap"
+        )
     try:
         return json.loads(body)
     except ValueError as exc:

--- a/backend/app/services/auth/oidc/discovery.py
+++ b/backend/app/services/auth/oidc/discovery.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.services.auth.oidc._http import (
+    DEFAULT_HTTP_TIMEOUT_SECONDS,
+    DEFAULT_MAX_RESPONSE_BYTES,
     ClientFactory,
     OidcHttpError,
     fetch_json,
@@ -67,9 +69,13 @@ class OidcDiscovery:
         self,
         *,
         cache_ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        http_timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
         client_factory: ClientFactory | None = None,
     ) -> None:
         self._cache_ttl = cache_ttl_seconds
+        self._timeout = http_timeout_seconds
+        self._max_bytes = max_response_bytes
         self._client_factory = client_factory
         self._cache: dict[str, _CachedMetadata] = {}
         self._locks: dict[str, asyncio.Lock] = {}
@@ -94,7 +100,12 @@ class OidcDiscovery:
     async def _fetch(self, base_issuer: str) -> OidcMetadata:
         url = f"{base_issuer}{_WELL_KNOWN_SUFFIX}"
         try:
-            document = await fetch_json(url, client_factory=self._client_factory)
+            document = await fetch_json(
+                url,
+                client_factory=self._client_factory,
+                timeout_seconds=self._timeout,
+                max_response_bytes=self._max_bytes,
+            )
         except OidcHttpError as exc:
             raise DiscoveryError(f"discovery fetch failed: {exc}") from exc
         return _parse_metadata(document, expected_issuer=base_issuer)

--- a/backend/app/services/auth/oidc/discovery.py
+++ b/backend/app/services/auth/oidc/discovery.py
@@ -1,0 +1,156 @@
+"""OIDC provider discovery — fetch + validate ``.well-known/openid-configuration``.
+
+Turns a configured ``issuer`` into the endpoints the relying-party flow needs
+(authorization, token, JWKS). The security-relevant checks:
+
+* the discovery document is fetched over https under a size cap (shared
+  :mod:`app.services.auth.oidc._http`);
+* the ``issuer`` inside the document must equal the configured issuer — a
+  provider may not use its metadata to point trust at a different identity;
+* ``authorization_endpoint`` / ``token_endpoint`` / ``jwks_uri`` must be present
+  and https.
+
+Cached per issuer (metadata changes rarely); any failure raises
+:class:`DiscoveryError` (fail-closed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from app.services.auth.oidc._http import (
+    ClientFactory,
+    OidcHttpError,
+    fetch_json,
+    require_https,
+)
+
+DEFAULT_CACHE_TTL_SECONDS: float = 3600.0
+_WELL_KNOWN_SUFFIX = "/.well-known/openid-configuration"
+
+
+class DiscoveryError(Exception):
+    """Provider discovery failed; the flow cannot proceed (fail-closed)."""
+
+
+@dataclass(frozen=True)
+class OidcMetadata:
+    """The subset of discovery metadata the relying-party flow uses."""
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    jwks_uri: str
+    # Advertised id_token signing algs, if the provider lists them — lets the
+    # caller narrow the verifier's allowlist to what this provider actually uses.
+    id_token_signing_alg_values_supported: tuple[str, ...] | None = None
+
+
+@dataclass
+class _CachedMetadata:
+    metadata: OidcMetadata
+    fetched_at: float  # monotonic clock
+
+
+class OidcDiscovery:
+    """Fetches + caches provider discovery metadata.
+
+    Hold one instance per process (the cache is shared). The network client is
+    built per fetch via ``client_factory`` so tests can inject a
+    ``httpx.MockTransport`` without patching globals.
+    """
+
+    def __init__(
+        self,
+        *,
+        cache_ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        client_factory: ClientFactory | None = None,
+    ) -> None:
+        self._cache_ttl = cache_ttl_seconds
+        self._client_factory = client_factory
+        self._cache: dict[str, _CachedMetadata] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    async def fetch(self, issuer: str) -> OidcMetadata:
+        """Return the (cached) discovery metadata for ``issuer`` or raise
+        :class:`DiscoveryError`."""
+        base = _normalize_issuer(issuer)
+        cached = self._cache.get(base)
+        if cached is not None and self._fresh(cached):
+            return cached.metadata
+        async with self._lock_for(base):
+            cached = self._cache.get(base)  # double-check under the lock
+            if cached is not None and self._fresh(cached):
+                return cached.metadata
+            metadata = await self._fetch(base)
+            self._cache[base] = _CachedMetadata(
+                metadata=metadata, fetched_at=time.monotonic()
+            )
+            return metadata
+
+    async def _fetch(self, base_issuer: str) -> OidcMetadata:
+        url = f"{base_issuer}{_WELL_KNOWN_SUFFIX}"
+        try:
+            document = await fetch_json(url, client_factory=self._client_factory)
+        except OidcHttpError as exc:
+            raise DiscoveryError(f"discovery fetch failed: {exc}") from exc
+        return _parse_metadata(document, expected_issuer=base_issuer)
+
+    def _fresh(self, cached: _CachedMetadata) -> bool:
+        return (time.monotonic() - cached.fetched_at) < self._cache_ttl
+
+    def _lock_for(self, base_issuer: str) -> asyncio.Lock:
+        lock = self._locks.get(base_issuer)
+        if lock is None:
+            lock = self._locks.setdefault(base_issuer, asyncio.Lock())
+        return lock
+
+
+def _normalize_issuer(issuer: str) -> str:
+    base = issuer.strip()
+    if base.endswith(_WELL_KNOWN_SUFFIX):
+        base = base[: -len(_WELL_KNOWN_SUFFIX)]
+    return base.rstrip("/")
+
+
+def _parse_metadata(document: Any, *, expected_issuer: str) -> OidcMetadata:
+    if not isinstance(document, dict):
+        raise DiscoveryError("discovery document is not a JSON object")
+
+    # The issuer in the document must match the one we discovered against —
+    # otherwise a provider could point trust at an identity we didn't configure.
+    doc_issuer = document.get("issuer")
+    if (
+        not isinstance(doc_issuer, str)
+        or _normalize_issuer(doc_issuer) != expected_issuer
+    ):
+        raise DiscoveryError(
+            f"discovery issuer {doc_issuer!r} does not match {expected_issuer!r}"
+        )
+
+    endpoints = {}
+    for field in ("authorization_endpoint", "token_endpoint", "jwks_uri"):
+        value = document.get(field)
+        if not isinstance(value, str) or not value:
+            raise DiscoveryError(f"discovery document missing {field}")
+        try:
+            require_https(value)
+        except OidcHttpError as exc:
+            raise DiscoveryError(f"{field} is not https: {exc}") from exc
+        endpoints[field] = value
+
+    algs = document.get("id_token_signing_alg_values_supported")
+    alg_tuple: tuple[str, ...] | None = None
+    if isinstance(algs, list) and all(isinstance(a, str) for a in algs):
+        alg_tuple = tuple(algs)
+
+    return OidcMetadata(
+        issuer=expected_issuer,
+        authorization_endpoint=endpoints["authorization_endpoint"],
+        token_endpoint=endpoints["token_endpoint"],
+        jwks_uri=endpoints["jwks_uri"],
+        id_token_signing_alg_values_supported=alg_tuple,
+    )

--- a/backend/app/services/auth/oidc/discovery_test.py
+++ b/backend/app/services/auth/oidc/discovery_test.py
@@ -172,6 +172,16 @@ async def test_http_error_raises_discovery_error():
         await discovery.fetch(ISSUER)
 
 
+async def test_response_size_cap_passes_through():
+    """The per-instance size cap reaches the shared fetch, and the cap error
+    surfaces as itself (not masked into a generic fetch failure)."""
+    endpoint = _Endpoint(_json(_doc(padding="x" * 5000)))
+    discovery = OidcDiscovery(client_factory=endpoint.factory(), max_response_bytes=256)
+
+    with pytest.raises(DiscoveryError, match="byte cap"):
+        await discovery.fetch(ISSUER)
+
+
 # --- caching ----------------------------------------------------------------
 
 

--- a/backend/app/services/auth/oidc/discovery_test.py
+++ b/backend/app/services/auth/oidc/discovery_test.py
@@ -1,0 +1,193 @@
+"""Tests for OIDC provider discovery.
+
+Outbound fetches are stubbed with ``httpx.MockTransport`` (injected via
+``client_factory`` — no network), so metadata parsing, the issuer-match check,
+the https guards, and caching are exercised in isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from app.services.auth.oidc.discovery import (
+    DiscoveryError,
+    OidcDiscovery,
+)
+
+pytestmark = pytest.mark.unit
+
+ISSUER = "https://idp.example.com"
+
+
+def _doc(**overrides) -> dict:
+    doc = {
+        "issuer": ISSUER,
+        "authorization_endpoint": f"{ISSUER}/authorize",
+        "token_endpoint": f"{ISSUER}/token",
+        "jwks_uri": f"{ISSUER}/jwks",
+        "id_token_signing_alg_values_supported": ["RS256", "ES256"],
+    }
+    for key, value in overrides.items():
+        if value is None:
+            doc.pop(key, None)
+        else:
+            doc[key] = value
+    return doc
+
+
+class _Endpoint:
+    """A MockTransport handler that counts calls and can change its response."""
+
+    def __init__(self, response):
+        self.calls = 0
+        self._response = response
+
+    def set_response(self, response) -> None:
+        self._response = response
+
+    def factory(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.calls += 1
+            resp = self._response
+            return resp(request) if callable(resp) else resp
+
+        return lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _json(payload) -> httpx.Response:
+    return httpx.Response(200, json=payload)
+
+
+# --- happy path -------------------------------------------------------------
+
+
+async def test_fetches_and_parses_metadata():
+    endpoint = _Endpoint(_json(_doc()))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    meta = await discovery.fetch(ISSUER)
+    assert meta.issuer == ISSUER
+    assert meta.authorization_endpoint == f"{ISSUER}/authorize"
+    assert meta.token_endpoint == f"{ISSUER}/token"
+    assert meta.jwks_uri == f"{ISSUER}/jwks"
+    assert meta.id_token_signing_alg_values_supported == ("RS256", "ES256")
+
+
+async def test_requests_the_well_known_url():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        return _json(_doc())
+
+    discovery = OidcDiscovery(
+        client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    )
+    # A trailing slash on the configured issuer must not double up the path.
+    await discovery.fetch(f"{ISSUER}/")
+    assert seen["url"] == f"{ISSUER}/.well-known/openid-configuration"
+
+
+async def test_already_well_known_issuer_not_doubled():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        return _json(_doc())
+
+    discovery = OidcDiscovery(
+        client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    )
+    await discovery.fetch(f"{ISSUER}/.well-known/openid-configuration")
+    assert seen["url"] == f"{ISSUER}/.well-known/openid-configuration"
+
+
+async def test_missing_optional_algs_is_none():
+    endpoint = _Endpoint(_json(_doc(id_token_signing_alg_values_supported=None)))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    meta = await discovery.fetch(ISSUER)
+    assert meta.id_token_signing_alg_values_supported is None
+
+
+# --- issuer-match + validation ---------------------------------------------
+
+
+async def test_issuer_mismatch_rejected():
+    """A document that claims a different issuer must not be trusted."""
+    endpoint = _Endpoint(_json(_doc(issuer="https://evil.example.com")))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    with pytest.raises(DiscoveryError):
+        await discovery.fetch(ISSUER)
+
+
+@pytest.mark.parametrize(
+    "field", ["authorization_endpoint", "token_endpoint", "jwks_uri"]
+)
+async def test_missing_required_endpoint_rejected(field):
+    endpoint = _Endpoint(_json(_doc(**{field: None})))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    with pytest.raises(DiscoveryError):
+        await discovery.fetch(ISSUER)
+
+
+@pytest.mark.parametrize(
+    "field", ["authorization_endpoint", "token_endpoint", "jwks_uri"]
+)
+async def test_non_https_endpoint_rejected(field):
+    endpoint = _Endpoint(_json(_doc(**{field: "http://idp.example.com/x"})))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    with pytest.raises(DiscoveryError):
+        await discovery.fetch(ISSUER)
+
+
+async def test_non_https_issuer_refused_without_fetching():
+    endpoint = _Endpoint(_json(_doc()))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    with pytest.raises(DiscoveryError):
+        await discovery.fetch("http://idp.example.com")
+    assert endpoint.calls == 0
+
+
+async def test_non_object_document_rejected():
+    endpoint = _Endpoint(_json(["not", "an", "object"]))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    with pytest.raises(DiscoveryError):
+        await discovery.fetch(ISSUER)
+
+
+async def test_http_error_raises_discovery_error():
+    endpoint = _Endpoint(httpx.Response(500, text="down"))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    with pytest.raises(DiscoveryError):
+        await discovery.fetch(ISSUER)
+
+
+# --- caching ----------------------------------------------------------------
+
+
+async def test_metadata_cached_within_ttl():
+    endpoint = _Endpoint(_json(_doc()))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    await discovery.fetch(ISSUER)
+    await discovery.fetch(ISSUER)
+    assert endpoint.calls == 1
+
+
+async def test_concurrent_cold_fetches_make_one_request():
+    endpoint = _Endpoint(_json(_doc()))
+    discovery = OidcDiscovery(client_factory=endpoint.factory())
+
+    results = await asyncio.gather(*(discovery.fetch(ISSUER) for _ in range(8)))
+    assert all(m.token_endpoint == f"{ISSUER}/token" for m in results)
+    assert endpoint.calls == 1

--- a/backend/app/services/auth/oidc/jwks.py
+++ b/backend/app/services/auth/oidc/jwks.py
@@ -20,22 +20,21 @@ See the auth design doc for the rationale.
 from __future__ import annotations
 
 import asyncio
-import json
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
-from urllib.parse import urlsplit
 
-import httpx
 import jwt
+
+from app.services.auth.oidc._http import (
+    DEFAULT_HTTP_TIMEOUT_SECONDS,
+    DEFAULT_MAX_RESPONSE_BYTES,
+    ClientFactory,
+    OidcHttpError,
+    fetch_json,
+)
 
 DEFAULT_CACHE_TTL_SECONDS: float = 300.0
 DEFAULT_MIN_REFETCH_INTERVAL_SECONDS: float = 10.0
-DEFAULT_HTTP_TIMEOUT_SECONDS: float = 10.0
-# A JWKS is a few KiB; 512 KiB is generous headroom.
-DEFAULT_MAX_RESPONSE_BYTES: int = 512 * 1024
-
-ClientFactory = Callable[[], httpx.AsyncClient]
 
 
 class JwksResolutionError(Exception):
@@ -70,12 +69,9 @@ class JwksResolver:
         self._min_refetch_interval = min_refetch_interval_seconds
         self._timeout = http_timeout_seconds
         self._max_bytes = max_response_bytes
-        self._client_factory = client_factory or self._default_client_factory
+        self._client_factory = client_factory  # None → fetch_json builds a default
         self._cache: dict[str, _CachedKeySet] = {}
         self._locks: dict[str, asyncio.Lock] = {}
-
-    def _default_client_factory(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(timeout=self._timeout)
 
     async def resolve_signing_key(self, raw_token: str, *, jwks_uri: str) -> jwt.PyJWK:
         """Return the ``PyJWK`` for ``raw_token``'s ``kid`` from the JWKS at
@@ -148,35 +144,18 @@ class JwksResolver:
         return lock
 
     async def _fetch(self, jwks_uri: str) -> jwt.PyJWKSet:
-        _require_https(jwks_uri)
         try:
-            async with self._client_factory() as client:
-                async with client.stream("GET", jwks_uri) as resp:
-                    resp.raise_for_status()
-                    body = bytearray()
-                    async for chunk in resp.aiter_bytes():
-                        body.extend(chunk)
-                        if len(body) > self._max_bytes:
-                            raise JwksResolutionError(
-                                f"JWKS at {jwks_uri} exceeds the "
-                                f"{self._max_bytes}-byte cap"
-                            )
-        except httpx.HTTPError as exc:
+            data = await fetch_json(
+                jwks_uri,
+                client_factory=self._client_factory,
+                timeout_seconds=self._timeout,
+                max_response_bytes=self._max_bytes,
+            )
+            return jwt.PyJWKSet.from_dict(data)
+        except (OidcHttpError, jwt.PyJWTError) as exc:
             raise JwksResolutionError(
-                f"JWKS fetch failed for {jwks_uri}: {exc}"
+                f"could not load JWKS at {jwks_uri}: {exc}"
             ) from exc
-        try:
-            return jwt.PyJWKSet.from_dict(json.loads(body))
-        except (ValueError, jwt.PyJWTError) as exc:
-            raise JwksResolutionError(f"invalid JWKS at {jwks_uri}: {exc}") from exc
-
-
-def _require_https(jwks_uri: str) -> None:
-    # urlsplit lowercases the scheme, so ``HTTP`` etc. are covered; a missing host
-    # (``https://``) is refused too.
-    parts = urlsplit(jwks_uri)
-    if parts.scheme != "https" or not parts.netloc:
-        raise JwksResolutionError(f"refusing non-https JWKS URI: {jwks_uri!r}")
 
 
 def _select_key(key_set: jwt.PyJWKSet, kid: str | None) -> jwt.PyJWK | None:

--- a/backend/app/services/auth/oidc/jwks_test.py
+++ b/backend/app/services/auth/oidc/jwks_test.py
@@ -266,7 +266,8 @@ async def test_response_size_cap_enforced():
     resolver = JwksResolver(client_factory=endpoint.factory(), max_response_bytes=256)
     token = _sign(RSA1, kid="k1")
 
-    with pytest.raises(JwksResolutionError):
+    # The cap error surfaces as itself, not masked into a generic fetch failure.
+    with pytest.raises(JwksResolutionError, match="byte cap"):
         await resolver.resolve_signing_key(token, jwks_uri=JWKS_URI)
 
 


### PR DESCRIPTION
## Context

Part of the auth rewrite (Phase 0). Turns a configured `issuer` into the endpoints the relying-party flow needs — `authorization_endpoint`, `token_endpoint`, `jwks_uri` — from the provider's `.well-known/openid-configuration`. Completes the "fetch from the IdP over https" layer alongside the JWKS resolver (#829); the `OidcProvider` that composes discovery → PKCE/nonce → token exchange → resolver → verifier comes next. Still **dormant** (not wired to any endpoint).

## What it does

`OidcDiscovery.fetch(issuer)` returns an `OidcMetadata` (the endpoints + advertised id_token signing algs), with validation:

- **issuer match** — the `issuer` inside the document must equal the configured issuer, so a provider can't use its metadata to point trust at a different identity.
- **required https endpoints** — `authorization_endpoint`/`token_endpoint`/`jwks_uri` must be present and https.
- **cached per issuer** (metadata changes rarely), with a per-issuer lock so concurrent cold fetches collapse to one request.
- **fail-closed** — any failure raises `DiscoveryError`.

## Shared fetch helper (dedup)

Discovery and the JWKS resolver both need the same https + response-size-cap fetch, so I extracted it into one place — `app/services/auth/oidc/_http.py` (`fetch_json` + `require_https`) — and moved the resolver onto it. The network hardening now lives in a single audited spot instead of two copies. The resolver's behavior is unchanged (its 19 tests still pass); the shared helper raises `OidcHttpError`, which each caller wraps in its own domain error.

## Tests

`app/services/auth/oidc/discovery_test.py` — 16 tests via `httpx.MockTransport` (no network): parse + field extraction, well-known URL construction (trailing-slash / already-well-known), issuer-mismatch rejection, each missing/non-https endpoint, non-object body, non-https issuer refused without fetching, HTTP error, within-TTL caching, concurrent-fetch collapse.

`cd backend && pytest app/services/auth/oidc/` → 60 passed. `ruff` clean.

## Not in this PR
PKCE/state/nonce generation, `OidcProvider.begin/complete` (token exchange), identity resolution — next slice.