### PR TITLE
Add billing service integration endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Platform admins can set a per-guild user limit (default unlimited) from the admin dashboard's Guilds tab; at the cap, new joins/invites are refused while existing members stay, and SSO auto-provisioning is exempt.
 - Platform admins can set a per-guild lifecycle status (`active` / `read_only` / `suspended`) for billing/moderation holds — `read_only` blocks writes, `suspended` hides the guild from members while its admins keep full settings access. Non-active guilds pause trash auto-purge and block new joins; operators can still reach them via a break-glass grant. Reversible, never touches stored data.
 - Time-bound support/moderator access grants now act as a database-enforced `support` guild role: read grants are read-only, read_write grants can edit content/settings but are blocked from managing membership, roles, or sharing. Break-glass admin access is unchanged.
+- Optional integration endpoints for an external billing service (`POST /api/v1/billing/guild-tier`, `POST /api/v1/billing/headcount`): signed service-to-service requests can set a guild's tier label, storage/member caps, and lifecycle status, and read member counts, under a dedicated database role limited to exactly those columns and the one guild named per request. Disabled unless `BILLING_PUBLIC_KEY_PEM` and `BILLING_HMAC_SECRET` are configured — self-hosted installs are unaffected.
 
 ### Changed
 

--- a/backend/alembic/versions/20260708_0134_billing_boundary.py
+++ b/backend/alembic/versions/20260708_0134_billing_boundary.py
@@ -1,0 +1,199 @@
+"""billing integration: tier label, event log, jti blocklist, billing role
+
+Adds what the /billing endpoints need:
+
+* ``guilds.tier_name`` — display label of the paid tier (NULL = none), plus
+  non-negativity CHECKs on the billing-writable caps (NULL stays legal —
+  it means unlimited);
+* ``billing_event_log`` — idempotency claim (UNIQUE event id) and
+  append-only record of billing writes; no FK so rows outlive the guild;
+* ``billing_jti_blocklist`` — one-shot service-JWT jti redemption (the
+  ``auto_delegation_jti_blocklist`` pattern);
+* the NOLOGIN ``initiative_billing`` role the endpoints assume via
+  ``SET ROLE`` (INHERIT FALSE), with column-scoped grants and RLS policies
+  keyed on the per-request ``app.billing_guild_id`` GUC.
+
+The public schema default-grants platform_base + app_guild_base full DML on
+every new table, so both new tables REVOKE those; the login roles get
+nothing (see app/db/system_grants.py). Unused unless both
+BILLING_PUBLIC_KEY_PEM and BILLING_HMAC_SECRET are configured.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+from app.core.config import settings
+
+revision = "20260708_0134"
+down_revision = "20260706_0133"
+branch_labels = None
+depends_on = None
+
+
+def _billing_role() -> str:
+    # Cluster-global role; carries the same prefix as the platform ladder so
+    # test workers don't collide with a co-located dev DB's role.
+    return f"{settings.PLATFORM_ROLE_PREFIX}initiative_billing"
+
+
+def _platform_base() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+# Always NULLIF-guard the cast: an unset GUC yields '' and a bare ''::int
+# would fault every PERMISSIVE policy on the table.
+_BILLING_GUILD_ID = "NULLIF(current_setting('app.billing_guild_id', true), '')::int"
+
+
+def _run(statements: list[str]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    role = _billing_role()
+
+    # --- Display-only tier label (NULL = no paid tier) ------------------------
+    op.add_column("guilds", sa.Column("tier_name", sa.String(64), nullable=True))
+    op.create_check_constraint(
+        "ck_guilds_max_storage_bytes_nonnegative",
+        "guilds",
+        "max_storage_bytes IS NULL OR max_storage_bytes >= 0",
+    )
+    op.create_check_constraint(
+        "ck_guilds_max_users_nonnegative",
+        "guilds",
+        "max_users IS NULL OR max_users >= 0",
+    )
+
+    # --- billing_event_log: idempotency claim + append-only audit ------------
+    op.create_table(
+        "billing_event_log",
+        sa.Column("event_id", sa.String(128), primary_key=True),
+        # No FK: rows outlive the guild they describe.
+        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("op", sa.String(32), nullable=False),
+        sa.Column("source", sa.String(32), nullable=False),
+        sa.Column("actor", sa.String(128), nullable=True),
+        sa.Column("applied_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_billing_event_log_guild_id", "billing_event_log", ["guild_id"])
+
+    # --- billing_jti_blocklist: one-shot service-JWT redemption --------------
+    op.create_table(
+        "billing_jti_blocklist",
+        sa.Column("jti", sa.String(64), primary_key=True),
+        sa.Column("redeemed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    # --- The billing role: NOLOGIN, SET ROLE-only, column-scoped -------------
+    op.execute(
+        text(
+            f"""
+            DO $$ BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                    CREATE ROLE "{role}" NOLOGIN;
+                END IF;
+            END $$;
+            """
+        )
+    )
+    _run(
+        [
+            # Not a member of platform_base/app_guild_base — no inherited
+            # floor; USAGE only, grants explicit.
+            f'GRANT USAGE ON SCHEMA public TO "{role}"',
+            f"""
+            DO $$ BEGIN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+                    GRANT "{role}" TO app_user WITH INHERIT FALSE;
+                END IF;
+            END $$;
+            """,
+            f"GRANT SELECT (id, tier_name, max_storage_bytes, max_users, status), "
+            f"UPDATE (tier_name, max_storage_bytes, max_users, status, "
+            f'status_changed_at, updated_at) ON public.guilds TO "{role}"',
+            f'GRANT SELECT (guild_id) ON public.guild_memberships TO "{role}"',
+            # Append-only: INSERT is the only verb on the event log.
+            f'GRANT INSERT ON public.billing_event_log TO "{role}"',
+            f'GRANT SELECT, INSERT ON public.billing_jti_blocklist TO "{role}"',
+        ]
+    )
+
+    # --- RLS: scope billing statements to the per-request guild GUC ----------
+    # guild_select's membership-EXISTS leg is evaluated with the querying
+    # role's privileges, so scope it to the roles that use it (previously
+    # TO PUBLIC): the bare login role, the guild-role floor, and the
+    # platform-ladder floor (tiers inherit it).
+    op.execute(
+        f"ALTER POLICY guild_select ON public.guilds "
+        f'TO app_user, app_guild_base, "{_platform_base()}"'
+    )
+    _run(
+        [
+            f"CREATE POLICY billing_guild_select ON public.guilds FOR SELECT "
+            f'TO "{role}" USING (id = {_BILLING_GUILD_ID})',
+            f"CREATE POLICY billing_guild_update ON public.guilds FOR UPDATE "
+            f'TO "{role}" USING (id = {_BILLING_GUILD_ID}) '
+            f"WITH CHECK (id = {_BILLING_GUILD_ID})",
+            f"CREATE POLICY billing_membership_select ON public.guild_memberships "
+            f'FOR SELECT TO "{role}" USING (guild_id = {_BILLING_GUILD_ID})',
+            "ALTER TABLE public.billing_event_log ENABLE ROW LEVEL SECURITY",
+            "ALTER TABLE public.billing_event_log FORCE ROW LEVEL SECURITY",
+            f"CREATE POLICY billing_event_insert ON public.billing_event_log "
+            f'FOR INSERT TO "{role}" WITH CHECK (guild_id = {_BILLING_GUILD_ID})',
+        ]
+    )
+
+    # --- Strip the schema-default DML from the routed floors -----------------
+    base = _platform_base()
+    _run(
+        [
+            f'REVOKE ALL ON TABLE public.billing_event_log FROM app_guild_base, "{base}"',
+            f'REVOKE ALL ON TABLE public.billing_jti_blocklist FROM app_guild_base, "{base}"',
+            # System-engine decisions (see app/db/system_grants.py): auditors
+            # read the evidence via the ops surface; a janitor may prune
+            # expired jtis. Neither may mutate the event log.
+            "GRANT SELECT ON TABLE public.billing_event_log TO app_admin",
+            "GRANT SELECT, DELETE ON TABLE public.billing_jti_blocklist TO app_admin",
+        ]
+    )
+
+
+def downgrade() -> None:
+    role = _billing_role()
+    _run(
+        [
+            "ALTER POLICY guild_select ON public.guilds TO PUBLIC",
+            "DROP POLICY IF EXISTS billing_guild_select ON public.guilds",
+            "DROP POLICY IF EXISTS billing_guild_update ON public.guilds",
+            "DROP POLICY IF EXISTS billing_membership_select ON public.guild_memberships",
+            f'REVOKE ALL ON public.guilds FROM "{role}"',
+            f'REVOKE ALL ON public.guild_memberships FROM "{role}"',
+        ]
+    )
+    op.execute("DROP TABLE IF EXISTS public.billing_event_log CASCADE")
+    op.execute("DROP TABLE IF EXISTS public.billing_jti_blocklist CASCADE")
+    op.drop_constraint("ck_guilds_max_users_nonnegative", "guilds")
+    op.drop_constraint("ck_guilds_max_storage_bytes_nonnegative", "guilds")
+    op.drop_column("guilds", "tier_name")
+    op.execute(
+        text(
+            f"""
+            DO $$ BEGIN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                    REVOKE USAGE ON SCHEMA public FROM "{role}";
+                    BEGIN
+                        DROP ROLE "{role}";
+                    EXCEPTION WHEN dependent_objects_still_exist THEN
+                        -- Role is referenced from another database on the same
+                        -- cluster; leaving it is harmless (it holds nothing here).
+                        NULL;
+                    END;
+                END IF;
+            END $$;
+            """
+        )
+    )

--- a/backend/alembic/versions/20260708_0134_billing_boundary.py
+++ b/backend/alembic/versions/20260708_0134_billing_boundary.py
@@ -118,7 +118,7 @@ def upgrade() -> None:
             f'GRANT SELECT (guild_id) ON public.guild_memberships TO "{role}"',
             # Append-only: INSERT is the only verb on the event log.
             f'GRANT INSERT ON public.billing_event_log TO "{role}"',
-            f'GRANT SELECT, INSERT ON public.billing_jti_blocklist TO "{role}"',
+            f'GRANT INSERT ON public.billing_jti_blocklist TO "{role}"',
         ]
     )
 

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -37,6 +37,7 @@ from app.api.v1.platform_endpoints import (
     admin,
     ai_settings as platform_ai_settings,
     auth,
+    billing,
     config,
     guilds,
     native,
@@ -68,6 +69,8 @@ api_router.include_router(
     access_grants.router, prefix="/access-grants", tags=["access-grants"]
 )
 api_router.include_router(settings.router, prefix="/settings", tags=["settings"])
+# Service-to-service endpoints for the external billing service.
+api_router.include_router(billing.router, prefix="/billing", tags=["billing"])
 api_router.include_router(
     platform_ai_settings.platform_router, prefix="/settings", tags=["ai-settings"]
 )

--- a/backend/app/api/v1/platform_endpoints/billing.py
+++ b/backend/app/api/v1/platform_endpoints/billing.py
@@ -1,0 +1,122 @@
+"""Endpoints for the external billing service.
+
+Machine-to-machine: requests are verified by
+``app.services.platform.billing.verify_billing_envelope`` over the raw body
+before parsing, run under the ``initiative_billing`` database role scoped to
+the request's guild, and share one transaction (jti redemption, event-log
+claim, and write commit or roll back together). Not part of the OpenAPI
+schema; no user is ever resolved.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import ValidationError
+
+from app.api.deps import SessionDep
+from app.core.messages import BillingMessages
+from app.db.session import set_billing_context
+from app.schemas.platform.billing import (
+    BillingGuildTierApply,
+    BillingGuildTierRead,
+    BillingHeadcountRead,
+    BillingHeadcountRequest,
+)
+from app.services.platform import billing as billing_service
+from app.services.platform.billing import (
+    BillingEnvelopeError,
+    BillingGuildNotFoundError,
+    BillingReplayError,
+)
+
+router = APIRouter(include_in_schema=False)
+
+
+def _payload_error_code(exc: ValidationError) -> str:
+    """Surface a BILLING_* code raised by a model validator (e.g. the
+    support-source restriction) instead of the generic payload code."""
+    for error in exc.errors():
+        message = str(error.get("msg", ""))
+        for code in (
+            BillingMessages.SUPPORT_SOURCE_RESTRICTED,
+            BillingMessages.ACTOR_REQUIRED,
+        ):
+            if code in message:
+                return code
+    return BillingMessages.INVALID_PAYLOAD
+
+
+async def _verify_and_parse(request: Request, model):
+    """Envelope first, parse second (see module docstring)."""
+    body = await request.body()
+    try:
+        claims = billing_service.verify_billing_envelope(
+            method=request.method,
+            path=request.url.path,
+            headers=request.headers,
+            body=body,
+        )
+    except BillingEnvelopeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=exc.code
+        ) from exc
+    try:
+        payload = model.model_validate_json(body)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_payload_error_code(exc),
+        ) from exc
+    return claims, payload
+
+
+async def _burn_jti(session, claims) -> None:
+    try:
+        await billing_service.record_jti(
+            session, jti=claims.jti, expires_at=claims.expires_at
+        )
+    except BillingReplayError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=BillingMessages.REPLAYED_TOKEN,
+        ) from exc
+
+
+@router.post("/guild-tier", response_model=BillingGuildTierRead)
+async def apply_guild_tier(
+    request: Request, session: SessionDep
+) -> BillingGuildTierRead:
+    claims, payload = await _verify_and_parse(request, BillingGuildTierApply)
+    await set_billing_context(session, guild_id=payload.guild_id)
+    await _burn_jti(session, claims)
+    try:
+        result = await billing_service.apply_guild_tier(session, payload)
+    except BillingGuildNotFoundError as exc:
+        # Rolls back with the jti unredeemed and the event id unconsumed, so
+        # the delivery can be retried once the guild exists.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=BillingMessages.GUILD_NOT_FOUND,
+        ) from exc
+    await session.commit()
+    return result
+
+
+@router.post("/headcount", response_model=BillingHeadcountRead)
+async def guild_headcount(
+    request: Request, session: SessionDep
+) -> BillingHeadcountRead:
+    claims, payload = await _verify_and_parse(request, BillingHeadcountRequest)
+    await set_billing_context(session, guild_id=payload.guild_id)
+    await _burn_jti(session, claims)
+    try:
+        member_count = await billing_service.guild_member_count(
+            session, payload.guild_id
+        )
+    except BillingGuildNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=BillingMessages.GUILD_NOT_FOUND,
+        ) from exc
+    await session.commit()  # persist the one-shot jti redemption
+    return BillingHeadcountRead(guild_id=payload.guild_id, member_count=member_count)

--- a/backend/app/api/v1/platform_endpoints/billing_test.py
+++ b/backend/app/api/v1/platform_endpoints/billing_test.py
@@ -1,0 +1,423 @@
+"""Integration tests for the billing write boundary.
+
+Exercises the security properties of ``POST /api/v1/billing/*``:
+
+* the double envelope — HMAC over METHOD/PATH/TIMESTAMP/sha256(body) inside
+  a replay window, plus an RS256 service JWT with one-shot jti — with
+  negative tests for every layer (unconfigured, missing headers, stale or
+  tampered signatures, wrong key/aud/iss, replayed jti);
+* exactly-once application via the ``billing_event_log`` claim (a retried
+  event id is a no-op; a 404'd attempt does NOT consume its event id);
+* omit-vs-null sentinel semantics on the writable fields;
+* the support_manual source restriction (storage cap only, actor required);
+* the audit row recorded for every applied write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_lib
+import json
+import secrets
+import time
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core import config as config_module
+from app.models.platform.billing import BillingEventLog
+from app.testing import create_guild, create_guild_membership, create_user
+
+pytestmark = pytest.mark.integration
+
+_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_PEM = _keypair.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+_PUBLIC_PEM = (
+    _keypair.public_key()
+    .public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+_OTHER_KEYPAIR = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_OTHER_PRIVATE_PEM = _OTHER_KEYPAIR.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+
+_HMAC_SECRET = "test-billing-hmac-secret"
+
+
+@pytest.fixture(autouse=True)
+def _configure_billing(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", _PUBLIC_PEM)
+    monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET", _HMAC_SECRET)
+
+
+def _mint_token(
+    *,
+    jti: str | None = None,
+    aud: str = "initiative:billing",
+    iss: str = "initiative-billing",
+    private_pem: str = _PRIVATE_PEM,
+    expires_in: int = 300,
+) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "jti": jti or secrets.token_hex(8),
+        "sub": "initiative-billing",
+        "aud": aud,
+        "iss": iss,
+        "iat": int(now.timestamp()),
+        "exp": now + timedelta(seconds=expires_in),
+    }
+    return jwt.encode(payload, private_pem, algorithm="RS256")
+
+
+def _signed_headers(
+    path: str,
+    body: bytes,
+    *,
+    token: str | None = None,
+    secret: str = _HMAC_SECRET,
+    timestamp: str | None = None,
+    method: str = "POST",
+) -> dict[str, str]:
+    ts = timestamp if timestamp is not None else str(int(time.time()))
+    message = "\n".join([method, path, ts, hashlib.sha256(body).hexdigest()]).encode()
+    signature = hmac_lib.new(secret.encode(), message, hashlib.sha256).hexdigest()
+    return {
+        "Authorization": f"Bearer {token or _mint_token()}",
+        "X-Billing-Timestamp": ts,
+        "X-Billing-Signature": signature,
+        "Content-Type": "application/json",
+    }
+
+
+async def _post(client: AsyncClient, endpoint: str, payload: dict, **overrides):
+    path = f"/api/v1/billing/{endpoint}"
+    body = json.dumps(payload).encode()
+    headers = _signed_headers(path, body, **overrides)
+    return await client.post(path, content=body, headers=headers)
+
+
+def _tier_payload(guild_id: int, **fields) -> dict:
+    return {
+        "guild_id": guild_id,
+        "event_id": fields.pop("event_id", f"evt-{secrets.token_hex(6)}"),
+        "source": fields.pop("source", "paddle_webhook"),
+        **fields,
+    }
+
+
+# --- Envelope verification ---------------------------------------------------
+
+
+async def test_unconfigured_boundary_refuses_everything(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", None)
+    guild = await create_guild(session)
+    response = await _post(client, "guild-tier", _tier_payload(guild.id))
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_NOT_CONFIGURED"
+
+
+async def test_missing_envelope_headers_rejected(
+    client: AsyncClient, session: AsyncSession
+):
+    guild = await create_guild(session)
+    body = json.dumps(_tier_payload(guild.id)).encode()
+    response = await client.post(
+        "/api/v1/billing/guild-tier",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_MISSING_SIGNATURE"
+
+
+async def test_stale_timestamp_rejected(client: AsyncClient, session: AsyncSession):
+    guild = await create_guild(session)
+    stale = str(int(time.time()) - 3600)
+    response = await _post(
+        client, "guild-tier", _tier_payload(guild.id), timestamp=stale
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_STALE_TIMESTAMP"
+
+
+async def test_wrong_hmac_secret_rejected(client: AsyncClient, session: AsyncSession):
+    guild = await create_guild(session)
+    response = await _post(
+        client, "guild-tier", _tier_payload(guild.id), secret="wrong-secret"
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_INVALID_SIGNATURE"
+
+
+async def test_tampered_body_rejected(client: AsyncClient, session: AsyncSession):
+    """A signature minted for one body must not authorize a different one."""
+    guild = await create_guild(session)
+    path = "/api/v1/billing/guild-tier"
+    signed_body = json.dumps(_tier_payload(guild.id, tier_name="silver")).encode()
+    headers = _signed_headers(path, signed_body)
+    tampered = json.dumps(_tier_payload(guild.id, tier_name="platinum")).encode()
+    response = await client.post(path, content=tampered, headers=headers)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_INVALID_SIGNATURE"
+
+
+async def test_wrong_jwt_key_rejected(client: AsyncClient, session: AsyncSession):
+    guild = await create_guild(session)
+    token = _mint_token(private_pem=_OTHER_PRIVATE_PEM)
+    response = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
+
+
+@pytest.mark.parametrize(
+    "claim_overrides",
+    [{"aud": "initiative:auto-delegation"}, {"iss": "someone-else"}],
+)
+async def test_wrong_audience_or_issuer_rejected(
+    client: AsyncClient, session: AsyncSession, claim_overrides: dict
+):
+    guild = await create_guild(session)
+    token = _mint_token(**claim_overrides)
+    response = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
+
+
+async def test_jti_is_one_shot(client: AsyncClient, session: AsyncSession):
+    """The same service JWT must not authorize two calls, even with distinct
+    event ids and fresh signatures."""
+    guild = await create_guild(session)
+    token = _mint_token(jti="billing-replay-001")
+
+    first = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    assert first.status_code == 200, first.text
+
+    second = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    assert second.status_code == 403
+    assert second.json()["detail"] == "BILLING_REPLAYED_TOKEN"
+
+
+# --- guild-tier ----------------------------------------------------------------
+
+
+async def test_apply_guild_tier_happy_path(client: AsyncClient, session: AsyncSession):
+    guild = await create_guild(session)
+    response = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(
+            guild.id,
+            event_id="evt-happy-1",
+            tier_name="gold",
+            max_storage_bytes=50 * 1024**3,
+            max_users=25,
+        ),
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["applied"] is True
+    assert data["tier_name"] == "gold"
+    assert data["max_storage_bytes"] == 50 * 1024**3
+    assert data["max_users"] == 25
+    assert data["status"] == "active"
+    assert data["member_count"] == 0  # the factory creates no membership rows
+
+    await session.refresh(guild)
+    assert guild.tier_name == "gold"
+    assert guild.max_storage_bytes == 50 * 1024**3
+    assert guild.max_users == 25
+
+    event = (
+        await session.exec(
+            select(BillingEventLog).where(BillingEventLog.event_id == "evt-happy-1")
+        )
+    ).one()
+    assert event.guild_id == guild.id
+    assert event.op == "guild_tier"
+    assert event.source == "paddle_webhook"
+    assert event.actor is None
+
+
+async def test_replayed_event_id_is_noop(client: AsyncClient, session: AsyncSession):
+    """Same event id, fresh token: claimed once, second delivery changes
+    nothing even though it carries different values."""
+    guild = await create_guild(session)
+    first = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, event_id="evt-dup", tier_name="gold"),
+    )
+    assert first.status_code == 200 and first.json()["applied"] is True
+
+    second = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, event_id="evt-dup", tier_name="platinum"),
+    )
+    assert second.status_code == 200
+    data = second.json()
+    assert data["applied"] is False
+    assert data["tier_name"] == "gold"  # untouched by the replay
+
+    await session.refresh(guild)
+    assert guild.tier_name == "gold"
+
+
+async def test_sentinel_semantics_omit_vs_null(
+    client: AsyncClient, session: AsyncSession
+):
+    guild = await create_guild(session)
+    setup = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, tier_name="gold", max_storage_bytes=1024, max_users=10),
+    )
+    assert setup.status_code == 200
+
+    # Omitted fields stay; null resets to unlimited.
+    response = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, max_storage_bytes=None),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tier_name"] == "gold"  # omitted -> untouched
+    assert data["max_users"] == 10  # omitted -> untouched
+    assert data["max_storage_bytes"] is None  # null -> unlimited
+
+
+async def test_status_change_stamps_status_changed_at(
+    client: AsyncClient, session: AsyncSession
+):
+    guild = await create_guild(session)
+    assert guild.status_changed_at is None
+    response = await _post(
+        client, "guild-tier", _tier_payload(guild.id, status="read_only")
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "read_only"
+
+    await session.refresh(guild)
+    assert guild.status == "read_only"
+    assert guild.status_changed_at is not None
+
+
+async def test_support_source_may_only_raise_storage(
+    client: AsyncClient, session: AsyncSession
+):
+    guild = await create_guild(session)
+
+    allowed = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(
+            guild.id,
+            source="support_manual",
+            actor="support:42",
+            max_storage_bytes=2048,
+        ),
+    )
+    assert allowed.status_code == 200, allowed.text
+    assert allowed.json()["max_storage_bytes"] == 2048
+
+    tier_change = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(
+            guild.id, source="support_manual", actor="support:42", tier_name="gold"
+        ),
+    )
+    assert tier_change.status_code == 422
+    assert tier_change.json()["detail"] == "BILLING_SUPPORT_SOURCE_RESTRICTED"
+
+    anonymous = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, source="support_manual", max_storage_bytes=4096),
+    )
+    assert anonymous.status_code == 422
+    assert anonymous.json()["detail"] == "BILLING_ACTOR_REQUIRED"
+
+
+async def test_unknown_guild_404_does_not_consume_event_id(
+    client: AsyncClient, session: AsyncSession
+):
+    guild = await create_guild(session)
+    missing = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(999_999_999, event_id="evt-preserved", tier_name="gold"),
+    )
+    assert missing.status_code == 404
+    assert missing.json()["detail"] == "BILLING_GUILD_NOT_FOUND"
+
+    retry = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, event_id="evt-preserved", tier_name="gold"),
+    )
+    assert retry.status_code == 200, retry.text
+    assert retry.json()["applied"] is True
+
+
+async def test_malformed_payload_rejected_after_verification(
+    client: AsyncClient, session: AsyncSession
+):
+    path = "/api/v1/billing/guild-tier"
+    body = b'{"guild_id": "not-a-number"}'
+    headers = _signed_headers(path, body)
+    response = await client.post(path, content=body, headers=headers)
+    assert response.status_code == 422
+    assert response.json()["detail"] == "BILLING_INVALID_PAYLOAD"
+
+
+# --- headcount ------------------------------------------------------------------
+
+
+async def test_headcount(client: AsyncClient, session: AsyncSession):
+    guild = await create_guild(session)
+    for i in range(2):
+        member = await create_user(session, email=f"member{i}@example.com")
+        await create_guild_membership(session, user=member, guild=guild)
+
+    response = await _post(client, "headcount", {"guild_id": guild.id})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"guild_id": guild.id, "member_count": 2}
+
+
+async def test_headcount_unknown_guild_404(client: AsyncClient, session: AsyncSession):
+    response = await _post(client, "headcount", {"guild_id": 999_999_999})
+    assert response.status_code == 404
+    assert response.json()["detail"] == "BILLING_GUILD_NOT_FOUND"
+
+
+async def test_headcount_burns_jti(client: AsyncClient, session: AsyncSession):
+    """Reads redeem their token too — a captured headcount request must not
+    be replayable inside the window."""
+    guild = await create_guild(session)
+    token = _mint_token(jti="billing-read-replay")
+    first = await _post(client, "headcount", {"guild_id": guild.id}, token=token)
+    assert first.status_code == 200
+    second = await _post(client, "headcount", {"guild_id": guild.id}, token=token)
+    assert second.status_code == 403
+    assert second.json()["detail"] == "BILLING_REPLAYED_TOKEN"

--- a/backend/app/api/v1/platform_endpoints/billing_test.py
+++ b/backend/app/api/v1/platform_endpoints/billing_test.py
@@ -216,6 +216,16 @@ async def test_jti_is_one_shot(client: AsyncClient, session: AsyncSession):
     assert second.json()["detail"] == "BILLING_REPLAYED_TOKEN"
 
 
+async def test_oversized_jti_rejected(client: AsyncClient, session: AsyncSession):
+    """A jti longer than the blocklist column must be refused at
+    verification, not surface as a database error at redemption."""
+    guild = await create_guild(session)
+    token = _mint_token(jti="x" * 65)
+    response = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
+
+
 # --- guild-tier ----------------------------------------------------------------
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -519,7 +519,7 @@ class Settings(BaseSettings):
     BILLING_AUDIENCE: str = "initiative:billing"
     BILLING_ISSUER: str = "initiative-billing"
     # Max |now - signed timestamp| accepted, in seconds. Never 0.
-    BILLING_REPLAY_WINDOW_SECONDS: int = 300
+    BILLING_REPLAY_WINDOW_SECONDS: int = Field(default=300, ge=1)
 
     # Local-dev escape hatch for the webhook SSRF guard. When TRUE, the
     # dispatcher accepts ``http://`` and private/loopback/link-local

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -509,6 +509,18 @@ class Settings(BaseSettings):
     AUTO_DELEGATION_AUDIENCE: str = "initiative:auto-delegation"
     AUTO_DELEGATION_ISSUER: str = "initiative-auto"
 
+    # Inbound calls from the billing service (initiative-billing). Requests
+    # carry an RS256 service JWT (verified against this public key) plus an
+    # HMAC-SHA256 over METHOD\nPATH\nTIMESTAMP\nsha256(body) keyed by the
+    # shared secret. Both must be configured or the /billing endpoints
+    # refuse every request.
+    BILLING_PUBLIC_KEY_PEM: str | None = None
+    BILLING_HMAC_SECRET: str | None = None
+    BILLING_AUDIENCE: str = "initiative:billing"
+    BILLING_ISSUER: str = "initiative-billing"
+    # Max |now - signed timestamp| accepted, in seconds. Never 0.
+    BILLING_REPLAY_WINDOW_SECONDS: int = 300
+
     # Local-dev escape hatch for the webhook SSRF guard. When TRUE, the
     # dispatcher accepts ``http://`` and private/loopback/link-local
     # targets — needed only for round-tripping with auto running on

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -441,3 +441,23 @@ class AIMessages:
 
 class NativeMessages:
     OTA_BUNDLE_NOT_AVAILABLE = "NATIVE_OTA_BUNDLE_NOT_AVAILABLE"
+
+
+class BillingMessages:
+    """Codes for the service-to-service billing write boundary.
+
+    These endpoints are machine-to-machine (the billing service, not the
+    SPA), so the codes are consumed by the caller's logs/retry logic rather
+    than errors.json.
+    """
+
+    NOT_CONFIGURED = "BILLING_NOT_CONFIGURED"
+    MISSING_SIGNATURE = "BILLING_MISSING_SIGNATURE"
+    STALE_TIMESTAMP = "BILLING_STALE_TIMESTAMP"
+    INVALID_SIGNATURE = "BILLING_INVALID_SIGNATURE"
+    INVALID_TOKEN = "BILLING_INVALID_TOKEN"
+    REPLAYED_TOKEN = "BILLING_REPLAYED_TOKEN"
+    INVALID_PAYLOAD = "BILLING_INVALID_PAYLOAD"
+    GUILD_NOT_FOUND = "BILLING_GUILD_NOT_FOUND"
+    SUPPORT_SOURCE_RESTRICTED = "BILLING_SUPPORT_SOURCE_RESTRICTED"
+    ACTOR_REQUIRED = "BILLING_ACTOR_REQUIRED"

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -53,6 +53,7 @@ from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.user_token import UserToken
 from app.models.platform.push_token import PushToken
 from app.models.platform.auto_delegation_jti import AutoDelegationJti
+from app.models.platform.billing import BillingEventLog, BillingJti
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.models.tenant.webhook_subscription import WebhookSubscription
 from app.models.tenant.resource_grant import ResourceGrant
@@ -113,6 +114,8 @@ __all__ = [
     "UserToken",
     "PushToken",
     "AutoDelegationJti",
+    "BillingEventLog",
+    "BillingJti",
     "TaskAssignmentDigestItem",
     "WebhookSubscription",
 ]

--- a/backend/app/db/billing_role_test.py
+++ b/backend/app/db/billing_role_test.py
@@ -1,0 +1,148 @@
+"""Least-privilege probes for the ``initiative_billing`` Postgres role.
+
+The billing write boundary's authorization lives in the database — a
+column-scoped role pinned to one guild per request by the
+``app.billing_guild_id`` GUC. These tests connect as the real ``app_user``
+login role, assume the billing context exactly as the endpoints do
+(``set_billing_context``), and assert the role is denied everything outside
+its four verbs:
+
+* columns beyond the tier/cap surface of ``guilds`` (name, description, …);
+* member identities (``guild_memberships.user_id``) — headcount only;
+* any other shared table (``users`` is the canary);
+* rows of any guild other than the pinned one (RLS, both read and write);
+* mutating the append-only ``billing_event_log``.
+
+This is the SOC 2 "isolation probe" the write-boundary plan calls for: the
+grants are the boundary, so the suite fails if a migration ever widens them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.session import set_billing_context
+from app.testing import create_guild, create_guild_membership
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def _denied(billing_session, sql: str) -> None:
+    """The statement must die at the Postgres privilege/policy layer."""
+    with pytest.raises(DBAPIError):
+        await billing_session.execute(text(sql))
+    # A privilege error aborts the transaction; recover for the next probe
+    # (the stored billing context replays on the next autobegin).
+    await billing_session.rollback()
+
+
+@pytest.fixture
+async def guilds(session):
+    guild_a = await create_guild(session, name="Billing Probe A")
+    guild_b = await create_guild(session, name="Billing Probe B")
+    await create_guild_membership(session, guild=guild_a)
+    return guild_a, guild_b
+
+
+async def test_billing_role_is_confined_to_its_column_and_guild_surface(
+    session, role_session, guilds
+):
+    guild_a, guild_b = guilds
+    s = await role_session("app_user")
+    await set_billing_context(s, guild_id=guild_a.id)
+
+    # --- Positive controls: the four legitimate verbs work ------------------
+    row = (
+        await s.execute(
+            text(
+                "SELECT id, tier_name, max_storage_bytes, max_users, status "
+                "FROM guilds WHERE id = :gid"
+            ),
+            {"gid": guild_a.id},
+        )
+    ).one()
+    assert row.id == guild_a.id
+
+    updated = await s.execute(
+        text("UPDATE guilds SET tier_name = 'gold' WHERE id = :gid"),
+        {"gid": guild_a.id},
+    )
+    assert updated.rowcount == 1
+
+    count = (
+        await s.execute(
+            text("SELECT count(guild_id) FROM guild_memberships WHERE guild_id = :gid"),
+            {"gid": guild_a.id},
+        )
+    ).scalar_one()
+    assert count == 1
+
+    await s.execute(
+        text(
+            "INSERT INTO billing_event_log (event_id, guild_id, op, source, applied_at) "
+            "VALUES ('probe-evt-a', :gid, 'guild_tier', 'paddle_webhook', now())"
+        ),
+        {"gid": guild_a.id},
+    )
+    await s.rollback()  # leave no probe state behind
+
+    # --- Column confinement: nothing beyond the tier/cap surface ------------
+    await set_billing_context(s, guild_id=guild_a.id)
+    await _denied(s, f"SELECT name FROM guilds WHERE id = {guild_a.id}")
+    await _denied(s, f"SELECT description FROM guilds WHERE id = {guild_a.id}")
+    await _denied(s, f"SELECT created_by_user_id FROM guilds WHERE id = {guild_a.id}")
+    await _denied(s, f"UPDATE guilds SET name = 'pwned' WHERE id = {guild_a.id}")
+    await _denied(s, "SELECT user_id FROM guild_memberships")
+    await _denied(s, "SELECT id FROM users")
+    await _denied(s, "DELETE FROM guilds WHERE id = 999999")
+    await _denied(s, "INSERT INTO guilds (name) VALUES ('forged')")
+
+    # --- Append-only evidence: INSERT is the only verb ----------------------
+    await _denied(s, "SELECT event_id FROM billing_event_log")
+    await _denied(s, "UPDATE billing_event_log SET actor = 'x'")
+    await _denied(s, "DELETE FROM billing_event_log")
+
+    # --- Guild pinning: the GUC's guild is the whole visible world ----------
+    invisible = (
+        await s.execute(
+            text("SELECT id FROM guilds WHERE id = :gid"), {"gid": guild_b.id}
+        )
+    ).one_or_none()
+    assert invisible is None, "RLS must hide every guild but the pinned one"
+
+    cross_update = await s.execute(
+        text("UPDATE guilds SET tier_name = 'stolen' WHERE id = :gid"),
+        {"gid": guild_b.id},
+    )
+    assert cross_update.rowcount == 0
+
+    cross_count = (
+        await s.execute(
+            text("SELECT count(guild_id) FROM guild_memberships WHERE guild_id = :gid"),
+            {"gid": guild_b.id},
+        )
+    ).scalar_one()
+    assert cross_count == 0
+
+    # Audit rows can only claim the pinned guild (RLS WITH CHECK).
+    await _denied(
+        s,
+        "INSERT INTO billing_event_log (event_id, guild_id, op, source, applied_at) "
+        f"VALUES ('probe-evt-b', {guild_b.id}, 'guild_tier', 'paddle_webhook', now())",
+    )
+    await s.rollback()
+
+
+async def test_unpinned_billing_guc_sees_nothing(session, role_session, guilds):
+    """Fail-closed: with the billing role assumed but NO guild pinned (an
+    impossible state for the endpoints, which derive the GUC from the
+    verified body), every row is invisible."""
+    guild_a, _ = guilds
+    s = await role_session("app_user")
+    await set_billing_context(s, guild_id=guild_a.id)
+    # Clear the pin within the transaction, keeping the role.
+    await s.execute(text("SELECT set_config('app.billing_guild_id', '', true)"))
+    visible = (await s.execute(text("SELECT id FROM guilds"))).all()
+    assert visible == []

--- a/backend/app/db/billing_role_test.py
+++ b/backend/app/db/billing_role_test.py
@@ -103,6 +103,8 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
     await _denied(s, "SELECT event_id FROM billing_event_log")
     await _denied(s, "UPDATE billing_event_log SET actor = 'x'")
     await _denied(s, "DELETE FROM billing_event_log")
+    await _denied(s, "SELECT jti FROM billing_jti_blocklist")
+    await _denied(s, "DELETE FROM billing_jti_blocklist")
 
     # --- Guild pinning: the GUC's guild is the whole visible world ----------
     invisible = (

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -113,6 +113,13 @@ def platform_role_name(role: str) -> str:
     return f"{settings.PLATFORM_ROLE_PREFIX}platform_{role}"
 
 
+def billing_role_name() -> str:
+    """Cluster-global Postgres role the billing-service endpoints assume
+    (created by migration 0134). Shares ``settings.PLATFORM_ROLE_PREFIX``
+    because it is cluster-global like the platform ladder."""
+    return f"{settings.PLATFORM_ROLE_PREFIX}initiative_billing"
+
+
 @dataclass(frozen=True)
 class ProvisioningBundle:
     """The per-process render of everything provisioning applies.

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -39,6 +39,7 @@ _RLS_SHARED_TABLES = {
     "auth_provider_secrets",
     "auth_providers",
     "auth_sessions",
+    "billing_event_log",
     "federated_identities",
     "guild_invites",
     "guild_memberships",
@@ -51,7 +52,11 @@ _RLS_SHARED_TABLES = {
 
 def _app_role_family() -> list[str]:
     """The fixed app roles plus this worker's prefixed platform ladder."""
-    from app.db.schema_provisioning import PLATFORM_TIERS, platform_role_name
+    from app.db.schema_provisioning import (
+        PLATFORM_TIERS,
+        billing_role_name,
+        platform_role_name,
+    )
 
     return [
         "app_user",
@@ -59,6 +64,7 @@ def _app_role_family() -> list[str]:
         "app_guild_base",
         f"{settings.PLATFORM_ROLE_PREFIX}platform_base",
         *(platform_role_name(t) for t in PLATFORM_TIERS),
+        billing_role_name(),
     ]
 
 
@@ -197,7 +203,8 @@ async def test_login_role_memberships_in_scoped_roles_are_inherit_false(engine):
                     "JOIN pg_roles m ON m.oid = am.member "
                     "JOIN pg_roles r ON r.oid = am.roleid "
                     "WHERE m.rolname IN ('app_user', 'app_admin') "
-                    "AND (r.rolname LIKE '%guild\\_%' OR r.rolname LIKE '%platform\\_%')"
+                    "AND (r.rolname LIKE '%guild\\_%' OR r.rolname LIKE '%platform\\_%' "
+                    "OR r.rolname LIKE '%initiative\\_billing')"
                 )
             )
         ).all()

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -119,6 +119,7 @@ _CONTEXT_SQL = (
     "set_config('app.pam_guild_id', :pgid, true), "
     "set_config('app.pam_read', :pr, true), "
     "set_config('app.pam_write', :pw, true), "
+    "set_config('app.billing_guild_id', :bgid, true), "
     "set_config('search_path', :sp, true), "
     "set_config('role', :role, true)"
 )
@@ -138,6 +139,25 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
     pam_write = bool(params.get("pam_write"))
     platform_role = params.get("platform_role")
     read_only = bool(params.get("read_only"))
+    billing_guild_id = params.get("billing_guild_id")
+
+    # Billing-service path (set_billing_context): assumes the
+    # initiative_billing role with only the billing GUC set — no
+    # user/guild/PAM context.
+    if billing_guild_id is not None:
+        from app.db.schema_provisioning import billing_role_name
+
+        return {
+            "uid": "",
+            "gid": "",
+            "grole": "",
+            "pgid": "",
+            "pr": "false",
+            "pw": "false",
+            "bgid": str(int(billing_guild_id)),
+            "sp": "public",
+            "role": billing_role_name(),
+        }
 
     # Route guild-scoped tables to the active guild's schema AND assume that
     # guild's role. The login role has no standing access to any guild schema
@@ -192,6 +212,7 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
         "pgid": str(int(pam_guild_id)) if pam_guild_id is not None else "",
         "pr": "true" if pam_read else "false",
         "pw": "true" if pam_write else "false",
+        "bgid": "",
         "sp": sp,
         "role": role_target,
     }
@@ -307,6 +328,22 @@ async def set_rls_context(
     # hook has already fired and the new context must land NOW. On a fresh
     # session, the caller's first statement autobegins and the hook applies
     # the stored params; applying here too would just do it twice.
+    if session.in_transaction():
+        await _apply_stored_context(session)
+
+
+async def set_billing_context(session: AsyncSession, *, guild_id: int) -> None:
+    """Route a verified billing-service request — transaction-local.
+
+    Assumes the ``initiative_billing`` role and sets ``app.billing_guild_id``
+    to the guild named in the verified request (see
+    ``app.services.platform.billing``), which the role's RLS policies key on.
+    Carries no user identity, so the ``RLS_CONTEXT_MAX_AGE_SECONDS`` freshness
+    bound does not apply. Same storage/replay mechanics as
+    :func:`set_rls_context`.
+    """
+    session.info[_RLS_PARAMS_INFO_KEY] = {"billing_guild_id": int(guild_id)}
+    session.info[_RLS_ESTABLISHED_INFO_KEY] = time.monotonic()
     if session.in_transaction():
         await _apply_stored_context(session)
 

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -96,6 +96,12 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     "push_tokens": frozenset({"SELECT", "INSERT", "DELETE"}),
     "user_api_keys": frozenset({"SELECT", "DELETE"}),
     "auto_delegation_jti_blocklist": frozenset({"SELECT", "INSERT"}),
+    # billing boundary: writes happen ONLY under the dedicated (SET ROLE)
+    # initiative_billing role, never the system engine. app_admin keeps
+    # read-only visibility into the append-only evidence, and may prune
+    # expired jtis (janitor); neither may mutate the event log.
+    "billing_event_log": frozenset({"SELECT"}),
+    "billing_jti_blocklist": frozenset({"SELECT", "DELETE"}),
     # migrations-only bookkeeping (the provisioning role owns it)
     "alembic_version": None,
 }
@@ -128,6 +134,10 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     "oidc_claim_mappings": None,
     "push_tokens": None,
     "user_view_preferences": None,
+    # billing tables are reached only via SET ROLE initiative_billing — the
+    # bare login role holds nothing (fail-closed, like the guild schemas)
+    "billing_event_log": None,
+    "billing_jti_blocklist": None,
     "alembic_version": None,
 }
 

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -78,6 +78,9 @@ SHARED_TABLES: frozenset[str] = frozenset(
         "app_settings",  # OIDC / SMTP / branding config
         "access_grants",  # PAM — inherently cross-guild (request -> approve -> scoped)
         "notifications",  # per-user inbox spanning guilds (carries guild_id after split)
+        # Billing write boundary (external billing service, initiative_billing role)
+        "billing_event_log",  # idempotency claim + append-only audit; weak guild ref
+        "billing_jti_blocklist",  # one-shot billing service-JWT redemption
     }
 )
 

--- a/backend/app/models/platform/billing.py
+++ b/backend/app/models/platform/billing.py
@@ -1,0 +1,45 @@
+"""Shared tables backing the external billing service integration.
+
+``BillingEventLog`` is the idempotency claim (UNIQUE ``event_id``, claimed
+before the work) and the append-only, actor-attributed record of billing
+writes. ``guild_id`` is a weak reference (no FK) so rows outlive the guild.
+
+``BillingJti`` is the one-shot redemption blocklist for billing service
+JWTs, mirroring ``auto_delegation_jti_blocklist``. ``expires_at`` mirrors
+the JWT ``exp`` so a janitor can prune old rows.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, Integer, String
+from sqlmodel import Field, SQLModel
+
+
+class BillingEventLog(SQLModel, table=True):
+    __tablename__ = "billing_event_log"
+
+    event_id: str = Field(sa_column=Column(String(length=128), primary_key=True))
+    guild_id: int = Field(sa_column=Column(Integer, nullable=False, index=True))
+    op: str = Field(sa_column=Column(String(length=32), nullable=False))
+    source: str = Field(sa_column=Column(String(length=32), nullable=False))
+    actor: Optional[str] = Field(
+        default=None, sa_column=Column(String(length=128), nullable=True)
+    )
+    applied_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False)
+    )
+
+
+class BillingJti(SQLModel, table=True):
+    __tablename__ = "billing_jti_blocklist"
+
+    jti: str = Field(sa_column=Column(String(length=64), primary_key=True))
+    redeemed_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False)
+    )
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False)
+    )

--- a/backend/app/models/platform/guild.py
+++ b/backend/app/models/platform/guild.py
@@ -61,6 +61,9 @@ class Guild(SQLModel, table=True):
     max_users: Optional[int] = Field(
         default=None, sa_column=Column(Integer, nullable=True)
     )
+    tier_name: Optional[str] = Field(
+        default=None, sa_column=Column(String(64), nullable=True)
+    )
     # Lifecycle status (see GuildStatus). Stored as a plain string with a CHECK
     # constraint (the access_grants pattern) rather than a Postgres enum.
     status: str = Field(

--- a/backend/app/schemas/platform/billing.py
+++ b/backend/app/schemas/platform/billing.py
@@ -1,0 +1,88 @@
+"""Payloads for the billing service endpoints.
+
+Parsed manually from the verified request body (see
+``app.services.platform.billing``) rather than by FastAPI's body machinery;
+excluded from the OpenAPI schema.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import Field, model_validator
+
+from app.core.messages import BillingMessages
+from app.models.platform.guild import GuildStatus
+from app.schemas.base import SanitizedBaseModel
+
+# Who initiated the write, recorded verbatim in billing_event_log.
+# support_manual is the human support path: storage cap only, actor required.
+BillingSource = Literal["paddle_webhook", "platinum_invoice", "support_manual"]
+
+
+class BillingGuildTierApply(SanitizedBaseModel):
+    """Body of ``POST /billing/guild-tier``.
+
+    Tier *definitions* live in the billing service's own database; what
+    crosses this boundary is only the display label (``tier_name``) and the
+    **computed** caps initiative already owns (``max_storage_bytes`` /
+    ``max_users``), plus the lifecycle ``status``.
+
+    The writable fields use omit-to-skip sentinel semantics (the service
+    inspects ``model_fields_set``): omit a field to leave it untouched, send
+    ``null`` to reset it to unlimited (or, for ``tier_name``, to no paid
+    tier). ``event_id`` is the idempotency key claimed in
+    ``billing_event_log`` before any write — a retried delivery with the
+    same id is a safe no-op.
+    """
+
+    guild_id: int = Field(ge=1)
+    event_id: str = Field(min_length=1, max_length=128)
+    source: BillingSource
+    # Acting human for manual ops (support grant id / staff id); NULL for
+    # automated webhook-driven writes.
+    actor: Optional[str] = Field(default=None, max_length=128)
+
+    tier_name: Optional[str] = Field(default=None, max_length=64)
+    max_storage_bytes: Optional[int] = Field(default=None, ge=0)
+    max_users: Optional[int] = Field(default=None, ge=1)
+    status: Optional[GuildStatus] = None
+
+    @model_validator(mode="after")
+    def _support_source_is_storage_only(self) -> "BillingGuildTierApply":
+        """support_manual may only change the storage cap, and must name an
+        actor; other fields require paddle_webhook or platinum_invoice."""
+        if self.source == "support_manual":
+            if not self.actor:
+                raise ValueError(BillingMessages.ACTOR_REQUIRED)
+            forbidden = {"tier_name", "max_users", "status"}
+            if forbidden & self.model_fields_set:
+                raise ValueError(BillingMessages.SUPPORT_SOURCE_RESTRICTED)
+        return self
+
+
+class BillingGuildTierRead(SanitizedBaseModel):
+    """State of the billing-writable surface after (or instead of) a write.
+
+    ``applied`` is False when the event id had already been claimed — the
+    values shown are the current state, untouched by the replayed delivery.
+    """
+
+    guild_id: int
+    tier_name: Optional[str] = None
+    max_storage_bytes: Optional[int] = None
+    max_users: Optional[int] = None
+    status: GuildStatus
+    member_count: int
+    applied: bool
+
+
+class BillingHeadcountRequest(SanitizedBaseModel):
+    """Body of ``POST /billing/headcount`` — the per-user-billing read."""
+
+    guild_id: int = Field(ge=1)
+
+
+class BillingHeadcountRead(SanitizedBaseModel):
+    guild_id: int
+    member_count: int

--- a/backend/app/services/platform/billing.py
+++ b/backend/app/services/platform/billing.py
@@ -120,8 +120,14 @@ def verify_billing_envelope(
     except jwt.PyJWTError as exc:
         raise BillingEnvelopeError(BillingMessages.INVALID_TOKEN) from exc
 
+    # Bound to the blocklist column (varchar 64) so an oversized jti is a
+    # clean 403 instead of a database error at redemption time.
+    jti = str(payload["jti"])
+    if not jti or len(jti) > 64:
+        raise BillingEnvelopeError(BillingMessages.INVALID_TOKEN)
+
     return BillingClaims(
-        jti=str(payload["jti"]),
+        jti=jti,
         expires_at=datetime.fromtimestamp(int(payload["exp"]), tz=timezone.utc),
     )
 

--- a/backend/app/services/platform/billing.py
+++ b/backend/app/services/platform/billing.py
@@ -1,0 +1,257 @@
+"""Verification and operations for the external billing service.
+
+``apply_guild_tier`` writes the tier label and billing-computed caps onto
+``public.guilds``; ``guild_member_count`` reads one guild's headcount. Tier
+definitions live in the billing service's own database.
+
+Requests carry an HMAC over ``METHOD\\nPATH\\nTIMESTAMP\\nsha256(body)``
+(bounded recency window) plus an RS256 service JWT whose ``jti`` is redeemed
+one-shot in ``billing_jti_blocklist``. Authorization is the database's: the
+caller runs as the ``initiative_billing`` role with ``app.billing_guild_id``
+set to the envelope's guild. Writes are claimed through ``billing_event_log``
+(UNIQUE event id), so retried deliveries apply once.
+
+Nothing here commits — the endpoint owns the transaction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping
+
+import jwt
+from sqlalchemy import func, insert, update
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.core.messages import BillingMessages
+from app.models.platform.billing import BillingEventLog, BillingJti
+from app.models.platform.guild import Guild, GuildMembership, GuildStatus
+from app.schemas.platform.billing import BillingGuildTierApply, BillingGuildTierRead
+
+logger = logging.getLogger(__name__)
+
+# The op recorded in billing_event_log for the tier write. The headcount read
+# mutates nothing and therefore claims no event.
+GUILD_TIER_OP = "guild_tier"
+
+
+class BillingEnvelopeError(Exception):
+    """The request failed envelope verification. ``code`` is the
+    BillingMessages constant the endpoint surfaces as a 403."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class BillingReplayError(Exception):
+    """The service JWT's ``jti`` was already redeemed."""
+
+
+class BillingGuildNotFoundError(Exception):
+    """The envelope's guild does not exist."""
+
+
+@dataclass(frozen=True)
+class BillingClaims:
+    """Validated identity of a billing service call."""
+
+    jti: str
+    expires_at: datetime
+
+
+def verify_billing_envelope(
+    *,
+    method: str,
+    path: str,
+    headers: Mapping[str, str],
+    body: bytes,
+) -> BillingClaims:
+    """Verify the envelope on a billing call. Pure — no DB.
+
+    Order: config presence, timestamp recency, HMAC over the raw body, then
+    the RS256 JWT. The one-shot ``jti`` redemption is not done here — it is
+    a DB write and belongs inside the endpoint's transaction.
+    """
+    if not settings.BILLING_PUBLIC_KEY_PEM or not settings.BILLING_HMAC_SECRET:
+        raise BillingEnvelopeError(BillingMessages.NOT_CONFIGURED)
+
+    ts_header = headers.get("X-Billing-Timestamp")
+    signature = headers.get("X-Billing-Signature")
+    authorization = headers.get("Authorization", "")
+    if not ts_header or not signature or not authorization.startswith("Bearer "):
+        raise BillingEnvelopeError(BillingMessages.MISSING_SIGNATURE)
+
+    try:
+        ts = int(ts_header)
+    except ValueError as exc:
+        raise BillingEnvelopeError(BillingMessages.STALE_TIMESTAMP) from exc
+    window = max(1, settings.BILLING_REPLAY_WINDOW_SECONDS)  # never 0 (P-6)
+    if abs(time.time() - ts) > window:
+        raise BillingEnvelopeError(BillingMessages.STALE_TIMESTAMP)
+
+    # Signed over the raw bytes, before any parsing.
+    message = "\n".join(
+        [method.upper(), path, ts_header, hashlib.sha256(body).hexdigest()]
+    ).encode()
+    expected = hmac.new(
+        settings.BILLING_HMAC_SECRET.encode(), message, hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected, signature.lower()):
+        raise BillingEnvelopeError(BillingMessages.INVALID_SIGNATURE)
+
+    try:
+        payload = jwt.decode(
+            authorization[len("Bearer ") :],
+            settings.BILLING_PUBLIC_KEY_PEM,
+            algorithms=["RS256"],
+            audience=settings.BILLING_AUDIENCE,
+            issuer=settings.BILLING_ISSUER,
+            options={"require": ["exp", "iat", "iss", "aud", "jti"]},
+        )
+    except jwt.PyJWTError as exc:
+        raise BillingEnvelopeError(BillingMessages.INVALID_TOKEN) from exc
+
+    return BillingClaims(
+        jti=str(payload["jti"]),
+        expires_at=datetime.fromtimestamp(int(payload["exp"]), tz=timezone.utc),
+    )
+
+
+async def record_jti(session: AsyncSession, *, jti: str, expires_at: datetime) -> None:
+    """Redeem a billing service JWT's ``jti`` — first presentation only.
+
+    Flushes (never commits) so the redemption shares the endpoint's
+    transaction; a later presentation collides on the PK and raises
+    :class:`BillingReplayError`.
+    """
+    session.add(
+        BillingJti(
+            jti=jti,
+            redeemed_at=datetime.now(timezone.utc),
+            expires_at=expires_at,
+        )
+    )
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        raise BillingReplayError(f"jti {jti} already redeemed") from exc
+
+
+_GUILD_TIER_COLUMNS = (
+    Guild.id,
+    Guild.tier_name,
+    Guild.max_storage_bytes,
+    Guild.max_users,
+    Guild.status,
+)
+
+
+async def _select_tier_row(session: AsyncSession, guild_id: int):
+    """Read the billing-visible slice of one guild. Explicit columns only —
+    the role's grants are column-scoped, so an ORM ``SELECT *`` would fail."""
+    return (
+        await session.execute(select(*_GUILD_TIER_COLUMNS).where(Guild.id == guild_id))
+    ).one_or_none()
+
+
+async def _member_count(session: AsyncSession, guild_id: int) -> int:
+    # count(guild_id), not count(*): guild_id (NOT NULL) is the role's only
+    # granted column on this table.
+    return (
+        await session.execute(
+            select(func.count(GuildMembership.guild_id)).where(
+                GuildMembership.guild_id == guild_id
+            )
+        )
+    ).scalar_one()
+
+
+async def apply_guild_tier(
+    session: AsyncSession, payload: BillingGuildTierApply
+) -> BillingGuildTierRead:
+    """Apply a tier-metadata write, exactly once per ``event_id``.
+
+    Sequence: existence check (404 before consuming the event id), then the
+    ``billing_event_log`` claim (a unique-violation means a prior delivery
+    already applied this event, so the values are left untouched), then the
+    UPDATE with ``model_fields_set`` sentinel semantics (omit = leave,
+    null = unlimited).
+    """
+    provided = payload.model_fields_set
+    row = await _select_tier_row(session, payload.guild_id)
+    if row is None:
+        raise BillingGuildNotFoundError(payload.guild_id)
+
+    # Plain INSERT in a savepoint rather than ON CONFLICT DO NOTHING: the
+    # billing role holds no SELECT on this table (append-only), and under RLS
+    # an ON CONFLICT insert would demand one. The unique-violation IS the
+    # replay signal; the savepoint confines the abort so the jti burn and the
+    # transaction survive.
+    claim = insert(BillingEventLog.__table__).values(
+        event_id=payload.event_id,
+        guild_id=payload.guild_id,
+        op=GUILD_TIER_OP,
+        source=payload.source,
+        actor=payload.actor,
+        applied_at=datetime.now(timezone.utc),
+    )
+    try:
+        async with session.begin_nested():
+            await session.execute(claim)
+        applied = True
+    except IntegrityError:
+        applied = False
+
+    if applied:
+        now = datetime.now(timezone.utc)
+        values: dict = {}
+        for field in ("tier_name", "max_storage_bytes", "max_users"):
+            if field in provided:
+                values[field] = getattr(payload, field)
+        if payload.status is not None and payload.status.value != row.status:
+            values["status"] = payload.status.value
+            values["status_changed_at"] = now
+            logger.info(
+                "billing: guild %s status %s -> %s (source=%s actor=%s event=%s)",
+                payload.guild_id,
+                row.status,
+                payload.status.value,
+                payload.source,
+                payload.actor,
+                payload.event_id,
+            )
+        if values:
+            values["updated_at"] = now
+            await session.execute(
+                update(Guild).where(Guild.id == payload.guild_id).values(**values)
+            )
+            row = await _select_tier_row(session, payload.guild_id)
+
+    return BillingGuildTierRead(
+        guild_id=row.id,
+        tier_name=row.tier_name,
+        max_storage_bytes=row.max_storage_bytes,
+        max_users=row.max_users,
+        status=GuildStatus(row.status),
+        member_count=await _member_count(session, payload.guild_id),
+        applied=applied,
+    )
+
+
+async def guild_member_count(session: AsyncSession, guild_id: int) -> int:
+    """Headcount for per-user billing."""
+    exists = (
+        await session.execute(select(Guild.id).where(Guild.id == guild_id))
+    ).one_or_none()
+    if exists is None:
+        raise BillingGuildNotFoundError(guild_id)
+    return await _member_count(session, guild_id)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1190,7 +1190,7 @@ requires-dist = [
     { name = "bcrypt", specifier = "==5.0.0" },
     { name = "boto3", specifier = ">=1.35,<2" },
     { name = "email-validator", specifier = ">=2.3.0,<3" },
-    { name = "fastapi", specifier = ">=0.136.1,<0.139" },
+    { name = "fastapi", specifier = ">=0.136.1,<0.140" },
     { name = "fastmcp", specifier = ">=3.4.2" },
     { name = "google-auth", specifier = ">=2.53.0" },
     { name = "greenlet", specifier = ">=3.0" },


### PR DESCRIPTION
## Problem

The billing service (see `initiative_billing/docs/billing-write-boundary-security-plan.md`) needs a way to apply guild tier state to initiative and read headcounts for per-user billing, without holding broad access to the FOSS database.

## Notable changes

- **Two service-to-service endpoints** (excluded from OpenAPI, no user auth): `POST /api/v1/billing/guild-tier` and `POST /api/v1/billing/headcount`. Requests carry an RS256 service JWT (distinct aud/iss, one-shot jti redeemed in the new `billing_jti_blocklist`) **plus** an HMAC-SHA256 over `METHOD\nPATH\nTIMESTAMP\nsha256(body)` in a ±5-min window, verified over the raw body before parsing. Fail-closed unless `BILLING_PUBLIC_KEY_PEM` + `BILLING_HMAC_SECRET` are set — self-hosted installs are unaffected.
- **Least-privilege DB role**: new NOLOGIN `initiative_billing` role (SET ROLE-only from `app_user`, INHERIT FALSE, no `platform_base`/`app_guild_base` membership). Column-scoped grants: `guilds (tier_name, max_storage_bytes, max_users, status[, timestamps])`, `guild_memberships (guild_id)` only — billing can count members, not identify them — and INSERT-only on the event log. RLS pins every statement to the one guild in the verified body (`app.billing_guild_id` GUC).
- **Exactly-once + audit**: `billing_event_log` (UNIQUE event_id claimed in the same transaction as the write, actor/source attributed, insert-only, no FK so rows outlive the guild). Retried deliveries return current state as a no-op; a 404 consumes neither the event id nor the jti.
- **Decision 2 revised** (owner call, recorded in the plan doc): only a display-only `guilds.tier_name` lands in the FOSS schema; tier definitions stay in billing, which pushes *computed* caps through the existing `max_storage_bytes`/`max_users`/`status` columns. `source=support_manual` writes are limited to the storage cap and require an actor.
- **Schema/RLS updates**: migration `20260708_0134`; `guild_select` policy rescoped from `TO PUBLIC` to `app_user, app_guild_base, platform_base` (its membership-EXISTS leg evaluates with the querying role's privileges); non-negativity CHECKs on the caps; registries (`SHARED_TABLES`, system grants) and security-invariant tests updated.

## Schema / env updates

- Migration `20260708_0134` (new tables + columns + role + policies; clean downgrade).
- New optional env: `BILLING_PUBLIC_KEY_PEM`, `BILLING_HMAC_SECRET`, `BILLING_AUDIENCE`, `BILLING_ISSUER`, `BILLING_REPLAY_WINDOW_SECONDS`.
- No frontend or OpenAPI changes (endpoints are schema-excluded; spec verified unchanged).

## Testing

```
cd backend
uv run pytest app/api/v1/platform_endpoints/billing_test.py app/db/billing_role_test.py       # 21 passed
uv run pytest app/db/                                                                          # 215 passed
uv run pytest app/api/v1/platform_endpoints/guilds_test.py app/api/v1/platform_endpoints/settings_test.py app/api/v1/tenant_endpoints/auto_delegation_test.py  # 87 passed
uv run ruff check app && uv run ruff format app
```

Includes least-privilege isolation probes (`app/db/billing_role_test.py`) asserting the billing role is denied every column, table, and guild outside its surface.