### PR TITLE
Add encrypted OIDC flow state (PKCE + nonce)

### DIFF
--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -17,6 +17,7 @@ from app.core.config import settings
 # here, and use encrypt_field / decrypt_field with that constant.
 SALT_OIDC_REFRESH_TOKEN = b"oidc-refresh-token"  # legacy name, do not rename
 SALT_OIDC_CLIENT_SECRET = b"oidc-client-secret"
+SALT_OIDC_FLOW_STATE = b"oidc-flow-state"  # transient login-flow state (never stored)
 SALT_SMTP_PASSWORD = b"smtp-password"
 SALT_AI_API_KEY = b"ai-api-key"
 SALT_EMAIL = b"email"
@@ -76,11 +77,18 @@ def encrypt_field(plaintext: str, salt: bytes, *, secret_key: str | None = None)
 
 
 def decrypt_field(
-    ciphertext: str, salt: bytes, *, secret_key: str | None = None
+    ciphertext: str,
+    salt: bytes,
+    *,
+    secret_key: str | None = None,
+    ttl_seconds: int | None = None,
 ) -> str:
+    """Decrypt ``ciphertext``. With ``ttl_seconds``, a token older than the TTL
+    (per its authenticated Fernet timestamp) is rejected as invalid — used for
+    transient values like the OIDC flow state."""
     return (
         _get_fernet(salt, _resolve_secret_key(secret_key))
-        .decrypt(ciphertext.encode())
+        .decrypt(ciphertext.encode(), ttl=ttl_seconds)
         .decode()
     )
 

--- a/backend/app/services/auth/oidc/__init__.py
+++ b/backend/app/services/auth/oidc/__init__.py
@@ -1,14 +1,20 @@
 """OpenID Connect relying-party building blocks.
 
-Small, independently-testable units — discovery, the id_token verifier, and the
-JWKS key resolver so far; PKCE/nonce and the ``OidcProvider`` that composes them
-land in follow-up slices.
+Small, independently-testable units — discovery, the id_token verifier, the
+JWKS key resolver, and the PKCE/nonce flow state so far; the ``OidcProvider``
+that composes them lands in a follow-up slice.
 """
 
 from app.services.auth.oidc.discovery import (
     DiscoveryError,
     OidcDiscovery,
     OidcMetadata,
+)
+from app.services.auth.oidc.flow_state import (
+    FlowStateError,
+    OidcFlowState,
+    create_flow_state,
+    decode_flow_state,
 )
 from app.services.auth.oidc.id_token import (
     IdTokenVerificationError,
@@ -18,10 +24,14 @@ from app.services.auth.oidc.jwks import JwksResolutionError, JwksResolver
 
 __all__ = [
     "DiscoveryError",
+    "FlowStateError",
     "IdTokenVerificationError",
     "JwksResolutionError",
     "JwksResolver",
     "OidcDiscovery",
+    "OidcFlowState",
     "OidcMetadata",
+    "create_flow_state",
+    "decode_flow_state",
     "verify_id_token",
 ]

--- a/backend/app/services/auth/oidc/flow_state.py
+++ b/backend/app/services/auth/oidc/flow_state.py
@@ -33,6 +33,10 @@ DEFAULT_MAX_AGE_SECONDS: int = 600
 _VERIFIER_BYTES: int = 64
 _NONCE_BYTES: int = 32
 
+# device_name is a client-supplied display label that rides inside the state
+# param and thus the authorization URL — cap it so it can't inflate the URL.
+DEVICE_NAME_MAX_CHARS: int = 64
+
 
 class FlowStateError(Exception):
     """The flow state is missing, expired, or invalid; the login attempt must
@@ -60,12 +64,14 @@ def create_flow_state(
 ) -> tuple[str, OidcFlowState]:
     """Generate a fresh verifier + nonce and return ``(state, payload)`` —
     ``state`` is the encrypted token to send to the IdP, ``payload`` supplies
-    the ``code_challenge`` and ``nonce`` for the authorization request."""
+    the ``code_challenge`` and ``nonce`` for the authorization request.
+    ``device_name`` is truncated to :data:`DEVICE_NAME_MAX_CHARS` (a display
+    label, not an identifier)."""
     payload = OidcFlowState(
         code_verifier=secrets.token_urlsafe(_VERIFIER_BYTES),
         nonce=secrets.token_urlsafe(_NONCE_BYTES),
         mobile=mobile,
-        device_name=device_name,
+        device_name=device_name[:DEVICE_NAME_MAX_CHARS],
     )
     plaintext = json.dumps(
         {
@@ -90,7 +96,9 @@ def decode_flow_state(
         plaintext = decrypt_field(
             state, SALT_OIDC_FLOW_STATE, ttl_seconds=max_age_seconds
         )
-    except InvalidToken as exc:
+    # UnicodeDecodeError: decrypt_field decodes the plaintext as UTF-8, and this
+    # function's contract is FlowStateError for every invalid input.
+    except (InvalidToken, UnicodeDecodeError) as exc:
         raise FlowStateError("invalid or expired flow state") from exc
     try:
         data = json.loads(plaintext)
@@ -98,7 +106,7 @@ def decode_flow_state(
             code_verifier=data["code_verifier"],
             nonce=data["nonce"],
             mobile=bool(data.get("mobile", False)),
-            device_name=str(data.get("device_name", "")),
+            device_name=str(data.get("device_name", ""))[:DEVICE_NAME_MAX_CHARS],
         )
     except (ValueError, KeyError, TypeError) as exc:
         raise FlowStateError("malformed flow state payload") from exc

--- a/backend/app/services/auth/oidc/flow_state.py
+++ b/backend/app/services/auth/oidc/flow_state.py
@@ -1,0 +1,104 @@
+"""PKCE + nonce generation and the encrypted OIDC login-flow state.
+
+One login attempt's transient secrets — the PKCE ``code_verifier`` and the
+id_token ``nonce`` — must round-trip from ``begin`` (the redirect to the IdP)
+to ``complete`` (the callback). They travel in the ``state`` parameter as a
+**Fernet-encrypted** payload: confidential (nothing readable in redirect URLs
+or logs), tamper-proof, and TTL-bound via the token's authenticated timestamp.
+Stateless — nothing is stored server-side, so it works across replicas; a
+``SECRET_KEY`` rotation simply invalidates in-flight logins (they retry).
+
+``create_flow_state()`` mints the state + payload; ``decode_flow_state()``
+returns the payload or raises :class:`FlowStateError` (fail-closed). The
+``code_challenge`` sent to the IdP is derived with S256 (RFC 7636).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+from dataclasses import dataclass
+
+from cryptography.fernet import InvalidToken
+
+from app.core.encryption import SALT_OIDC_FLOW_STATE, decrypt_field, encrypt_field
+
+# One login attempt should complete well within this window; older state is
+# rejected (the user just signs in again).
+DEFAULT_MAX_AGE_SECONDS: int = 600
+
+# 64 random bytes -> 86 urlsafe chars, within RFC 7636's 43-128 verifier length.
+_VERIFIER_BYTES: int = 64
+_NONCE_BYTES: int = 32
+
+
+class FlowStateError(Exception):
+    """The flow state is missing, expired, or invalid; the login attempt must
+    be rejected (fail-closed)."""
+
+
+@dataclass(frozen=True)
+class OidcFlowState:
+    """The per-login-attempt payload carried (encrypted) in ``state``."""
+
+    code_verifier: str
+    nonce: str
+    mobile: bool = False
+    device_name: str = ""
+
+    @property
+    def code_challenge(self) -> str:
+        """S256 challenge for ``code_verifier`` (RFC 7636 §4.2)."""
+        digest = hashlib.sha256(self.code_verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def create_flow_state(
+    *, mobile: bool = False, device_name: str = ""
+) -> tuple[str, OidcFlowState]:
+    """Generate a fresh verifier + nonce and return ``(state, payload)`` —
+    ``state`` is the encrypted token to send to the IdP, ``payload`` supplies
+    the ``code_challenge`` and ``nonce`` for the authorization request."""
+    payload = OidcFlowState(
+        code_verifier=secrets.token_urlsafe(_VERIFIER_BYTES),
+        nonce=secrets.token_urlsafe(_NONCE_BYTES),
+        mobile=mobile,
+        device_name=device_name,
+    )
+    plaintext = json.dumps(
+        {
+            "code_verifier": payload.code_verifier,
+            "nonce": payload.nonce,
+            "mobile": payload.mobile,
+            "device_name": payload.device_name,
+        },
+        separators=(",", ":"),
+    )
+    return encrypt_field(plaintext, SALT_OIDC_FLOW_STATE), payload
+
+
+def decode_flow_state(
+    state: str, *, max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS
+) -> OidcFlowState:
+    """Decrypt and validate the callback's ``state``, or raise
+    :class:`FlowStateError` (expired, tampered, wrong key/salt, malformed)."""
+    if not state:
+        raise FlowStateError("missing flow state")
+    try:
+        plaintext = decrypt_field(
+            state, SALT_OIDC_FLOW_STATE, ttl_seconds=max_age_seconds
+        )
+    except InvalidToken as exc:
+        raise FlowStateError("invalid or expired flow state") from exc
+    try:
+        data = json.loads(plaintext)
+        return OidcFlowState(
+            code_verifier=data["code_verifier"],
+            nonce=data["nonce"],
+            mobile=bool(data.get("mobile", False)),
+            device_name=str(data.get("device_name", "")),
+        )
+    except (ValueError, KeyError, TypeError) as exc:
+        raise FlowStateError("malformed flow state payload") from exc

--- a/backend/app/services/auth/oidc/flow_state_test.py
+++ b/backend/app/services/auth/oidc/flow_state_test.py
@@ -1,0 +1,169 @@
+"""Adversarial tests for the encrypted OIDC flow state.
+
+The state parameter round-trips through the browser, so the suite attacks it
+from that position: tampering, expiry, cross-context tokens, wrong keys, and
+malformed payloads must all be rejected; the secrets it carries must not be
+readable from the token itself.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+
+import pytest
+
+from app.core.config import settings
+from app.core.encryption import (
+    SALT_OIDC_CLIENT_SECRET,
+    SALT_OIDC_FLOW_STATE,
+    _get_fernet,
+    encrypt_field,
+)
+from app.services.auth.oidc.flow_state import (
+    FlowStateError,
+    OidcFlowState,
+    create_flow_state,
+    decode_flow_state,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- round-trip ---------------------------------------------------------------
+
+
+def test_round_trip():
+    state, payload = create_flow_state(mobile=True, device_name="Léa's Pixel 9")
+    decoded = decode_flow_state(state)
+    assert decoded == payload
+    assert decoded.mobile is True
+    assert decoded.device_name == "Léa's Pixel 9"
+
+
+def test_defaults_round_trip():
+    state, payload = create_flow_state()
+    decoded = decode_flow_state(state)
+    assert decoded.mobile is False
+    assert decoded.device_name == ""
+    assert decoded.code_verifier == payload.code_verifier
+    assert decoded.nonce == payload.nonce
+
+
+def test_each_flow_is_unique():
+    s1, p1 = create_flow_state()
+    s2, p2 = create_flow_state()
+    assert s1 != s2
+    assert p1.code_verifier != p2.code_verifier
+    assert p1.nonce != p2.nonce
+
+
+# --- confidentiality ----------------------------------------------------------
+
+
+def test_secrets_not_readable_from_state_token():
+    """The whole point of encrypting: the verifier and nonce must not appear in
+    the state string that transits the browser."""
+    state, payload = create_flow_state(device_name="pixel")
+    assert payload.code_verifier not in state
+    assert payload.nonce not in state
+    assert "pixel" not in state
+
+
+# --- PKCE correctness -----------------------------------------------------------
+
+
+def test_code_challenge_is_rfc7636_s256():
+    _, payload = create_flow_state()
+    expected = (
+        base64.urlsafe_b64encode(
+            hashlib.sha256(payload.code_verifier.encode("ascii")).digest()
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert payload.code_challenge == expected
+    assert "=" not in payload.code_challenge  # unpadded per the RFC
+
+
+def test_verifier_meets_rfc7636_requirements():
+    _, payload = create_flow_state()
+    assert 43 <= len(payload.code_verifier) <= 128
+    allowed = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+    assert set(payload.code_verifier) <= allowed
+
+
+# --- rejection paths ------------------------------------------------------------
+
+
+def test_tampered_state_rejected():
+    state, _ = create_flow_state()
+    i = len(state) // 2
+    tampered = state[:i] + ("A" if state[i] != "A" else "B") + state[i + 1 :]
+    with pytest.raises(FlowStateError):
+        decode_flow_state(tampered)
+
+
+def test_expired_state_rejected():
+    payload = json.dumps(
+        {"code_verifier": "v" * 43, "nonce": "n", "mobile": False, "device_name": ""}
+    )
+    fernet = _get_fernet(SALT_OIDC_FLOW_STATE, settings.SECRET_KEY)
+    old = fernet.encrypt_at_time(
+        payload.encode(), current_time=int(time.time()) - 3600
+    ).decode()
+    with pytest.raises(FlowStateError):
+        decode_flow_state(old, max_age_seconds=600)
+
+
+def test_cross_context_token_rejected():
+    """A Fernet token minted under a different salt (e.g. an encrypted client
+    secret) must not decode as flow state."""
+    other = encrypt_field('{"code_verifier":"v","nonce":"n"}', SALT_OIDC_CLIENT_SECRET)
+    with pytest.raises(FlowStateError):
+        decode_flow_state(other)
+
+
+def test_token_from_different_secret_key_rejected():
+    other = encrypt_field(
+        '{"code_verifier":"v","nonce":"n"}',
+        SALT_OIDC_FLOW_STATE,
+        secret_key="a-different-secret-key",
+    )
+    with pytest.raises(FlowStateError):
+        decode_flow_state(other)
+
+
+@pytest.mark.parametrize("state", ["", "garbage", "gAAAAA..not-a-token"])
+def test_missing_or_garbage_state_rejected(state):
+    with pytest.raises(FlowStateError):
+        decode_flow_state(state)
+
+
+def test_valid_token_with_non_json_payload_rejected():
+    token = encrypt_field("not json", SALT_OIDC_FLOW_STATE)
+    with pytest.raises(FlowStateError):
+        decode_flow_state(token)
+
+
+def test_valid_token_missing_required_field_rejected():
+    token = encrypt_field('{"nonce":"n"}', SALT_OIDC_FLOW_STATE)  # no code_verifier
+    with pytest.raises(FlowStateError):
+        decode_flow_state(token)
+
+
+# --- dataclass behavior ---------------------------------------------------------
+
+
+def test_flow_state_is_immutable():
+    _, payload = create_flow_state()
+    with pytest.raises(AttributeError):
+        payload.nonce = "overwritten"  # type: ignore[misc]
+
+
+def test_challenge_is_deterministic_for_a_verifier():
+    a = OidcFlowState(code_verifier="v" * 43, nonce="n")
+    b = OidcFlowState(code_verifier="v" * 43, nonce="m")
+    assert a.code_challenge == b.code_challenge

--- a/backend/app/services/auth/oidc/flow_state_test.py
+++ b/backend/app/services/auth/oidc/flow_state_test.py
@@ -154,6 +154,34 @@ def test_valid_token_missing_required_field_rejected():
         decode_flow_state(token)
 
 
+def test_valid_token_with_non_utf8_plaintext_rejected():
+    """A same-key token whose plaintext isn't UTF-8 must still surface as
+    FlowStateError — the function's whole contract — not UnicodeDecodeError."""
+    fernet = _get_fernet(SALT_OIDC_FLOW_STATE, settings.SECRET_KEY)
+    token = fernet.encrypt(b"\xff\xfe\xfa garbage bytes").decode()
+    with pytest.raises(FlowStateError):
+        decode_flow_state(token)
+
+
+# --- device_name cap ------------------------------------------------------------
+
+
+def test_device_name_truncated_on_create():
+    state, payload = create_flow_state(device_name="x" * 500)
+    assert len(payload.device_name) == 64
+    assert len(decode_flow_state(state).device_name) == 64
+
+
+def test_device_name_capped_on_decode():
+    """Even a hand-minted token with an oversized device_name is capped at the
+    decode boundary."""
+    token = encrypt_field(
+        json.dumps({"code_verifier": "v" * 43, "nonce": "n", "device_name": "y" * 500}),
+        SALT_OIDC_FLOW_STATE,
+    )
+    assert len(decode_flow_state(token).device_name) == 64
+
+
 # --- dataclass behavior ---------------------------------------------------------
 
 

--- a/backend/app/services/auth/oidc/flow_state_test.py
+++ b/backend/app/services/auth/oidc/flow_state_test.py
@@ -159,8 +159,10 @@ def test_valid_token_missing_required_field_rejected():
 
 def test_flow_state_is_immutable():
     _, payload = create_flow_state()
+    # setattr rather than direct assignment: the runtime frozen-dataclass check is
+    # what's under test, and static checkers rightly refuse the assignment form.
     with pytest.raises(AttributeError):
-        payload.nonce = "overwritten"  # type: ignore[misc]
+        setattr(payload, "nonce", "overwritten")
 
 
 def test_challenge_is_deterministic_for_a_verifier():


### PR DESCRIPTION
## Context

Auth rewrite Phase 0, slice 2b-ii — PKCE/state/nonce, following discovery (#837), the JWKS resolver (#829), and the id_token verifier (#828). Still **dormant** (not wired to any endpoint). One slice left before the wiring PR: the `OidcProvider` that composes all of these.

## What it does

One login attempt's transient secrets — the PKCE `code_verifier` and the id_token `nonce` — must round-trip from `begin` (redirect to the IdP) to `complete` (the callback). They travel in the `state` parameter as a **Fernet-encrypted payload** (new named salt `SALT_OIDC_FLOW_STATE`, existing `encryption.py` infra):

- **Confidential** — nothing readable in redirect URLs, proxy logs, or browser history. This is an upgrade over the current hand-rolled scheme, which HMAC-signs the state but carries the `code_verifier` in **readable** form through the browser (user-ratified choice over migrating that as-is or adding a server-side flow-state table).
- **Tamper-proof + TTL-bound** — Fernet authenticates the token and its timestamp; `decode_flow_state` rejects anything older than the window (default 10 min).
- **Stateless** — no server-side store, works across replicas; a `SECRET_KEY` rotation just invalidates in-flight logins (they retry). Nothing lands in the rotation registry because nothing is persisted.

`create_flow_state()` → `(state, payload)`; `payload.code_challenge` derives the S256 challenge (RFC 7636); `decode_flow_state()` returns the payload or raises `FlowStateError` (fail-closed). Carries the native-flow fields (`mobile`, `device_name`) the current scheme already round-trips.

`decrypt_field` gains an optional `ttl_seconds` parameter — backwards-compatible (all 13 existing callers unchanged).

## Tests

17 tests: round-trip (incl. unicode device names), **secrets not readable from the state token**, RFC 7636 S256 challenge correctness + verifier length/charset requirements, uniqueness across flows, and rejection of tampered / expired (minted with a backdated Fernet timestamp) / cross-salt (a token encrypted under another context's salt) / wrong-`SECRET_KEY` / empty / garbage / non-JSON / missing-field states.

`cd backend && pytest app/services/auth/oidc/ app/core/encryption_test.py` → 89 passed. `ruff` clean.

## Not in this PR
`OidcProvider.begin/complete` (authorization-URL construction, code exchange, identity resolution) — next slice, which consumes this + #828/#829/#837. Browser-session binding of the state (double-submit cookie) is a wiring-time concern, noted for slice 3.