### PR TITLE
Verify system engine bypasses RLS at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Operator "delete this guild" (offered when deleting a guild's sole admin) is now scoped to that user's solely-admined guild instead of accepting any guild id; guild admins still delete their own guild as before.
 
+### Deprecated
+
+- Running migrations as a Postgres superuser (a superuser or `BYPASSRLS` role in `DATABASE_URL`) is deprecated and a future release will refuse to start with it. Affected deployments now get a prominent migration banner in the startup log on every boot: run `backend/scripts/create-provisioner.sql` once and point `DATABASE_URL` at the least-privilege `app_provisioner` role (fresh docker-compose installs already use it; `DATABASE_URL_APP`/`DATABASE_URL_ADMIN` are unaffected).
+
 ### Fixed
 
 - Anonymizing or deleting a user now scrubs their email out of any guild invite addressed to them (invite addresses are stored reversibly encrypted, so a lingering invite kept a recoverable copy); the invite is neutralized so this can't turn it into an open shareable link.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Anonymizing or deleting a user now scrubs their email out of any guild invite addressed to them (invite addresses are stored reversibly encrypted, so a lingering invite kept a recoverable copy); the invite is neutralized so this can't turn it into an open shareable link.
+- Startup no longer fails with `new row violates row-level security policy for table "guilds"` when the system-engine login (`DATABASE_URL_ADMIN`) has lost its `BYPASSRLS` attribute — typically after restoring a database from a dump, which recreates no roles (#835). Boot now verifies the attribute right after migrations, restores it automatically when `DATABASE_URL` is privileged enough, and otherwise stops with the exact `ALTER ROLE` command to run instead of the opaque seeding error.
 
 ## [0.54.2] - 2026-07-04
 

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -9,7 +9,10 @@ from sqlmodel import select
 from app.core.config import settings
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.security import get_password_hash
-from app.db.schema_provisioning import deprovision_guild
+from app.db.schema_provisioning import (
+    deprovision_guild,
+    ensure_system_engine_bypassrls,
+)
 from app.db.session import AdminSessionLocal, run_migrations, set_rls_context
 from app.models.platform.guild import Guild
 from app.models.platform.user import User, UserRole
@@ -160,6 +163,11 @@ async def check_pre_baseline_db() -> None:
 async def init() -> None:
     await check_pre_baseline_db()
     await run_migrations()
+    # A policy-bound system engine (restored database, hand-created role) reads
+    # shared tables as empty; the seeding below would then try to re-create the
+    # primary guild and die on the guilds RLS policy (issue #835). Verify —
+    # and, when DATABASE_URL lawfully can, repair — before touching data.
+    await ensure_system_engine_bypassrls()
     await init_owner()
     async with AdminSessionLocal() as session:
         # guild_settings is guild-scoped; route into the primary guild's schema so

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -519,6 +519,44 @@ _EFFECTIVE_BYPASS_SQL = (
 )
 
 
+def _bypassrls_exit_message(admin_login: str, heal_attempted: bool) -> str:
+    """The boot-stopping message for a policy-bound system engine.
+
+    ``heal_attempted`` distinguishes "this process may not repair the role"
+    from "an in-place repair ran without error yet the re-check still sees no
+    bypass" — the operator must know a repair already happened, or the
+    instruction to run the same ALTER reads as the whole fix when something
+    deeper (e.g. a pooler authenticating the admin URL as a different role)
+    is eating it.
+    """
+    if heal_attempted:
+        attempted = (
+            "An automatic repair (ALTER ROLE … WITH BYPASSRLS via DATABASE_URL)\n"
+            "already ran without error, but a fresh DATABASE_URL_ADMIN\n"
+            "connection still reports no bypass — the URL is likely reaching a\n"
+            "different role than it names (e.g. through a connection pooler).\n"
+            "Verify which role the connection really lands on:\n\n"
+            "  SELECT current_user, rolbypassrls FROM pg_roles\n"
+            "   WHERE rolname = current_user;\n\n"
+            "and repair that role as a Postgres superuser:\n"
+        )
+    else:
+        attempted = "Repair it as a Postgres superuser:\n"
+    return (
+        f"\n{'=' * 70}\n"
+        f"DATABASE_URL_ADMIN connects as {admin_login!r}, which does not hold\n"
+        "the BYPASSRLS attribute. This login is the app's system engine\n"
+        "(startup seeding, background jobs); policy-bound, it reads every\n"
+        "shared table as empty and boot fails with a row-level security\n"
+        "error. Roles are cluster state — restoring a database from a dump\n"
+        "does not restore them.\n\n"
+        f"{attempted}\n"
+        f'  ALTER ROLE "{admin_login}" WITH BYPASSRLS;\n\n'
+        "then restart the app.\n"
+        f"{'=' * 70}"
+    )
+
+
 async def ensure_system_engine_bypassrls() -> None:
     """Verify the system engine (``DATABASE_URL_ADMIN``) actually bypasses RLS,
     re-asserting the attribute when the provisioning login lawfully can.
@@ -583,17 +621,12 @@ async def ensure_system_engine_bypassrls() -> None:
                 admin_login,
             )
             return
+        logger.error(
+            "Re-asserted BYPASSRLS on %r via DATABASE_URL, but a fresh "
+            "DATABASE_URL_ADMIN connection still reports no bypass.",
+            admin_login,
+        )
 
     raise SystemExit(
-        f"\n{'=' * 70}\n"
-        f"DATABASE_URL_ADMIN connects as {admin_login!r}, which does not hold\n"
-        "the BYPASSRLS attribute. This login is the app's system engine\n"
-        "(startup seeding, background jobs); policy-bound, it reads every\n"
-        "shared table as empty and boot fails with a row-level security\n"
-        "error. Roles are cluster state — restoring a database from a dump\n"
-        "does not restore them.\n\n"
-        "Repair it as a Postgres superuser:\n\n"
-        f'  ALTER ROLE "{admin_login}" WITH BYPASSRLS;\n\n'
-        "then restart the app.\n"
-        f"{'=' * 70}"
+        _bypassrls_exit_message(admin_login, heal_attempted=bool(can_heal))
     )

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -464,7 +464,8 @@ async def backfill_guild_schemas() -> BackfillSummary:
 
 
 async def warn_if_privileged_database_url() -> None:
-    """Warn when DATABASE_URL connects as a superuser (or BYPASSRLS) role.
+    """Emit a deprecation banner when DATABASE_URL connects as a superuser
+    (or BYPASSRLS) role.
 
     The app never needs a Postgres superuser: migrations + guild provisioning
     fit in the least-privilege ``app_provisioner`` role (NOSUPERUSER CREATEROLE
@@ -473,6 +474,11 @@ async def warn_if_privileged_database_url() -> None:
     get the role from the Postgres image's ``docker-entrypoint-initdb.d``
     script; existing deployments run ``scripts/create-provisioner.sql`` once
     (see the deployment docs), then point DATABASE_URL at ``app_provisioner``.
+
+    Superuser DATABASE_URL support is DEPRECATED and a future release will
+    refuse to start with it, so the banner is deliberately loud — a framed
+    multi-line block at WARNING every boot, not a one-liner that scrolls past —
+    to move the remaining legacy deployments before the hard cutoff.
     """
     async with db_session.provisioning_engine.connect() as conn:
         rolsuper, rolbypassrls = (
@@ -485,10 +491,26 @@ async def warn_if_privileged_database_url() -> None:
         ).one()
     if rolsuper or rolbypassrls:
         logger.warning(
-            "DATABASE_URL connects as %s role — the app does not need this. "
-            "Run backend/scripts/create-provisioner.sql once (see the "
-            "deployment docs) and point DATABASE_URL at app_provisioner.",
+            "\n%s\n"
+            "DEPRECATED: DATABASE_URL connects as %s role.\n"
+            "The app never needs these privileges, and a FUTURE RELEASE WILL\n"
+            "REFUSE TO START with them. Migrate once (about a minute):\n"
+            "\n"
+            "  1. Create the least-privilege provisioning role — connected as\n"
+            "     the current DATABASE_URL role, run\n"
+            "     backend/scripts/create-provisioner.sql, e.g.:\n"
+            "       docker exec -i initiative-db \\\n"
+            "         psql -v ON_ERROR_STOP=1 -U <user> -d <database> \\\n"
+            "              -v provisioner_password='CHANGE-ME' \\\n"
+            "              -f - < backend/scripts/create-provisioner.sql\n"
+            "  2. Point DATABASE_URL at app_provisioner and restart.\n"
+            "\n"
+            "DATABASE_URL_APP / DATABASE_URL_ADMIN are unaffected. See the\n"
+            "deployment docs for details.\n"
+            "%s",
+            "=" * 70,
             "a SUPERUSER" if rolsuper else "a BYPASSRLS",
+            "=" * 70,
         )
 
 

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -490,3 +490,88 @@ async def warn_if_privileged_database_url() -> None:
             "deployment docs) and point DATABASE_URL at app_provisioner.",
             "a SUPERUSER" if rolsuper else "a BYPASSRLS",
         )
+
+
+_EFFECTIVE_BYPASS_SQL = (
+    "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user"
+)
+
+
+async def ensure_system_engine_bypassrls() -> None:
+    """Verify the system engine (``DATABASE_URL_ADMIN``) actually bypasses RLS,
+    re-asserting the attribute when the provisioning login lawfully can.
+
+    Every seeding/background-job query assumes the system engine holds
+    BYPASSRLS. A login that connects fine but is policy-bound (roles are
+    cluster state — a ``pg_dump``-based restore recreates none of their
+    attributes, and hand-created logins may omit the attribute) reads every
+    shared table as empty, so the first boot after such a restore dies deep in
+    startup seeding with an opaque "new row violates row-level security policy
+    for table \"guilds\"" while trying to re-create the primary guild it cannot
+    see (issue #835). The baseline migration verifies this contract, but only
+    fresh databases run it — an already-stamped database is never re-checked.
+
+    Runs right after migrations on every boot. When ``DATABASE_URL`` holds
+    BYPASSRLS or superuser (Postgres reserves BYPASSRLS surgery for holders of
+    it — true for legacy deployments that still migrate as the compose
+    superuser), the attribute is repaired in place, preserving the baseline's
+    self-healing behavior. Otherwise boot stops with the exact repair command
+    instead of the downstream RLS error.
+    """
+    async with db_session.admin_engine.connect() as conn:
+        admin_login, bypasses = (
+            await conn.execute(
+                text(
+                    "SELECT current_user, "
+                    "(SELECT rolsuper OR rolbypassrls FROM pg_roles "
+                    " WHERE rolname = current_user)"
+                )
+            )
+        ).one()
+    if bypasses:
+        return
+
+    async with db_session.provisioning_engine.begin() as conn:
+        can_heal = (await conn.execute(text(_EFFECTIVE_BYPASS_SQL))).scalar()
+        if can_heal:
+            # Role DDL takes no bind parameters; pin the identifier through a
+            # transaction-local GUC and quote it server-side with format(%I),
+            # mirroring the baseline migration's role DDL.
+            await conn.execute(
+                text("SELECT set_config('app._system_engine_login', :name, true)"),
+                {"name": admin_login},
+            )
+            await conn.execute(
+                text(
+                    "DO $$ BEGIN "
+                    "EXECUTE format('ALTER ROLE %I WITH BYPASSRLS', "
+                    "current_setting('app._system_engine_login')); "
+                    "END $$"
+                )
+            )
+
+    if can_heal:
+        async with db_session.admin_engine.connect() as conn:
+            healed = (await conn.execute(text(_EFFECTIVE_BYPASS_SQL))).scalar()
+        if healed:
+            logger.warning(
+                "System engine login %r was missing BYPASSRLS — re-asserted it "
+                "via DATABASE_URL. Restored databases lose role attributes; "
+                "no action needed.",
+                admin_login,
+            )
+            return
+
+    raise SystemExit(
+        f"\n{'=' * 70}\n"
+        f"DATABASE_URL_ADMIN connects as {admin_login!r}, which does not hold\n"
+        "the BYPASSRLS attribute. This login is the app's system engine\n"
+        "(startup seeding, background jobs); policy-bound, it reads every\n"
+        "shared table as empty and boot fails with a row-level security\n"
+        "error. Roles are cluster state — restoring a database from a dump\n"
+        "does not restore them.\n\n"
+        "Repair it as a Postgres superuser:\n\n"
+        f'  ALTER ROLE "{admin_login}" WITH BYPASSRLS;\n\n'
+        "then restart the app.\n"
+        f"{'=' * 70}"
+    )

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -798,6 +798,8 @@ async def test_system_engine_check_fails_closed_when_it_cannot_heal(
             await schema_provisioning.ensure_system_engine_bypassrls()
         assert "ALTER ROLE" in str(excinfo.value)
         assert role in str(excinfo.value)
+        # No repair was possible here, so the message must not claim one ran.
+        assert "already ran" not in str(excinfo.value)
         async with engine.connect() as conn:
             still_bound = (
                 await conn.execute(
@@ -809,3 +811,20 @@ async def test_system_engine_check_fails_closed_when_it_cannot_heal(
     finally:
         await bound_engine.dispose()
         await _drop_login(engine, role)
+
+
+def test_bypassrls_exit_message_distinguishes_attempted_repair():
+    """The heal-attempted variant must say a repair already ran (so the
+    operator doesn't re-run an ALTER that silently changed nothing) and point
+    at role-resolution debugging; the plain variant must not claim one ran."""
+    plain = schema_provisioning._bypassrls_exit_message(
+        "app_admin", heal_attempted=False
+    )
+    attempted = schema_provisioning._bypassrls_exit_message(
+        "app_admin", heal_attempted=True
+    )
+    for message in (plain, attempted):
+        assert 'ALTER ROLE "app_admin" WITH BYPASSRLS;' in message
+    assert "already ran" not in plain
+    assert "already ran" in attempted
+    assert "current_user" in attempted  # the which-role-am-I diagnostic query

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -705,3 +705,107 @@ async def test_provisioning_stamp_tracks_grant_behavior_not_cosmetics(engine):
     assert changed != baseline, "a behavioral grants change must move the stamp"
     assert cosmetic == baseline, "a cosmetic rewrite must NOT move the stamp"
     assert (await sp.get_provisioning_bundle()).stamp == baseline
+
+
+# --- ensure_system_engine_bypassrls (issue #835) -----------------------------
+#
+# A system-engine login without BYPASSRLS reads shared tables as empty and
+# boot seeding dies on the guilds RLS policy. The boot check must pass a
+# healthy posture untouched, repair the attribute when the provisioning login
+# lawfully can, and stop boot with instructions when it can't.
+
+
+async def _login_can_alter_bypassrls(engine) -> bool:
+    async with engine.connect() as conn:
+        return bool(
+            (
+                await conn.execute(
+                    text(
+                        "SELECT rolsuper OR rolbypassrls FROM pg_roles "
+                        "WHERE rolname = current_user"
+                    )
+                )
+            ).scalar()
+        )
+
+
+async def _create_policy_bound_login(engine, role: str, password: str):
+    """Create a LOGIN role WITHOUT BYPASSRLS and return an engine for it."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    async with engine.begin() as conn:
+        await conn.execute(text(f'DROP ROLE IF EXISTS "{role}"'))
+        await conn.execute(
+            text(f"CREATE ROLE \"{role}\" WITH LOGIN NOBYPASSRLS PASSWORD '{password}'")
+        )
+    return create_async_engine(
+        engine.url.set(username=role, password=password), echo=False
+    )
+
+
+async def _drop_login(engine, role: str) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(text(f'DROP ROLE IF EXISTS "{role}"'))
+
+
+async def test_system_engine_check_passes_on_healthy_posture():
+    # The harness routes the admin engine to the real app_admin (BYPASSRLS)
+    # against the test DB — the check must be a silent no-op.
+    await schema_provisioning.ensure_system_engine_bypassrls()
+
+
+async def test_system_engine_check_heals_missing_bypassrls(engine, monkeypatch):
+    import app.db.session as db_session
+
+    if not await _login_can_alter_bypassrls(engine):
+        pytest.skip("test login may not alter BYPASSRLS roles")
+
+    role = f"{engine.url.database}_heal_role"
+    bound_engine = await _create_policy_bound_login(engine, role, "heal-pw")
+    monkeypatch.setattr(db_session, "admin_engine", bound_engine)
+    # provisioning_engine is the (privileged) test engine via the harness.
+    try:
+        await schema_provisioning.ensure_system_engine_bypassrls()
+        async with engine.connect() as conn:
+            healed = (
+                await conn.execute(
+                    text("SELECT rolbypassrls FROM pg_roles WHERE rolname = :r"),
+                    {"r": role},
+                )
+            ).scalar()
+        assert healed, "the check must re-assert BYPASSRLS on the system engine"
+    finally:
+        await bound_engine.dispose()
+        await _drop_login(engine, role)
+
+
+async def test_system_engine_check_fails_closed_when_it_cannot_heal(
+    engine, monkeypatch
+):
+    import app.db.session as db_session
+
+    if not await _login_can_alter_bypassrls(engine):
+        pytest.skip("test login may not alter BYPASSRLS roles")
+
+    role = f"{engine.url.database}_unheal_role"
+    bound_engine = await _create_policy_bound_login(engine, role, "unheal-pw")
+    # Point BOTH engines at the policy-bound login: the provisioning side may
+    # not alter BYPASSRLS, so the check must stop boot with instructions.
+    monkeypatch.setattr(db_session, "admin_engine", bound_engine)
+    monkeypatch.setattr(db_session, "provisioning_engine", bound_engine)
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            await schema_provisioning.ensure_system_engine_bypassrls()
+        assert "ALTER ROLE" in str(excinfo.value)
+        assert role in str(excinfo.value)
+        async with engine.connect() as conn:
+            still_bound = (
+                await conn.execute(
+                    text("SELECT rolbypassrls FROM pg_roles WHERE rolname = :r"),
+                    {"r": role},
+                )
+            ).scalar()
+        assert not still_bound, "an unprivileged check must not change the role"
+    finally:
+        await bound_engine.dispose()
+        await _drop_login(engine, role)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,9 +71,14 @@ async def lifespan(app: FastAPI):
     # guilds stamped with the current artifact version are skipped entirely.
     from app.db.schema_provisioning import (
         backfill_guild_schemas,
+        ensure_system_engine_bypassrls,
         warn_if_privileged_database_url,
     )
 
+    # Before anything touches the system engine: a policy-bound admin login
+    # (restored database, hand-created role) reads shared tables as empty and
+    # the seeding below would die with an opaque RLS violation (issue #835).
+    await ensure_system_engine_bypassrls()
     await warn_if_privileged_database_url()
     backfill = await backfill_guild_schemas()
     if backfill.failed:


### PR DESCRIPTION
## Problem

Fixes #835. Upgraded installs can fail startup with:

```
new row violates row-level security policy for table "guilds"
```

That error can only occur when the system-engine login (`DATABASE_URL_ADMIN`) is **not** actually `BYPASSRLS` — a true system engine never evaluates policies. Roles are cluster state, not database state: a `pg_dump`-based restore (NAS volume moves, Postgres major upgrades) recreates none of them, and a hand-recreated `app_admin` easily loses the attribute. Policy-bound, the login reads every shared table as empty, so boot seeding (`ensure_defaults` → `get_primary_guild`) can't see the existing guilds, tries to re-create "Primary Guild", and dies on the `guilds` insert policy's `WITH CHECK (current_user_id IS NOT NULL)`.

The baseline migration already verifies/heals this contract — but only fresh databases run it. An already-stamped database is never re-checked, and pre-0.54 the `is_superadmin` policy legs masked nothing here either (boot seeding always relied purely on the attribute), so any restore event leaves a time bomb that detonates on the next boot.

## Changes

- `ensure_system_engine_bypassrls()` (schema_provisioning): verifies on every boot, right after migrations, that the admin engine's login is effectively RLS-bypassing (`rolsuper OR rolbypassrls`).
  - When `DATABASE_URL` holds BYPASSRLS/superuser (legacy deployments that still migrate as the compose superuser), it re-asserts the attribute in place — same self-healing the baseline performs, no operator action needed.
  - Otherwise it stops boot with the exact `ALTER ROLE … WITH BYPASSRLS` command instead of the opaque downstream RLS error (`app_provisioner` may not perform BYPASSRLS surgery on PG16+, so instructing is the only lawful option there).
- Wired into both boot paths: the FastAPI lifespan and `python -m app.db.init_db`.
- Changelog entry under Unreleased → Fixed.

No schema or env changes.

## Testing

```
cd backend && pytest app/db/schema_provisioning_test.py -k system_engine   # 3 passed
cd backend && pytest app/db/init_db_test.py                               # 1 passed
ruff check / ruff format on touched files
```

New tests cover: healthy posture is a silent no-op; a policy-bound login is healed via a privileged provisioning engine; an unprivileged provisioning engine fails closed with `SystemExit` carrying the repair command and leaves the role untouched.

## Follow-up in this PR: superuser DATABASE_URL deprecation banner

The old one-line "you don't need a superuser" warning scrolled past unnoticed. Since superuser `DATABASE_URL` support is slated for removal, `warn_if_privileged_database_url` now emits a framed multi-line WARNING banner on every boot — stating that a future release will refuse to start with it and giving the exact one-time migration (`create-provisioner.sql` → point `DATABASE_URL` at `app_provisioner`; `DATABASE_URL_APP`/`DATABASE_URL_ADMIN` unaffected). Changelog gains a `### Deprecated` entry. Banner output verified live against a superuser-URL database.
