### PR TITLE
Add OidcProvider (begin/complete relying-party flow)

### DIFF
--- a/backend/app/services/auth/oidc/__init__.py
+++ b/backend/app/services/auth/oidc/__init__.py
@@ -1,8 +1,9 @@
 """OpenID Connect relying-party building blocks.
 
 Small, independently-testable units — discovery, the id_token verifier, the
-JWKS key resolver, and the PKCE/nonce flow state so far; the ``OidcProvider``
-that composes them lands in a follow-up slice.
+JWKS key resolver, the PKCE/nonce flow state, and the ``OidcProvider`` that
+composes them into the begin/complete relying-party flow. Identity resolution
+against the database is the caller's step after ``complete``.
 """
 
 from app.services.auth.oidc.discovery import (
@@ -21,6 +22,13 @@ from app.services.auth.oidc.id_token import (
     verify_id_token,
 )
 from app.services.auth.oidc.jwks import JwksResolutionError, JwksResolver
+from app.services.auth.oidc.provider import (
+    OidcBegin,
+    OidcClientConfig,
+    OidcCompletion,
+    OidcFlowError,
+    OidcProvider,
+)
 
 __all__ = [
     "DiscoveryError",
@@ -28,10 +36,15 @@ __all__ = [
     "IdTokenVerificationError",
     "JwksResolutionError",
     "JwksResolver",
+    "OidcBegin",
+    "OidcClientConfig",
+    "OidcCompletion",
     "OidcDiscovery",
+    "OidcFlowError",
     "OidcFlowState",
     "OidcMetadata",
+    "OidcProvider",
+    "verify_id_token",
     "create_flow_state",
     "decode_flow_state",
-    "verify_id_token",
 ]

--- a/backend/app/services/auth/oidc/_http.py
+++ b/backend/app/services/auth/oidc/_http.py
@@ -1,6 +1,7 @@
-"""Shared HTTPS JSON fetch for the OIDC client (discovery + JWKS).
+"""Shared HTTPS JSON requests for the OIDC client (discovery, JWKS, token
+endpoint).
 
-One place for the network hardening both fetchers need — https-only, a fixed
+One place for the network hardening every OIDC call needs — https-only, a fixed
 response size cap, a timeout — so it is written and audited once rather than
 copied. Callers add their own caching and wrap :class:`OidcHttpError` in a
 domain-specific error.
@@ -48,6 +49,45 @@ async def fetch_json(
     ``client_factory`` builds the ``httpx.AsyncClient`` per call (tests inject a
     ``MockTransport``); it defaults to a timeout-configured client.
     """
+    return await _request_json(
+        "GET",
+        url,
+        client_factory=client_factory,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+    )
+
+
+async def post_form_json(
+    url: str,
+    data: dict[str, str],
+    *,
+    client_factory: ClientFactory | None = None,
+    timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+    max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+) -> Any:
+    """POST ``data`` as a form to ``url`` and return the parsed JSON response,
+    with the same https / size-cap / fail-closed contract as :func:`fetch_json`.
+    Used for the token-endpoint exchange."""
+    return await _request_json(
+        "POST",
+        url,
+        data=data,
+        client_factory=client_factory,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+    )
+
+
+async def _request_json(
+    method: str,
+    url: str,
+    *,
+    data: dict[str, str] | None = None,
+    client_factory: ClientFactory | None,
+    timeout_seconds: float,
+    max_response_bytes: int,
+) -> Any:
     require_https(url)
     factory = client_factory or (lambda: httpx.AsyncClient(timeout=timeout_seconds))
     body = bytearray()
@@ -57,7 +97,7 @@ async def fetch_json(
     over_cap = False
     try:
         async with factory() as client:
-            async with client.stream("GET", url) as resp:
+            async with client.stream(method, url, data=data) as resp:
                 resp.raise_for_status()
                 async for chunk in resp.aiter_bytes():
                     body.extend(chunk)

--- a/backend/app/services/auth/oidc/_http.py
+++ b/backend/app/services/auth/oidc/_http.py
@@ -21,6 +21,8 @@ ClientFactory = Callable[[], httpx.AsyncClient]
 DEFAULT_HTTP_TIMEOUT_SECONDS: float = 10.0
 # A discovery doc / JWKS is a few KiB; 512 KiB is generous headroom.
 DEFAULT_MAX_RESPONSE_BYTES: int = 512 * 1024
+# Error bodies are logged, so keep only enough for the diagnostic payload.
+_ERROR_SNIPPET_MAX_BYTES: int = 2048
 
 
 class OidcHttpError(Exception):
@@ -91,21 +93,33 @@ async def _request_json(
     require_https(url)
     factory = client_factory or (lambda: httpx.AsyncClient(timeout=timeout_seconds))
     body = bytearray()
-    # The cap is flagged and raised AFTER the stream context exits: raising inside
-    # it would leave our exception exposed to replacement by a teardown error from
-    # the abandoned body (the transport may fault when we stop reading mid-stream).
+    # Failures are flagged and raised AFTER the stream context exits: raising
+    # inside it would leave our exception exposed to replacement by a teardown
+    # error from the abandoned body (the transport may fault when we stop
+    # reading mid-stream).
     over_cap = False
+    error_status: int | None = None
     try:
         async with factory() as client:
             async with client.stream(method, url, data=data) as resp:
-                resp.raise_for_status()
+                if resp.status_code >= 400:
+                    # Read a bounded snippet of the error body: an OAuth error
+                    # response ({"error": "invalid_grant", ...}) is the one
+                    # diagnostic the server operator needs in the logs.
+                    error_status = resp.status_code
+                    max_bytes = _ERROR_SNIPPET_MAX_BYTES
+                else:
+                    max_bytes = max_response_bytes
                 async for chunk in resp.aiter_bytes():
                     body.extend(chunk)
-                    if len(body) > max_response_bytes:
+                    if len(body) > max_bytes:
                         over_cap = True
                         break
     except httpx.HTTPError as exc:
         raise OidcHttpError(f"fetch failed for {url}: {exc}") from exc
+    if error_status is not None:
+        snippet = body[:_ERROR_SNIPPET_MAX_BYTES].decode("utf-8", errors="replace")
+        raise OidcHttpError(f"{url} returned {error_status}: {snippet}")
     if over_cap:
         raise OidcHttpError(
             f"response from {url} exceeds the {max_response_bytes}-byte cap"

--- a/backend/app/services/auth/oidc/flow_state.py
+++ b/backend/app/services/auth/oidc/flow_state.py
@@ -102,7 +102,7 @@ def decode_flow_state(
         raise FlowStateError("invalid or expired flow state") from exc
     try:
         data = json.loads(plaintext)
-        return OidcFlowState(
+        decoded = OidcFlowState(
             code_verifier=data["code_verifier"],
             nonce=data["nonce"],
             mobile=bool(data.get("mobile", False)),
@@ -110,3 +110,10 @@ def decode_flow_state(
         )
     except (ValueError, KeyError, TypeError) as exc:
         raise FlowStateError("malformed flow state payload") from exc
+    # A flow state exists to carry these two secrets; empty ones are malformed
+    # (and downstream verification treats them as caller errors, not bad input).
+    if not isinstance(decoded.code_verifier, str) or not decoded.code_verifier:
+        raise FlowStateError("malformed flow state payload")
+    if not isinstance(decoded.nonce, str) or not decoded.nonce:
+        raise FlowStateError("malformed flow state payload")
+    return decoded

--- a/backend/app/services/auth/oidc/flow_state_test.py
+++ b/backend/app/services/auth/oidc/flow_state_test.py
@@ -154,6 +154,24 @@ def test_valid_token_missing_required_field_rejected():
         decode_flow_state(token)
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"code_verifier":"","nonce":"n"}',
+        '{"code_verifier":"v","nonce":""}',
+        '{"code_verifier":null,"nonce":"n"}',
+        '{"code_verifier":"v","nonce":42}',
+    ],
+)
+def test_empty_or_non_string_secrets_rejected(payload):
+    """A decoded flow state must always carry non-empty string secrets — an
+    empty nonce/verifier would otherwise surface downstream as a caller error
+    instead of a rejected login."""
+    token = encrypt_field(payload, SALT_OIDC_FLOW_STATE)
+    with pytest.raises(FlowStateError):
+        decode_flow_state(token)
+
+
 def test_valid_token_with_non_utf8_plaintext_rejected():
     """A same-key token whose plaintext isn't UTF-8 must still surface as
     FlowStateError — the function's whole contract — not UnicodeDecodeError."""

--- a/backend/app/services/auth/oidc/id_token.py
+++ b/backend/app/services/auth/oidc/id_token.py
@@ -28,7 +28,7 @@ import jwt
 
 # Asymmetric signature algorithms only. HMAC (``HS*``) and ``none`` are excluded
 # by construction so they can't be selected — not merely discouraged.
-_ASYMMETRIC_ALGORITHMS: frozenset[str] = frozenset(
+ASYMMETRIC_ALGORITHMS: frozenset[str] = frozenset(
     {
         "RS256",
         "RS384",
@@ -87,7 +87,7 @@ def verify_id_token(
     requested = tuple(algorithms)
     if not requested:
         raise ValueError("id_token algorithms allowlist must be non-empty")
-    illegal = sorted(a for a in requested if a not in _ASYMMETRIC_ALGORITHMS)
+    illegal = sorted(a for a in requested if a not in ASYMMETRIC_ALGORITHMS)
     if illegal:
         # The allowlist is asymmetric by contract — refuse a symmetric/``none`` alg.
         raise ValueError(f"id_token algorithms must be asymmetric; refused {illegal}")

--- a/backend/app/services/auth/oidc/provider.py
+++ b/backend/app/services/auth/oidc/provider.py
@@ -1,0 +1,247 @@
+"""The OIDC relying-party flow: ``begin`` (authorization redirect) and
+``complete`` (code exchange + verified identity).
+
+Composes the package's building blocks — discovery, the encrypted flow state,
+the JWKS resolver, and the id_token verifier — into the two operations a login
+endpoint needs. Pure with respect to storage: configuration comes in as plain
+values (the caller loads the provider row and decrypts the client secret), and
+the result is the token response plus **verified** id_token claims; identity
+resolution against the database is the caller's next step.
+
+``complete`` accepts nothing on trust: the callback's ``state`` must decrypt
+and be fresh, the token response must carry an ``id_token``, and the id_token
+must verify (signature via the provider's JWKS, issuer, audience, expiry, and
+the nonce bound to this login attempt). Signing algorithms are the
+intersection of what discovery advertises with the asymmetric allowlist —
+empty intersection is an error, never a fallback.
+
+Every failure raises :class:`OidcFlowError` carrying a stable ``code`` for the
+endpoint to map to a user-facing error; details stay server-side.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode, urlsplit
+
+from app.services.auth.oidc._http import (
+    DEFAULT_HTTP_TIMEOUT_SECONDS,
+    ClientFactory,
+    OidcHttpError,
+    post_form_json,
+)
+from app.services.auth.oidc.discovery import (
+    DiscoveryError,
+    OidcDiscovery,
+    OidcMetadata,
+)
+from app.services.auth.oidc.flow_state import (
+    DEFAULT_MAX_AGE_SECONDS,
+    FlowStateError,
+    create_flow_state,
+    decode_flow_state,
+)
+from app.services.auth.oidc.id_token import (
+    ASYMMETRIC_ALGORITHMS,
+    DEFAULT_ALGORITHMS,
+    IdTokenVerificationError,
+    verify_id_token,
+)
+from app.services.auth.oidc.jwks import JwksResolutionError, JwksResolver
+
+DEFAULT_SCOPES = "openid email profile"
+
+
+class OidcFlowError(Exception):
+    """A login flow step failed; the attempt must be rejected (fail-closed).
+
+    ``code`` is a stable machine-readable identifier for the endpoint to map to
+    a localized user-facing error; the message is for server logs only.
+    """
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class OidcClientConfig:
+    """One provider's client registration, as plain values."""
+
+    issuer: str
+    client_id: str
+    redirect_uri: str
+    client_secret: str | None = None  # None = public client (PKCE-only)
+    scopes: str = DEFAULT_SCOPES
+
+
+@dataclass(frozen=True)
+class OidcBegin:
+    """What the login endpoint needs to redirect the user to the IdP."""
+
+    authorization_url: str
+    state: str
+
+
+@dataclass(frozen=True)
+class OidcCompletion:
+    """The outcome of a verified code exchange.
+
+    ``claims`` are the **verified** id_token claims — the identity source of
+    truth. ``access_token`` is kept for userinfo/claim-mapping enrichment;
+    ``refresh_token`` (if the IdP issued one) for group re-sync.
+    """
+
+    subject: str
+    claims: dict[str, Any]
+    id_token: str
+    access_token: str | None
+    refresh_token: str | None
+    mobile: bool
+    device_name: str
+
+
+class OidcProvider:
+    """A relying-party client for one configured OIDC provider."""
+
+    def __init__(
+        self,
+        config: OidcClientConfig,
+        *,
+        discovery: OidcDiscovery | None = None,
+        jwks: JwksResolver | None = None,
+        client_factory: ClientFactory | None = None,
+        http_timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+        max_state_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+    ) -> None:
+        self._config = config
+        self._client_factory = client_factory
+        self._timeout = http_timeout_seconds
+        self._max_state_age = max_state_age_seconds
+        self._discovery = discovery or OidcDiscovery(
+            client_factory=client_factory, http_timeout_seconds=http_timeout_seconds
+        )
+        self._jwks = jwks or JwksResolver(
+            client_factory=client_factory, http_timeout_seconds=http_timeout_seconds
+        )
+
+    async def begin(self, *, mobile: bool = False, device_name: str = "") -> OidcBegin:
+        """Mint the flow state and build the authorization redirect URL."""
+        metadata = await self._fetch_metadata()
+        state, payload = create_flow_state(mobile=mobile, device_name=device_name)
+        params = {
+            "response_type": "code",
+            "client_id": self._config.client_id,
+            "redirect_uri": self._config.redirect_uri,
+            "scope": self._config.scopes,
+            "state": state,
+            "nonce": payload.nonce,
+            "code_challenge": payload.code_challenge,
+            "code_challenge_method": "S256",
+        }
+        endpoint = metadata.authorization_endpoint
+        separator = "&" if urlsplit(endpoint).query else "?"
+        return OidcBegin(
+            authorization_url=f"{endpoint}{separator}{urlencode(params)}",
+            state=state,
+        )
+
+    async def complete(self, *, code: str, state: str) -> OidcCompletion:
+        """Exchange the callback's authorization code and verify the id_token."""
+        if not code:
+            raise OidcFlowError("missing_authorization_code", "callback without code")
+        try:
+            flow = decode_flow_state(state, max_age_seconds=self._max_state_age)
+        except FlowStateError as exc:
+            raise OidcFlowError("invalid_state", str(exc)) from exc
+
+        metadata = await self._fetch_metadata()
+        token_data = await self._exchange_code(
+            metadata, code=code, code_verifier=flow.code_verifier
+        )
+        raw_id_token = token_data.get("id_token")
+        if not raw_id_token or not isinstance(raw_id_token, str):
+            raise OidcFlowError(
+                "token_missing_id_token", "token response carried no id_token"
+            )
+
+        try:
+            signing_key = await self._jwks.resolve_signing_key(
+                raw_id_token, jwks_uri=metadata.jwks_uri
+            )
+        except JwksResolutionError as exc:
+            raise OidcFlowError("id_token_unverifiable", str(exc)) from exc
+        try:
+            claims = verify_id_token(
+                raw_id_token,
+                signing_key=signing_key,
+                issuer=metadata.issuer,
+                audience=self._config.client_id,
+                nonce=flow.nonce,
+                algorithms=self._allowed_algorithms(metadata),
+            )
+        except IdTokenVerificationError as exc:
+            raise OidcFlowError("id_token_rejected", str(exc)) from exc
+
+        access_token = token_data.get("access_token")
+        refresh_token = token_data.get("refresh_token")
+        return OidcCompletion(
+            subject=claims["sub"],
+            claims=claims,
+            id_token=raw_id_token,
+            access_token=access_token if isinstance(access_token, str) else None,
+            refresh_token=refresh_token if isinstance(refresh_token, str) else None,
+            mobile=flow.mobile,
+            device_name=flow.device_name,
+        )
+
+    async def _fetch_metadata(self) -> OidcMetadata:
+        try:
+            return await self._discovery.fetch(self._config.issuer)
+        except DiscoveryError as exc:
+            raise OidcFlowError("discovery_failed", str(exc)) from exc
+
+    async def _exchange_code(
+        self, metadata: OidcMetadata, *, code: str, code_verifier: str
+    ) -> dict[str, Any]:
+        payload = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self._config.redirect_uri,
+            "client_id": self._config.client_id,
+            "code_verifier": code_verifier,
+        }
+        # client_secret_post, matching the existing flow; a public (PKCE-only)
+        # client simply sends no secret.
+        if self._config.client_secret:
+            payload["client_secret"] = self._config.client_secret
+        try:
+            token_data = await post_form_json(
+                metadata.token_endpoint,
+                payload,
+                client_factory=self._client_factory,
+                timeout_seconds=self._timeout,
+            )
+        except OidcHttpError as exc:
+            raise OidcFlowError("token_request_failed", str(exc)) from exc
+        if not isinstance(token_data, dict):
+            raise OidcFlowError(
+                "token_request_failed", "token response is not a JSON object"
+            )
+        return token_data
+
+    def _allowed_algorithms(self, metadata: OidcMetadata) -> tuple[str, ...]:
+        """The verifier allowlist: discovery's advertised algs filtered to the
+        asymmetric set, or the default pair when discovery doesn't advertise.
+        An intersection that comes up empty is an error, never a fallback."""
+        advertised = metadata.id_token_signing_alg_values_supported
+        if advertised is None:
+            return DEFAULT_ALGORITHMS
+        allowed = tuple(a for a in advertised if a in ASYMMETRIC_ALGORITHMS)
+        if not allowed:
+            raise OidcFlowError(
+                "id_token_rejected",
+                f"provider advertises no asymmetric id_token algs: {advertised}",
+            )
+        return allowed

--- a/backend/app/services/auth/oidc/provider.py
+++ b/backend/app/services/auth/oidc/provider.py
@@ -67,13 +67,23 @@ class OidcFlowError(Exception):
 
 @dataclass(frozen=True)
 class OidcClientConfig:
-    """One provider's client registration, as plain values."""
+    """One provider's client registration, as plain values.
+
+    Raises :class:`ValueError` at construction for an empty ``issuer``,
+    ``client_id``, or ``redirect_uri`` — a misconfiguration must surface where
+    the provider is built, not as a stray error mid-login.
+    """
 
     issuer: str
     client_id: str
     redirect_uri: str
     client_secret: str | None = None  # None = public client (PKCE-only)
     scopes: str = DEFAULT_SCOPES
+
+    def __post_init__(self) -> None:
+        for field_name in ("issuer", "client_id", "redirect_uri"):
+            if not getattr(self, field_name):
+                raise ValueError(f"OidcClientConfig.{field_name} must be non-empty")
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/auth/oidc/provider_test.py
+++ b/backend/app/services/auth/oidc/provider_test.py
@@ -1,0 +1,366 @@
+"""Tests for the composed OIDC relying-party flow (begin/complete).
+
+A fake IdP (discovery + JWKS + token endpoint) runs behind an
+``httpx.MockTransport``, so the full begin → callback → verified-claims path is
+exercised with no network. Failure tests attack each trust decision in
+``complete``: the state, the token response, the signing key, and the id_token
+claims.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+from app.services.auth.oidc.flow_state import decode_flow_state
+from app.services.auth.oidc.provider import (
+    OidcClientConfig,
+    OidcFlowError,
+    OidcProvider,
+)
+
+pytestmark = pytest.mark.unit
+
+ISSUER = "https://idp.example.com"
+CLIENT_ID = "client-123"
+REDIRECT_URI = "https://app.example.com/api/v1/auth/oidc/callback"
+
+IDP_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+OTHER_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _pem(priv) -> str:
+    return priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _jwks_doc(priv=IDP_KEY, kid: str = "k1") -> dict:
+    data = json.loads(RSAAlgorithm.to_jwk(priv.public_key()))
+    data.update({"kid": kid, "alg": "RS256", "use": "sig"})
+    return {"keys": [data]}
+
+
+def _mint_id_token(
+    *, nonce: str, priv=IDP_KEY, kid: str = "k1", **claim_overrides
+) -> str:
+    now = datetime.now(timezone.utc)
+    claims = {
+        "iss": ISSUER,
+        "sub": "idp-subject-1",
+        "aud": CLIENT_ID,
+        "exp": now + timedelta(minutes=5),
+        "iat": now,
+        "nonce": nonce,
+        "email": "alice@example.com",
+    }
+    claims.update(claim_overrides)
+    return jwt.encode(claims, _pem(priv), algorithm="RS256", headers={"kid": kid})
+
+
+class FakeIdp:
+    """Routes discovery/JWKS/token requests; records the token-request form."""
+
+    def __init__(self, *, algs: list[str] | None = ["RS256", "ES256"]):
+        doc = {
+            "issuer": ISSUER,
+            "authorization_endpoint": f"{ISSUER}/authorize",
+            "token_endpoint": f"{ISSUER}/token",
+            "jwks_uri": f"{ISSUER}/jwks",
+        }
+        if algs is not None:
+            doc["id_token_signing_alg_values_supported"] = algs
+        self.discovery_doc = doc
+        self.jwks_doc = _jwks_doc()
+        # Callable building the token response from the parsed form, or a fixed
+        # httpx.Response.
+        self.token_response = None
+        self.token_request_form: dict[str, str] = {}
+        self.calls: list[str] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        self.calls.append(path)
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(200, json=self.discovery_doc)
+        if path == "/jwks":
+            return httpx.Response(200, json=self.jwks_doc)
+        if path == "/token":
+            form = parse_qs(request.content.decode())
+            self.token_request_form = {k: v[0] for k, v in form.items()}
+            resp = self.token_response
+            if callable(resp):
+                return resp(self.token_request_form)
+            return resp
+        return httpx.Response(404)
+
+    def client_factory(self):
+        transport = httpx.MockTransport(self.handler)
+        return lambda: httpx.AsyncClient(transport=transport)
+
+
+def _provider(idp: FakeIdp, *, client_secret: str | None = "s3cret") -> OidcProvider:
+    config = OidcClientConfig(
+        issuer=ISSUER,
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        client_secret=client_secret,
+    )
+    return OidcProvider(config, client_factory=idp.client_factory())
+
+
+async def _begin_and_complete(idp: FakeIdp, provider: OidcProvider):
+    """Run the full flow, minting the id_token with the nonce the flow chose
+    (read from the authorization URL, as the real IdP would)."""
+    begun = await provider.begin()
+    nonce = parse_qs(urlsplit(begun.authorization_url).query)["nonce"][0]
+    if idp.token_response is None:
+        idp.token_response = httpx.Response(
+            200,
+            json={
+                "access_token": "at-123",
+                "refresh_token": "rt-456",
+                "id_token": _mint_id_token(nonce=nonce),
+                "token_type": "Bearer",
+            },
+        )
+    return await provider.complete(code="auth-code-1", state=begun.state)
+
+
+# --- begin -------------------------------------------------------------------
+
+
+async def test_begin_builds_authorization_url():
+    idp = FakeIdp()
+    provider = _provider(idp)
+
+    begun = await provider.begin(mobile=True, device_name="Pixel")
+    parts = urlsplit(begun.authorization_url)
+    assert f"{parts.scheme}://{parts.netloc}{parts.path}" == f"{ISSUER}/authorize"
+    params = {k: v[0] for k, v in parse_qs(parts.query).items()}
+    assert params["response_type"] == "code"
+    assert params["client_id"] == CLIENT_ID
+    assert params["redirect_uri"] == REDIRECT_URI
+    assert params["scope"] == "openid email profile"
+    assert params["code_challenge_method"] == "S256"
+    assert params["state"] == begun.state
+
+    # The URL's nonce and challenge must be the ones sealed inside the state.
+    flow = decode_flow_state(begun.state)
+    assert params["nonce"] == flow.nonce
+    assert params["code_challenge"] == flow.code_challenge
+    assert flow.mobile is True
+    assert flow.device_name == "Pixel"
+
+
+async def test_begin_appends_to_existing_query():
+    idp = FakeIdp()
+    idp.discovery_doc["authorization_endpoint"] = f"{ISSUER}/authorize?tenant=acme"
+    provider = _provider(idp)
+
+    begun = await provider.begin()
+    params = parse_qs(urlsplit(begun.authorization_url).query)
+    assert params["tenant"] == ["acme"]
+    assert "client_id" in params
+
+
+# --- complete: happy path ------------------------------------------------------
+
+
+async def test_complete_returns_verified_identity():
+    idp = FakeIdp()
+    provider = _provider(idp)
+
+    done = await _begin_and_complete(idp, provider)
+    assert done.subject == "idp-subject-1"
+    assert done.claims["email"] == "alice@example.com"
+    assert done.access_token == "at-123"
+    assert done.refresh_token == "rt-456"
+    assert done.mobile is False
+
+
+async def test_complete_sends_code_exchange_form():
+    idp = FakeIdp()
+    provider = _provider(idp)
+
+    begun = await provider.begin()
+    flow = decode_flow_state(begun.state)
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce=flow.nonce)}
+    )
+    await provider.complete(code="auth-code-1", state=begun.state)
+
+    form = idp.token_request_form
+    assert form["grant_type"] == "authorization_code"
+    assert form["code"] == "auth-code-1"
+    assert form["redirect_uri"] == REDIRECT_URI
+    assert form["client_id"] == CLIENT_ID
+    assert form["client_secret"] == "s3cret"
+    # PKCE: the verifier sent must be the one sealed in the state.
+    assert form["code_verifier"] == flow.code_verifier
+
+
+async def test_public_client_sends_no_secret():
+    idp = FakeIdp()
+    provider = _provider(idp, client_secret=None)
+
+    begun = await provider.begin()
+    flow = decode_flow_state(begun.state)
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce=flow.nonce)}
+    )
+    done = await provider.complete(code="c", state=begun.state)
+    assert done.subject == "idp-subject-1"
+    assert "client_secret" not in idp.token_request_form
+
+
+# --- complete: rejection paths ---------------------------------------------------
+
+
+async def test_missing_code_rejected_without_network():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="", state="whatever")
+    assert err.value.code == "missing_authorization_code"
+    assert idp.calls == []
+
+
+async def test_invalid_state_rejected_without_network():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state="garbage")
+    assert err.value.code == "invalid_state"
+    assert idp.calls == []
+
+
+async def test_token_endpoint_error_rejected():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    begun = await provider.begin()
+    idp.token_response = httpx.Response(400, json={"error": "invalid_grant"})
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "token_request_failed"
+
+
+async def test_token_response_missing_id_token_rejected():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    begun = await provider.begin()
+    idp.token_response = httpx.Response(200, json={"access_token": "at-only"})
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "token_missing_id_token"
+
+
+async def test_token_response_non_object_rejected():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    begun = await provider.begin()
+    idp.token_response = httpx.Response(200, json=["not", "an", "object"])
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "token_request_failed"
+
+
+async def test_id_token_with_unknown_kid_rejected():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    begun = await provider.begin()
+    nonce = decode_flow_state(begun.state).nonce
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce=nonce, kid="not-in-jwks")}
+    )
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "id_token_unverifiable"
+
+
+async def test_id_token_signed_by_wrong_key_rejected():
+    """Same kid, different private key: resolves a key but the signature fails."""
+    idp = FakeIdp()
+    provider = _provider(idp)
+    begun = await provider.begin()
+    nonce = decode_flow_state(begun.state).nonce
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce=nonce, priv=OTHER_KEY)}
+    )
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "id_token_rejected"
+
+
+async def test_id_token_with_wrong_nonce_rejected():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    begun = await provider.begin()
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce="a-replayed-nonce")}
+    )
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "id_token_rejected"
+
+
+async def test_id_token_for_other_audience_rejected():
+    idp = FakeIdp()
+    provider = _provider(idp)
+    begun = await provider.begin()
+    nonce = decode_flow_state(begun.state).nonce
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce=nonce, aud="another-client")}
+    )
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "id_token_rejected"
+
+
+# --- algorithm negotiation --------------------------------------------------------
+
+
+async def test_provider_advertising_only_symmetric_algs_rejected():
+    """A discovery doc advertising only HMAC algs must be an OidcFlowError —
+    never a fallback to accepting HMAC, and never a raw ValueError."""
+    idp = FakeIdp(algs=["HS256"])
+    provider = _provider(idp)
+    begun = await provider.begin()
+    nonce = decode_flow_state(begun.state).nonce
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce=nonce)}
+    )
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "id_token_rejected"
+
+
+async def test_token_alg_outside_advertised_set_rejected():
+    """Discovery advertises ES256 only; an RS256 id_token must be refused."""
+    idp = FakeIdp(algs=["ES256"])
+    provider = _provider(idp)
+    begun = await provider.begin()
+    nonce = decode_flow_state(begun.state).nonce
+    idp.token_response = httpx.Response(
+        200, json={"id_token": _mint_id_token(nonce=nonce)}
+    )
+    with pytest.raises(OidcFlowError) as err:
+        await provider.complete(code="c", state=begun.state)
+    assert err.value.code == "id_token_rejected"
+
+
+async def test_no_advertised_algs_uses_default_pair():
+    idp = FakeIdp(algs=None)  # discovery omits the field entirely
+    provider = _provider(idp)
+    done = await _begin_and_complete(idp, provider)
+    assert done.subject == "idp-subject-1"

--- a/backend/app/services/auth/oidc/provider_test.py
+++ b/backend/app/services/auth/oidc/provider_test.py
@@ -69,9 +69,14 @@ def _mint_id_token(
 
 
 class FakeIdp:
-    """Routes discovery/JWKS/token requests; records the token-request form."""
+    """Routes discovery/JWKS/token requests; records the token-request form.
 
-    def __init__(self, *, algs: list[str] | None = ["RS256", "ES256"]):
+    ``algs`` fills ``id_token_signing_alg_values_supported``; ``None`` means the
+    discovery document omits the field entirely (an immutable tuple default —
+    do not "fix" it to ``None``, which has that distinct meaning).
+    """
+
+    def __init__(self, *, algs: tuple[str, ...] | None = ("RS256", "ES256")):
         doc = {
             "issuer": ISSUER,
             "authorization_endpoint": f"{ISSUER}/authorize",
@@ -79,7 +84,7 @@ class FakeIdp:
             "jwks_uri": f"{ISSUER}/jwks",
         }
         if algs is not None:
-            doc["id_token_signing_alg_values_supported"] = algs
+            doc["id_token_signing_alg_values_supported"] = list(algs)
         self.discovery_doc = doc
         self.jwks_doc = _jwks_doc()
         # Callable building the token response from the parsed form, or a fixed
@@ -253,6 +258,18 @@ async def test_token_endpoint_error_rejected():
     with pytest.raises(OidcFlowError) as err:
         await provider.complete(code="c", state=begun.state)
     assert err.value.code == "token_request_failed"
+    # The OAuth error body survives into the (server-side) detail for debugging.
+    assert "invalid_grant" in str(err.value)
+
+
+def test_empty_client_id_rejected_at_construction():
+    """Config problems surface where the provider is built, not mid-login."""
+    with pytest.raises(ValueError):
+        OidcClientConfig(issuer=ISSUER, client_id="", redirect_uri=REDIRECT_URI)
+    with pytest.raises(ValueError):
+        OidcClientConfig(issuer="", client_id=CLIENT_ID, redirect_uri=REDIRECT_URI)
+    with pytest.raises(ValueError):
+        OidcClientConfig(issuer=ISSUER, client_id=CLIENT_ID, redirect_uri="")
 
 
 async def test_token_response_missing_id_token_rejected():
@@ -333,7 +350,7 @@ async def test_id_token_for_other_audience_rejected():
 async def test_provider_advertising_only_symmetric_algs_rejected():
     """A discovery doc advertising only HMAC algs must be an OidcFlowError —
     never a fallback to accepting HMAC, and never a raw ValueError."""
-    idp = FakeIdp(algs=["HS256"])
+    idp = FakeIdp(algs=("HS256",))
     provider = _provider(idp)
     begun = await provider.begin()
     nonce = decode_flow_state(begun.state).nonce
@@ -347,7 +364,7 @@ async def test_provider_advertising_only_symmetric_algs_rejected():
 
 async def test_token_alg_outside_advertised_set_rejected():
     """Discovery advertises ES256 only; an RS256 id_token must be refused."""
-    idp = FakeIdp(algs=["ES256"])
+    idp = FakeIdp(algs=("ES256",))
     provider = _provider(idp)
     begun = await provider.begin()
     nonce = decode_flow_state(begun.state).nonce

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1209,7 +1209,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.49,<3" },
     { name = "sqlmodel", specifier = ">=0.0.38,<0.0.40" },
     { name = "tzdata", specifier = ">=2026.2" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0,<0.50" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0,<0.52" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Context

Auth rewrite Phase 0, slice 2b-iii — the composition layer over the four building blocks (#828 verifier, #829 JWKS resolver, #837 discovery, #839 flow state). Still **dormant** (not wired to any endpoint). Remaining before the wiring PR: identity resolution (DB slice).

## What it does

`OidcProvider` is a relying-party client for one configured provider, exposing exactly what a login endpoint needs:

- **`begin()`** — mints the encrypted flow state and builds the authorization URL: PKCE S256 challenge **and `nonce`** (the current live flow sends no nonce; this one does). Handles authorization endpoints that already carry query params.
- **`complete(code, state)`** — accepts nothing on trust: the state must decrypt and be fresh; the code is exchanged at the token endpoint (`client_secret_post`, matching the existing flow — public/PKCE-only clients simply send no secret); the token response must carry an `id_token`; and the id_token must verify — signature via the provider's JWKS, issuer, audience, expiry, and the nonce bound to this login attempt. Returns `OidcCompletion`: verified claims + subject, plus `access_token`/`refresh_token` for the enrichment/re-sync steps.

**Algorithm negotiation:** the verifier allowlist is discovery's advertised `id_token_signing_alg_values_supported` intersected with the asymmetric set; when discovery omits it, the default pair (RS256/ES256). An intersection that comes up empty (e.g. a provider advertising only HMAC) is an **error, never a fallback**.

**Storage-free by design:** configuration comes in as plain values (`OidcClientConfig` — the wiring PR loads the provider row and decrypts the secret from `auth_provider_secrets` on the system engine), and identity resolution against the DB is the caller's next step. Every failure raises `OidcFlowError` with a stable machine-readable `code` for the endpoint to map to a localized user-facing error; details stay in server logs.

Also: `_http.py` gains `post_form_json` (same https-only / size-cap / fail-closed contract as `fetch_json`, shared request core) for the token exchange, and the asymmetric algorithm set is now a public constant.

## Tests

17 tests against a **fake IdP** (one `MockTransport` routing discovery + JWKS + token endpoints, recording the exchange form):

- Full `begin → complete` round trip: URL params (incl. nonce/challenge matching what's sealed in the state), verified claims out.
- Exchange form correctness: grant/code/redirect/client_id/**code_verifier matches the state's**, secret present for confidential clients, absent for public.
- Rejections, each asserting its stable error code: missing code and invalid state (both **without any network call**), token-endpoint 4xx, non-object token response, missing id_token, unknown `kid`, wrong signing key, wrong nonce, wrong audience, symmetric-only advertised algs, and an id_token whose alg falls outside the advertised set.

`cd backend && pytest app/services/auth/oidc/` → 98 passed. `ruff` clean.

## Not in this PR
Identity resolution (`(provider, subject)` → `federated_identities`, verified-email explicit linking, `allow_jit`-gated JIT) — next slice. Then the wiring PR (live callback + one-time config reconcile).