### PR TITLE
Add auth_scope setting (platform vs guild login)

### DIFF
--- a/backend/alembic/versions/20260709_0136_add_auth_scope.py
+++ b/backend/alembic/versions/20260709_0136_add_auth_scope.py
@@ -30,7 +30,16 @@ def upgrade() -> None:
             server_default="platform",
         ),
     )
+    # The posture gate compares literally ('platform' activates the platform
+    # provider), so an out-of-vocabulary value would silently disable login —
+    # refuse it at the database layer, not just in the API schema.
+    op.create_check_constraint(
+        "ck_app_settings_auth_scope",
+        "app_settings",
+        "auth_scope IN ('platform', 'guild')",
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint("ck_app_settings_auth_scope", "app_settings", type_="check")
     op.drop_column("app_settings", "auth_scope")

--- a/backend/alembic/versions/20260709_0136_add_auth_scope.py
+++ b/backend/alembic/versions/20260709_0136_add_auth_scope.py
@@ -1,0 +1,36 @@
+"""add app_settings.auth_scope (platform-wide vs guild-scoped login)
+
+One operator-chosen posture for where login is configured: ``'platform'``
+(sign-in configured once for the whole server) or ``'guild'`` (each guild
+configures its own — multi-tenant). The postures are mutually exclusive; the
+dormant side's provider configuration is kept, never deleted, so switching is
+reversible (history/auth-settings-scope-design.md).
+
+Defaults to ``'platform'`` so every existing install (platform-level OIDC or
+password-only) upgrades with zero behavior change. Plain column addition on an
+existing shared table — grants and RLS policies are unchanged.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260709_0136"
+down_revision = "20260708_0134"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "app_settings",
+        sa.Column(
+            "auth_scope",
+            sa.String(length=20),
+            nullable=False,
+            server_default="platform",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("app_settings", "auth_scope")

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -41,6 +41,7 @@ from app.core.security import (
     verify_password,
 )
 from app.core.user_input_validators import normalize_timezone
+from app.models.platform.app_setting import AuthScope
 from app.models.platform.user import User, UserRole, UserStatus
 from app.models.platform.guild import Guild, GuildRole
 from app.schemas.platform.token import Token
@@ -722,14 +723,23 @@ async def _fetch_oidc_metadata(issuer_url: str) -> dict[str, Any]:
     return metadata
 
 
-async def _get_oidc_runtime_config(session: SessionDep) -> tuple[Any, dict[str, Any]]:
-    app_settings = await app_settings_service.get_app_settings(session)
-    if not (
-        app_settings.oidc_enabled
+def _platform_oidc_active(app_settings: Any) -> bool:
+    """The platform OIDC login is offered only when the platform posture is
+    live AND the provider is enabled + fully configured. In guild scope the
+    platform provider is dormant (kept, not deleted) and must not authenticate
+    anyone — enforced here, server-side, not just hidden in the UI."""
+    return bool(
+        app_settings.auth_scope == AuthScope.platform.value
+        and app_settings.oidc_enabled
         and app_settings.oidc_issuer
         and app_settings.oidc_client_id
         and app_settings.oidc_client_secret_encrypted
-    ):
+    )
+
+
+async def _get_oidc_runtime_config(session: SessionDep) -> tuple[Any, dict[str, Any]]:
+    app_settings = await app_settings_service.get_app_settings(session)
+    if not _platform_oidc_active(app_settings):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=OidcMessages.OIDC_NOT_ENABLED
         )
@@ -748,12 +758,7 @@ async def _get_oidc_runtime_config(session: SessionDep) -> tuple[Any, dict[str, 
 @router.get("/oidc/status")
 async def oidc_status(request: Request, session: SessionDep) -> dict[str, Any]:
     app_settings = await app_settings_service.get_app_settings(session)
-    enabled = bool(
-        app_settings.oidc_enabled
-        and app_settings.oidc_issuer
-        and app_settings.oidc_client_id
-        and app_settings.oidc_client_secret_encrypted
-    )
+    enabled = _platform_oidc_active(app_settings)
     login_url = None
     provider_name = None
     if enabled:

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -25,6 +25,7 @@ from app.models.platform.oidc_claim_mapping import (
     OIDCMappingTargetType,
 )
 from app.schemas.platform.settings import (
+    AuthScopeUpdate,
     EmailSettingsResponse,
     EmailSettingsUpdate,
     EmailTestRequest,
@@ -92,6 +93,7 @@ async def get_oidc_settings(
 ) -> OIDCSettingsResponse:
     settings_obj = await app_settings_service.get_app_settings(session)
     return OIDCSettingsResponse(
+        auth_scope=settings_obj.auth_scope,
         enabled=settings_obj.oidc_enabled,
         issuer=settings_obj.oidc_issuer,
         client_id=settings_obj.oidc_client_id,
@@ -119,6 +121,35 @@ async def update_oidc_settings(
         scopes=payload.scopes,
     )
     return OIDCSettingsResponse(
+        auth_scope=updated.auth_scope,
+        enabled=updated.oidc_enabled,
+        issuer=updated.oidc_issuer,
+        client_id=updated.oidc_client_id,
+        redirect_uri=_backend_redirect_uri(),
+        post_login_redirect=_frontend_redirect_uri(),
+        mobile_redirect_uri=_mobile_redirect_uri(),
+        provider_name=updated.oidc_provider_name,
+        scopes=updated.oidc_scopes,
+    )
+
+
+@router.put("/auth-scope", response_model=OIDCSettingsResponse)
+async def update_auth_scope(
+    payload: AuthScopeUpdate,
+    session: UserSessionDep,
+    _admin: ConfigManageDep,
+) -> OIDCSettingsResponse:
+    """Switch where login is configured (platform-wide vs per-guild).
+
+    Non-destructive: the dormant posture's provider configuration is kept, so
+    switching back restores it exactly. Enforcement is server-side — the OIDC
+    login endpoints refuse when the platform posture isn't active.
+    """
+    updated = await app_settings_service.update_auth_scope(
+        session, scope=payload.scope.value
+    )
+    return OIDCSettingsResponse(
+        auth_scope=updated.auth_scope,
         enabled=updated.oidc_enabled,
         issuer=updated.oidc_issuer,
         client_id=updated.oidc_client_id,
@@ -138,6 +169,7 @@ async def get_interface_settings(
     return InterfaceSettingsResponse(
         light_accent_color=settings_obj.light_accent_color,
         dark_accent_color=settings_obj.dark_accent_color,
+        auth_scope=settings_obj.auth_scope,
     )
 
 
@@ -155,6 +187,7 @@ async def update_interface_settings(
     return InterfaceSettingsResponse(
         light_accent_color=settings_obj.light_accent_color,
         dark_accent_color=settings_obj.dark_accent_color,
+        auth_scope=settings_obj.auth_scope,
     )
 
 

--- a/backend/app/api/v1/platform_endpoints/settings_test.py
+++ b/backend/app/api/v1/platform_endpoints/settings_test.py
@@ -11,6 +11,8 @@ import logging
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole, GuildStatus
@@ -858,3 +860,21 @@ async def test_auth_scope_requires_config_manage(
         headers=get_auth_headers(member),
     )
     assert resp.status_code == 403
+
+
+@pytest.mark.integration
+async def test_auth_scope_check_constraint_rejects_garbage(
+    session: AsyncSession,
+) -> None:
+    """The posture gate compares literally, so an out-of-vocabulary value would
+    silently disable login — the DB CHECK refuses it even for a privileged
+    writer that bypasses the API schema. (INSERT, not UPDATE: the settings
+    singleton may not exist yet, and a zero-row UPDATE never fires the check.)"""
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(
+                text(
+                    "INSERT INTO app_settings (id, oidc_enabled, auth_scope) "
+                    "VALUES (999, false, 'both')"
+                )
+            )

--- a/backend/app/api/v1/platform_endpoints/settings_test.py
+++ b/backend/app/api/v1/platform_endpoints/settings_test.py
@@ -742,3 +742,119 @@ async def test_guild_storage_endpoints_reject_below_admin(
             f"{method.upper()} {url} as {role.value}: {resp.status_code}"
         )
         assert resp.json()["detail"] == "INSUFFICIENT_PRIVILEGES"
+
+
+# --- auth scope (platform-wide vs guild-scoped login) -------------------------
+
+
+async def _configure_platform_oidc(client: AsyncClient, headers: dict) -> None:
+    resp = await client.put(
+        "/api/v1/settings/auth",
+        json={
+            "enabled": True,
+            "issuer": "https://idp.example.com",
+            "client_id": "client-123",
+            "client_secret": "s3cret",
+            "provider_name": "Okta",
+            "scopes": ["openid", "email"],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.integration
+async def test_auth_scope_defaults_to_platform(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    owner = await create_user(session, role=UserRole.owner)
+
+    resp = await client.get("/api/v1/settings/auth", headers=get_auth_headers(owner))
+    assert resp.status_code == 200
+    assert resp.json()["auth_scope"] == "platform"
+
+    # Non-secret posture info is readable without config.manage (login page,
+    # guild settings) via the interface settings.
+    resp = await client.get("/api/v1/settings/interface")
+    assert resp.status_code == 200
+    assert resp.json()["auth_scope"] == "platform"
+
+
+@pytest.mark.integration
+async def test_auth_scope_switch_is_non_destructive(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """Switching postures never touches the dormant side's configuration —
+    switching back restores platform OIDC exactly."""
+    owner = await create_user(session, role=UserRole.owner)
+    headers = get_auth_headers(owner)
+    await _configure_platform_oidc(client, headers)
+
+    status_resp = await client.get("/api/v1/auth/oidc/status")
+    assert status_resp.json()["enabled"] is True
+
+    # Switch to guild scope: OIDC config is retained but the login goes dormant.
+    resp = await client.put(
+        "/api/v1/settings/auth-scope", json={"scope": "guild"}, headers=headers
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["auth_scope"] == "guild"
+    assert body["enabled"] is True  # stored config untouched...
+    assert body["issuer"] == "https://idp.example.com"
+    status_resp = await client.get("/api/v1/auth/oidc/status")
+    assert status_resp.json()["enabled"] is False  # ...but not offered
+
+    # Switch back: everything as before.
+    resp = await client.put(
+        "/api/v1/settings/auth-scope", json={"scope": "platform"}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["auth_scope"] == "platform"
+    status_resp = await client.get("/api/v1/auth/oidc/status")
+    assert status_resp.json()["enabled"] is True
+
+
+@pytest.mark.integration
+async def test_guild_scope_refuses_platform_oidc_login(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """Server-side enforcement: in guild scope the dormant platform provider
+    must not authenticate anyone, regardless of what a client requests."""
+    owner = await create_user(session, role=UserRole.owner)
+    headers = get_auth_headers(owner)
+    await _configure_platform_oidc(client, headers)
+    resp = await client.put(
+        "/api/v1/settings/auth-scope", json={"scope": "guild"}, headers=headers
+    )
+    assert resp.status_code == 200
+
+    login_resp = await client.get("/api/v1/auth/oidc/login")
+    assert login_resp.status_code == 404
+    assert login_resp.json()["detail"] == "OIDC_NOT_ENABLED"
+
+
+@pytest.mark.integration
+async def test_auth_scope_rejects_unknown_value(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    owner = await create_user(session, role=UserRole.owner)
+    resp = await client.put(
+        "/api/v1/settings/auth-scope",
+        json={"scope": "both"},
+        headers=get_auth_headers(owner),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+async def test_auth_scope_requires_config_manage(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    member = await create_user(session, role=UserRole.member)
+    resp = await client.put(
+        "/api/v1/settings/auth-scope",
+        json={"scope": "guild"},
+        headers=get_auth_headers(member),
+    )
+    assert resp.status_code == 403

--- a/backend/app/models/platform/app_setting.py
+++ b/backend/app/models/platform/app_setting.py
@@ -1,8 +1,21 @@
+from enum import Enum
 from typing import Optional
 
 from sqlalchemy import Boolean, Column, Integer, JSON, String
 from sqlmodel import Field, SQLModel
 from pydantic import ConfigDict
+
+
+class AuthScope(str, Enum):
+    """Where login is configured: once for the whole platform, or per guild.
+
+    Mutually exclusive postures (see the auth-settings-scope design doc): the
+    inactive side's provider configuration stays stored but dormant — switching
+    is non-destructive and reversible.
+    """
+
+    platform = "platform"
+    guild = "guild"
 
 
 class AppSetting(SQLModel, table=True):
@@ -11,6 +24,12 @@ class AppSetting(SQLModel, table=True):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     id: int = Field(default=1, primary_key=True)
+
+    # Which posture is live; the dormant side's config is kept, not deleted.
+    auth_scope: str = Field(
+        default=AuthScope.platform.value,
+        sa_column=Column(String(20), nullable=False, server_default="platform"),
+    )
 
     oidc_enabled: bool = Field(default=False, nullable=False)
     oidc_issuer: Optional[str] = None

--- a/backend/app/schemas/platform/settings.py
+++ b/backend/app/schemas/platform/settings.py
@@ -2,12 +2,20 @@ from typing import List, Optional
 
 from pydantic import ConfigDict, EmailStr, Field
 
+from app.models.platform.app_setting import AuthScope
 from app.schemas.base import RawTextStr, SanitizedBaseModel
+
+
+class AuthScopeUpdate(SanitizedBaseModel):
+    """Switch where login is configured (platform-wide vs per-guild)."""
+
+    scope: AuthScope
 
 
 class OIDCSettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
+    auth_scope: AuthScope
     enabled: bool
     issuer: Optional[str] = None
     client_id: Optional[str] = None
@@ -34,6 +42,9 @@ class InterfaceSettingsResponse(SanitizedBaseModel):
 
     light_accent_color: str
     dark_accent_color: str
+    # Non-secret posture info: the login page and guild settings need to know
+    # where sign-in is configured without a config.manage read.
+    auth_scope: AuthScope = AuthScope.platform
 
 
 class InterfaceSettingsUpdate(SanitizedBaseModel):

--- a/backend/app/schemas/platform/settings.py
+++ b/backend/app/schemas/platform/settings.py
@@ -43,8 +43,9 @@ class InterfaceSettingsResponse(SanitizedBaseModel):
     light_accent_color: str
     dark_accent_color: str
     # Non-secret posture info: the login page and guild settings need to know
-    # where sign-in is configured without a config.manage read.
-    auth_scope: AuthScope = AuthScope.platform
+    # where sign-in is configured without a config.manage read. Required — a
+    # construction site that forgets it must fail, not silently claim platform.
+    auth_scope: AuthScope
 
 
 class InterfaceSettingsUpdate(SanitizedBaseModel):

--- a/backend/app/services/platform/app_settings.py
+++ b/backend/app/services/platform/app_settings.py
@@ -198,6 +198,18 @@ async def get_app_settings(
     return await _ensure_app_settings(session)
 
 
+async def update_auth_scope(session: AsyncSession, *, scope: str) -> AppSetting:
+    """Switch the login-configuration posture. Non-destructive by design: only
+    the scope value changes — the dormant side's provider configuration
+    (``oidc_*``, ``auth_providers`` rows) is left untouched."""
+    settings_row = await _ensure_app_settings(session)
+    settings_row.auth_scope = scope
+    session.add(settings_row)
+    await session.commit()
+    await session.refresh(settings_row)
+    return settings_row
+
+
 async def update_oidc_settings(
     session: AsyncSession,
     *,

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -35,7 +35,8 @@
       "users": "Benutzer",
       "initiatives": "Initiativen",
       "trash": "Papierkorb",
-      "dangerZone": "Gefahrenzone"
+      "dangerZone": "Gefahrenzone",
+      "auth": "Authentifizierung"
     }
   },
   "profile": {
@@ -574,7 +575,17 @@
     "mappingSelectInitiativeFirst": "Zuerst Initiative auswählen",
     "loadingOptions": "Optionen werden geladen…",
     "loadingOidcMappings": "OIDC-Zuordnungen werden geladen…",
-    "oidcMappingsLoadError": "OIDC-Zuordnungen konnten nicht geladen werden."
+    "oidcMappingsLoadError": "OIDC-Zuordnungen konnten nicht geladen werden.",
+    "scope": {
+      "title": "Anmeldekonfiguration",
+      "description": "Lege fest, wo die Anmeldung für diesen Server konfiguriert wird.",
+      "platformLabel": "Plattformweit",
+      "platformHelp": "Die Anmeldung wird einmal, hier, für den gesamten Server konfiguriert. Alle Gilden verwenden sie. Ideal für eine einzelne Organisation mit eigener Instanz.",
+      "guildLabel": "Pro Gilde",
+      "guildHelp": "Jede Gilde konfiguriert ihre Anmeldung und Mitgliedschaftsregeln in ihren Gildeneinstellungen. Ideal für einen Server mit mehreren unabhängigen Organisationen.",
+      "comingSoon": "Demnächst",
+      "passwordNote": "Die Passwort-Anmeldung bleibt in beiden Modi verfügbar."
+    }
   },
   "platformUsers": {
     "title": "Plattformbenutzer",
@@ -752,7 +763,7 @@
     "title": "Plattformeinstellungen",
     "subtitle": "Konfiguriere Authentifizierung, Branding, E-Mail und KI für die gesamte Plattform.",
     "tabs": {
-      "auth": "Auth",
+      "auth": "Authentifizierung",
       "branding": "Branding",
       "email": "E-Mail",
       "ai": "KI"
@@ -804,5 +815,11 @@
       "storageLimit": "Speicherlimit",
       "status": "Status"
     }
+  },
+  "guildAuth": {
+    "title": "Authentifizierung",
+    "comingSoon": "Demnächst",
+    "description": "Anmeldekonfiguration für diese Gilde.",
+    "body": "Dieser Server verwendet die Anmeldung pro Gilde. Bald können Gilden-Admins hier Single Sign-on und Mitgliedschaftsregeln für diese Gilde konfigurieren."
   }
 }

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -35,7 +35,8 @@
       "users": "Users",
       "initiatives": "Initiatives",
       "trash": "Trash",
-      "dangerZone": "Danger zone"
+      "dangerZone": "Danger zone",
+      "auth": "Authentication"
     }
   },
   "profile": {
@@ -574,7 +575,17 @@
     "mappingSelectInitiativeFirst": "Select initiative first",
     "loadingOptions": "Loading options…",
     "loadingOidcMappings": "Loading OIDC mappings…",
-    "oidcMappingsLoadError": "Unable to load OIDC mappings."
+    "oidcMappingsLoadError": "Unable to load OIDC mappings.",
+    "scope": {
+      "title": "Login configuration",
+      "description": "Choose where sign-in is configured for this server.",
+      "platformLabel": "Platform-wide",
+      "platformHelp": "Sign-in is configured once, here, for the entire server. Every guild uses it. Best for a single organization running its own instance.",
+      "guildLabel": "Per-guild",
+      "guildHelp": "Each guild configures its own sign-in and membership rules in its guild settings. Best for a server hosting multiple independent organizations.",
+      "comingSoon": "Coming soon",
+      "passwordNote": "Password sign-in stays available in both modes."
+    }
   },
   "platformUsers": {
     "title": "Platform users",
@@ -752,7 +763,7 @@
     "title": "Platform settings",
     "subtitle": "Configure authentication, branding, email, AI, and guild storage for the entire platform.",
     "tabs": {
-      "auth": "Auth",
+      "auth": "Authentication",
       "branding": "Branding",
       "email": "Email",
       "ai": "AI"
@@ -804,5 +815,11 @@
       "access": "Access",
       "guilds": "Guilds"
     }
+  },
+  "guildAuth": {
+    "title": "Authentication",
+    "comingSoon": "Coming soon",
+    "description": "Sign-in configuration for this guild.",
+    "body": "This server uses per-guild login. Soon, guild admins will configure single sign-on and membership rules for this guild here."
   }
 }

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -35,7 +35,8 @@
       "users": "Usuarios",
       "initiatives": "Iniciativas",
       "trash": "Papelera",
-      "dangerZone": "Zona de peligro"
+      "dangerZone": "Zona de peligro",
+      "auth": "Autenticación"
     }
   },
   "profile": {
@@ -574,7 +575,17 @@
     "mappingSelectInitiativeFirst": "Selecciona una iniciativa primero",
     "loadingOptions": "Cargando opciones…",
     "loadingOidcMappings": "Cargando mapeos OIDC…",
-    "oidcMappingsLoadError": "No se pudieron cargar los mapeos OIDC."
+    "oidcMappingsLoadError": "No se pudieron cargar los mapeos OIDC.",
+    "scope": {
+      "title": "Configuración de inicio de sesión",
+      "description": "Elige dónde se configura el inicio de sesión para este servidor.",
+      "platformLabel": "Para toda la plataforma",
+      "platformHelp": "El inicio de sesión se configura una sola vez, aquí, para todo el servidor. Todos los gremios lo usan. Ideal para una sola organización con su propia instancia.",
+      "guildLabel": "Por gremio",
+      "guildHelp": "Cada gremio configura su propio inicio de sesión y sus reglas de membresía en los ajustes del gremio. Ideal para un servidor que aloja varias organizaciones independientes.",
+      "comingSoon": "Próximamente",
+      "passwordNote": "El inicio de sesión con contraseña sigue disponible en ambos modos."
+    }
   },
   "platformUsers": {
     "title": "Usuarios de la plataforma",
@@ -804,5 +815,11 @@
       "storageLimit": "Límite de almacenamiento",
       "status": "Estado"
     }
+  },
+  "guildAuth": {
+    "title": "Autenticación",
+    "comingSoon": "Próximamente",
+    "description": "Configuración de inicio de sesión para este gremio.",
+    "body": "Este servidor usa inicio de sesión por gremio. Pronto, los administradores del gremio podrán configurar aquí el inicio de sesión único y las reglas de membresía de este gremio."
   }
 }

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -35,7 +35,8 @@
       "users": "Utilisateurs",
       "initiatives": "Initiatives",
       "trash": "Corbeille",
-      "dangerZone": "Zone de danger"
+      "dangerZone": "Zone de danger",
+      "auth": "Authentification"
     }
   },
   "profile": {
@@ -574,7 +575,17 @@
     "mappingSelectInitiativeFirst": "Sélectionnez d'abord une initiative",
     "loadingOptions": "Chargement des options…",
     "loadingOidcMappings": "Chargement des correspondances OIDC…",
-    "oidcMappingsLoadError": "Impossible de charger les correspondances OIDC."
+    "oidcMappingsLoadError": "Impossible de charger les correspondances OIDC.",
+    "scope": {
+      "title": "Configuration de connexion",
+      "description": "Choisissez où la connexion est configurée pour ce serveur.",
+      "platformLabel": "À l'échelle de la plateforme",
+      "platformHelp": "La connexion est configurée une seule fois, ici, pour tout le serveur. Toutes les guildes l'utilisent. Idéal pour une organisation unique gérant sa propre instance.",
+      "guildLabel": "Par guilde",
+      "guildHelp": "Chaque guilde configure sa propre connexion et ses règles d'adhésion dans ses paramètres de guilde. Idéal pour un serveur hébergeant plusieurs organisations indépendantes.",
+      "comingSoon": "Bientôt disponible",
+      "passwordNote": "La connexion par mot de passe reste disponible dans les deux modes."
+    }
   },
   "platformUsers": {
     "title": "Utilisateurs de la plateforme",
@@ -752,7 +763,7 @@
     "title": "Paramètres de la plateforme",
     "subtitle": "Configurez l'authentification, la personnalisation, l'email et l'IA pour toute la plateforme.",
     "tabs": {
-      "auth": "Auth",
+      "auth": "Authentification",
       "branding": "Image de marque",
       "email": "E-mail",
       "ai": "IA"
@@ -804,5 +815,11 @@
       "storageLimit": "Limite de stockage",
       "status": "Statut"
     }
+  },
+  "guildAuth": {
+    "title": "Authentification",
+    "comingSoon": "Bientôt disponible",
+    "description": "Configuration de connexion pour cette guilde.",
+    "body": "Ce serveur utilise la connexion par guilde. Bientôt, les admins de guilde configureront ici l'authentification unique et les règles d'adhésion de cette guilde."
   }
 }

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -459,6 +459,27 @@ export interface AttachmentUploadResponse {
   size: number;
 }
 
+/**
+ * Where login is configured: once for the whole platform, or per guild.
+ *
+ * Mutually exclusive postures (see the auth-settings-scope design doc): the
+ * inactive side's provider configuration stays stored but dormant — switching
+ * is non-destructive and reversible.
+ */
+export type AuthScope = (typeof AuthScope)[keyof typeof AuthScope];
+
+export const AuthScope = {
+  platform: "platform",
+  guild: "guild",
+} as const;
+
+/**
+ * Switch where login is configured (platform-wide vs per-guild).
+ */
+export interface AuthScopeUpdate {
+  scope: AuthScope;
+}
+
 export interface BodyLoginAccessTokenApiV1AuthTokenPost {
   grant_type?: string | null;
   username: string;
@@ -1585,6 +1606,7 @@ export interface InitiativeUpdate {
 export interface InterfaceSettingsResponse {
   light_accent_color: string;
   dark_accent_color: string;
+  auth_scope: AuthScope;
 }
 
 export interface InterfaceSettingsUpdate {
@@ -1747,6 +1769,7 @@ export interface OIDCMappingsResponse {
 }
 
 export interface OIDCSettingsResponse {
+  auth_scope: AuthScope;
   enabled: boolean;
   issuer: string | null;
   client_id: string | null;

--- a/frontend/src/api/generated/settings/settings.ts
+++ b/frontend/src/api/generated/settings/settings.ts
@@ -21,6 +21,7 @@ import type {
 } from "@tanstack/react-query";
 
 import type {
+  AuthScopeUpdate,
   EmailSettingsResponse,
   EmailSettingsUpdate,
   EmailTestRequest,
@@ -273,6 +274,101 @@ export const useUpdateOidcSettingsApiV1SettingsAuthPut = <
 > => {
   return useMutation(
     getUpdateOidcSettingsApiV1SettingsAuthPutMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Switch where login is configured (platform-wide vs per-guild).
+ *
+ * Non-destructive: the dormant posture's provider configuration is kept, so
+ * switching back restores it exactly. Enforcement is server-side — the OIDC
+ * login endpoints refuse when the platform posture isn't active.
+ * @summary Update Auth Scope
+ */
+export const updateAuthScopeApiV1SettingsAuthScopePut = (
+  authScopeUpdate: BodyType<AuthScopeUpdate>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<OIDCSettingsResponse>(
+    {
+      url: `/api/v1/settings/auth-scope`,
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      data: authScopeUpdate,
+      signal,
+    },
+    options
+  );
+};
+
+export const getUpdateAuthScopeApiV1SettingsAuthScopePutMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateAuthScopeApiV1SettingsAuthScopePut>>,
+    TError,
+    { data: BodyType<AuthScopeUpdate> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateAuthScopeApiV1SettingsAuthScopePut>>,
+  TError,
+  { data: BodyType<AuthScopeUpdate> },
+  TContext
+> => {
+  const mutationKey = ["updateAuthScopeApiV1SettingsAuthScopePut"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateAuthScopeApiV1SettingsAuthScopePut>>,
+    { data: BodyType<AuthScopeUpdate> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return updateAuthScopeApiV1SettingsAuthScopePut(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateAuthScopeApiV1SettingsAuthScopePutMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateAuthScopeApiV1SettingsAuthScopePut>>
+>;
+export type UpdateAuthScopeApiV1SettingsAuthScopePutMutationBody = BodyType<AuthScopeUpdate>;
+export type UpdateAuthScopeApiV1SettingsAuthScopePutMutationError = ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Update Auth Scope
+ */
+export const useUpdateAuthScopeApiV1SettingsAuthScopePut = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateAuthScopeApiV1SettingsAuthScopePut>>,
+      TError,
+      { data: BodyType<AuthScopeUpdate> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateAuthScopeApiV1SettingsAuthScopePut>>,
+  TError,
+  { data: BodyType<AuthScopeUpdate> },
+  TContext
+> => {
+  return useMutation(
+    getUpdateAuthScopeApiV1SettingsAuthScopePutMutationOptions(options),
     queryClient
   );
 };

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import type {
+  AuthScopeUpdate,
   EmailSettingsResponse,
   EmailSettingsUpdate,
   FCMConfigResponse,
@@ -35,6 +36,7 @@ import {
   getOidcSettingsApiV1SettingsAuthGet,
   listPlatformGuildStorageApiV1SettingsGuildsGet,
   sendTestEmailApiV1SettingsEmailTestPost,
+  updateAuthScopeApiV1SettingsAuthScopePut,
   updateEmailSettingsApiV1SettingsEmailPut,
   updateInterfaceSettingsApiV1SettingsInterfacePut,
   updateOidcClaimPathApiV1SettingsOidcMappingsClaimPathPut,
@@ -185,6 +187,30 @@ export const useUpdateOidcSettings = (
     },
     onSuccess: (...args) => {
       void invalidateAuthSettings();
+      onSuccess?.(...args);
+    },
+    onError,
+    onSettled,
+  });
+};
+
+export const useUpdateAuthScope = (
+  options?: MutationOpts<OIDCSettingsResponse, AuthScopeUpdate>
+) => {
+  const { onSuccess, onError, onSettled, ...rest } = options ?? {};
+
+  return useMutation({
+    ...rest,
+    mutationFn: async (data: AuthScopeUpdate) => {
+      return updateAuthScopeApiV1SettingsAuthScopePut(
+        data
+      ) as unknown as Promise<OIDCSettingsResponse>;
+    },
+    onSuccess: (...args) => {
+      // The posture is read from both the admin auth settings and the public
+      // interface settings (login page / guild tab visibility).
+      void invalidateAuthSettings();
+      void invalidateInterfaceSettings();
       onSuccess?.(...args);
     },
     onError,

--- a/frontend/src/pages/GuildSettingsLayout.tsx
+++ b/frontend/src/pages/GuildSettingsLayout.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useInterfaceSettings } from "@/hooks/useSettings";
 import { extractSubPath, guildPath, isGuildScopedPath } from "@/lib/guildUrl";
 
 export const GuildSettingsLayout = () => {
@@ -19,6 +20,10 @@ export const GuildSettingsLayout = () => {
   // tool URL configured; OSS instances without it never see this tab even
   // if a user is a guild admin.
   const { advancedTool } = useAppConfig();
+  // The Authentication tab exists only in the guild-scoped login posture
+  // (non-secret posture info from the public interface settings).
+  const interfaceSettings = useInterfaceSettings();
+  const guildAuthEnabled = interfaceSettings.data?.auth_scope === "guild";
 
   // Get guild ID from URL params or active guild
   const urlGuildId = params.guildId ? Number(params.guildId) : activeGuildId;
@@ -41,6 +46,15 @@ export const GuildSettingsLayout = () => {
         label: t("guildLayout.tabs.users"),
         path: urlGuildId ? guildPath(urlGuildId, "/settings/users") : "/settings/users",
       },
+      ...(guildAuthEnabled
+        ? [
+            {
+              value: "auth",
+              label: t("guildLayout.tabs.auth"),
+              path: urlGuildId ? guildPath(urlGuildId, "/settings/auth") : "/settings/auth",
+            },
+          ]
+        : []),
       {
         value: "initiatives",
         label: t("guildLayout.tabs.initiatives"),
@@ -72,7 +86,7 @@ export const GuildSettingsLayout = () => {
       path: urlGuildId ? guildPath(urlGuildId, "/settings/danger-zone") : "/settings/danger-zone",
     });
     return tabs;
-  }, [urlGuildId, t, advancedTool]);
+  }, [urlGuildId, t, advancedTool, guildAuthEnabled]);
 
   const canViewSettings = isGuildAdmin;
   const availableTabs = isGuildAdmin ? guildSettingsTabs : [];

--- a/frontend/src/pages/SettingsAuthPage.tsx
+++ b/frontend/src/pages/SettingsAuthPage.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { OidcClaimMappingsSection } from "@/components/admin/OidcClaimMappingsSection";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -13,9 +14,10 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/hooks/useAuth";
-import { useOidcSettings, useUpdateOidcSettings } from "@/hooks/useSettings";
+import { useOidcSettings, useUpdateAuthScope, useUpdateOidcSettings } from "@/hooks/useSettings";
 import { Capability, hasCapability } from "@/lib/permissions";
 
 interface OidcSettings {
@@ -49,6 +51,7 @@ export const SettingsAuthPage = () => {
       setClientSecret("");
     },
   });
+  const updateAuthScope = useUpdateAuthScope();
 
   useEffect(() => {
     if (oidcQuery.data) {
@@ -90,8 +93,53 @@ export const SettingsAuthPage = () => {
     } as OidcSettings & { client_secret?: string });
   };
 
+  const authScope = oidcQuery.data.auth_scope;
+
   return (
     <div className="space-y-6">
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle>{t("auth.scope.title")}</CardTitle>
+          <CardDescription>{t("auth.scope.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <RadioGroup
+            value={authScope}
+            onValueChange={(value) => {
+              if (value !== authScope) {
+                updateAuthScope.mutate({ scope: value as "platform" | "guild" });
+              }
+            }}
+            className="gap-3"
+          >
+            <div className="flex items-start gap-3 rounded-md border px-3 py-3">
+              <RadioGroupItem id="auth-scope-platform" value="platform" className="mt-1" />
+              <div>
+                <Label htmlFor="auth-scope-platform" className="font-medium text-base">
+                  {t("auth.scope.platformLabel")}
+                </Label>
+                <p className="text-muted-foreground text-sm">{t("auth.scope.platformHelp")}</p>
+              </div>
+            </div>
+            {/* Per-guild sign-in ships disabled until guild-side configuration
+                exists; the backend + enforcement are already wired. */}
+            <div className="flex items-start gap-3 rounded-md border px-3 py-3 opacity-70">
+              <RadioGroupItem id="auth-scope-guild" value="guild" disabled className="mt-1" />
+              <div>
+                <Label
+                  htmlFor="auth-scope-guild"
+                  className="flex items-center gap-2 font-medium text-base"
+                >
+                  {t("auth.scope.guildLabel")}
+                  <Badge variant="secondary">{t("auth.scope.comingSoon")}</Badge>
+                </Label>
+                <p className="text-muted-foreground text-sm">{t("auth.scope.guildHelp")}</p>
+              </div>
+            </div>
+          </RadioGroup>
+          <p className="text-muted-foreground text-sm">{t("auth.scope.passwordNote")}</p>
+        </CardContent>
+      </Card>
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle>{t("auth.title")}</CardTitle>

--- a/frontend/src/pages/SettingsGuildAuthPage.tsx
+++ b/frontend/src/pages/SettingsGuildAuthPage.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Placeholder for guild-scoped sign-in configuration (visible only when the
+ * platform's login posture is per-guild). Guild provider CRUD and membership
+ * rules land here in a later phase; until then this page states what's coming.
+ */
+export const SettingsGuildAuthPage = () => {
+  const { t } = useTranslation("settings");
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {t("guildAuth.title")}
+          <Badge variant="secondary">{t("guildAuth.comingSoon")}</Badge>
+        </CardTitle>
+        <CardDescription>{t("guildAuth.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-muted-foreground text-sm">{t("guildAuth.body")}</p>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -73,6 +73,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdSettingsUsersRouteImport } 
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsTrashRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/trash'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsInitiativesRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/initiatives'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/danger-zone'
+import { Route as ServerRequiredAuthenticatedGGuildIdSettingsAuthRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/auth'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsAiRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/ai'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool'
 import { Route as ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/queues_.$queueId'
@@ -467,6 +468,12 @@ const ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute =
     path: '/danger-zone',
     getParentRoute: () => ServerRequiredAuthenticatedGGuildIdSettingsRoute,
   } as any)
+const ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute =
+  ServerRequiredAuthenticatedGGuildIdSettingsAuthRouteImport.update({
+    id: '/auth',
+    path: '/auth',
+    getParentRoute: () => ServerRequiredAuthenticatedGGuildIdSettingsRoute,
+  } as any)
 const ServerRequiredAuthenticatedGGuildIdSettingsAiRoute =
   ServerRequiredAuthenticatedGGuildIdSettingsAiRouteImport.update({
     id: '/ai',
@@ -642,6 +649,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/queues/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   '/g/$guildId/settings/ai': typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  '/g/$guildId/settings/auth': typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   '/g/$guildId/settings/danger-zone': typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   '/g/$guildId/settings/initiatives': typeof ServerRequiredAuthenticatedGGuildIdSettingsInitiativesRoute
   '/g/$guildId/settings/trash': typeof ServerRequiredAuthenticatedGGuildIdSettingsTrashRoute
@@ -716,6 +724,7 @@ export interface FileRoutesByTo {
   '/g/$guildId/queues/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   '/g/$guildId/settings/ai': typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  '/g/$guildId/settings/auth': typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   '/g/$guildId/settings/danger-zone': typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   '/g/$guildId/settings/initiatives': typeof ServerRequiredAuthenticatedGGuildIdSettingsInitiativesRoute
   '/g/$guildId/settings/trash': typeof ServerRequiredAuthenticatedGGuildIdSettingsTrashRoute
@@ -799,6 +808,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/ai': typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  '/_serverRequired/_authenticated/g/$guildId/settings/auth': typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/danger-zone': typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/initiatives': typeof ServerRequiredAuthenticatedGGuildIdSettingsInitiativesRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/trash': typeof ServerRequiredAuthenticatedGGuildIdSettingsTrashRoute
@@ -881,6 +891,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/queues/$queueId'
     | '/g/$guildId/settings/advanced-tool'
     | '/g/$guildId/settings/ai'
+    | '/g/$guildId/settings/auth'
     | '/g/$guildId/settings/danger-zone'
     | '/g/$guildId/settings/initiatives'
     | '/g/$guildId/settings/trash'
@@ -955,6 +966,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/queues/$queueId'
     | '/g/$guildId/settings/advanced-tool'
     | '/g/$guildId/settings/ai'
+    | '/g/$guildId/settings/auth'
     | '/g/$guildId/settings/danger-zone'
     | '/g/$guildId/settings/initiatives'
     | '/g/$guildId/settings/trash'
@@ -1037,6 +1049,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId'
     | '/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool'
     | '/_serverRequired/_authenticated/g/$guildId/settings/ai'
+    | '/_serverRequired/_authenticated/g/$guildId/settings/auth'
     | '/_serverRequired/_authenticated/g/$guildId/settings/danger-zone'
     | '/_serverRequired/_authenticated/g/$guildId/settings/initiatives'
     | '/_serverRequired/_authenticated/g/$guildId/settings/trash'
@@ -1509,6 +1522,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsRoute
     }
+    '/_serverRequired/_authenticated/g/$guildId/settings/auth': {
+      id: '/_serverRequired/_authenticated/g/$guildId/settings/auth'
+      path: '/auth'
+      fullPath: '/g/$guildId/settings/auth'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsRoute
+    }
     '/_serverRequired/_authenticated/g/$guildId/settings/ai': {
       id: '/_serverRequired/_authenticated/g/$guildId/settings/ai'
       path: '/ai'
@@ -1759,6 +1779,7 @@ const ServerRequiredAuthenticatedSettingsRouteWithChildren =
 interface ServerRequiredAuthenticatedGGuildIdSettingsRouteChildren {
   ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   ServerRequiredAuthenticatedGGuildIdSettingsAiRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   ServerRequiredAuthenticatedGGuildIdSettingsInitiativesRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsInitiativesRoute
   ServerRequiredAuthenticatedGGuildIdSettingsTrashRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsTrashRoute
@@ -1772,6 +1793,8 @@ const ServerRequiredAuthenticatedGGuildIdSettingsRouteChildren: ServerRequiredAu
       ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute,
     ServerRequiredAuthenticatedGGuildIdSettingsAiRoute:
       ServerRequiredAuthenticatedGGuildIdSettingsAiRoute,
+    ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute:
+      ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute,
     ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute:
       ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute,
     ServerRequiredAuthenticatedGGuildIdSettingsInitiativesRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/settings/auth.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/settings/auth.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/settings/auth")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/SettingsGuildAuthPage").then((m) => ({ default: m.SettingsGuildAuthPage }))
+  ),
+});


### PR DESCRIPTION
## Context

The approved settings reframe (`history/auth-settings-scope-design.md`): the platform's OIDC tab becomes an **Authentication** tab opening with one clear choice — **where login is configured**. Backend + enforcement + the minimal frontend, in one PR.

## Backend

`app_settings.auth_scope` — `'platform'` (sign-in configured once for the whole server; the enterprise/self-host posture) or `'guild'` (each guild configures its own; the multi-tenant posture). The postures are **mutually exclusive** by design decision — no operator-global + guild layering.

- **Migration 0136**: column with server default `'platform'` — every existing install upgrades with zero behavior change. Plain column addition; grants/RLS unchanged.
- **`PUT /settings/auth-scope`** (`config.manage`-gated). **Non-destructive**: switching only changes the scope value — the dormant side's provider configuration is kept exactly, so switching back restores it (same reversibility pattern as guild lifecycle status).
- **Read surfaces**: `auth_scope` on the OIDC settings response (admin tab) and on the public interface settings (non-secret posture info — login page + guild-tab visibility without `config.manage`).
- **Server-side enforcement, not just UI**: `/auth/oidc/status`, `/auth/oidc/login`, and `/auth/oidc/callback` all gate on the platform posture being live (one shared `_platform_oidc_active` predicate), so a dormant provider can never authenticate anyone regardless of what a client requests.

This supersedes the `ENTERPRISE_GUILD_SSO` env var from the auth design doc (§5b/§9) — the posture is runtime-switchable in the UI and the env var is never introduced. The upcoming wiring PR and Phase 1/2 surfaces hang their visibility off this same setting.

## Frontend

- Platform settings tab relabeled **Authentication** (en/de/es/fr), opening with the **Login configuration** card: a radio pair — **Platform-wide** (active) and **Per-guild**, which ships **disabled with a "Coming soon" badge** until guild-side configuration exists (user decision). The `useUpdateAuthScope` mutation + query invalidation are fully wired for when it's enabled. A note states password sign-in stays available in both modes.
- When the posture is `guild`, **guild settings gain an Authentication tab** (visibility driven by the public interface-settings posture) holding a coming-soon placeholder that describes what will live there.
- New strings in all four locales; route tree + generated API types regenerated.

## Tests

Backend — 5 new integration tests: default is `platform` (admin + public read); the switch round-trip is **non-destructive** (OIDC config intact, status re-enables); guild scope **refuses** the platform OIDC login (404, machine-readable code); unknown scope → 422; non-`config.manage` → 403. `settings_test.py` 33 passed, `auth_test.py` 51 passed. `ruff` clean.

Frontend — `pnpm typecheck` clean; changed-file suite 782 passed.

## Coordination note

Migration `0136` chains off `0134`. The in-flight auto-delegation-janitor branch carries `20260709_0135` — whichever PR merges **second** needs a one-line `down_revision` rebase (I'll handle it if that's me).
