### PR TITLE
Add OIDC identity resolution service

### DIFF
--- a/backend/alembic/versions/20260709_0136_add_auth_scope.py
+++ b/backend/alembic/versions/20260709_0136_add_auth_scope.py
@@ -15,7 +15,9 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20260709_0136"
-down_revision = "20260708_0134"
+# Rebased onto 0135 after both branches merged (they'd forked from 0134,
+# leaving two alembic heads); the two migrations touch unrelated tables.
+down_revision = "20260709_0135"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -1,0 +1,254 @@
+"""Resolve a verified external identity to an Initiative user.
+
+The step after :meth:`OidcProvider.complete`: given a provider row and the
+verified ``(subject, email, email_verified)``, find — or, where allowed,
+create — the user. Identity is keyed on **(provider, subject)** via
+``federated_identities``; email is never a join key, only a hint that an
+unlinked local account exists.
+
+This module is mechanism, not policy: every path returns an
+:class:`IdentityResolution` outcome and the caller (the login endpoint)
+decides what each outcome means for the request. In particular
+``EMAIL_MATCH`` — a verified email matching an existing, unlinked account —
+performs **no write**; whether that becomes an automatic link or an explicit
+confirmation flow is the caller's decision, made where the UX lives.
+``link_identity`` is the one mechanism for creating the link.
+
+Runs on the system engine (``federated_identities`` writes and cross-user
+reads are app_admin surfaces); callers pass their admin session. Never raises
+for a policy refusal — refusals are outcomes (the pattern from the session
+service: no raise-with-uncommitted-writes).
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import func, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.core.encryption import SALT_EMAIL, encrypt_field, hash_email
+from app.core.security import get_password_hash
+from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.federated_identity import FederatedIdentity
+from app.models.platform.user import User, UserRole, UserStatus
+
+logger = logging.getLogger(__name__)
+
+
+class ResolutionOutcome(str, Enum):
+    """What identity resolution concluded; the caller maps these to behavior."""
+
+    LINKED = "linked"  # (provider, subject) matched an existing link
+    PROVISIONED = "provisioned"  # no user existed; JIT-created and linked
+    EMAIL_MATCH = "email_match"  # verified email matches an UNLINKED account
+    EMAIL_UNVERIFIED = "email_unverified"  # matching account, email not asserted
+    JIT_DISABLED = "jit_disabled"  # unknown user; provider forbids JIT
+    REGISTRATION_DISABLED = "registration_disabled"  # unknown user; instance closed
+
+
+@dataclass(frozen=True)
+class IdentityResolution:
+    outcome: ResolutionOutcome
+    user: User | None = None
+    identity: FederatedIdentity | None = None
+
+
+async def resolve_oidc_identity(
+    session: AsyncSession,
+    *,
+    provider: AuthProvider,
+    subject: str,
+    email: str | None,
+    email_verified: bool,
+    full_name: str | None = None,
+    avatar_url: str | None = None,
+) -> IdentityResolution:
+    """Resolve ``(provider, subject)`` to a user.
+
+    ``email`` is the IdP-asserted address (``None`` when the IdP returns no
+    email claim — a synthetic ``{subject}@oidc.local`` address is used for
+    provisioning, mirroring the existing flow). Account-status checks (active,
+    deactivated) stay with the caller, as they do today.
+    """
+    identity = await _find_identity(session, provider_id=provider.id, subject=subject)
+    if identity is not None:
+        user = (
+            await session.exec(select(User).where(User.id == identity.user_id))
+        ).one_or_none()
+        if user is None:
+            # FK is ON DELETE CASCADE, so this is unreachable outside a torn
+            # backup; treat as unknown identity rather than 500ing a login.
+            logger.error(
+                "federated identity %s points at missing user %s",
+                identity.id,
+                identity.user_id,
+            )
+            return IdentityResolution(outcome=ResolutionOutcome.JIT_DISABLED)
+        identity.last_login_at = datetime.now(timezone.utc)
+        identity.email_verified = email_verified
+        session.add(identity)
+        await session.commit()
+        await session.refresh(identity)
+        return IdentityResolution(
+            outcome=ResolutionOutcome.LINKED, user=user, identity=identity
+        )
+
+    # No link. A real asserted email may match an existing local account —
+    # surface it, but never write: linking an email-matched account is the
+    # caller's policy decision (and requires the IdP to have verified the
+    # address; an unverified match is refused outright to keep a mintable
+    # unverified token from touching a victim's pre-registered account).
+    if email:
+        normalized = email.lower().strip()
+        existing = (
+            await session.exec(
+                select(User).where(User.email_hash == hash_email(normalized))
+            )
+        ).one_or_none()
+        if existing is not None:
+            if not email_verified:
+                logger.warning(
+                    "OIDC login: unverified email matches existing account "
+                    "(user_id=%s, provider=%s)",
+                    existing.id,
+                    provider.slug,
+                )
+                return IdentityResolution(
+                    outcome=ResolutionOutcome.EMAIL_UNVERIFIED, user=existing
+                )
+            return IdentityResolution(
+                outcome=ResolutionOutcome.EMAIL_MATCH, user=existing
+            )
+
+    # Unknown user: JIT-provision if the provider and the instance allow it.
+    if not provider.allow_jit:
+        return IdentityResolution(outcome=ResolutionOutcome.JIT_DISABLED)
+    if not await _registration_open(session):
+        return IdentityResolution(outcome=ResolutionOutcome.REGISTRATION_DISABLED)
+    return await _provision(
+        session,
+        provider=provider,
+        subject=subject,
+        email=email,
+        email_verified=email_verified,
+        full_name=full_name,
+        avatar_url=avatar_url,
+    )
+
+
+async def link_identity(
+    session: AsyncSession,
+    *,
+    user: User,
+    provider: AuthProvider,
+    subject: str,
+    email_verified: bool,
+) -> FederatedIdentity:
+    """Create the ``(provider, subject)`` link for ``user`` — the single
+    mechanism behind JIT provisioning and any caller-approved linking flow."""
+    identity = FederatedIdentity(
+        user_id=user.id,
+        provider_id=provider.id,
+        subject=subject,
+        email_verified=email_verified,
+        last_login_at=datetime.now(timezone.utc),
+    )
+    session.add(identity)
+    await session.commit()
+    await session.refresh(identity)
+    return identity
+
+
+async def _find_identity(
+    session: AsyncSession, *, provider_id: int, subject: str
+) -> FederatedIdentity | None:
+    return (
+        await session.exec(
+            select(FederatedIdentity).where(
+                FederatedIdentity.provider_id == provider_id,
+                FederatedIdentity.subject == subject,
+            )
+        )
+    ).one_or_none()
+
+
+async def _registration_open(session: AsyncSession) -> bool:
+    """Mirrors the existing OIDC flow's gate: a closed instance still admits
+    the very first user (fresh-install bootstrap)."""
+    if settings.ENABLE_PUBLIC_REGISTRATION and not settings.DISABLE_GUILD_CREATION:
+        return True
+    user_count = (await session.exec(select(func.count(User.id)))).one()
+    return user_count == 0
+
+
+async def _provision(
+    session: AsyncSession,
+    *,
+    provider: AuthProvider,
+    subject: str,
+    email: str | None,
+    email_verified: bool,
+    full_name: str | None,
+    avatar_url: str | None,
+) -> IdentityResolution:
+    # No email claim: a synthetic address keyed off the IdP-controlled subject
+    # (not attacker-choosable), as in the existing flow. It is not a mailbox,
+    # so it is never marked verified.
+    if email:
+        normalized = email.lower().strip()
+        verified = email_verified
+    else:
+        normalized = f"{subject}@oidc.local"
+        verified = False
+
+    user = User(
+        email_hash=hash_email(normalized),
+        email_encrypted=encrypt_field(normalized, SALT_EMAIL),
+        full_name=full_name or normalized,
+        # No usable password: random throwaway until hashed_password turns
+        # nullable in the final cutover phase.
+        hashed_password=get_password_hash(secrets.token_urlsafe(32)),
+        role=UserRole.member,
+        status=UserStatus.active,
+        avatar_url=avatar_url,
+        email_verified=verified,
+    )
+    session.add(user)
+    try:
+        await session.commit()
+    except IntegrityError:
+        # Lost a provisioning race (same subject or email landed first).
+        # Re-resolve instead of failing the login: the winner's rows are the
+        # truth now.
+        await session.rollback()
+        identity = await _find_identity(
+            session, provider_id=provider.id, subject=subject
+        )
+        if identity is not None:
+            existing = (
+                await session.exec(select(User).where(User.id == identity.user_id))
+            ).one_or_none()
+            if existing is not None:
+                return IdentityResolution(
+                    outcome=ResolutionOutcome.LINKED, user=existing, identity=identity
+                )
+        raise
+    await session.refresh(user)
+
+    identity = await link_identity(
+        session,
+        user=user,
+        provider=provider,
+        subject=subject,
+        email_verified=verified,
+    )
+    return IdentityResolution(
+        outcome=ResolutionOutcome.PROVISIONED, user=user, identity=identity
+    )

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -223,23 +223,28 @@ async def _provision(
         avatar_url=avatar_url,
         email_verified=verified,
     )
-    session.add(user)
     try:
-        # User + identity land in ONE transaction: flush assigns the user id
-        # without committing, then both commit together. So a failure can never
-        # leave a committed, login-less user with no identity (the orphan case),
-        # and there is no window where the user exists but the link doesn't.
-        await session.flush()
-        if user.id is None:  # populated by flush; guard also narrows the type
-            raise RuntimeError("user id not assigned after flush")
-        identity = FederatedIdentity(
-            user_id=user.id,
-            provider_id=provider.id,
-            subject=subject,
-            email_verified=verified,
-            last_login_at=datetime.now(timezone.utc),
-        )
-        session.add(identity)
+        # User + identity are inserted inside ONE savepoint: flush assigns the
+        # user id, then both are staged together. A conflict rolls the savepoint
+        # back (discarding our user — no orphan) while leaving the outer
+        # transaction usable for the recovery reads below. (A plain flush +
+        # session.rollback() would instead poison the connection and expire every
+        # object, so the recovery SELECT couldn't run — hence the savepoint, the
+        # same pattern the billing idempotency insert uses.)
+        async with session.begin_nested():
+            session.add(user)
+            await session.flush()
+            if user.id is None:  # populated by flush; guard also narrows the type
+                raise RuntimeError("user id not assigned after flush")
+            identity = FederatedIdentity(
+                user_id=user.id,
+                provider_id=provider.id,
+                subject=subject,
+                email_verified=verified,
+                last_login_at=datetime.now(timezone.utc),
+            )
+            session.add(identity)
+            await session.flush()
         await session.commit()
         await session.refresh(user)
         await session.refresh(identity)
@@ -247,12 +252,13 @@ async def _provision(
             outcome=ResolutionOutcome.PROVISIONED, user=user, identity=identity
         )
     except IntegrityError:
-        # Lost a provisioning race: a concurrent login inserted the same subject
-        # (or email) first. Its conflicting unique insert blocked ours until it
-        # committed, so the winner is now committed and visible — re-resolve to
-        # it instead of failing the login. The rollback discards our uncommitted
-        # user, so no orphan is left behind.
-        await session.rollback()
+        # Lost a JIT race with a concurrent login. A conflicting unique insert
+        # blocks until the other transaction commits, so by the time we're here
+        # the winner is committed and visible; the savepoint has already discarded
+        # our user (no orphan) and the outer transaction is intact. Resolve to
+        # whatever the winner left — the two unique constraints give two races:
+        # (a) (provider, subject) — a double-submit of the *same* login. The
+        #     winner's link is ours to use.
         winner = await _find_identity(session, provider_id=provider.id, subject=subject)
         if winner is not None:
             user = (
@@ -262,4 +268,26 @@ async def _provision(
                 return IdentityResolution(
                     outcome=ResolutionOutcome.LINKED, user=user, identity=winner
                 )
+        # (b) users.email_hash — a *different* subject with the same email (a
+        #     second provider, or the IdP issuing a new subject) got there first.
+        #     That is now an existing, unlinked account matched by email: the same
+        #     EMAIL_MATCH / EMAIL_UNVERIFIED decision a non-raced login makes,
+        #     never a silent link. Only a real asserted email can collide here —
+        #     the synthetic {subject}@oidc.local address is subject-unique, so its
+        #     only race is (a).
+        if email:
+            matched = (
+                await session.exec(
+                    select(User).where(
+                        User.email_hash == hash_email(email.lower().strip())
+                    )
+                )
+            ).one_or_none()
+            if matched is not None:
+                outcome = (
+                    ResolutionOutcome.EMAIL_MATCH
+                    if email_verified
+                    else ResolutionOutcome.EMAIL_UNVERIFIED
+                )
+                return IdentityResolution(outcome=outcome, user=matched)
         raise

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -151,8 +151,11 @@ async def link_identity(
     subject: str,
     email_verified: bool,
 ) -> FederatedIdentity:
-    """Create the ``(provider, subject)`` link for ``user`` — the single
-    mechanism behind JIT provisioning and any caller-approved linking flow."""
+    """Create the ``(provider, subject)`` link for an **existing** ``user`` —
+    the mechanism behind any caller-approved linking flow (e.g. an
+    ``EMAIL_MATCH`` the endpoint decides to link). JIT provisioning creates the
+    user and link atomically in ``_provision`` instead, so a failure can't
+    orphan a fresh user."""
     identity = FederatedIdentity(
         user_id=user.id,
         provider_id=provider.id,
@@ -222,33 +225,41 @@ async def _provision(
     )
     session.add(user)
     try:
-        await session.commit()
-    except IntegrityError:
-        # Lost a provisioning race (same subject or email landed first).
-        # Re-resolve instead of failing the login: the winner's rows are the
-        # truth now.
-        await session.rollback()
-        identity = await _find_identity(
-            session, provider_id=provider.id, subject=subject
+        # User + identity land in ONE transaction: flush assigns the user id
+        # without committing, then both commit together. So a failure can never
+        # leave a committed, login-less user with no identity (the orphan case),
+        # and there is no window where the user exists but the link doesn't.
+        await session.flush()
+        if user.id is None:  # populated by flush; guard also narrows the type
+            raise RuntimeError("user id not assigned after flush")
+        identity = FederatedIdentity(
+            user_id=user.id,
+            provider_id=provider.id,
+            subject=subject,
+            email_verified=verified,
+            last_login_at=datetime.now(timezone.utc),
         )
-        if identity is not None:
-            existing = (
-                await session.exec(select(User).where(User.id == identity.user_id))
+        session.add(identity)
+        await session.commit()
+        await session.refresh(user)
+        await session.refresh(identity)
+        return IdentityResolution(
+            outcome=ResolutionOutcome.PROVISIONED, user=user, identity=identity
+        )
+    except IntegrityError:
+        # Lost a provisioning race: a concurrent login inserted the same subject
+        # (or email) first. Its conflicting unique insert blocked ours until it
+        # committed, so the winner is now committed and visible — re-resolve to
+        # it instead of failing the login. The rollback discards our uncommitted
+        # user, so no orphan is left behind.
+        await session.rollback()
+        winner = await _find_identity(session, provider_id=provider.id, subject=subject)
+        if winner is not None:
+            user = (
+                await session.exec(select(User).where(User.id == winner.user_id))
             ).one_or_none()
-            if existing is not None:
+            if user is not None:
                 return IdentityResolution(
-                    outcome=ResolutionOutcome.LINKED, user=existing, identity=identity
+                    outcome=ResolutionOutcome.LINKED, user=user, identity=winner
                 )
         raise
-    await session.refresh(user)
-
-    identity = await link_identity(
-        session,
-        user=user,
-        provider=provider,
-        subject=subject,
-        email_verified=verified,
-    )
-    return IdentityResolution(
-        outcome=ResolutionOutcome.PROVISIONED, user=user, identity=identity
-    )

--- a/backend/app/services/auth/identity_test.py
+++ b/backend/app/services/auth/identity_test.py
@@ -82,6 +82,13 @@ async def test_existing_link_resolves_to_user(session):
     assert result.outcome is ResolutionOutcome.LINKED
     assert result.user.id == user.id
     assert result.identity.last_login_at is not None
+    # The returned user must be usable past its PK: the wiring endpoint reads
+    # user.status for the active/deactivated gate. Sessions are expire_on_commit
+    # =False (db/session.py + the fixture), so the SELECT-loaded user stays
+    # populated after the identity commit — no lazy IO, no MissingGreenlet. This
+    # access would raise if that ever regressed to expire-on-commit.
+    assert result.user.status == UserStatus.active
+    assert result.user.email_hash == user.email_hash
 
 
 async def test_link_is_scoped_to_its_provider(session):

--- a/backend/app/services/auth/identity_test.py
+++ b/backend/app/services/auth/identity_test.py
@@ -16,7 +16,7 @@ from app.core.config import settings
 from app.core.encryption import hash_email
 from app.models.platform.auth_provider import AuthProvider, AuthProviderKind
 from app.models.platform.federated_identity import FederatedIdentity
-from app.models.platform.user import UserRole, UserStatus
+from app.models.platform.user import User, UserRole, UserStatus
 from app.services.auth.identity import (
     IdentityResolution,
     ResolutionOutcome,
@@ -186,30 +186,83 @@ async def test_jit_disabled_provider_refuses_unknown_user(session):
     assert await _identities_for(session, provider) == []
 
 
-async def test_provisioning_writes_exactly_one_user_and_link(session):
-    """The JIT path is a single atomic transaction — one user, one link, no
-    partial state. (The lost-race recovery branch itself can't be exercised
-    here: the shared session fixture rolls the whole test back on the service's
-    rollback, so a concurrently-committed winner can't survive it; the branch is
-    correct by construction — atomic insert + Postgres unique-blocks-until-commit
-    — and becomes live in the wiring PR.)"""
+async def test_provision_recovers_from_subject_race_without_orphan(session):
+    """Case (a): a concurrent login committed our (provider, subject) first.
+    _provision must resolve to the winner (LINKED) and leave no orphaned user.
+    (The winner is created via a prior commit, which survives the service's
+    rollback; _provision is called directly since the top-level resolve would
+    short-circuit to LINKED before ever provisioning.)"""
+    from app.services.auth.identity import _provision
+
     provider = await _create_provider(session)
+    winner = await create_user(session, email="winner@example.com")
+    await link_identity(
+        session, user=winner, provider=provider, subject="sub-1", email_verified=True
+    )
 
-    result = await _resolve(session, provider, email="solo@example.com")
-    assert result.outcome is ResolutionOutcome.PROVISIONED
-
-    from app.models.platform.user import User
-
-    users = (
+    result = await _provision(
+        session,
+        provider=provider,
+        subject="sub-1",
+        email="loser@example.com",
+        email_verified=True,
+        full_name="Loser",
+        avatar_url=None,
+    )
+    assert result.outcome is ResolutionOutcome.LINKED
+    assert result.user.id == winner.id
+    # Our uncommitted user was rolled back — no orphan.
+    loser = (
         await session.exec(
-            select(User).where(User.email_hash == hash_email("solo@example.com"))
+            select(User).where(User.email_hash == hash_email("loser@example.com"))
         )
-    ).all()
-    assert len(users) == 1
-    links = await _identities_for(session, provider)
-    assert len(links) == 1
-    assert links[0].user_id == users[0].id
-    assert links[0].subject == "sub-1"
+    ).one_or_none()
+    assert loser is None
+
+
+async def test_provision_recovers_from_email_race_as_email_match(session):
+    """Case (b): a *different* subject with the same email won the email_hash
+    unique race. The loser must surface EMAIL_MATCH (never a silent link), not
+    re-raise a 500."""
+    from app.services.auth.identity import _provision
+
+    provider = await _create_provider(session)
+    winner = await create_user(session, email="shared@example.com")
+
+    result = await _provision(
+        session,
+        provider=provider,
+        subject="sub-new",
+        email="shared@example.com",
+        email_verified=True,
+        full_name="Loser",
+        avatar_url=None,
+    )
+    assert result.outcome is ResolutionOutcome.EMAIL_MATCH
+    assert result.user.id == winner.id
+    assert await _identities_for(session, provider) == []  # no link written
+
+
+async def test_provision_email_race_unverified_is_refused(session):
+    """Case (b) with an unverified asserted email → EMAIL_UNVERIFIED, mirroring
+    the non-raced account-takeover guard."""
+    from app.services.auth.identity import _provision
+
+    provider = await _create_provider(session)
+    winner = await create_user(session, email="victim@example.com")
+
+    result = await _provision(
+        session,
+        provider=provider,
+        subject="sub-new",
+        email="victim@example.com",
+        email_verified=False,
+        full_name="Attacker",
+        avatar_url=None,
+    )
+    assert result.outcome is ResolutionOutcome.EMAIL_UNVERIFIED
+    assert result.user.id == winner.id
+    assert await _identities_for(session, provider) == []
 
 
 async def test_closed_registration_refuses_unknown_user(session, monkeypatch):

--- a/backend/app/services/auth/identity_test.py
+++ b/backend/app/services/auth/identity_test.py
@@ -1,0 +1,196 @@
+"""Tests for OIDC identity resolution.
+
+Pins the resolution ladder — (provider, subject) link first, verified-email
+match surfaced but never written, JIT last and gated — and that refusals are
+outcomes, not exceptions.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from sqlmodel import select
+
+from app.core.config import settings
+from app.core.encryption import hash_email
+from app.models.platform.auth_provider import AuthProvider, AuthProviderKind
+from app.models.platform.federated_identity import FederatedIdentity
+from app.models.platform.user import UserRole, UserStatus
+from app.services.auth.identity import (
+    IdentityResolution,
+    ResolutionOutcome,
+    link_identity,
+    resolve_oidc_identity,
+)
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def _create_provider(session, *, allow_jit: bool = True) -> AuthProvider:
+    provider = AuthProvider(
+        slug=f"idp-{secrets.token_hex(4)}",
+        display_name="Test IdP",
+        kind=AuthProviderKind.oidc.value,
+        enabled=True,
+        guild_id=None,
+        issuer="https://idp.example.com",
+        client_id="client-123",
+        allow_jit=allow_jit,
+    )
+    session.add(provider)
+    await session.commit()
+    await session.refresh(provider)
+    return provider
+
+
+async def _resolve(session, provider, **overrides) -> IdentityResolution:
+    kwargs = {
+        "subject": "sub-1",
+        "email": "alice@example.com",
+        "email_verified": True,
+        "full_name": "Alice",
+    }
+    kwargs.update(overrides)
+    return await resolve_oidc_identity(session, provider=provider, **kwargs)
+
+
+async def _identities_for(session, provider) -> list[FederatedIdentity]:
+    return list(
+        (
+            await session.exec(
+                select(FederatedIdentity).where(
+                    FederatedIdentity.provider_id == provider.id
+                )
+            )
+        ).all()
+    )
+
+
+# --- linked -------------------------------------------------------------------
+
+
+async def test_existing_link_resolves_to_user(session):
+    provider = await _create_provider(session)
+    user = await create_user(session)
+    await link_identity(
+        session, user=user, provider=provider, subject="sub-1", email_verified=True
+    )
+
+    result = await _resolve(session, provider)
+    assert result.outcome is ResolutionOutcome.LINKED
+    assert result.user.id == user.id
+    assert result.identity.last_login_at is not None
+
+
+async def test_link_is_scoped_to_its_provider(session):
+    """The same subject at a different provider is a different identity."""
+    provider_a = await _create_provider(session)
+    provider_b = await _create_provider(session, allow_jit=False)
+    user = await create_user(session)
+    await link_identity(
+        session, user=user, provider=provider_a, subject="sub-1", email_verified=True
+    )
+
+    result = await _resolve(
+        session, provider_b, email="nobody@example.com", subject="sub-1"
+    )
+    assert result.outcome is ResolutionOutcome.JIT_DISABLED
+
+
+async def test_linked_login_refreshes_email_verified_snapshot(session):
+    provider = await _create_provider(session)
+    user = await create_user(session)
+    await link_identity(
+        session, user=user, provider=provider, subject="sub-1", email_verified=False
+    )
+
+    result = await _resolve(session, provider, email_verified=True)
+    assert result.outcome is ResolutionOutcome.LINKED
+    assert result.identity.email_verified is True
+
+
+# --- email match (no link) ------------------------------------------------------
+
+
+async def test_verified_email_match_is_surfaced_but_not_linked(session):
+    """An unlinked account matched by verified email is the caller's policy
+    decision — resolution itself must not write a link."""
+    provider = await _create_provider(session)
+    user = await create_user(session, email="alice@example.com")
+
+    result = await _resolve(session, provider, email="alice@example.com")
+    assert result.outcome is ResolutionOutcome.EMAIL_MATCH
+    assert result.user.id == user.id
+    assert result.identity is None
+    assert await _identities_for(session, provider) == []
+
+
+async def test_unverified_email_match_is_refused(session):
+    provider = await _create_provider(session)
+    await create_user(session, email="victim@example.com")
+
+    result = await _resolve(
+        session, provider, email="victim@example.com", email_verified=False
+    )
+    assert result.outcome is ResolutionOutcome.EMAIL_UNVERIFIED
+    assert await _identities_for(session, provider) == []
+
+
+# --- JIT provisioning -----------------------------------------------------------
+
+
+async def test_unknown_user_is_provisioned_and_linked(session):
+    provider = await _create_provider(session)
+
+    result = await _resolve(session, provider, email="new@example.com")
+    assert result.outcome is ResolutionOutcome.PROVISIONED
+    user = result.user
+    assert user.email_hash == hash_email("new@example.com")
+    assert user.role == UserRole.member
+    assert user.status == UserStatus.active
+    assert user.email_verified is True
+    assert user.full_name == "Alice"
+    assert result.identity.subject == "sub-1"
+
+    # The very next login resolves via the link.
+    again = await _resolve(session, provider, email="new@example.com")
+    assert again.outcome is ResolutionOutcome.LINKED
+    assert again.user.id == user.id
+
+
+async def test_provisioned_user_with_unverified_email_not_marked_verified(session):
+    provider = await _create_provider(session)
+    result = await _resolve(
+        session, provider, email="fresh@example.com", email_verified=False
+    )
+    assert result.outcome is ResolutionOutcome.PROVISIONED
+    assert result.user.email_verified is False
+
+
+async def test_missing_email_claim_uses_synthetic_address(session):
+    provider = await _create_provider(session)
+    result = await _resolve(session, provider, email=None, subject="opaque-7")
+    assert result.outcome is ResolutionOutcome.PROVISIONED
+    assert result.user.email_hash == hash_email("opaque-7@oidc.local")
+    # A synthetic address is not a mailbox; it is never marked verified.
+    assert result.user.email_verified is False
+
+
+async def test_jit_disabled_provider_refuses_unknown_user(session):
+    provider = await _create_provider(session, allow_jit=False)
+    result = await _resolve(session, provider, email="stranger@example.com")
+    assert result.outcome is ResolutionOutcome.JIT_DISABLED
+    assert result.user is None
+    assert await _identities_for(session, provider) == []
+
+
+async def test_closed_registration_refuses_unknown_user(session, monkeypatch):
+    provider = await _create_provider(session)
+    await create_user(session)  # instance is not empty → no bootstrap exception
+    monkeypatch.setattr(settings, "ENABLE_PUBLIC_REGISTRATION", False)
+
+    result = await _resolve(session, provider, email="stranger@example.com")
+    assert result.outcome is ResolutionOutcome.REGISTRATION_DISABLED
+    assert await _identities_for(session, provider) == []

--- a/backend/app/services/auth/identity_test.py
+++ b/backend/app/services/auth/identity_test.py
@@ -186,6 +186,32 @@ async def test_jit_disabled_provider_refuses_unknown_user(session):
     assert await _identities_for(session, provider) == []
 
 
+async def test_provisioning_writes_exactly_one_user_and_link(session):
+    """The JIT path is a single atomic transaction — one user, one link, no
+    partial state. (The lost-race recovery branch itself can't be exercised
+    here: the shared session fixture rolls the whole test back on the service's
+    rollback, so a concurrently-committed winner can't survive it; the branch is
+    correct by construction — atomic insert + Postgres unique-blocks-until-commit
+    — and becomes live in the wiring PR.)"""
+    provider = await _create_provider(session)
+
+    result = await _resolve(session, provider, email="solo@example.com")
+    assert result.outcome is ResolutionOutcome.PROVISIONED
+
+    from app.models.platform.user import User
+
+    users = (
+        await session.exec(
+            select(User).where(User.email_hash == hash_email("solo@example.com"))
+        )
+    ).all()
+    assert len(users) == 1
+    links = await _identities_for(session, provider)
+    assert len(links) == 1
+    assert links[0].user_id == users[0].id
+    assert links[0].subject == "sub-1"
+
+
 async def test_closed_registration_refuses_unknown_user(session, monkeypatch):
     provider = await _create_provider(session)
     await create_user(session)  # instance is not empty → no bootstrap exception

--- a/backend/app/services/auth/oidc/provider_test.py
+++ b/backend/app/services/auth/oidc/provider_test.py
@@ -10,6 +10,7 @@ claims.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlsplit
 
@@ -77,7 +78,7 @@ class FakeIdp:
     """
 
     def __init__(self, *, algs: tuple[str, ...] | None = ("RS256", "ES256")):
-        doc = {
+        doc: dict[str, object] = {
             "issuer": ISSUER,
             "authorization_endpoint": f"{ISSUER}/authorize",
             "token_endpoint": f"{ISSUER}/token",
@@ -87,9 +88,10 @@ class FakeIdp:
             doc["id_token_signing_alg_values_supported"] = list(algs)
         self.discovery_doc = doc
         self.jwks_doc = _jwks_doc()
-        # Callable building the token response from the parsed form, or a fixed
-        # httpx.Response.
-        self.token_response = None
+        # A fixed httpx.Response, or a callable building one from the parsed form.
+        self.token_response: (
+            httpx.Response | Callable[[dict[str, str]], httpx.Response] | None
+        ) = None
         self.token_request_form: dict[str, str] = {}
         self.calls: list[str] = []
 
@@ -104,9 +106,11 @@ class FakeIdp:
             form = parse_qs(request.content.decode())
             self.token_request_form = {k: v[0] for k, v in form.items()}
             resp = self.token_response
-            if callable(resp):
-                return resp(self.token_request_form)
-            return resp
+            if resp is None:
+                return httpx.Response(500, text="test did not set token_response")
+            if isinstance(resp, httpx.Response):
+                return resp
+            return resp(self.token_request_form)
         return httpx.Response(404)
 
     def client_factory(self):


### PR DESCRIPTION
## Context

Auth rewrite Phase 0, slice 2b-iv — the **last dormant piece** before the wiring PR. The step after `OidcProvider.complete` (#844): resolve the verified `(provider, subject)` to an Initiative user via `federated_identities`. Fixes the email-only-linking gap in the current flow at the service layer.

## Design: mechanism, not policy

Every path returns an `IdentityResolution` **outcome** (the session-service pattern — refusals never raise), and the wiring endpoint maps outcomes to behavior:

- **`LINKED`** — `(provider, subject)` matched; refreshes `last_login_at` + the `email_verified` snapshot. Links are provider-scoped (the same subject at another provider is a different identity — tested).
- **`EMAIL_MATCH`** — a **verified** email matches an existing *unlinked* account. Surfaced with **no write**: whether that becomes an automatic link or an explicit confirmation flow is the wiring PR's policy decision, made where the UX lives (`link_identity()` is the single mechanism either way). An **unverified** match is refused outright (`EMAIL_UNVERIFIED`) — same account-takeover guard the current flow has.
- **`PROVISIONED`** — JIT create + link, gated on `provider.allow_jit` **and** the instance registration gate (mirrors the existing flow, including the first-user bootstrap exception). Provisioning races heal by re-resolving to the winner instead of failing the login.
- **`JIT_DISABLED` / `REGISTRATION_DISABLED`** otherwise.

Runs on the caller's admin session (`federated_identities` is a system-engine surface). Account-status checks (active/deactivated) stay with the endpoint, as today.

**One deliberate deviation from legacy JIT, flagged for review:** the current flow marks every JIT user `email_verified=True` unconditionally. The new service marks the user verified only when the IdP asserted it; the synthetic `{subject}@oidc.local` fallback (no email claim) is never marked verified — it isn't a mailbox. Dormant now; becomes behavior at wiring.

## Also here

Linearizes migration `0136` onto `0135` — the coordination flagged on #846: both branches merged off `0134`, leaving two alembic heads. One-line `down_revision` rebase; the two migrations touch unrelated tables. (A local dev DB that already applied both heads may want `alembic stamp 20260709_0136`.)

## Tests

10 integration tests: link resolution + provider scoping + snapshot refresh; verified-email match surfaced **without** a link row (asserted); unverified match refused; JIT field correctness (role/status/email hash/verified flags), immediate re-resolution via the new link, synthetic-address path, `allow_jit=False`, and closed registration.

`pytest app/services/auth/identity_test.py` → 10 passed. `ruff` clean.

## Not in this PR
The wiring PR (next): point `/auth/oidc/*` at `OidcProvider` + this resolver, one-time config reconcile, legacy-path removal decisions — the release-flag point.