### PR TITLE
Demote fixed config to constants, clean up env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Platform admins can set a per-guild user limit (default unlimited) from the admin dashboard's Guilds tab; at the cap, new joins/invites are refused while existing members stay, and SSO auto-provisioning is exempt.
-- Platform admins can set a per-guild lifecycle status (`active` / `read_only` / `suspended`) for moderation holds — `read_only` blocks writes, `suspended` hides the guild from members while its admins keep full settings access. Non-active guilds pause trash auto-purge and block new joins; operators can still reach them via a break-glass grant. Reversible, never touches stored data.
-- Time-bound support/moderator access grants now act as a database-enforced `support` guild role: read grants are read-only, read_write grants can edit content/settings but are blocked from managing membership, roles, or sharing. Break-glass admin access is unchanged.
+- Per-guild user limits (default unlimited), set from the admin dashboard's Guilds tab. At the cap, new joins/invites are refused; existing members and SSO auto-provisioning are unaffected.
+- Per-guild lifecycle status for moderation holds: `read_only` blocks writes, `suspended` hides the guild from members (admins keep settings access). Reversible; never touches stored data.
+- Support/moderator access grants are now database-enforced: read grants are read-only; read_write grants can edit content but not membership, roles, or sharing.
 
 ### Changed
 
-- Operator "delete this guild" (offered when deleting a guild's sole admin) is now scoped to that user's solely-admined guild instead of accepting any guild id; guild admins still delete their own guild as before.
-- SSO (OIDC) sign-in has been rebuilt on a hardened relying-party flow: the provider's identity token is now cryptographically verified against its published signing keys (with issuer, audience, expiry, and per-login nonce checks) before any account is touched, and the login state is carried in an encrypted, expiring token. Accounts now link to the provider by its stable subject identifier rather than by email, so an email change at the provider no longer detaches (or misdirects) a login; a verified matching email still signs in to an existing account exactly as before.
+- Operator "delete this guild" is now scoped to the deleted user's solely-admined guild instead of accepting any guild id.
+- Removed the `ALGORITHM`, `COOKIE_NAME`, `REFRESH_COOKIE_NAME`, `PROJECT_NAME`, and `API_V1_STR` settings — their values are now fixed. Drop them from your `.env`; leftovers are ignored.
+- Removed the `OIDC_REDIRECT_URI` and `OIDC_POST_LOGIN_REDIRECT` settings (read by nothing — redirect URLs derive from `APP_URL`) and the legacy `OIDC_DISCOVERY_URL` alias. OIDC is configured in Settings → Admin; the `OIDC_*` env vars only pre-fill it on first boot. If you still set `OIDC_DISCOVERY_URL`, use `OIDC_ISSUER` instead.
+- `backend/.env.example` was rewritten; optional OIDC/SMTP/S3 lines are commented out so placeholder values no longer seed the admin settings on first boot.
+- SSO (OIDC) sign-in now fully verifies the provider's identity token (signature, issuer, audience, expiry, nonce) and links accounts by the provider's stable subject id instead of email. No action needed; existing logins keep working.
 
 ### Deprecated
 
-- Running migrations as a Postgres superuser (a superuser or `BYPASSRLS` role in `DATABASE_URL`) is deprecated and a future release will refuse to start with it. Affected deployments now get a prominent migration banner in the startup log on every boot. To fix it: (1) run `backend/scripts/create-provisioner.sql` once, connected as your current `DATABASE_URL` role, passing `-v provisioner_password='<pick-a-password>'`; (2) update `DATABASE_URL` in your `.env` to connect as `app_provisioner` with that password; (3) restart the app. Fresh docker-compose installs already use `app_provisioner`, and `DATABASE_URL_APP`/`DATABASE_URL_ADMIN` are unaffected.
-- Removed the `AUTO_APPROVED_EMAIL_DOMAINS` setting, an orphaned no-op left over from a removed approval-gated registration flow — it was read by nothing. Registration is controlled by `ENABLE_PUBLIC_REGISTRATION`, invite codes, and captcha; drop the variable from your `.env` if present (it is otherwise ignored).
+- A superuser (or `BYPASSRLS`) role in `DATABASE_URL` is deprecated; a future release will refuse to start with it. To migrate: run `backend/scripts/create-provisioner.sql` once (`-v provisioner_password='<password>'`), point `DATABASE_URL` at `app_provisioner`, restart. Fresh docker-compose installs already do this.
+- Removed the unused `AUTO_APPROVED_EMAIL_DOMAINS` setting (read by nothing). Drop it from your `.env` if present.
 
 ### Fixed
 
-- Guild lifecycle status is now enforced everywhere, not just on guild-addressed requests: a suspended guild's content no longer leaks through the cross-guild "My tasks/documents/projects/calendar" views, recent tabs, trash, stats, or notification digests, and a read-only guild routes those same aggregate reads through its read-only database role. Effective permission levels (`my_permission_level`, writable-project lists, live document collaboration) now report read-only while a guild is frozen — computed once in the permission engine, so the UI's edit affordances and the collaboration socket's write gate follow automatically. Members of a read-only guild see a banner and lose create/edit affordances instead of hitting errors; guild admins of a suspended guild land directly on guild settings (the surface that still works) instead of a wall of denied pages.
-- Guild storage caps can no longer be edited through the guild-facing settings endpoint — caps, member limits, tier label, and lifecycle status are platform-operator inputs, and the database now enforces that with column-scoped grants on `guilds` (a guild's own role can only update its name, description, and icon).
-- Anonymizing or deleting a user now scrubs their email out of any guild invite addressed to them (invite addresses are stored reversibly encrypted, so a lingering invite kept a recoverable copy); the invite is neutralized so this can't turn it into an open shareable link.
-- Startup no longer fails with `new row violates row-level security policy for table "guilds"` when the system-engine login (`DATABASE_URL_ADMIN`) has lost its `BYPASSRLS` attribute — typically after restoring a database from a dump, which recreates no roles (#835). Boot now verifies the attribute right after migrations, restores it automatically when `DATABASE_URL` is privileged enough, and otherwise stops with the exact `ALTER ROLE` command to run instead of the opaque seeding error.
+- `backend/scripts/create-provisioner.sql` missed the per-guild support roles: after switching `DATABASE_URL` to `app_provisioner`, deployments with existing guilds failed to boot with `permission denied to grant role "guild_N_support"`. If that hit you, run the fixed script once against your app database, connected as the Postgres superuser: `psql -v ON_ERROR_STOP=1 -U <superuser> -d <app-db> -v provisioner_password='<your password>' -f backend/scripts/create-provisioner.sql`. Running it again on a healthy install changes nothing.
+- Guild storage caps, member limits, tier label, and lifecycle status can no longer be edited through guild-facing settings — they are platform-operator inputs, now enforced with column-scoped database grants.
+- Anonymizing or deleting a user now scrubs their email from guild invites addressed to them, and neutralizes the invite so it can't become an open shareable link.
+- Startup no longer fails with an RLS error when `DATABASE_URL_ADMIN` has lost its `BYPASSRLS` attribute (typical after restoring from a dump, #835): boot restores it automatically when possible, and otherwise prints the exact `ALTER ROLE` command to run.
 
 ## [0.54.2] - 2026-07-04
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,150 +1,115 @@
-# FastAPI settings
-PROJECT_NAME=Initiative API
-API_V1_STR=/api/v1
-# REQUIRED: generate with: openssl rand -hex 32
-# The app refuses to start when SECRET_KEY is unset, a known placeholder, or shorter than 32 chars.
-# SECRET_KEY roots all encrypted-at-rest data (emails, OIDC/SMTP/AI secrets) and the
-# email-lookup hash — do NOT swap it in place. To change it, set PREVIOUS_SECRET_KEY to
-# the old value, set SECRET_KEY to the new one, and redeploy: the app re-encrypts
-# everything on startup (or run `python -m app.db.secret_key_rotation`). Unset
-# PREVIOUS_SECRET_KEY once the logs report 0 failures.
-SECRET_KEY=
-# OPTIONAL: the previous SECRET_KEY, set only while rotating it (see above). Taken
-# verbatim — leave unset in normal operation.
-PREVIOUS_SECRET_KEY=
-# OPTIONAL: dedicated JWT signing key. When set, session tokens are signed with this
-# instead of SECRET_KEY, so it can be rotated freely — the only effect is forcing every
-# user to log in again, with no impact on stored data. Same strength rules as SECRET_KEY.
-# Falls back to SECRET_KEY when unset. Generate with: openssl rand -hex 32
-JWT_SIGNING_KEY=
-ACCESS_TOKEN_EXPIRE_MINUTES=60
-ALGORITHM=HS256
+# Initiative backend configuration.
+# Copy to .env and fill in the required section. Everything else is optional —
+# most of it can be configured later in the app under Settings → Admin.
 
-# Database
-# Superuser connection (used for migrations and role creation)
-DATABASE_URL=postgresql+asyncpg://initiative:initiative@localhost:5432/initiative
-# Non-superuser connection for RLS-enforced queries (required)
+# --- Required ------------------------------------------------------------------
+
+# Generate with: openssl rand -hex 32
+# Never swap this on an existing install — it encrypts stored data. To rotate it
+# safely, see PREVIOUS_SECRET_KEY under "Advanced" below.
+SECRET_KEY=
+
+# Postgres connections (three roles, one database). Docker-compose installs
+# create the roles automatically on a fresh volume; for an existing database
+# run backend/scripts/create-provisioner.sql once.
+DATABASE_URL=postgresql+asyncpg://app_provisioner:provisioner_password@localhost:5432/initiative
 DATABASE_URL_APP=postgresql+asyncpg://app_user:app_user_password@localhost:5432/initiative
-# Admin connection with BYPASSRLS role for background jobs (required)
 DATABASE_URL_ADMIN=postgresql+asyncpg://app_admin:app_admin_password@localhost:5432/initiative
 
-# App URL (used to derive OIDC redirect URIs and links)
+# Public URL users reach the app at (links, login redirects).
 APP_URL=http://localhost:5173
 
-# Extra browser origins allowed to make credentialed cross-origin requests
-# (comma-separated). APP_URL and the native mobile app origins are always allowed
-# automatically, so this is only needed when the SPA is served from a different
-# origin than APP_URL: CORS_ALLOWED_ORIGINS=https://admin.example.com
-# A wildcard "*" is intentionally NOT supported — combined with cookie auth it
-# lets any website make authenticated requests on a user's behalf (CRIT-001).
-CORS_ALLOWED_ORIGINS=
+# --- Common options (defaults shown) --------------------------------------------
 
-# Guild creation
-DISABLE_GUILD_CREATION=false
+# Bootstrap owner. Leave unset (default) and the first person who signs up
+# becomes the platform owner — simplest and avoids a shared password. Or set
+# all three to auto-create the owner on first boot; if you do, pick a strong
+# password — the bootstrap path does NOT apply the normal password policy.
+# FIRST_OWNER_EMAIL=admin@example.com
+# FIRST_OWNER_PASSWORD=
+# FIRST_OWNER_FULL_NAME=Admin User
 
-# Public registration (set to false to require invite codes for all new users)
+# Session lifetime in minutes.
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+# Allow anyone to register (false = new users need an invite code).
 ENABLE_PUBLIC_REGISTRATION=true
-
-# Password policy: reject passwords found in the HaveIBeenPwned breach
-# corpus (k-anonymity API; only a 5-char SHA-1 prefix is sent). Set to
-# false for air-gapped or egress-restricted deployments — the 12-char
-# minimum still applies.
-HIBP_CHECK_ENABLED=true
-
-# Interactive API docs (Swagger UI at /api/v1/docs) and the raw OpenAPI schema
-# (/api/v1/openapi.json). Defaults to true for local dev. Set to false in
-# production so the full route/parameter/error map isn't publicly exposed.
-ENABLE_API_DOCS=true
-
-# In-app MCP server (Model Context Protocol) mounted at /api/v1/mcp/. Lets MCP
-# clients (e.g. Claude Code) drive a curated, read-mostly slice of the API as the
-# calling user, authenticated with a personal API key. Off by default; tools ride
-# the real auth + RLS, and a read-only API key blocks writes. Mounted at startup,
-# so a restart is required after changing this.
-ENABLE_MCP=false
-
-# Proxy settings (set true when behind nginx/load balancer)
+# Stop members from creating new guilds.
+DISABLE_GUILD_CREATION=false
+# Set true when running behind a reverse proxy (nginx, Traefik, ...).
 BEHIND_PROXY=false
-# Restrict which IPs are trusted to set proxy headers (default: * when BEHIND_PROXY=true)
+# IPs/CIDRs trusted to set proxy headers (comma-separated).
 # FORWARDED_ALLOW_IPS=127.0.0.1,172.16.0.0/12
+# Extra browser origins allowed to call the API, beyond APP_URL. No "*".
+# CORS_ALLOWED_ORIGINS=https://admin.example.com
 
-# Rate limiting (per-client IP). RATE_LIMIT_DEFAULT is applied to every route
-# that lacks its own decorator; set it empty to disable the global default
-# (per-route limits still apply). RATE_LIMIT_STORAGE_URI defaults to in-process
-# memory (per-worker) — point it at Redis for a shared counter across multiple
-# workers/replicas, no code change required.
+# --- Production hardening (defaults shown) ---------------------------------------
+
+# Reject passwords that appear in known breaches (HaveIBeenPwned; only a
+# 5-char hash prefix leaves the server). Set false for air-gapped installs.
+HIBP_CHECK_ENABLED=true
+# Interactive API docs at /api/v1/docs. Set false in production.
+ENABLE_API_DOCS=true
+# Per-IP rate limit for routes without their own limit. Point the storage at
+# Redis (redis://host:6379/0) when running multiple workers or replicas.
 RATE_LIMIT_DEFAULT=100/minute
 RATE_LIMIT_STORAGE_URI=memory://
-# RATE_LIMIT_STORAGE_URI=redis://redis:6379/0
-
-# Absolute server-side ceiling on how many rows one list request may return when
-# it asks for "all" (page_size=0). Bounds an otherwise-unbounded table dump while
-# keeping the "0 = all" convention the SPA relies on. Raise if a single guild
-# legitimately has more than this many tasks/documents on one board.
+# Cap on rows returned by a single "fetch all" list request.
 MAX_UNBOUNDED_PAGE_SIZE=1000
+# In-app MCP server at /api/v1/mcp/ (personal API keys, acts as the calling user).
+ENABLE_MCP=false
 
-# OIDC (optional)
-OIDC_ENABLED=false
-OIDC_ISSUER=https://accounts.example.com
-OIDC_CLIENT_ID=your-client-id
-OIDC_CLIENT_SECRET=your-client-secret
-OIDC_PROVIDER_NAME=Example SSO
-OIDC_SCOPES=openid,profile,email,offline_access
+# --- Optional integrations -------------------------------------------------------
+# OIDC and SMTP settings here only pre-fill the admin settings on FIRST boot;
+# after that the app UI owns them. Prefer configuring both in Settings → Admin.
 
-# SMTP (optional)
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_SECURE=false
-SMTP_REJECT_UNAUTHORIZED=true
-SMTP_USERNAME=
-SMTP_PASSWORD=
-SMTP_FROM_ADDRESS="Initiative <no-reply@example.com>"
-SMTP_TEST_RECIPIENT=
+# OIDC single sign-on
+# OIDC_ENABLED=true
+# OIDC_ISSUER=https://accounts.example.com
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_PROVIDER_NAME=Example SSO
+# OIDC_SCOPES=openid,profile,email,offline_access
 
-# Push Notifications (Firebase Cloud Messaging) - Optional
-# Required for mobile push notifications. See docs/FIREBASE_SETUP.md for complete setup guide.
-# Note: Mobile app also requires google-services.json in frontend/android/app/
+# Outgoing email (SMTP)
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_SECURE=false
+# SMTP_REJECT_UNAUTHORIZED=true
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_FROM_ADDRESS="Initiative <no-reply@example.com>"
+
+# Mobile push notifications (Firebase) — see docs/en/admin/push-notifications.md
 FCM_ENABLED=false
-FCM_PROJECT_ID=
-FCM_APPLICATION_ID=  # From google-services.json: client[0].client_info.mobilesdk_app_id
-FCM_API_KEY=  # From Firebase Console → Project Settings → Web API Key
-FCM_SENDER_ID=  # From google-services.json: project_info.project_number
-FCM_SERVICE_ACCOUNT_JSON=  # Service account JSON from Firebase (private, minified, keep secure)
+# FCM_PROJECT_ID=
+# FCM_APPLICATION_ID=
+# FCM_API_KEY=
+# FCM_SENDER_ID=
+# FCM_SERVICE_ACCOUNT_JSON=
 
-# Captcha on registration (optional). Pick a provider and supply the
-# matching key pair to gate public registration against bots. Leave
-# blank to disable — bootstrap-first-user registrations always skip.
-# For ``recaptcha``, only **v2** is supported (checkbox or invisible).
-# A v3 key will load the SDK but render "Invalid key type" inside the
-# widget — pick v2 when creating the key in the Google admin console.
-CAPTCHA_PROVIDER=  # one of: hcaptcha, turnstile, recaptcha (v2)
-CAPTCHA_SITE_KEY=  # public key, embedded in the SPA widget
-CAPTCHA_SECRET_KEY=  # server-side, used for siteverify
+# Captcha on public registration: hcaptcha, turnstile, or recaptcha (v2 keys only).
+# CAPTCHA_PROVIDER=
+# CAPTCHA_SITE_KEY=
+# CAPTCHA_SECRET_KEY=
 
-# Blob storage backend: "local" (default) stores uploads on the filesystem under
-# UPLOADS_DIR; "s3" stores them in any S3-compatible object store you point it at.
+# File storage: "local" (default, saved under UPLOADS_DIR) or "s3" (any
+# S3-compatible store — see docs/en/admin/object-storage.md).
 STORAGE_BACKEND=local
 UPLOADS_DIR=uploads
-# --- S3 / S3-compatible object storage (only read when STORAGE_BACKEND=s3) ---
-# Point these at your own object store (e.g. a self-hosted Garage instance). The
-# bucket must already exist; the app reads/writes objects but never creates it.
-# See docs/OBJECT_STORAGE.md.
-S3_BUCKET=
-S3_REGION=garage            # must match the region your store enforces (SigV4)
-S3_ENDPOINT_URL=            # your store's S3 API endpoint, e.g. http://garage:3900
-S3_ACCESS_KEY_ID=           # leave blank to use the ambient credential chain
-S3_SECRET_ACCESS_KEY=
-S3_USE_PATH_STYLE=true      # true for Garage and most self-hosted/non-AWS stores
-S3_KMS_KEY_ID=              # optional SSE-KMS key id/ARN; blank otherwise
-S3_LOCAL_FALLBACK=false     # migration window only: serve S3 read-misses from local disk
+# S3_BUCKET=
+# S3_REGION=garage
+# S3_ENDPOINT_URL=http://garage:3900
+# S3_ACCESS_KEY_ID=
+# S3_SECRET_ACCESS_KEY=
+# S3_USE_PATH_STYLE=true
+# S3_KMS_KEY_ID=
+# S3_LOCAL_FALLBACK=false
 
-# Initial superuser
-# DATABASE_URL should be the least-privilege app_provisioner role, NOT a
-# superuser. Fresh docker-compose installs create it automatically (initdb
-# script); existing deployments run backend/scripts/create-provisioner.sql once
-# — see the deployment docs. The app warns at boot if it detects a superuser.
+# --- Advanced --------------------------------------------------------------------
 
-# Becomes the platform `owner` (legacy FIRST_SUPERUSER_* names still accepted)
-FIRST_OWNER_EMAIL=admin@example.com
-FIRST_OWNER_PASSWORD=changeme
-FIRST_OWNER_FULL_NAME=Admin User
+# Rotating SECRET_KEY: move the old key here, set a new SECRET_KEY, and restart —
+# the app re-encrypts stored data on startup. Remove once the logs report success.
+# PREVIOUS_SECRET_KEY=
+# Separate signing key for session tokens. Rotating it just signs everyone out.
+# Same strength rules as SECRET_KEY; falls back to SECRET_KEY when unset.
+# JWT_SIGNING_KEY=

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -10,7 +10,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.capabilities import Capability, user_has_capability
-from app.core.config import settings
+from app.core.config import API_V1_STR, settings
 from app.core.pam_context import set_active_grant
 from app.core.role_context import (
     set_active_role,
@@ -19,6 +19,7 @@ from app.core.role_context import (
 )
 from app.core.messages import AuthMessages, GuildMessages, UserMessages
 from app.core.security import (
+    SESSION_COOKIE_NAME,
     AutoDelegationVerificationError,
     UploadTokenError,
     decode_session_token,
@@ -40,7 +41,7 @@ from app.services.platform import user_tokens
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 
 oauth2_scheme = OAuth2PasswordBearer(
-    tokenUrl=f"{settings.API_V1_STR}/auth/token", auto_error=False
+    tokenUrl=f"{API_V1_STR}/auth/token", auto_error=False
 )
 
 
@@ -166,7 +167,7 @@ async def get_current_user(
     request: Request,
     session: SessionDep,
     bearer_token: Annotated[Optional[str], Depends(oauth2_scheme)] = None,
-    session_cookie: Annotated[Optional[str], Cookie(alias=settings.COOKIE_NAME)] = None,
+    session_cookie: Annotated[Optional[str], Cookie(alias=SESSION_COOKIE_NAME)] = None,
 ) -> User:
     # Check for Authorization header - could be Bearer, DeviceToken, or API key
     auth_header = request.headers.get("Authorization", "")
@@ -247,7 +248,7 @@ async def get_current_user_optional(
     request: Request,
     session: SessionDep,
     bearer_token: Annotated[Optional[str], Depends(oauth2_scheme)] = None,
-    session_cookie: Annotated[Optional[str], Cookie(alias=settings.COOKIE_NAME)] = None,
+    session_cookie: Annotated[Optional[str], Cookie(alias=SESSION_COOKIE_NAME)] = None,
 ) -> User | None:
     try:
         return await get_current_user(request, session, bearer_token, session_cookie)
@@ -756,7 +757,7 @@ async def get_upload_user(
     session: SessionDep,
     bearer_token: Annotated[Optional[str], Depends(oauth2_scheme)] = None,
     token_param: Annotated[Optional[str], Query(alias="token")] = None,
-    session_cookie: Annotated[Optional[str], Cookie(alias=settings.COOKIE_NAME)] = None,
+    session_cookie: Annotated[Optional[str], Cookie(alias=SESSION_COOKIE_NAME)] = None,
 ) -> User:
     """Auth dependency for /uploads/* and authenticated document downloads.
 

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -13,7 +13,7 @@ from sqlmodel import delete as sql_delete, select
 
 from app.api.deps import SessionDep, get_current_active_user, get_current_user_optional
 from app.db.session import get_admin_session
-from app.core.config import settings
+from app.core.config import API_V1_STR, settings
 from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.rate_limit import get_real_client_ip, limiter
 from app.core.encryption import (
@@ -27,6 +27,8 @@ from app.core.encryption import (
 from app.core.messages import AuthMessages, OidcMessages
 from app.core.password_policy import enforce_password_policy
 from app.core.security import (
+    REFRESH_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
     create_access_token,
     create_upload_token,
     get_password_hash,
@@ -86,7 +88,7 @@ _oidc_jwks = JwksResolver()
 
 # The refresh cookie is scoped to the auth routes so it never rides along on
 # ordinary API requests — it is only presented to /auth/refresh and /auth/logout.
-REFRESH_COOKIE_PATH = f"{settings.API_V1_STR}/auth"
+REFRESH_COOKIE_PATH = f"{API_V1_STR}/auth"
 
 
 def _client_ip(request: Request) -> str | None:
@@ -105,7 +107,7 @@ def _set_session_cookie(response: Response, token: str, *, max_age: int) -> None
     cutover this holds a legacy JWT at login and a new-model access token after
     the first refresh — the verifier accepts either."""
     response.set_cookie(
-        key=settings.COOKIE_NAME,
+        key=SESSION_COOKIE_NAME,
         value=token,
         httponly=True,
         samesite="lax",
@@ -117,7 +119,7 @@ def _set_session_cookie(response: Response, token: str, *, max_age: int) -> None
 
 def _set_refresh_cookie(response: Response, token: str) -> None:
     response.set_cookie(
-        key=settings.REFRESH_COOKIE_NAME,
+        key=REFRESH_COOKIE_NAME,
         value=token,
         httponly=True,
         samesite="lax",
@@ -129,7 +131,7 @@ def _set_refresh_cookie(response: Response, token: str) -> None:
 
 def _clear_refresh_cookie(response: Response) -> None:
     response.delete_cookie(
-        key=settings.REFRESH_COOKIE_NAME,
+        key=REFRESH_COOKIE_NAME,
         path=REFRESH_COOKIE_PATH,
         httponly=True,
         secure=settings.cookie_secure,
@@ -151,7 +153,7 @@ def _refresh_rejected(detail: str) -> JSONResponse:
         headers={"WWW-Authenticate": "Bearer"},
     )
     _clear_refresh_cookie(response)
-    response.delete_cookie(key=settings.COOKIE_NAME, path="/")
+    response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
     return response
 
 
@@ -457,7 +459,7 @@ async def refresh_access_token(
     was detected. Runs on the system engine: validation is a pre-auth lookup by
     refresh-token hash.
     """
-    raw = request.cookies.get(settings.REFRESH_COOKIE_NAME)
+    raw = request.cookies.get(REFRESH_COOKIE_NAME)
     if not raw:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -545,7 +547,7 @@ async def logout(
         )
         await admin_session.commit()
     response.delete_cookie(
-        key=settings.COOKIE_NAME,
+        key=SESSION_COOKIE_NAME,
         path="/",
         httponly=True,
         secure=settings.cookie_secure,
@@ -658,7 +660,7 @@ async def revoke_device_token(
 
 def _backend_redirect_uri() -> str:
     base = settings.APP_URL.rstrip("/")
-    return f"{base}{settings.API_V1_STR}/auth/oidc/callback"
+    return f"{base}{API_V1_STR}/auth/oidc/callback"
 
 
 def _frontend_redirect_uri() -> str:
@@ -723,7 +725,7 @@ async def oidc_status(request: Request, session: SessionDep) -> dict[str, Any]:
     login_url = None
     provider_name = None
     if enabled:
-        login_url = f"{settings.API_V1_STR}/auth/oidc/login"
+        login_url = f"{API_V1_STR}/auth/oidc/login"
         provider_name = app_settings.oidc_provider_name
     return {"enabled": enabled, "login_url": login_url, "provider_name": provider_name}
 
@@ -934,7 +936,7 @@ async def oidc_callback(
     )
     oidc_response = RedirectResponse(_frontend_redirect_uri())
     oidc_response.set_cookie(
-        key=settings.COOKIE_NAME,
+        key=SESSION_COOKIE_NAME,
         value=app_token,
         httponly=True,
         samesite="lax",

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -27,6 +27,7 @@ from app.core.encryption import (
 )
 from app.core.messages import OidcMessages
 from app.core.security import (
+    SESSION_COOKIE_NAME,
     create_access_token,
     create_upload_token,
     get_password_hash,
@@ -949,8 +950,6 @@ async def test_oidc_callback_provisions_new_user_and_sets_cookie(
 ):
     """Happy path: a verified id_token provisions the unknown user, links the
     federated identity, and issues the web session cookie."""
-    from app.core.config import settings as app_config
-
     await _enable_platform_oidc(session)
     idp = FakeIdp()
     _wire_fake_idp(monkeypatch, idp)
@@ -966,7 +965,7 @@ async def test_oidc_callback_provisions_new_user_and_sets_cookie(
     )
     assert response.status_code in (302, 307)
     assert response.headers["location"].endswith("/oidc/callback")
-    assert app_config.COOKIE_NAME in response.cookies
+    assert SESSION_COOKIE_NAME in response.cookies
 
     user = (
         await session.exec(
@@ -1111,8 +1110,6 @@ async def test_oidc_callback_links_existing_account_when_email_verified(
     """SEC-9 counterpart: a matching email with ``email_verified=true`` logs
     into the existing account, promotes it to verified, and now writes the
     (provider, subject) link so later logins resolve by subject."""
-    from app.core.config import settings as app_config
-
     existing = await create_user(
         session,
         email="member@example.com",
@@ -1128,7 +1125,7 @@ async def test_oidc_callback_links_existing_account_when_email_verified(
 
     assert response.status_code in (302, 307)
     assert "OIDC_EMAIL_UNVERIFIED" not in response.headers["location"]
-    assert app_config.COOKIE_NAME in response.cookies
+    assert SESSION_COOKIE_NAME in response.cookies
     await session.refresh(existing)
     assert existing.email_verified is True
     identities = await _federated_identities(session)
@@ -1138,7 +1135,7 @@ async def test_oidc_callback_links_existing_account_when_email_verified(
 
     # The second login resolves through the link (and still issues a session).
     again = await _run_oidc_flow(client, idp, id_token_claims=claims)
-    assert app_config.COOKIE_NAME in again.cookies
+    assert SESSION_COOKIE_NAME in again.cookies
     assert len(await _federated_identities(session)) == 1
 
 

--- a/backend/app/api/v1/platform_endpoints/guilds_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_test.py
@@ -828,7 +828,7 @@ async def test_guild_advanced_tool_handoff_succeeds_for_admin(
         body["handoff_token"],
         app_settings.SECRET_KEY,
         # Hardcoded HS256 — the handoff signing path uses HS256 in its
-        # no-private-key fallback regardless of settings.ALGORITHM. See
+        # no-private-key fallback regardless of JWT_ALGORITHM. See
         # initiatives_test.py for the same rationale.
         algorithms=["HS256"],
         audience=ADVANCED_TOOL_AUDIENCE,

--- a/backend/app/api/v1/platform_endpoints/native.py
+++ b/backend/app/api/v1/platform_endpoints/native.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
-from app.core.config import settings
+from app.core.config import API_V1_STR
 from app.core.messages import NativeMessages
 from app.core.version import __version__, get_min_native_version
 
@@ -45,7 +45,7 @@ def get_bundle_manifest() -> dict[str, object]:
         )
     return {
         "version": __version__,
-        "url": f"{settings.API_V1_STR}/native/bundle/download",
+        "url": f"{API_V1_STR}/native/bundle/download",
         "checksum": _CHECKSUM_PATH.read_text().strip(),
         "minNativeVersion": get_min_native_version(),
     }

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -14,6 +14,7 @@ from app.api.deps import (
     require_guild_roles,
 )
 from app.api.v1.platform_endpoints.admin import ConfigManageDep, GuildsManageDep
+from app.core.config import API_V1_STR
 from app.core.config import settings as app_config
 from app.core.rate_limit import limiter
 from app.db.session import get_admin_session, set_rls_context
@@ -67,7 +68,7 @@ GuildAdminContext = Annotated[
 
 
 def _backend_redirect_uri() -> str:
-    return f"{app_config.APP_URL.rstrip('/')}{app_config.API_V1_STR}/auth/oidc/callback"
+    return f"{app_config.APP_URL.rstrip('/')}{API_V1_STR}/auth/oidc/callback"
 
 
 def _frontend_redirect_uri() -> str:

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -16,7 +16,12 @@ from app.api.deps import (
 from app.core.config import settings
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.password_policy import enforce_password_policy
-from app.core.security import create_access_token, get_password_hash, verify_password
+from app.core.security import (
+    SESSION_COOKIE_NAME,
+    create_access_token,
+    get_password_hash,
+    verify_password,
+)
 from app.core.user_input_validators import (
     normalize_notification_time,
     normalize_reminder_minutes,
@@ -354,7 +359,7 @@ async def update_users_me(
             token_version=current_user.token_version,
         )
         response.set_cookie(
-            key=settings.COOKIE_NAME,
+            key=SESSION_COOKIE_NAME,
             value=refreshed_token,
             httponly=True,
             samesite="lax",

--- a/backend/app/api/v1/tenant_endpoints/collaboration.py
+++ b/backend/app/api/v1/tenant_endpoints/collaboration.py
@@ -35,7 +35,7 @@ from app.api.deps import (
     GuildAccessError,
     GuildContext,
 )
-from app.core.config import settings
+from app.core.security import SESSION_COOKIE_NAME
 from app.db.session import AsyncSessionLocal, set_rls_context
 from app.models.tenant.document import Document
 from app.models.tenant.resource_grant import ResourceGrant
@@ -147,7 +147,7 @@ async def websocket_collaborate(
             token = auth_payload.get("token")
             if not token:
                 # Fall back to session cookie (web sessions after page refresh)
-                token = websocket.cookies.get(settings.COOKIE_NAME)
+                token = websocket.cookies.get(SESSION_COOKIE_NAME)
             if not token:
                 raise ValueError("Missing token")
         except (json.JSONDecodeError, ValueError) as e:

--- a/backend/app/api/v1/tenant_endpoints/counters.py
+++ b/backend/app/api/v1/tenant_endpoints/counters.py
@@ -28,7 +28,7 @@ from app.api.deps import (
     GuildAccessError,
     GuildContext,
 )
-from app.core.config import settings
+from app.core.security import SESSION_COOKIE_NAME
 from app.core.messages import CounterMessages, InitiativeMessages
 from app.db.session import AsyncSessionLocal
 from app.models.tenant.counter import (
@@ -893,7 +893,7 @@ async def websocket_counter_group(
         auth_payload = json.loads(raw)
         token = auth_payload.get("token")
         if not token:
-            token = websocket.cookies.get(settings.COOKIE_NAME)
+            token = websocket.cookies.get(SESSION_COOKIE_NAME)
         if not token:
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
             return

--- a/backend/app/api/v1/tenant_endpoints/events.py
+++ b/backend/app/api/v1/tenant_endpoints/events.py
@@ -9,7 +9,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import establish_guild_access, GuildAccessError
-from app.core.config import settings
+from app.core.security import SESSION_COOKIE_NAME
 from app.db.session import AsyncSessionLocal
 from app.models.tenant.initiative import Initiative
 from app.models.platform.user import User
@@ -82,7 +82,7 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
             token = auth_payload.get("token")
             if not token:
                 # Fall back to session cookie (web sessions after page refresh)
-                token = websocket.cookies.get(settings.COOKIE_NAME)
+                token = websocket.cookies.get(SESSION_COOKIE_NAME)
             if not token:
                 raise ValueError("Missing token")
         except (json.JSONDecodeError, ValueError, TypeError) as e:

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -853,10 +853,10 @@ async def test_advanced_tool_handoff_succeeds_for_initiative_manager(
     payload = jwt.decode(
         body["handoff_token"],
         app_settings.SECRET_KEY,
-        # Hardcoded HS256 (not settings.ALGORITHM) — the handoff signing
+        # Hardcoded HS256 (not JWT_ALGORITHM) — the handoff signing
         # path explicitly uses HS256 in its no-private-key fallback, so
         # tests must assert against that algorithm directly. Decoupling
-        # from settings.ALGORITHM keeps these tests stable if the global
+        # from JWT_ALGORITHM keeps these tests stable if the global
         # session-token algorithm is ever changed.
         algorithms=["HS256"],
         audience=ADVANCED_TOOL_AUDIENCE,
@@ -933,10 +933,10 @@ async def test_advanced_tool_handoff_can_create_false_for_view_only_role(
     payload = jwt.decode(
         response.json()["handoff_token"],
         app_settings.SECRET_KEY,
-        # Hardcoded HS256 (not settings.ALGORITHM) — the handoff signing
+        # Hardcoded HS256 (not JWT_ALGORITHM) — the handoff signing
         # path explicitly uses HS256 in its no-private-key fallback, so
         # tests must assert against that algorithm directly. Decoupling
-        # from settings.ALGORITHM keeps these tests stable if the global
+        # from JWT_ALGORITHM keeps these tests stable if the global
         # session-token algorithm is ever changed.
         algorithms=["HS256"],
         audience=ADVANCED_TOOL_AUDIENCE,

--- a/backend/app/api/v1/tenant_endpoints/queues.py
+++ b/backend/app/api/v1/tenant_endpoints/queues.py
@@ -31,7 +31,7 @@ from app.api.deps import (
     GuildAccessError,
     GuildContext,
 )
-from app.core.config import settings
+from app.core.security import SESSION_COOKIE_NAME
 from app.db.session import AsyncSessionLocal
 from app.models.tenant.queue import (
     Queue,
@@ -1090,7 +1090,7 @@ async def websocket_queue(
         auth_payload = json.loads(raw)
         token = auth_payload.get("token")
         if not token:
-            token = websocket.cookies.get(settings.COOKIE_NAME)
+            token = websocket.cookies.get(SESSION_COOKIE_NAME)
         if not token:
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
             return

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,8 +1,14 @@
 from functools import lru_cache
 from urllib.parse import urlsplit
 
-from pydantic import AliasChoices, EmailStr, Field, field_validator, model_validator
+from pydantic import AliasChoices, EmailStr, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# App identity/shape — deliberately constants, not settings: the SPA, the
+# docs-CSP route, and the OpenAPI export all assume this prefix, so making it
+# configurable only creates ways to break them.
+PROJECT_NAME = "Initiative API"
+API_V1_STR = "/api/v1"
 
 # Origins used by the Capacitor native mobile app (iOS and Android).
 # Must always be allowed regardless of CORS_ALLOWED_ORIGINS setting.
@@ -127,9 +133,6 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    PROJECT_NAME: str = "Initiative API"
-    API_V1_STR: str = "/api/v1"
-
     DATABASE_URL: str = (
         "postgresql+asyncpg://initiative:initiative@localhost:5432/initiative"
     )
@@ -151,12 +154,10 @@ class Settings(BaseSettings):
     # with no impact on encrypted-at-rest data. Falls back to SECRET_KEY when unset.
     JWT_SIGNING_KEY: str | None = None
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
-    ALGORITHM: str = "HS256"
-    COOKIE_NAME: str = "session_token"
-    # New login model: the rotating refresh token rides in its own HttpOnly
-    # cookie, path-scoped to the auth routes (sent only on refresh/logout, never
-    # on ordinary API calls — smaller exposure than the session cookie).
-    REFRESH_COOKIE_NAME: str = "refresh_token"
+    # The JWT algorithm and cookie names are constants in app.core.security
+    # (JWT_ALGORITHM, SESSION_COOKIE_NAME, REFRESH_COOKIE_NAME) — a settable
+    # JWT algorithm is an alg-confusion hazard, and the cookie names are part
+    # of the auth contract, not deployment configuration.
 
     # New login model (auth rewrite, Phase 0 — history/auth-detailed-design.md §3).
     # The access token is short-lived + stateless: verified locally with no
@@ -343,8 +344,6 @@ class Settings(BaseSettings):
     OIDC_ISSUER: str | None = None
     OIDC_CLIENT_ID: str | None = None
     OIDC_CLIENT_SECRET: str | None = None
-    OIDC_REDIRECT_URI: str | None = None
-    OIDC_POST_LOGIN_REDIRECT: str | None = None
     OIDC_PROVIDER_NAME: str | None = None
     OIDC_SCOPES: list[str] | str | None = None
     SMTP_HOST: str | None = None
@@ -657,13 +656,6 @@ class Settings(BaseSettings):
             if cleaned and cleaned not in normalized:
                 normalized.append(cleaned)
         return normalized or ["openid", "profile", "email"]
-
-    @model_validator(mode="before")
-    @classmethod
-    def _oidc_issuer_compat(cls, values: dict) -> dict:
-        if not values.get("OIDC_ISSUER") and values.get("OIDC_DISCOVERY_URL"):
-            values["OIDC_ISSUER"] = values["OIDC_DISCOVERY_URL"]
-        return values
 
 
 @lru_cache

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -10,6 +10,17 @@ from argon2.exceptions import InvalidHashError, VerificationError, VerifyMismatc
 
 from app.core.config import settings
 
+# Deliberately a constant, not a setting: every encode/verify in this module
+# assumes HS256, and a configurable JWT algorithm invites algorithm-confusion.
+JWT_ALGORITHM = "HS256"
+
+# Cookie names are part of the auth contract, not deployment configuration.
+SESSION_COOKIE_NAME = "session_token"
+# The rotating refresh token rides in its own HttpOnly cookie, path-scoped to
+# the auth routes (sent only on refresh/logout, never on ordinary API calls —
+# smaller exposure than the session cookie).
+REFRESH_COOKIE_NAME = "refresh_token"
+
 # argon2id with library defaults — OWASP-aligned. Stored hashes embed the
 # parameters, so verification keeps working if we tune these later.
 _argon2_hasher = PasswordHasher()
@@ -65,7 +76,7 @@ def create_access_token(
         expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode: dict[str, Any] = {"sub": subject, "exp": expire, "ver": token_version}
-    return jwt.encode(to_encode, settings.jwt_signing_key, algorithm=settings.ALGORITHM)
+    return jwt.encode(to_encode, settings.jwt_signing_key, algorithm=JWT_ALGORITHM)
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -119,7 +130,7 @@ def mint_access_token(
         "iat": int(issued.timestamp()),
         "exp": issued + ttl,
     }
-    token = jwt.encode(payload, settings.jwt_signing_key, algorithm=settings.ALGORITHM)
+    token = jwt.encode(payload, settings.jwt_signing_key, algorithm=JWT_ALGORITHM)
     return token, int(ttl.total_seconds())
 
 
@@ -146,7 +157,7 @@ def decode_session_token(token: str) -> dict[str, Any]:
         return jwt.decode(
             token,
             settings.jwt_signing_key,
-            algorithms=[settings.ALGORITHM],
+            algorithms=[JWT_ALGORITHM],
             audience=AUTH_ACCESS_AUDIENCE,
             issuer=AUTH_TOKEN_ISSUER,
             options={"require": ["exp", "sub", "ver", "aud", "iss"]},
@@ -164,9 +175,7 @@ def decode_session_token(token: str) -> dict[str, Any]:
         # legacy decode's audience error — keeping cutover-window logs honest.
         # A legacy token bearing any aud (upload/handoff) still fails the legacy
         # decode below and is rejected.
-        return jwt.decode(
-            token, settings.jwt_signing_key, algorithms=[settings.ALGORITHM]
-        )
+        return jwt.decode(token, settings.jwt_signing_key, algorithms=[JWT_ALGORITHM])
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -218,7 +227,7 @@ def create_upload_token(
         "iat": int(now.timestamp()),
         "exp": now + expires_in,
     }
-    token = jwt.encode(payload, settings.jwt_signing_key, algorithm=settings.ALGORITHM)
+    token = jwt.encode(payload, settings.jwt_signing_key, algorithm=JWT_ALGORITHM)
     return token, int(expires_in.total_seconds())
 
 
@@ -234,7 +243,7 @@ def verify_upload_token(token: str) -> int:
         payload = jwt.decode(
             token,
             settings.jwt_signing_key,
-            algorithms=[settings.ALGORITHM],
+            algorithms=[JWT_ALGORITHM],
             audience=UPLOAD_TOKEN_AUDIENCE,
             options={"require": ["exp", "iat", "sub", "aud"]},
         )

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -24,6 +24,7 @@ from app.core.security import (
     ADVANCED_TOOL_HANDOFF_LIFETIME,
     AUTH_ACCESS_AUDIENCE,
     AUTH_TOKEN_ISSUER,
+    JWT_ALGORITHM,
     UPLOAD_TOKEN_AUDIENCE,
     UPLOAD_TOKEN_LIFETIME,
     UPLOAD_TOKEN_SCOPE,
@@ -273,14 +274,14 @@ def test_session_jwt_signed_with_dedicated_jwt_signing_key(monkeypatch):
 
     token = security.create_access_token(subject="7", token_version=1)
     # Verifies under the dedicated key...
-    payload = jwt.decode(token, jwt_key, algorithms=[security.settings.ALGORITHM])
+    payload = jwt.decode(token, jwt_key, algorithms=[security.JWT_ALGORITHM])
     assert payload["sub"] == "7"
     # ...and NOT under SECRET_KEY (proving the keys are actually decoupled).
     with pytest.raises(jwt.InvalidSignatureError):
         jwt.decode(
             token,
             security.settings.SECRET_KEY,
-            algorithms=[security.settings.ALGORITHM],
+            algorithms=[security.JWT_ALGORITHM],
         )
 
 
@@ -380,7 +381,7 @@ def test_mint_access_token_is_verifiable_with_expected_audience():
     payload = jwt.decode(
         token,
         settings.jwt_signing_key,
-        algorithms=[settings.ALGORITHM],
+        algorithms=[JWT_ALGORITHM],
         audience=AUTH_ACCESS_AUDIENCE,
         issuer=AUTH_TOKEN_ISSUER,
         options={"require": ["exp", "iat", "sub", "sid", "aud", "iss"]},

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,7 @@ from app.api.deps import get_upload_user
 from app.api.v1.api import api_router
 from app.core.messages import GuildMessages
 from app.core.rate_limit import limiter
-from app.core.config import settings
+from app.core.config import API_V1_STR, PROJECT_NAME, settings
 from app.core.version import __version__
 from app.db.session import AdminSessionLocal, get_admin_session, run_migrations
 from app.models.platform.user import User
@@ -39,9 +39,7 @@ static_path.mkdir(parents=True, exist_ok=True)
 static_index_path = static_path / "index.html"
 static_root = static_path.resolve()
 reserved_prefixes = [
-    prefix.strip("/")
-    for prefix in {settings.API_V1_STR}
-    if prefix and prefix.strip("/")
+    prefix.strip("/") for prefix in {API_V1_STR} if prefix and prefix.strip("/")
 ]
 
 
@@ -156,13 +154,11 @@ async def lifespan(app: FastAPI):
 # inherit the app-wide CSP and the jsDelivr-hosted Swagger assets get blocked.
 # A custom route below serves the same UI with a docs-scoped CSP instead.
 app = FastAPI(
-    title=settings.PROJECT_NAME,
+    title=PROJECT_NAME,
     version=__version__,
     lifespan=lifespan,
     docs_url=None,
-    openapi_url=(
-        f"{settings.API_V1_STR}/openapi.json" if settings.ENABLE_API_DOCS else None
-    ),
+    openapi_url=(f"{API_V1_STR}/openapi.json" if settings.ENABLE_API_DOCS else None),
     redoc_url=None,
 )
 
@@ -171,14 +167,14 @@ if settings.ENABLE_API_DOCS:
 
     _DOCS_CSP = settings.docs_content_security_policy
 
-    @app.get(f"{settings.API_V1_STR}/docs", include_in_schema=False)
+    @app.get(f"{API_V1_STR}/docs", include_in_schema=False)
     async def swagger_ui_html() -> Response:
         # get_swagger_ui_html returns the Swagger HTML that loads its JS/CSS from
         # jsDelivr; attach the docs-scoped CSP so only this response permits them.
         # The middleware uses setdefault, so this explicit header wins.
         response = get_swagger_ui_html(
-            openapi_url=f"{settings.API_V1_STR}/openapi.json",
-            title=f"{settings.PROJECT_NAME} - Swagger UI",
+            openapi_url=f"{API_V1_STR}/openapi.json",
+            title=f"{PROJECT_NAME} - Swagger UI",
         )
         response.headers["Content-Security-Policy"] = _DOCS_CSP
         return response
@@ -395,7 +391,7 @@ async def serve_upload_file(
     return build_upload_response(blob, headers=headers)
 
 
-app.include_router(api_router, prefix=settings.API_V1_STR)
+app.include_router(api_router, prefix=API_V1_STR)
 
 
 def _inject_query_schemas(openapi_schema: dict) -> None:
@@ -520,7 +516,7 @@ if settings.ENABLE_MCP:
     from app.mcp_server import build_mcp_server
 
     _mcp_app = build_mcp_server(app).http_app(path="/")
-    app.mount(f"{settings.API_V1_STR}/mcp", _mcp_app)
+    app.mount(f"{API_V1_STR}/mcp", _mcp_app)
     app.router.lifespan_context = combine_lifespans(lifespan, _mcp_app.lifespan)
 
 

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -11,7 +11,7 @@ from fastapi.exceptions import RequestValidationError
 from httpx import ASGITransport, AsyncClient
 
 import app.main as main_module
-from app.core.config import Settings
+from app.core.config import API_V1_STR, Settings
 from app.main import SecurityHeadersMiddleware, validation_exception_handler
 
 
@@ -177,7 +177,7 @@ def test_docs_routes_return_404_when_disabled() -> None:
     cfg = Settings(ENABLE_API_DOCS=False)  # ty: ignore[missing-argument]
     disabled = FastAPI(
         docs_url=None,
-        openapi_url=(f"{cfg.API_V1_STR}/openapi.json" if cfg.ENABLE_API_DOCS else None),
+        openapi_url=(f"{API_V1_STR}/openapi.json" if cfg.ENABLE_API_DOCS else None),
         redoc_url=None,
     )
     http = TestClient(disabled)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -24,7 +24,7 @@ from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.providers.openapi import MCPType, RouteMap
 
-from app.core.config import settings
+from app.core.config import PROJECT_NAME
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -77,7 +77,7 @@ def build_mcp_server(app: "FastAPI") -> FastMCP:
     """
     return FastMCP.from_fastapi(
         app=app,
-        name=settings.PROJECT_NAME,
+        name=PROJECT_NAME,
         route_maps=_ROUTE_MAPS,
         httpx_client_kwargs={"event_hooks": {"request": [_forward_authorization]}},
     )

--- a/backend/app/services/platform/ws_auth_test.py
+++ b/backend/app/services/platform/ws_auth_test.py
@@ -8,7 +8,7 @@ honour ``token_version`` so that logout / password reset / password change
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.security import create_access_token
+from app.core.security import JWT_ALGORITHM, create_access_token
 from app.models.platform.user import UserStatus
 from app.services.platform import user_tokens
 from app.services.platform.ws_auth import authenticate_ws_token
@@ -125,7 +125,7 @@ async def test_token_without_version_claim_rejected(session: AsyncSession):
             "exp": datetime.now(timezone.utc) + timedelta(minutes=10),
         },
         settings.SECRET_KEY,
-        algorithm=settings.ALGORITHM,
+        algorithm=JWT_ALGORITHM,
     )
 
     assert await authenticate_ws_token(legacy_token, session) is None
@@ -153,7 +153,7 @@ async def test_jwt_without_sub_does_not_fall_through_to_device_lookup(
     subless_token = pyjwt.encode(
         {"exp": datetime.now(timezone.utc) + timedelta(minutes=10)},
         settings.SECRET_KEY,
-        algorithm=settings.ALGORITHM,
+        algorithm=JWT_ALGORITHM,
     )
 
     assert await authenticate_ws_token(subless_token, session) is None

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -14,7 +14,7 @@ from collections.abc import AsyncGenerator
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import asyncpg
 import pytest
@@ -54,8 +54,24 @@ WORKER_ID = os.environ.get("PYTEST_XDIST_WORKER", "master")
 settings.GUILD_ROLE_PREFIX = f"test_{WORKER_ID}_"
 settings.PLATFORM_ROLE_PREFIX = f"test_{WORKER_ID}_"
 
+# --- Test-infrastructure superuser ---------------------------------------------
+# The suite needs cluster-superuser powers the APP must never hold: CREATE
+# DATABASE per worker, raw setup/assertion writes on FORCE-RLS tables (the
+# ``session`` fixture), and session_replication_role truncation. That is test
+# infrastructure, so it is deliberately NOT a Settings field — the app's
+# DATABASE_URL stays the least-privilege app_provisioner role. Host/port come
+# from DATABASE_URL (same cluster); credentials are the dev-compose/CI
+# bootstrap superuser, overridable via the standard postgres-image variables.
+_su_user = os.environ.get("POSTGRES_USER", "initiative")
+_su_password = os.environ.get("POSTGRES_PASSWORD", "initiative")
+_app_db = urlparse(settings.DATABASE_URL.replace("+asyncpg", ""))
+_su_netloc = f"{_app_db.hostname}:{_app_db.port or 5432}"
+_base_url = (
+    f"postgresql+asyncpg://{quote(_su_user, safe='')}:"
+    f"{quote(_su_password, safe='')}@{_su_netloc}"
+)
+
 # Per-worker database so a worker's TRUNCATE/DROP never clobbers another's data.
-_base_url = settings.DATABASE_URL.rsplit("/", 1)[0]
 TEST_DB_NAME = f"initiative_test_{WORKER_ID}"
 TEST_DATABASE_URL = f"{_base_url}/{TEST_DB_NAME}"
 
@@ -69,6 +85,17 @@ TEST_STATEMENT_TIMEOUT = "30s"
 BACKEND_DIR = Path(__file__).resolve().parent
 
 
+async def _connect_su_postgres() -> asyncpg.Connection:
+    """Test-infra superuser connection to the always-present ``postgres`` DB."""
+    return await asyncpg.connect(
+        user=_su_user,
+        password=_su_password,
+        host=_app_db.hostname,
+        port=_app_db.port or 5432,
+        database="postgres",
+    )
+
+
 async def _ensure_test_database() -> None:
     """Create this worker's test database if it doesn't exist.
 
@@ -77,14 +104,7 @@ async def _ensure_test_database() -> None:
     being accessed"), so retry. ``CREATE DATABASE`` can't run inside a transaction,
     hence the autocommit asyncpg connection.
     """
-    parsed = urlparse(settings.DATABASE_URL.replace("+asyncpg", ""))
-    conn = await asyncpg.connect(
-        user=parsed.username,
-        password=parsed.password,
-        host=parsed.hostname,
-        port=parsed.port or 5432,
-        database="postgres",
-    )
+    conn = await _connect_su_postgres()
     try:
         for _attempt in range(12):
             exists = await conn.fetchval(
@@ -111,14 +131,7 @@ async def _ensure_test_database() -> None:
 async def _set_db_statement_timeout() -> None:
     """Apply a DB-level statement_timeout to the worker's test DB (catch-all net
     for cross-connection deadlocks). Affects connections opened afterward."""
-    parsed = urlparse(settings.DATABASE_URL.replace("+asyncpg", ""))
-    conn = await asyncpg.connect(
-        user=parsed.username,
-        password=parsed.password,
-        host=parsed.hostname,
-        port=parsed.port or 5432,
-        database="postgres",
-    )
+    conn = await _connect_su_postgres()
     try:
         await conn.execute(
             f'ALTER DATABASE "{TEST_DB_NAME}" SET statement_timeout = '
@@ -158,14 +171,7 @@ async def _migrate_under_lock() -> None:
     ``postgres`` DB for the whole migration; ``command.upgrade`` runs in a worker
     thread (where it can spin its own loop) while THIS loop keeps the lock
     connection — and thus the lock — alive."""
-    parsed = urlparse(settings.DATABASE_URL.replace("+asyncpg", ""))
-    lock_conn = await asyncpg.connect(
-        user=parsed.username,
-        password=parsed.password,
-        host=parsed.hostname,
-        port=parsed.port or 5432,
-        database="postgres",
-    )
+    lock_conn = await _connect_su_postgres()
     try:
         await lock_conn.execute("SELECT pg_advisory_lock($1)", _MIGRATION_LOCK_KEY)
         await _ensure_test_database()

--- a/backend/scripts/create-provisioner.sql
+++ b/backend/scripts/create-provisioner.sql
@@ -55,7 +55,7 @@ BEGIN
             'platform_member', 'platform_support', 'platform_moderator',
             'platform_admin', 'platform_owner'
         )
-        OR rolname ~ '^guild_[0-9]+(_ro)?$'
+        OR rolname ~ '^guild_[0-9]+(_ro|_support)?$'
     LOOP
         EXECUTE format('GRANT %I TO app_provisioner WITH ADMIN OPTION', r.rolname);
     END LOOP;


### PR DESCRIPTION
## Problem

An audit of the backend config surface turned up several settings that were configurable but shouldn't be, dead settings read by nothing, and a `.env.example` that seeded placeholder values into the database on first boot. It also surfaced a real boot-breaking bug in the provisioner handover script.

## Changes

**Config demoted to constants** (`config.py`, `security.py`)
- `ALGORITHM` → `JWT_ALGORITHM` constant in `app.core.security`. A settable JWT algorithm is an algorithm-confusion hazard, and every encode/verify already assumes HS256.
- `COOKIE_NAME`/`REFRESH_COOKIE_NAME` → `SESSION_COOKIE_NAME`/`REFRESH_COOKIE_NAME` constants — cookie names are part of the auth contract, not deployment config.
- `PROJECT_NAME`/`API_V1_STR` → module constants in `config.py` — the SPA, docs-CSP route, and OpenAPI export all assume these; making them configurable only creates ways to break them.
- Removed the dead `OIDC_REDIRECT_URI`, `OIDC_POST_LOGIN_REDIRECT`, and `OIDC_DISCOVERY_URL` settings (read by nothing — redirect URLs derive from `APP_URL`, OIDC is configured in Settings → Admin).

All ~20 call sites updated to import the constants.

**`.env.example` rewritten for first-time setup**
- Required values first, concise comments, optional integrations commented out.
- Optional OIDC/SMTP/S3 lines are now commented out — copying the example verbatim no longer seeds placeholder values (e.g. `smtp.example.com`) into the admin settings on first boot, where a non-null `smtp_host` makes the app believe email is configured.

**Test harness no longer needs a superuser `DATABASE_URL`** (`conftest.py`)
- The suite sources its own superuser connection (host/port from `DATABASE_URL`; credentials from `POSTGRES_USER`/`POSTGRES_PASSWORD`, dev-compose/CI defaults). The app's `DATABASE_URL` can now be the least-privilege `app_provisioner` role in local dev, matching production. Test-infra credentials are deliberately kept out of `Settings`.

**Bug fix** (`create-provisioner.sql`)
- The role-grant regex predated the `guild_<id>_support` PAM role, so the handover failed boot with `permission denied to grant role "guild_N_support"` on any install with existing guilds. Regex now includes `_support`.

## Testing

- `ruff check` + `ruff format` clean.
- Passing: security (34), auth + main + settings (114), core (118), calendar-events + queues (48).
- API boots clean on the `app_provisioner` role — `{"version":"0.54.2"}`, no errors, no superuser warning.

## Notes

- Removed settings are harmless if left in an existing `.env` (`Settings` uses `extra="ignore"`). CHANGELOG documents what to drop.
- `docker-compose.yml` is gitignored (dev-local); the committed `docker-compose.example.yml` already provisions `app_provisioner`.
