### PR TITLE
Add delegated advanced-tool run endpoint

### DIFF
--- a/backend/app/api/v1/platform_endpoints/settings_test.py
+++ b/backend/app/api/v1/platform_endpoints/settings_test.py
@@ -940,7 +940,7 @@ async def test_storage_backfill_status_reads_shared_row(
     # The UNLOGGED status row persists across tests within a worker; clear it so a
     # prior test's terminal status doesn't bleed into this fresh-state assertion.
     await storage_backfill._ensure_table()
-    await session.execute(text("DELETE FROM storage_backfill_state"))
+    await session.exec(text("DELETE FROM storage_backfill_state"))
     await session.commit()
 
     owner = await create_user(

--- a/backend/app/api/v1/tenant_endpoints/advanced_tool.py
+++ b/backend/app/api/v1/tenant_endpoints/advanced_tool.py
@@ -11,10 +11,11 @@ Scope: ``initiative_id`` set → an initiative-scoped tool (needs
 which is admin-only by RLS (no per-user grants).
 """
 
+import logging
 from datetime import datetime, timezone
 from typing import Annotated, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import func, or_
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
@@ -36,6 +37,8 @@ from app.schemas.tenant.advanced_tool import (
     AdvancedToolCreate,
     AdvancedToolListResponse,
     AdvancedToolRead,
+    AdvancedToolRunRequest,
+    AdvancedToolRunResult,
     AdvancedToolUpdate,
     serialize_advanced_tool,
 )
@@ -43,6 +46,8 @@ from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.services import permissions as permissions_service
 from app.services import rls as rls_service
 from app.services.tenant import advanced_tool as advanced_tool_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -160,6 +165,63 @@ async def read_advanced_tool(
     return serialize_advanced_tool(
         tool,
         my_permission_level=_compute_my_permission(tool, current_user, guild_context),
+    )
+
+
+@router.post("/{advanced_tool_id}/run", response_model=AdvancedToolRunResult)
+async def run_advanced_tool(
+    advanced_tool_id: int,
+    run_in: AdvancedToolRunRequest,
+    request: Request,
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> AdvancedToolRunResult:
+    """The automation service's delegated run call.
+
+    Only a caller authenticated with an initiative-auto delegation token may
+    start a run — interactive sessions and API keys are refused. The delegated
+    user then goes through the standard DAC path (write access to the tool), so
+    a run carries exactly the authority that user holds at fire time. A tool
+    that is trashed, out of reach, or nonexistent answers 404, which the runner
+    treats as "tool gone" and cancels the run.
+
+    We don't interpret the definition: the response hands back the current
+    ``data`` blob (plus the echoed run context) for the service to execute.
+    """
+    if getattr(request.state, "delegated_guild_id", None) is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=AdvancedToolMessages.DELEGATED_RUN_ONLY,
+        )
+    tool = await resource_access.load_authorized(
+        session,
+        Tool.advanced_tool,
+        advanced_tool_id,
+        current_user,
+        guild_context,
+        access="write",
+    )
+    ran_at = datetime.now(timezone.utc)
+    logger.info(
+        "advanced tool run: guild=%s tool=%s user=%s node_key=%s cause=%s "
+        "source_event_id=%s",
+        tool.guild_id,
+        tool.id,
+        current_user.id,
+        run_in.node_key,
+        run_in.cause,
+        run_in.source_event_id,
+    )
+    return AdvancedToolRunResult(
+        advanced_tool_id=tool.id,
+        guild_id=tool.guild_id,
+        initiative_id=tool.initiative_id,
+        node_key=run_in.node_key,
+        cause=run_in.cause,
+        source_event_id=run_in.source_event_id,
+        data=tool.data,
+        ran_at=ran_at,
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/advanced_tool_run_test.py
+++ b/backend/app/api/v1/tenant_endpoints/advanced_tool_run_test.py
@@ -196,6 +196,7 @@ async def test_delegated_run_feature_disabled_403(
 
     await route_session_to_guild(session, a.guild.id)
     init = await session.get(Initiative, a.initiative.id)
+    assert init is not None
     init.advanced_tools_enabled = False
     session.add(init)
     await session.commit()

--- a/backend/app/api/v1/tenant_endpoints/advanced_tool_run_test.py
+++ b/backend/app/api/v1/tenant_endpoints/advanced_tool_run_test.py
@@ -119,7 +119,6 @@ async def test_delegated_run_returns_current_definition(
     )
     assert response.status_code == 200, response.text
     body = response.json()
-    assert body["ok"] is True
     assert body["advanced_tool_id"] == tool["id"]
     assert body["guild_id"] == a.guild.id
     assert body["initiative_id"] == a.initiative.id
@@ -128,6 +127,28 @@ async def test_delegated_run_returns_current_definition(
     assert body["node_key"] == "digest"
     assert body["cause"] == "schedule"
     assert body["source_event_id"] == "evt-7"
+
+
+async def test_delegated_run_opaque_ids_survive_sanitization(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """node_key indexes into the unsanitized definition blob, so it must come
+    back byte-for-byte — even if it contains markup characters that the plain
+    -text HTML stripper would otherwise mangle (the RawTextStr guarantee)."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_advanced_tool(session, a.initiative)
+    tool = await _create_tool(client, a, initiative_id=a.initiative.id)
+
+    tricky = "node <a & b>"
+    response = await client.post(
+        a.g(f"/advanced-tools/{tool['id']}/run"),
+        headers=_delegation_headers(user_id=a.user.id, guild_id=a.guild.id),
+        json={"node_key": tricky, "source_event_id": "<evt>&1"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["node_key"] == tricky
+    assert body["source_event_id"] == "<evt>&1"
 
 
 async def test_delegated_run_missing_tool_404(client: AsyncClient, acting_user):

--- a/backend/app/api/v1/tenant_endpoints/advanced_tool_run_test.py
+++ b/backend/app/api/v1/tenant_endpoints/advanced_tool_run_test.py
@@ -1,0 +1,240 @@
+"""Delegated run endpoint tests.
+
+``POST /g/{guild_id}/advanced-tools/{id}/run`` is the automation service's
+execution call: it must accept only delegation-token callers, apply the
+standard DAC path as the delegated user, answer 404 for a tool that is gone
+(trashed / invisible / never existed), and hand back the current definition
+blob for the service to execute.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core import config as config_module
+from app.models.platform.guild import GuildRole
+from app.models.tenant.initiative import Initiative
+from app.testing import route_session_to_guild
+
+pytestmark = pytest.mark.integration
+
+_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_PEM = _keypair.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+_PUBLIC_PEM = (
+    _keypair.public_key()
+    .public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+
+
+def _delegation_headers(*, user_id: int, guild_id: int) -> dict[str, str]:
+    """Mint a fresh (one-shot) delegation JWT for the user + guild."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "jti": secrets.token_hex(8),
+            "sub": str(user_id),
+            "aud": "initiative:auto-delegation",
+            "iss": "initiative-auto",
+            "iat": int(now.timestamp()),
+            "exp": now + timedelta(seconds=900),
+            "guild_id": guild_id,
+        },
+        _PRIVATE_PEM,
+        algorithm="RS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def _enable_delegation(monkeypatch):
+    monkeypatch.setattr(
+        config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _PUBLIC_PEM
+    )
+
+
+async def _enable_advanced_tool(session: AsyncSession, initiative) -> None:
+    await route_session_to_guild(session, initiative.guild_id)
+    init = await session.get(Initiative, initiative.id)
+    assert init is not None
+    init.advanced_tools_enabled = True
+    session.add(init)
+    await session.commit()
+
+
+async def _create_tool(client: AsyncClient, actor, *, initiative_id=None, data=None):
+    payload: dict = {"name": "Runner target", "data": data or {"nodes": []}}
+    if initiative_id is not None:
+        payload["initiative_id"] = initiative_id
+    response = await client.post(
+        actor.g("/advanced-tools/"), headers=actor.headers, json=payload
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def test_run_refuses_non_delegated_callers(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Even the tool's owner on a normal session can't hit the run endpoint —
+    it exists solely for the automation service's delegation tokens."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_advanced_tool(session, a.initiative)
+    tool = await _create_tool(client, a, initiative_id=a.initiative.id)
+
+    response = await client.post(
+        a.g(f"/advanced-tools/{tool['id']}/run"), headers=a.headers, json={}
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "ADVANCED_TOOL_DELEGATED_RUN_ONLY"
+
+
+async def test_delegated_run_returns_current_definition(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_advanced_tool(session, a.initiative)
+    blob = {"nodes": [{"key": "digest", "type": "action", "action": "run_report"}]}
+    tool = await _create_tool(client, a, initiative_id=a.initiative.id, data=blob)
+
+    response = await client.post(
+        a.g(f"/advanced-tools/{tool['id']}/run"),
+        headers=_delegation_headers(user_id=a.user.id, guild_id=a.guild.id),
+        json={"node_key": "digest", "cause": "schedule", "source_event_id": "evt-7"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["advanced_tool_id"] == tool["id"]
+    assert body["guild_id"] == a.guild.id
+    assert body["initiative_id"] == a.initiative.id
+    # The definition comes back verbatim, with the run context echoed.
+    assert body["data"] == blob
+    assert body["node_key"] == "digest"
+    assert body["cause"] == "schedule"
+    assert body["source_event_id"] == "evt-7"
+
+
+async def test_delegated_run_missing_tool_404(client: AsyncClient, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    response = await client.post(
+        a.g("/advanced-tools/999999/run"),
+        headers=_delegation_headers(user_id=a.user.id, guild_id=a.guild.id),
+        json={},
+    )
+    assert response.status_code == 404
+
+
+async def test_delegated_run_trashed_tool_404(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A trashed tool is gone for the runner — 404 is its cancel signal, so
+    the soft-delete filter must apply here too."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_advanced_tool(session, a.initiative)
+    tool = await _create_tool(client, a, initiative_id=a.initiative.id)
+
+    deleted = await client.delete(
+        a.g(f"/advanced-tools/{tool['id']}"), headers=a.headers
+    )
+    assert deleted.status_code == 204
+
+    response = await client.post(
+        a.g(f"/advanced-tools/{tool['id']}/run"),
+        headers=_delegation_headers(user_id=a.user.id, guild_id=a.guild.id),
+        json={},
+    )
+    assert response.status_code == 404
+
+
+async def test_delegated_run_requires_write_access(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The default create grant gives initiative members read — a delegated
+    run as such a member must fail the DAC write check, not sneak through."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_advanced_tool(session, a.initiative)
+    tool = await _create_tool(client, a, initiative_id=a.initiative.id)
+
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    response = await client.post(
+        member.g(f"/advanced-tools/{tool['id']}/run"),
+        headers=_delegation_headers(user_id=member.user.id, guild_id=a.guild.id),
+        json={},
+    )
+    assert response.status_code == 403
+
+
+async def test_delegated_run_feature_disabled_403(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Disabling advanced tools on the initiative blocks delegated runs of its
+    tools (403, the runner's retry-then-fail path)."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await _enable_advanced_tool(session, a.initiative)
+    tool = await _create_tool(client, a, initiative_id=a.initiative.id)
+
+    await route_session_to_guild(session, a.guild.id)
+    init = await session.get(Initiative, a.initiative.id)
+    init.advanced_tools_enabled = False
+    session.add(init)
+    await session.commit()
+
+    response = await client.post(
+        a.g(f"/advanced-tools/{tool['id']}/run"),
+        headers=_delegation_headers(user_id=a.user.id, guild_id=a.guild.id),
+        json={},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "ADVANCED_TOOL_NOT_ENABLED"
+
+
+async def test_delegated_run_guild_wide_tool(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Guild-wide tools run for a delegated guild admin; a plain member never
+    even sees the row (RLS), so their delegated run answers 404."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    tool = await _create_tool(client, admin)  # no initiative_id → guild-wide
+    assert tool["initiative_id"] is None
+
+    ok = await client.post(
+        admin.g(f"/advanced-tools/{tool['id']}/run"),
+        headers=_delegation_headers(user_id=admin.user.id, guild_id=admin.guild.id),
+        json={"cause": "event"},
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["initiative_id"] is None
+
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    hidden = await client.post(
+        member.g(f"/advanced-tools/{tool['id']}/run"),
+        headers=_delegation_headers(user_id=member.user.id, guild_id=admin.guild.id),
+        json={},
+    )
+    assert hidden.status_code == 404

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -431,6 +431,8 @@ class AdvancedToolMessages:
     GUILD_WIDE_REQUIRES_ADMIN = "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN"
     # Guild-wide tools are admin-only and hold no per-user/role grants.
     GUILD_WIDE_NOT_SHAREABLE = "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE"
+    # The run endpoint only accepts the automation service's delegation tokens.
+    DELEGATED_RUN_ONLY = "ADVANCED_TOOL_DELEGATED_RUN_ONLY"
 
 
 class WebhookSubscriptionMessages:

--- a/backend/app/schemas/tenant/advanced_tool.py
+++ b/backend/app/schemas/tenant/advanced_tool.py
@@ -15,7 +15,7 @@ from typing import Any, List, Optional
 
 from pydantic import ConfigDict, Field
 
-from app.schemas.base import SanitizedBaseModel
+from app.schemas.base import RawTextStr, SanitizedBaseModel
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 
 
@@ -62,24 +62,30 @@ class AdvancedToolRead(AdvancedToolBase):
 
 
 class AdvancedToolRunRequest(SanitizedBaseModel):
-    # Names the flow entry inside the definition blob being fired (None = the
-    # default entry). Opaque to us — echoed back to the caller, never resolved.
-    node_key: Optional[str] = Field(default=None, max_length=255)
+    # These three are opaque machine identifiers: echoed straight back to the
+    # runner, and node_key indexes into the (never-sanitized) definition blob.
+    # RawTextStr so HTML stripping can't silently mangle a value that contains
+    # markup characters — the max_length caps still bound the input.
+    # node_key names the flow entry being fired (None = the default entry).
+    node_key: Optional[RawTextStr] = Field(default=None, max_length=255)
     # Provenance for the run log (e.g. "schedule", "event").
-    cause: Optional[str] = Field(default=None, max_length=64)
-    source_event_id: Optional[str] = Field(default=None, max_length=255)
+    cause: Optional[RawTextStr] = Field(default=None, max_length=64)
+    source_event_id: Optional[RawTextStr] = Field(default=None, max_length=255)
 
 
 class AdvancedToolRunResult(SanitizedBaseModel):
+    # Success is the HTTP status: a 200 body is always a completed run (the
+    # runner treats 404 as "tool gone" and 403 as retriable), so there is no
+    # ``ok`` flag to carry.
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
-    ok: bool = True
     advanced_tool_id: int
     guild_id: int
     initiative_id: Optional[int] = None
-    node_key: Optional[str] = None
-    cause: Optional[str] = None
-    source_event_id: Optional[str] = None
+    # Echoed verbatim from the request — RawTextStr for the same reason.
+    node_key: Optional[RawTextStr] = None
+    cause: Optional[RawTextStr] = None
+    source_event_id: Optional[RawTextStr] = None
     # The tool's current definition — the caller interprets it, we don't.
     data: dict[str, Any] = Field(default_factory=dict)
     ran_at: datetime

--- a/backend/app/schemas/tenant/advanced_tool.py
+++ b/backend/app/schemas/tenant/advanced_tool.py
@@ -61,6 +61,30 @@ class AdvancedToolRead(AdvancedToolBase):
     grants: List[ResourceGrantSchema] = Field(default_factory=list)
 
 
+class AdvancedToolRunRequest(SanitizedBaseModel):
+    # Names the flow entry inside the definition blob being fired (None = the
+    # default entry). Opaque to us — echoed back to the caller, never resolved.
+    node_key: Optional[str] = Field(default=None, max_length=255)
+    # Provenance for the run log (e.g. "schedule", "event").
+    cause: Optional[str] = Field(default=None, max_length=64)
+    source_event_id: Optional[str] = Field(default=None, max_length=255)
+
+
+class AdvancedToolRunResult(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    ok: bool = True
+    advanced_tool_id: int
+    guild_id: int
+    initiative_id: Optional[int] = None
+    node_key: Optional[str] = None
+    cause: Optional[str] = None
+    source_event_id: Optional[str] = None
+    # The tool's current definition — the caller interprets it, we don't.
+    data: dict[str, Any] = Field(default_factory=dict)
+    ran_at: datetime
+
+
 class AdvancedToolListResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 

--- a/backend/app/services/storage_backfill.py
+++ b/backend/app/services/storage_backfill.py
@@ -108,20 +108,21 @@ def reset_for_tests() -> None:
 
 
 async def _fetch(session: AsyncSession) -> dict | None:
-    result = await session.execute(
-        text("SELECT * FROM storage_backfill_state WHERE id = :id"), {"id": GLOBAL_ID}
+    result = await session.exec(
+        text("SELECT * FROM storage_backfill_state WHERE id = :id"),
+        params={"id": GLOBAL_ID},
     )
     row = result.mappings().first()
     return dict(row) if row is not None else None
 
 
 async def _ensure_row(session: AsyncSession) -> None:
-    await session.execute(
+    await session.exec(
         text(
             "INSERT INTO storage_backfill_state (id, status) VALUES (:id, 'idle') "
             "ON CONFLICT (id) DO NOTHING"
         ),
-        {"id": GLOBAL_ID},
+        params={"id": GLOBAL_ID},
     )
     await session.commit()
 
@@ -147,7 +148,7 @@ async def try_claim(session: AsyncSession) -> bool:
     await _ensure_table()
     await _ensure_row(session)
     now = _now()
-    result = await session.execute(
+    result = await session.exec(
         text(
             "UPDATE storage_backfill_state SET "
             "status = 'running', started_at = :now, finished_at = NULL, "
@@ -156,7 +157,7 @@ async def try_claim(session: AsyncSession) -> bool:
             "WHERE id = :id AND "
             "(status <> 'running' OR heartbeat IS NULL OR heartbeat < :stale)"
         ),
-        {"id": GLOBAL_ID, "now": now, "stale": now - _STALE_AFTER},
+        params={"id": GLOBAL_ID, "now": now, "stale": now - _STALE_AFTER},
     )
     await session.commit()
     return (result.rowcount or 0) == 1
@@ -193,9 +194,9 @@ async def _persist(
     if finished:
         sets.append("finished_at = :fin")
         params["fin"] = _now()
-    await session.execute(
+    await session.exec(
         text(f"UPDATE storage_backfill_state SET {', '.join(sets)} WHERE id = :id"),
-        params,
+        params=params,
     )
     await session.commit()
 

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -275,6 +275,7 @@
   "ADVANCED_TOOL_CREATE_PERMISSION_REQUIRED": "Berechtigung zum Erstellen erweiterter Tools erforderlich",
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Nur Gilden-Admins können gildenweite erweiterte Tools erstellen",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Gildenweite erweiterte Tools sind nur für Admins und können nicht geteilt werden",
+  "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Läufe erweiterter Tools können nur vom Automatisierungsdienst gestartet werden",
   "AI_INVALID_BASE_URL": "Die Basis-URL ist nicht zulässig. Verwende einen öffentlichen Hostnamen.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama kann nur auf Plattformebene konfiguriert werden.",
   "fallback": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -275,6 +275,7 @@
   "ADVANCED_TOOL_CREATE_PERMISSION_REQUIRED": "Permission required to create advanced tools",
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Only guild admins can create guild-wide advanced tools",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Guild-wide advanced tools are admin-only and can't be shared",
+  "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Advanced tool runs can only be started by the automation service",
   "AI_INVALID_BASE_URL": "Base URL is not allowed. Use a public hostname.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama can only be configured at the platform level.",
   "fallback": "Something went wrong. Please try again.",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -261,6 +261,7 @@
   "ADVANCED_TOOL_CREATE_PERMISSION_REQUIRED": "Se requiere permiso para crear herramientas avanzadas",
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Solo los administradores del gremio pueden crear herramientas avanzadas para todo el gremio",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Las herramientas avanzadas para todo el gremio son solo para administradores y no se pueden compartir",
+  "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Las ejecuciones de herramientas avanzadas solo puede iniciarlas el servicio de automatización",
   "AI_INVALID_BASE_URL": "La URL base no está permitida. Use un nombre de host público.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama solo se puede configurar a nivel de plataforma.",
   "fallback": "Algo salió mal. Por favor intenta de nuevo.",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -261,6 +261,7 @@
   "ADVANCED_TOOL_CREATE_PERMISSION_REQUIRED": "Autorisation requise pour créer des outils avancés",
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Seuls les administrateurs de guilde peuvent créer des outils avancés à l’échelle de la guilde",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Les outils avancés à l’échelle de la guilde sont réservés aux administrateurs et ne peuvent pas être partagés",
+  "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Les exécutions d’outils avancés ne peuvent être lancées que par le service d’automatisation",
   "AI_INVALID_BASE_URL": "L'URL de base n'est pas autorisée. Utilisez un nom d'hôte public.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama ne peut être configuré qu'au niveau de la plateforme.",
   "fallback": "Une erreur s'est produite. Veuillez réessayer.",

--- a/frontend/src/api/generated/advanced-tools/advanced-tools.ts
+++ b/frontend/src/api/generated/advanced-tools/advanced-tools.ts
@@ -24,6 +24,8 @@ import type {
   AdvancedToolCreate,
   AdvancedToolListResponse,
   AdvancedToolRead,
+  AdvancedToolRunRequest,
+  AdvancedToolRunResult,
   AdvancedToolUpdate,
   HTTPValidationError,
   ListAdvancedToolsApiV1GGuildIdAdvancedToolsGetParams,
@@ -672,6 +674,117 @@ export const useDeleteAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdDelete
 > => {
   return useMutation(
     getDeleteAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdDeleteMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * The automation service's delegated run call.
+ *
+ * Only a caller authenticated with an initiative-auto delegation token may
+ * start a run — interactive sessions and API keys are refused. The delegated
+ * user then goes through the standard DAC path (write access to the tool), so
+ * a run carries exactly the authority that user holds at fire time. A tool
+ * that is trashed, out of reach, or nonexistent answers 404, which the runner
+ * treats as "tool gone" and cancels the run.
+ *
+ * We don't interpret the definition: the response hands back the current
+ * ``data`` blob (plus the echoed run context) for the service to execute.
+ * @summary Run Advanced Tool
+ */
+export const runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost = (
+  guildId: number,
+  advancedToolId: number,
+  advancedToolRunRequest: BodyType<AdvancedToolRunRequest>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<AdvancedToolRunResult>(
+    {
+      url: `/api/v1/g/${guildId}/advanced-tools/${advancedToolId}/run`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: advancedToolRunRequest,
+      signal,
+    },
+    options
+  );
+};
+
+export const getRunAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost>>,
+    TError,
+    { guildId: number; advancedToolId: number; data: BodyType<AdvancedToolRunRequest> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost>>,
+  TError,
+  { guildId: number; advancedToolId: number; data: BodyType<AdvancedToolRunRequest> },
+  TContext
+> => {
+  const mutationKey = ["runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost>>,
+    { guildId: number; advancedToolId: number; data: BodyType<AdvancedToolRunRequest> }
+  > = (props) => {
+    const { guildId, advancedToolId, data } = props ?? {};
+
+    return runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost(
+      guildId,
+      advancedToolId,
+      data,
+      requestOptions
+    );
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RunAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPostMutationResult =
+  NonNullable<
+    Awaited<ReturnType<typeof runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost>>
+  >;
+export type RunAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPostMutationBody =
+  BodyType<AdvancedToolRunRequest>;
+export type RunAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Run Advanced Tool
+ */
+export const useRunAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost>>,
+      TError,
+      { guildId: number; advancedToolId: number; data: BodyType<AdvancedToolRunRequest> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof runAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPost>>,
+  TError,
+  { guildId: number; advancedToolId: number; data: BodyType<AdvancedToolRunRequest> },
+  TContext
+> => {
+  return useMutation(
+    getRunAdvancedToolApiV1GGuildIdAdvancedToolsAdvancedToolIdRunPostMutationOptions(options),
     queryClient
   );
 };

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -386,6 +386,26 @@ export interface AdvancedToolListResponse {
   has_next: boolean;
 }
 
+export interface AdvancedToolRunRequest {
+  node_key?: string | null;
+  cause?: string | null;
+  source_event_id?: string | null;
+}
+
+export type AdvancedToolRunResultData = { [key: string]: unknown };
+
+export interface AdvancedToolRunResult {
+  ok: boolean;
+  advanced_tool_id: number;
+  guild_id: number;
+  initiative_id: number | null;
+  node_key: string | null;
+  cause: string | null;
+  source_event_id: string | null;
+  data: AdvancedToolRunResultData;
+  ran_at: string;
+}
+
 export type AdvancedToolUpdateData = { [key: string]: unknown } | null;
 
 export interface AdvancedToolUpdate {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -395,7 +395,6 @@ export interface AdvancedToolRunRequest {
 export type AdvancedToolRunResultData = { [key: string]: unknown };
 
 export interface AdvancedToolRunResult {
-  ok: boolean;
   advanced_tool_id: number;
   guild_id: number;
   initiative_id: number | null;


### PR DESCRIPTION
## Problem

The automation service's execution runner needs a run endpoint on Initiative: `POST /g/{guild_id}/advanced-tools/{id}/run`. Until it exists, every delegated execution 404s.

## Changes

- **New endpoint** `POST /g/{guild_id}/advanced-tools/{advanced_tool_id}/run` (`advanced_tool.py`):
  - **Restricted access**: only callers authenticated with an initiative-auto delegation token may start a run — interactive sessions, API keys, and device tokens get 403 `ADVANCED_TOOL_DELEGATED_RUN_ONLY`. The existing delegation stack (one-shot jti, guild-claim pinning to the path) applies unchanged.
  - The delegated user then goes through the standard DAC path (**write** access to the tool), so a run carries exactly the authority the owner holds at fire time.
  - A trashed / out-of-reach / nonexistent tool answers **404**, which the runner treats as "tool gone" and cancels; a disabled initiative feature answers 403 `ADVANCED_TOOL_NOT_ENABLED` (the runner's retry path).
  - Initiative stays opaque to the definition: the response returns the current `data` blob plus the echoed run context (`node_key`, `cause`, `source_event_id`) and logs one structured line for the run trail.
- New schemas `AdvancedToolRunRequest` / `AdvancedToolRunResult`; new error code mapped in **all four locales** (en/de/es/fr).
- Orval types regenerated and committed.

No schema/env changes.

## Testing

```
cd backend && pytest app/api/v1/tenant_endpoints/advanced_tool_run_test.py   # 7 passed
cd backend && pytest app/api/v1/tenant_endpoints/advanced_tool_test.py app/api/v1/tenant_endpoints/auto_delegation_test.py   # 16 passed
ruff check app && ruff format app
cd frontend && pnpm typecheck && pnpm lint   # clean (1 pre-existing styles.css warning)
```

New tests cover: non-delegated caller refusal (incl. the tool's owner), happy-path definition round-trip with echoed run context, missing tool 404, trashed tool 404 (soft-delete filter), DAC write requirement for read-only grantees, feature-gate 403, and guild-wide tools (admin runs, member gets RLS-hidden 404).