### PR TITLE
Fix new-user redirect to documents create dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Newly registered users are no longer bounced from the home page to the documents page with the "create document" dialog open: the create-document wizard's auto-advance no longer runs while its dialog is closed. The create-task wizard shared the same defect (silently pre-fetching and advancing while closed) and was fixed alongside it.
 - Task boards, document pickers, and project lists with more than 1000 items no longer silently lose rows: "fetch all" list requests now walk bounded server windows until the complete set is retrieved, and truncation is always reported via `has_next`.
 - `backend/scripts/create-provisioner.sql` missed the per-guild support roles: after switching `DATABASE_URL` to `app_provisioner`, deployments with existing guilds failed to boot with `permission denied to grant role "guild_N_support"`. If that hit you, run the fixed script once against your app database, connected as the Postgres superuser: `psql -v ON_ERROR_STOP=1 -U <superuser> -d <app-db> -v provisioner_password='<your password>' -f backend/scripts/create-provisioner.sql`. Running it again on a healthy install changes nothing.
 - Guild storage caps, member limits, tier label, and lifecycle status can no longer be edited through guild-facing settings — they are platform-operator inputs, now enforced with column-scoped database grants.

--- a/frontend/src/components/documents/CreateDocumentWizard.tsx
+++ b/frontend/src/components/documents/CreateDocumentWizard.tsx
@@ -160,6 +160,7 @@ export const CreateDocumentWizard = () => {
   // Auto-advance guild step
   useEffect(() => {
     if (
+      open &&
       step === "select-guild" &&
       guilds.length === 1 &&
       !lastUsed &&
@@ -168,11 +169,12 @@ export const CreateDocumentWizard = () => {
       autoAdvancedRef.current = "guild";
       handleGuildSelect(guilds[0].id, guilds[0].name);
     }
-  }, [step, guilds, lastUsed, handleGuildSelect]);
+  }, [open, step, guilds, lastUsed, handleGuildSelect]);
 
   // Auto-advance initiative step
   useEffect(() => {
     if (
+      open &&
       step === "select-initiative" &&
       !initiativesQuery.isLoading &&
       initiatives.length === 1 &&
@@ -181,7 +183,7 @@ export const CreateDocumentWizard = () => {
       autoAdvancedRef.current = "initiative";
       handleInitiativeSelect(initiatives[0].id, initiatives[0].name);
     }
-  }, [step, initiatives, initiativesQuery.isLoading, handleInitiativeSelect]);
+  }, [open, step, initiatives, initiativesQuery.isLoading, handleInitiativeSelect]);
 
   const handleBack = useCallback(() => {
     autoAdvancedRef.current = null;

--- a/frontend/src/components/tasks/CreateTaskWizard.tsx
+++ b/frontend/src/components/tasks/CreateTaskWizard.tsx
@@ -191,6 +191,7 @@ export const CreateTaskWizard = () => {
   // Auto-advance guild step
   useEffect(() => {
     if (
+      open &&
       step === "select-guild" &&
       guilds.length === 1 &&
       !lastUsed &&
@@ -199,11 +200,12 @@ export const CreateTaskWizard = () => {
       autoAdvancedRef.current = "guild";
       handleGuildSelect(guilds[0].id, guilds[0].name);
     }
-  }, [step, guilds, lastUsed, handleGuildSelect]);
+  }, [open, step, guilds, lastUsed, handleGuildSelect]);
 
   // Auto-advance initiative step
   useEffect(() => {
     if (
+      open &&
       step === "select-initiative" &&
       !initiativesQuery.isLoading &&
       initiatives.length === 1 &&
@@ -212,7 +214,7 @@ export const CreateTaskWizard = () => {
       autoAdvancedRef.current = "initiative";
       handleInitiativeSelect(initiatives[0].id, initiatives[0].name);
     }
-  }, [step, initiatives, initiativesQuery.isLoading, handleInitiativeSelect]);
+  }, [open, step, initiatives, initiativesQuery.isLoading, handleInitiativeSelect]);
 
   const navigateToProject = useCallback(
     (


### PR DESCRIPTION
## Problem

When a user first registers, instead of landing on the home page (`/`), they were bounced to the documents page with the "create document" dialog automatically open.

## Root cause

`CreateDocumentWizard` is mounted unconditionally in the authenticated app layout, so it is alive on every page. Its two "auto-advance when only one option" effects were **not gated on the dialog being open**. For a fresh account (exactly one guild + one initiative — the typical new-user state), the chain fired on mount while closed:

1. Guild auto-advance: 1 guild → step becomes `select-initiative`
2. Initiative auto-advance: 1 initiative → `handoffToDocuments()` navigates to `/g/<id>/documents?create=true`
3. The documents page reads `?create=true` and opens the create dialog

Registration itself correctly navigates to `/`; the wizard's ungated side effect immediately redirected the user onward.

`CreateTaskWizard` is also always-mounted and shares the same defect. It does **not** cause a visible redirect (its auto-advance stops at the project step, and the `create=true` navigation only fires on an explicit click), but while closed it silently advanced to `select-project`, firing background initiative/project fetches and opening mid-flow.

## Changes

- Gate both auto-advance effects in `CreateDocumentWizard` on `open === true`.
- Apply the same gate to `CreateTaskWizard` for correctness and consistency.
- Changelog entry under `[Unreleased] → Fixed`.

## Testing

- `pnpm typecheck` passes.
- Manual verification of the new-user flow recommended before merge.