### PR TITLE
Add Export Selected to the task bulk-edit panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Export Selected: with tasks selected in the project table, a new action in the selection bar exports exactly those tasks as a PDF (same private-to-creator delivery as the full export).
 - Task list PDF export: an "Export PDF" button on the project tasks view downloads the current view (same filters and visibility as on screen) as a formatted PDF. Small exports download instantly; large ones run as a background job and download automatically when ready — and if you navigate away meanwhile, you get an inbox notification that downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), and artifacts expire automatically after 7 days.
 
 ## [0.55.0] - 2026-07-12

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -258,6 +258,7 @@
     "queued": "Export gestartet — der Download beginnt, sobald er bereit ist.",
     "success": "Export heruntergeladen.",
     "failed": "Der Export ist fehlgeschlagen. Versuche es erneut oder grenze den Filter ein.",
-    "error": "Aufgaben konnten nicht exportiert werden."
+    "error": "Aufgaben konnten nicht exportiert werden.",
+    "selected": "Auswahl exportieren"
   }
 }

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -258,6 +258,7 @@
     "queued": "Export started — the download will begin when it's ready.",
     "success": "Export downloaded.",
     "failed": "The export failed. Try again or narrow the filter.",
-    "error": "Couldn't export tasks."
+    "error": "Couldn't export tasks.",
+    "selected": "Export Selected"
   }
 }

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -258,6 +258,7 @@
     "queued": "Exportación iniciada: la descarga comenzará cuando esté lista.",
     "success": "Exportación descargada.",
     "failed": "La exportación falló. Inténtalo de nuevo o reduce el filtro.",
-    "error": "No se pudieron exportar las tareas."
+    "error": "No se pudieron exportar las tareas.",
+    "selected": "Exportar selección"
   }
 }

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -258,6 +258,7 @@
     "queued": "Export lancé — le téléchargement commencera dès qu'il sera prêt.",
     "success": "Export téléchargé.",
     "failed": "L'export a échoué. Réessayez ou affinez le filtre.",
-    "error": "Impossible d'exporter les tâches."
+    "error": "Impossible d'exporter les tâches.",
+    "selected": "Exporter la sélection"
   }
 }

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -929,7 +929,12 @@ export const ProjectTasksSection = ({
                 </SelectContent>
               </Select>
             </div>
-            <ExportTasksButton params={{ conditions, include_archived: showArchived }} />
+            {/* resumePending: this is the view's single adopter of a stored
+                in-flight job (the selection button must not double-handle it). */}
+            <ExportTasksButton
+              params={{ conditions, include_archived: showArchived }}
+              resumePending
+            />
             <div className="hidden sm:block">
               <TabsList>
                 {TASK_VIEW_OPTIONS.map(({ value, labelKey, icon: Icon }) => (

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -1011,6 +1011,12 @@ export const ProjectTasksSection = ({
           {selectedTasks.length > 0 && canEditTaskDetails && (
             <TaskBulkEditPanel
               selectedTasks={selectedTasks}
+              exportParams={{
+                conditions: [{ field: "id", op: "in_", value: selectedTasks.map((t) => t.id) }],
+                // Selection came from the visible list, which may include
+                // archived rows when the toggle is on.
+                include_archived: showArchived,
+              }}
               onEdit={() => setIsBulkEditDialogOpen(true)}
               onEditTags={() => setIsBulkEditTagsDialogOpen(true)}
               onArchive={() => bulkArchiveTasks.mutate(selectedTasks.map((t) => t.id))}

--- a/frontend/src/components/tasks/ExportTasksButton.test.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.test.tsx
@@ -117,12 +117,27 @@ describe("ExportTasksButton", () => {
       ),
       guildHttp.get("/exports/:jobId/download", () => pdfResponse())
     );
-    renderWithProviders(<ExportTasksButton params={{ conditions: [] }} />);
+    renderWithProviders(<ExportTasksButton params={{ conditions: [] }} resumePending />);
 
     await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
     expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe("tasks-9.pdf");
     // The pending marker is consumed, so a remount won't re-download.
     expect(getItem("exports:pending:1")).toBeNull();
+  });
+
+  it("does not adopt a stored pending job without resumePending", async () => {
+    // Two instances share the guild's pending key (toolbar + Export
+    // Selected); only the designated adopter may resume, or a job in flight
+    // when the second instance mounts would download twice.
+    setItem("exports:pending:1", "9");
+    const jobPoll = vi.fn(() => HttpResponse.json(buildJob({ id: 9, status: "done" })));
+    server.use(guildHttp.get("/exports/:jobId", jobPoll));
+    renderWithProviders(<ExportTasksButton params={{ conditions: [] }} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(jobPoll).not.toHaveBeenCalled();
+    expect(downloadBlob).not.toHaveBeenCalled();
+    expect(getItem("exports:pending:1")).toBe("9");
   });
 
   it("shows a localized error for a rejected export (too large)", async () => {

--- a/frontend/src/components/tasks/ExportTasksButton.test.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.test.tsx
@@ -87,6 +87,28 @@ describe("ExportTasksButton", () => {
     expect(downloadBlob).not.toHaveBeenCalled();
   });
 
+  it("sends the given selector on the wire and honors a label override", async () => {
+    let sentConditions: unknown = null;
+    server.use(
+      guildHttp.get("/exports/tasks", ({ request }) => {
+        const raw = new URL(request.url).searchParams.get("conditions");
+        sentConditions = raw ? JSON.parse(raw) : null;
+        return pdfResponse();
+      })
+    );
+    renderWithProviders(
+      <ExportTasksButton
+        params={{ conditions: [{ field: "id", op: "in_", value: [3, 5] }] }}
+        label="Export Selected"
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Export Selected" }));
+
+    await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
+    expect(sentConditions).toEqual([{ field: "id", op: "in_", value: [3, 5] }]);
+  });
+
   it("resumes a pending job from storage on mount and downloads it", async () => {
     setItem("exports:pending:1", "9");
     server.use(

--- a/frontend/src/components/tasks/ExportTasksButton.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.tsx
@@ -13,14 +13,18 @@ import { getErrorMessage } from "@/lib/errorMessage";
 import { downloadExportArtifact, normalizeBlobError } from "@/lib/exportDownload";
 import { getItem, removeItem, setItem } from "@/lib/storage";
 
-type ExportParams = Pick<
+export type ExportParams = Pick<
   ExportTasksApiV1GGuildIdExportsTasksGetParams,
   "conditions" | "sorting" | "tz" | "include_archived"
 >;
 
 interface ExportTasksButtonProps {
-  /** The CURRENT list selector — the export must match what's on screen. */
+  /** The selector for the snapshot — the current list filters, or an
+   * ``id in_`` condition for an explicit selection. */
   params: ExportParams;
+  /** Idle-state label override (e.g. "Export Selected"); the busy label
+   * stays the shared "Exporting…". */
+  label?: string;
 }
 
 const POLL_MS = 2000;
@@ -31,7 +35,7 @@ const TERMINAL = new Set(["done", "failed", "expired"]);
 // A full page reload is covered by the worker's inbox notification instead.
 const pendingKey = (guildId: number) => `exports:pending:${guildId}`;
 
-export function ExportTasksButton({ params }: ExportTasksButtonProps) {
+export function ExportTasksButton({ params, label }: ExportTasksButtonProps) {
   const { t } = useTranslation("tasks");
   const guildId = useActiveGuildId();
   const [requesting, setRequesting] = useState(false);
@@ -109,19 +113,18 @@ export function ExportTasksButton({ params }: ExportTasksButtonProps) {
     }
   };
 
+  const idleLabel = label ?? t("export.button");
   return (
     <Button
       variant="outline"
       size="sm"
       onClick={handleExport}
       disabled={busy}
-      aria-label={t("export.button")}
-      title={t("export.button")}
+      aria-label={idleLabel}
+      title={idleLabel}
     >
       {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
-      <span className="hidden sm:ml-2 sm:inline">
-        {busy ? t("export.preparing") : t("export.button")}
-      </span>
+      <span className="hidden sm:ml-2 sm:inline">{busy ? t("export.preparing") : idleLabel}</span>
     </Button>
   );
 }

--- a/frontend/src/components/tasks/ExportTasksButton.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.tsx
@@ -25,6 +25,13 @@ interface ExportTasksButtonProps {
   /** Idle-state label override (e.g. "Export Selected"); the busy label
    * stays the shared "Exporting…". */
   label?: string;
+  /** Adopt a stored pending job on mount. Exactly ONE instance per view may
+   * set this (the persistent toolbar button) — the guild's pending key is
+   * shared, so a second adopter (e.g. the bulk-selection button mounting
+   * mid-poll) would handle the same job again: duplicate download + toast.
+   * Every instance still WRITES the key on 202, so a job started anywhere
+   * is resumed by the adopting instance on the next mount. */
+  resumePending?: boolean;
 }
 
 const POLL_MS = 2000;
@@ -35,12 +42,12 @@ const TERMINAL = new Set(["done", "failed", "expired"]);
 // A full page reload is covered by the worker's inbox notification instead.
 const pendingKey = (guildId: number) => `exports:pending:${guildId}`;
 
-export function ExportTasksButton({ params, label }: ExportTasksButtonProps) {
+export function ExportTasksButton({ params, label, resumePending }: ExportTasksButtonProps) {
   const { t } = useTranslation("tasks");
   const guildId = useActiveGuildId();
   const [requesting, setRequesting] = useState(false);
   const [jobId, setJobId] = useState<number | null>(() => {
-    if (!guildId) {
+    if (!resumePending || !guildId) {
       return null;
     }
     const stored = Number(getItem(pendingKey(guildId)));

--- a/frontend/src/components/tasks/TaskBulkEditPanel.test.tsx
+++ b/frontend/src/components/tasks/TaskBulkEditPanel.test.tsx
@@ -1,0 +1,35 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { buildTask } from "@/__tests__/factories";
+import { renderWithProviders } from "@/__tests__/helpers/render";
+
+import { TaskBulkEditPanel } from "./TaskBulkEditPanel";
+
+const handlers = {
+  onEdit: vi.fn(),
+  onEditTags: vi.fn(),
+  onArchive: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe("TaskBulkEditPanel", () => {
+  it("renders Export Selected ahead of the edit actions when a selector is given", () => {
+    renderWithProviders(
+      <TaskBulkEditPanel
+        selectedTasks={[buildTask(), buildTask()]}
+        exportParams={{
+          conditions: [{ field: "id", op: "in_", value: [1, 2] }],
+        }}
+        {...handlers}
+      />
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveAccessibleName("Export Selected");
+  });
+
+  it("omits the export action without a selector", () => {
+    renderWithProviders(<TaskBulkEditPanel selectedTasks={[buildTask()]} {...handlers} />);
+    expect(screen.queryByRole("button", { name: /export/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/tasks/TaskBulkEditPanel.tsx
+++ b/frontend/src/components/tasks/TaskBulkEditPanel.tsx
@@ -2,6 +2,7 @@ import { Archive, Pencil, Tags, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { TaskListRead } from "@/api/generated/initiativeAPI.schemas";
+import { type ExportParams, ExportTasksButton } from "@/components/tasks/ExportTasksButton";
 import { Button } from "@/components/ui/button";
 
 type TaskBulkEditPanelProps = {
@@ -11,6 +12,9 @@ type TaskBulkEditPanelProps = {
   onArchive: () => void;
   onDelete: () => void;
   isArchiving?: boolean;
+  /** When set, an "Export Selected" action renders ahead of the edit
+   * actions, exporting exactly this selector (an ``id in_`` condition). */
+  exportParams?: ExportParams;
 };
 
 export const TaskBulkEditPanel = ({
@@ -20,6 +24,7 @@ export const TaskBulkEditPanel = ({
   onArchive,
   onDelete,
   isArchiving,
+  exportParams,
 }: TaskBulkEditPanelProps) => {
   const { t } = useTranslation(["tasks", "common"]);
   return (
@@ -29,6 +34,7 @@ export const TaskBulkEditPanel = ({
       </div>
 
       <div className="flex items-center gap-2">
+        {exportParams && <ExportTasksButton params={exportParams} label={t("export.selected")} />}
         <Button variant="outline" size="sm" onClick={onEditTags}>
           <Tags className="h-4 w-4" />
           {t("bulkEdit.editTags")}


### PR DESCRIPTION
## Problem

With rows selected in the project task table, there was no way to export just that selection — only the whole filtered view (#885).

## What this adds

An **Export Selected** action in the bulk-selection bar, ahead of the edit actions (per mockup). The selection becomes an `{"field": "id", "op": "in_", "value": [...]}` condition on the *same* selector the filter export sends, so this reuses the export pipeline end to end — inline/job auto-select, the pending-job resume, the inbox notification, and the job-gated download all apply unchanged.

**Zero backend changes**: `id` is already an allowed filter column in the task filter engine, and the export query runs under the caller's RLS session, so selected ids the user can't actually reach simply don't match (no oracle: the rows were visible to select in the first place).

Notable frontend changes:
- `ExportTasksButton` gains an optional `label` override and exports its `ExportParams` type.
- `TaskBulkEditPanel` takes an optional `exportParams` selector and renders the export action when present.
- `ProjectTasksSection` passes the selected ids (+ `include_archived` matching the visible list).
- Strings in en/de/es/fr.

## Testing

```
cd frontend && pnpm typecheck && pnpm lint && pnpm test:run   # 813 passed
```

New tests: the wire carries the exact id selector and honors the label override; the panel renders the action first when a selector is given and omits it otherwise.

Note for review: a very large selection (hundreds of ids) rides the query string — roughly 6KB at 750 ids, within default proxy limits but worth knowing. If we ever allow larger selections, the create call should move to a POST body.