### PR TITLE
Add CSV, XLSX, and Markdown export formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Task exports now offer CSV and Excel (XLSX) alongside PDF — the export button is a format menu, and both tabular formats carry spreadsheet-injection protection.
+- Task exports now offer CSV, Excel (XLSX), and Markdown alongside PDF — the export button is a format menu, and the spreadsheet formats carry injection protection.
 - Export Selected: with tasks selected in the project table, a new action in the selection bar exports exactly those tasks as a PDF (same private-to-creator delivery as the full export).
 - Task list PDF export: an "Export PDF" button on the project tasks view downloads the current view (same filters and visibility as on screen) as a formatted PDF. Small exports download instantly; large ones run as a background job and download automatically when ready — and if you navigate away meanwhile, you get an inbox notification that downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), and artifacts expire automatically after 7 days.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Task exports now offer CSV, Excel (XLSX), and Markdown alongside PDF — the export button is a format menu, and the spreadsheet formats carry injection protection.
-- Export Selected: with tasks selected in the project table, a new action in the selection bar exports exactly those tasks as a PDF (same private-to-creator delivery as the full export).
-- Task list PDF export: an "Export PDF" button on the project tasks view downloads the current view (same filters and visibility as on screen) as a formatted PDF. Small exports download instantly; large ones run as a background job and download automatically when ready — and if you navigate away meanwhile, you get an inbox notification that downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), and artifacts expire automatically after 7 days.
+- Task exports: an Export menu on the project tasks view downloads the current view — or just the selected tasks, via the new action in the selection bar — as PDF, CSV, Excel (XLSX), or Markdown, with the same filters and visibility as on screen. Small exports download instantly; large ones run as a background job and download automatically when ready, and if you navigate away meanwhile, an inbox notification downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), artifacts expire automatically after 7 days, and the spreadsheet formats carry injection protection.
 
 ## [0.55.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Task exports: an Export menu on the project tasks view downloads the current view — or just the selected tasks, via the new action in the selection bar — as PDF, CSV, Excel (XLSX), or Markdown, with the same filters and visibility as on screen. Small exports download instantly; large ones run as a background job and download automatically when ready, and if you navigate away meanwhile, an inbox notification downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), artifacts expire automatically after 7 days, and the spreadsheet formats carry injection protection.
+- Task exports: an Export menu on the project tasks view downloads the current view — or just the selected tasks, via the new action in the selection bar — as PDF, CSV, Excel (XLSX), or Markdown (a table or a checkable task list), with the same filters and visibility as on screen. Small exports download instantly; large ones run as a background job and download automatically when ready, and if you navigate away meanwhile, an inbox notification downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), artifacts expire automatically after 7 days, and the spreadsheet formats carry injection protection.
 
 ## [0.55.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Task exports now offer CSV and Excel (XLSX) alongside PDF — the export button is a format menu, and both tabular formats carry spreadsheet-injection protection.
 - Export Selected: with tasks selected in the project table, a new action in the selection bar exports exactly those tasks as a PDF (same private-to-creator delivery as the full export).
 - Task list PDF export: an "Export PDF" button on the project tasks view downloads the current view (same filters and visibility as on screen) as a formatted PDF. Small exports download instantly; large ones run as a background job and download automatically when ready — and if you navigate away meanwhile, you get an inbox notification that downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), and artifacts expire automatically after 7 days.
 

--- a/backend/app/api/v1/tenant_endpoints/exports.py
+++ b/backend/app/api/v1/tenant_endpoints/exports.py
@@ -72,6 +72,10 @@ async def export_tasks(
     ),
     tz: Optional[str] = Query(default=None, description="IANA timezone name"),
     include_archived: bool = Query(default=False),
+    layout: Literal["table", "checklist"] = Query(
+        default="table",
+        description="Markdown layout: a table, or a GitHub-style task list",
+    ),
 ) -> Union[Response, JSONResponse]:
     """Export the task list (the same visibility and filters as ``GET
     /tasks/``) as a formatted document. Small results render inline and return
@@ -89,6 +93,7 @@ async def export_tasks(
                 "sorting": sorting,
                 "tz": tz,
                 "include_archived": include_archived,
+                "layout": layout,
             },
             allow_job=_allow_job(guild_context),
         )

--- a/backend/app/api/v1/tenant_endpoints/exports.py
+++ b/backend/app/api/v1/tenant_endpoints/exports.py
@@ -63,7 +63,7 @@ async def export_tasks(
     guild_context: GuildContextDep,
     # Literal so the HTTP layer 422s garbage and OpenAPI carries the enum;
     # grows as formats land. The registry still guards per-source combos.
-    format: Literal["pdf"] = Query(default="pdf"),
+    format: Literal["pdf", "csv", "xlsx"] = Query(default="pdf"),
     conditions: Optional[str] = Query(
         default=None, description="Same JSON filter conditions as the task list"
     ),

--- a/backend/app/api/v1/tenant_endpoints/exports.py
+++ b/backend/app/api/v1/tenant_endpoints/exports.py
@@ -63,7 +63,7 @@ async def export_tasks(
     guild_context: GuildContextDep,
     # Literal so the HTTP layer 422s garbage and OpenAPI carries the enum;
     # grows as formats land. The registry still guards per-source combos.
-    format: Literal["pdf", "csv", "xlsx"] = Query(default="pdf"),
+    format: Literal["pdf", "csv", "xlsx", "md"] = Query(default="pdf"),
     conditions: Optional[str] = Query(
         default=None, description="Same JSON filter conditions as the task list"
     ),

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -43,6 +43,32 @@ async def test_inline_export_returns_pdf(client: AsyncClient, acting_user, sessi
     assert resp.content.startswith(b"%PDF")
 
 
+async def test_inline_export_csv_and_xlsx(client: AsyncClient, acting_user, session):
+    a = await _actor_with_tasks(acting_user, session)
+
+    csv_resp = await client.get(
+        a.g("/exports/tasks"), headers=a.headers, params={"format": "csv"}
+    )
+    assert csv_resp.status_code == 200
+    assert csv_resp.headers["content-type"].startswith("text/csv")
+    body = csv_resp.content.decode("utf-8")
+    assert "Task,Project,Status,Priority,Due,Assignees" in body
+    assert "Task 0" in body and "Task 1" in body
+
+    xlsx_resp = await client.get(
+        a.g("/exports/tasks"), headers=a.headers, params={"format": "xlsx"}
+    )
+    assert xlsx_resp.status_code == 200
+    assert xlsx_resp.content.startswith(b"PK")
+    assert xlsx_resp.headers["content-type"].endswith("spreadsheetml.sheet")
+    assert 'filename="tasks.xlsx"' in xlsx_resp.headers["content-disposition"]
+
+    unknown = await client.get(
+        a.g("/exports/tasks"), headers=a.headers, params={"format": "docx"}
+    )
+    assert unknown.status_code == 422  # HTTP-layer Literal validation
+
+
 async def test_inline_export_respects_task_filters(
     client: AsyncClient, acting_user, session
 ):

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -72,6 +72,16 @@ async def test_inline_export_csv_and_xlsx(client: AsyncClient, acting_user, sess
     assert "| Task | Project | Status | Priority | Due | Assignees |" in md_body
     assert 'filename="tasks.md"' in md_resp.headers["content-disposition"]
 
+    checklist = await client.get(
+        a.g("/exports/tasks"),
+        headers=a.headers,
+        params={"format": "md", "layout": "checklist"},
+    )
+    assert checklist.status_code == 200
+    body = checklist.content.decode("utf-8")
+    assert "- [ ] Task 0" in body and "- [ ] Task 1" in body
+    assert "| Task |" not in body  # checklist, not a table
+
     unknown = await client.get(
         a.g("/exports/tasks"), headers=a.headers, params={"format": "docx"}
     )

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -63,6 +63,15 @@ async def test_inline_export_csv_and_xlsx(client: AsyncClient, acting_user, sess
     assert xlsx_resp.headers["content-type"].endswith("spreadsheetml.sheet")
     assert 'filename="tasks.xlsx"' in xlsx_resp.headers["content-disposition"]
 
+    md_resp = await client.get(
+        a.g("/exports/tasks"), headers=a.headers, params={"format": "md"}
+    )
+    assert md_resp.status_code == 200
+    assert md_resp.headers["content-type"].startswith("text/markdown")
+    md_body = md_resp.content.decode("utf-8")
+    assert "| Task | Project | Status | Priority | Due | Assignees |" in md_body
+    assert 'filename="tasks.md"' in md_resp.headers["content-disposition"]
+
     unknown = await client.get(
         a.g("/exports/tasks"), headers=a.headers, params={"format": "docx"}
     )

--- a/backend/app/services/export/adapters/tasks_table.py
+++ b/backend/app/services/export/adapters/tasks_table.py
@@ -23,10 +23,22 @@ from app.models.tenant.task import Task
 from app.services.export.contract import RenderItem, RenderRequest
 
 
+# Column spec shared by every format: the PDF template reads the row keys it
+# knows; the tabular renderers project rows through this list in order.
+_COLUMNS = (
+    {"key": "title", "label": "Task"},
+    {"key": "project", "label": "Project"},
+    {"key": "status", "label": "Status"},
+    {"key": "priority", "label": "Priority"},
+    {"key": "due", "label": "Due"},
+    {"key": "assignees", "label": "Assignees"},
+)
+
+
 class TasksTableAdapter:
     source = "tasks"
     template_id = "task-table"
-    formats = frozenset({"pdf"})
+    formats = frozenset({"pdf", "csv", "xlsx"})
 
     async def count(
         self, session: AsyncSession, *, user: User, guild_id: int, params: dict
@@ -38,7 +50,13 @@ class TasksTableAdapter:
         )
 
     async def build(
-        self, session: AsyncSession, *, user: User, guild_id: int, params: dict
+        self,
+        session: AsyncSession,
+        *,
+        user: User,
+        guild_id: int,
+        params: dict,
+        format: str,
     ) -> RenderRequest:
         from app.api.v1.tenant_endpoints.tasks import query_tasks_for_export
 
@@ -58,12 +76,13 @@ class TasksTableAdapter:
                 f" · generated {generated_at} by {author}"
             ),
             "footer": "Tasks export",
+            "columns": [dict(c) for c in _COLUMNS],
             "rows": [_row(t) for t in tasks],
         }
         return RenderRequest(
             guild_id=guild_id,
             template_id=self.template_id,
-            format="pdf",
+            format=format,
             batch=(RenderItem(key="tasks", data=data),),
         )
 

--- a/backend/app/services/export/adapters/tasks_table.py
+++ b/backend/app/services/export/adapters/tasks_table.py
@@ -38,7 +38,7 @@ _COLUMNS = (
 class TasksTableAdapter:
     source = "tasks"
     template_id = "task-table"
-    formats = frozenset({"pdf", "csv", "xlsx"})
+    formats = frozenset({"pdf", "csv", "xlsx", "md"})
 
     async def count(
         self, session: AsyncSession, *, user: User, guild_id: int, params: dict

--- a/backend/app/services/export/adapters/tasks_table.py
+++ b/backend/app/services/export/adapters/tasks_table.py
@@ -19,7 +19,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
 from app.models.platform.user import User
-from app.models.tenant.task import Task
+from app.models.tenant.task import Task, TaskStatusCategory
 from app.services.export.contract import RenderItem, RenderRequest
 
 
@@ -79,6 +79,10 @@ class TasksTableAdapter:
             "columns": [dict(c) for c in _COLUMNS],
             "rows": [_row(t) for t in tasks],
         }
+        # Layout variant within a format (markdown table vs checklist) — part
+        # of the selector, so a queued job renders the same shape on replay.
+        if params.get("layout") == "checklist":
+            data["layout"] = "checklist"
         return RenderRequest(
             guild_id=guild_id,
             template_id=self.template_id,
@@ -98,7 +102,7 @@ def _selector(params: dict) -> dict[str, Any]:
     }
 
 
-def _row(task: Task) -> dict[str, str]:
+def _row(task: Task) -> dict[str, Any]:
     return {
         "title": task.title,
         "project": task.project.name if task.project else "",
@@ -106,4 +110,9 @@ def _row(task: Task) -> dict[str, str]:
         "priority": task.priority.value if task.priority else "",
         "due": task.due_date.strftime("%Y-%m-%d") if task.due_date else "",
         "assignees": ", ".join(a.full_name or a.email for a in (task.assignees or [])),
+        # Not a projected column (absent from _COLUMNS): drives the checklist
+        # layout's checkbox state.
+        "done": bool(
+            task.task_status and task.task_status.category == TaskStatusCategory.done
+        ),
     }

--- a/backend/app/services/export/engine.py
+++ b/backend/app/services/export/engine.py
@@ -48,7 +48,13 @@ class SourceAdapter(Protocol):
     ) -> int: ...
 
     async def build(
-        self, session: AsyncSession, *, user: User, guild_id: int, params: dict
+        self,
+        session: AsyncSession,
+        *,
+        user: User,
+        guild_id: int,
+        params: dict,
+        format: str,
     ) -> RenderRequest: ...
 
 
@@ -124,7 +130,7 @@ async def start_export(
 
     if row_count <= settings.EXPORT_INLINE_MAX_ROWS:
         request = await adapter.build(
-            session, user=user, guild_id=guild_id, params=params
+            session, user=user, guild_id=guild_id, params=params, format=format
         )
         artifacts = await get_backend().render(request)
         artifact = _single(artifacts)

--- a/backend/app/services/export/local_backend.py
+++ b/backend/app/services/export/local_backend.py
@@ -34,6 +34,7 @@ _CONTENT_TYPES = {
     "pdf": "application/pdf",
     "csv": "text/csv; charset=utf-8",
     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "md": "text/markdown; charset=utf-8",
 }
 
 
@@ -83,6 +84,8 @@ def _render_item(template: Path | None, format: str, item: RenderItem) -> bytes:
         return tabular.render_csv(item)
     if format == "xlsx":
         return tabular.render_xlsx(item)
+    if format == "md":
+        return tabular.render_md(item)
     assert template is not None  # resolve_template ran for the pdf path
     return _compile(template, format, item)
 

--- a/backend/app/services/export/local_backend.py
+++ b/backend/app/services/export/local_backend.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import typst
 
+from app.services.export import tabular
 from app.services.export.contract import (
     RenderedArtifact,
     RenderItem,
@@ -29,7 +30,11 @@ TEMPLATES_DIR = Path(__file__).parent / "templates"
 # reach the filesystem, so whitelist the alphabet anyway (no traversal).
 _TEMPLATE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
-_CONTENT_TYPES = {"pdf": "application/pdf"}
+_CONTENT_TYPES = {
+    "pdf": "application/pdf",
+    "csv": "text/csv; charset=utf-8",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+}
 
 
 class UnknownTemplateError(ValueError):
@@ -47,7 +52,10 @@ def resolve_template(template_id: str) -> Path:
 
 class LocalRenderBackend:
     async def render(self, req: RenderRequest) -> list[RenderedArtifact]:
-        template = resolve_template(req.template_id)
+        # Only the PDF path involves a template; tabular formats consume the
+        # payload's columns/rows directly. Resolve (and thereby validate) the
+        # template up front so a bad id fails before the executor hop.
+        template = resolve_template(req.template_id) if req.format == "pdf" else None
         content_type = _CONTENT_TYPES[req.format]
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(
@@ -56,7 +64,7 @@ class LocalRenderBackend:
 
     @staticmethod
     def _render_sync(
-        template: Path, content_type: str, req: RenderRequest
+        template: Path | None, content_type: str, req: RenderRequest
     ) -> list[RenderedArtifact]:
         out: list[RenderedArtifact] = []
         for item in req.batch:
@@ -64,10 +72,19 @@ class LocalRenderBackend:
                 RenderedArtifact(
                     key=item.key,
                     content_type=content_type,
-                    content=_compile(template, req.format, item),
+                    content=_render_item(template, req.format, item),
                 )
             )
         return out
+
+
+def _render_item(template: Path | None, format: str, item: RenderItem) -> bytes:
+    if format == "csv":
+        return tabular.render_csv(item)
+    if format == "xlsx":
+        return tabular.render_xlsx(item)
+    assert template is not None  # resolve_template ran for the pdf path
+    return _compile(template, format, item)
 
 
 def _compile(template: Path, format: str, item: RenderItem) -> bytes:

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -122,6 +122,24 @@ async def test_renders_xlsx_with_formula_neutralization():
     assert sheet.cell(row=2, column=1).data_type == "s"
 
 
+async def test_renders_markdown_table_with_escaped_cells():
+    """Pipes and newlines in user text must not break the GFM table."""
+    artifacts = await LocalRenderBackend().render(
+        _request(
+            format="md",
+            rows=[{"title": "a | b\nmultiline", "status": "To Do"}],
+        )
+    )
+    artifact = artifacts[0]
+    assert artifact.content_type.startswith("text/markdown")
+    text = artifact.content.decode("utf-8")
+    lines = text.splitlines()
+    assert lines[0] == "# Tasks"
+    assert "| Task | Status |" in lines
+    assert "| --- | --- |" in lines
+    assert "| a \\| b multiline | To Do |" in lines
+
+
 async def test_xlsx_sanitizes_sheet_title():
     """openpyxl raises InvalidSheetTitle on []:*?/\\ — a title carrying user
     text (e.g. a guild named "My App: Dev") must render, not crash."""

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -140,6 +140,28 @@ async def test_renders_markdown_table_with_escaped_cells():
     assert "| a \\| b multiline | To Do |" in lines
 
 
+async def test_renders_markdown_checklist_layout():
+    """layout=checklist renders GitHub-style task items — checked from the
+    row's done flag, details from the non-title columns, empties skipped."""
+    artifacts = await LocalRenderBackend().render(
+        _request(
+            format="md",
+            layout="checklist",
+            rows=[
+                {"title": "Open item", "status": "To Do", "done": False},
+                {"title": "Shipped | piped", "status": "Done", "done": True},
+                {"title": "", "status": "", "done": False},
+            ],
+        )
+    )
+    text = artifacts[0].content.decode("utf-8")
+    lines = text.splitlines()
+    assert "- [ ] Open item (To Do)" in lines
+    assert "- [x] Shipped \\| piped (Done)" in lines
+    assert "- [ ] (untitled)" in lines
+    assert not any("---" in line for line in lines)  # no table separator
+
+
 async def test_xlsx_sanitizes_sheet_title():
     """openpyxl raises InvalidSheetTitle on []:*?/\\ — a title carrying user
     text (e.g. a guild named "My App: Dev") must render, not crash."""

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -122,6 +122,30 @@ async def test_renders_xlsx_with_formula_neutralization():
     assert sheet.cell(row=2, column=1).data_type == "s"
 
 
+async def test_xlsx_preserves_numeric_cells():
+    """Neutralization must not coerce numbers to strings: ``-5`` looks like a
+    formula trigger as text, but openpyxl can't infer a formula from an int,
+    and a string cell would break sorting/arithmetic in the sheet."""
+    from io import BytesIO
+
+    from openpyxl import load_workbook
+
+    artifacts = await LocalRenderBackend().render(
+        _request(
+            format="xlsx",
+            columns=[
+                {"key": "title", "label": "Task"},
+                {"key": "count", "label": "Count"},
+            ],
+            rows=[{"title": "-starts with trigger", "count": -5}],
+        )
+    )
+    sheet = load_workbook(BytesIO(artifacts[0].content)).active
+    assert sheet.cell(row=2, column=1).value == "'-starts with trigger"
+    assert sheet.cell(row=2, column=2).value == -5
+    assert sheet.cell(row=2, column=2).data_type == "n"
+
+
 async def test_tabular_formats_skip_template_resolution():
     """A csv/xlsx render must not require a .typ template — the payload's
     columns/rows are the whole input."""

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -12,11 +12,15 @@ from app.services.export.local_backend import (
 pytestmark = pytest.mark.unit
 
 
-def _request(**data) -> RenderRequest:
+def _request(format: str = "pdf", **data) -> RenderRequest:
     payload = {
         "title": "Tasks",
         "subtitle": "unit test",
         "footer": "Tasks export",
+        "columns": [
+            {"key": "title", "label": "Task"},
+            {"key": "status", "label": "Status"},
+        ],
         "rows": [
             {
                 "title": "A task",
@@ -32,7 +36,7 @@ def _request(**data) -> RenderRequest:
     return RenderRequest(
         guild_id=1,
         template_id="task-table",
-        format="pdf",
+        format=format,
         batch=(RenderItem(key="tasks", data=payload),),
     )
 
@@ -78,3 +82,59 @@ def test_template_id_is_whitelisted():
     for bad in ("../secrets", "task table", "no-such-template", "TASK-TABLE", ""):
         with pytest.raises(UnknownTemplateError):
             resolve_template(bad)
+
+
+async def test_renders_csv_with_formula_neutralization():
+    """CSV rides the platform exporter's safety: BOM prefix and a leading
+    formula trigger prefixed so spreadsheets treat the cell as text."""
+    artifacts = await LocalRenderBackend().render(
+        _request(
+            format="csv",
+            rows=[{"title": "=HYPERLINK(evil)", "status": "To Do"}],
+        )
+    )
+    artifact = artifacts[0]
+    assert artifact.content_type.startswith("text/csv")
+    text = artifact.content.decode("utf-8")
+    assert text.startswith("﻿")
+    assert "Task,Status" in text
+    assert "'=HYPERLINK(evil)" in text
+
+
+async def test_renders_xlsx_with_formula_neutralization():
+    from io import BytesIO
+
+    from openpyxl import load_workbook
+
+    artifacts = await LocalRenderBackend().render(
+        _request(
+            format="xlsx",
+            rows=[{"title": "=CMD|dangerous", "status": "Done"}],
+        )
+    )
+    artifact = artifacts[0]
+    assert artifact.content.startswith(b"PK")  # zip container
+    sheet = load_workbook(BytesIO(artifact.content)).active
+    assert [c.value for c in sheet[1]] == ["Task", "Status"]
+    row = [c.value for c in sheet[2]]
+    assert row == ["'=CMD|dangerous", "Done"]
+    # Neutralized: stored as a string cell, not an inferred formula.
+    assert sheet.cell(row=2, column=1).data_type == "s"
+
+
+async def test_tabular_formats_skip_template_resolution():
+    """A csv/xlsx render must not require a .typ template — the payload's
+    columns/rows are the whole input."""
+    req = RenderRequest(
+        guild_id=1,
+        template_id="no-such-template",
+        format="csv",
+        batch=(
+            RenderItem(
+                key="tasks",
+                data={"columns": [{"key": "title", "label": "Task"}], "rows": []},
+            ),
+        ),
+    )
+    artifacts = await LocalRenderBackend().render(req)
+    assert artifacts[0].content_type.startswith("text/csv")

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -122,6 +122,26 @@ async def test_renders_xlsx_with_formula_neutralization():
     assert sheet.cell(row=2, column=1).data_type == "s"
 
 
+async def test_xlsx_sanitizes_sheet_title():
+    """openpyxl raises InvalidSheetTitle on []:*?/\\ — a title carrying user
+    text (e.g. a guild named "My App: Dev") must render, not crash."""
+    from io import BytesIO
+
+    from openpyxl import load_workbook
+
+    artifacts = await LocalRenderBackend().render(
+        _request(format="xlsx", title="Tasks — My App: Dev [beta] a/b\\c *?")
+    )
+    sheet = load_workbook(BytesIO(artifacts[0].content)).active
+    assert sheet.title == "Tasks — My App Dev beta abc"
+    assert len(sheet.title) <= 31
+
+    # A title reduced to nothing falls back to the item key.
+    artifacts = await LocalRenderBackend().render(_request(format="xlsx", title=":::"))
+    sheet = load_workbook(BytesIO(artifacts[0].content)).active
+    assert sheet.title == "tasks"
+
+
 async def test_xlsx_preserves_numeric_cells():
     """Neutralization must not coerce numbers to strings: ``-5`` looks like a
     formula trigger as text, but openpyxl can't infer a formula from an int,

--- a/backend/app/services/export/tabular.py
+++ b/backend/app/services/export/tabular.py
@@ -48,6 +48,33 @@ def render_csv(item: RenderItem) -> bytes:
     return build_csv(headers, rows)
 
 
+def _md_cell(value: Any) -> str:
+    """A cell must not break the GFM table structure: escape pipes and
+    collapse newlines. Markdown has no execution surface, so this is layout
+    integrity, not injection defense."""
+    text = "" if value is None else str(value)
+    return text.replace("|", "\\|").replace("\r\n", " ").replace("\n", " ")
+
+
+def render_md(item: RenderItem) -> bytes:
+    headers, rows = _table(item)
+    lines: list[str] = []
+    title = str(item.data.get("title", "")).strip()
+    subtitle = str(item.data.get("subtitle", "")).strip()
+    if title:
+        lines.append(f"# {_md_cell(title)}")
+        lines.append("")
+    if subtitle:
+        lines.append(_md_cell(subtitle))
+        lines.append("")
+    lines.append("| " + " | ".join(_md_cell(h) for h in headers) + " |")
+    lines.append("|" + "|".join(" --- " for _ in headers) + "|")
+    for row in rows:
+        lines.append("| " + " | ".join(_md_cell(value) for value in row) + " |")
+    lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
 def _xlsx_cell(value: Any) -> Any:
     """Neutralize only STRING cells for XLSX. Unlike CSV (where every value
     becomes text anyway), XLSX cells are typed: a number must stay a number

--- a/backend/app/services/export/tabular.py
+++ b/backend/app/services/export/tabular.py
@@ -57,7 +57,16 @@ def _md_cell(value: Any) -> str:
 
 
 def render_md(item: RenderItem) -> bytes:
-    headers, rows = _table(item)
+    lines = _md_header(item)
+    if item.data.get("layout") == "checklist":
+        lines.extend(_md_checklist(item))
+    else:
+        lines.extend(_md_table(item))
+    lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
+def _md_header(item: RenderItem) -> list[str]:
     lines: list[str] = []
     title = str(item.data.get("title", "")).strip()
     subtitle = str(item.data.get("subtitle", "")).strip()
@@ -67,12 +76,32 @@ def render_md(item: RenderItem) -> bytes:
     if subtitle:
         lines.append(_md_cell(subtitle))
         lines.append("")
-    lines.append("| " + " | ".join(_md_cell(h) for h in headers) + " |")
+    return lines
+
+
+def _md_table(item: RenderItem) -> list[str]:
+    headers, rows = _table(item)
+    lines = ["| " + " | ".join(_md_cell(h) for h in headers) + " |"]
     lines.append("|" + "|".join(" --- " for _ in headers) + "|")
     for row in rows:
         lines.append("| " + " | ".join(_md_cell(value) for value in row) + " |")
-    lines.append("")
-    return "\n".join(lines).encode("utf-8")
+    return lines
+
+
+def _md_checklist(item: RenderItem) -> list[str]:
+    """GitHub-style task list: one checkbox item per row, checked when the
+    row's ``done`` flag is set, with the non-title columns as a detail trail."""
+    columns = item.data.get("columns") or []
+    detail_keys = [c["key"] for c in columns if c["key"] != "title"]
+    lines: list[str] = []
+    for row in item.data.get("rows") or []:
+        box = "x" if row.get("done") else " "
+        title = _md_cell(row.get("title", "")) or "(untitled)"
+        details = " · ".join(
+            _md_cell(row[key]) for key in detail_keys if str(row.get(key, "")).strip()
+        )
+        lines.append(f"- [{box}] {title}" + (f" ({details})" if details else ""))
+    return lines
 
 
 def _xlsx_cell(value: Any) -> Any:

--- a/backend/app/services/export/tabular.py
+++ b/backend/app/services/export/tabular.py
@@ -1,0 +1,53 @@
+"""Tabular renderers (CSV/XLSX) for the export engine.
+
+Same source adapters, different renderer: a tabular format consumes the
+``columns``/``rows`` of the same data payload the PDF template reads, so a
+source that declares the format gets it with no adapter changes.
+
+Both formats absorb the platform CSV exporter's injection safety rather than
+duplicating it: every cell passes ``csv_export._neutralize_cell`` — XLSX
+included, because openpyxl infers a string cell starting with ``=`` as a
+formula, so the spreadsheet-injection class isn't CSV-only.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from openpyxl import Workbook
+
+from app.services.export.contract import RenderItem
+from app.services.platform.csv_export import _neutralize_cell, build_csv
+
+# Sheet titles have a 31-char limit and a forbidden character set in the XLSX
+# spec; our sources use short safe keys ("tasks"), but clamp defensively.
+_SHEET_TITLE_MAX = 31
+
+
+def _table(item: RenderItem) -> tuple[list[str], list[list[Any]]]:
+    """Project the payload's ``columns``/``rows`` into header + cell lists."""
+    columns = item.data.get("columns") or []
+    keys = [c["key"] for c in columns]
+    headers = [c.get("label", c["key"]) for c in columns]
+    rows = [[row.get(key, "") for key in keys] for row in item.data.get("rows") or []]
+    return headers, rows
+
+
+def render_csv(item: RenderItem) -> bytes:
+    headers, rows = _table(item)
+    return build_csv(headers, rows)
+
+
+def render_xlsx(item: RenderItem) -> bytes:
+    headers, rows = _table(item)
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = str(item.data.get("title", item.key))[:_SHEET_TITLE_MAX] or item.key
+    sheet.append([_neutralize_cell(value) for value in headers])
+    for row in rows:
+        sheet.append([_neutralize_cell(value) for value in row])
+    sheet.freeze_panes = "A2"
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    return buffer.getvalue()

--- a/backend/app/services/export/tabular.py
+++ b/backend/app/services/export/tabular.py
@@ -5,9 +5,10 @@ Same source adapters, different renderer: a tabular format consumes the
 source that declares the format gets it with no adapter changes.
 
 Both formats absorb the platform CSV exporter's injection safety rather than
-duplicating it: every cell passes ``csv_export._neutralize_cell`` — XLSX
-included, because openpyxl infers a string cell starting with ``=`` as a
-formula, so the spreadsheet-injection class isn't CSV-only.
+duplicating it (``csv_export.neutralize_cell``) — XLSX included, because
+openpyxl infers a *string* cell starting with ``=`` as a formula, so the
+spreadsheet-injection class isn't CSV-only. XLSX neutralizes string cells
+only, keeping numeric cells typed (see ``_xlsx_cell``).
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ from typing import Any
 from openpyxl import Workbook
 
 from app.services.export.contract import RenderItem
-from app.services.platform.csv_export import _neutralize_cell, build_csv
+from app.services.platform.csv_export import build_csv, neutralize_cell
 
 # Sheet titles have a 31-char limit and a forbidden character set in the XLSX
 # spec; our sources use short safe keys ("tasks"), but clamp defensively.
@@ -39,14 +40,25 @@ def render_csv(item: RenderItem) -> bytes:
     return build_csv(headers, rows)
 
 
+def _xlsx_cell(value: Any) -> Any:
+    """Neutralize only STRING cells for XLSX. Unlike CSV (where every value
+    becomes text anyway), XLSX cells are typed: a number must stay a number
+    (coercing ``-5`` to ``"'-5"`` would break sorting/arithmetic in the
+    sheet), and openpyxl cannot infer a formula from an int/float/date, so
+    only strings can smuggle a formula trigger."""
+    if isinstance(value, str):
+        return neutralize_cell(value)
+    return value
+
+
 def render_xlsx(item: RenderItem) -> bytes:
     headers, rows = _table(item)
     workbook = Workbook()
     sheet = workbook.active
     sheet.title = str(item.data.get("title", item.key))[:_SHEET_TITLE_MAX] or item.key
-    sheet.append([_neutralize_cell(value) for value in headers])
+    sheet.append([_xlsx_cell(value) for value in headers])
     for row in rows:
-        sheet.append([_neutralize_cell(value) for value in row])
+        sheet.append([_xlsx_cell(value) for value in row])
     sheet.freeze_panes = "A2"
     buffer = io.BytesIO()
     workbook.save(buffer)

--- a/backend/app/services/export/tabular.py
+++ b/backend/app/services/export/tabular.py
@@ -22,8 +22,16 @@ from app.services.export.contract import RenderItem
 from app.services.platform.csv_export import build_csv, neutralize_cell
 
 # Sheet titles have a 31-char limit and a forbidden character set in the XLSX
-# spec; our sources use short safe keys ("tasks"), but clamp defensively.
+# spec (openpyxl raises InvalidSheetTitle). The payload title can carry user
+# text (a guild or project name), so sanitize rather than trust it.
 _SHEET_TITLE_MAX = 31
+_SHEET_TITLE_FORBIDDEN = str.maketrans("", "", "[]:*?/\\")
+
+
+def _sheet_title(item: RenderItem) -> str:
+    raw = str(item.data.get("title", item.key)).translate(_SHEET_TITLE_FORBIDDEN)
+    fallback = item.key.translate(_SHEET_TITLE_FORBIDDEN)[:_SHEET_TITLE_MAX]
+    return raw.strip()[:_SHEET_TITLE_MAX] or fallback or "Export"
 
 
 def _table(item: RenderItem) -> tuple[list[str], list[list[Any]]]:
@@ -55,7 +63,7 @@ def render_xlsx(item: RenderItem) -> bytes:
     headers, rows = _table(item)
     workbook = Workbook()
     sheet = workbook.active
-    sheet.title = str(item.data.get("title", item.key))[:_SHEET_TITLE_MAX] or item.key
+    sheet.title = _sheet_title(item)
     sheet.append([_xlsx_cell(value) for value in headers])
     for row in rows:
         sheet.append([_xlsx_cell(value) for value in row])

--- a/backend/app/services/export/worker.py
+++ b/backend/app/services/export/worker.py
@@ -165,7 +165,11 @@ async def _execute(session: AsyncSession, job: ExportJob, *, guild_id: int) -> s
         # GuildAccessError (-> failed job) if their access is gone.
         await establish_guild_access(user_session, user, guild_id)
         request = await adapter.build(
-            user_session, user=user, guild_id=guild_id, params=job.params or {}
+            user_session,
+            user=user,
+            guild_id=guild_id,
+            params=job.params or {},
+            format=job.format,
         )
 
     return await export_engine.render_to_storage(request, job_id=job.id)

--- a/backend/app/services/platform/csv_export.py
+++ b/backend/app/services/platform/csv_export.py
@@ -16,7 +16,7 @@ _BOM = "\ufeff"
 _FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
 
 
-def _neutralize_cell(value: object) -> object:
+def neutralize_cell(value: object) -> object:
     """Prefix a leading formula trigger with a single quote so spreadsheets treat
     the cell as text. Non-string and benign values are returned unchanged."""
     if value is None:
@@ -30,14 +30,14 @@ def _neutralize_cell(value: object) -> object:
 def build_csv(headers: Sequence[str], rows: Iterable[Sequence[object]]) -> bytes:
     """Serialize rows to a UTF-8 encoded CSV byte string with a BOM prefix.
 
-    Every cell (headers included) is passed through ``_neutralize_cell`` so a
+    Every cell (headers included) is passed through ``neutralize_cell`` so a
     value beginning with a formula trigger cannot execute when the export is
     opened in a spreadsheet application (CSV injection)."""
     buffer = io.StringIO()
     writer = csv.writer(buffer)
-    writer.writerow([_neutralize_cell(value) for value in headers])
+    writer.writerow([neutralize_cell(value) for value in headers])
     for row in rows:
-        writer.writerow([_neutralize_cell(value) for value in row])
+        writer.writerow([neutralize_cell(value) for value in row])
     return (_BOM + buffer.getvalue()).encode("utf-8")
 
 

--- a/backend/app/services/platform/csv_export_test.py
+++ b/backend/app/services/platform/csv_export_test.py
@@ -100,8 +100,8 @@ def test_build_csv_treats_none_as_empty() -> None:
 
 
 @pytest.mark.unit
-def test_neutralize_cell_only_targets_leading_trigger() -> None:
+def testneutralize_cell_only_targets_leading_trigger() -> None:
     """A trigger character in the middle of a value is not escaped."""
-    assert csv_export._neutralize_cell("Foo=Bar") == "Foo=Bar"
-    assert csv_export._neutralize_cell("a-b-c") == "a-b-c"
-    assert csv_export._neutralize_cell("=danger") == "'=danger"
+    assert csv_export.neutralize_cell("Foo=Bar") == "Foo=Bar"
+    assert csv_export.neutralize_cell("a-b-c") == "a-b-c"
+    assert csv_export.neutralize_cell("=danger") == "'=danger"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "fastmcp>=3.4.2",
     "boto3>=1.35,<2",                    # S3 / S3-compatible (MinIO) object storage; only imported when STORAGE_BACKEND=s3
     "typst>=0.15.0",
+    "openpyxl>=3.1.5",
 ]
 
 [dependency-groups]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -808,6 +808,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1157,6 +1166,7 @@ dependencies = [
     { name = "httpx" },
     { name = "icalendar" },
     { name = "nh3" },
+    { name = "openpyxl" },
     { name = "premailer" },
     { name = "pycrdt" },
     { name = "pycrdt-websocket" },
@@ -1198,6 +1208,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "icalendar", specifier = ">=6.0.0" },
     { name = "nh3", specifier = ">=0.3.5,<0.4" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "premailer", specifier = ">=3.10.0" },
     { name = "pycrdt", specifier = ">=0.13.0,<0.15" },
     { name = "pycrdt-websocket", specifier = ">=0.16.1,<0.17" },
@@ -1660,6 +1671,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -253,12 +253,15 @@
     "archiving": "Wird archiviert…"
   },
   "export": {
-    "button": "PDF exportieren",
+    "button": "Exportieren",
     "preparing": "Wird exportiert…",
     "queued": "Export gestartet — der Download beginnt, sobald er bereit ist.",
     "success": "Export heruntergeladen.",
     "failed": "Der Export ist fehlgeschlagen. Versuche es erneut oder grenze den Filter ein.",
     "error": "Aufgaben konnten nicht exportiert werden.",
-    "selected": "Auswahl exportieren"
+    "selected": "Auswahl exportieren",
+    "formatPdf": "PDF-Dokument",
+    "formatCsv": "CSV",
+    "formatXlsx": "Excel (XLSX)"
   }
 }

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -262,6 +262,7 @@
     "selected": "Auswahl exportieren",
     "formatPdf": "PDF-Dokument",
     "formatCsv": "CSV",
-    "formatXlsx": "Excel (XLSX)"
+    "formatXlsx": "Excel (XLSX)",
+    "formatMd": "Markdown"
   }
 }

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -263,6 +263,7 @@
     "formatPdf": "PDF-Dokument",
     "formatCsv": "CSV",
     "formatXlsx": "Excel (XLSX)",
-    "formatMd": "Markdown"
+    "formatMd": "Markdown-Tabelle",
+    "formatMdChecklist": "Markdown-Aufgabenliste"
   }
 }

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -253,12 +253,15 @@
     "archiving": "Archiving…"
   },
   "export": {
-    "button": "Export PDF",
+    "button": "Export",
     "preparing": "Exporting…",
     "queued": "Export started — the download will begin when it's ready.",
     "success": "Export downloaded.",
     "failed": "The export failed. Try again or narrow the filter.",
     "error": "Couldn't export tasks.",
-    "selected": "Export Selected"
+    "selected": "Export Selected",
+    "formatPdf": "PDF document",
+    "formatCsv": "CSV",
+    "formatXlsx": "Excel (XLSX)"
   }
 }

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -262,6 +262,7 @@
     "selected": "Export Selected",
     "formatPdf": "PDF document",
     "formatCsv": "CSV",
-    "formatXlsx": "Excel (XLSX)"
+    "formatXlsx": "Excel (XLSX)",
+    "formatMd": "Markdown"
   }
 }

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -263,6 +263,7 @@
     "formatPdf": "PDF document",
     "formatCsv": "CSV",
     "formatXlsx": "Excel (XLSX)",
-    "formatMd": "Markdown"
+    "formatMd": "Markdown table",
+    "formatMdChecklist": "Markdown task list"
   }
 }

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -262,6 +262,7 @@
     "selected": "Exportar selección",
     "formatPdf": "Documento PDF",
     "formatCsv": "CSV",
-    "formatXlsx": "Excel (XLSX)"
+    "formatXlsx": "Excel (XLSX)",
+    "formatMd": "Markdown"
   }
 }

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -263,6 +263,7 @@
     "formatPdf": "Documento PDF",
     "formatCsv": "CSV",
     "formatXlsx": "Excel (XLSX)",
-    "formatMd": "Markdown"
+    "formatMd": "Tabla Markdown",
+    "formatMdChecklist": "Lista de tareas Markdown"
   }
 }

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -253,12 +253,15 @@
     "archiving": "Archivando…"
   },
   "export": {
-    "button": "Exportar PDF",
+    "button": "Exportar",
     "preparing": "Exportando…",
     "queued": "Exportación iniciada: la descarga comenzará cuando esté lista.",
     "success": "Exportación descargada.",
     "failed": "La exportación falló. Inténtalo de nuevo o reduce el filtro.",
     "error": "No se pudieron exportar las tareas.",
-    "selected": "Exportar selección"
+    "selected": "Exportar selección",
+    "formatPdf": "Documento PDF",
+    "formatCsv": "CSV",
+    "formatXlsx": "Excel (XLSX)"
   }
 }

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -253,12 +253,15 @@
     "archiving": "Archivage…"
   },
   "export": {
-    "button": "Exporter en PDF",
+    "button": "Exporter",
     "preparing": "Export en cours…",
     "queued": "Export lancé — le téléchargement commencera dès qu'il sera prêt.",
     "success": "Export téléchargé.",
     "failed": "L'export a échoué. Réessayez ou affinez le filtre.",
     "error": "Impossible d'exporter les tâches.",
-    "selected": "Exporter la sélection"
+    "selected": "Exporter la sélection",
+    "formatPdf": "Document PDF",
+    "formatCsv": "CSV",
+    "formatXlsx": "Excel (XLSX)"
   }
 }

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -263,6 +263,7 @@
     "formatPdf": "Document PDF",
     "formatCsv": "CSV",
     "formatXlsx": "Excel (XLSX)",
-    "formatMd": "Markdown"
+    "formatMd": "Tableau Markdown",
+    "formatMdChecklist": "Liste de tâches Markdown"
   }
 }

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -262,6 +262,7 @@
     "selected": "Exporter la sélection",
     "formatPdf": "Document PDF",
     "formatCsv": "CSV",
-    "formatXlsx": "Excel (XLSX)"
+    "formatXlsx": "Excel (XLSX)",
+    "formatMd": "Markdown"
   }
 }

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4049,6 +4049,7 @@ export const ExportTasksApiV1GGuildIdExportsTasksGetFormat = {
   pdf: "pdf",
   csv: "csv",
   xlsx: "xlsx",
+  md: "md",
 } as const;
 
 export type ListQueuesApiV1GGuildIdQueuesGetParams = {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4040,6 +4040,10 @@ export type ExportTasksApiV1GGuildIdExportsTasksGetParams = {
    */
   tz?: string | null;
   include_archived?: boolean;
+  /**
+   * Markdown layout: a table, or a GitHub-style task list
+   */
+  layout?: ExportTasksApiV1GGuildIdExportsTasksGetLayout;
 };
 
 export type ExportTasksApiV1GGuildIdExportsTasksGetFormat =
@@ -4050,6 +4054,14 @@ export const ExportTasksApiV1GGuildIdExportsTasksGetFormat = {
   csv: "csv",
   xlsx: "xlsx",
   md: "md",
+} as const;
+
+export type ExportTasksApiV1GGuildIdExportsTasksGetLayout =
+  (typeof ExportTasksApiV1GGuildIdExportsTasksGetLayout)[keyof typeof ExportTasksApiV1GGuildIdExportsTasksGetLayout];
+
+export const ExportTasksApiV1GGuildIdExportsTasksGetLayout = {
+  table: "table",
+  checklist: "checklist",
 } as const;
 
 export type ListQueuesApiV1GGuildIdQueuesGetParams = {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4026,7 +4026,7 @@ export type AutocompleteDocumentsApiV1GGuildIdDocumentsAutocompleteGetParams = {
 };
 
 export type ExportTasksApiV1GGuildIdExportsTasksGetParams = {
-  format?: "pdf";
+  format?: ExportTasksApiV1GGuildIdExportsTasksGetFormat;
   /**
    * Same JSON filter conditions as the task list
    */
@@ -4041,6 +4041,15 @@ export type ExportTasksApiV1GGuildIdExportsTasksGetParams = {
   tz?: string | null;
   include_archived?: boolean;
 };
+
+export type ExportTasksApiV1GGuildIdExportsTasksGetFormat =
+  (typeof ExportTasksApiV1GGuildIdExportsTasksGetFormat)[keyof typeof ExportTasksApiV1GGuildIdExportsTasksGetFormat];
+
+export const ExportTasksApiV1GGuildIdExportsTasksGetFormat = {
+  pdf: "pdf",
+  csv: "csv",
+  xlsx: "xlsx",
+} as const;
 
 export type ListQueuesApiV1GGuildIdQueuesGetParams = {
   initiative_id?: number | null;

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -237,7 +237,7 @@ const notificationText = (
  * call needs, or null when the payload is malformed. */
 const exportDownloadTarget = (
   notification: NotificationRead
-): { guildId: number; jobId: number; source: string } | null => {
+): { guildId: number; jobId: number; source: string; format: string } | null => {
   if (notification.type !== "export_ready") {
     return null;
   }
@@ -251,6 +251,7 @@ const exportDownloadTarget = (
     guildId,
     jobId,
     source: typeof data.source === "string" ? data.source : "tasks",
+    format: typeof data.format === "string" ? data.format : "pdf",
   };
 };
 
@@ -297,7 +298,8 @@ export const NotificationBell = () => {
         exportTarget.guildId,
         exportTarget.jobId,
         t as (key: string, options?: Record<string, unknown>) => string,
-        exportTarget.source
+        exportTarget.source,
+        exportTarget.format
       );
       return;
     }

--- a/frontend/src/components/tasks/ExportTasksButton.test.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.test.tsx
@@ -50,7 +50,8 @@ describe("ExportTasksButton", () => {
     server.use(guildHttp.get("/exports/tasks", () => pdfResponse()));
     renderWithProviders(<ExportTasksButton params={{ conditions: [] }} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /export pdf/i }));
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /pdf/i }));
 
     await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
     expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe("tasks.pdf");
@@ -66,7 +67,8 @@ describe("ExportTasksButton", () => {
     );
     renderWithProviders(<ExportTasksButton params={{ conditions: [] }} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /export pdf/i }));
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /pdf/i }));
 
     await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
     expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe("tasks-7.pdf");
@@ -81,18 +83,22 @@ describe("ExportTasksButton", () => {
     );
     renderWithProviders(<ExportTasksButton params={{ conditions: [] }} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /export pdf/i }));
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /pdf/i }));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
     expect(downloadBlob).not.toHaveBeenCalled();
   });
 
-  it("sends the given selector on the wire and honors a label override", async () => {
+  it("sends the given selector and chosen format on the wire, honoring a label override", async () => {
     let sentConditions: unknown = null;
+    let sentFormat: string | null = null;
     server.use(
       guildHttp.get("/exports/tasks", ({ request }) => {
-        const raw = new URL(request.url).searchParams.get("conditions");
+        const url = new URL(request.url);
+        const raw = url.searchParams.get("conditions");
         sentConditions = raw ? JSON.parse(raw) : null;
+        sentFormat = url.searchParams.get("format");
         return pdfResponse();
       })
     );
@@ -104,9 +110,12 @@ describe("ExportTasksButton", () => {
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Export Selected" }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /csv/i }));
 
     await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
     expect(sentConditions).toEqual([{ field: "id", op: "in_", value: [3, 5] }]);
+    expect(sentFormat).toBe("csv");
+    expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe("tasks.csv");
   });
 
   it("resumes a pending job from storage on mount and downloads it", async () => {
@@ -148,7 +157,8 @@ describe("ExportTasksButton", () => {
     );
     renderWithProviders(<ExportTasksButton params={{ conditions: [] }} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /export pdf/i }));
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /pdf/i }));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
     expect(downloadBlob).not.toHaveBeenCalled();

--- a/frontend/src/components/tasks/ExportTasksButton.test.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.test.tsx
@@ -118,6 +118,28 @@ describe("ExportTasksButton", () => {
     expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe("tasks.csv");
   });
 
+  it("sends layout=checklist for the Markdown task list entry", async () => {
+    let sent: { format: string | null; layout: string | null } | null = null;
+    server.use(
+      guildHttp.get("/exports/tasks", ({ request }) => {
+        const url = new URL(request.url);
+        sent = {
+          format: url.searchParams.get("format"),
+          layout: url.searchParams.get("layout"),
+        };
+        return pdfResponse();
+      })
+    );
+    renderWithProviders(<ExportTasksButton params={{ conditions: [] }} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /task list/i }));
+
+    await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
+    expect(sent).toEqual({ format: "md", layout: "checklist" });
+    expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe("tasks.md");
+  });
+
   it("resumes a pending job from storage on mount and downloads it", async () => {
     setItem("exports:pending:1", "9");
     server.use(

--- a/frontend/src/components/tasks/ExportTasksButton.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.tsx
@@ -1,11 +1,20 @@
-import { FileDown, Loader2 } from "lucide-react";
+import { ChevronDown, FileDown, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { apiClient } from "@/api/client";
 import { useGetExportJobApiV1GGuildIdExportsJobIdGet } from "@/api/generated/exports/exports";
-import type { ExportTasksApiV1GGuildIdExportsTasksGetParams } from "@/api/generated/initiativeAPI.schemas";
+import type {
+  ExportTasksApiV1GGuildIdExportsTasksGetFormat,
+  ExportTasksApiV1GGuildIdExportsTasksGetParams,
+} from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { toast } from "@/lib/chesterToast";
 import { downloadBlob } from "@/lib/csv";
@@ -17,6 +26,8 @@ export type ExportParams = Pick<
   ExportTasksApiV1GGuildIdExportsTasksGetParams,
   "conditions" | "sorting" | "tz" | "include_archived"
 >;
+
+type ExportFormat = ExportTasksApiV1GGuildIdExportsTasksGetFormat;
 
 interface ExportTasksButtonProps {
   /** The selector for the snapshot — the current list filters, or an
@@ -36,6 +47,12 @@ interface ExportTasksButtonProps {
 
 const POLL_MS = 2000;
 const TERMINAL = new Set(["done", "failed", "expired"]);
+
+const FORMATS: { value: ExportFormat; labelKey: string }[] = [
+  { value: "pdf", labelKey: "export.formatPdf" },
+  { value: "csv", labelKey: "export.formatCsv" },
+  { value: "xlsx", labelKey: "export.formatXlsx" },
+];
 
 // A pending job id survives the component unmounting (navigation) so a
 // return to any tasks view resumes the poll and still delivers the download.
@@ -83,29 +100,30 @@ export function ExportTasksButton({ params, label, resumePending }: ExportTasksB
       guildId,
       jobId,
       t as (key: string, options?: Record<string, unknown>) => string,
-      job.source
+      job.source,
+      job.format
     );
   }, [job, jobId, guildId, t]);
 
   const busy = requesting || jobId != null;
 
-  const handleExport = async () => {
+  const handleExport = async (format: ExportFormat) => {
     if (busy || !guildId) {
       return;
     }
     setRequesting(true);
     try {
       // The generated client discards the HTTP status (mutator returns data
-      // only), and this endpoint is a 200-PDF / 202-job union — call the
+      // only), and this endpoint is a 200-file / 202-job union — call the
       // shared axios instance directly so auth/guild interceptors and the
       // conditions/sorting paramsSerializer still apply.
       const res = await apiClient.get<Blob>(`/g/${guildId}/exports/tasks`, {
-        params: { ...params, format: "pdf" },
+        params: { ...params, format },
         responseType: "blob",
         validateStatus: (s) => s === 200 || s === 202,
       });
       if (res.status === 200) {
-        downloadBlob(res.data, "tasks.pdf");
+        downloadBlob(res.data, `tasks.${format}`);
         toast.success(t("export.success"));
       } else {
         const queued = JSON.parse(await res.data.text()) as { id: number };
@@ -122,16 +140,29 @@ export function ExportTasksButton({ params, label, resumePending }: ExportTasksB
 
   const idleLabel = label ?? t("export.button");
   return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={handleExport}
-      disabled={busy}
-      aria-label={idleLabel}
-      title={idleLabel}
-    >
-      {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
-      <span className="hidden sm:ml-2 sm:inline">{busy ? t("export.preparing") : idleLabel}</span>
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          aria-label={idleLabel}
+          title={idleLabel}
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
+          <span className="hidden sm:ml-2 sm:inline">
+            {busy ? t("export.preparing") : idleLabel}
+          </span>
+          {!busy && <ChevronDown className="ml-1 h-3 w-3 opacity-60" />}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {FORMATS.map(({ value, labelKey }) => (
+          <DropdownMenuItem key={value} onSelect={() => void handleExport(value)}>
+            {t(labelKey as never)}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/src/components/tasks/ExportTasksButton.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.tsx
@@ -52,6 +52,7 @@ const FORMATS: { value: ExportFormat; labelKey: string }[] = [
   { value: "pdf", labelKey: "export.formatPdf" },
   { value: "csv", labelKey: "export.formatCsv" },
   { value: "xlsx", labelKey: "export.formatXlsx" },
+  { value: "md", labelKey: "export.formatMd" },
 ];
 
 // A pending job id survives the component unmounting (navigation) so a

--- a/frontend/src/components/tasks/ExportTasksButton.tsx
+++ b/frontend/src/components/tasks/ExportTasksButton.tsx
@@ -48,11 +48,12 @@ interface ExportTasksButtonProps {
 const POLL_MS = 2000;
 const TERMINAL = new Set(["done", "failed", "expired"]);
 
-const FORMATS: { value: ExportFormat; labelKey: string }[] = [
+const FORMATS: { value: ExportFormat; labelKey: string; layout?: "checklist" }[] = [
   { value: "pdf", labelKey: "export.formatPdf" },
   { value: "csv", labelKey: "export.formatCsv" },
   { value: "xlsx", labelKey: "export.formatXlsx" },
   { value: "md", labelKey: "export.formatMd" },
+  { value: "md", labelKey: "export.formatMdChecklist", layout: "checklist" },
 ];
 
 // A pending job id survives the component unmounting (navigation) so a
@@ -108,7 +109,7 @@ export function ExportTasksButton({ params, label, resumePending }: ExportTasksB
 
   const busy = requesting || jobId != null;
 
-  const handleExport = async (format: ExportFormat) => {
+  const handleExport = async (format: ExportFormat, layout?: "checklist") => {
     if (busy || !guildId) {
       return;
     }
@@ -119,7 +120,7 @@ export function ExportTasksButton({ params, label, resumePending }: ExportTasksB
       // shared axios instance directly so auth/guild interceptors and the
       // conditions/sorting paramsSerializer still apply.
       const res = await apiClient.get<Blob>(`/g/${guildId}/exports/tasks`, {
-        params: { ...params, format },
+        params: { ...params, format, ...(layout && { layout }) },
         responseType: "blob",
         validateStatus: (s) => s === 200 || s === 202,
       });
@@ -158,8 +159,8 @@ export function ExportTasksButton({ params, label, resumePending }: ExportTasksB
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {FORMATS.map(({ value, labelKey }) => (
-          <DropdownMenuItem key={value} onSelect={() => void handleExport(value)}>
+        {FORMATS.map(({ value, labelKey, layout }) => (
+          <DropdownMenuItem key={labelKey} onSelect={() => void handleExport(value, layout)}>
             {t(labelKey as never)}
           </DropdownMenuItem>
         ))}

--- a/frontend/src/lib/exportDownload.ts
+++ b/frontend/src/lib/exportDownload.ts
@@ -25,13 +25,14 @@ export async function downloadExportArtifact(
   guildId: number,
   jobId: number,
   t: (key: string, options?: Record<string, unknown>) => string,
-  source = "tasks"
+  source = "tasks",
+  format = "pdf"
 ): Promise<void> {
   try {
     const res = await apiClient.get<Blob>(`/g/${guildId}/exports/${jobId}/download`, {
       responseType: "blob",
     });
-    downloadBlob(res.data, `${source}-${jobId}.pdf`);
+    downloadBlob(res.data, `${source}-${jobId}.${format}`);
     toast.success(t("tasks:export.success"));
   } catch (err) {
     toast.error(getErrorMessage(await normalizeBlobError(err), "tasks:export.error"));


### PR DESCRIPTION
## Problem

The export engine shipped PDF-only. The design's registry (source × format) anticipated tabular formats behind the same engine — this lands CSV, XLSX, and Markdown for the tasks source.

## What this adds

**Backend** — same source adapters, different renderer:
- The tasks payload gains a `columns` spec (`key` + `label`); the PDF template ignores it, the tabular renderers project rows through it — so any source that declares a tabular format gets it with no adapter changes.
- `LocalRenderBackend` dispatches per format: Typst for PDF, new `tabular.py` for CSV/XLSX. Template resolution only happens on the PDF path.
- **Injection safety absorbed, not duplicated**: both tabular paths route every cell through the platform CSV exporter's neutralization. XLSX explicitly included — openpyxl infers a string cell starting with `=` as a formula, so the spreadsheet-injection class isn't CSV-only (tests assert the stored cell type is string).
- Fixed a latent bug this exposed: `adapter.build()` hardcoded `format="pdf"` in the `RenderRequest`; the requested format now threads through the adapter protocol (engine inline path + worker job path).
- `format` param is `Literal["pdf", "csv", "xlsx", "md"]`; new dependency `openpyxl` (pinned).
- Markdown renders title + subtitle + a GFM table; cells escape pipes and collapse newlines (layout integrity — Markdown has no execution surface).

**Frontend**:
- The export button (both the toolbar and Export Selected) is now a format menu: PDF / CSV / Excel / Markdown.
- Downloads are extension-aware end to end: inline (`tasks.csv`), resumed job, and notification-bell downloads all name the file by the job's actual format.

## Testing

```
cd backend && pytest app/services/export app/api/v1/tenant_endpoints/exports_test.py   # 17 passed
cd frontend && pnpm typecheck && pnpm lint && pnpm test:run                            # 813 passed
```

New tests: CSV renders with BOM + neutralized formula triggers; XLSX round-trips through openpyxl with string-typed (non-formula) cells; tabular formats skip template resolution; endpoint returns correct content types and 422s unknown formats; the frontend menu sends the chosen format and names files accordingly.

