### PR TITLE
Add Lexical document exports: Markdown, PDF, DOCX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Editor documents now export as PDF, Markdown, and Word (DOCX) alongside the lossless .lexical file. Referenced images are embedded in the PDF and DOCX; a Markdown export with images downloads as a zip bundle with an assets folder. Mentions, wikilinks, and embeds degrade gracefully to text and links.
+
 - Document export: an Export menu on every document offers type-appropriate formats — importable JSON for editor documents and whiteboards (standard Excalidraw file), CSV/Excel for spreadsheets (formatting carried over), the original file for uploads, and Markdown for smart links. Whiteboards additionally export PNG/SVG images, rendered in the browser by Excalidraw itself. Read access suffices; delivery matches the other exports (instant for small documents, background job with notification pickup for large ones).
 
 - Task exports: an Export menu on the project tasks view downloads the current view — or just the selected tasks, via the new action in the selection bar — as PDF, CSV, Excel (XLSX), or Markdown (a table or a checkable task list), with the same filters and visibility as on screen. Small exports download instantly; large ones run as a background job and download automatically when ready, and if you navigate away meanwhile, an inbox notification downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), artifacts expire automatically after 7 days, and the spreadsheet formats carry injection protection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Editor documents now export as PDF, Markdown, and Word (DOCX) alongside the lossless .lexical file. Referenced images are embedded in the PDF and DOCX; a Markdown export with images downloads as a zip bundle with an assets folder. Mentions, wikilinks, and embeds degrade gracefully to text and links.
-
 - Document export: an Export menu on every document offers type-appropriate formats — importable JSON for editor documents and whiteboards (standard Excalidraw file), CSV/Excel for spreadsheets (formatting carried over), the original file for uploads, and Markdown for smart links. Whiteboards additionally export PNG/SVG images, rendered in the browser by Excalidraw itself. Read access suffices; delivery matches the other exports (instant for small documents, background job with notification pickup for large ones).
+
+- Text documents now export as PDF, Markdown, and Word (DOCX) alongside the lossless .lexical file. Referenced images are embedded in the PDF and DOCX; a Markdown export with images downloads as a zip bundle with an assets folder. Mentions, wikilinks, and embeds degrade gracefully to text and links.
 
 - Task exports: an Export menu on the project tasks view downloads the current view — or just the selected tasks, via the new action in the selection bar — as PDF, CSV, Excel (XLSX), or Markdown (a table or a checkable task list), with the same filters and visibility as on screen. Small exports download instantly; large ones run as a background job and download automatically when ready, and if you navigate away meanwhile, an inbox notification downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), artifacts expire automatically after 7 days, and the spreadsheet formats carry injection protection.
 
+- Project export: now also offers a formatted report as PDF, CSV, or Excel (XLSX) alongside the JSON backup — the report covers the project's unarchived tasks; the backup file is unchanged and still imports.
+
 ### Changed
 
-- Project export now also offers a formatted report as PDF, CSV, or Excel (XLSX) alongside the JSON backup — the report covers the project's unarchived tasks; the backup file is unchanged and still imports.
 - Project backup (JSON) export now runs through the export engine: large projects export as a background job with the inbox-notification pickup instead of one long request, and artifacts follow the same private-to-creator delivery and 7-day expiry. The downloaded file and the import flow are unchanged. (API: `GET /projects/{id}/export` was replaced by `GET /exports/project?project_id=…`.)
 
 ## [0.55.0] - 2026-07-12

--- a/backend/app/api/v1/tenant_endpoints/exports.py
+++ b/backend/app/api/v1/tenant_endpoints/exports.py
@@ -158,7 +158,7 @@ async def export_document(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
     document_id: int = Query(),
-    format: Literal["json", "md", "csv", "xlsx", "file"] = Query(),
+    format: Literal["json", "md", "csv", "xlsx", "file", "pdf", "docx"] = Query(),
 ) -> Union[Response, JSONResponse]:
     """Export a document. Valid formats depend on the document type:
     ``json`` for Lexical (importable envelope) and whiteboards (standard

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -414,6 +414,131 @@ async def test_document_export_per_type_formats(
         assert resp.json()["detail"] == "EXPORT_INVALID_FORMAT"
 
 
+async def test_document_export_lexical_formats(
+    client: AsyncClient, acting_user, session
+):
+    """Lexical documents render to md/pdf/docx from one tree walk; a
+    referenced same-guild image turns the markdown into a zip with assets and
+    embeds into the pdf/docx."""
+    import io
+    import struct
+    import zipfile
+    import zlib
+
+    from app.models.tenant.document import DocumentType  # noqa: F401
+    from app.testing.factories import create_document
+
+    def make_png():
+        def chunk(tag, data):
+            c = tag + data
+            return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c))
+
+        ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+        return (
+            b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(b"\x00\xff\x00\x00"))
+            + chunk(b"IEND", b"")
+        )
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    get_guild_storage(a.guild.id).write(
+        "att-1.png", make_png(), content_type="image/png"
+    )
+    content = {
+        "root": {
+            "type": "root",
+            "children": [
+                {
+                    "type": "heading",
+                    "tag": "h2",
+                    "children": [{"type": "text", "text": "Section", "format": 0}],
+                },
+                {
+                    "type": "paragraph",
+                    "children": [{"type": "text", "text": "Hello world", "format": 1}],
+                },
+                {
+                    "type": "image",
+                    "src": f"/uploads/{a.guild.id}/att-1.png",
+                    "altText": "pic",
+                },
+            ],
+        }
+    }
+    doc = await create_document(
+        session, a.initiative, a.user, title="Rich Notes", content=content
+    )
+
+    async def export(format):
+        return await client.get(
+            a.g("/exports/document"),
+            headers=a.headers,
+            params={"document_id": doc.id, "format": format},
+        )
+
+    # md with an asset -> zip bundle
+    md_resp = await export("md")
+    assert md_resp.status_code == 200
+    assert md_resp.headers["content-type"].startswith("application/zip")
+    assert ".zip" in md_resp.headers["content-disposition"]
+    archive = zipfile.ZipFile(io.BytesIO(md_resp.content))
+    md_name = next(n for n in archive.namelist() if n.endswith(".md"))
+    assert "assets/att-1.png" in archive.namelist()
+    md_text = archive.read(md_name).decode("utf-8")
+    assert "# Rich Notes" in md_text
+    assert "**Hello world**" in md_text
+    assert "![pic](assets/att-1.png)" in md_text
+
+    # pdf embeds the staged image
+    pdf_resp = await export("pdf")
+    assert pdf_resp.status_code == 200
+    assert pdf_resp.content.startswith(b"%PDF")
+
+    # docx embeds the image too
+    import docx
+
+    docx_resp = await export("docx")
+    assert docx_resp.status_code == 200
+    assert docx_resp.headers["content-type"].endswith("wordprocessingml.document")
+    document = docx.Document(io.BytesIO(docx_resp.content))
+    assert any("Hello world" in p.text for p in document.paragraphs)
+    assert len(document.inline_shapes) == 1
+
+
+async def test_document_export_lexical_md_plain_without_assets(
+    client: AsyncClient, acting_user, session
+):
+    from app.testing.factories import create_document
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        title="Plain",
+        content={
+            "root": {
+                "type": "root",
+                "children": [
+                    {
+                        "type": "paragraph",
+                        "children": [{"type": "text", "text": "no images here"}],
+                    }
+                ],
+            }
+        },
+    )
+    resp = await client.get(
+        a.g("/exports/document"),
+        headers=a.headers,
+        params={"document_id": doc.id, "format": "md"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/markdown")
+    assert "no images here" in resp.content.decode("utf-8")
+
+
 async def test_document_export_spreadsheet_formats(
     client: AsyncClient, acting_user, session
 ):

--- a/backend/app/services/export/adapters/document.py
+++ b/backend/app/services/export/adapters/document.py
@@ -4,10 +4,12 @@ A document's exportable formats depend on its type, so the static registry
 declares the union and this adapter enforces the per-type subset at count
 time (before a job is created, so a mismatch is an immediate 400):
 
-* ``native`` (Lexical)  -> ``json``  — a ``.lexical`` file in the exact
-  ``@lexical/file`` schema the editor's toolbar IMPORT button consumes
-  ({editorState, lastSaved, source, version}), so an engine export
-  round-trips through the existing import. (md/pdf/docx is the next phase.)
+* ``native`` (Lexical)  -> ``json`` (a ``.lexical`` file in the exact
+  ``@lexical/file`` schema the editor's toolbar IMPORT button consumes, so
+  an engine export round-trips through the existing import), plus ``md``
+  (zipped with an ``assets/`` folder when images are referenced), ``pdf``
+  and ``docx`` (both embedding referenced same-guild images) via the
+  ``lexical`` converter module.
 * ``whiteboard``        -> ``json``  — the scene wrapped in the standard
   Excalidraw file shape, so the download opens in any Excalidraw. Pixel
   exports (PNG/SVG) are deliberately client-side: only Excalidraw's own JS
@@ -39,7 +41,7 @@ from app.services.export.engine import ExportError
 from app.services.platform.csv_export import safe_filename_component
 
 _TYPE_FORMATS: dict[str, frozenset[str]] = {
-    DocumentType.native.value: frozenset({"json"}),
+    DocumentType.native.value: frozenset({"json", "md", "pdf", "docx"}),
     DocumentType.whiteboard.value: frozenset({"json"}),
     DocumentType.spreadsheet.value: frozenset({"csv", "xlsx", "json"}),
     DocumentType.file.value: frozenset({"file"}),
@@ -53,7 +55,7 @@ _FILE_SIZE_ROW_BYTES = 1_048_576
 
 class DocumentAdapter:
     source = "document"
-    template_id = "document"  # no PDF template yet (Lexical PDF is next phase)
+    template_id = "document"  # the Lexical PDF template
     formats = frozenset().union(*_TYPE_FORMATS.values())
 
     async def count(
@@ -87,6 +89,26 @@ class DocumentAdapter:
         date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         stem = f"{safe_filename_component(document.title).lower()}-{date}"
 
+        if doc_type == DocumentType.native.value and format != "json":
+            from app.services.export.lexical import blocks_from_editor_state
+
+            blocks, assets = blocks_from_editor_state(
+                document.content or {}, guild_id=guild_id
+            )
+            data = {
+                "title": document.title,
+                "subtitle": f"exported {date}",
+                "footer": document.title,
+                "stem": stem,
+                "blocks": blocks,
+                "assets": assets,
+            }
+            return RenderRequest(
+                guild_id=guild_id,
+                template_id=self.template_id,
+                format=format,
+                batch=(RenderItem(key=stem, data=data),),
+            )
         if doc_type == DocumentType.whiteboard.value:
             # The standard Excalidraw file shape — importable by any
             # Excalidraw (app or excalidraw.com), not just this instance.

--- a/backend/app/services/export/engine.py
+++ b/backend/app/services/export/engine.py
@@ -170,7 +170,7 @@ async def start_export(
 
     job = ExportJob(
         guild_id=guild_id,
-        created_by_id=user.id,  # ty: ignore[invalid-argument-type]
+        created_by_id=user.id,
         source=source,
         template_id=adapter.template_id,
         format=format,

--- a/backend/app/services/export/lexical.py
+++ b/backend/app/services/export/lexical.py
@@ -294,7 +294,14 @@ def render_markdown(data: dict, read_blob: ReadBlob) -> tuple[bytes, str, str | 
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(f"{stem}.md", md)
         for asset in assets:
-            archive.writestr(f"assets/{asset['name']}", read_blob(asset["key"]))
+            try:
+                content = read_blob(asset["key"])
+            except Exception:
+                # A referenced image that's gone from storage must not fail
+                # the whole export — the .md keeps its (dangling) ref, same
+                # as the document itself would show a broken image.
+                continue
+            archive.writestr(f"assets/{asset['name']}", content)
     return buffer.getvalue(), "application/zip", f"{stem}.zip"
 
 
@@ -380,7 +387,8 @@ def _md_runs(runs: list[dict]) -> str:
             parts.append("  \n")
             continue
         if run.get("code"):
-            text = f"`{text}`"
+            # A backtick inside code needs the double-backtick spaced form.
+            text = f"`` {text} ``" if "`" in text else f"`{text}`"
         else:
             if run.get("bold") and run.get("italic"):
                 text = f"***{text}***"

--- a/backend/app/services/export/lexical.py
+++ b/backend/app/services/export/lexical.py
@@ -232,10 +232,27 @@ class _Parser:
                         n += 1
                 existing = {"key": key, "name": name}
                 self.assets[key] = existing
-            self.blocks.append({"type": "image", "asset": existing["name"], "alt": alt})
+            block = {"type": "image", "asset": existing["name"], "alt": alt}
+            block.update(_image_size(node))
+            self.blocks.append(block)
         elif src:
             # External (or cross-guild) image: never fetched — link only.
             self.blocks.append({"type": "image", "asset": None, "url": src, "alt": alt})
+
+
+def _image_size(node: dict) -> dict:
+    """The editor stores a resize as width/height px on the node ("inherit"
+    when untouched). Width alone is carried — the renderers derive height
+    from the aspect ratio, so a stale stored height can't distort."""
+    for field in ("width", "height"):
+        value = node.get(field)
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value > 0
+        ):
+            return {field: int(value)}
+    return {}
 
 
 def _code_text(children: list) -> str:
@@ -462,10 +479,18 @@ def render_docx(data: dict, read_blob: ReadBlob) -> bytes:
             if block.get("asset"):
                 key = name_to_key.get(block["asset"])
                 if key:
+                    # Editor resize is CSS px; Word wants inches (96 dpi).
+                    # Cap at the ~6.5" content width of the default page.
+                    width_px = block.get("width")
+                    height_px = block.get("height")
+                    if width_px:
+                        size = {"width": Inches(min(width_px / 96, 6.5))}
+                    elif height_px:
+                        size = {"height": Inches(min(height_px / 96, 9))}
+                    else:
+                        size = {"width": Inches(6)}
                     try:
-                        document.add_picture(
-                            io.BytesIO(read_blob(key)), width=Inches(6)
-                        )
+                        document.add_picture(io.BytesIO(read_blob(key)), **size)
                     except Exception:
                         # Unreadable/unsupported image: degrade to alt text
                         # rather than failing the whole document.

--- a/backend/app/services/export/lexical.py
+++ b/backend/app/services/export/lexical.py
@@ -216,9 +216,23 @@ class _Parser:
         prefix = f"/uploads/{self.guild_id}/"
         if src.startswith(prefix):
             key = src.removeprefix(prefix).split("?")[0]
-            name = safe_filename_component(key)
-            self.assets.setdefault(key, {"key": key, "name": name})
-            self.blocks.append({"type": "image", "asset": name, "alt": alt})
+            existing = self.assets.get(key)
+            if existing is None:
+                # Distinct keys can sanitize to the same name ("a img.png" /
+                # "a_img.png") — suffix until unique so one archive entry
+                # can't silently overwrite another.
+                name = safe_filename_component(key)
+                taken = {a["name"] for a in self.assets.values()}
+                if name in taken:
+                    stem, dot, ext = name.rpartition(".")
+                    base = stem if dot else name
+                    n = 2
+                    while name in taken:
+                        name = f"{base}-{n}{dot}{ext}" if dot else f"{base}-{n}"
+                        n += 1
+                existing = {"key": key, "name": name}
+                self.assets[key] = existing
+            self.blocks.append({"type": "image", "asset": existing["name"], "alt": alt})
         elif src:
             # External (or cross-guild) image: never fetched — link only.
             self.blocks.append({"type": "image", "asset": None, "url": src, "alt": alt})
@@ -327,7 +341,10 @@ def _md_table(block: dict) -> list[str]:
 
     def cells(row: list) -> str:
         padded = list(row) + [[]] * (width - len(row))
-        return "| " + " | ".join(_md_runs(c).replace("\n", " ") for c in padded) + " |"
+        # Escape pipes AFTER rendering (a raw | in cell text would split the
+        # column); _md_escape would also mangle the link syntax just emitted.
+        rendered = (_md_runs(c).replace("\n", " ").replace("|", "\\|") for c in padded)
+        return "| " + " | ".join(rendered) + " |"
 
     lines = [cells(rows[0]), "|" + "|".join(" --- " for _ in range(width)) + "|"]
     lines.extend(cells(row) for row in rows[1:])
@@ -369,7 +386,7 @@ def _md_runs(runs: list[dict]) -> str:
 
 def render_docx(data: dict, read_blob: ReadBlob) -> bytes:
     import docx
-    from docx.enum.text import WD_BREAK
+    from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_BREAK
     from docx.shared import Inches, Pt
 
     document = docx.Document()
@@ -409,6 +426,7 @@ def render_docx(data: dict, read_blob: ReadBlob) -> bytes:
             for nested in item.get("children") or []:
                 add_list(nested, level + 1)
 
+    name_to_key = {a["name"]: a["key"] for a in (data.get("assets") or [])}
     for block in data.get("blocks") or []:
         btype = block.get("type")
         if btype == "heading":
@@ -426,7 +444,8 @@ def render_docx(data: dict, read_blob: ReadBlob) -> bytes:
             code_run.font.name = "Consolas"
             code_run.font.size = Pt(9)
         elif btype == "hr":
-            document.add_paragraph("· · ·").alignment = 1  # centered separator
+            separator = document.add_paragraph("· · ·")
+            separator.alignment = WD_ALIGN_PARAGRAPH.CENTER
         elif btype == "list":
             add_list(block)
         elif btype == "table":
@@ -441,7 +460,6 @@ def render_docx(data: dict, read_blob: ReadBlob) -> bytes:
                         add_runs(cell_paragraph, cell_runs)
         elif btype == "image":
             if block.get("asset"):
-                name_to_key = {a["name"]: a["key"] for a in (data.get("assets") or [])}
                 key = name_to_key.get(block["asset"])
                 if key:
                     try:

--- a/backend/app/services/export/lexical.py
+++ b/backend/app/services/export/lexical.py
@@ -1,0 +1,467 @@
+"""Lexical editor-state conversion for document exports (md / pdf / docx).
+
+One tree walk (``blocks_from_editor_state``) turns the serialized editor
+state into a JSON-safe intermediate — a flat list of typed blocks with
+inline "runs" — that all three renderers consume: the Markdown emitter
+(zipped with an ``assets/`` folder when images are referenced), the DOCX
+emitter (python-docx, images embedded), and the ``document`` Typst template
+(images staged into the compile root by the backend).
+
+Degradation contract: any unknown node with ``text`` renders as text (this
+covers mentions, wikilinks, hashtags, emojis, keywords — all TextNode
+subclasses); unknown containers recurse into their children; embeds
+(YouTube/Tweet) degrade to a link; anything else is dropped silently. A new
+editor node can never break an export, it just exports as its text.
+
+Images: only same-guild uploads (``/uploads/{guild_id}/…``) are collected as
+assets and embedded — an external URL is never fetched (no SSRF surface, per
+the export design); it renders as a plain link instead.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import Any, Callable
+
+from app.services.platform.csv_export import safe_filename_component
+
+# Lexical TextNode format bitmask.
+_BOLD = 1
+_ITALIC = 2
+_STRIKE = 4
+_UNDERLINE = 8
+_CODE = 16
+
+ReadBlob = Callable[[str], bytes]
+
+# ---------------------------------------------------------------------------
+# Parse: editor state -> blocks + referenced assets
+# ---------------------------------------------------------------------------
+
+
+def blocks_from_editor_state(
+    content: dict, *, guild_id: int
+) -> tuple[list[dict], list[dict]]:
+    """Walk the serialized editor state into (blocks, assets).
+
+    ``assets`` lists the same-guild upload blobs the document references:
+    ``{"key": <storage key>, "name": <archive-safe file name>}``.
+    """
+    parser = _Parser(guild_id)
+    root = (content or {}).get("root") or {}
+    parser.walk_children(root.get("children") or [])
+    parser.flush_paragraph()
+    return parser.blocks, list(parser.assets.values())
+
+
+class _Parser:
+    def __init__(self, guild_id: int) -> None:
+        self.guild_id = guild_id
+        self.blocks: list[dict] = []
+        self.assets: dict[str, dict] = {}
+        self._pending_runs: list[dict] = []
+
+    # -- inline ------------------------------------------------------------
+
+    def collect_runs(self, children: list, link: str | None = None) -> list[dict]:
+        runs: list[dict] = []
+        for node in children or []:
+            ntype = node.get("type")
+            if ntype in ("link", "autolink"):
+                runs.extend(
+                    self.collect_runs(
+                        node.get("children") or [], link=node.get("url") or link
+                    )
+                )
+                continue
+            if ntype == "linebreak":
+                runs.append({"text": "\n"})
+                continue
+            if ntype == "image":
+                # An inline image splits the paragraph: emit what we have,
+                # then the image as its own block.
+                self._pending_runs.extend(runs)
+                runs = []
+                self.flush_paragraph()
+                self.image_block(node)
+                continue
+            text = node.get("text")
+            if isinstance(text, str) and text:
+                fmt = int(node.get("format") or 0)
+                run: dict[str, Any] = {"text": text}
+                if fmt & _BOLD:
+                    run["bold"] = True
+                if fmt & _ITALIC:
+                    run["italic"] = True
+                if fmt & _STRIKE:
+                    run["strike"] = True
+                if fmt & _UNDERLINE:
+                    run["underline"] = True
+                if fmt & _CODE:
+                    run["code"] = True
+                if link:
+                    run["link"] = link
+                runs.append(run)
+                continue
+            # Unknown node: recurse if it has children, else drop.
+            if node.get("children"):
+                runs.extend(self.collect_runs(node["children"], link=link))
+        return runs
+
+    def flush_paragraph(self) -> None:
+        if self._pending_runs:
+            self.blocks.append({"type": "paragraph", "runs": self._pending_runs})
+            self._pending_runs = []
+
+    # -- blocks ------------------------------------------------------------
+
+    def walk_children(self, children: list) -> None:
+        for node in children or []:
+            self.block(node)
+
+    def block(self, node: dict) -> None:
+        ntype = node.get("type")
+        children = node.get("children") or []
+        if ntype == "paragraph":
+            runs = self.collect_runs(children)
+            runs = self._pending_runs + runs
+            self._pending_runs = []
+            if runs:
+                self.blocks.append({"type": "paragraph", "runs": runs})
+        elif ntype == "heading":
+            tag = str(node.get("tag") or "h1")
+            level = int(tag[1]) if len(tag) == 2 and tag[1].isdigit() else 1
+            self.blocks.append(
+                {"type": "heading", "level": level, "runs": self.collect_runs(children)}
+            )
+            self.flush_paragraph()
+        elif ntype == "quote":
+            self.blocks.append({"type": "quote", "runs": self.collect_runs(children)})
+            self.flush_paragraph()
+        elif ntype == "code":
+            self.blocks.append(
+                {
+                    "type": "code",
+                    "language": str(node.get("language") or ""),
+                    "text": _code_text(children),
+                }
+            )
+        elif ntype == "list":
+            self.blocks.append(self.list_block(node))
+        elif ntype == "horizontalrule":
+            self.blocks.append({"type": "hr"})
+        elif ntype == "table":
+            self.blocks.append(self.table_block(node))
+        elif ntype == "image":
+            self.image_block(node)
+        elif ntype in ("youtube", "tweet"):
+            url = _embed_url(node)
+            if url:
+                self.blocks.append(
+                    {"type": "paragraph", "runs": [{"text": url, "link": url}]}
+                )
+        elif children:
+            # Unknown container (layout containers/items, future nodes):
+            # its children still export.
+            self.walk_children(children)
+
+    def list_block(self, node: dict) -> dict:
+        list_type = node.get("listType")  # "bullet" | "number" | "check"
+        items: list[dict] = []
+        for child in node.get("children") or []:
+            if child.get("type") != "listitem":
+                continue
+            nested = [
+                gc for gc in (child.get("children") or []) if gc.get("type") == "list"
+            ]
+            inline = [
+                gc for gc in (child.get("children") or []) if gc.get("type") != "list"
+            ]
+            item: dict[str, Any] = {"runs": self.collect_runs(inline)}
+            if list_type == "check":
+                item["checked"] = bool(child.get("checked"))
+            if nested:
+                item["children"] = [self.list_block(n) for n in nested]
+            items.append(item)
+        return {
+            "type": "list",
+            "ordered": list_type == "number",
+            "checklist": list_type == "check",
+            "items": items,
+        }
+
+    def table_block(self, node: dict) -> dict:
+        rows: list[list[list[dict]]] = []
+        for row in node.get("children") or []:
+            if row.get("type") != "tablerow":
+                continue
+            cells: list[list[dict]] = []
+            for cell in row.get("children") or []:
+                if cell.get("type") != "tablecell":
+                    continue
+                cell_runs: list[dict] = []
+                for para in cell.get("children") or []:
+                    if cell_runs:
+                        cell_runs.append({"text": "\n"})
+                    cell_runs.extend(self.collect_runs(para.get("children") or []))
+                cells.append(cell_runs)
+            if cells:
+                rows.append(cells)
+        return {"type": "table", "rows": rows}
+
+    def image_block(self, node: dict) -> None:
+        src = str(node.get("src") or "")
+        alt = str(node.get("altText") or "")
+        prefix = f"/uploads/{self.guild_id}/"
+        if src.startswith(prefix):
+            key = src.removeprefix(prefix).split("?")[0]
+            name = safe_filename_component(key)
+            self.assets.setdefault(key, {"key": key, "name": name})
+            self.blocks.append({"type": "image", "asset": name, "alt": alt})
+        elif src:
+            # External (or cross-guild) image: never fetched — link only.
+            self.blocks.append({"type": "image", "asset": None, "url": src, "alt": alt})
+
+
+def _code_text(children: list) -> str:
+    parts: list[str] = []
+    for node in children or []:
+        if node.get("type") == "linebreak":
+            parts.append("\n")
+        else:
+            text = node.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+def _embed_url(node: dict) -> str | None:
+    if node.get("type") == "youtube" and node.get("videoID"):
+        return f"https://www.youtube.com/watch?v={node['videoID']}"
+    if node.get("type") == "tweet" and node.get("tweetID"):
+        return f"https://x.com/i/status/{node['tweetID']}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Markdown
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(data: dict, read_blob: ReadBlob) -> tuple[bytes, str, str | None]:
+    """Emit Markdown. With referenced assets: a zip of ``{stem}.md`` +
+    ``assets/``, image refs rewritten to the relative paths. Returns
+    (content, content_type, filename_override)."""
+    stem = str(data.get("stem") or "document")
+    md = _markdown_text(data)
+    assets = data.get("assets") or []
+    if not assets:
+        return md.encode("utf-8"), "text/markdown; charset=utf-8", None
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(f"{stem}.md", md)
+        for asset in assets:
+            archive.writestr(f"assets/{asset['name']}", read_blob(asset["key"]))
+    return buffer.getvalue(), "application/zip", f"{stem}.zip"
+
+
+def _markdown_text(data: dict) -> str:
+    lines: list[str] = []
+    title = str(data.get("title") or "").strip()
+    if title:
+        lines.append(f"# {title}")
+        lines.append("")
+    for block in data.get("blocks") or []:
+        lines.extend(_md_block(block))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _md_block(block: dict, indent: str = "") -> list[str]:
+    btype = block.get("type")
+    if btype == "heading":
+        # Document title is H1; shift content headings down one level.
+        level = min(int(block.get("level") or 1) + 1, 6)
+        return [f"{'#' * level} {_md_runs(block.get('runs') or [])}"]
+    if btype == "quote":
+        return [f"> {_md_runs(block.get('runs') or [])}"]
+    if btype == "code":
+        return [f"```{block.get('language') or ''}", block.get("text") or "", "```"]
+    if btype == "hr":
+        return ["---"]
+    if btype == "image":
+        alt = _md_escape(block.get("alt") or "")
+        if block.get("asset"):
+            return [f"![{alt}](assets/{block['asset']})"]
+        return [f"![{alt}](<{block.get('url') or ''}>)"]
+    if btype == "list":
+        return _md_list(block, indent)
+    if btype == "table":
+        return _md_table(block)
+    return [f"{indent}{_md_runs(block.get('runs') or [])}"]
+
+
+def _md_list(block: dict, indent: str = "") -> list[str]:
+    lines: list[str] = []
+    for index, item in enumerate(block.get("items") or [], start=1):
+        if block.get("checklist"):
+            box = "x" if item.get("checked") else " "
+            marker = f"- [{box}]"
+        elif block.get("ordered"):
+            marker = f"{index}."
+        else:
+            marker = "-"
+        lines.append(f"{indent}{marker} {_md_runs(item.get('runs') or [])}")
+        for nested in item.get("children") or []:
+            lines.extend(_md_list(nested, indent + "  "))
+    return lines
+
+
+def _md_table(block: dict) -> list[str]:
+    rows = block.get("rows") or []
+    if not rows:
+        return []
+    width = max(len(r) for r in rows)
+
+    def cells(row: list) -> str:
+        padded = list(row) + [[]] * (width - len(row))
+        return "| " + " | ".join(_md_runs(c).replace("\n", " ") for c in padded) + " |"
+
+    lines = [cells(rows[0]), "|" + "|".join(" --- " for _ in range(width)) + "|"]
+    lines.extend(cells(row) for row in rows[1:])
+    return lines
+
+
+def _md_escape(text: str) -> str:
+    return text.replace("|", "\\|").replace("[", "\\[").replace("]", "\\]")
+
+
+def _md_runs(runs: list[dict]) -> str:
+    parts: list[str] = []
+    for run in runs or []:
+        text = run.get("text") or ""
+        if text == "\n":
+            parts.append("  \n")
+            continue
+        if run.get("code"):
+            text = f"`{text}`"
+        else:
+            if run.get("bold") and run.get("italic"):
+                text = f"***{text}***"
+            elif run.get("bold"):
+                text = f"**{text}**"
+            elif run.get("italic"):
+                text = f"*{text}*"
+            if run.get("strike"):
+                text = f"~~{text}~~"
+        if run.get("link"):
+            text = f"[{text}](<{run['link']}>)"
+        parts.append(text)
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# DOCX
+# ---------------------------------------------------------------------------
+
+
+def render_docx(data: dict, read_blob: ReadBlob) -> bytes:
+    import docx
+    from docx.enum.text import WD_BREAK
+    from docx.shared import Inches, Pt
+
+    document = docx.Document()
+    title = str(data.get("title") or "").strip()
+    if title:
+        document.add_heading(title, level=0)
+
+    def add_runs(paragraph, runs: list[dict]) -> None:
+        for run in runs or []:
+            text = run.get("text") or ""
+            if text == "\n":
+                paragraph.add_run().add_break(WD_BREAK.LINE)
+                continue
+            r = paragraph.add_run(text)
+            r.bold = bool(run.get("bold")) or None
+            r.italic = bool(run.get("italic")) or None
+            r.font.strike = bool(run.get("strike")) or None
+            r.underline = bool(run.get("underline")) or None
+            if run.get("code"):
+                r.font.name = "Consolas"
+            if run.get("link"):
+                # python-docx has no first-class hyperlink on runs; keep the
+                # text and append the target so it survives visibly.
+                r.underline = True
+                paragraph.add_run(f" ({run['link']})").font.size = Pt(8)
+
+    def add_list(block: dict, level: int = 0) -> None:
+        style = "List Number" if block.get("ordered") else "List Bullet"
+        # python-docx built-in list styles support levels 1-3 via suffixes.
+        if level:
+            style = f"{style} {min(level + 1, 3)}"
+        for item in block.get("items") or []:
+            paragraph = document.add_paragraph(style=style)
+            if block.get("checklist"):
+                paragraph.add_run("☑ " if item.get("checked") else "☐ ")
+            add_runs(paragraph, item.get("runs") or [])
+            for nested in item.get("children") or []:
+                add_list(nested, level + 1)
+
+    for block in data.get("blocks") or []:
+        btype = block.get("type")
+        if btype == "heading":
+            document.add_heading(
+                _plain_text(block.get("runs") or []),
+                level=min(int(block.get("level") or 1), 9),
+            )
+        elif btype == "quote":
+            add_runs(
+                document.add_paragraph(style="Intense Quote"), block.get("runs") or []
+            )
+        elif btype == "code":
+            paragraph = document.add_paragraph()
+            code_run = paragraph.add_run(block.get("text") or "")
+            code_run.font.name = "Consolas"
+            code_run.font.size = Pt(9)
+        elif btype == "hr":
+            document.add_paragraph("· · ·").alignment = 1  # centered separator
+        elif btype == "list":
+            add_list(block)
+        elif btype == "table":
+            rows = block.get("rows") or []
+            if rows:
+                width = max(len(r) for r in rows)
+                table = document.add_table(rows=len(rows), cols=width)
+                table.style = "Table Grid"
+                for r_idx, row in enumerate(rows):
+                    for c_idx, cell_runs in enumerate(row):
+                        cell_paragraph = table.cell(r_idx, c_idx).paragraphs[0]
+                        add_runs(cell_paragraph, cell_runs)
+        elif btype == "image":
+            if block.get("asset"):
+                name_to_key = {a["name"]: a["key"] for a in (data.get("assets") or [])}
+                key = name_to_key.get(block["asset"])
+                if key:
+                    try:
+                        document.add_picture(
+                            io.BytesIO(read_blob(key)), width=Inches(6)
+                        )
+                    except Exception:
+                        # Unreadable/unsupported image: degrade to alt text
+                        # rather than failing the whole document.
+                        document.add_paragraph(block.get("alt") or "[image]")
+            else:
+                paragraph = document.add_paragraph(block.get("alt") or "")
+                paragraph.add_run(f" ({block.get('url') or ''})")
+        else:  # paragraph
+            add_runs(document.add_paragraph(), block.get("runs") or [])
+
+    out = io.BytesIO()
+    document.save(out)
+    return out.getvalue()
+
+
+def _plain_text(runs: list[dict]) -> str:
+    return "".join(run.get("text") or "" for run in runs)

--- a/backend/app/services/export/lexical_test.py
+++ b/backend/app/services/export/lexical_test.py
@@ -242,6 +242,60 @@ def test_docx_renders_and_embeds_image():
     assert len(document.inline_shapes) == 1  # the embedded upload image
 
 
+def test_image_resize_carried_and_honored_in_docx():
+    """The editor's resize (width px on the node) must survive into the
+    block and set the DOCX picture width — not the fixed 6-inch default."""
+    import struct
+    import zlib
+
+    import docx
+    from docx.shared import Inches
+
+    def make_png():
+        def chunk(tag, data):
+            c = tag + data
+            return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c))
+
+        ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+        return (
+            b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(b"\x00\xff\x00\x00"))
+            + chunk(b"IEND", b"")
+        )
+
+    state = _state(
+        [
+            {
+                "type": "image",
+                "src": f"/uploads/{GUILD}/pic.png",
+                "altText": "sized",
+                "width": 192,  # 2 inches at 96 dpi
+                "height": 120,
+            },
+            {
+                "type": "image",
+                "src": f"/uploads/{GUILD}/pic.png",
+                "altText": "untouched",
+                "width": "inherit",  # editor default: no resize stored
+            },
+        ]
+    )
+    blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)
+    assert blocks[0]["width"] == 192  # width wins; stale height not carried
+    assert "height" not in blocks[0]
+    assert "width" not in blocks[1]  # "inherit" ignored
+
+    content = render_docx(
+        {"title": "", "blocks": blocks, "assets": assets}, lambda key: make_png()
+    )
+    document = docx.Document(io.BytesIO(content))
+    shapes = document.inline_shapes
+    assert len(shapes) == 2
+    assert shapes[0].width == Inches(2)  # resized: 192px / 96dpi
+    assert shapes[1].width == Inches(6)  # untouched: the default cap
+
+
 def test_docx_degrades_unreadable_image_to_alt_text():
     state = _state(
         [{"type": "image", "src": f"/uploads/{GUILD}/bad.png", "altText": "broken"}]

--- a/backend/app/services/export/lexical_test.py
+++ b/backend/app/services/export/lexical_test.py
@@ -198,6 +198,48 @@ def test_asset_names_deduped_on_sanitize_collision():
     assert set(stored.values()) == {b"a img.png", b"a_img.png"}  # both survive
 
 
+def test_markdown_zip_survives_missing_asset():
+    """An image gone from storage skips its archive entry; the export (and
+    the other assets) still ship."""
+    state = _state(
+        [
+            {"type": "image", "src": f"/uploads/{GUILD}/gone.png", "altText": "gone"},
+            {"type": "image", "src": f"/uploads/{GUILD}/here.png", "altText": "here"},
+        ]
+    )
+    blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)
+
+    def read(key: str) -> bytes:
+        if key == "gone.png":
+            raise FileNotFoundError(key)
+        return b"bytes"
+
+    content, content_type, _ = render_markdown(
+        {"title": "", "stem": "d", "blocks": blocks, "assets": assets}, read
+    )
+    assert content_type == "application/zip"
+    archive = zipfile.ZipFile(io.BytesIO(content))
+    assert "assets/here.png" in archive.namelist()
+    assert "assets/gone.png" not in archive.namelist()
+
+
+def test_markdown_inline_code_with_backticks():
+    state = _state(
+        [
+            {
+                "type": "paragraph",
+                "children": [_text("use `backticks` here", 16)],  # code format
+            }
+        ]
+    )
+    blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)
+    content, _, _ = render_markdown(
+        {"title": "", "blocks": blocks, "assets": assets}, lambda key: b""
+    )
+    # Double-backtick spaced form keeps the inner backticks literal.
+    assert "`` use `backticks` here ``" in content.decode("utf-8")
+
+
 def test_markdown_plain_without_assets():
     state = _state([{"type": "paragraph", "children": [_text("hello")]}])
     blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)

--- a/backend/app/services/export/lexical_test.py
+++ b/backend/app/services/export/lexical_test.py
@@ -141,6 +141,63 @@ def test_markdown_zips_when_assets_present():
     assert "still exported" in md
 
 
+def test_markdown_table_escapes_pipes():
+    state = _state(
+        [
+            {
+                "type": "table",
+                "children": [
+                    {
+                        "type": "tablerow",
+                        "children": [
+                            {
+                                "type": "tablecell",
+                                "children": [
+                                    {
+                                        "type": "paragraph",
+                                        "children": [_text("a | b")],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+    blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)
+    content, _, _ = render_markdown(
+        {"title": "", "blocks": blocks, "assets": assets}, lambda key: b""
+    )
+    md = content.decode("utf-8")
+    assert "| a \\| b |" in md  # a raw pipe would split the column
+
+
+def test_asset_names_deduped_on_sanitize_collision():
+    """Two distinct storage keys can sanitize to one archive name — each must
+    keep its own entry or one image silently replaces the other."""
+    state = _state(
+        [
+            {"type": "image", "src": f"/uploads/{GUILD}/a img.png", "altText": "one"},
+            {"type": "image", "src": f"/uploads/{GUILD}/a_img.png", "altText": "two"},
+        ]
+    )
+    blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)
+    names = [a["name"] for a in assets]
+    assert len(assets) == 2
+    assert len(set(names)) == 2  # unique archive names
+    # Blocks reference their own (deduped) names.
+    assert {b["asset"] for b in blocks} == set(names)
+    content, content_type, _ = render_markdown(
+        {"title": "", "stem": "d", "blocks": blocks, "assets": assets},
+        lambda key: key.encode(),
+    )
+    archive = zipfile.ZipFile(io.BytesIO(content))
+    stored = {n: archive.read(n) for n in archive.namelist() if n.startswith("assets/")}
+    assert len(stored) == 2
+    assert set(stored.values()) == {b"a img.png", b"a_img.png"}  # both survive
+
+
 def test_markdown_plain_without_assets():
     state = _state([{"type": "paragraph", "children": [_text("hello")]}])
     blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)

--- a/backend/app/services/export/lexical_test.py
+++ b/backend/app/services/export/lexical_test.py
@@ -1,0 +1,200 @@
+"""Unit tests for the Lexical editor-state converters."""
+
+import io
+import zipfile
+
+import pytest
+
+from app.services.export.lexical import (
+    blocks_from_editor_state,
+    render_docx,
+    render_markdown,
+)
+
+pytestmark = pytest.mark.unit
+
+GUILD = 7
+
+
+def _text(text, fmt=0):
+    return {"type": "text", "text": text, "format": fmt}
+
+
+def _state(children):
+    return {"root": {"type": "root", "children": children}}
+
+
+FIXTURE = _state(
+    [
+        {"type": "heading", "tag": "h2", "children": [_text("Overview")]},
+        {
+            "type": "paragraph",
+            "children": [
+                _text("plain "),
+                _text("bold", 1),
+                _text(" italic", 2),
+                _text(" code", 16),
+                {
+                    "type": "link",
+                    "url": "https://example.com",
+                    "children": [_text("a link")],
+                },
+                {"type": "mention", "text": "@alice", "mentionName": "alice"},
+            ],
+        },
+        {"type": "quote", "children": [_text("wisdom")]},
+        {
+            "type": "code",
+            "language": "python",
+            "children": [_text("x = 1"), {"type": "linebreak"}, _text("y = 2")],
+        },
+        {
+            "type": "list",
+            "listType": "check",
+            "children": [
+                {"type": "listitem", "checked": True, "children": [_text("done")]},
+                {
+                    "type": "listitem",
+                    "checked": False,
+                    "children": [
+                        _text("todo"),
+                        {
+                            "type": "list",
+                            "listType": "bullet",
+                            "children": [
+                                {"type": "listitem", "children": [_text("nested")]}
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        {"type": "image", "src": f"/uploads/{GUILD}/img-abc.png", "altText": "our pic"},
+        {"type": "image", "src": "https://elsewhere.example/x.png", "altText": "ext"},
+        {"type": "horizontalrule"},
+        {"type": "youtube", "videoID": "dQw4w9WgXcQ"},
+        {
+            "type": "unknown-future-node",
+            "children": [{"type": "paragraph", "children": [_text("still exported")]}],
+        },
+    ]
+)
+
+
+def test_parser_blocks_and_assets():
+    blocks, assets = blocks_from_editor_state(FIXTURE, guild_id=GUILD)
+    types = [b["type"] for b in blocks]
+    assert types == [
+        "heading",
+        "paragraph",
+        "quote",
+        "code",
+        "list",
+        "image",
+        "image",
+        "hr",
+        "paragraph",  # youtube degrades to a link paragraph
+        "paragraph",  # unknown container's child
+    ]
+    # Same-guild upload collected as an asset; external stays a URL.
+    assert assets == [{"key": "img-abc.png", "name": "img-abc.png"}]
+    assert blocks[5]["asset"] == "img-abc.png"
+    assert blocks[6]["asset"] is None
+    assert blocks[6]["url"] == "https://elsewhere.example/x.png"
+    # Format bitmask decoded; mention degraded to its text.
+    para = blocks[1]["runs"]
+    assert {"text": "bold", "bold": True} in para
+    assert {"text": " code", "code": True} in para
+    assert {"text": "a link", "link": "https://example.com"} in para
+    assert {"text": "@alice"} in para
+    # Code block joins its lines.
+    assert blocks[3]["text"] == "x = 1\ny = 2"
+    # Checklist with nesting.
+    items = blocks[4]["items"]
+    assert items[0]["checked"] is True
+    assert items[1]["children"][0]["items"][0]["runs"] == [{"text": "nested"}]
+
+
+def test_markdown_zips_when_assets_present():
+    blocks, assets = blocks_from_editor_state(FIXTURE, guild_id=GUILD)
+    data = {"title": "Notes", "stem": "notes", "blocks": blocks, "assets": assets}
+    content, content_type, filename = render_markdown(
+        data, lambda key: b"png-bytes-" + key.encode()
+    )
+    assert content_type == "application/zip"
+    assert filename == "notes.zip"
+    archive = zipfile.ZipFile(io.BytesIO(content))
+    assert set(archive.namelist()) == {"notes.md", "assets/img-abc.png"}
+    assert archive.read("assets/img-abc.png") == b"png-bytes-img-abc.png"
+    md = archive.read("notes.md").decode("utf-8")
+    assert "# Notes" in md
+    assert "### Overview" in md  # content h2 shifted below the title
+    assert "**bold**" in md and "` code`" in md
+    assert "[a link](<https://example.com>)" in md
+    assert "> wisdom" in md
+    assert "```python" in md
+    assert "- [x] done" in md and "- [ ] todo" in md
+    assert "  - nested" in md
+    assert "![our pic](assets/img-abc.png)" in md
+    assert "![ext](<https://elsewhere.example/x.png>)" in md
+    assert "https://www.youtube.com/watch?v=dQw4w9WgXcQ" in md
+    assert "still exported" in md
+
+
+def test_markdown_plain_without_assets():
+    state = _state([{"type": "paragraph", "children": [_text("hello")]}])
+    blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)
+    content, content_type, filename = render_markdown(
+        {"title": "T", "stem": "t", "blocks": blocks, "assets": assets},
+        lambda key: b"",
+    )
+    assert content_type.startswith("text/markdown")
+    assert filename is None
+    assert "hello" in content.decode("utf-8")
+
+
+def test_docx_renders_and_embeds_image():
+    import struct
+    import zlib
+
+    def make_png():
+        def chunk(tag, data):
+            c = tag + data
+            return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c))
+
+        ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+        return (
+            b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(b"\x00\xff\x00\x00"))
+            + chunk(b"IEND", b"")
+        )
+
+    import docx
+
+    blocks, assets = blocks_from_editor_state(FIXTURE, guild_id=GUILD)
+    data = {"title": "Notes", "stem": "notes", "blocks": blocks, "assets": assets}
+    content = render_docx(data, lambda key: make_png())
+    assert content.startswith(b"PK")
+    document = docx.Document(io.BytesIO(content))
+    texts = [p.text for p in document.paragraphs]
+    assert "Notes" in texts  # title
+    assert any("wisdom" in t for t in texts)
+    assert any("still exported" in t for t in texts)
+    assert any("☑ done" in t for t in texts)
+    assert len(document.inline_shapes) == 1  # the embedded upload image
+
+
+def test_docx_degrades_unreadable_image_to_alt_text():
+    state = _state(
+        [{"type": "image", "src": f"/uploads/{GUILD}/bad.png", "altText": "broken"}]
+    )
+    import docx
+
+    blocks, assets = blocks_from_editor_state(state, guild_id=GUILD)
+    content = render_docx(
+        {"title": "", "blocks": blocks, "assets": assets},
+        lambda key: b"not-an-image",
+    )
+    document = docx.Document(io.BytesIO(content))
+    assert any("broken" in p.text for p in document.paragraphs)

--- a/backend/app/services/export/local_backend.py
+++ b/backend/app/services/export/local_backend.py
@@ -190,13 +190,30 @@ def _compile_with_assets(
         shutil.copyfile(template, main)
         assets_dir = root / "assets"
         assets_dir.mkdir()
+        staged: set[str] = set()
         for asset in item.data.get("assets") or []:
+            try:
+                content = read(asset["key"])
+            except Exception:
+                # Gone from storage: skip — the block degrades below rather
+                # than the whole export failing.
+                continue
             # Names come from safe_filename_component — no traversal.
-            (assets_dir / asset["name"]).write_bytes(read(asset["key"]))
+            (assets_dir / asset["name"]).write_bytes(content)
+            staged.add(asset["name"])
+        # Typst FAILS the compile on a missing image file, so any image block
+        # whose asset didn't stage degrades to its alt text.
+        data = dict(item.data)
+        data["blocks"] = [
+            {"type": "paragraph", "runs": [{"text": b.get("alt") or "[image]"}]}
+            if b.get("type") == "image" and b.get("asset") and b["asset"] not in staged
+            else b
+            for b in data.get("blocks") or []
+        ]
         return typst.compile(
             str(main),
             root=str(root),
             format=format,
-            sys_inputs={"data": json.dumps(item.data, ensure_ascii=False)},
+            sys_inputs={"data": json.dumps(data, ensure_ascii=False)},
             ignore_system_fonts=True,
         )

--- a/backend/app/services/export/local_backend.py
+++ b/backend/app/services/export/local_backend.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import typst
 
-from app.services.export import spreadsheet, tabular
+from app.services.export import lexical, spreadsheet, tabular
 from app.services.export.contract import (
     RenderedArtifact,
     RenderItem,
@@ -43,6 +43,7 @@ _CONTENT_TYPES = {
     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "md": "text/markdown; charset=utf-8",
     "json": "application/json",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "file": "application/octet-stream",  # per-item override from the blob
 }
 
@@ -99,34 +100,59 @@ def _render_item(
             else tabular.render_xlsx(item)
         )
     elif format == "md":
-        content = tabular.render_md(item)
+        if "blocks" in item.data:
+            content, content_type, lexical_name = lexical.render_markdown(
+                item.data, _blob_reader(req.guild_id)
+            )
+            filename = lexical_name or filename
+        else:
+            content = tabular.render_md(item)
+    elif format == "docx":
+        content = lexical.render_docx(item.data, _blob_reader(req.guild_id))
     elif format == "json":
         # The payload IS the artifact (e.g. a backup envelope); indent for a
         # human-inspectable file.
         content = json.dumps(item.data, ensure_ascii=False, indent=2).encode("utf-8")
     else:
         assert template is not None  # resolve_template ran for the pdf path
-        content = _compile(template, format, item)
+        if item.data.get("assets"):
+            content = _compile_with_assets(template, format, item, req.guild_id)
+        else:
+            content = _compile(template, format, item)
     return RenderedArtifact(
         key=item.key, content_type=content_type, content=content, filename=filename
     )
 
 
+def _blob_reader(guild_id: int):
+    """Bytes-by-storage-key reader for renderers that embed uploads (asset
+    images, file passthrough). Keys are derived by adapters from document
+    rows under the caller's RLS session — never from raw user input."""
+    from app.services.storage import get_guild_storage
+
+    storage = get_guild_storage(guild_id)
+
+    def read(key: str) -> bytes:
+        blob = storage.open_readable(str(key))
+        if blob is None:
+            raise FileNotFoundError(key)
+        if blob.path is not None:
+            return Path(blob.path).read_bytes()
+        return blob.stream.read()  # type: ignore[union-attr]
+
+    return read
+
+
 def _read_passthrough(
     guild_id: int, data: dict[str, Any]
 ) -> tuple[bytes, str, str | None]:
-    """Read a stored upload blob for unconverted export. The storage key was
-    derived by the adapter from the document row under the caller's RLS
-    session — never from raw user input."""
+    """Read a stored upload blob for unconverted export."""
     from app.services.storage import get_guild_storage
 
     blob = get_guild_storage(guild_id).open_readable(str(data["storage_key"]))
     if blob is None:
         raise FileNotFoundError(data["storage_key"])
-    if blob.path is not None:
-        content = Path(blob.path).read_bytes()
-    else:
-        content = blob.stream.read()  # type: ignore[union-attr]
+    content = _blob_reader(guild_id)(str(data["storage_key"]))
     content_type = (
         str(data.get("content_type") or "")
         or blob.content_type
@@ -146,3 +172,31 @@ def _compile(template: Path, format: str, item: RenderItem) -> bytes:
         sys_inputs={"data": json.dumps(item.data, ensure_ascii=False)},
         ignore_system_fonts=True,
     )
+
+
+def _compile_with_assets(
+    template: Path, format: str, item: RenderItem, guild_id: int
+) -> bytes:
+    """Compile with referenced upload images staged into the project root —
+    Typst reads files only under its root, so a temp dir holds a copy of the
+    template plus an assets/ folder with the document's images."""
+    import shutil
+    import tempfile
+
+    read = _blob_reader(guild_id)
+    with tempfile.TemporaryDirectory(prefix="export-render-") as tmp:
+        root = Path(tmp)
+        main = root / template.name
+        shutil.copyfile(template, main)
+        assets_dir = root / "assets"
+        assets_dir.mkdir()
+        for asset in item.data.get("assets") or []:
+            # Names come from safe_filename_component — no traversal.
+            (assets_dir / asset["name"]).write_bytes(read(asset["key"]))
+        return typst.compile(
+            str(main),
+            root=str(root),
+            format=format,
+            sys_inputs={"data": json.dumps(item.data, ensure_ascii=False)},
+            ignore_system_fonts=True,
+        )

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -206,6 +206,58 @@ async def test_xlsx_preserves_numeric_cells():
     assert sheet.cell(row=2, column=2).data_type == "n"
 
 
+async def test_document_template_interleaves_nested_lists():
+    """A nested list must render directly beneath its parent item, not after
+    all siblings — and the parent numbering must continue past the detour."""
+    import io
+
+    from pypdf import PdfReader
+
+    request = RenderRequest(
+        guild_id=1,
+        template_id="document",
+        format="pdf",
+        batch=(
+            RenderItem(
+                key="doc",
+                data={
+                    "title": "T",
+                    "blocks": [
+                        {
+                            "type": "list",
+                            "ordered": True,
+                            "checklist": False,
+                            "items": [
+                                {"runs": [{"text": "ALPHA"}]},
+                                {
+                                    "runs": [{"text": "BRAVO"}],
+                                    "children": [
+                                        {
+                                            "type": "list",
+                                            "ordered": False,
+                                            "checklist": False,
+                                            "items": [
+                                                {"runs": [{"text": "NESTEDBRAVO"}]}
+                                            ],
+                                        }
+                                    ],
+                                },
+                                {"runs": [{"text": "CHARLIE"}]},
+                            ],
+                        }
+                    ],
+                },
+            ),
+        ),
+    )
+    artifacts = await LocalRenderBackend().render(request)
+    text = PdfReader(io.BytesIO(artifacts[0].content)).pages[0].extract_text()
+    assert text.index("ALPHA") < text.index("BRAVO")
+    assert text.index("BRAVO") < text.index("NESTEDBRAVO")
+    assert text.index("NESTEDBRAVO") < text.index("CHARLIE")
+    assert "3. CHARLIE" in text  # numbering survives the nested detour
+
+
 async def test_tabular_formats_skip_template_resolution():
     """A csv/xlsx render must not require a .typ template — the payload's
     columns/rows are the whole input."""

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -258,6 +258,40 @@ async def test_document_template_interleaves_nested_lists():
     assert "3. CHARLIE" in text  # numbering survives the nested detour
 
 
+async def test_document_pdf_degrades_missing_asset(monkeypatch, tmp_path):
+    """Typst fails a compile on a missing image file, so an asset gone from
+    storage must degrade its block to alt text — not fail the export."""
+    import io
+
+    from pypdf import PdfReader
+
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "UPLOADS_DIR", str(tmp_path))
+    request = RenderRequest(
+        guild_id=1,
+        template_id="document",
+        format="pdf",
+        batch=(
+            RenderItem(
+                key="doc",
+                data={
+                    "title": "T",
+                    "blocks": [
+                        {"type": "image", "asset": "gone.png", "alt": "GONEALT"},
+                        {"type": "paragraph", "runs": [{"text": "AFTERWARDS"}]},
+                    ],
+                    "assets": [{"key": "gone.png", "name": "gone.png"}],
+                },
+            ),
+        ),
+    )
+    artifacts = await LocalRenderBackend().render(request)
+    text = PdfReader(io.BytesIO(artifacts[0].content)).pages[0].extract_text()
+    assert "GONEALT" in text  # degraded to alt text
+    assert "AFTERWARDS" in text  # rest of the document survived
+
+
 async def test_tabular_formats_skip_template_resolution():
     """A csv/xlsx render must not require a .typ template — the payload's
     columns/rows are the whole input."""

--- a/backend/app/services/export/templates/document.typ
+++ b/backend/app/services/export/templates/document.typ
@@ -35,23 +35,28 @@
     .join()
 }
 
-#let render_list(block, depth) = {
-  let items = block.at("items", default: ())
-  let checklist = block.at("checklist", default: false)
-  let ordered = block.at("ordered", default: false)
-  pad(left: depth * 1em)[
-    #if checklist {
-      for item in items [
-        #box(if item.at("checked", default: false) [☑] else [☐]) #render_runs(item.at("runs", default: ())) \
-      ]
-    } else if ordered {
-      enum(..items.map(i => render_runs(i.at("runs", default: ()))))
-    } else {
-      list(..items.map(i => render_runs(i.at("runs", default: ()))))
-    }
-  ]
-  // One nesting pass per item (deeper levels flatten to this one).
+#let render_list(lst, depth) = {
+  // Items render one at a time so each item's nested lists appear directly
+  // BENEATH it, not after all its siblings. Ordered lists keep their
+  // numbering across the single-item enum() calls via start:. Tighten block
+  // spacing so per-item calls read as one list.
+  set block(above: 3pt, below: 3pt)
+  let items = lst.at("items", default: ())
+  let checklist = lst.at("checklist", default: false)
+  let ordered = lst.at("ordered", default: false)
+  let index = 1
   for item in items {
+    let body = render_runs(item.at("runs", default: ()))
+    pad(left: depth * 1em)[
+      #if checklist [
+        #box(if item.at("checked", default: false) [☑] else [☐]) #body
+      ] else if ordered [
+        #enum(start: index, body)
+      ] else [
+        #list(body)
+      ]
+    ]
+    index += 1
     for nested in item.at("children", default: ()) {
       render_list(nested, depth + 1)
     }

--- a/backend/app/services/export/templates/document.typ
+++ b/backend/app/services/export/templates/document.typ
@@ -105,7 +105,18 @@
   } else if btype == "image" {
     let asset = b.at("asset", default: none)
     if asset != none {
-      image("assets/" + asset, width: 80%)
+      // Honor the editor's resize (CSS px -> pt at 0.75), clamped to the
+      // content width (~470pt on A4 with these margins); untouched images
+      // keep the 80% default.
+      let wpx = b.at("width", default: none)
+      let hpx = b.at("height", default: none)
+      if wpx != none {
+        image("assets/" + asset, width: calc.min(wpx * 0.75, 470) * 1pt)
+      } else if hpx != none {
+        image("assets/" + asset, height: calc.min(hpx * 0.75, 680) * 1pt)
+      } else {
+        image("assets/" + asset, width: 80%)
+      }
     } else {
       let url = b.at("url", default: "")
       link(url)[#b.at("alt", default: url)]

--- a/backend/app/services/export/templates/document.typ
+++ b/backend/app/services/export/templates/document.typ
@@ -1,0 +1,127 @@
+// Lexical document export template. All data arrives as ONE json string via
+// sys.inputs (never interpolated into this source) — user text stays data.
+// Referenced images are staged by the backend under assets/ in the compile
+// root; the payload's image blocks name them by file.
+#let payload = json(bytes(sys.inputs.at("data", default: "{}")))
+#let blocks = payload.at("blocks", default: ())
+
+#set page(
+  paper: "a4",
+  margin: (x: 1.8cm, y: 2cm),
+  footer: context {
+    set text(size: 8pt, fill: luma(120))
+    grid(
+      columns: (1fr, auto),
+      payload.at("footer", default: ""),
+      counter(page).display("1 of 1", both: true),
+    )
+  },
+)
+#set text(size: 10pt)
+
+#let render_runs(runs) = {
+  runs
+    .map(r => {
+      let t = r.at("text", default: "")
+      let body = if r.at("code", default: false) { raw(t) } else { [#t] }
+      if r.at("bold", default: false) { body = strong(body) }
+      if r.at("italic", default: false) { body = emph(body) }
+      if r.at("strike", default: false) { body = strike(body) }
+      if r.at("underline", default: false) { body = underline(body) }
+      let url = r.at("link", default: none)
+      if url != none { body = link(url, body) }
+      body
+    })
+    .join()
+}
+
+#let render_list(block, depth) = {
+  let items = block.at("items", default: ())
+  let checklist = block.at("checklist", default: false)
+  let ordered = block.at("ordered", default: false)
+  pad(left: depth * 1em)[
+    #if checklist {
+      for item in items [
+        #box(if item.at("checked", default: false) [☑] else [☐]) #render_runs(item.at("runs", default: ())) \
+      ]
+    } else if ordered {
+      enum(..items.map(i => render_runs(i.at("runs", default: ()))))
+    } else {
+      list(..items.map(i => render_runs(i.at("runs", default: ()))))
+    }
+  ]
+  // One nesting pass per item (deeper levels flatten to this one).
+  for item in items {
+    for nested in item.at("children", default: ()) {
+      render_list(nested, depth + 1)
+    }
+  }
+}
+
+#let title = payload.at("title", default: "")
+#if title != "" [
+  #text(size: 18pt, weight: "bold", title)
+  #v(2pt)
+  #text(size: 9pt, fill: luma(100), payload.at("subtitle", default: ""))
+  #v(10pt)
+]
+
+#for b in blocks {
+  let btype = b.at("type", default: "paragraph")
+  if btype == "heading" {
+    let level = calc.min(b.at("level", default: 1), 4)
+    let sizes = (14pt, 12.5pt, 11.5pt, 10.5pt)
+    v(6pt)
+    text(size: sizes.at(level - 1), weight: "bold", render_runs(b.at("runs", default: ())))
+    v(2pt)
+  } else if btype == "quote" {
+    pad(
+      left: 8pt,
+      block(
+        stroke: (left: 2pt + luma(180)),
+        inset: (left: 8pt, y: 4pt),
+        text(fill: luma(90), render_runs(b.at("runs", default: ()))),
+      ),
+    )
+  } else if btype == "code" {
+    block(
+      fill: luma(246),
+      inset: 8pt,
+      radius: 3pt,
+      width: 100%,
+      raw(b.at("text", default: ""), lang: b.at("language", default: "")),
+    )
+  } else if btype == "hr" {
+    v(4pt)
+    line(length: 100%, stroke: 0.5pt + luma(200))
+    v(4pt)
+  } else if btype == "list" {
+    render_list(b, 0)
+  } else if btype == "image" {
+    let asset = b.at("asset", default: none)
+    if asset != none {
+      image("assets/" + asset, width: 80%)
+    } else {
+      let url = b.at("url", default: "")
+      link(url)[#b.at("alt", default: url)]
+    }
+  } else if btype == "table" {
+    let rows = b.at("rows", default: ())
+    if rows.len() > 0 {
+      let width = calc.max(..rows.map(r => r.len()))
+      table(
+        columns: width,
+        inset: (x: 6pt, y: 5pt),
+        stroke: 0.5pt + luma(210),
+        ..rows
+          .map(r => {
+            let padded = r + ((),) * (width - r.len())
+            padded.map(c => render_runs(c))
+          })
+          .flatten()
+      )
+    }
+  } else {
+    par(render_runs(b.at("runs", default: ())))
+  }
+}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "boto3>=1.35,<2",                    # S3 / S3-compatible (MinIO) object storage; only imported when STORAGE_BACKEND=s3
     "typst>=0.15.0",
     "openpyxl>=3.1.5",
+    "python-docx>=1.2.0",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pypdf>=6.14.2",
     "pytest>=9.0.3,<10",
     "pytest-asyncio>=1.3.0,<2",
     "pytest-cov>=7.1.0,<8",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1172,6 +1172,7 @@ dependencies = [
     { name = "pycrdt-websocket" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "python-docx" },
     { name = "python-magic" },
     { name = "python-multipart" },
     { name = "requests" },
@@ -1214,6 +1215,7 @@ requires-dist = [
     { name = "pycrdt-websocket", specifier = ">=0.16.1,<0.17" },
     { name = "pydantic-settings", specifier = ">=2.14.2,<3" },
     { name = "pyjwt", specifier = ">=2.13.0,<3" },
+    { name = "python-docx", specifier = ">=1.2.0" },
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "python-multipart", specifier = ">=0.0.31,<0.0.33" },
     { name = "requests", specifier = ">=2.34.2" },
@@ -2136,6 +2138,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1186,6 +1186,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pypdf" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1229,6 +1230,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
@@ -2061,6 +2063,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -270,6 +270,8 @@
     "formatOriginal": "Originaldatei",
     "formatMarkdown": "Markdown",
     "formatPng": "PNG-Bild",
-    "formatSvg": "SVG-Bild"
+    "formatSvg": "SVG-Bild",
+    "formatDocx": "Word (DOCX)",
+    "formatLexical": "Lexical-Datei (.lexical)"
   }
 }

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -270,6 +270,8 @@
     "formatOriginal": "Original file",
     "formatMarkdown": "Markdown",
     "formatPng": "PNG image",
-    "formatSvg": "SVG image"
+    "formatSvg": "SVG image",
+    "formatDocx": "Word (DOCX)",
+    "formatLexical": "Lexical file (.lexical)"
   }
 }

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -270,6 +270,8 @@
     "formatOriginal": "Archivo original",
     "formatMarkdown": "Markdown",
     "formatPng": "Imagen PNG",
-    "formatSvg": "Imagen SVG"
+    "formatSvg": "Imagen SVG",
+    "formatDocx": "Word (DOCX)",
+    "formatLexical": "Archivo Lexical (.lexical)"
   }
 }

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -270,6 +270,8 @@
     "formatOriginal": "Fichier d'origine",
     "formatMarkdown": "Markdown",
     "formatPng": "Image PNG",
-    "formatSvg": "Image SVG"
+    "formatSvg": "Image SVG",
+    "formatDocx": "Word (DOCX)",
+    "formatLexical": "Fichier Lexical (.lexical)"
   }
 }

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3985,6 +3985,8 @@ export const ExportDocumentApiV1GGuildIdExportsDocumentGetFormat = {
   csv: "csv",
   xlsx: "xlsx",
   file: "file",
+  pdf: "pdf",
+  docx: "docx",
 } as const;
 
 export type ListQueuesApiV1GGuildIdQueuesGetParams = {

--- a/frontend/src/components/documents/DocumentExportMenu.test.tsx
+++ b/frontend/src/components/documents/DocumentExportMenu.test.tsx
@@ -75,6 +75,7 @@ describe("DocumentExportMenu", () => {
     renderWithProviders(<DocumentExportMenu documentId={5} documentType="native" title="Notes" />);
 
     await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /lexical/i }));
 
     await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
     // The server name wins over the client's {stem}.{format} fallback —

--- a/frontend/src/components/documents/DocumentExportMenu.tsx
+++ b/frontend/src/components/documents/DocumentExportMenu.tsx
@@ -26,7 +26,13 @@ const safeFilename = (name: string): string =>
 
 // Engine formats per document type — mirrors the backend adapter's rules.
 const TYPE_FORMATS: Record<DocumentReadDocumentType, ExportFormatOption[]> = {
-  native: [{ format: "json", labelKey: "export.formatJson" }],
+  native: [
+    { format: "pdf", labelKey: "export.formatPdf" },
+    { format: "md", labelKey: "export.formatMarkdown" },
+    { format: "docx", labelKey: "export.formatDocx" },
+    // The lossless one: round-trips through the editor toolbar's import.
+    { format: "json", labelKey: "export.formatLexical" },
+  ],
   whiteboard: [{ format: "json", labelKey: "export.formatExcalidraw" }],
   spreadsheet: [
     { format: "csv", labelKey: "export.formatCsv" },


### PR DESCRIPTION
## Problem

Phase B of the document-export plan: editor (Lexical) documents could only export as the lossless `.lexical` file. This adds the human-readable formats — Markdown, PDF, and Word — with referenced images embedded, per the agreed decisions (pdf/docx embed; md ships as a zip with an `assets/` folder; read access suffices).

## How it works

**One tree walk, three renderers** (`app/services/export/lexical.py`): `blocks_from_editor_state` turns the serialized editor state into a JSON-safe intermediate (typed blocks with inline runs) that rides the existing `RenderRequest` payload; each format consumes the same blocks.

- **Markdown**: full GFM emit (headings shifted under the doc title, bold/italic/strike/code runs, links, quotes, fenced code, bullet/numbered/check lists with nesting, tables, hr). With referenced images the artifact becomes a **zip** — `{stem}.md` + `assets/` — with image refs rewritten to relative paths; without images it's a plain `.md`.
- **PDF**: a new `document` Typst template renders the same blocks. Referenced images are **staged into a temp compile root** (Typst reads files only under its root) by the backend; the `sys.inputs` injection guard is unchanged.
- **DOCX**: `python-docx` (new pinned dep) emits headings, styled runs, quotes, code, lists (checklists via ☐/☑), tables, and embedded images (6-inch width cap; an unreadable image degrades to its alt text rather than failing the export).

**Degradation contract** (documented in the module): any unknown node with `text` exports as text — which covers mentions, wikilinks, hashtags, emojis, keywords for free; unknown containers recurse into children; YouTube/Tweet embeds become links; anything else drops silently. A future editor node can never break an export.

**Asset rules**: only same-guild uploads (`/uploads/{guild_id}/…`) are collected and embedded. External image URLs are **never fetched** (no SSRF surface, per the export design) — they render as links. Asset bytes are read by the render backend from guild storage (keys derived from the document row under the caller's RLS session), so the job path works unchanged.

The document menu for editor docs is now: PDF document / Markdown / Word (DOCX) / Lexical file (.lexical) — the last being the canonical re-importable one.

## Testing

```
cd backend && pytest app/services/export app/api/v1/tenant_endpoints/exports_test.py   # 38 passed
cd frontend && pnpm typecheck && pnpm lint && pnpm test:run                            # 813 passed
```

Unit tests cover the parser (bitmask, nesting, asset collection, degradation), the Markdown zip bundle (content + rewritten refs), and DOCX (read back with python-docx, embedded image counted, unreadable-image degradation). Endpoint tests render all three formats end-to-end with a real stored PNG, including the md-zip Content-Disposition and the plain-md no-assets path. The Typst template was probe-rendered with every block type.