### PR TITLE
Queue and counter group exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Document export: an Export menu on every document offers type-appropriate formats — importable JSON for editor documents and whiteboards (standard Excalidraw file), CSV/Excel for spreadsheets (formatting carried over), the original file for uploads, and Markdown for smart links. Whiteboards additionally export PNG/SVG images, rendered in the browser by Excalidraw itself. Read access suffices; delivery matches the other exports (instant for small documents, background job with notification pickup for large ones).
-
-- Text documents now export as PDF, Markdown, and Word (DOCX) alongside the lossless .lexical file. Referenced images are embedded in the PDF and DOCX; a Markdown export with images downloads as a zip bundle with an assets folder. Mentions, wikilinks, and embeds degrade gracefully to text and links.
-
-- Task exports: an Export menu on the project tasks view downloads the current view — or just the selected tasks, via the new action in the selection bar — as PDF, CSV, Excel (XLSX), or Markdown (a table or a checkable task list), with the same filters and visibility as on screen. Small exports download instantly; large ones run as a background job and download automatically when ready, and if you navigate away meanwhile, an inbox notification downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), artifacts expire automatically after 7 days, and the spreadsheet formats carry injection protection.
-
-- Project export: now also offers a formatted report as PDF, CSV, or Excel (XLSX) alongside the JSON backup — the report covers the project's unarchived tasks; the backup file is unchanged and still imports.
+- New data export engine powers exporting your guild data as importable JSON envelopes or various report formats
+  - Document export: an Export menu on every document offers type-appropriate formats — importable JSON for editor documents and whiteboards (standard Excalidraw file), CSV/Excel for spreadsheets (formatting carried over), the original file for uploads, and Markdown for smart links. Whiteboards additionally export PNG/SVG images, rendered in the browser by Excalidraw itself. Read access suffices; delivery matches the other exports (instant for small documents, background job with notification pickup for large ones).
+  - Text documents now export as PDF, Markdown, and Word (DOCX) alongside the lossless .lexical file. Referenced images are embedded in the PDF and DOCX; a Markdown export with images downloads as a zip bundle with an assets folder. Mentions, wikilinks, and embeds degrade gracefully to text and links.
+  - Task exports: an Export menu on the project tasks view downloads the current view — or just the selected tasks, via the new action in the selection bar — as PDF, CSV, Excel (XLSX), or Markdown (a table or a checkable task list), with the same filters and visibility as on screen. Small exports download instantly; large ones run as a background job and download automatically when ready, and if you navigate away meanwhile, an inbox notification downloads the finished export when clicked. Exports are private to their creator (guild admins can see a guild's exports), artifacts expire automatically after 7 days, and the spreadsheet formats carry injection protection.
+  - Project export: now also offers a formatted report as PDF, CSV, or Excel (XLSX) alongside the JSON backup — the report covers the project's unarchived tasks; the backup file is unchanged and still imports.
+  - Queue and counter exports: an Export button on every queue and counter group downloads a report as PDF, CSV, Excel (XLSX), or Markdown — queues render as a numbered turn order with the current, held, and hidden entries marked; counter groups as a table of values and bounds — plus an importable JSON envelope carrying the tool's full configuration (queue envelopes keep tags by name and rotation state; member assignments and linked documents/tasks are guild-local, so they ship as names and titles rather than ids). Read access suffices.
 
 ### Changed
 
 - Project backup (JSON) export now runs through the export engine: large projects export as a background job with the inbox-notification pickup instead of one long request, and artifacts follow the same private-to-creator delivery and 7-day expiry. The downloaded file and the import flow are unchanged. (API: `GET /projects/{id}/export` was replaced by `GET /exports/project?project_id=…`.)
+- The queue page header now matches the other tool pages: a labeled Settings button sized like its neighbors, with queue deletion living in the settings page (where it already had a confirm dialog) instead of a header trash icon.
+
+### Fixed
+
+- Guild admins can now load the member roster of initiatives they haven't joined. The roster API returned 403 for them — every other initiative read already honored the guild-admin override — which left the linked-member and assignee pickers empty when an admin viewed another member's initiative.
 
 ## [0.55.0] - 2026-07-12
 

--- a/backend/app/api/v1/tenant_endpoints/exports.py
+++ b/backend/app/api/v1/tenant_endpoints/exports.py
@@ -184,6 +184,69 @@ async def export_document(
     return _job_response(result, status_code=status.HTTP_202_ACCEPTED)
 
 
+@router.get("/queue", response_model=None)
+async def export_queue(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+    queue_id: int = Query(),
+    format: Literal["json", "pdf", "csv", "xlsx", "md"] = Query(default="json"),
+) -> Union[Response, JSONResponse]:
+    """Export a queue: ``json`` is an importable envelope (items, rotation
+    state, tags by name — member assignments and linked documents/tasks ride
+    along as display text); ``pdf``/``csv``/``xlsx`` render the turn order as
+    a table and ``md`` as a numbered list. Read access suffices.
+    Small queues return the file inline; large ones return ``202`` with a
+    queued job to poll and download."""
+    try:
+        result = await start_export(
+            session,
+            user=current_user,
+            guild_id=guild_context.guild_id,
+            source="queue",
+            format=format,
+            params={"queue_id": queue_id},
+            allow_job=_allow_job(guild_context),
+        )
+    except ExportError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.code)
+
+    if isinstance(result, InlineExport):
+        return _inline_response(result)
+    return _job_response(result, status_code=status.HTTP_202_ACCEPTED)
+
+
+@router.get("/counter-group", response_model=None)
+async def export_counter_group(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+    counter_group_id: int = Query(),
+    format: Literal["json", "pdf", "csv", "xlsx", "md"] = Query(default="json"),
+) -> Union[Response, JSONResponse]:
+    """Export a counter group: ``json`` is an importable envelope (every
+    counter's configuration and current value); ``pdf``/``csv``/``xlsx``/
+    ``md`` render the counters as a table. Read access suffices. Small groups
+    return the file inline; large ones return ``202`` with a queued job to
+    poll and download."""
+    try:
+        result = await start_export(
+            session,
+            user=current_user,
+            guild_id=guild_context.guild_id,
+            source="counter-group",
+            format=format,
+            params={"counter_group_id": counter_group_id},
+            allow_job=_allow_job(guild_context),
+        )
+    except ExportError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.code)
+
+    if isinstance(result, InlineExport):
+        return _inline_response(result)
+    return _job_response(result, status_code=status.HTTP_202_ACCEPTED)
+
+
 @router.get("/", response_model=list[ExportJobRead])
 async def list_export_jobs(
     session: RLSSessionDep,

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -865,3 +865,257 @@ async def test_gc_expires_row_even_when_artifact_delete_fails(
     refreshed = await session.get(ExportJob, job.id)
     assert refreshed.status == ExportJobStatus.expired.value
     assert refreshed.artifact_ref is None
+
+
+async def _queue_with_items(acting_user, session):
+    from app.models.tenant.queue import QueueItemDocument, QueueItemTag, QueueItemTask
+    from app.testing.factories import (
+        create_document,
+        create_queue,
+        create_queue_item,
+        create_tag,
+    )
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    queue = await create_queue(
+        session,
+        a.initiative,
+        a.user,
+        name="Battle Order",
+        description="Round tracker",
+        is_active=True,
+        current_round=3,
+    )
+    # Rotation order is position DESCENDING: Alice acts first.
+    current = await create_queue_item(session, queue, label="Alice", position=30)
+    await create_queue_item(
+        session, queue, label="Bob", position=20, held_at_round=2, notes="waiting"
+    )
+    lurker = await create_queue_item(
+        session, queue, label="Lurker", position=10, is_visible=False
+    )
+    tag = await create_tag(session, a.guild, name="npc")
+    session.add(QueueItemTag(queue_item_id=lurker.id, tag_id=tag.id))
+    doc = await create_document(session, a.initiative, a.user, title="Dungeon map")
+    task = await create_task(session, a.project, title="Prep loot")
+    session.add(
+        QueueItemDocument(
+            queue_item_id=current.id, document_id=doc.id, guild_id=a.guild.id
+        )
+    )
+    session.add(
+        QueueItemTask(queue_item_id=current.id, task_id=task.id, guild_id=a.guild.id)
+    )
+    queue.current_item_id = current.id
+    session.add(queue)
+    await session.commit()
+    return a, queue
+
+
+async def test_queue_export_json_envelope(client: AsyncClient, acting_user, session):
+    import json
+
+    a, queue = await _queue_with_items(acting_user, session)
+    resp = await client.get(
+        a.g("/exports/queue"),
+        headers=a.headers,
+        params={"queue_id": queue.id, "format": "json"},
+    )
+    assert resp.status_code == 200
+    assert ".initiative-queue.json" in resp.headers["content-disposition"]
+    envelope = json.loads(resp.content)
+    assert envelope["kind"] == "initiative-queue"
+    assert envelope["schema_version"] == 1
+    assert envelope["name"] == "Battle Order"
+    assert envelope["is_active"] is True
+    assert envelope["current_round"] == 3
+
+    items = envelope["items"]
+    assert [i["label"] for i in items] == ["Alice", "Bob", "Lurker"]  # rotation order
+    assert [i["is_current"] for i in items] == [True, False, False]
+    assert items[1]["held_at_round"] == 2
+    assert items[2]["is_visible"] is False
+    assert items[2]["tags"] == ["npc"]
+    # Guild-local references ride along as display text only (an import can't
+    # rebind them): member name, linked document/task titles — never raw ids.
+    assert "member" in items[0] and "user_id" not in items[0]
+    assert items[0]["documents"] == ["Dungeon map"]
+    assert items[0]["tasks"] == ["Prep loot"]
+    assert items[1]["documents"] == [] and items[1]["tasks"] == []
+
+
+async def test_queue_export_report_formats(client: AsyncClient, acting_user, session):
+    import io
+
+    from pypdf import PdfReader
+
+    a, queue = await _queue_with_items(acting_user, session)
+
+    csv_resp = await client.get(
+        a.g("/exports/queue"),
+        headers=a.headers,
+        params={"queue_id": queue.id, "format": "csv"},
+    )
+    assert csv_resp.status_code == 200
+    text = csv_resp.content.decode("utf-8")
+    assert "#,Item,Member,Tags,Notes,Status" in text
+    assert "1,Alice,,,,Current" in text
+    assert "2,Bob,,,waiting,Held" in text
+    assert "3,Lurker,,npc,,Hidden" in text
+
+    md_resp = await client.get(
+        a.g("/exports/queue"),
+        headers=a.headers,
+        params={"queue_id": queue.id, "format": "md"},
+    )
+    assert md_resp.status_code == 200
+    md = md_resp.content.decode("utf-8")
+    assert "# Battle Order" in md
+    assert "1. **Alice** (Current)" in md  # numbered turn order, current bolded
+    assert "2. Bob (waiting · Held)" in md
+    assert "3. Lurker (npc · Hidden)" in md
+    assert "| Item |" not in md  # a list, not a table
+
+    pdf_resp = await client.get(
+        a.g("/exports/queue"),
+        headers=a.headers,
+        params={"queue_id": queue.id, "format": "pdf"},
+    )
+    assert pdf_resp.status_code == 200
+    assert pdf_resp.content.startswith(b"%PDF")
+    pdf_text = PdfReader(io.BytesIO(pdf_resp.content)).pages[0].extract_text()
+    assert "Battle Order" in pdf_text
+    assert "Alice" in pdf_text and "Lurker" in pdf_text
+    assert "Round tracker" in pdf_text  # description block rendered
+
+
+async def _counter_group_with_counters(acting_user, session):
+    from decimal import Decimal
+
+    from app.testing.factories import create_counter, create_counter_group
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    group = await create_counter_group(
+        session, a.initiative, a.user, name="Party Resources", description="Session 12"
+    )
+    await create_counter(
+        session,
+        group,
+        name="Torches",
+        count=Decimal("5.0000000000"),
+        min=Decimal("0"),
+        max=Decimal("10"),
+        position=Decimal("1"),
+    )
+    await create_counter(
+        session,
+        group,
+        name="Rations",
+        count=Decimal("2.5"),
+        step=Decimal("0.5"),
+        position=Decimal("2"),
+    )
+    return a, group
+
+
+async def test_counter_group_export_json_envelope(
+    client: AsyncClient, acting_user, session
+):
+    import json
+
+    a, group = await _counter_group_with_counters(acting_user, session)
+    resp = await client.get(
+        a.g("/exports/counter-group"),
+        headers=a.headers,
+        params={"counter_group_id": group.id, "format": "json"},
+    )
+    assert resp.status_code == 200
+    assert ".initiative-counter-group.json" in resp.headers["content-disposition"]
+    envelope = json.loads(resp.content)
+    assert envelope["kind"] == "initiative-counter-group"
+    assert envelope["schema_version"] == 1
+    assert envelope["name"] == "Party Resources"
+
+    by_name = {c["name"]: c for c in envelope["counters"]}
+    # NUMERIC(20,10) scale must not leak: integral Decimals become plain ints.
+    assert by_name["Torches"]["count"] == 5
+    assert isinstance(by_name["Torches"]["count"], int)
+    assert by_name["Torches"]["min"] == 0 and by_name["Torches"]["max"] == 10
+    assert by_name["Rations"]["count"] == 2.5
+    assert by_name["Rations"]["step"] == 0.5
+    assert by_name["Rations"]["min"] is None
+    assert by_name["Torches"]["view_mode"] == "number"
+
+
+async def test_counter_group_export_report_formats(
+    client: AsyncClient, acting_user, session
+):
+    import io
+    from io import BytesIO
+
+    from openpyxl import load_workbook
+    from pypdf import PdfReader
+
+    a, group = await _counter_group_with_counters(acting_user, session)
+
+    csv_resp = await client.get(
+        a.g("/exports/counter-group"),
+        headers=a.headers,
+        params={"counter_group_id": group.id, "format": "csv"},
+    )
+    assert csv_resp.status_code == 200
+    text = csv_resp.content.decode("utf-8")
+    assert "Counter,Count,Min,Max,Step" in text
+    assert "Torches,5,0,10,1" in text
+    assert "Rations,2.5,,,0.5" in text  # unbounded min/max stay empty
+
+    xlsx_resp = await client.get(
+        a.g("/exports/counter-group"),
+        headers=a.headers,
+        params={"counter_group_id": group.id, "format": "xlsx"},
+    )
+    assert xlsx_resp.status_code == 200
+    sheet = load_workbook(BytesIO(xlsx_resp.content)).active
+    assert [c.value for c in sheet[1]] == ["Counter", "Count", "Min", "Max", "Step"]
+    assert sheet.cell(row=2, column=2).value == 5
+    assert sheet.cell(row=2, column=2).data_type == "n"  # counts stay numeric
+    assert sheet.cell(row=3, column=2).value == 2.5
+
+    pdf_resp = await client.get(
+        a.g("/exports/counter-group"),
+        headers=a.headers,
+        params={"counter_group_id": group.id, "format": "pdf"},
+    )
+    assert pdf_resp.status_code == 200
+    assert pdf_resp.content.startswith(b"%PDF")
+    pdf_text = PdfReader(io.BytesIO(pdf_resp.content)).pages[0].extract_text()
+    assert "Party Resources" in pdf_text
+    assert "Torches" in pdf_text and "Rations" in pdf_text
+
+
+async def test_tool_exports_hidden_outside_initiative(
+    client: AsyncClient, acting_user, session
+):
+    """The initiative gate: a same-guild member outside the initiative gets
+    404 (RLS hides the row) for both tool sources."""
+    a, queue = await _queue_with_items(acting_user, session)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=a.guild)
+
+    resp = await client.get(
+        a.g("/exports/queue"),
+        headers=outsider.headers,
+        params={"queue_id": queue.id, "format": "json"},
+    )
+    assert resp.status_code == 404
+
+    from app.testing.factories import create_counter_group
+
+    group = await create_counter_group(
+        session, a.initiative, a.user, name="Secret counters"
+    )
+    resp = await client.get(
+        a.g("/exports/counter-group"),
+        headers=outsider.headers,
+        params={"counter_group_id": group.id, "format": "json"},
+    )
+    assert resp.status_code == 404

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -858,11 +858,18 @@ async def get_initiative_members(
         initiative_id=initiative_id,
         user_id=current_user.id,
     )
-    # A PAM / break-glass grantee has guild-wide read access but no membership
-    # row; let them load the member roster (used for assignee pickers and
-    # avatars). There is no standing ``data.bypass`` bypass — an admin/owner
-    # reaches this guild only via a grant, which surfaces as ``is_pam``.
-    if not membership and not guild_context.is_pam:
+    # A guild admin sees every initiative in their guild without holding a
+    # membership row (the same override the RLS admin leg grants), and a PAM /
+    # break-glass grantee has guild-wide read access but no membership row;
+    # both may load the member roster (used for assignee and linked-member
+    # pickers). There is no standing ``data.bypass`` bypass — a platform
+    # operator/owner reaches this guild only via a grant, which surfaces as
+    # ``is_pam``.
+    if (
+        not membership
+        and not guild_context.is_pam
+        and not rls_service.is_guild_admin(guild_context.role)
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=InitiativeMessages.NOT_A_MEMBER,

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -412,6 +412,35 @@ async def test_get_initiative_members(
 
 
 @pytest.mark.integration
+async def test_get_initiative_members_as_nonmember_guild_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A guild admin sees the roster of an initiative they never joined —
+    the same guild-admin override every other initiative read honors (they
+    already see the initiative's content via the RLS admin leg, and the
+    assignee / linked-member pickers need the roster). A plain guild member
+    outside the initiative stays locked out."""
+    creator = await acting_user(guild_role=GuildRole.member, initiative=True)
+    other_admin = await acting_user(guild_role=GuildRole.admin, guild=creator.guild)
+
+    response = await client.get(
+        other_admin.g(f"/initiatives/{creator.initiative.id}/members"),
+        headers=other_admin.headers,
+    )
+    assert response.status_code == 200
+    emails = {user["email"] for user in response.json()}
+    assert creator.user.email in emails
+
+    outsider = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
+    response = await client.get(
+        outsider.g(f"/initiatives/{creator.initiative.id}/members"),
+        headers=outsider.headers,
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "INITIATIVE_NOT_A_MEMBER"
+
+
+@pytest.mark.integration
 async def test_add_initiative_member_as_manager(
     client: AsyncClient, session: AsyncSession, acting_user
 ):

--- a/backend/app/services/export/adapters/__init__.py
+++ b/backend/app/services/export/adapters/__init__.py
@@ -2,13 +2,21 @@
 supports. Unsupported source×format combos are rejected centrally by
 ``engine.get_adapter``."""
 
+from app.services.export.adapters.counter_group import CounterGroupAdapter
 from app.services.export.adapters.document import DocumentAdapter
 from app.services.export.adapters.project import ProjectAdapter
+from app.services.export.adapters.queue import QueueAdapter
 from app.services.export.adapters.tasks_table import TasksTableAdapter
 
 ADAPTERS = {
     adapter.source: adapter
-    for adapter in (TasksTableAdapter(), ProjectAdapter(), DocumentAdapter())
+    for adapter in (
+        TasksTableAdapter(),
+        ProjectAdapter(),
+        DocumentAdapter(),
+        QueueAdapter(),
+        CounterGroupAdapter(),
+    )
 }
 
 __all__ = ["ADAPTERS"]

--- a/backend/app/services/export/adapters/counter_group.py
+++ b/backend/app/services/export/adapters/counter_group.py
@@ -1,0 +1,171 @@
+"""Counter-group source adapter: importable backup envelope (json) and a
+counter table (pdf/csv/xlsx/md).
+
+The json envelope round-trips the group's full configuration — every counter
+with its current value, bounds, step, initial value, view mode, color, and
+position — so an import can rebuild the group exactly.
+
+The report formats project the counters into the shared columns/rows payload:
+name and the numeric fields, in the group's display order. Numeric cells stay
+numbers (int when integral, float otherwise) so xlsx keeps them typed and the
+json envelope stays plain-JSON serializable (the render path's ``json.dumps``
+does not accept ``Decimal``).
+
+Access rule for every format: READ on the group (exporting is a formatted
+read), enforced by the ``get_counter_group_for_export`` seam at both count
+and build time, under the caller's RLS session.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import ExportMessages
+from app.models.platform.user import User
+from app.models.tenant.counter import Counter, CounterGroup
+from app.services.export.contract import RenderItem, RenderRequest
+from app.services.export.engine import ExportError
+from app.services.platform.csv_export import safe_filename_component
+
+_COLUMNS = (
+    {"key": "title", "label": "Counter", "width": "2fr"},
+    {"key": "count", "label": "Count"},
+    {"key": "min", "label": "Min"},
+    {"key": "max", "label": "Max"},
+    {"key": "step", "label": "Step"},
+)
+
+
+class CounterGroupAdapter:
+    source = "counter-group"
+    template_id = "data-table"
+    formats = frozenset({"json", "pdf", "csv", "xlsx", "md"})
+
+    async def count(
+        self,
+        session: AsyncSession,
+        *,
+        user: User,
+        guild_id: int,
+        params: dict,
+        format: str,
+    ) -> int:
+        group = await self._group(session, user, guild_id, params)
+        return len(group.counters)
+
+    async def build(
+        self,
+        session: AsyncSession,
+        *,
+        user: User,
+        guild_id: int,
+        params: dict,
+        format: str,
+    ) -> RenderRequest:
+        group = await self._group(session, user, guild_id, params)
+        # One clock read: the filename date and the subtitle timestamp must
+        # not straddle midnight into disagreeing dates.
+        now = datetime.now(timezone.utc)
+        date = now.strftime("%Y-%m-%d")
+        stem = safe_filename_component(group.name).lower()
+        if format == "json":
+            item = RenderItem(
+                key=f"{stem}-{date}.initiative-counter-group",
+                data=_envelope(group),
+            )
+        else:
+            item = RenderItem(
+                key=f"{stem}-{date}", data=_report_payload(group, user, now)
+            )
+        return RenderRequest(
+            guild_id=guild_id,
+            template_id=self.template_id,
+            format=format,
+            batch=(item,),
+        )
+
+    async def _group(
+        self, session: AsyncSession, user: User, guild_id: int, params: dict
+    ) -> CounterGroup:
+        from app.services.tenant.counters import get_counter_group_for_export
+
+        return await get_counter_group_for_export(
+            session, user, guild_id, group_id=_group_id(params)
+        )
+
+
+def _envelope(group: CounterGroup) -> dict[str, Any]:
+    return {
+        "kind": "initiative-counter-group",
+        "schema_version": 1,
+        "name": group.name,
+        "description": group.description,
+        "counters": [
+            {
+                "name": counter.name,
+                "color": counter.color,
+                "count": _number(counter.count),
+                "min": _number(counter.min),
+                "max": _number(counter.max),
+                "step": _number(counter.step),
+                "initial_count": _number(counter.initial_count),
+                "view_mode": counter.view_mode.value,
+                "position": _number(counter.position),
+            }
+            for counter in group.counters
+        ],
+    }
+
+
+def _report_payload(group: CounterGroup, user: User, now: datetime) -> dict[str, Any]:
+    counters = group.counters
+    generated_at = now.strftime("%Y-%m-%d %H:%M UTC")
+    # Both attribution fields can be absent (some OAuth-provisioned accounts
+    # carry neither) — never render the literal "None".
+    author = user.full_name or user.email or "unknown"
+    return {
+        "title": group.name,
+        "subtitle": (
+            f"{len(counters)} counter{'s' if len(counters) != 1 else ''}"
+            f" · generated {generated_at} by {author}"
+        ),
+        "footer": f"{group.name} — counters export",
+        "description": group.description or "",
+        "columns": [dict(c) for c in _COLUMNS],
+        "rows": [_row(counter) for counter in counters],
+    }
+
+
+def _row(counter: Counter) -> dict[str, Any]:
+    return {
+        "title": counter.name,
+        "count": _number(counter.count),
+        "min": _number(counter.min) if counter.min is not None else "",
+        "max": _number(counter.max) if counter.max is not None else "",
+        "step": _number(counter.step),
+    }
+
+
+def _number(value: Decimal | None) -> int | float | None:
+    """NUMERIC(20,10) comes back as ``Decimal`` — not JSON-serializable, and
+    ugly as text (``5.0000000000``). Integral values become int, the rest
+    float; counter values are user-clicked numbers, so float precision is a
+    non-issue."""
+    if value is None:
+        return None
+    decimal = value if isinstance(value, Decimal) else Decimal(str(value))
+    if decimal == decimal.to_integral_value():
+        return int(decimal)
+    return float(decimal)
+
+
+def _group_id(params: dict) -> int:
+    """The job row's params round-trip through JSON — validate, don't trust."""
+    try:
+        return int(params["counter_group_id"])
+    except (KeyError, TypeError, ValueError):
+        raise ExportError(ExportMessages.EXPORT_INVALID_PARAMS)

--- a/backend/app/services/export/adapters/queue.py
+++ b/backend/app/services/export/adapters/queue.py
@@ -1,0 +1,204 @@
+"""Queue source adapter: importable backup envelope (json) and turn-order
+reports (pdf/csv/xlsx/md).
+
+The json envelope round-trips the queue's own state — items with rotation
+order, colors, notes, visibility, and held/current markers, tags by name.
+Member assignments and linked documents/tasks ship as display text only
+(names and titles): they reference guild-local rows that won't exist wherever
+the envelope is imported, so an import can't rebind them.
+
+The report formats list every item in rotation order (position descending,
+matching the on-screen timeline) with hidden/held/current flagged in a status
+column, so the printout is the full queue, not just the visible rotation.
+Markdown renders as a numbered turn-order list rather than a table.
+
+Access rule for every format: READ on the queue (exporting is a formatted
+read), enforced by the ``get_queue_for_export`` seam at both count and build
+time, under the caller's RLS session.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import ExportMessages
+from app.models.platform.user import User
+from app.models.tenant.queue import Queue, QueueItem
+from app.services.export.contract import RenderItem, RenderRequest
+from app.services.export.engine import ExportError
+from app.services.platform.csv_export import safe_filename_component
+
+_COLUMNS = (
+    {"key": "order", "label": "#"},
+    {"key": "title", "label": "Item", "width": "2fr"},
+    {"key": "member", "label": "Member", "width": "1fr"},
+    {"key": "tags", "label": "Tags", "width": "1fr"},
+    {"key": "notes", "label": "Notes", "width": "2fr"},
+    {"key": "status", "label": "Status"},
+)
+
+
+class QueueAdapter:
+    source = "queue"
+    template_id = "data-table"
+    formats = frozenset({"json", "pdf", "csv", "xlsx", "md"})
+
+    async def count(
+        self,
+        session: AsyncSession,
+        *,
+        user: User,
+        guild_id: int,
+        params: dict,
+        format: str,
+    ) -> int:
+        queue = await self._queue(session, user, guild_id, params)
+        return len(queue.items)
+
+    async def build(
+        self,
+        session: AsyncSession,
+        *,
+        user: User,
+        guild_id: int,
+        params: dict,
+        format: str,
+    ) -> RenderRequest:
+        queue = await self._queue(session, user, guild_id, params)
+        items = _rotation_order(queue.items)
+        # One clock read: the filename date and the subtitle timestamp must
+        # not straddle midnight into disagreeing dates.
+        now = datetime.now(timezone.utc)
+        date = now.strftime("%Y-%m-%d")
+        stem = safe_filename_component(queue.name).lower()
+        if format == "json":
+            item = RenderItem(
+                key=f"{stem}-{date}.initiative-queue",
+                data=_envelope(queue, items),
+            )
+        else:
+            item = RenderItem(
+                key=f"{stem}-{date}", data=_report_payload(queue, items, user, now)
+            )
+        return RenderRequest(
+            guild_id=guild_id,
+            template_id=self.template_id,
+            format=format,
+            batch=(item,),
+        )
+
+    async def _queue(
+        self, session: AsyncSession, user: User, guild_id: int, params: dict
+    ) -> Queue:
+        from app.services.tenant.queues import get_queue_for_export
+
+        return await get_queue_for_export(
+            session, user, guild_id, queue_id=_queue_id(params)
+        )
+
+
+def _rotation_order(items: list[QueueItem]) -> list[QueueItem]:
+    """Position descending — the rotation's acting order (see
+    ``queues.py:_visible_items_desc``), with id as the deterministic
+    tiebreaker the timeline also uses."""
+    return sorted(items, key=lambda i: (-i.position, i.id or 0))
+
+
+def _envelope(queue: Queue, items: list[QueueItem]) -> dict[str, Any]:
+    return {
+        "kind": "initiative-queue",
+        "schema_version": 1,
+        "name": queue.name,
+        "description": queue.description,
+        "is_active": queue.is_active,
+        "current_round": queue.current_round,
+        "items": [
+            {
+                "label": item.label,
+                "position": item.position,
+                "color": item.color,
+                "notes": item.notes,
+                "is_visible": item.is_visible,
+                "held_at_round": item.held_at_round,
+                "is_current": item.id == queue.current_item_id,
+                # Informational only: user/document/task ids are guild-local,
+                # so an import can't rebind them — names and titles it is.
+                "member": _member(item),
+                "tags": _tags(item),
+                "documents": sorted(
+                    link.document.title
+                    for link in item.document_links
+                    if link.document is not None
+                ),
+                "tasks": sorted(
+                    link.task.title for link in item.task_links if link.task is not None
+                ),
+            }
+            for item in items
+        ],
+    }
+
+
+def _report_payload(
+    queue: Queue, items: list[QueueItem], user: User, now: datetime
+) -> dict[str, Any]:
+    generated_at = now.strftime("%Y-%m-%d %H:%M UTC")
+    # Both attribution fields can be absent (some OAuth-provisioned accounts
+    # carry neither) — never render the literal "None".
+    author = user.full_name or user.email or "unknown"
+    round_part = f" · round {queue.current_round}" if queue.is_active else ""
+    return {
+        "title": queue.name,
+        "subtitle": (
+            f"{len(items)} item{'s' if len(items) != 1 else ''}{round_part}"
+            f" · generated {generated_at} by {author}"
+        ),
+        "footer": f"{queue.name} — queue export",
+        "description": queue.description or "",
+        # Markdown renders the rotation as a numbered turn-order list; the
+        # other formats consume the columns/rows table.
+        "layout": "numbered",
+        "columns": [dict(c) for c in _COLUMNS],
+        "rows": [_row(queue, item, order) for order, item in enumerate(items, 1)],
+    }
+
+
+def _row(queue: Queue, item: QueueItem, order: int) -> dict[str, Any]:
+    flags = []
+    if item.id == queue.current_item_id:
+        flags.append("Current")
+    if item.held_at_round is not None:
+        flags.append("Held")
+    if not item.is_visible:
+        flags.append("Hidden")
+    return {
+        "order": order,
+        "title": item.label,
+        "member": _member(item) or "",
+        "tags": ", ".join(_tags(item)),
+        "notes": item.notes or "",
+        "status": ", ".join(flags),
+        # Not a projected column: drives the numbered layout's current marker.
+        "current": item.id == queue.current_item_id,
+    }
+
+
+def _member(item: QueueItem) -> str | None:
+    if item.user is None:
+        return None
+    return item.user.full_name or item.user.email or None
+
+
+def _tags(item: QueueItem) -> list[str]:
+    return sorted(link.tag.name for link in item.tag_links if link.tag is not None)
+
+
+def _queue_id(params: dict) -> int:
+    """The job row's params round-trip through JSON — validate, don't trust."""
+    try:
+        return int(params["queue_id"])
+    except (KeyError, TypeError, ValueError):
+        raise ExportError(ExportMessages.EXPORT_INVALID_PARAMS)

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -308,3 +308,109 @@ async def test_tabular_formats_skip_template_resolution():
     )
     artifacts = await LocalRenderBackend().render(req)
     assert artifacts[0].content_type.startswith("text/csv")
+
+
+async def test_renders_markdown_numbered_layout():
+    """layout=numbered renders an ordered turn-order list — details from the
+    non-title columns, the ``current`` row bolded, ``order`` never doubled
+    into the detail trail."""
+    artifacts = await LocalRenderBackend().render(
+        _request(
+            format="md",
+            layout="numbered",
+            columns=[
+                {"key": "order", "label": "#"},
+                {"key": "title", "label": "Item"},
+                {"key": "status", "label": "Status"},
+            ],
+            rows=[
+                {
+                    "order": 1,
+                    "title": "Alice | piped",
+                    "status": "Current",
+                    "current": True,
+                },
+                {"order": 2, "title": "Bob", "status": ""},
+                {"order": 3, "title": "", "status": "Hidden"},
+            ],
+        )
+    )
+    text = artifacts[0].content.decode("utf-8")
+    lines = text.splitlines()
+    assert "1. **Alice \\| piped** (Current)" in lines
+    assert "2. Bob" in lines
+    assert "3. (untitled) (Hidden)" in lines
+    assert not any("---" in line for line in lines)  # no table separator
+
+
+async def test_data_table_template_renders_payload_columns():
+    """The generic template's whole point: the column set (labels, order,
+    numeric cells) comes from the payload, no bespoke .typ per source."""
+    import io
+
+    from pypdf import PdfReader
+
+    request = RenderRequest(
+        guild_id=1,
+        template_id="data-table",
+        format="pdf",
+        batch=(
+            RenderItem(
+                key="counters",
+                data={
+                    "title": "Party Resources",
+                    "subtitle": "unit test",
+                    "footer": "counters export",
+                    "description": "Session 12 snapshot",
+                    "columns": [
+                        {"key": "title", "label": "Counter", "width": "2fr"},
+                        {"key": "count", "label": "Count"},
+                        {"key": "max", "label": "Max"},
+                    ],
+                    "rows": [
+                        {"title": "Torches", "count": 5, "max": 10},
+                        {"title": "Rations", "count": 2.5, "max": ""},
+                    ],
+                },
+            ),
+        ),
+    )
+    artifacts = await LocalRenderBackend().render(request)
+    assert artifacts[0].content.startswith(b"%PDF")
+    text = PdfReader(io.BytesIO(artifacts[0].content)).pages[0].extract_text()
+    assert "Party Resources" in text
+    assert "Session 12 snapshot" in text
+    assert "Counter" in text and "Torches" in text
+    assert "2.5" in text  # numeric cells render as text
+
+
+async def test_data_table_template_survives_hostile_text_and_empty_rows():
+    """sys.inputs guard holds for the generic template too: Typst markup in
+    user strings stays data, and zero rows still compile."""
+    hostile = RenderRequest(
+        guild_id=1,
+        template_id="data-table",
+        format="pdf",
+        batch=(
+            RenderItem(
+                key="q",
+                data={
+                    "title": '#import "x.typ"; *bold* [',
+                    "description": "#eval(1+1) ]] $ broken math",
+                    "columns": [{"key": "title", "label": "*"}],
+                    "rows": [{"title": "#sys.inputs ["}],
+                },
+            ),
+        ),
+    )
+    artifacts = await LocalRenderBackend().render(hostile)
+    assert artifacts[0].content.startswith(b"%PDF")
+
+    empty = RenderRequest(
+        guild_id=1,
+        template_id="data-table",
+        format="pdf",
+        batch=(RenderItem(key="q", data={"title": "T", "columns": [], "rows": []}),),
+    )
+    artifacts = await LocalRenderBackend().render(empty)
+    assert artifacts[0].content.startswith(b"%PDF")

--- a/backend/app/services/export/local_backend_test.py
+++ b/backend/app/services/export/local_backend_test.py
@@ -321,17 +321,22 @@ async def test_renders_markdown_numbered_layout():
             columns=[
                 {"key": "order", "label": "#"},
                 {"key": "title", "label": "Item"},
+                {"key": "member", "label": "Member"},
                 {"key": "status", "label": "Status"},
             ],
             rows=[
+                # member=None must be skipped BEFORE stringifying — str(None)
+                # passes a truthiness guard, and its empty rendering would
+                # smuggle a spurious "( · Current)" into the detail trail.
                 {
                     "order": 1,
                     "title": "Alice | piped",
+                    "member": None,
                     "status": "Current",
                     "current": True,
                 },
-                {"order": 2, "title": "Bob", "status": ""},
-                {"order": 3, "title": "", "status": "Hidden"},
+                {"order": 2, "title": "Bob", "member": "", "status": ""},
+                {"order": 3, "title": "", "member": None, "status": "Hidden"},
             ],
         )
     )

--- a/backend/app/services/export/tabular.py
+++ b/backend/app/services/export/tabular.py
@@ -96,6 +96,17 @@ def _md_table(item: RenderItem) -> list[str]:
     return lines
 
 
+def _md_details(row: dict, detail_keys: list[str]) -> str:
+    """The parenthesized detail trail shared by the list layouts. ``None``
+    must be skipped BEFORE stringifying — ``str(None)`` is truthy, and
+    ``_md_cell(None)`` returns ``""``, so a None value would otherwise smuggle
+    an empty segment (and its spurious ``·`` separator) into the join."""
+    values = (row.get(key) for key in detail_keys)
+    return " · ".join(
+        _md_cell(value) for value in values if value is not None and str(value).strip()
+    )
+
+
 def _md_checklist(item: RenderItem) -> list[str]:
     """GitHub-style task list: one checkbox item per row, checked when the
     row's ``done`` flag is set, with the non-title columns as a detail trail."""
@@ -105,9 +116,7 @@ def _md_checklist(item: RenderItem) -> list[str]:
     for row in item.data.get("rows") or []:
         box = "x" if row.get("done") else " "
         title = _md_cell(row.get("title", "")) or "(untitled)"
-        details = " · ".join(
-            _md_cell(row[key]) for key in detail_keys if str(row.get(key, "")).strip()
-        )
+        details = _md_details(row, detail_keys)
         lines.append(f"- [{box}] {title}" + (f" ({details})" if details else ""))
     return lines
 
@@ -123,9 +132,7 @@ def _md_numbered(item: RenderItem) -> list[str]:
         title = _md_cell(row.get("title", "")) or "(untitled)"
         if row.get("current"):
             title = f"**{title}**"
-        details = " · ".join(
-            _md_cell(row[key]) for key in detail_keys if str(row.get(key, "")).strip()
-        )
+        details = _md_details(row, detail_keys)
         lines.append(f"{order}. {title}" + (f" ({details})" if details else ""))
     return lines
 

--- a/backend/app/services/export/tabular.py
+++ b/backend/app/services/export/tabular.py
@@ -66,6 +66,8 @@ def render_md(item: RenderItem) -> bytes:
         lines.append(f"<{item.data.get('url', '')}>")
     elif layout == "checklist":
         lines.extend(_md_checklist(item))
+    elif layout == "numbered":
+        lines.extend(_md_numbered(item))
     else:
         lines.extend(_md_table(item))
     lines.append("")
@@ -107,6 +109,24 @@ def _md_checklist(item: RenderItem) -> list[str]:
             _md_cell(row[key]) for key in detail_keys if str(row.get(key, "")).strip()
         )
         lines.append(f"- [{box}] {title}" + (f" ({details})" if details else ""))
+    return lines
+
+
+def _md_numbered(item: RenderItem) -> list[str]:
+    """Ordered list: one numbered entry per row (a queue's turn order), with
+    the non-title columns as a detail trail. The row driving the rotation
+    (``current`` flag) renders bold."""
+    columns = item.data.get("columns") or []
+    detail_keys = [c["key"] for c in columns if c["key"] not in ("title", "order")]
+    lines: list[str] = []
+    for order, row in enumerate(item.data.get("rows") or [], start=1):
+        title = _md_cell(row.get("title", "")) or "(untitled)"
+        if row.get("current"):
+            title = f"**{title}**"
+        details = " · ".join(
+            _md_cell(row[key]) for key in detail_keys if str(row.get(key, "")).strip()
+        )
+        lines.append(f"{order}. {title}" + (f" ({details})" if details else ""))
     return lines
 
 

--- a/backend/app/services/export/templates/data-table.typ
+++ b/backend/app/services/export/templates/data-table.typ
@@ -1,0 +1,60 @@
+// Generic data-table export template: unlike task-table/project-report the
+// column set comes from the payload (key/label, optional width hint), so any
+// source with a columns/rows payload renders without a bespoke template.
+// All data arrives as ONE json string via sys.inputs (never interpolated
+// into this source) — user text stays data.
+#let payload = json(bytes(sys.inputs.at("data", default: "{}")))
+#let cols = payload.at("columns", default: ())
+#let rows = payload.at("rows", default: ())
+#let description = payload.at("description", default: "")
+
+#set page(
+  paper: "a4",
+  margin: (x: 1.5cm, y: 1.8cm),
+  footer: context {
+    set text(size: 8pt, fill: luma(120))
+    grid(
+      columns: (1fr, auto),
+      payload.at("footer", default: ""),
+      counter(page).display("1 of 1", both: true),
+    )
+  },
+)
+#set text(size: 9pt)
+
+#text(size: 16pt, weight: "bold", payload.at("title", default: "Export"))
+#v(2pt)
+#text(size: 9pt, fill: luma(100), payload.at("subtitle", default: ""))
+#v(6pt)
+
+#if description != "" [
+  #block(
+    inset: (x: 8pt, y: 6pt),
+    fill: luma(248),
+    radius: 3pt,
+    width: 100%,
+    text(size: 9pt, description),
+  )
+  #v(8pt)
+]
+
+// Width hints are a closed vocabulary (payload-controlled, so no arbitrary
+// track expressions); unknown values fall back to auto.
+#let track(w) = if w == "2fr" { 2fr } else if w == "1fr" { 1fr } else { auto }
+// Cells can be numbers (counter values, rotation order) — render as text.
+#let cell(v) = if v == none { "" } else { str(v) }
+
+#if rows.len() == 0 [
+  _Nothing to export._
+] else [
+  #table(
+    columns: cols.map(c => track(c.at("width", default: "auto"))),
+    inset: (x: 6pt, y: 5pt),
+    stroke: none,
+    fill: (_, y) => if y == 0 { luma(230) } else if calc.odd(y) { luma(247) } else { white },
+    table.header(..cols.map(c => strong(cell(c.at("label", default: ""))))),
+    ..rows
+      .map(r => cols.map(c => cell(r.at(c.at("key", default: ""), default: ""))))
+      .flatten()
+  )
+]

--- a/backend/app/services/tenant/counters.py
+++ b/backend/app/services/tenant/counters.py
@@ -52,6 +52,7 @@ def require_counter_group_access(
     *,
     access: str = "read",
     require_owner: bool = False,
+    guild_role: str | None = None,
 ) -> None:
     require_access(
         DAC_RESOURCES["counter_group"],
@@ -59,6 +60,7 @@ def require_counter_group_access(
         user,
         access=access,
         require_owner=require_owner,
+        guild_role=guild_role,
     )
 
 
@@ -86,6 +88,46 @@ async def get_counter_group(
         stmt = stmt.execution_options(populate_existing=True)
     result = await session.exec(stmt)
     return result.one_or_none()
+
+
+async def get_counter_group_for_export(
+    session: AsyncSession,
+    current_user: User,
+    guild_id: int,
+    *,
+    group_id: int,
+) -> CounterGroup:
+    """The counter-export adapter's seam: fetch + authorize in one place so
+    the rule holds on the worker's render-time replay too. READ access
+    suffices — exporting is a formatted read. The guild role is resolved here
+    rather than taken from a request context, so the seam works
+    transport-free."""
+    from fastapi import HTTPException, status as http_status
+
+    from app.core.messages import CounterMessages
+    from app.services.platform import guilds as guilds_service
+
+    group = await get_counter_group(session, group_id)
+    if group is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=CounterMessages.GROUP_NOT_FOUND,
+        )
+    if group.initiative is not None and not group.initiative.counter_groups_enabled:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail=CounterMessages.FEATURE_DISABLED,
+        )
+    membership = await guilds_service.get_membership(
+        session, guild_id=guild_id, user_id=current_user.id
+    )
+    require_counter_group_access(
+        group,
+        current_user,
+        access="read",
+        guild_role=membership.role if membership else None,
+    )
+    return group
 
 
 async def get_counter(

--- a/backend/app/services/tenant/queues.py
+++ b/backend/app/services/tenant/queues.py
@@ -65,6 +65,7 @@ def require_queue_access(
     *,
     access: str = "read",
     require_owner: bool = False,
+    guild_role: str | None = None,
 ) -> None:
     require_access(
         DAC_RESOURCES["queue"],
@@ -72,6 +73,7 @@ def require_queue_access(
         user,
         access=access,
         require_owner=require_owner,
+        guild_role=guild_role,
     )
 
 
@@ -109,6 +111,42 @@ async def get_queue(
         stmt = stmt.execution_options(populate_existing=True)
     result = await session.exec(stmt)
     return result.one_or_none()
+
+
+async def get_queue_for_export(
+    session: AsyncSession,
+    current_user: User,
+    guild_id: int,
+    *,
+    queue_id: int,
+) -> Queue:
+    """The queue-export adapter's seam: fetch + authorize in one place so the
+    rule holds on the worker's render-time replay too. READ access suffices —
+    exporting is a formatted read. The guild role is resolved here rather than
+    taken from a request context, so the seam works transport-free."""
+    from app.services.platform import guilds as guilds_service
+
+    queue = await get_queue(session, queue_id)
+    if queue is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=QueueMessages.NOT_FOUND,
+        )
+    if queue.initiative is not None and not queue.initiative.queues_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=QueueMessages.FEATURE_DISABLED,
+        )
+    membership = await guilds_service.get_membership(
+        session, guild_id=guild_id, user_id=current_user.id
+    )
+    require_queue_access(
+        queue,
+        current_user,
+        access="read",
+        guild_role=membership.role if membership else None,
+    )
+    return queue
 
 
 async def get_queue_item(

--- a/frontend/src/api/generated/exports/exports.ts
+++ b/frontend/src/api/generated/exports/exports.ts
@@ -18,9 +18,11 @@ import type {
 } from "@tanstack/react-query";
 
 import type {
+  ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams,
   ExportDocumentApiV1GGuildIdExportsDocumentGetParams,
   ExportJobRead,
   ExportProjectApiV1GGuildIdExportsProjectGetParams,
+  ExportQueueApiV1GGuildIdExportsQueueGetParams,
   ExportTasksApiV1GGuildIdExportsTasksGetParams,
   HTTPValidationError,
 } from "../initiativeAPI.schemas";
@@ -549,6 +551,361 @@ export function useExportDocumentApiV1GGuildIdExportsDocumentGet<
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getExportDocumentApiV1GGuildIdExportsDocumentGetQueryOptions(
+    guildId,
+    params,
+    options
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * Export a queue: ``json`` is an importable envelope (items, rotation
+ * state, tags by name — member assignments are informational and linked
+ * documents/tasks are omitted); ``pdf``/``csv``/``xlsx`` render the turn
+ * order as a table and ``md`` as a numbered list. Read access suffices.
+ * Small queues return the file inline; large ones return ``202`` with a
+ * queued job to poll and download.
+ * @summary Export Queue
+ */
+export const exportQueueApiV1GGuildIdExportsQueueGet = (
+  guildId: number,
+  params: ExportQueueApiV1GGuildIdExportsQueueGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<unknown>(
+    { url: `/api/v1/g/${guildId}/exports/queue`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getExportQueueApiV1GGuildIdExportsQueueGetQueryKey = (
+  guildId: number,
+  params?: ExportQueueApiV1GGuildIdExportsQueueGetParams
+) => {
+  return [`/api/v1/g/${guildId}/exports/queue`, ...(params ? [params] : [])] as const;
+};
+
+export const getExportQueueApiV1GGuildIdExportsQueueGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportQueueApiV1GGuildIdExportsQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getExportQueueApiV1GGuildIdExportsQueueGetQueryKey(guildId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>
+  > = ({ signal }) =>
+    exportQueueApiV1GGuildIdExportsQueueGet(guildId, params, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: guildId !== null && guildId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ExportQueueApiV1GGuildIdExportsQueueGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>
+>;
+export type ExportQueueApiV1GGuildIdExportsQueueGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useExportQueueApiV1GGuildIdExportsQueueGet<
+  TData = Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportQueueApiV1GGuildIdExportsQueueGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+          TError,
+          Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useExportQueueApiV1GGuildIdExportsQueueGet<
+  TData = Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportQueueApiV1GGuildIdExportsQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+          TError,
+          Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useExportQueueApiV1GGuildIdExportsQueueGet<
+  TData = Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportQueueApiV1GGuildIdExportsQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Export Queue
+ */
+
+export function useExportQueueApiV1GGuildIdExportsQueueGet<
+  TData = Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportQueueApiV1GGuildIdExportsQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportQueueApiV1GGuildIdExportsQueueGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getExportQueueApiV1GGuildIdExportsQueueGetQueryOptions(
+    guildId,
+    params,
+    options
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * Export a counter group: ``json`` is an importable envelope (every
+ * counter's configuration and current value); ``pdf``/``csv``/``xlsx``/
+ * ``md`` render the counters as a table. Read access suffices. Small groups
+ * return the file inline; large ones return ``202`` with a queued job to
+ * poll and download.
+ * @summary Export Counter Group
+ */
+export const exportCounterGroupApiV1GGuildIdExportsCounterGroupGet = (
+  guildId: number,
+  params: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<unknown>(
+    { url: `/api/v1/g/${guildId}/exports/counter-group`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getExportCounterGroupApiV1GGuildIdExportsCounterGroupGetQueryKey = (
+  guildId: number,
+  params?: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams
+) => {
+  return [`/api/v1/g/${guildId}/exports/counter-group`, ...(params ? [params] : [])] as const;
+};
+
+export const getExportCounterGroupApiV1GGuildIdExportsCounterGroupGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getExportCounterGroupApiV1GGuildIdExportsCounterGroupGetQueryKey(guildId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>
+  > = ({ signal }) =>
+    exportCounterGroupApiV1GGuildIdExportsCounterGroupGet(guildId, params, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: guildId !== null && guildId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>
+>;
+export type ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useExportCounterGroupApiV1GGuildIdExportsCounterGroupGet<
+  TData = Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+          TError,
+          Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useExportCounterGroupApiV1GGuildIdExportsCounterGroupGet<
+  TData = Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+          TError,
+          Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useExportCounterGroupApiV1GGuildIdExportsCounterGroupGet<
+  TData = Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Export Counter Group
+ */
+
+export function useExportCounterGroupApiV1GGuildIdExportsCounterGroupGet<
+  TData = Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof exportCounterGroupApiV1GGuildIdExportsCounterGroupGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getExportCounterGroupApiV1GGuildIdExportsCounterGroupGetQueryOptions(
     guildId,
     params,
     options

--- a/frontend/src/api/generated/exports/exports.ts
+++ b/frontend/src/api/generated/exports/exports.ts
@@ -565,9 +565,9 @@ export function useExportDocumentApiV1GGuildIdExportsDocumentGet<
 
 /**
  * Export a queue: ``json`` is an importable envelope (items, rotation
- * state, tags by name — member assignments are informational and linked
- * documents/tasks are omitted); ``pdf``/``csv``/``xlsx`` render the turn
- * order as a table and ``md`` as a numbered list. Read access suffices.
+ * state, tags by name — member assignments and linked documents/tasks ride
+ * along as display text); ``pdf``/``csv``/``xlsx`` render the turn order as
+ * a table and ``md`` as a numbered list. Read access suffices.
  * Small queues return the file inline; large ones return ``202`` with a
  * queued job to poll and download.
  * @summary Export Queue

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3989,6 +3989,38 @@ export const ExportDocumentApiV1GGuildIdExportsDocumentGetFormat = {
   docx: "docx",
 } as const;
 
+export type ExportQueueApiV1GGuildIdExportsQueueGetParams = {
+  queue_id: number;
+  format?: ExportQueueApiV1GGuildIdExportsQueueGetFormat;
+};
+
+export type ExportQueueApiV1GGuildIdExportsQueueGetFormat =
+  (typeof ExportQueueApiV1GGuildIdExportsQueueGetFormat)[keyof typeof ExportQueueApiV1GGuildIdExportsQueueGetFormat];
+
+export const ExportQueueApiV1GGuildIdExportsQueueGetFormat = {
+  json: "json",
+  pdf: "pdf",
+  csv: "csv",
+  xlsx: "xlsx",
+  md: "md",
+} as const;
+
+export type ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetParams = {
+  counter_group_id: number;
+  format?: ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetFormat;
+};
+
+export type ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetFormat =
+  (typeof ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetFormat)[keyof typeof ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetFormat];
+
+export const ExportCounterGroupApiV1GGuildIdExportsCounterGroupGetFormat = {
+  json: "json",
+  pdf: "pdf",
+  csv: "csv",
+  xlsx: "xlsx",
+  md: "md",
+} as const;
+
 export type ListQueuesApiV1GGuildIdQueuesGetParams = {
   initiative_id?: number | null;
   /**

--- a/frontend/src/components/documents/DocumentExportMenu.tsx
+++ b/frontend/src/components/documents/DocumentExportMenu.tsx
@@ -6,6 +6,7 @@ import type { WhiteboardScene } from "@/components/documents/WhiteboardDocumentE
 import { ExportButton, type ExportFormatOption } from "@/components/exports/ExportButton";
 import { toast } from "@/lib/chesterToast";
 import { downloadBlob } from "@/lib/csv";
+import { exportFilenameStem } from "@/lib/exportDownload";
 
 interface DocumentExportMenuProps {
   documentId: number;
@@ -16,13 +17,6 @@ interface DocumentExportMenuProps {
    * produced in the browser while the engine handles the importable JSON. */
   whiteboardScene?: WhiteboardScene;
 }
-
-const safeFilename = (name: string): string =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 60) || "document";
 
 // Engine formats per document type — mirrors the backend adapter's rules.
 const TYPE_FORMATS: Record<DocumentReadDocumentType, ExportFormatOption[]> = {
@@ -50,8 +44,7 @@ export function DocumentExportMenu({
   whiteboardScene,
 }: DocumentExportMenuProps) {
   const { t } = useTranslation("tasks");
-  const date = new Date().toISOString().slice(0, 10);
-  const stem = `${safeFilename(title)}-${date}`;
+  const stem = exportFilenameStem(title, "document");
   // Engine entries are debounced by ExportButton's busy state; the
   // client-side renders need their own in-flight guard.
   const sceneExporting = useRef(false);

--- a/frontend/src/components/exports/ExportButton.tsx
+++ b/frontend/src/components/exports/ExportButton.tsx
@@ -176,8 +176,8 @@ export function ExportButton({
       onClick={menuMode ? undefined : () => void handleExport(formats[0])}
     >
       {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
-      <span className="hidden sm:ml-2 sm:inline">{busy ? t("export.preparing") : idleLabel}</span>
-      {withChevron && !busy && <ChevronDown className="ml-1 h-3 w-3 opacity-60" />}
+      <span className="hidden sm:inline">{busy ? t("export.preparing") : idleLabel}</span>
+      {withChevron && !busy && <ChevronDown className="h-3 w-3 opacity-60" />}
     </Button>
   );
 

--- a/frontend/src/lib/exportDownload.test.ts
+++ b/frontend/src/lib/exportDownload.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { exportFilenameStem, filenameFromDisposition } from "./exportDownload";
+
+describe("exportFilenameStem", () => {
+  it("slugifies the resource name and appends the date", () => {
+    const stem = exportFilenameStem("Battle Order: Round 2!", "queue");
+    expect(stem).toMatch(/^battle-order-round-2-\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("falls back when the name has no usable characters", () => {
+    expect(exportFilenameStem("???", "queue")).toMatch(/^queue-\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("caps runaway names at 60 slug characters", () => {
+    const stem = exportFilenameStem("x".repeat(200), "queue");
+    const [slug] = stem.split(/-\d{4}-\d{2}-\d{2}$/);
+    expect(slug).toHaveLength(60);
+  });
+});
+
+describe("filenameFromDisposition", () => {
+  it("prefers the RFC 5987 form and decodes it", () => {
+    expect(
+      filenameFromDisposition(
+        "attachment; filename=\"fallback.json\"; filename*=utf-8''party%20resources.initiative-counter-group.json"
+      )
+    ).toBe("party resources.initiative-counter-group.json");
+  });
+
+  it("reads the plain quoted form", () => {
+    expect(filenameFromDisposition('attachment; filename="rotation.initiative-queue.json"')).toBe(
+      "rotation.initiative-queue.json"
+    );
+  });
+
+  it("returns null when absent", () => {
+    expect(filenameFromDisposition(undefined)).toBeNull();
+  });
+});

--- a/frontend/src/lib/exportDownload.ts
+++ b/frontend/src/lib/exportDownload.ts
@@ -24,6 +24,19 @@ export function filenameFromDisposition(header: string | undefined): string | nu
   return plain ? plain[1] : null;
 }
 
+/** Client-side fallback stem for export downloads: the slugified resource
+ * name plus today's date, mirroring the server's naming convention. Only a
+ * fallback — the server's Content-Disposition name wins when present. */
+export function exportFilenameStem(name: string, fallback: string): string {
+  const slug =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || fallback;
+  return `${slug}-${new Date().toISOString().slice(0, 10)}`;
+}
+
 /** Axios error bodies arrive as Blobs under responseType "blob"; recover the
  * JSON detail so getErrorMessage can map it to a localized message. */
 export async function normalizeBlobError(err: unknown): Promise<unknown> {

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
@@ -27,6 +27,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { CounterRead } from "@/api/generated/initiativeAPI.schemas";
+import { ExportButton, type ExportFormatOption } from "@/components/exports/ExportButton";
 import { CounterFormDialog } from "@/components/initiativeTools/counters/CounterFormDialog";
 import { type CounterLayout, CounterRow } from "@/components/initiativeTools/counters/CounterRow";
 import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
@@ -51,7 +52,18 @@ import {
 } from "@/hooks/useCounters";
 import { useRecordRecentView } from "@/hooks/useRecents";
 import { useViewPreference } from "@/hooks/useViewPreference";
+import { exportFilenameStem } from "@/lib/exportDownload";
 import { useGuildPath } from "@/lib/guildUrl";
+
+// Mirrors the backend counter-group adapter: table reports plus the
+// importable JSON envelope.
+const COUNTER_EXPORT_FORMATS: ExportFormatOption[] = [
+  { format: "pdf", labelKey: "export.formatPdf" },
+  { format: "csv", labelKey: "export.formatCsv" },
+  { format: "xlsx", labelKey: "export.formatXlsx" },
+  { format: "md", labelKey: "export.formatMd" },
+  { format: "json", labelKey: "export.formatJson" },
+];
 
 const layoutStorageKey = (groupId: number) => `counter-group-${groupId}-layout`;
 
@@ -200,9 +212,15 @@ export function CounterGroupDetailPage() {
           )}
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <ExportButton
+            endpoint="/exports/counter-group"
+            params={{ counter_group_id: group.id }}
+            formats={COUNTER_EXPORT_FORMATS}
+            filenameStem={exportFilenameStem(group.name, "counters")}
+          />
           <Button
             variant="outline"
-            size="icon"
+            size="icon-sm"
             onClick={toggleLayout}
             aria-label={
               layout === "row"
@@ -219,14 +237,14 @@ export function CounterGroupDetailPage() {
           </Button>
           {canWrite && (
             <>
-              <Button variant="outline" onClick={() => setAddOpen(true)}>
+              <Button variant="outline" size="sm" onClick={() => setAddOpen(true)}>
                 <Plus className="h-4 w-4" />
                 {t("addCounter")}
               </Button>
               {counters.length > 1 && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="outline" disabled={sortCounters.isPending}>
+                    <Button variant="outline" size="sm" disabled={sortCounters.isPending}>
                       <ArrowDownUp className="h-4 w-4" />
                       {t("sort")}
                     </Button>
@@ -257,6 +275,7 @@ export function CounterGroupDetailPage() {
               )}
               <Button
                 variant="outline"
+                size="sm"
                 onClick={() => setResetAllOpen(true)}
                 disabled={counters.length === 0 || resetAll.isPending}
               >
@@ -268,6 +287,7 @@ export function CounterGroupDetailPage() {
           {canManage && (
             <Button
               variant="outline"
+              size="sm"
               onClick={() => router.navigate({ to: gp(`/counter-groups/${group.id}/settings`) })}
             >
               <Settings className="h-4 w-4" />

--- a/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
@@ -1,9 +1,10 @@
-import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { Loader2, Plus, SearchX, Settings, ShieldAlert, Trash2 } from "lucide-react";
+import { Link, useParams } from "@tanstack/react-router";
+import { Loader2, Plus, SearchX, Settings, ShieldAlert } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { QueueItemRead } from "@/api/generated/initiativeAPI.schemas";
+import { ExportButton, type ExportFormatOption } from "@/components/exports/ExportButton";
 import { ActHeldButton } from "@/components/initiativeTools/queues/ActHeldButton";
 import { AddQueueItemDialog } from "@/components/initiativeTools/queues/AddQueueItemDialog";
 import { EditQueueItemDialog } from "@/components/initiativeTools/queues/EditQueueItemDialog";
@@ -24,13 +25,11 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useQueueRealtime } from "@/hooks/useQueueRealtime";
 import {
   useAdvanceTurn,
-  useDeleteQueue,
   useHoldCurrent,
   usePreviousTurn,
   useQueue,
@@ -45,13 +44,23 @@ import { useQueueView } from "@/hooks/useQueueView";
 import { useRecordRecentView } from "@/hooks/useRecents";
 import { toast } from "@/lib/chesterToast";
 import { getHttpStatus } from "@/lib/errorMessage";
+import { exportFilenameStem } from "@/lib/exportDownload";
 import { useGuildPath } from "@/lib/guildUrl";
+
+// Mirrors the backend queue adapter: reports as pdf/csv/xlsx, Markdown as a
+// numbered turn-order list, and the importable JSON envelope.
+const QUEUE_EXPORT_FORMATS: ExportFormatOption[] = [
+  { format: "pdf", labelKey: "export.formatPdf" },
+  { format: "csv", labelKey: "export.formatCsv" },
+  { format: "xlsx", labelKey: "export.formatXlsx" },
+  { format: "md", labelKey: "export.formatMarkdown" },
+  { format: "json", labelKey: "export.formatJson" },
+];
 
 export function QueueDetailPage() {
   const { t } = useTranslation(["queues", "common"]);
   const { guildId, queueId } = useParams({ strict: false }) as { guildId: string; queueId: string };
   const parsedId = Number(queueId);
-  const navigate = useNavigate();
   const gp = useGuildPath();
 
   const queueQuery = useQueue(Number.isFinite(parsedId) ? parsedId : null);
@@ -105,15 +114,6 @@ export function QueueDetailPage() {
     }
     updateQueue.mutate({ name: trimmed });
   };
-
-  // Delete queue
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-  const deleteQueue = useDeleteQueue({
-    onSuccess: () => {
-      toast.success(t("queueDeleted"));
-      void navigate({ to: gp("/queues") });
-    },
-  });
 
   // Turn controls
   const startQueue = useStartQueue(parsedId, {
@@ -236,21 +236,21 @@ export function QueueDetailPage() {
           <Badge variant={queue.is_active ? "default" : "secondary"}>
             {queue.is_active ? t("active") : t("inactive")}
           </Badge>
+          <ExportButton
+            endpoint="/exports/queue"
+            params={{ queue_id: queue.id }}
+            formats={QUEUE_EXPORT_FORMATS}
+            filenameStem={exportFilenameStem(queue.name, "queue")}
+          />
           {canEdit && (
-            <Button variant="ghost" size="sm" asChild>
-              <Link to={gp(`/queues/${queue.id}/settings`)}>
+            <Button variant="outline" size="sm" asChild>
+              <Link
+                to={gp(`/queues/${queue.id}/settings`)}
+                className="inline-flex items-center gap-2"
+              >
                 <Settings className="h-4 w-4" />
+                {t("settings")}
               </Link>
-            </Button>
-          )}
-          {canEdit && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-destructive hover:text-destructive"
-              onClick={() => setDeleteConfirmOpen(true)}
-            >
-              <Trash2 className="h-4 w-4" />
             </Button>
           )}
         </div>
@@ -404,19 +404,6 @@ export function QueueDetailPage() {
           readOnly={!canEdit}
         />
       )}
-
-      {/* Delete Queue Confirmation */}
-      <ConfirmDialog
-        open={deleteConfirmOpen}
-        onOpenChange={setDeleteConfirmOpen}
-        title={t("deleteQueue")}
-        description={t("deleteQueueConfirm")}
-        confirmLabel={t("deleteQueue")}
-        cancelLabel={t("common:cancel")}
-        onConfirm={() => deleteQueue.mutate(parsedId)}
-        isLoading={deleteQueue.isPending}
-        destructive
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Queues and counter groups were the last major tools without exports — no way to print a session's turn order, chart counter values externally, or take an importable backup of either tool.

Separately, while testing: the initiative members API returned **403 for guild admins** who hadn't explicitly joined the initiative, leaving the queue dialogs' linked-member picker (and any assignee picker in the same situation) empty.

## Changes

### Queue & counter group exports (engine sources `queue`, `counter-group`)

- **Formats** (both tools): `pdf` / `csv` / `xlsx` / `md` reports plus an importable `json` envelope. Read access suffices — exporting is a formatted read, enforced by new fetch+authorize seams (`get_queue_for_export`, `get_counter_group_for_export`) that also hold on the worker's render-time replay.
- **Queue reports** list every item in rotation order (position descending) with Current/Held/Hidden flagged in a status column; Markdown renders a numbered turn order with the current item bolded.
- **Queue envelope** (`kind: initiative-queue`, schema_version 1): items with position, color, notes, visibility, held/current markers, tags by name — plus member names and linked document/task **titles** as display text (guild-local ids can't rebind on import).
- **Counter envelope** (`kind: initiative-counter-group`): full counter config (count, min/max, step, initial, view mode, color, position) with `NUMERIC(20,10)` scale normalized to plain ints/floats (`5.0000000000` → `5`).
- **New generic `data-table.typ` template** — the column set (labels, order, width hints) comes from the payload, so future tabular sources need no bespoke template. Hostile-text (sys.inputs guard) and empty-rows compile tests included.
- New `numbered` Markdown layout in the tabular renderer.
- Frontend: Export buttons on the queue and counter group detail pages via the shared `ExportButton`; downloads named from `Content-Disposition` with a shared `exportFilenameStem` fallback (DocumentExportMenu refactored onto it). No new i18n keys needed.

### Fix: initiative member roster for guild admins

`GET /initiatives/{id}/members` was the only initiative read missing the guild-admin override (PAM grantees were already allowed). Admins see the initiative's content via the RLS admin leg, so the roster the pickers rely on must load too. Non-member plain guild members still 403.

### UI consistency

- Queue page header matches the document/counter pattern: labeled outline Settings button; the redundant header trash icon removed (deletion lives in queue settings with its own confirm).
- Counter group header buttons sized `sm` to match the Export button.

## Testing

```
cd backend && pytest app/api/v1/tenant_endpoints/exports_test.py app/services/export/ \
  app/api/v1/tenant_endpoints/initiatives_test.py \
  app/api/v1/tenant_endpoints/queues_test.py app/api/v1/tenant_endpoints/counters_test.py
cd backend && ruff check app && uv run ty check app
cd frontend && pnpm typecheck && pnpm lint && pnpm test:run
```

- 53 export tests (5 new integration: envelopes, report formats incl. pypdf text assertions, initiative isolation 404s; 3 new unit: data-table template, numbered layout, hostile-text guard)
- New roster regression test: non-member guild admin 200, plain non-member 403
- 819 frontend tests passing; new `exportFilenameStem`/`filenameFromDisposition` unit tests
- The two `advanced_tool_handoff` failures are pre-existing on `dev` (local `.env` interference), verified via stash

No schema or env changes. Generated API types regenerated.