### PR TITLE
Wire advanced-tool create as external hand-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The advanced tool's Create button now works. The sidebar "+" and the "New Advanced Tool" button (in the tool tab) were previously a disabled placeholder; they now open the connected tool's embedded page on its new-item screen, where the tool is built. Nothing is created on our side until it's saved there.
 - Guild admins can now load the member roster of initiatives they haven't joined. The roster API returned 403 for them — every other initiative read already honored the guild-admin override — which left the linked-member and assignee pickers empty when an admin viewed another member's initiative.
 
 ## [0.55.0] - 2026-07-12

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -243,6 +243,7 @@ export const InitiativeSection = memo(
                 const def = TOOL_REGISTRY[tool];
                 const Icon = def.icon;
                 const link = toolLink(tool);
+                const createTarget = createLink(tool);
                 return (
                   <SidebarMenuItem key={tool}>
                     <div className="group/tool flex w-full min-w-0 items-center gap-1">
@@ -273,7 +274,7 @@ export const InitiativeSection = memo(
                               {/* Regular tools open a create dialog at their list
                                   route; the advanced tool hands off to its embedded
                                   external page with a "new" intent. */}
-                              <Link to={createLink(tool).to} search={createLink(tool).search}>
+                              <Link to={createTarget.to} search={createTarget.search}>
                                 <Plus className="h-3 w-3" />
                               </Link>
                             </Button>

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -89,6 +89,22 @@ export const InitiativeSection = memo(
         ? advancedTool.name
         : t(toolNavLabelKey(tool));
 
+    /** Whether to surface a create affordance for a tool. Mirrors showTool's
+     * deployment-config gate for the advanced tool (no integration → no create). */
+    const canCreateTool = (tool: Tool): boolean =>
+      access[tool].create && (tool !== Tool.advanced_tool || Boolean(advancedTool));
+
+    /** Create target for a tool. Regular tools open a create dialog at their
+     * list route; the advanced tool hands off to its embedded external page
+     * with a "new" intent (authoring happens fully in that service, not here). */
+    const createLink = (tool: Tool) =>
+      tool === Tool.advanced_tool
+        ? { to: gp(`/initiatives/${initiative.id}/advanced-tool`), search: { create: "true" } }
+        : {
+            to: gp(toolListRoute(tool)),
+            search: { create: "true", initiativeId: String(initiative.id) },
+          };
+
     // Load initial state from storage, default to true if not found
     const [isOpen, setIsOpen] = useState(() => {
       try {
@@ -196,19 +212,17 @@ export const InitiativeSection = memo(
                       {t("initiativeSettings")}
                     </Link>
                   </DropdownMenuItem>
-                  {SIDEBAR_TOOLS.filter(
-                    (tool) => TOOL_REGISTRY[tool].inAppCreate && access[tool].create
-                  ).map((tool) => (
-                    <DropdownMenuItem key={tool} asChild>
-                      <Link
-                        to={gp(toolListRoute(tool))}
-                        search={{ create: "true", initiativeId: String(initiative.id) }}
-                      >
-                        <Plus className="mr-2 h-4 w-4" />
-                        {t(toolCreateLabelKey(tool))}
-                      </Link>
-                    </DropdownMenuItem>
-                  ))}
+                  {SIDEBAR_TOOLS.filter(canCreateTool).map((tool) => {
+                    const link = createLink(tool);
+                    return (
+                      <DropdownMenuItem key={tool} asChild>
+                        <Link to={link.to} search={link.search}>
+                          <Plus className="mr-2 h-4 w-4" />
+                          {t(toolCreateLabelKey(tool))}
+                        </Link>
+                      </DropdownMenuItem>
+                    );
+                  })}
                 </DropdownMenuContent>
               </DropdownMenu>
             </>
@@ -247,51 +261,28 @@ export const InitiativeSection = memo(
                           )}
                         </Link>
                       </SidebarMenuButton>
-                      {access[tool].create &&
-                        (def.inAppCreate ? (
-                          <Tooltip delayDuration={300}>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 lg:flex"
-                                asChild
-                              >
-                                <Link
-                                  to={gp(toolListRoute(tool))}
-                                  search={{ create: "true", initiativeId: String(initiative.id) }}
-                                >
-                                  <Plus className="h-3 w-3" />
-                                </Link>
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="top">
-                              <p>{t(toolCreateLabelKey(tool))}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          /* Clearly-marked placeholder: this tool's content is
-                             authored in the external service, so the + explains
-                             where instead of opening a dialog. */
-                          <Tooltip delayDuration={300}>
-                            <TooltipTrigger asChild>
-                              <span className="hidden shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 lg:flex">
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  disabled
-                                  aria-label={t("createExternally", { name: toolLabel(tool) })}
-                                  className="h-6 w-6"
-                                >
-                                  <Plus className="h-3 w-3" />
-                                </Button>
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent side="top">
-                              <p>{t("createExternally", { name: toolLabel(tool) })}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        ))}
+                      {canCreateTool(tool) && (
+                        <Tooltip delayDuration={300}>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 lg:flex"
+                              asChild
+                            >
+                              {/* Regular tools open a create dialog at their list
+                                  route; the advanced tool hands off to its embedded
+                                  external page with a "new" intent. */}
+                              <Link to={createLink(tool).to} search={createLink(tool).search}>
+                                <Plus className="h-3 w-3" />
+                              </Link>
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">
+                            <p>{t(toolCreateLabelKey(tool))}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
                     </div>
                   </SidebarMenuItem>
                 );

--- a/frontend/src/lib/tools.ts
+++ b/frontend/src/lib/tools.ts
@@ -74,9 +74,11 @@ export interface ToolDef {
   /** Personal cross-guild page under the top-level router, if any. */
   personalRoute: string | null;
   /**
-   * The tool's rows are created inside the app. The advanced tool's content
-   * is authored in the external service (name comes from runtime
-   * config), so its create affordance is a hand-off, not a dialog.
+   * The tool's rows are created inside the app (a create dialog at the list
+   * route). The advanced tool's content is authored in the external service
+   * (name comes from runtime config), so its create affordance is a live
+   * hand-off to the embedded page — which signals a "new" intent to that
+   * service — rather than an in-app dialog.
    */
   inAppCreate: boolean;
 }

--- a/frontend/src/pages/initiativeTools/AdvancedToolPage.tsx
+++ b/frontend/src/pages/initiativeTools/AdvancedToolPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, useParams, useSearch } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,7 +20,7 @@ import { useGuildPath } from "@/lib/guildUrl";
  *
  *   1. Page is only reachable when the runtime config exposes an
  *      `advanced_tool` block (otherwise the route renders an empty state).
- *   2. Backend handoff already verifies: AUTOMATIONS_URL configured,
+ *   2. Backend handoff already verifies: ADVANCED_TOOL_URL configured,
  *      initiative exists in active guild, user is guild admin or initiative
  *      member, advanced_tools_enabled=true.
  *   3. The handoff token is delivered to the iframe via postMessage *only*
@@ -36,6 +36,14 @@ export const AdvancedToolPage = () => {
   };
   const parsedInitiativeId = Number(initiativeIdParam);
   const initiativeId = Number.isFinite(parsedInitiativeId) ? parsedInitiativeId : null;
+
+  // Set by the sidebar "+" / list-view "New Advanced Tool" button. Creation is
+  // fully owned by the external service (our advanced_tools table only stores
+  // what that service builds), so "create" here is a hand-off: we forward the
+  // intent to the embed so it opens its new-creation screen instead of its
+  // list. No row is created on our side.
+  const { create } = useSearch({ strict: false }) as { create?: string };
+  const createIntent = create === "true";
 
   const { t, i18n } = useTranslation(["initiatives", "common"]);
   const gp = useGuildPath();
@@ -285,15 +293,18 @@ export const AdvancedToolPage = () => {
   // 3rem sticky header on top and the 20rem sidebar on desktop. On mobile
   // the sidebar is offcanvas, so the wrapper extends edge-to-edge.
   //
-  // The iframe URL has NO secrets in it — only the initiative id. The
-  // handoff token is delivered via postMessage after the iframe sends
-  // its `ready` signal, so it never lands in browser history, proxy
+  // The iframe URL has NO secrets in it — only the initiative id and, when
+  // the user clicked "create", an `intent=create` routing hint (mirrors the
+  // guild page's `?scope=guild`). The embed MUST still trust the signed
+  // handoff token, not this param — it only tells the service which screen to
+  // render. The handoff token is delivered via postMessage after the iframe
+  // sends its `ready` signal, so it never lands in browser history, proxy
   // logs, or referrer headers.
   return (
     <div className="fixed inset-x-0 top-12 bottom-0 md:left-[var(--sidebar-width,20rem)]">
       <iframe
         ref={iframeRef}
-        src={`${advancedTool.url}/embed/${initiative.id}`}
+        src={`${advancedTool.url}/embed/${initiative.id}${createIntent ? "?intent=create" : ""}`}
         title={advancedTool.name}
         className="block h-full w-full border-0 bg-background"
         // Minimum capabilities for an embedded SPA. Notably absent:

--- a/frontend/src/pages/initiativeTools/advancedTools/AdvancedToolsView.tsx
+++ b/frontend/src/pages/initiativeTools/advancedTools/AdvancedToolsView.tsx
@@ -1,4 +1,5 @@
-import { ExternalLink, Loader2, Sparkles } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ExternalLink, Loader2, Plus, Sparkles } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -12,26 +13,41 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { useAdvancedToolsList } from "@/hooks/useAdvancedTools";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { useGridSelection } from "@/hooks/useGridSelection";
+import { useGuildPath } from "@/lib/guildUrl";
 
 type AdvancedToolsViewProps = {
   /** Initiative whose advanced tools to list (this view is initiative-scoped;
    * guild-wide tools are managed from guild settings instead). */
   fixedInitiativeId: number;
-  /** Whether the user may author new tools — surfaces the external-authoring
-   * note, since creation happens in the connected automation service. */
+  /** Whether the user may author new tools — surfaces the "New" button, which
+   * hands off to the connected service where creation happens. */
   canCreate?: boolean;
 };
 
 /**
  * Lists an initiative's advanced tools with the standard Select → Edit access
- * bulk-sharing flow. There is deliberately no create dialog: tool content is
- * authored in the external automation service (rows sync into the
- * advanced_tools table), so the create affordance is an explanatory note.
+ * bulk-sharing flow. Create is a hand-off, not an in-app dialog: tool content
+ * is authored in the external service (rows sync back into the advanced_tools
+ * table), so the "New" button opens the embedded page with a "new" intent
+ * instead of POSTing a row here.
  */
 export const AdvancedToolsView = ({ fixedInitiativeId, canCreate }: AdvancedToolsViewProps) => {
-  const { t } = useTranslation(["advancedTools", "access"]);
+  const { t } = useTranslation(["advancedTools", "access", "nav"]);
   const { advancedTool } = useAppConfig();
+  const gp = useGuildPath();
   const serviceName = advancedTool?.name ?? t("title");
+
+  // "Create" is a hand-off: authoring happens fully in the external service,
+  // so the button opens the embedded page with a "new" intent rather than
+  // POSTing a row here (our table only stores what that service builds).
+  const createButton = (
+    <Button asChild size="sm">
+      <Link to={gp(`/initiatives/${fixedInitiativeId}/advanced-tool`)} search={{ create: "true" }}>
+        <Plus className="mr-2 h-4 w-4" />
+        {t("nav:createAdvancedTool")}
+      </Link>
+    </Button>
+  );
 
   const toolsQuery = useAdvancedToolsList({
     initiative_id: fixedInitiativeId,
@@ -46,10 +62,13 @@ export const AdvancedToolsView = ({ fixedInitiativeId, canCreate }: AdvancedTool
   return (
     <div className="space-y-6">
       {canCreate && (
-        <p className="flex items-center gap-2 text-muted-foreground text-sm">
-          <ExternalLink className="h-4 w-4" />
-          {t("createdExternally", { name: serviceName })}
-        </p>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="flex items-center gap-2 text-muted-foreground text-sm">
+            <ExternalLink className="h-4 w-4" />
+            {t("createdExternally", { name: serviceName })}
+          </p>
+          {createButton}
+        </div>
       )}
 
       {toolsQuery.isLoading ? (
@@ -107,10 +126,11 @@ export const AdvancedToolsView = ({ fixedInitiativeId, canCreate }: AdvancedTool
             <CardTitle>{t("noTools")}</CardTitle>
             <CardDescription>{t("noToolsDescription", { name: serviceName })}</CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <p className="text-muted-foreground text-sm">
               {t("createdExternally", { name: serviceName })}
             </p>
+            {canCreate && createButton}
           </CardContent>
         </Card>
       )}

--- a/frontend/src/pages/initiativeTools/advancedTools/AdvancedToolsView.tsx
+++ b/frontend/src/pages/initiativeTools/advancedTools/AdvancedToolsView.tsx
@@ -61,7 +61,9 @@ export const AdvancedToolsView = ({ fixedInitiativeId, canCreate }: AdvancedTool
 
   return (
     <div className="space-y-6">
-      {canCreate && (
+      {/* Header note + button only when tools exist; the empty state below
+          carries its own note + button, so exactly one shows in every case. */}
+      {canCreate && tools.length > 0 && (
         <div className="flex flex-wrap items-center justify-between gap-3">
           <p className="flex items-center gap-2 text-muted-foreground text-sm">
             <ExternalLink className="h-4 w-4" />

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/initiatives_.$initiativeId_.advanced-tool.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/initiatives_.$initiativeId_.advanced-tool.tsx
@@ -3,6 +3,9 @@ import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 export const Route = createFileRoute(
   "/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/advanced-tool"
 )({
+  validateSearch: (search: Record<string, unknown>): { create?: string } => ({
+    create: typeof search.create === "string" ? search.create : undefined,
+  }),
   component: lazyRouteComponent(() =>
     import("@/pages/initiativeTools/AdvancedToolPage").then((m) => ({
       default: m.AdvancedToolPage,


### PR DESCRIPTION
## Problem

The advanced tool's "create" affordances didn't work. A recent change gated them off: the sidebar "+" rendered as a `disabled` button, and the tool tab showed only an explanatory note. There was no way to start creating an advanced tool from the familiar UI.

## Approach

Creation of an advanced tool is owned entirely by the connected external service — our `advanced_tools` table only stores what that service builds and syncs back. So "create" here is a **hand-off**, not an in-app insert: the button takes you into the embedded page on its new-item screen (via the existing handoff API, which mints only a short-lived token). No row is created on our side until the tool is saved there.

`inAppCreate: false` in the tool registry now means "create is a **live hand-off**", not "create is disabled".

## Changes

- **Embed page** (`AdvancedToolPage.tsx`) — reads a `create=true` search param and forwards `?intent=create` to the embedded iframe `src`, reusing the same routing-hint pattern as the guild page's `?scope=guild`. The signed handoff token remains the trust boundary; the param only tells the service which screen to render.
- **Sidebar** (`InitiativeSection.tsx`) — replaced the `disabled` placeholder with a live hand-off `<Link>` (new `canCreateTool` / `createLink` helpers), and included the advanced tool in the mobile three-dot create menu. Regular tools still open their in-app create dialog; the advanced tool hands off to the embed.
- **Tool tab** (`AdvancedToolsView.tsx`) — added a real "New Advanced Tool" button (header + empty state).
- **Route** — declared the `create` search param on the advanced-tool route.
- **Registry doc** (`tools.ts`) — clarified the `inAppCreate` semantics.

## Env / schema

None. Backend is unchanged — this only wires the existing handoff flow to the create buttons.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec biome check` on touched files — clean (also ran via lint-staged on commit)
- `pnpm exec vitest run src/lib/tools.test.ts` — tool-registry drift tests pass (14/14)

Full end-to-end click-through requires `ADVANCED_TOOL_URL` + the running external service, so it wasn't exercised in CI here. Manual check: click the sidebar "+" / "New Advanced Tool" → you should land on the embed on its new-item screen. Note the external service must handle `?intent=create` to open that screen directly; without it the button still works but shows the default embed view.
