### PR TITLE
Heal missing shared-table grants at boot

### DIFF
--- a/.claude/agents/fastapi-backend.md
+++ b/.claude/agents/fastapi-backend.md
@@ -60,6 +60,7 @@ Initiative is a project management application with a FastAPI backend. The codeb
 - `PascalCase` for SQLModel and Pydantic classes
 - Async/await for all database operations
 - Ruff must pass: `cd backend && ruff check app`
+- **No security-issue detail in comments**: never write comments that reference direct security issues — specific vulnerabilities, exploit/bypass mechanisms, or "without this an attacker could…" narratives. This source is public; such comments are an attack-targeting surface. Use only simple functional explanations of what the code does, not how a control could be defeated.
 
 ## Testing Requirements
 

--- a/.claude/agents/react-frontend-dev.md
+++ b/.claude/agents/react-frontend-dev.md
@@ -72,6 +72,10 @@ cd frontend && pnpm test     # Run Vitest tests
 
 ## Code Quality Standards
 
+### Security-sensitive comments
+
+- **Never write comments that reference direct security issues** — specific vulnerabilities, exploit/bypass mechanisms, or "without this an attacker could…" narratives. This source is public; such comments are an attack-targeting surface. Use only simple functional explanations of what the code does, not how a protection works or could be defeated.
+
 ### TypeScript Best Practices
 
 - Use strict mode, avoid `any` - prefer `unknown` when type is truly unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Guild admins can now load the member roster of initiatives they haven't joined. The roster API returned 403 for them — every other initiative read already honored the guild-admin override — which left the linked-member and assignee pickers empty when an admin viewed another member's initiative.
+- Boot now heals missing shared-table grants for the system engine. Startup now re-asserts the audited `system_grants` registry for `app_admin`/`app_user` (tables and their row-id sequences), idempotently and additively — completing the issue #835 fix.
 
 ## [0.55.0] - 2026-07-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,10 @@ All `HTTPException` detail strings must use constants from `backend/app/core/mes
 
 Python uses 4-space indentation, full type hints, `snake_case` modules/functions, and `PascalCase` SQLModel or schema classes; keep routing thin and push validation to `schemas` and `services`. React components are `PascalCase` files, hooks follow the `useThing` convention, and shared helpers live in `frontend/src/lib` or `api`. Ruff and ESLint must pass before opening a PR.
 
+### Security-sensitive comments
+
+**Do not write code comments that reference direct security issues** — specific vulnerabilities, exploit or bypass mechanisms, "without this an attacker could…" narratives, or step-by-step descriptions of how a control could be defeated. This source is public, so such comments are an attack-targeting surface: they hand an attacker a roadmap. Keep comments to **simple functional explanations** of what the code does and why, not how a protection works internally or how it could fail. Put exploit-level detail in the private issue tracker or a security doc, not inline.
+
 ## Testing Guidelines
 
 Tests are co-located next to their source files using a `_test.py` suffix (e.g., `app/services/guilds_test.py` tests `app/services/guilds.py`). Shared test factories live in `app/testing/factories.py` and are re-exported from `app/testing/__init__.py`. The root `backend/conftest.py` provides session, client, and auth fixtures. Run all tests with `cd backend && pytest` (testpaths is set to `app` in `pytest.ini`). For new UI logic, add Vitest + Testing Library specs under the relevant feature folder (or `frontend/src/__tests__`); prioritize coverage for auth, project CRUD, and optimistic updates.

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -11,6 +11,7 @@ from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.security import get_password_hash
 from app.db.schema_provisioning import (
     deprovision_guild,
+    ensure_shared_table_grants,
     ensure_system_engine_bypassrls,
 )
 from app.db.session import AdminSessionLocal, run_migrations, set_rls_context
@@ -168,6 +169,11 @@ async def init() -> None:
     # primary guild and die on the guilds RLS policy (issue #835). Verify —
     # and, when DATABASE_URL lawfully can, repair — before touching data.
     await ensure_system_engine_bypassrls()
+    # And, one gate deeper, the shared-table GRANTs the system engine needs to
+    # actually write (BYPASSRLS skips policies, not privilege checks) — a
+    # restored role can be missing them, failing with "permission denied for
+    # table guilds" (issue #835 follow-up).
+    await ensure_shared_table_grants()
     await init_owner()
     async with AdminSessionLocal() as session:
         # guild_settings is guild-scoped; route into the primary guild's schema so

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -636,3 +636,145 @@ async def ensure_system_engine_bypassrls() -> None:
     raise SystemExit(
         _bypassrls_exit_message(admin_login, heal_attempted=bool(can_heal))
     )
+
+
+# --- shared-table grant healing (issue #835, deeper than the BYPASSRLS heal) --
+#
+# BYPASSRLS (above) lets the system engine skip RLS *policies*; it does NOT skip
+# table-level privilege checks. A restored/recreated cluster can bring app_admin
+# back with LOGIN + BYPASSRLS but WITHOUT the per-table GRANTs the migrations
+# applied — roles are cluster state, and an already-stamped database never
+# re-runs the grant-issuing migrations. The system engine then fails one gate
+# deeper than #835's first report: "permission denied for table guilds" while
+# seeding the primary guild it can read (BYPASSRLS) but not INSERT (no grant).
+# `backfill_guild_schemas` re-asserts GUILD-schema grants on every boot; nothing
+# did the same for the shared `public` tables. This does, sourced from the
+# audited `system_grants` registry (the single truth for those grants),
+# additively and idempotently.
+#
+# The bare login role (`app_user`, the pre-routing surface) is healed the same
+# way from its own registry — a restore loses its grants too.
+
+# A directly-connecting role that may INSERT needs privilege on the row-id
+# sequence as well; match what the baseline grants each role.
+_SEQUENCE_GRANT_BY_ROLE: dict[str, str] = {
+    "app_admin": "ALL",
+    "app_user": "SELECT, USAGE",
+}
+
+
+def _expected_shared_table_grants() -> list[tuple[str, str, frozenset[str]]]:
+    """`(role, table, verbs)` the two directly-connecting roles must hold on the
+    shared `public` tables, from the audited registries. Tables mapped to
+    ``None`` (no access) are omitted."""
+    from app.db import system_grants
+
+    expected: list[tuple[str, str, frozenset[str]]] = []
+    for role, matrix in (
+        ("app_admin", system_grants.SHARED_TABLE_SYSTEM_GRANTS),
+        ("app_user", system_grants.SHARED_TABLE_APP_USER_GRANTS),
+    ):
+        for table, verbs in matrix.items():
+            if verbs:
+                expected.append((role, table, verbs))
+    return expected
+
+
+async def _shared_grants_intact(
+    conn: AsyncConnection, expected: list[tuple[str, str, frozenset[str]]]
+) -> bool:
+    """True when every expected `(role, table, verb)` privilege is already held.
+
+    A single round-trip via ``has_table_privilege`` (authoritative — it respects
+    role membership and the live ACL, and any login may query another role's
+    privilege). Probes table grants only: a role recreation loses a role's table
+    AND sequence grants together, so a missing table grant reliably signals the
+    restore damage this heals; the heal then re-asserts both.
+    """
+    # Registry table names are trusted constants (not user input); inline them.
+    values = ", ".join(
+        f"('{role}', 'public.{table}', '{verb}')"
+        for role, table, verbs in expected
+        for verb in verbs
+    )
+    intact = (
+        await conn.execute(
+            text(
+                "SELECT bool_and(has_table_privilege(role, tbl, priv)) "
+                f"FROM (VALUES {values}) AS t(role, tbl, priv)"
+            )
+        )
+    ).scalar()
+    return bool(intact)
+
+
+async def _reassert_shared_grants(
+    conn: AsyncConnection, expected: list[tuple[str, str, frozenset[str]]]
+) -> int:
+    """Re-GRANT the audited table verbs (and, for insertable tables, the owned
+    row-id sequence) to each role. Additive and idempotent — never REVOKEs, so
+    it can only restore missing grants, never contradict a migration that
+    intentionally reduced them. Returns the number of table grants asserted."""
+    from app.db import system_grants
+
+    for role, table, verbs in expected:
+        verb_list = system_grants.grant_sql(verbs)
+        await conn.execute(
+            text(f'GRANT {verb_list} ON TABLE public."{table}" TO "{role}"')
+        )
+        if "INSERT" not in verbs:
+            continue
+        # INSERT needs privilege on the row-id sequence too. Discover sequences
+        # OWNED BY the table (robust to a serial column not named `id`) instead
+        # of assuming a name.
+        seqs = (
+            await conn.execute(
+                text(
+                    "SELECT quote_ident(n.nspname) || '.' || quote_ident(s.relname) "
+                    "FROM pg_class s "
+                    "JOIN pg_depend d ON d.objid = s.oid "
+                    "  AND d.classid = 'pg_class'::regclass "
+                    "  AND d.refclassid = 'pg_class'::regclass AND d.deptype = 'a' "
+                    "JOIN pg_class t ON t.oid = d.refobjid "
+                    "JOIN pg_namespace n ON n.oid = s.relnamespace "
+                    "WHERE s.relkind = 'S' AND n.nspname = 'public' "
+                    "  AND t.relname = :table"
+                ),
+                {"table": table},
+            )
+        ).scalars()
+        seq_grant = _SEQUENCE_GRANT_BY_ROLE[role]
+        for seq in seqs:
+            await conn.execute(text(f'GRANT {seq_grant} ON SEQUENCE {seq} TO "{role}"'))
+    return len(expected)
+
+
+async def ensure_shared_table_grants() -> None:
+    """Heal missing table/sequence GRANTs on the shared ``public`` tables for the
+    app's directly-connecting roles (``app_admin`` system engine, ``app_user``
+    bare login).
+
+    Companion to :func:`ensure_system_engine_bypassrls`: that repairs the RLS
+    *attribute*, this repairs the table *grants* one gate deeper. Both close the
+    same class of drift — a ``pg_dump``-based restore or a hand-recreated role
+    loses cluster state that an already-stamped database never re-applies
+    (issue #835). Runs right after the BYPASSRLS check on every boot; a healthy
+    posture is a single-SELECT no-op.
+    """
+    expected = _expected_shared_table_grants()
+    if not expected:
+        return
+    async with db_session.provisioning_engine.connect() as conn:
+        if await _shared_grants_intact(conn, expected):
+            return
+    # Something is missing — re-assert the full audited set via the object owner
+    # (the provisioning engine, which the grant-issuing migrations also use).
+    async with db_session.provisioning_engine.begin() as conn:
+        asserted = await _reassert_shared_grants(conn, expected)
+    logger.warning(
+        "Shared-table grants were incomplete for the app's directly-connecting "
+        "roles (app_admin/app_user) — re-asserted %d audited table grant(s) "
+        "from the system_grants registry. Restored databases lose role grants "
+        "(issue #835); no action needed.",
+        asserted,
+    )

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -719,6 +719,11 @@ async def _reassert_shared_grants(
 
     for role, table, verbs in expected:
         verb_list = system_grants.grant_sql(verbs)
+        if not verb_list:
+            # Unreachable: _expected_shared_table_grants already drops None/empty
+            # entries. The guard makes that invariant explicit and narrows
+            # grant_sql's `str | None` to `str` (no `GRANT None …` can render).
+            continue
         await conn.execute(
             text(f'GRANT {verb_list} ON TABLE public."{table}" TO "{role}"')
         )
@@ -774,7 +779,8 @@ async def ensure_shared_table_grants() -> None:
     logger.warning(
         "Shared-table grants were incomplete for the app's directly-connecting "
         "roles (app_admin/app_user) — re-asserted %d audited table grant(s) "
-        "from the system_grants registry. Restored databases lose role grants "
-        "(issue #835); no action needed.",
+        "(plus the row-id sequences of insertable tables) from the system_grants "
+        "registry. Restored databases lose role grants (issue #835); no action "
+        "needed.",
         asserted,
     )

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -828,3 +828,144 @@ def test_bypassrls_exit_message_distinguishes_attempted_repair():
     assert "already ran" not in plain
     assert "already ran" in attempted
     assert "current_user" in attempted  # the which-role-am-I diagnostic query
+
+
+# --- ensure_shared_table_grants (issue #835 follow-up) -----------------------
+#
+# BYPASSRLS skips RLS *policies*, not table GRANTs. A restored/recreated role
+# can bypass RLS yet be missing the per-table grants, failing one gate deeper
+# with "permission denied for table ...". The boot heal must leave a healthy
+# posture untouched and otherwise re-assert the audited grants (table + owned
+# sequence). These tests point the registry at a throwaway public table so they
+# never mutate the real app_admin/app_user grants (cluster-global roles shared
+# across xdist workers); the per-worker test DB keeps the throwaway isolated.
+
+_PROBE_TABLE = "grant_heal_probe"
+
+
+async def _make_probe_table(engine, *, admin_grants, user_grants):
+    async with engine.begin() as conn:
+        await conn.execute(text(f"DROP TABLE IF EXISTS public.{_PROBE_TABLE}"))
+        await conn.execute(
+            text(f"CREATE TABLE public.{_PROBE_TABLE} (id serial PRIMARY KEY)")
+        )
+        # Fresh table created by the (superuser) test engine gives app_admin /
+        # app_user nothing (default privileges were revoked for them); the
+        # explicit REVOKE is belt-and-suspenders for the "restored role" state.
+        await conn.execute(
+            text(f"REVOKE ALL ON public.{_PROBE_TABLE} FROM app_admin, app_user")
+        )
+        if admin_grants:
+            await conn.execute(
+                text(f"GRANT {admin_grants} ON public.{_PROBE_TABLE} TO app_admin")
+            )
+        if user_grants:
+            await conn.execute(
+                text(f"GRANT {user_grants} ON public.{_PROBE_TABLE} TO app_user")
+            )
+
+
+async def _drop_probe_table(engine):
+    async with engine.begin() as conn:
+        await conn.execute(text(f"DROP TABLE IF EXISTS public.{_PROBE_TABLE}"))
+
+
+def _point_registry_at_probe(monkeypatch, *, sys_verbs, user_verbs):
+    from app.db import system_grants
+
+    monkeypatch.setattr(
+        system_grants,
+        "SHARED_TABLE_SYSTEM_GRANTS",
+        {_PROBE_TABLE: frozenset(sys_verbs) if sys_verbs else None},
+    )
+    monkeypatch.setattr(
+        system_grants,
+        "SHARED_TABLE_APP_USER_GRANTS",
+        {_PROBE_TABLE: frozenset(user_verbs) if user_verbs else None},
+    )
+
+
+async def test_shared_grants_heal_restores_missing_table_and_sequence(
+    engine, monkeypatch
+):
+    # A restored role: the table exists but app_admin/app_user hold no grants —
+    # exactly issue #835's second report ("permission denied for table guilds").
+    await _make_probe_table(engine, admin_grants=None, user_grants=None)
+    _point_registry_at_probe(
+        monkeypatch, sys_verbs={"SELECT", "INSERT"}, user_verbs={"SELECT"}
+    )
+    try:
+        await schema_provisioning.ensure_shared_table_grants()
+        async with engine.connect() as conn:
+            admin_insert, user_select, admin_seq, user_seq = (
+                await conn.execute(
+                    text(
+                        "SELECT has_table_privilege('app_admin', :t, 'INSERT'), "
+                        "has_table_privilege('app_user', :t, 'SELECT'), "
+                        "has_sequence_privilege('app_admin', :s, 'USAGE'), "
+                        "has_sequence_privilege('app_user', :s, 'USAGE')"
+                    ),
+                    {
+                        "t": f"public.{_PROBE_TABLE}",
+                        "s": f"public.{_PROBE_TABLE}_id_seq",
+                    },
+                )
+            ).one()
+        assert admin_insert, "system engine INSERT grant must be restored"
+        assert user_select, "bare login SELECT grant must be restored"
+        assert admin_seq, "INSERT needs the row-id sequence — must be restored too"
+        # app_user is SELECT-only on this table, so it needs NO sequence grant:
+        # the heal grants a sequence only where the role actually holds INSERT
+        # (least privilege), matching each role's real per-table need.
+        assert not user_seq, "a SELECT-only role must not receive a sequence grant"
+    finally:
+        await _drop_probe_table(engine)
+
+
+async def test_shared_grants_heal_is_noop_when_intact(engine, monkeypatch):
+    # Already fully granted (table + sequence) — the heal must not re-assert.
+    await _make_probe_table(engine, admin_grants="SELECT, INSERT", user_grants="SELECT")
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(f"GRANT ALL ON SEQUENCE public.{_PROBE_TABLE}_id_seq TO app_admin")
+        )
+        await conn.execute(
+            text(
+                f"GRANT SELECT, USAGE ON SEQUENCE public.{_PROBE_TABLE}_id_seq "
+                "TO app_user"
+            )
+        )
+    _point_registry_at_probe(
+        monkeypatch, sys_verbs={"SELECT", "INSERT"}, user_verbs={"SELECT"}
+    )
+    reasserted = False
+
+    async def _spy(*args, **kwargs):
+        nonlocal reasserted
+        reasserted = True
+        return 0
+
+    monkeypatch.setattr(schema_provisioning, "_reassert_shared_grants", _spy)
+    try:
+        await schema_provisioning.ensure_shared_table_grants()
+        assert not reasserted, "a healthy grant posture must be a single-probe no-op"
+    finally:
+        await _drop_probe_table(engine)
+
+
+async def test_shared_grants_probe_detects_partial_grant(engine, monkeypatch):
+    import app.db.session as db_session
+
+    # SELECT present but INSERT missing → the probe must report NOT intact, so a
+    # partially-restored role still triggers the heal.
+    await _make_probe_table(engine, admin_grants="SELECT", user_grants="SELECT")
+    _point_registry_at_probe(
+        monkeypatch, sys_verbs={"SELECT", "INSERT"}, user_verbs={"SELECT"}
+    )
+    try:
+        expected = schema_provisioning._expected_shared_table_grants()
+        async with db_session.provisioning_engine.connect() as conn:
+            intact = await schema_provisioning._shared_grants_intact(conn, expected)
+        assert intact is False
+    finally:
+        await _drop_probe_table(engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,6 +69,7 @@ async def lifespan(app: FastAPI):
     # guilds stamped with the current artifact version are skipped entirely.
     from app.db.schema_provisioning import (
         backfill_guild_schemas,
+        ensure_shared_table_grants,
         ensure_system_engine_bypassrls,
         warn_if_privileged_database_url,
     )
@@ -77,6 +78,11 @@ async def lifespan(app: FastAPI):
     # (restored database, hand-created role) reads shared tables as empty and
     # the seeding below would die with an opaque RLS violation (issue #835).
     await ensure_system_engine_bypassrls()
+    # One gate deeper: a restored/recreated role can bypass RLS yet be missing
+    # the per-table GRANTs (cluster state a stamped DB never re-applies), so
+    # seeding dies on "permission denied for table guilds" instead. Re-assert
+    # the audited shared-table grants from the registry (issue #835 follow-up).
+    await ensure_shared_table_grants()
     await warn_if_privileged_database_url()
     backfill = await backfill_guild_schemas()
     if backfill.failed:


### PR DESCRIPTION
## Problem

Follow-up to #840. Issue #835's reporter upgraded to the image with the BYPASSRLS heal and got a **different** boot failure:

```
sqlalchemy...InsufficientPrivilegeError: permission denied for table guilds
INSERT INTO guilds (...) RETURNING guilds.id
```

Postgres checks table-level `GRANT`s **before** RLS. #840's `ensure_system_engine_bypassrls()` healed the `BYPASSRLS` **attribute**, which is exactly why the error moved down one gate — from `new row violates row-level security policy` (RLS layer) to `permission denied for table guilds` (GRANT layer). A restored/recreated cluster can bring `app_admin` back with `LOGIN + BYPASSRLS` (matching the baseline's `CREATE ROLE` instruction) but **without** the per-table grants, because those grants are applied by migrations and an already-stamped database never re-runs them. `backfill_guild_schemas()` re-asserts **guild-schema** grants every boot; nothing did the same for the shared `public` tables — the same class of drift #840 closed for the role attribute, one layer deeper.

## Changes

- **`ensure_shared_table_grants()`** (`schema_provisioning.py`): right after the BYPASSRLS check, a single-round-trip `has_table_privilege` probe verifies `app_admin`/`app_user` hold their audited grants on the shared `public` tables. If any are missing, it re-asserts the full set from the **`system_grants` registry** (the existing single source of truth), including the owned row-id **sequence** grants for insertable tables. Additive and idempotent — never `REVOKE`s, so it can only restore missing grants, never contradict a migration that intentionally reduced them. Healthy boots are a single-SELECT no-op; a heal logs a WARNING.
- Wired into **both** boot paths — the FastAPI lifespan and `python -m app.db.init_db` — mirroring #840.
- Runs via the provisioning engine (the object owner that the grant-issuing migrations already use).
- Tests: heal restores missing table + sequence grants; a healthy posture is a no-op; the probe detects a partial (SELECT-but-not-INSERT) grant. Tests point the registry at a throwaway `public` table so the real cluster-global roles are never mutated.
- Changelog entry under Unreleased → Fixed.

No schema or env changes.

## Security

The heal is deliberately low-risk: it is **registry-sourced** (can't grant beyond what CI already enforces as the intended set), **additive-only** (can't resurrect a deliberately-removed privilege or open a privilege-loss window), **boot-only** with **no user input** reaching it (table/role/verb are trusted constants; the one bind param is the sequence-discovery `:table`), and touches only the shared identity/config tables — RLS and guild isolation are unaffected. It restores the sanctioned floor; drift-detection (`security_invariants_test`) still owns the ceiling.

## Testing

```
cd backend && pytest app/db/schema_provisioning_test.py app/db/init_db_test.py   # 24 passed
ruff check / ruff format on touched files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
