### PR TITLE
Rename envelope discriminator field kind → type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Export envelopes and backup manifests now use a `type` field as their format discriminator instead of `kind` (values unchanged, no schema version bump), and project backups carry `type: "initiative-project"` like the other tools. Files exported by 0.56.0 still import: the editor's import accepts both spellings, and project backups never depended on the field.
+
 ## [0.56.0] - 2026-07-14
 
 ### Added

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -382,7 +382,7 @@ async def test_document_export_per_type_formats(
     assert resp.status_code == 200
     assert ".json" in resp.headers["content-disposition"]
     serialized = json.loads(resp.content)
-    assert serialized["kind"] == "initiative-document"
+    assert serialized["type"] == "initiative-document"
     assert serialized["document_type"] == "native"
     assert serialized["content"]["root"]["type"] == "root"
     assert serialized["tags"] == [] and serialized["properties"] == []
@@ -400,7 +400,7 @@ async def test_document_export_per_type_formats(
     resp = await export(board, "json")
     assert resp.status_code == 200
     envelope = json.loads(resp.content)
-    assert envelope["kind"] == "initiative-document"
+    assert envelope["type"] == "initiative-document"
     assert envelope["document_type"] == "whiteboard"
     scene = envelope["content"]
     assert scene["type"] == "excalidraw"
@@ -628,7 +628,7 @@ async def test_document_export_spreadsheet_formats(
     )
     assert json_resp.status_code == 200
     envelope = json.loads(json_resp.content)
-    assert envelope["kind"] == "initiative-document"
+    assert envelope["type"] == "initiative-document"
     assert envelope["document_type"] == "spreadsheet"
     assert envelope["title"] == "Budget: Q3"
     assert envelope["content"] == sheet_doc.content
@@ -938,7 +938,7 @@ async def test_queue_export_json_envelope(client: AsyncClient, acting_user, sess
     assert resp.status_code == 200
     assert ".initiative-queue.json" in resp.headers["content-disposition"]
     envelope = json.loads(resp.content)
-    assert envelope["kind"] == "initiative-queue"
+    assert envelope["type"] == "initiative-queue"
     assert envelope["schema_version"] == 1
     assert envelope["name"] == "Battle Order"
     assert envelope["is_active"] is True
@@ -1046,7 +1046,7 @@ async def test_counter_group_export_json_envelope(
     assert resp.status_code == 200
     assert ".initiative-counter-group.json" in resp.headers["content-disposition"]
     envelope = json.loads(resp.content)
-    assert envelope["kind"] == "initiative-counter-group"
+    assert envelope["type"] == "initiative-counter-group"
     assert envelope["schema_version"] == 1
     assert envelope["name"] == "Party Resources"
 
@@ -1196,7 +1196,7 @@ async def test_queue_export_localizes_status_flags_and_headers(
         params={"queue_id": queue.id, "format": "json"},
     )
     envelope = json.loads(json_resp.content)
-    assert envelope["kind"] == "initiative-queue"
+    assert envelope["type"] == "initiative-queue"
     assert "items" in envelope and "is_current" in envelope["items"][0]
 
 
@@ -1431,7 +1431,7 @@ async def test_bulk_document_selection_exports_as_zip(
     assert all(n.endswith(".json") for n in names)
     assert len(set(names)) == 3  # the twin "Session Notes" title deduped
     envelopes = [json.loads(archive.read(n)) for n in names]
-    assert all(e["kind"] == "initiative-document" for e in envelopes)
+    assert all(e["type"] == "initiative-document" for e in envelopes)
     assert {e["document_type"] for e in envelopes} == {"native", "spreadsheet"}
     assert {e["title"] for e in envelopes} == {"Session Notes", "Budget"}
 
@@ -1667,7 +1667,7 @@ async def test_calendar_event_export_ics_and_json(
     )
     assert js.status_code == 200
     envelope = json.loads(js.content)
-    assert envelope["kind"] == "initiative-calendar-events"
+    assert envelope["type"] == "initiative-calendar-events"
     assert envelope["schema_version"] == 1
     titles = {e["title"] for e in envelope["events"]}
     assert titles == {"Session 13", "One-shot night"}
@@ -1796,7 +1796,7 @@ async def test_smart_link_exports_importable_json_envelope(
     assert resp.status_code == 200
     envelope = json.loads(resp.content)
     assert envelope == {
-        "kind": "initiative-document",
+        "type": "initiative-document",
         "schema_version": 1,
         "document_type": "smart_link",
         "title": "Session zero notes",
@@ -1939,7 +1939,7 @@ async def test_initiative_backup_zip_layout_and_manifest(
     assert "manifest.json" in names
 
     manifest = json.loads(archive.read("manifest.json"))
-    assert manifest["kind"] == "initiative-backup"
+    assert manifest["type"] == "initiative-backup"
     assert manifest["schema_version"] == 1
     assert manifest["guild"]["id"] == a.guild.id
     assert [i["id"] for i in manifest["initiatives"]] == [a.initiative.id]
@@ -1958,8 +1958,8 @@ async def test_initiative_backup_zip_layout_and_manifest(
 
     folder = next(n for n in names if n != "manifest.json").split("/")[1]
     assert folder.startswith(f"{a.initiative.id}-")
-    by_kind = {e["kind"]: e for e in manifest["entries"]}
-    assert set(by_kind) == {
+    by_type = {e["type"]: e for e in manifest["entries"]}
+    assert set(by_type) == {
         "initiative-project",
         "initiative-document",
         "initiative-queue",
@@ -1968,15 +1968,15 @@ async def test_initiative_backup_zip_layout_and_manifest(
     }
 
     # Spot-check envelopes round-trip through the archive paths.
-    project_env = json.loads(archive.read(by_kind["initiative-project"]["path"]))
+    project_env = json.loads(archive.read(by_type["initiative-project"]["path"]))
     assert project_env["project"]["name"] == "Main Arc"
     assert [t["title"] for t in project_env["tasks"]] == ["Fell the tower"]
-    doc_env = json.loads(archive.read(by_kind["initiative-document"]["path"]))
-    assert doc_env["kind"] == "initiative-document"
+    doc_env = json.loads(archive.read(by_type["initiative-document"]["path"]))
+    assert doc_env["type"] == "initiative-document"
     assert doc_env["title"] == "Campaign Notes"
-    events_env = json.loads(archive.read(by_kind["initiative-calendar-events"]["path"]))
+    events_env = json.loads(archive.read(by_type["initiative-calendar-events"]["path"]))
     assert [e["title"] for e in events_env["events"]] == ["Session Zero"]
-    assert by_kind["initiative-calendar-events"]["path"].endswith(
+    assert by_type["initiative-calendar-events"]["path"].endswith(
         "/calendar-events.json"
     )
 
@@ -2107,7 +2107,7 @@ async def test_guild_backup_spans_initiatives_and_refreshes_access(
     resp = await client.get(a.g("/exports/guild"), headers=a.headers)
     archive = await _rendered_zip(client, a, monkeypatch, role_session, resp)
     manifest = json.loads(archive.read("manifest.json"))
-    assert manifest["kind"] == "guild-backup"
+    assert manifest["type"] == "guild-backup"
     assert {i["name"] for i in manifest["initiatives"]} >= {
         a.initiative.name,
         "Second Front",
@@ -2205,7 +2205,7 @@ async def test_backup_uploads_toggle_and_asset_bundling(
             e["path"] for e in manifest["entries"] if e["title"] == "Illustrated Notes"
         )
     ]
-    (entry,) = [e for e in manifest["entries"] if e["kind"] == "file"]
+    (entry,) = [e for e in manifest["entries"] if e["type"] == "file"]
     assert entry["entity_id"] == file_doc.id
     assert entry["asset"] == "assets/handout-xyz.pdf"
 
@@ -2223,7 +2223,7 @@ async def test_backup_uploads_toggle_and_asset_bundling(
     (skip,) = manifest2["skipped"]
     assert skip["entity_id"] == file_doc.id
     assert skip["reason"] == "uploads_excluded"
-    assert not any(e["kind"] == "file" for e in manifest2["entries"])
+    assert not any(e["type"] == "file" for e in manifest2["entries"])
 
 
 async def test_backup_upload_byte_cap(

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -1969,6 +1969,7 @@ async def test_initiative_backup_zip_layout_and_manifest(
 
     # Spot-check envelopes round-trip through the archive paths.
     project_env = json.loads(archive.read(by_type["initiative-project"]["path"]))
+    assert project_env["type"] == "initiative-project"
     assert project_env["project"]["name"] == "Main Arc"
     assert [t["title"] for t in project_env["tasks"]] == ["Fell the tower"]
     doc_env = json.loads(archive.read(by_type["initiative-document"]["path"]))

--- a/backend/app/schemas/tenant/backup_export.py
+++ b/backend/app/schemas/tenant/backup_export.py
@@ -1,9 +1,9 @@
 """Initiative/guild backup manifest — the index at the root of a backup zip.
 
 A backup is a zip of per-tool JSON envelopes (each independently versioned by
-its own ``kind`` + ``schema_version``) plus optional upload blobs under
+its own ``type`` + ``schema_version``) plus optional upload blobs under
 ``assets/``. The manifest is what a future import wizard reads first: it
-inventories every entry by kind so files dispatch to the right importer, maps
+inventories every entry by type so files dispatch to the right importer, maps
 assets back to the documents that reference them, and records what was
 deliberately left out (``skipped``) so a backup never silently loses data.
 
@@ -28,7 +28,7 @@ class ManifestEntry(SanitizedBaseModel):
 
     path: str
     tool: str  # "project" | "document" | "queue" | "counter_group" | "calendar_event"
-    kind: str  # envelope kind, or "file"
+    type: str  # envelope type, or "file"
     schema_version: Optional[int] = None  # None for foreign formats
     entity_id: int
     title: str
@@ -71,7 +71,7 @@ class ManifestInitiative(SanitizedBaseModel):
 
 
 class BackupManifest(SanitizedBaseModel):
-    kind: str  # "initiative-backup" | "guild-backup"
+    type: str  # "initiative-backup" | "guild-backup"
     schema_version: int = BACKUP_SCHEMA_VERSION
     app_version: str
     exported_at: datetime

--- a/backend/app/schemas/tenant/project_export.py
+++ b/backend/app/schemas/tenant/project_export.py
@@ -137,6 +137,10 @@ class ProjectExportEnvelope(SanitizedBaseModel):
     every list, so requiring them costs nothing at runtime.
     """
 
+    # File-type discriminator, matching the other tool envelopes — a future
+    # import dispatches on it. Defaulted so files exported before the field
+    # existed still validate.
+    type: str = "initiative-project"
     schema_version: int = SCHEMA_VERSION
     app_version: str
     exported_at: datetime

--- a/backend/app/services/export/adapters/backup.py
+++ b/backend/app/services/export/adapters/backup.py
@@ -95,11 +95,15 @@ class InitiativeExportAdapter:
         return settings.EXPORT_MAX_BACKUP_ROWS
 
     async def count(self, session, *, user, guild_id, params, format) -> int:
-        scope = await _resolve_scope(session, user, guild_id, params, kind=self.source)
+        scope = await _resolve_scope(
+            session, user, guild_id, params, scope_kind=self.source
+        )
         return await _count_scope(session, user, guild_id, params, scope)
 
     async def build(self, session, *, user, guild_id, params, format) -> RenderRequest:
-        scope = await _resolve_scope(session, user, guild_id, params, kind=self.source)
+        scope = await _resolve_scope(
+            session, user, guild_id, params, scope_kind=self.source
+        )
         return await _build_scope(session, user, guild_id, params, scope, self.source)
 
 
@@ -113,7 +117,7 @@ class GuildExportAdapter(InitiativeExportAdapter):
 
 
 async def _resolve_scope(
-    session: AsyncSession, user: User, guild_id: int, params: dict, *, kind: str
+    session: AsyncSession, user: User, guild_id: int, params: dict, *, scope_kind: str
 ):
     """The initiatives this export covers, authorization included: guild scope
     demands a guild ADMIN creator (re-checked on worker replay); initiative
@@ -126,9 +130,9 @@ async def _resolve_scope(
     from app.services.platform import guilds as guilds_service
     from app.services.rls import is_guild_admin
 
-    _validate_params(params, kind=kind)
+    _validate_params(params, scope_kind=scope_kind)
 
-    if kind == "guild":
+    if scope_kind == "guild":
         membership = await guilds_service.get_membership(
             session, guild_id=guild_id, user_id=user.id
         )
@@ -161,7 +165,7 @@ async def _resolve_scope(
     return [initiative]
 
 
-def _validate_params(params: dict, *, kind: str) -> None:
+def _validate_params(params: dict, *, scope_kind: str) -> None:
     mode = params.get("mode") or "backup"
     if mode not in ("backup", "report"):
         raise ExportError(ExportMessages.EXPORT_INVALID_PARAMS)
@@ -313,7 +317,7 @@ async def _build_scope(
     guild_id: int,
     params: dict,
     initiatives,
-    kind: str,
+    scope_kind: str,
 ) -> RenderRequest:
     from app.core.version import get_version
     from app.models.platform.guild import Guild
@@ -340,7 +344,7 @@ async def _build_scope(
     if mode == "backup":
         guild = await session.get(Guild, guild_id)
         manifest = BackupManifest(
-            kind=f"{kind}-backup",
+            type=f"{scope_kind}-backup",
             schema_version=BACKUP_SCHEMA_VERSION,
             app_version=get_version(),
             exported_at=datetime.now(timezone.utc),
@@ -466,7 +470,7 @@ class _ScopeBuilder:
                     item,
                     path=path,
                     tool="project",
-                    kind="initiative-project",
+                    type="initiative-project",
                     schema_version=envelope.schema_version,
                     entity_id=project_id,
                     title=envelope.project.name,
@@ -539,7 +543,7 @@ class _ScopeBuilder:
                     item,
                     path=path,
                     tool="document",
-                    kind="initiative-document",
+                    type="initiative-document",
                     schema_version=1,
                     entity_id=document.id,
                     title=document.title,
@@ -566,7 +570,7 @@ class _ScopeBuilder:
                 ManifestEntry(
                     path=asset_path,
                     tool="document",
-                    kind="file",
+                    type="file",
                     schema_version=None,
                     entity_id=document.id,
                     title=document.title,
@@ -601,7 +605,7 @@ class _ScopeBuilder:
                     item,
                     path=f"{path_stem}.initiative-queue.json",
                     tool="queue",
-                    kind="initiative-queue",
+                    type="initiative-queue",
                     schema_version=1,
                     entity_id=queue.id,
                     title=queue.name,
@@ -634,7 +638,7 @@ class _ScopeBuilder:
                     item,
                     path=f"{path_stem}.initiative-counter-group.json",
                     tool="counter_group",
-                    kind="initiative-counter-group",
+                    type="initiative-counter-group",
                     schema_version=1,
                     entity_id=group.id,
                     title=group.name,
@@ -672,7 +676,7 @@ class _ScopeBuilder:
             item = RenderItem(
                 key=f"{folder}/calendar-events",
                 data={
-                    "kind": "initiative-calendar-events",
+                    "type": "initiative-calendar-events",
                     "schema_version": 1,
                     "events": dicts,
                 },
@@ -687,7 +691,7 @@ class _ScopeBuilder:
                     ManifestEntry(
                         path=f"{folder}/calendar-events.json",
                         tool="calendar_event",
-                        kind="initiative-calendar-events",
+                        type="initiative-calendar-events",
                         schema_version=1,
                         entity_id=initiative.id,
                         title="calendar-events",
@@ -872,7 +876,9 @@ async def estimate_backup(
     from app.services.tenant.attachments import get_guild_storage_usage
 
     params = {"initiative_id": initiative_id, "include_uploads": include_uploads}
-    initiatives = await _resolve_scope(session, user, guild_id, params, kind=scope)
+    initiatives = await _resolve_scope(
+        session, user, guild_id, params, scope_kind=scope
+    )
     ids = await _enumerate(session, user, guild_id, params, initiatives)
 
     tools: dict[str, BackupToolEstimate] = {}

--- a/backend/app/services/export/adapters/calendar_event.py
+++ b/backend/app/services/export/adapters/calendar_event.py
@@ -86,7 +86,7 @@ class CalendarEventAdapter:
             # The envelope is importable machine data — stays canonical, never
             # localized (translating field keys / enum values breaks import).
             data: dict[str, Any] = {
-                "kind": "initiative-calendar-events",
+                "type": "initiative-calendar-events",
                 "schema_version": 1,
                 "events": dicts,
             }

--- a/backend/app/services/export/adapters/counter_group.py
+++ b/backend/app/services/export/adapters/counter_group.py
@@ -118,7 +118,7 @@ def build_counter_group_item(
 
 def _envelope(group: CounterGroup) -> dict[str, Any]:
     return {
-        "kind": "initiative-counter-group",
+        "type": "initiative-counter-group",
         "schema_version": 1,
         "name": group.name,
         "description": group.description,

--- a/backend/app/services/export/adapters/document.py
+++ b/backend/app/services/export/adapters/document.py
@@ -170,7 +170,7 @@ def build_document_item(
     if doc_type == DocumentType.whiteboard.value:
         # Importable backup: the scene wrapped as the standard Excalidraw
         # file shape INSIDE the generic envelope — a future import
-        # discriminates by kind like every other document type, and
+        # discriminates by type like every other document type, and
         # unwrapping `content` still yields a file any Excalidraw opens.
         content = document.content or {}
         data = _envelope(
@@ -193,7 +193,7 @@ def build_document_item(
         if format == "json":
             # Importable backup: the canonical (already-versioned) snapshot
             # in the generic document envelope, so a future import can
-            # discriminate file kinds uniformly.
+            # discriminate file types uniformly.
             data = _envelope(document, content=document.content or {})
         else:
             data = {"title": document.title, "grid": document.content or {}}
@@ -221,14 +221,14 @@ def build_document_item(
 
 
 def _envelope(document: Document, *, content: dict) -> dict:
-    """The generic ``initiative-document`` envelope: kind + schema_version
+    """The generic ``initiative-document`` envelope: type + schema_version
     discriminate the file for a future import; tags (by name) and custom
     properties (flat, by name) ride along so a backup keeps the document's
     metadata."""
     from app.services.export.property_values import property_export_dict
 
     return {
-        "kind": "initiative-document",
+        "type": "initiative-document",
         "schema_version": 1,
         "document_type": _doc_type(document),
         "title": document.title,

--- a/backend/app/services/export/adapters/queue.py
+++ b/backend/app/services/export/adapters/queue.py
@@ -127,7 +127,7 @@ def _rotation_order(items: list[QueueItem]) -> list[QueueItem]:
 
 def _envelope(queue: Queue, items: list[QueueItem]) -> dict[str, Any]:
     return {
-        "kind": "initiative-queue",
+        "type": "initiative-queue",
         "schema_version": 1,
         "name": queue.name,
         "description": queue.description,

--- a/backend/app/services/export/i18n.py
+++ b/backend/app/services/export/i18n.py
@@ -9,7 +9,7 @@ locale is available at both delivery paths: inline (the request's
 so no locale needs to be persisted in the job selector.
 
 Scope: only human-facing report chrome is translated. JSON envelopes stay
-canonical (``kind``/``schema_version``/``view_mode`` and field keys are
+canonical (``type``/``schema_version``/``view_mode`` and field keys are
 importable machine data — translating them would break round-trip), and user
 data (titles, names, tags, status names) is never touched.
 """

--- a/frontend/src/components/ui/editor/plugins/actions/import-export-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/actions/import-export-plugin.tsx
@@ -5,9 +5,10 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 // Export moved to the document header's engine-backed Export menu; the toolbar
-// keeps only the import side. Import accepts BOTH file shapes the app has ever
+// keeps only the import side. Import accepts EVERY file shape the app has ever
 // exported: the generic initiative-document envelope (current engine export,
-// editor state under `content`) and the legacy @lexical/file .lexical shape
+// editor state under `content`, discriminated by `type` — or `kind`, the
+// field's name in early exports) and the legacy @lexical/file .lexical shape
 // (editor state under `editorState`).
 function extractEditorState(parsed: unknown): unknown | null {
   if (typeof parsed !== "object" || parsed === null) {
@@ -15,7 +16,7 @@ function extractEditorState(parsed: unknown): unknown | null {
   }
   const record = parsed as Record<string, unknown>;
   if (
-    record.kind === "initiative-document" &&
+    (record.type === "initiative-document" || record.kind === "initiative-document") &&
     record.document_type === "native" &&
     typeof record.content === "object" &&
     record.content !== null


### PR DESCRIPTION
## Problem

Export envelopes and backup manifests use `kind` as their format discriminator, which collides with a library the team uses named "kind". Also, the project backup envelope never carried a discriminator at all — every other tool's envelope has one.

## Notable changes

- Every envelope builder and the backup manifest now emit **`type`** instead of `kind` — values unchanged (`initiative-document`, `initiative-queue`, `initiative-counter-group`, `initiative-calendar-events`, `initiative-backup`/`guild-backup`, `file`). **No schema version bump**: the export release is days old.
- `ProjectExportEnvelope` gains the previously missing discriminator, `type: "initiative-project"`, **defaulted** so files exported before the field existed still validate on import.
- The editor toolbar's import accepts **both** spellings (`type` and `kind`) — files exported by 0.56.0 exist in the wild and must keep round-tripping.
- Backup adapter internals renamed (`kind=` scope params → `scope_kind`) so the word doesn't linger in signatures.
- **Deliberately untouched**: the spreadsheet document *content* snapshot's internal `"kind": "spreadsheet"` (mirrored in `SpreadsheetDocumentEditor.tsx`) — that's the stored content model, and renaming it requires migrating existing rows. Separate change if wanted.

## Schema / env

No DB migrations, no config changes. No generated-type changes (the manifest models aren't exposed in OpenAPI, and the project import endpoint types its envelope as `dict`).

## Testing

```
cd backend && pytest app/api/v1/tenant_endpoints/exports_test.py app/services/export/ app/api/v1/tenant_endpoints/projects_test.py   # 155 passed
cd backend && ruff check app && uv run ty check app   # clean
cd frontend && pnpm typecheck && pnpm test:run        # 862 passed
```

Coverage: the export test suite asserts `"type"` in every envelope and manifest (documents/queues/counter groups/events/backups), and the editor import's dual-spelling acceptance is exercised by its envelope-unwrap path. Not manually tested against a live 0.56.0 export file.
