### PR TITLE
OIDC callback establishes refresh session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Single sign-on (OIDC) logins now establish the same renewable server-side session as password logins, so upcoming silent session renewal will cover both sign-in methods. No action needed; existing logins keep working.
+
 ## [0.56.0] - 2026-07-14
 
 ### Added

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -953,12 +953,17 @@ async def oidc_callback(
     # Best-effort: this is additive and not yet load-bearing, so a transient DB
     # error here must not turn a successful SSO login into a failure — the
     # legacy session cookie above already authenticates the user.
+    #
+    # ``user`` is attached to ``admin_session``, so the rollback below expires
+    # its attributes; the plain ints are captured up front so the failure path
+    # never touches the ORM object again.
+    user_id, provider_id, provider_slug = user.id, provider_row.id, provider_row.slug
     try:
         issued = await session_service.create_session(
             admin_session,
-            user_id=user.id,
-            amr=[f"oidc:{provider_row.slug}"],
-            satisfied_providers=[provider_row.id],
+            user_id=user_id,
+            amr=[f"oidc:{provider_slug}"],
+            satisfied_providers=[provider_id],
             user_agent=request.headers.get("user-agent"),
             ip=_client_ip(request),
         )
@@ -966,7 +971,7 @@ async def oidc_callback(
         _set_refresh_cookie(oidc_response, issued.refresh_token)
     except Exception:
         await admin_session.rollback()
-        logger.exception("Failed to establish refresh session for user %s", user.id)
+        logger.exception("Failed to establish refresh session for user %s", user_id)
     return oidc_response
 
 

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -944,6 +944,29 @@ async def oidc_callback(
         max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         path="/",
     )
+
+    # Additively establish the server-side session + rotating refresh cookie,
+    # mirroring the password login path (history/auth-detailed-design.md §3).
+    # The session records which provider satisfied this login (amr/sat) — the
+    # inputs the per-guild auth-policy gate and step-up read later.
+    #
+    # Best-effort: this is additive and not yet load-bearing, so a transient DB
+    # error here must not turn a successful SSO login into a failure — the
+    # legacy session cookie above already authenticates the user.
+    try:
+        issued = await session_service.create_session(
+            admin_session,
+            user_id=user.id,
+            amr=[f"oidc:{provider_row.slug}"],
+            satisfied_providers=[provider_row.id],
+            user_agent=request.headers.get("user-agent"),
+            ip=_client_ip(request),
+        )
+        await admin_session.commit()
+        _set_refresh_cookie(oidc_response, issued.refresh_token)
+    except Exception:
+        await admin_session.rollback()
+        logger.exception("Failed to establish refresh session for user %s", user.id)
     return oidc_response
 
 

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -27,6 +27,7 @@ from app.core.encryption import (
 )
 from app.core.messages import OidcMessages
 from app.core.security import (
+    REFRESH_COOKIE_NAME,
     SESSION_COOKIE_NAME,
     create_access_token,
     create_upload_token,
@@ -1000,7 +1001,7 @@ async def test_oidc_callback_establishes_refresh_session(
         id_token_claims={"email": "sso-session@example.com", "email_verified": True},
     )
     assert response.status_code in (302, 307)
-    assert response.cookies.get("refresh_token")
+    assert response.cookies.get(REFRESH_COOKIE_NAME)
     assert SESSION_COOKIE_NAME in response.cookies  # legacy cookie unchanged
 
     provider = (
@@ -1018,6 +1019,46 @@ async def test_oidc_callback_establishes_refresh_session(
     ).one()
     assert auth_session.amr == [f"oidc:{PLATFORM_OIDC_SLUG}"]
     assert auth_session.satisfied_providers == [provider.id]
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_oidc_callback_survives_session_store_failure(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """The refresh session is additive, not load-bearing: a failure writing it
+    must not fail a successful SSO login — the redirect and legacy session
+    cookie still go out, just without a refresh cookie."""
+    await _enable_platform_oidc(session)
+    idp = FakeIdp()
+    _wire_fake_idp(monkeypatch, idp)
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("session store down")
+
+    monkeypatch.setattr("app.services.auth.sessions.create_session", _boom)
+
+    response = await _run_oidc_flow(
+        client,
+        idp,
+        id_token_claims={"email": "sso-besteffort@example.com", "email_verified": True},
+    )
+    assert response.status_code in (302, 307)
+    assert response.headers["location"].endswith("/oidc/callback")
+    assert SESSION_COOKIE_NAME in response.cookies
+    assert response.cookies.get(REFRESH_COOKIE_NAME) is None
+
+    user = (
+        await session.exec(
+            select(User).where(
+                User.email_hash == hash_email("sso-besteffort@example.com")
+            )
+        )
+    ).one()
+    rows = (
+        await session.exec(select(AuthSession).where(AuthSession.user_id == user.id))
+    ).all()
+    assert rows == []
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -33,9 +33,12 @@ from app.core.security import (
     get_password_hash,
 )
 from app.models.platform.app_setting import AppSetting, AuthScope
+from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.auth_session import AuthSession
 from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.user import User, UserStatus
 from app.services.auth.oidc.provider import OidcClientConfig, OidcProvider
+from app.services.auth.platform_provider import PLATFORM_OIDC_SLUG
 from app.testing.factories import (
     create_user,
     get_auth_headers,
@@ -977,6 +980,74 @@ async def test_oidc_callback_provisions_new_user_and_sets_cookie(
     assert user.oidc_sub == "idp-subject-1"
     identities = await _federated_identities(session)
     assert [(i.user_id, i.subject) for i in identities] == [(user.id, "idp-subject-1")]
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_oidc_callback_establishes_refresh_session(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """The web callback additively opens a server-side session recording which
+    provider satisfied the login (amr/sat) and issues the rotating refresh
+    cookie — parity with the password login path (additive-first)."""
+    await _enable_platform_oidc(session)
+    idp = FakeIdp()
+    _wire_fake_idp(monkeypatch, idp)
+
+    response = await _run_oidc_flow(
+        client,
+        idp,
+        id_token_claims={"email": "sso-session@example.com", "email_verified": True},
+    )
+    assert response.status_code in (302, 307)
+    assert response.cookies.get("refresh_token")
+    assert SESSION_COOKIE_NAME in response.cookies  # legacy cookie unchanged
+
+    provider = (
+        await session.exec(
+            select(AuthProvider).where(AuthProvider.slug == PLATFORM_OIDC_SLUG)
+        )
+    ).one()
+    user = (
+        await session.exec(
+            select(User).where(User.email_hash == hash_email("sso-session@example.com"))
+        )
+    ).one()
+    auth_session = (
+        await session.exec(select(AuthSession).where(AuthSession.user_id == user.id))
+    ).one()
+    assert auth_session.amr == [f"oidc:{PLATFORM_OIDC_SLUG}"]
+    assert auth_session.satisfied_providers == [provider.id]
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_oidc_refresh_cookie_rotates_into_access_token(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """The refresh cookie issued by the OIDC callback rotates into a fresh
+    access token that authenticates, same as the password-login one."""
+    await _enable_platform_oidc(session)
+    idp = FakeIdp()
+    _wire_fake_idp(monkeypatch, idp)
+
+    response = await _run_oidc_flow(
+        client,
+        idp,
+        id_token_claims={"email": "sso-rotate@example.com", "email_verified": True},
+    )
+    assert response.status_code in (302, 307)
+
+    resp = await client.post("/api/v1/auth/refresh")
+    assert resp.status_code == 200
+    access_token = resp.json()["access_token"]
+
+    me = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert me.status_code == 200
+    assert me.json()["email"] == "sso-rotate@example.com"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Problem

Password login additively opens a server-side `auth_session` and issues the rotating refresh cookie (#824), but the OIDC web callback still only sets the legacy 60-minute session cookie. SSO logins therefore have no renewable session, and no session record carries the `oidc:<slug>` AMR / satisfied-provider set that the per-guild auth-policy gate and step-up (Phase 2 of `history/auth-detailed-design.md`) will read.

## Changes

- The web OIDC callback now additively creates an `auth_session` with `amr=["oidc:<slug>"]` and `satisfied_providers=[provider_id]`, and sets the rotating refresh cookie on the redirect — mirroring the password login path, including its best-effort rule (a transient session-store failure never fails a successful SSO login; the legacy cookie still authenticates).
- The mobile flow is untouched: device tokens remain until the native refresh-token release (Phase 4).
- Tests: session row carries the right amr/sat and the refresh cookie is issued; the SSO-issued refresh cookie rotates into a working access token end-to-end against the fake IdP.

## Schema / env

None.

## Testing

```
cd backend && uv run pytest app/api/v1/platform_endpoints/auth_test.py  # 62 passed
cd backend && uv run ruff check app/api/v1/platform_endpoints/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)