### PR TITLE
Record federated_identity_secrets in the RLS invariant test

### DIFF
--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -41,6 +41,7 @@ _RLS_SHARED_TABLES = {
     "auth_sessions",
     "billing_event_log",
     "federated_identities",
+    "federated_identity_secrets",
     "guild_invites",
     "guild_memberships",
     "guilds",


### PR DESCRIPTION
## Problem

`test_rls_shared_tables_are_forced` fails on every CI run since #923 merged: the PR added `federated_identity_secrets` (with FORCE RLS + policies, correctly registered in `tenancy.py` and `system_grants.py`) but missed the invariant test's own hardcoded `_RLS_SHARED_TABLES` set — the drift alarm is firing on a decision that was already made. This is currently blocking CI on all open PRs (e.g. #922).

## Change

One line: add the table to `_RLS_SHARED_TABLES` in `security_invariants_test.py`, recording the decision.

## Testing

`pytest app/db/security_invariants_test.py` — 8 passed against a freshly created + migrated database (fresh DB matters: the invariant reads the live catalog).