### PR TITLE
Login mints the new session model directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The web app now renews your session silently in the background instead of interrupting you with a "session expired" sign-out when the short-lived access token lapses. You stay signed in as long as you use the app at least once every 30 days; signing out still ends the session everywhere immediately.
+- Signing in (password or SSO) now issues the short-lived renewable session token directly, completing the new login model: the browser session rides the rotating refresh token instead of a single hour-long token. If the session store is briefly unavailable, sign-in falls back to the legacy token so nobody is locked out. Changing your password now keeps the device you changed it on signed in, while still signing out every other session immediately.
 - Single sign-on account data (the IdP subject, refresh token, and sync timestamp) now lives on the per-provider identity links instead of the user row; a boot backfill migrates existing data automatically and nothing changes for signed-in users. The API's `UserRead.oidc_sub` field is replaced by a `has_federated_identity` boolean (read by the profile and deletion dialogs to hide the password confirmation for SSO-only accounts).
 - The project import dialog now uses the shared import engine (API: `POST /projects/import` was replaced by `POST /imports/envelope`, which accepts every tool's envelope — the file's `type` field selects the importer).
 

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -36,6 +36,11 @@ from app.core.security import (
     verify_password,
 )
 from app.core.user_input_validators import normalize_timezone
+from app.api.v1.platform_endpoints.session_cookies import (
+    clear_refresh_cookie,
+    set_refresh_cookie,
+    set_session_cookie,
+)
 from app.models.platform.app_setting import AuthScope
 from app.models.platform.user import User, UserRole, UserStatus
 from app.models.platform.guild import Guild, GuildRole
@@ -86,12 +91,8 @@ logger = logging.getLogger(__name__)
 _oidc_discovery = OidcDiscovery()
 _oidc_jwks = JwksResolver()
 
-# The refresh cookie is scoped to the auth routes so it never rides along on
-# ordinary API requests — it is only presented to /auth/refresh and /auth/logout.
-REFRESH_COOKIE_PATH = f"{API_V1_STR}/auth"
 
-
-def _client_ip(request: Request) -> str | None:
+def client_ip(request: Request) -> str | None:
     """The client IP as a value the INET ``auth_sessions.ip`` column accepts, or
     ``None`` when it isn't a parseable address (e.g. the ``testclient`` peer).
     Guards the login/refresh path from faulting on a non-IP host string."""
@@ -100,43 +101,6 @@ def _client_ip(request: Request) -> str | None:
     except ValueError:
         return None
     return get_real_client_ip(request)
-
-
-def _set_session_cookie(response: Response, token: str, *, max_age: int) -> None:
-    """Set the session-auth cookie (read by ``get_current_user``). During the
-    cutover this holds a legacy JWT at login and a new-model access token after
-    the first refresh — the verifier accepts either."""
-    response.set_cookie(
-        key=SESSION_COOKIE_NAME,
-        value=token,
-        httponly=True,
-        samesite="lax",
-        secure=settings.cookie_secure,
-        max_age=max_age,
-        path="/",
-    )
-
-
-def _set_refresh_cookie(response: Response, token: str) -> None:
-    response.set_cookie(
-        key=REFRESH_COOKIE_NAME,
-        value=token,
-        httponly=True,
-        samesite="lax",
-        secure=settings.cookie_secure,
-        max_age=settings.AUTH_REFRESH_TTL_DAYS * 86400,
-        path=REFRESH_COOKIE_PATH,
-    )
-
-
-def _clear_refresh_cookie(response: Response) -> None:
-    response.delete_cookie(
-        key=REFRESH_COOKIE_NAME,
-        path=REFRESH_COOKIE_PATH,
-        httponly=True,
-        secure=settings.cookie_secure,
-        samesite="lax",
-    )
 
 
 def _refresh_rejected(detail: str) -> JSONResponse:
@@ -152,7 +116,7 @@ def _refresh_rejected(detail: str) -> JSONResponse:
         content={"detail": detail},
         headers={"WWW-Authenticate": "Bearer"},
     )
-    _clear_refresh_cookie(response)
+    clear_refresh_cookie(response)
     response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
     return response
 
@@ -408,23 +372,15 @@ async def login_access_token(
             await session.rollback()
             logger.exception("Failed to upgrade password hash for user %s", user.id)
 
-    access_token = create_access_token(
-        subject=str(user.id), token_version=user.token_version
-    )
-    _set_session_cookie(
-        response, access_token, max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
-    )
-
-    # Additively establish a server-side session + rotating refresh cookie (the
-    # new login model, history/auth-detailed-design.md §3). The legacy session
-    # cookie above is untouched, so existing clients are unaffected; the refresh
-    # cookie only matters once a client calls /auth/refresh. Session writes run
-    # on the system engine (auth_sessions is app_admin-only).
+    # The new login model end-to-end (history/auth-detailed-design.md §3): the
+    # server-side session is load-bearing — the access token carries sid/amr/sat
+    # and lives AUTH_ACCESS_TTL_MINUTES; the rotating refresh cookie carries the
+    # session (the SPA renews silently). Session writes run on the system engine
+    # (auth_sessions is app_admin-only).
     #
-    # Best-effort: this is additive and not yet load-bearing, so a transient DB
-    # error establishing the session must NOT turn a successful password auth
-    # into a 500 (same rule as the hash-upgrade above) — legacy clients that
-    # never touch the refresh cookie would otherwise be broken by it.
+    # Fallback: a transient session-store failure must not block sign-in — issue
+    # a legacy long-lived token instead (the dual-verify window accepts both);
+    # that session just can't renew silently.
     try:
         issued = await session_service.create_session(
             admin_session,
@@ -432,14 +388,33 @@ async def login_access_token(
             amr=["pwd"],
             satisfied_providers=[],
             user_agent=request.headers.get("user-agent"),
-            ip=_client_ip(request),
+            ip=client_ip(request),
         )
         await admin_session.commit()
-        _set_refresh_cookie(response, issued.refresh_token)
     except Exception:
         await admin_session.rollback()
-        logger.exception("Failed to establish refresh session for user %s", user.id)
+        logger.exception(
+            "Failed to establish refresh session for user %s; "
+            "falling back to a legacy access token",
+            user.id,
+        )
+        access_token = create_access_token(
+            subject=str(user.id), token_version=user.token_version
+        )
+        set_session_cookie(
+            response, access_token, max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+        )
+        return Token(access_token=access_token)
 
+    access_token, access_max_age = mint_access_token(
+        user_id=user.id,
+        token_version=user.token_version,
+        session_id=issued.session.id,
+        amr=issued.session.amr,
+        satisfied_providers=issued.session.satisfied_providers,
+    )
+    set_session_cookie(response, access_token, max_age=access_max_age)
+    set_refresh_cookie(response, issued.refresh_token)
     return Token(access_token=access_token)
 
 
@@ -471,7 +446,7 @@ async def refresh_access_token(
         admin_session,
         raw_refresh_token=raw,
         user_agent=request.headers.get("user-agent"),
-        ip=_client_ip(request),
+        ip=client_ip(request),
     )
     # Commit BEFORE branching: one commit persists the rotation (ROTATED) or the
     # theft-revocation (REUSED), so a rejection can't leave the chain kill
@@ -499,8 +474,8 @@ async def refresh_access_token(
         amr=issued.session.amr,
         satisfied_providers=issued.session.satisfied_providers,
     )
-    _set_session_cookie(response, access_token, max_age=access_max_age)
-    _set_refresh_cookie(response, issued.refresh_token)
+    set_session_cookie(response, access_token, max_age=access_max_age)
+    set_refresh_cookie(response, issued.refresh_token)
     return Token(access_token=access_token)
 
 
@@ -547,7 +522,7 @@ async def logout(
         secure=settings.cookie_secure,
         samesite="lax",
     )
-    _clear_refresh_cookie(response)
+    clear_refresh_cookie(response)
 
 
 @router.post("/upload-token", response_model=UploadTokenResponse)
@@ -933,33 +908,21 @@ async def oidc_callback(
         redirect_params = {"token": device_token, "token_type": "device_token"}
         redirect_url = f"{_mobile_redirect_uri()}?{urlencode(redirect_params)}"
         return RedirectResponse(redirect_url)
-    app_token = create_access_token(
-        subject=str(user.id), token_version=user.token_version
-    )
-    oidc_response = RedirectResponse(_frontend_redirect_uri())
-    oidc_response.set_cookie(
-        key=SESSION_COOKIE_NAME,
-        value=app_token,
-        httponly=True,
-        samesite="lax",
-        secure=settings.cookie_secure,
-        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-        path="/",
-    )
-
-    # Additively establish the server-side session + rotating refresh cookie,
-    # mirroring the password login path (history/auth-detailed-design.md §3).
-    # The session records which provider satisfied this login (amr/sat) — the
-    # inputs the per-guild auth-policy gate and step-up read later.
+    # The new login model, mirroring the password path (§3): the session is
+    # load-bearing — the access token carries sid/amr/sat (the inputs the
+    # per-guild auth-policy gate and step-up read later) and the rotating
+    # refresh cookie carries the session.
     #
-    # Best-effort: this is additive and not yet load-bearing, so a transient DB
-    # error here must not turn a successful SSO login into a failure — the
-    # legacy session cookie above already authenticates the user.
+    # Fallback: a transient session-store failure must not fail a successful
+    # SSO login — issue a legacy long-lived token instead (dual-verify window);
+    # that session just can't renew silently.
     #
     # ``user`` is attached to ``admin_session``, so the rollback below expires
-    # its attributes; the plain ints are captured up front so the failure path
-    # never touches the ORM object again.
-    user_id, provider_id, provider_slug = user.id, provider_row.id, provider_row.slug
+    # its attributes; the plain values are captured up front so the failure
+    # path never touches the ORM object again.
+    user_id, token_version = user.id, user.token_version
+    provider_id, provider_slug = provider_row.id, provider_row.slug
+    oidc_response = RedirectResponse(_frontend_redirect_uri())
     try:
         issued = await session_service.create_session(
             admin_session,
@@ -967,13 +930,35 @@ async def oidc_callback(
             amr=[f"oidc:{provider_slug}"],
             satisfied_providers=[provider_id],
             user_agent=request.headers.get("user-agent"),
-            ip=_client_ip(request),
+            ip=client_ip(request),
         )
         await admin_session.commit()
-        _set_refresh_cookie(oidc_response, issued.refresh_token)
     except Exception:
         await admin_session.rollback()
-        logger.exception("Failed to establish refresh session for user %s", user_id)
+        logger.exception(
+            "Failed to establish refresh session for user %s; "
+            "falling back to a legacy access token",
+            user_id,
+        )
+        legacy_token = create_access_token(
+            subject=str(user_id), token_version=token_version
+        )
+        set_session_cookie(
+            oidc_response,
+            legacy_token,
+            max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        )
+        return oidc_response
+
+    app_token, access_max_age = mint_access_token(
+        user_id=user_id,
+        token_version=token_version,
+        session_id=issued.session.id,
+        amr=issued.session.amr,
+        satisfied_providers=issued.session.satisfied_providers,
+    )
+    set_session_cookie(oidc_response, app_token, max_age=access_max_age)
+    set_refresh_cookie(oidc_response, issued.refresh_token)
     return oidc_response
 
 

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-import ipaddress
 import logging
 from typing import Any, Annotated
 from urllib.parse import urlencode
@@ -15,7 +14,7 @@ from app.api.deps import SessionDep, get_current_active_user, get_current_user_o
 from app.db.session import get_admin_session
 from app.core.config import API_V1_STR, settings
 from sqlmodel.ext.asyncio.session import AsyncSession
-from app.core.rate_limit import get_real_client_ip, limiter
+from app.core.rate_limit import get_inet_client_ip, limiter
 from app.core.encryption import (
     decrypt_field,
     encrypt_field,
@@ -90,17 +89,6 @@ logger = logging.getLogger(__name__)
 # per-request OidcProvider is just configuration composed around them.
 _oidc_discovery = OidcDiscovery()
 _oidc_jwks = JwksResolver()
-
-
-def client_ip(request: Request) -> str | None:
-    """The client IP as a value the INET ``auth_sessions.ip`` column accepts, or
-    ``None`` when it isn't a parseable address (e.g. the ``testclient`` peer).
-    Guards the login/refresh path from faulting on a non-IP host string."""
-    try:
-        ipaddress.ip_address(get_real_client_ip(request))
-    except ValueError:
-        return None
-    return get_real_client_ip(request)
 
 
 def _refresh_rejected(detail: str) -> JSONResponse:
@@ -388,7 +376,7 @@ async def login_access_token(
             amr=["pwd"],
             satisfied_providers=[],
             user_agent=request.headers.get("user-agent"),
-            ip=client_ip(request),
+            ip=get_inet_client_ip(request),
         )
         await admin_session.commit()
     except Exception:
@@ -404,6 +392,10 @@ async def login_access_token(
         set_session_cookie(
             response, access_token, max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
         )
+        # A leftover refresh cookie from an earlier session (possibly another
+        # account on this browser) must not ride the new login — clear it so a
+        # later silent renewal can't swap the session out from under the user.
+        clear_refresh_cookie(response)
         return Token(access_token=access_token)
 
     access_token, access_max_age = mint_access_token(
@@ -446,7 +438,7 @@ async def refresh_access_token(
         admin_session,
         raw_refresh_token=raw,
         user_agent=request.headers.get("user-agent"),
-        ip=client_ip(request),
+        ip=get_inet_client_ip(request),
     )
     # Commit BEFORE branching: one commit persists the rotation (ROTATED) or the
     # theft-revocation (REUSED), so a rejection can't leave the chain kill
@@ -930,7 +922,7 @@ async def oidc_callback(
             amr=[f"oidc:{provider_slug}"],
             satisfied_providers=[provider_id],
             user_agent=request.headers.get("user-agent"),
-            ip=client_ip(request),
+            ip=get_inet_client_ip(request),
         )
         await admin_session.commit()
     except Exception:
@@ -948,6 +940,9 @@ async def oidc_callback(
             legacy_token,
             max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         )
+        # Same rule as the password-login fallback: a leftover refresh cookie
+        # must not ride the new login.
+        clear_refresh_cookie(oidc_response)
         return oidc_response
 
     app_token, access_max_age = mint_access_token(

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -997,9 +997,11 @@ async def test_oidc_callback_provisions_new_user_and_sets_cookie(
 async def test_oidc_callback_establishes_refresh_session(
     client: AsyncClient, session: AsyncSession, monkeypatch
 ):
-    """The web callback additively opens a server-side session recording which
-    provider satisfied the login (amr/sat) and issues the rotating refresh
-    cookie — parity with the password login path (additive-first)."""
+    """The web callback opens a server-side session recording which provider
+    satisfied the login (amr/sat), mints the new-model access token from it,
+    and issues the rotating refresh cookie — parity with password login."""
+    import jwt as pyjwt
+
     await _enable_platform_oidc(session)
     idp = FakeIdp()
     _wire_fake_idp(monkeypatch, idp)
@@ -1011,7 +1013,7 @@ async def test_oidc_callback_establishes_refresh_session(
     )
     assert response.status_code in (302, 307)
     assert response.cookies.get(REFRESH_COOKIE_NAME)
-    assert SESSION_COOKIE_NAME in response.cookies  # legacy cookie unchanged
+    assert SESSION_COOKIE_NAME in response.cookies
 
     provider = (
         await session.exec(
@@ -1028,6 +1030,14 @@ async def test_oidc_callback_establishes_refresh_session(
     ).one()
     assert auth_session.amr == [f"oidc:{PLATFORM_OIDC_SLUG}"]
     assert auth_session.satisfied_providers == [provider.id]
+
+    # The cookie carries the new-model access token minted from that session.
+    claims = pyjwt.decode(
+        response.cookies[SESSION_COOKIE_NAME], options={"verify_signature": False}
+    )
+    assert claims["sid"] == str(auth_session.id)
+    assert claims["amr"] == [f"oidc:{PLATFORM_OIDC_SLUG}"]
+    assert claims["sat"] == [provider.id]
 
 
 @pytest.mark.integration
@@ -1056,6 +1066,13 @@ async def test_oidc_callback_survives_session_store_failure(
     assert response.headers["location"].endswith("/oidc/callback")
     assert SESSION_COOKIE_NAME in response.cookies
     assert response.cookies.get(REFRESH_COOKIE_NAME) is None
+    # The fallback cookie is a legacy (session-less) token.
+    import jwt as pyjwt
+
+    claims = pyjwt.decode(
+        response.cookies[SESSION_COOKIE_NAME], options={"verify_signature": False}
+    )
+    assert "sid" not in claims
 
     user = (
         await session.exec(
@@ -1633,6 +1650,65 @@ async def test_login_sets_refresh_cookie(client: AsyncClient, session: AsyncSess
     assert resp.status_code == 200
     assert resp.cookies.get("refresh_token")
     assert resp.cookies.get("session_token")  # legacy cookie unchanged
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_login_issues_session_access_token(
+    client: AsyncClient, session: AsyncSession
+):
+    """Login mints the new-model access token: short-lived (AUTH_ACCESS_TTL),
+    carrying the server-side session id and satisfied factors (sid/amr/sat)."""
+    import jwt as pyjwt
+
+    from app.core.config import settings as app_settings
+
+    _, password = await _make_login_user(session, "newmodel@example.com")
+    resp = await _login(client, "newmodel@example.com", password)
+    assert resp.status_code == 200
+
+    claims = pyjwt.decode(
+        resp.json()["access_token"], options={"verify_signature": False}
+    )
+    assert claims["amr"] == ["pwd"]
+    assert claims["sat"] == []
+    assert claims["sid"]
+    assert resp.cookies.get(REFRESH_COOKIE_NAME)
+    set_cookies = resp.headers.get_list("set-cookie")
+    expected_age = f"Max-Age={app_settings.AUTH_ACCESS_TTL_MINUTES * 60}"
+    assert any(
+        c.startswith(f"{SESSION_COOKIE_NAME}=") and expected_age in c
+        for c in set_cookies
+    ), set_cookies
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_login_session_store_failure_falls_back_to_legacy(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """A session-store failure must not block sign-in: login falls back to a
+    legacy long-lived token (no refresh cookie) that still authenticates."""
+    import jwt as pyjwt
+
+    _, password = await _make_login_user(session, "fallback@example.com")
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("session store down")
+
+    monkeypatch.setattr("app.services.auth.sessions.create_session", _boom)
+
+    resp = await _login(client, "fallback@example.com", password)
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    claims = pyjwt.decode(token, options={"verify_signature": False})
+    assert "sid" not in claims
+    assert resp.cookies.get(REFRESH_COOKIE_NAME) is None
+
+    me = await client.get(
+        "/api/v1/users/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert me.status_code == 200
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -1704,6 +1704,13 @@ async def test_login_session_store_failure_falls_back_to_legacy(
     claims = pyjwt.decode(token, options={"verify_signature": False})
     assert "sid" not in claims
     assert resp.cookies.get(REFRESH_COOKIE_NAME) is None
+    # Any leftover refresh cookie is actively cleared so it can't ride the
+    # new login into a later silent renewal.
+    set_cookies = resp.headers.get_list("set-cookie")
+    assert any(
+        c.startswith(f"{REFRESH_COOKIE_NAME}=") and ("Max-Age=0" in c or "1970" in c)
+        for c in set_cookies
+    ), set_cookies
 
     me = await client.get(
         "/api/v1/users/me", headers={"Authorization": f"Bearer {token}"}

--- a/backend/app/api/v1/platform_endpoints/session_cookies.py
+++ b/backend/app/api/v1/platform_endpoints/session_cookies.py
@@ -1,0 +1,50 @@
+"""Session/refresh cookie emission shared by the auth and account endpoints.
+
+The session cookie carries the access token ``get_current_user`` reads; the
+refresh cookie is scoped to the auth routes so it never rides along on
+ordinary API requests — it is only presented to /auth/refresh and /auth/logout.
+"""
+
+from fastapi import Response
+
+from app.core.config import API_V1_STR, settings
+from app.core.security import REFRESH_COOKIE_NAME, SESSION_COOKIE_NAME
+
+REFRESH_COOKIE_PATH = f"{API_V1_STR}/auth"
+
+
+def set_session_cookie(response: Response, token: str, *, max_age: int) -> None:
+    """Set the session-auth cookie (read by ``get_current_user``). During the
+    cutover this holds a legacy JWT on the fallback path and a new-model access
+    token otherwise — the verifier accepts either."""
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite="lax",
+        secure=settings.cookie_secure,
+        max_age=max_age,
+        path="/",
+    )
+
+
+def set_refresh_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=REFRESH_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite="lax",
+        secure=settings.cookie_secure,
+        max_age=settings.AUTH_REFRESH_TTL_DAYS * 86400,
+        path=REFRESH_COOKIE_PATH,
+    )
+
+
+def clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=REFRESH_COOKIE_NAME,
+        path=REFRESH_COOKIE_PATH,
+        httponly=True,
+        secure=settings.cookie_secure,
+        samesite="lax",
+    )

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -1,7 +1,8 @@
+import logging
 from datetime import datetime, timezone
 from typing import Annotated, List, Optional, Sequence
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlmodel import select
 
 from app.api.deps import (
@@ -13,13 +14,18 @@ from app.api.deps import (
     GuildContext,
     require_guild_roles,
 )
+from app.api.v1.platform_endpoints.auth import client_ip
+from app.api.v1.platform_endpoints.session_cookies import (
+    set_refresh_cookie,
+    set_session_cookie,
+)
 from app.core.config import settings
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.password_policy import enforce_password_policy
 from app.core.security import (
-    SESSION_COOKIE_NAME,
     create_access_token,
     get_password_hash,
+    mint_access_token,
     verify_password,
 )
 from app.core.user_input_validators import (
@@ -55,6 +61,7 @@ from app.schemas.platform.api_key import (
 from app.schemas.tenant.stats import UserStatsResponse
 from app.core.messages import AuthMessages, GuildMessages, UserMessages
 from app.services import notifications as notifications_service
+from app.services.auth import sessions as session_service
 from app.services.auth.identity import has_federated_identity
 from app.services.tenant import initiatives as initiatives_service
 from app.services.platform import guilds as guilds_service
@@ -72,6 +79,8 @@ from app.services.tenant import recent_views as recent_views_service
 TASK_COMPLETION_VISUAL_FEEDBACK_VALUES: frozenset[str] = frozenset(
     {"none", "confetti", "heart", "d20", "gold_coin", "random"}
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 # Cross-guild "my" aggregate (user stats). Mounted under /api/v1/me; user-scoped
@@ -299,6 +308,7 @@ async def create_user(
 
 @router.patch("/me", response_model=UserRead)
 async def update_users_me(
+    request: Request,
     user_in: UserSelfUpdate,
     session: UserSessionDep,
     admin_session: AdminSessionDep,
@@ -363,23 +373,51 @@ async def update_users_me(
         await user_tokens_service.revoke_user_sessions(
             session, user=current_user, admin_session=admin_session
         )
-        # ...but keep THIS session alive. The version bump above invalidates the
-        # caller's own token too, so re-issue the session cookie with the new
-        # version: every *other* session/device still dies, while the user who
-        # just changed their password stays logged in (web cookie auth).
-        refreshed_token = create_access_token(
-            subject=str(current_user.id),
-            token_version=current_user.token_version,
-        )
-        response.set_cookie(
-            key=SESSION_COOKIE_NAME,
-            value=refreshed_token,
-            httponly=True,
-            samesite="lax",
-            secure=settings.cookie_secure,
-            max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-            path="/",
-        )
+        # ...but keep THIS device signed in: the revocation above killed the
+        # caller's own access token AND refresh chain, so open a fresh session
+        # and re-issue both cookies — every *other* session/device still dies.
+        # ``amr`` records what this request proved: the current password for
+        # local accounts; nothing for the SSO-exempt path (no factor was
+        # presented here).
+        #
+        # Fallback: a transient session-store failure must not fail the
+        # password change — re-issue a legacy long-lived token instead (the
+        # dual-verify window accepts both); that session just can't renew.
+        try:
+            issued = await session_service.create_session(
+                admin_session,
+                user_id=current_user.id,
+                amr=[] if is_sso_account else ["pwd"],
+                satisfied_providers=[],
+                user_agent=request.headers.get("user-agent"),
+                ip=client_ip(request),
+            )
+            await admin_session.commit()
+            refreshed_token, refreshed_max_age = mint_access_token(
+                user_id=current_user.id,
+                token_version=current_user.token_version,
+                session_id=issued.session.id,
+                amr=issued.session.amr,
+                satisfied_providers=issued.session.satisfied_providers,
+            )
+            set_session_cookie(response, refreshed_token, max_age=refreshed_max_age)
+            set_refresh_cookie(response, issued.refresh_token)
+        except Exception:
+            await admin_session.rollback()
+            logger.exception(
+                "Failed to establish refresh session for user %s after password "
+                "change; falling back to a legacy access token",
+                current_user.id,
+            )
+            refreshed_token = create_access_token(
+                subject=str(current_user.id),
+                token_version=current_user.token_version,
+            )
+            set_session_cookie(
+                response,
+                refreshed_token,
+                max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+            )
 
     if "avatar_base64" in update_data:
         avatar_value = update_data["avatar_base64"]

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -14,14 +14,15 @@ from app.api.deps import (
     GuildContext,
     require_guild_roles,
 )
-from app.api.v1.platform_endpoints.auth import client_ip
 from app.api.v1.platform_endpoints.session_cookies import (
+    clear_refresh_cookie,
     set_refresh_cookie,
     set_session_cookie,
 )
 from app.core.config import settings
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.password_policy import enforce_password_policy
+from app.core.rate_limit import get_inet_client_ip
 from app.core.security import (
     create_access_token,
     get_password_hash,
@@ -390,7 +391,7 @@ async def update_users_me(
                 amr=[] if is_sso_account else ["pwd"],
                 satisfied_providers=[],
                 user_agent=request.headers.get("user-agent"),
-                ip=client_ip(request),
+                ip=get_inet_client_ip(request),
             )
             await admin_session.commit()
             refreshed_token, refreshed_max_age = mint_access_token(
@@ -418,6 +419,10 @@ async def update_users_me(
                 refreshed_token,
                 max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
             )
+            # The browser still holds the refresh cookie whose chain was just
+            # revoked above — clear it so the SPA doesn't resend a dead token
+            # on its next silent renewal.
+            clear_refresh_cookie(response)
 
     if "avatar_base64" in update_data:
         avatar_value = update_data["avatar_base64"]

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -1000,6 +1000,40 @@ async def test_password_change_keeps_this_device_signed_in(
 
 
 @pytest.mark.integration
+async def test_password_change_fallback_clears_dead_refresh_cookie(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """If the session store fails right after the global revocation, the
+    legacy re-issue must also clear the (now revoked) refresh cookie so the
+    SPA doesn't resend a dead token on its next silent renewal."""
+    await create_user(session, email="pwfall@example.com")
+
+    login = await client.post(
+        "/api/v1/auth/token",
+        data={"username": "pwfall@example.com", "password": "testpassword123"},
+    )
+    assert login.status_code == 200
+    assert login.cookies.get("refresh_token")
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("session store down")
+
+    monkeypatch.setattr("app.services.auth.sessions.create_session", _boom)
+
+    change = await client.patch(
+        "/api/v1/users/me",
+        json={"password": "newpassword456", "current_password": "testpassword123"},
+    )
+    assert change.status_code == 200
+    set_cookies = change.headers.get_list("set-cookie")
+    assert any(
+        c.startswith("refresh_token=") and ("Max-Age=0" in c or "1970" in c)
+        for c in set_cookies
+    ), set_cookies
+    assert any(c.startswith("session_token=") for c in set_cookies)
+
+
+@pytest.mark.integration
 async def test_users_me_reports_linked_identity(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -969,6 +969,37 @@ async def test_export_users_csv_user_outside_guild(
 
 
 @pytest.mark.integration
+async def test_password_change_keeps_this_device_signed_in(
+    client: AsyncClient, session: AsyncSession
+):
+    """Changing the password revokes every other session, but THIS device gets
+    a fresh server-side session: both cookies are re-issued and the new
+    refresh chain rotates."""
+    await create_user(session, email="pwkeep@example.com")
+
+    login = await client.post(
+        "/api/v1/auth/token",
+        data={"username": "pwkeep@example.com", "password": "testpassword123"},
+    )
+    assert login.status_code == 200
+
+    change = await client.patch(
+        "/api/v1/users/me",
+        json={"password": "newpassword456", "current_password": "testpassword123"},
+    )
+    assert change.status_code == 200
+    assert change.cookies.get("refresh_token")  # fresh chain for this device
+
+    rotated = await client.post("/api/v1/auth/refresh")
+    assert rotated.status_code == 200
+    me = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {rotated.json()['access_token']}"},
+    )
+    assert me.status_code == 200
+
+
+@pytest.mark.integration
 async def test_users_me_reports_linked_identity(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,5 +1,7 @@
 """Shared rate limiter configuration for the application."""
 
+import ipaddress
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from starlette.requests import Request
@@ -26,6 +28,17 @@ def get_real_client_ip(request: Request) -> str:
 
     # Direct connection IP (or BEHIND_PROXY not set)
     return get_remote_address(request)
+
+
+def get_inet_client_ip(request: Request) -> str | None:
+    """The client IP as a value an INET column accepts, or ``None`` when it
+    isn't a parseable address (e.g. the ``testclient`` peer). Guards session
+    bookkeeping writes from faulting on a non-IP host string."""
+    try:
+        ipaddress.ip_address(get_real_client_ip(request))
+    except ValueError:
+        return None
+    return get_real_client_ip(request)
 
 
 def _default_limits() -> list[str]:

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -41,6 +41,7 @@ _RLS_SHARED_TABLES = {
     "auth_sessions",
     "billing_event_log",
     "federated_identities",
+    "federated_identity_secrets",
     "guild_invites",
     "guild_memberships",
     "guilds",


### PR DESCRIPTION
## Problem

The server-side session (#824/#915) and silent renewal (#919) are live, but login still issues the legacy hour-long JWT as the primary credential — the new short-lived access token only appears after the first `/auth/refresh`. And a password change revokes the caller's refresh chain without replacing it, so the device that just changed the password gets silently signed out an hour later.

## Changes

- **Password login and the OIDC callback** now create the server-side session first and mint the access token from it — short-lived (`AUTH_ACCESS_TTL_MINUTES`, 15 min) and carrying `sid`/`amr`/`sat` — with the rotating refresh cookie as the session carrier. The legacy 60-minute token is demoted to a **fallback**: a transient session-store failure still signs the user in (dual-verify accepts both), that session just can't renew silently.
- **Password change** opens a fresh session for the calling device after the global revocation and re-issues both cookies, so "every other session dies, this one stays" now survives past access-token expiry. `amr` records what the request proved: the verified current password for local accounts, nothing on the SSO-exempt path (fail-closed for future MFA/step-up gates).
- The session/refresh cookie helpers move to a shared `session_cookies` module (auth.py + users.py both emit them now); `client_ip` becomes public for the same reason.
- Includes #924's one-line invariant fix (identical content, merges cleanly) so CI is green here while that PR is open.

No frontend changes needed — the SPA already renews silently and treats the token opaquely. Native (device tokens) untouched. `ACCESS_TOKEN_EXPIRE_MINUTES` now only sizes the fallback token; it goes away with the rest of the legacy scheme at final cutover.

## Schema / env

None.

## Testing

```
cd backend && uv run pytest app/api/v1/platform_endpoints/auth_test.py \
  app/api/v1/platform_endpoints/users_test.py app/core/security_test.py   # green
cd backend && uv run ruff check app
```

New tests: login token carries sid/amr/sat with the short cookie Max-Age; session-store failure falls back to a legacy token (no refresh cookie) that still authenticates; the OIDC callback cookie is the new-model token minted from the recorded session (and its fallback stays legacy); password change re-issues a refresh chain that rotates.
