### PR TITLE
Generalize login endpoints to per-provider slugs

### DIFF
--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -817,10 +817,16 @@ async def list_login_providers(
             .where(
                 AuthProvider.guild_id.is_(None),
                 AuthProvider.slug != PLATFORM_OIDC_SLUG,
+                AuthProvider.enabled.is_(True),
+                AuthProvider.kind == "oidc",
+                AuthProvider.issuer.is_not(None),
+                AuthProvider.client_id.is_not(None),
             )
             .order_by(AuthProvider.display_name)
         )
     ).all()
+    # _row_login_ready re-checks the same predicates and stays the single
+    # authority (it also guards empty strings, which SQL NULL checks miss).
     entries.extend(_login_entry(row) for row in rows if _row_login_ready(row))
     return LoginProvidersResponse(providers=entries)
 

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -3,7 +3,16 @@ import logging
 from typing import Any, Annotated
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
@@ -41,6 +50,8 @@ from app.api.v1.platform_endpoints.session_cookies import (
     set_session_cookie,
 )
 from app.models.platform.app_setting import AuthScope
+from app.models.platform.auth_provider import AuthProvider
+from app.models.platform.auth_provider_secret import AuthProviderSecret
 from app.models.platform.user import User, UserRole, UserStatus
 from app.models.platform.guild import Guild, GuildRole
 from app.schemas.platform.token import Token
@@ -48,6 +59,8 @@ from app.schemas.platform.auth import (
     DeviceTokenInfo,
     DeviceTokenRequest,
     DeviceTokenResponse,
+    LoginProviderEntry,
+    LoginProvidersResponse,
     PasswordResetRequest,
     PasswordResetSubmit,
     UploadTokenResponse,
@@ -71,7 +84,10 @@ from app.services.auth.oidc.provider import (
     OidcFlowError,
     OidcProvider,
 )
-from app.services.auth.platform_provider import ensure_platform_provider
+from app.services.auth.platform_provider import (
+    PLATFORM_OIDC_SLUG,
+    ensure_platform_provider,
+)
 from app.services.auth.sessions import RefreshOutcome
 from app.services.platform import app_settings as app_settings_service
 from app.services import email as email_service
@@ -619,9 +635,12 @@ async def revoke_device_token(
         )
 
 
-def _backend_redirect_uri() -> str:
+def _provider_redirect_uri(provider_slug: str) -> str:
+    """Per-provider callback URL. For the platform slug this is the same
+    ``/auth/oidc/callback`` operators registered at their IdP before the
+    routes were generalized — the slug is literally ``oidc``."""
     base = settings.APP_URL.rstrip("/")
-    return f"{base}{API_V1_STR}/auth/oidc/callback"
+    return f"{base}{API_V1_STR}/auth/{provider_slug}/callback"
 
 
 def _frontend_redirect_uri() -> str:
@@ -643,14 +662,46 @@ def _platform_oidc_active(app_settings: Any) -> bool:
     )
 
 
-async def _require_platform_oidc(session: AsyncSession) -> Any:
-    """The app settings row, or 404 when platform OIDC login is not live."""
-    app_settings = await app_settings_service.get_app_settings(session)
-    if not _platform_oidc_active(app_settings):
+def _row_login_ready(row: AuthProvider) -> bool:
+    """Whether a registry row is offerable for login: enabled, OIDC, and
+    carrying the non-secret client config discovery needs."""
+    return bool(row.enabled and row.kind == "oidc" and row.issuer and row.client_id)
+
+
+async def _resolve_login_provider(
+    app_settings: Any, admin_session: AsyncSession, provider_slug: str
+) -> AuthProvider:
+    """The enabled operator-global provider row for one login slug, or 404.
+
+    The scope gate comes first: in guild posture every operator-global provider
+    is dormant and must not authenticate anyone — enforced server-side, not
+    just hidden in the UI. The platform slug keeps ``app_settings`` as its
+    config surface (reconciled into the registry row on every resolve); any
+    other slug is a registry row directly."""
+    if app_settings.auth_scope != AuthScope.platform.value:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=OidcMessages.OIDC_NOT_ENABLED
         )
-    return app_settings
+    if provider_slug == PLATFORM_OIDC_SLUG:
+        if not _platform_oidc_active(app_settings):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=OidcMessages.OIDC_NOT_ENABLED,
+            )
+        return await ensure_platform_provider(admin_session, app_settings)
+    row = (
+        await admin_session.exec(
+            select(AuthProvider).where(
+                AuthProvider.slug == provider_slug,
+                AuthProvider.guild_id.is_(None),
+            )
+        )
+    ).one_or_none()
+    if row is None or not _row_login_ready(row):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=OidcMessages.OIDC_NOT_ENABLED
+        )
+    return row
 
 
 def _build_oidc_provider(app_settings: Any) -> OidcProvider:
@@ -670,7 +721,7 @@ def _build_oidc_provider(app_settings: Any) -> OidcProvider:
         OidcClientConfig(
             issuer=app_settings.oidc_issuer,
             client_id=app_settings.oidc_client_id,
-            redirect_uri=_backend_redirect_uri(),
+            redirect_uri=_provider_redirect_uri(PLATFORM_OIDC_SLUG),
             client_secret=client_secret,
             scopes=" ".join(scopes),
         ),
@@ -679,8 +730,45 @@ def _build_oidc_provider(app_settings: Any) -> OidcProvider:
     )
 
 
+async def _build_row_oidc_provider(
+    admin_session: AsyncSession, row: AuthProvider
+) -> OidcProvider:
+    """The relying-party client for a registry-managed provider row. The
+    client secret comes from the app_admin-only companion table; ``None``
+    (public / PKCE-only client) is valid. Tests monkeypatch this builder to
+    point a row-based flow at a fake IdP."""
+    secret_row = await admin_session.get(AuthProviderSecret, row.id)
+    client_secret = (
+        decrypt_field(secret_row.client_secret_encrypted, SALT_OIDC_CLIENT_SECRET)
+        if secret_row and secret_row.client_secret_encrypted
+        else None
+    )
+    return OidcProvider(
+        OidcClientConfig(
+            issuer=row.issuer,
+            client_id=row.client_id,
+            redirect_uri=_provider_redirect_uri(row.slug),
+            client_secret=client_secret,
+            scopes=row.scopes or "openid",
+        ),
+        discovery=_oidc_discovery,
+        jwks=_oidc_jwks,
+    )
+
+
+async def _oidc_client_for(
+    app_settings: Any, admin_session: AsyncSession, row: AuthProvider
+) -> OidcProvider:
+    if row.slug == PLATFORM_OIDC_SLUG:
+        return _build_oidc_provider(app_settings)
+    return await _build_row_oidc_provider(admin_session, row)
+
+
 @router.get("/oidc/status")
 async def oidc_status(request: Request, session: SessionDep) -> dict[str, Any]:
+    """Legacy single-provider status for the current login page. Superseded by
+    ``GET /auth/providers``; removed once the SPA switches to the provider
+    loop."""
     app_settings = await app_settings_service.get_app_settings(session)
     enabled = _platform_oidc_active(app_settings)
     login_url = None
@@ -691,16 +779,70 @@ async def oidc_status(request: Request, session: SessionDep) -> dict[str, Any]:
     return {"enabled": enabled, "login_url": login_url, "provider_name": provider_name}
 
 
-@router.get("/oidc/login")
+def _login_entry(row: AuthProvider) -> LoginProviderEntry:
+    return LoginProviderEntry(
+        slug=row.slug,
+        display_name=row.display_name,
+        kind=row.kind,
+        login_url=f"{API_V1_STR}/auth/{row.slug}/login",
+        icon=row.icon,
+        button_style=row.button_style,
+    )
+
+
+@router.get("/providers", response_model=LoginProvidersResponse)
+async def list_login_providers(
+    session: SessionDep, admin_session: AdminSessionDep
+) -> LoginProvidersResponse:
+    """The sign-in providers the login page offers — non-secret metadata only.
+
+    Empty in guild posture (operator-global providers are dormant there) and
+    on instances with no SSO configured. The platform provider is reconciled
+    from ``app_settings`` on the way out, same as the login flow, so the
+    listing can never disagree with what ``/auth/oidc/login`` would do.
+    Registry rows are read on the system engine (``auth_providers`` carries no
+    request-path grant)."""
+    app_settings = await app_settings_service.get_app_settings(session)
+    if app_settings.auth_scope != AuthScope.platform.value:
+        return LoginProvidersResponse(providers=[])
+
+    entries: list[LoginProviderEntry] = []
+    if _platform_oidc_active(app_settings):
+        platform_row = await ensure_platform_provider(admin_session, app_settings)
+        entries.append(_login_entry(platform_row))
+
+    rows = (
+        await admin_session.exec(
+            select(AuthProvider)
+            .where(
+                AuthProvider.guild_id.is_(None),
+                AuthProvider.slug != PLATFORM_OIDC_SLUG,
+            )
+            .order_by(AuthProvider.display_name)
+        )
+    ).all()
+    entries.extend(_login_entry(row) for row in rows if _row_login_ready(row))
+    return LoginProvidersResponse(providers=entries)
+
+
+@router.get("/{provider_slug}/login")
 @limiter.limit("20/minute")
-async def oidc_login(
+async def provider_login(
     request: Request,
     session: SessionDep,
+    admin_session: AdminSessionDep,
+    provider_slug: Annotated[str, Path(pattern=r"^[a-z0-9][a-z0-9-]{0,63}$")],
     mobile: bool = Query(default=False),
     device_name: str = Query(default="Mobile Device"),
 ) -> RedirectResponse:
-    app_settings = await _require_platform_oidc(session)
-    provider = _build_oidc_provider(app_settings)
+    """Begin the relying-party flow for one provider. The platform provider's
+    slug is ``oidc``, so the pre-generalization ``/auth/oidc/login`` URL is
+    this same route."""
+    app_settings = await app_settings_service.get_app_settings(session)
+    provider_row = await _resolve_login_provider(
+        app_settings, admin_session, provider_slug
+    )
+    provider = await _oidc_client_for(app_settings, admin_session, provider_row)
     try:
         begun = await provider.begin(
             mobile=mobile, device_name=device_name if mobile else ""
@@ -731,16 +873,23 @@ def _error_redirect(is_mobile: bool | None, error: str) -> RedirectResponse:
     return RedirectResponse(url)
 
 
-@router.get("/oidc/callback")
+@router.get("/{provider_slug}/callback")
 @limiter.limit("20/minute")
-async def oidc_callback(
+async def provider_callback(
     request: Request,
     session: SessionDep,
     admin_session: AdminSessionDep,
+    provider_slug: Annotated[str, Path(pattern=r"^[a-z0-9][a-z0-9-]{0,63}$")],
     code: str | None = Query(default=None),
     state: str | None = Query(default=None),
 ):
-    app_settings = await _require_platform_oidc(session)
+    """Complete the relying-party flow for one provider (see provider_login:
+    the platform provider's slug is ``oidc``, so the URL operators registered
+    at their IdP is this same route)."""
+    app_settings = await app_settings_service.get_app_settings(session)
+    provider_row = await _resolve_login_provider(
+        app_settings, admin_session, provider_slug
+    )
 
     # Best-effort mobile flag so even early failures land on the right surface
     # (app vs. web); ``complete()`` re-validates the state authoritatively.
@@ -751,7 +900,7 @@ async def oidc_callback(
         except FlowStateError:
             is_mobile = None
 
-    provider = _build_oidc_provider(app_settings)
+    provider = await _oidc_client_for(app_settings, admin_session, provider_row)
     try:
         completion = await provider.complete(code=code or "", state=state or "")
     except OidcFlowError as exc:
@@ -795,7 +944,6 @@ async def oidc_callback(
         picture_claim if isinstance(picture_claim, str) and picture_claim else None
     )
 
-    provider_row = await ensure_platform_provider(admin_session, app_settings)
     resolution = await resolve_oidc_identity(
         admin_session,
         provider=provider_row,
@@ -867,7 +1015,7 @@ async def oidc_callback(
 
     # OIDC claim-to-role sync (the id_token claims are verified upstream now).
     try:
-        claim_path = getattr(app_settings, "oidc_role_claim_path", None)
+        claim_path = provider_row.role_claim_path
         if claim_path:
             claim_values = extract_claim_values(
                 userinfo or {}, completion.claims, claim_path

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -49,7 +49,7 @@ from app.api.v1.platform_endpoints.session_cookies import (
     set_refresh_cookie,
     set_session_cookie,
 )
-from app.models.platform.app_setting import AuthScope
+from app.models.platform.app_setting import AppSetting, AuthScope
 from app.models.platform.auth_provider import AuthProvider
 from app.models.platform.auth_provider_secret import AuthProviderSecret
 from app.models.platform.user import User, UserRole, UserStatus
@@ -87,6 +87,7 @@ from app.services.auth.oidc.provider import (
 from app.services.auth.platform_provider import (
     PLATFORM_OIDC_SLUG,
     ensure_platform_provider,
+    get_platform_provider,
 )
 from app.services.auth.sessions import RefreshOutcome
 from app.services.platform import app_settings as app_settings_service
@@ -648,7 +649,7 @@ def _frontend_redirect_uri() -> str:
     return f"{base}/oidc/callback"
 
 
-def _platform_oidc_active(app_settings: Any) -> bool:
+def _platform_oidc_active(app_settings: AppSetting) -> bool:
     """The platform OIDC login is offered only when the platform posture is
     live AND the provider is enabled + fully configured. In guild scope the
     platform provider is dormant (kept, not deleted) and must not authenticate
@@ -669,7 +670,7 @@ def _row_login_ready(row: AuthProvider) -> bool:
 
 
 async def _resolve_login_provider(
-    app_settings: Any, admin_session: AsyncSession, provider_slug: str
+    app_settings: AppSetting, admin_session: AsyncSession, provider_slug: str
 ) -> AuthProvider:
     """The enabled operator-global provider row for one login slug, or 404.
 
@@ -704,39 +705,15 @@ async def _resolve_login_provider(
     return row
 
 
-def _build_oidc_provider(app_settings: Any) -> OidcProvider:
-    """The relying-party client for the platform provider, configured from
-    ``app_settings`` (still the operator's config surface until the provider
-    registry gets its own CRUD). Tests monkeypatch this builder to point the
-    flow at a fake IdP."""
-    scopes = app_settings.oidc_scopes or ["openid"]
-    client_secret = (
-        decrypt_field(
-            app_settings.oidc_client_secret_encrypted, SALT_OIDC_CLIENT_SECRET
-        )
-        if app_settings.oidc_client_secret_encrypted
-        else None
-    )
-    return OidcProvider(
-        OidcClientConfig(
-            issuer=app_settings.oidc_issuer,
-            client_id=app_settings.oidc_client_id,
-            redirect_uri=_provider_redirect_uri(PLATFORM_OIDC_SLUG),
-            client_secret=client_secret,
-            scopes=" ".join(scopes),
-        ),
-        discovery=_oidc_discovery,
-        jwks=_oidc_jwks,
-    )
-
-
 async def _build_row_oidc_provider(
     admin_session: AsyncSession, row: AuthProvider
 ) -> OidcProvider:
-    """The relying-party client for a registry-managed provider row. The
-    client secret comes from the app_admin-only companion table; ``None``
-    (public / PKCE-only client) is valid. Tests monkeypatch this builder to
-    point a row-based flow at a fake IdP."""
+    """The relying-party client for one provider row — the single builder for
+    every slug. The platform row is reconciled from ``app_settings`` (config
+    AND secret) by ``_resolve_login_provider`` before it gets here, so the
+    registry row is always the client's source of truth. The secret comes from
+    the app_admin-only companion table; ``None`` (public / PKCE-only client)
+    is valid. Tests monkeypatch this builder to point flows at a fake IdP."""
     secret_row = await admin_session.get(AuthProviderSecret, row.id)
     client_secret = (
         decrypt_field(secret_row.client_secret_encrypted, SALT_OIDC_CLIENT_SECRET)
@@ -750,18 +727,11 @@ async def _build_row_oidc_provider(
             redirect_uri=_provider_redirect_uri(row.slug),
             client_secret=client_secret,
             scopes=row.scopes or "openid",
+            provider_slug=row.slug,
         ),
         discovery=_oidc_discovery,
         jwks=_oidc_jwks,
     )
-
-
-async def _oidc_client_for(
-    app_settings: Any, admin_session: AsyncSession, row: AuthProvider
-) -> OidcProvider:
-    if row.slug == PLATFORM_OIDC_SLUG:
-        return _build_oidc_provider(app_settings)
-    return await _build_row_oidc_provider(admin_session, row)
 
 
 @router.get("/oidc/status")
@@ -797,9 +767,10 @@ async def list_login_providers(
     """The sign-in providers the login page offers — non-secret metadata only.
 
     Empty in guild posture (operator-global providers are dormant there) and
-    on instances with no SSO configured. The platform provider is reconciled
-    from ``app_settings`` on the way out, same as the login flow, so the
-    listing can never disagree with what ``/auth/oidc/login`` would do.
+    on instances with no SSO configured. Strictly read-only: an
+    unauthenticated GET must not trigger writes, so the platform entry is
+    built from ``app_settings`` (its config surface) rather than the
+    write-capable reconcile — that runs in the login flow and at boot.
     Registry rows are read on the system engine (``auth_providers`` carries no
     request-path grant)."""
     app_settings = await app_settings_service.get_app_settings(session)
@@ -808,8 +779,19 @@ async def list_login_providers(
 
     entries: list[LoginProviderEntry] = []
     if _platform_oidc_active(app_settings):
-        platform_row = await ensure_platform_provider(admin_session, app_settings)
-        entries.append(_login_entry(platform_row))
+        # Row read only for display extras (icon/button_style); name and
+        # liveness come from app_settings, matching what login would do.
+        platform_row = await get_platform_provider(admin_session)
+        entries.append(
+            LoginProviderEntry(
+                slug=PLATFORM_OIDC_SLUG,
+                display_name=app_settings.oidc_provider_name or "SSO",
+                kind="oidc",
+                login_url=f"{API_V1_STR}/auth/{PLATFORM_OIDC_SLUG}/login",
+                icon=platform_row.icon if platform_row else None,
+                button_style=platform_row.button_style if platform_row else None,
+            )
+        )
 
     rows = (
         await admin_session.exec(
@@ -848,7 +830,7 @@ async def provider_login(
     provider_row = await _resolve_login_provider(
         app_settings, admin_session, provider_slug
     )
-    provider = await _oidc_client_for(app_settings, admin_session, provider_row)
+    provider = await _build_row_oidc_provider(admin_session, provider_row)
     try:
         begun = await provider.begin(
             mobile=mobile, device_name=device_name if mobile else ""
@@ -906,7 +888,7 @@ async def provider_callback(
         except FlowStateError:
             is_mobile = None
 
-    provider = await _oidc_client_for(app_settings, admin_session, provider_row)
+    provider = await _build_row_oidc_provider(admin_session, provider_row)
     try:
         completion = await provider.complete(code=code or "", state=state or "")
     except OidcFlowError as exc:

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -19,7 +19,6 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import (
-    decrypt_field,
     decrypt_token,
     encrypt_field,
     hash_email,
@@ -767,35 +766,29 @@ async def test_logout_clears_session_cookie(client: AsyncClient, session: AsyncS
 
 
 def _wire_fake_idp(monkeypatch, idp: FakeIdp) -> None:
-    """Point the endpoints' provider builder at the fake IdP's transport.
+    """Point the (single) provider-client builder at the fake IdP's transport.
 
-    Same client configuration the real builder derives from app_settings, but
-    every OIDC HTTP call (discovery, JWKS, token, userinfo) is routed through
-    the fake — skipping the module-level discovery/JWKS caches keeps tests
-    isolated from each other.
+    Same client configuration the real builder derives from the resolved
+    registry row, but every OIDC HTTP call (discovery, JWKS, token, userinfo)
+    is routed through the fake — skipping the module-level discovery/JWKS
+    caches keeps tests isolated from each other.
     """
     import app.api.v1.platform_endpoints.auth as auth_module
 
-    def _builder(app_settings):
-        secret = (
-            decrypt_field(
-                app_settings.oidc_client_secret_encrypted, SALT_OIDC_CLIENT_SECRET
-            )
-            if app_settings.oidc_client_secret_encrypted
-            else None
-        )
+    async def _builder(admin_session, row):
         return OidcProvider(
             OidcClientConfig(
-                issuer=app_settings.oidc_issuer,
-                client_id=app_settings.oidc_client_id,
-                redirect_uri=auth_module._provider_redirect_uri(PLATFORM_OIDC_SLUG),
-                client_secret=secret,
-                scopes=" ".join(app_settings.oidc_scopes or ["openid"]),
+                issuer=row.issuer,
+                client_id=row.client_id,
+                redirect_uri=auth_module._provider_redirect_uri(row.slug),
+                client_secret="s3cret",
+                scopes=row.scopes or "openid",
+                provider_slug=row.slug,
             ),
             client_factory=idp.client_factory(),
         )
 
-    monkeypatch.setattr(auth_module, "_build_oidc_provider", _builder)
+    monkeypatch.setattr(auth_module, "_build_row_oidc_provider", _builder)
 
 
 async def _enable_platform_oidc(session: AsyncSession, **overrides) -> None:
@@ -1172,24 +1165,26 @@ async def test_login_providers_empty_in_guild_posture_or_unconfigured(
     assert response.json()["providers"] == []  # dormant in guild posture
 
 
-def _wire_fake_idp_for_row(monkeypatch, idp: FakeIdp) -> None:
-    """Point the registry-row client builder at the fake IdP's transport —
-    the row-based twin of ``_wire_fake_idp``."""
-    import app.api.v1.platform_endpoints.auth as auth_module
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_state_from_one_provider_rejected_by_another(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """A flow state begun with one provider must not complete against another
+    — the state carries the slug it was minted for."""
+    await _enable_platform_oidc(session)
+    await create_auth_provider(session, slug="corp")
+    _wire_fake_idp(monkeypatch, FakeIdp())
 
-    async def _builder(admin_session, row):
-        return OidcProvider(
-            OidcClientConfig(
-                issuer=row.issuer,
-                client_id=row.client_id,
-                redirect_uri=auth_module._provider_redirect_uri(row.slug),
-                client_secret="s3cret",
-                scopes=row.scopes or "openid",
-            ),
-            client_factory=idp.client_factory(),
-        )
-
-    monkeypatch.setattr(auth_module, "_build_row_oidc_provider", _builder)
+    state, _nonce = await _begin_login(client)  # begun with the platform slug
+    response = await client.get(
+        "/api/v1/auth/corp/callback",
+        params={"code": "code-1", "state": state},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307)
+    assert "invalid_state" in response.headers["location"]
+    assert "session_token" not in response.cookies
 
 
 @pytest.mark.integration
@@ -1203,7 +1198,7 @@ async def test_row_provider_full_login_flow(
     await _enable_platform_oidc(session)
     row = await create_auth_provider(session, slug="corp")
     idp = FakeIdp()
-    _wire_fake_idp_for_row(monkeypatch, idp)
+    _wire_fake_idp(monkeypatch, idp)
 
     begin = await client.get("/api/v1/auth/corp/login", follow_redirects=False)
     assert begin.status_code in (302, 307)

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -43,6 +43,7 @@ from app.models.platform.user import User, UserStatus
 from app.services.auth.oidc.provider import OidcClientConfig, OidcProvider
 from app.services.auth.platform_provider import PLATFORM_OIDC_SLUG
 from app.testing.factories import (
+    create_auth_provider,
     create_user,
     get_auth_headers,
     get_auth_token,
@@ -1117,26 +1118,6 @@ async def test_oidc_refresh_cookie_rotates_into_access_token(
     assert me.json()["email"] == "sso-rotate@example.com"
 
 
-async def _create_provider_row(session: AsyncSession, **overrides) -> AuthProvider:
-    """A registry-managed (non-platform) operator-global provider row."""
-    defaults = {
-        "slug": "corp",
-        "display_name": "Corp SSO",
-        "kind": "oidc",
-        "enabled": True,
-        "guild_id": None,
-        "issuer": OIDC_ISSUER,
-        "client_id": OIDC_CLIENT_ID,
-        "scopes": "openid email",
-        "allow_jit": True,
-    }
-    row = AuthProvider(**{**defaults, **overrides})
-    session.add(row)
-    await session.commit()
-    await session.refresh(row)
-    return row
-
-
 @pytest.mark.integration
 @pytest.mark.auth
 async def test_provider_login_unknown_or_unready_slug_is_404(
@@ -1145,8 +1126,8 @@ async def test_provider_login_unknown_or_unready_slug_is_404(
     """A slug with no registry row — or a row that is disabled or missing its
     client config — must not begin a login."""
     await _enable_platform_oidc(session)
-    await _create_provider_row(session, slug="off", enabled=False)
-    await _create_provider_row(session, slug="bare", issuer=None)
+    await create_auth_provider(session, slug="off", enabled=False)
+    await create_auth_provider(session, slug="bare", issuer=None)
 
     for slug in ("nope", "off", "bare"):
         response = await client.get(
@@ -1162,9 +1143,9 @@ async def test_login_providers_listing(client: AsyncClient, session: AsyncSessio
     """/auth/providers lists the platform provider plus login-ready registry
     rows — and only those."""
     await _enable_platform_oidc(session)
-    await _create_provider_row(session, slug="corp", display_name="Corp SSO")
-    await _create_provider_row(session, slug="off", enabled=False)
-    await _create_provider_row(session, slug="bare", issuer=None)
+    await create_auth_provider(session, slug="corp", display_name="Corp SSO")
+    await create_auth_provider(session, slug="off", enabled=False)
+    await create_auth_provider(session, slug="bare", issuer=None)
 
     response = await client.get("/api/v1/auth/providers")
     assert response.status_code == 200
@@ -1186,7 +1167,7 @@ async def test_login_providers_empty_in_guild_posture_or_unconfigured(
     assert response.json()["providers"] == []  # nothing configured
 
     await _enable_platform_oidc(session, auth_scope=AuthScope.guild.value)
-    await _create_provider_row(session, slug="corp")
+    await create_auth_provider(session, slug="corp")
     response = await client.get("/api/v1/auth/providers")
     assert response.json()["providers"] == []  # dormant in guild posture
 
@@ -1220,7 +1201,7 @@ async def test_row_provider_full_login_flow(
     per-slug login URL, complete at its callback, and the provisioned identity
     and session belong to THAT provider (not the platform one)."""
     await _enable_platform_oidc(session)
-    row = await _create_provider_row(session, slug="corp")
+    row = await create_auth_provider(session, slug="corp")
     idp = FakeIdp()
     _wire_fake_idp_for_row(monkeypatch, idp)
 

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -787,7 +787,7 @@ def _wire_fake_idp(monkeypatch, idp: FakeIdp) -> None:
             OidcClientConfig(
                 issuer=app_settings.oidc_issuer,
                 client_id=app_settings.oidc_client_id,
-                redirect_uri=auth_module._backend_redirect_uri(),
+                redirect_uri=auth_module._provider_redirect_uri(PLATFORM_OIDC_SLUG),
                 client_secret=secret,
                 scopes=" ".join(app_settings.oidc_scopes or ["openid"]),
             ),
@@ -1115,6 +1115,159 @@ async def test_oidc_refresh_cookie_rotates_into_access_token(
     )
     assert me.status_code == 200
     assert me.json()["email"] == "sso-rotate@example.com"
+
+
+async def _create_provider_row(session: AsyncSession, **overrides) -> AuthProvider:
+    """A registry-managed (non-platform) operator-global provider row."""
+    defaults = {
+        "slug": "corp",
+        "display_name": "Corp SSO",
+        "kind": "oidc",
+        "enabled": True,
+        "guild_id": None,
+        "issuer": OIDC_ISSUER,
+        "client_id": OIDC_CLIENT_ID,
+        "scopes": "openid email",
+        "allow_jit": True,
+    }
+    row = AuthProvider(**{**defaults, **overrides})
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_provider_login_unknown_or_unready_slug_is_404(
+    client: AsyncClient, session: AsyncSession
+):
+    """A slug with no registry row — or a row that is disabled or missing its
+    client config — must not begin a login."""
+    await _enable_platform_oidc(session)
+    await _create_provider_row(session, slug="off", enabled=False)
+    await _create_provider_row(session, slug="bare", issuer=None)
+
+    for slug in ("nope", "off", "bare"):
+        response = await client.get(
+            f"/api/v1/auth/{slug}/login", follow_redirects=False
+        )
+        assert response.status_code == 404, slug
+        assert response.json()["detail"] == "OIDC_NOT_ENABLED"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_login_providers_listing(client: AsyncClient, session: AsyncSession):
+    """/auth/providers lists the platform provider plus login-ready registry
+    rows — and only those."""
+    await _enable_platform_oidc(session)
+    await _create_provider_row(session, slug="corp", display_name="Corp SSO")
+    await _create_provider_row(session, slug="off", enabled=False)
+    await _create_provider_row(session, slug="bare", issuer=None)
+
+    response = await client.get("/api/v1/auth/providers")
+    assert response.status_code == 200
+    providers = response.json()["providers"]
+    assert [(p["slug"], p["login_url"]) for p in providers] == [
+        ("oidc", "/api/v1/auth/oidc/login"),
+        ("corp", "/api/v1/auth/corp/login"),
+    ]
+    assert providers[0]["display_name"] == "Test IdP"
+    assert providers[1]["kind"] == "oidc"
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_login_providers_empty_in_guild_posture_or_unconfigured(
+    client: AsyncClient, session: AsyncSession
+):
+    response = await client.get("/api/v1/auth/providers")
+    assert response.json()["providers"] == []  # nothing configured
+
+    await _enable_platform_oidc(session, auth_scope=AuthScope.guild.value)
+    await _create_provider_row(session, slug="corp")
+    response = await client.get("/api/v1/auth/providers")
+    assert response.json()["providers"] == []  # dormant in guild posture
+
+
+def _wire_fake_idp_for_row(monkeypatch, idp: FakeIdp) -> None:
+    """Point the registry-row client builder at the fake IdP's transport —
+    the row-based twin of ``_wire_fake_idp``."""
+    import app.api.v1.platform_endpoints.auth as auth_module
+
+    async def _builder(admin_session, row):
+        return OidcProvider(
+            OidcClientConfig(
+                issuer=row.issuer,
+                client_id=row.client_id,
+                redirect_uri=auth_module._provider_redirect_uri(row.slug),
+                client_secret="s3cret",
+                scopes=row.scopes or "openid",
+            ),
+            client_factory=idp.client_factory(),
+        )
+
+    monkeypatch.setattr(auth_module, "_build_row_oidc_provider", _builder)
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+async def test_row_provider_full_login_flow(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """End-to-end against a registry-managed provider row: begin at the
+    per-slug login URL, complete at its callback, and the provisioned identity
+    and session belong to THAT provider (not the platform one)."""
+    await _enable_platform_oidc(session)
+    row = await _create_provider_row(session, slug="corp")
+    idp = FakeIdp()
+    _wire_fake_idp_for_row(monkeypatch, idp)
+
+    begin = await client.get("/api/v1/auth/corp/login", follow_redirects=False)
+    assert begin.status_code in (302, 307)
+    location = begin.headers["location"]
+    assert location.startswith(f"{OIDC_ISSUER}/authorize?")
+    query = {k: v[0] for k, v in parse_qs(urlsplit(location).query).items()}
+    assert query["redirect_uri"].endswith("/api/v1/auth/corp/callback")
+
+    idp.token_response = httpx.Response(
+        200,
+        json={
+            "access_token": "at-corp",
+            "refresh_token": "rt-corp",
+            "id_token": mint_id_token(
+                nonce=query["nonce"],
+                email="corp-user@example.com",
+                email_verified=True,
+            ),
+            "token_type": "Bearer",
+        },
+    )
+    response = await client.get(
+        "/api/v1/auth/corp/callback",
+        params={"code": "code-corp", "state": query["state"]},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307)
+    assert SESSION_COOKIE_NAME in response.cookies
+
+    user = (
+        await session.exec(
+            select(User).where(User.email_hash == hash_email("corp-user@example.com"))
+        )
+    ).one()
+    identity = (
+        await session.exec(
+            select(FederatedIdentity).where(FederatedIdentity.user_id == user.id)
+        )
+    ).one()
+    assert identity.provider_id == row.id
+    auth_session = (
+        await session.exec(select(AuthSession).where(AuthSession.user_id == user.id))
+    ).one()
+    assert auth_session.amr == ["oidc:corp"]
+    assert auth_session.satisfied_providers == [row.id]
 
 
 @pytest.mark.integration

--- a/backend/app/schemas/platform/auth.py
+++ b/backend/app/schemas/platform/auth.py
@@ -1,9 +1,28 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import ConfigDict, EmailStr, Field
 
 from app.schemas.base import RawTextStr, SanitizedBaseModel
+
+
+class LoginProviderEntry(SanitizedBaseModel):
+    """One sign-in provider offered on the login page (non-secret metadata)."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    slug: str
+    display_name: str
+    kind: str
+    login_url: str
+    icon: Optional[str] = None
+    button_style: Optional[str] = None
+
+
+class LoginProvidersResponse(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    providers: List[LoginProviderEntry]
 
 
 class VerificationSendResponse(SanitizedBaseModel):

--- a/backend/app/services/auth/oidc/flow_state.py
+++ b/backend/app/services/auth/oidc/flow_state.py
@@ -51,6 +51,10 @@ class OidcFlowState:
     nonce: str
     mobile: bool = False
     device_name: str = ""
+    # The provider slug this login attempt was begun with; verified at
+    # complete so the state can't be replayed against another provider.
+    # Empty only in states minted before the field existed.
+    provider_slug: str = ""
 
     @property
     def code_challenge(self) -> str:
@@ -60,7 +64,7 @@ class OidcFlowState:
 
 
 def create_flow_state(
-    *, mobile: bool = False, device_name: str = ""
+    *, mobile: bool = False, device_name: str = "", provider_slug: str = ""
 ) -> tuple[str, OidcFlowState]:
     """Generate a fresh verifier + nonce and return ``(state, payload)`` —
     ``state`` is the encrypted token to send to the IdP, ``payload`` supplies
@@ -72,6 +76,7 @@ def create_flow_state(
         nonce=secrets.token_urlsafe(_NONCE_BYTES),
         mobile=mobile,
         device_name=device_name[:DEVICE_NAME_MAX_CHARS],
+        provider_slug=provider_slug,
     )
     plaintext = json.dumps(
         {
@@ -79,6 +84,7 @@ def create_flow_state(
             "nonce": payload.nonce,
             "mobile": payload.mobile,
             "device_name": payload.device_name,
+            "provider_slug": payload.provider_slug,
         },
         separators=(",", ":"),
     )
@@ -107,6 +113,7 @@ def decode_flow_state(
             nonce=data["nonce"],
             mobile=bool(data.get("mobile", False)),
             device_name=str(data.get("device_name", ""))[:DEVICE_NAME_MAX_CHARS],
+            provider_slug=str(data.get("provider_slug", "")),
         )
     except (ValueError, KeyError, TypeError) as exc:
         raise FlowStateError("malformed flow state payload") from exc

--- a/backend/app/services/auth/oidc/provider.py
+++ b/backend/app/services/auth/oidc/provider.py
@@ -80,6 +80,9 @@ class OidcClientConfig:
     redirect_uri: str
     client_secret: str | None = None  # None = public client (PKCE-only)
     scopes: str = DEFAULT_SCOPES
+    # The registry slug this client serves. Bound into the login flow state so
+    # a state begun with one provider only completes against that provider.
+    provider_slug: str = ""
 
     def __post_init__(self) -> None:
         for field_name in ("issuer", "client_id", "redirect_uri"):
@@ -140,7 +143,11 @@ class OidcProvider:
     async def begin(self, *, mobile: bool = False, device_name: str = "") -> OidcBegin:
         """Mint the flow state and build the authorization redirect URL."""
         metadata = await self._fetch_metadata()
-        state, payload = create_flow_state(mobile=mobile, device_name=device_name)
+        state, payload = create_flow_state(
+            mobile=mobile,
+            device_name=device_name,
+            provider_slug=self._config.provider_slug,
+        )
         params = {
             "response_type": "code",
             "client_id": self._config.client_id,
@@ -166,6 +173,13 @@ class OidcProvider:
             flow = decode_flow_state(state, max_age_seconds=self._max_state_age)
         except FlowStateError as exc:
             raise OidcFlowError("invalid_state", str(exc)) from exc
+        # A state begun with one provider completes only against that provider.
+        # An empty recorded slug is accepted for states minted before the field
+        # existed (in-flight logins across a deploy).
+        if flow.provider_slug and flow.provider_slug != self._config.provider_slug:
+            raise OidcFlowError(
+                "invalid_state", "flow state belongs to a different provider"
+            )
 
         metadata = await self._fetch_metadata()
         token_data = await self._exchange_code(

--- a/backend/app/testing/__init__.py
+++ b/backend/app/testing/__init__.py
@@ -12,6 +12,7 @@ guild's ``guild_<id>`` schema before touching the database (see
 
 from app.testing.actor import Actor, make_actor
 from app.testing.factories import (
+    create_auth_provider,
     create_calendar_event,
     create_calendar_event_property_value,
     create_comment,
@@ -44,6 +45,7 @@ from app.testing.schema_harness import route_session_to_guild
 __all__ = [
     "Actor",
     "make_actor",
+    "create_auth_provider",
     "create_calendar_event",
     "create_calendar_event_property_value",
     "create_comment",

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -1125,6 +1125,39 @@ async def create_upload(
     return upload
 
 
+async def create_auth_provider(
+    session: AsyncSession,
+    commit: bool = True,
+    **overrides: Any,
+) -> AuthProvider:
+    """Create an operator-global auth provider registry row.
+
+    Defaults to a login-ready OIDC row pointing at the test IdP constants
+    (``app.testing.oidc``), so a fake-IdP flow verifies against it as-is.
+    """
+    from app.testing.oidc import CLIENT_ID as _TEST_CLIENT_ID, ISSUER as _TEST_ISSUER
+
+    defaults = {
+        "slug": "corp",
+        "display_name": "Corp SSO",
+        "kind": AuthProviderKind.oidc.value,
+        "enabled": True,
+        "guild_id": None,
+        "issuer": _TEST_ISSUER,
+        "client_id": _TEST_CLIENT_ID,
+        "scopes": "openid email",
+        "allow_jit": True,
+    }
+    provider = AuthProvider(**{**defaults, **overrides})
+    session.add(provider)
+
+    if commit:
+        await session.commit()
+        await session.refresh(provider)
+
+    return provider
+
+
 async def create_federated_identity(
     session: AsyncSession,
     user: User,

--- a/frontend/src/api/generated/auth/auth.ts
+++ b/frontend/src/api/generated/auth/auth.ts
@@ -27,11 +27,12 @@ import type {
   DeviceTokenRequest,
   DeviceTokenResponse,
   HTTPValidationError,
-  OidcCallbackApiV1AuthOidcCallbackGetParams,
-  OidcLoginApiV1AuthOidcLoginGetParams,
+  LoginProvidersResponse,
   OidcStatusApiV1AuthOidcStatusGet200,
   PasswordResetRequest,
   PasswordResetSubmit,
+  ProviderCallbackApiV1AuthProviderSlugCallbackGetParams,
+  ProviderLoginApiV1AuthProviderSlugLoginGetParams,
   RegisterUserApiV1AuthRegisterPostParams,
   Token,
   UploadTokenResponse,
@@ -959,6 +960,9 @@ export const useRevokeDeviceTokenApiV1AuthDeviceTokensTokenIdDelete = <
   );
 };
 /**
+ * Legacy single-provider status for the current login page. Superseded by
+ * ``GET /auth/providers``; removed once the SPA switches to the provider
+ * loop.
  * @summary Oidc Status
  */
 export const oidcStatusApiV1AuthOidcStatusGet = (
@@ -1082,71 +1086,80 @@ export function useOidcStatusApiV1AuthOidcStatusGet<
 }
 
 /**
- * @summary Oidc Login
+ * The sign-in providers the login page offers — non-secret metadata only.
+ *
+ * Empty in guild posture (operator-global providers are dormant there) and
+ * on instances with no SSO configured. The platform provider is reconciled
+ * from ``app_settings`` on the way out, same as the login flow, so the
+ * listing can never disagree with what ``/auth/oidc/login`` would do.
+ * Registry rows are read on the system engine (``auth_providers`` carries no
+ * request-path grant).
+ * @summary List Login Providers
  */
-export const oidcLoginApiV1AuthOidcLoginGet = (
-  params?: OidcLoginApiV1AuthOidcLoginGetParams,
+export const listLoginProvidersApiV1AuthProvidersGet = (
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<unknown>(
-    { url: `/api/v1/auth/oidc/login`, method: "GET", params, signal },
+  return apiMutator<LoginProvidersResponse>(
+    { url: `/api/v1/auth/providers`, method: "GET", signal },
     options
   );
 };
 
-export const getOidcLoginApiV1AuthOidcLoginGetQueryKey = (
-  params?: OidcLoginApiV1AuthOidcLoginGetParams
-) => {
-  return [`/api/v1/auth/oidc/login`, ...(params ? [params] : [])] as const;
+export const getListLoginProvidersApiV1AuthProvidersGetQueryKey = () => {
+  return [`/api/v1/auth/providers`] as const;
 };
 
-export const getOidcLoginApiV1AuthOidcLoginGetQueryOptions = <
-  TData = Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  params?: OidcLoginApiV1AuthOidcLoginGetParams,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }
-) => {
+export const getListLoginProvidersApiV1AuthProvidersGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+  TError = ErrorType<unknown>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}) => {
   const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getOidcLoginApiV1AuthOidcLoginGetQueryKey(params);
+  const queryKey = queryOptions?.queryKey ?? getListLoginProvidersApiV1AuthProvidersGetQueryKey();
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>> = ({
-    signal,
-  }) => oidcLoginApiV1AuthOidcLoginGet(params, requestOptions, signal);
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>
+  > = ({ signal }) => listLoginProvidersApiV1AuthProvidersGet(requestOptions, signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
+    Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData, TError> };
 };
 
-export type OidcLoginApiV1AuthOidcLoginGetQueryResult = NonNullable<
-  Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>
+export type ListLoginProvidersApiV1AuthProvidersGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>
 >;
-export type OidcLoginApiV1AuthOidcLoginGetQueryError = ErrorType<HTTPValidationError>;
+export type ListLoginProvidersApiV1AuthProvidersGetQueryError = ErrorType<unknown>;
 
-export function useOidcLoginApiV1AuthOidcLoginGet<
-  TData = Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
-  TError = ErrorType<HTTPValidationError>,
+export function useListLoginProvidersApiV1AuthProvidersGet<
+  TData = Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+  TError = ErrorType<unknown>,
 >(
-  params: undefined | OidcLoginApiV1AuthOidcLoginGetParams,
   options: {
     query: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>, TError, TData>
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+        TError,
+        TData
+      >
     > &
       Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
+          Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
           TError,
-          Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>
+          Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>
         >,
         "initialData"
       >;
@@ -1154,20 +1167,23 @@ export function useOidcLoginApiV1AuthOidcLoginGet<
   },
   queryClient?: QueryClient
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useOidcLoginApiV1AuthOidcLoginGet<
-  TData = Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
-  TError = ErrorType<HTTPValidationError>,
+export function useListLoginProvidersApiV1AuthProvidersGet<
+  TData = Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+  TError = ErrorType<unknown>,
 >(
-  params?: OidcLoginApiV1AuthOidcLoginGetParams,
   options?: {
     query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>, TError, TData>
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+        TError,
+        TData
+      >
     > &
       Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
+          Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
           TError,
-          Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>
+          Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>
         >,
         "initialData"
       >;
@@ -1175,37 +1191,43 @@ export function useOidcLoginApiV1AuthOidcLoginGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useOidcLoginApiV1AuthOidcLoginGet<
-  TData = Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
-  TError = ErrorType<HTTPValidationError>,
+export function useListLoginProvidersApiV1AuthProvidersGet<
+  TData = Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+  TError = ErrorType<unknown>,
 >(
-  params?: OidcLoginApiV1AuthOidcLoginGetParams,
   options?: {
     query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>, TError, TData>
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+        TError,
+        TData
+      >
     >;
     request?: SecondParameter<typeof apiMutator>;
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
- * @summary Oidc Login
+ * @summary List Login Providers
  */
 
-export function useOidcLoginApiV1AuthOidcLoginGet<
-  TData = Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>,
-  TError = ErrorType<HTTPValidationError>,
+export function useListLoginProvidersApiV1AuthProvidersGet<
+  TData = Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+  TError = ErrorType<unknown>,
 >(
-  params?: OidcLoginApiV1AuthOidcLoginGetParams,
   options?: {
     query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof oidcLoginApiV1AuthOidcLoginGet>>, TError, TData>
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listLoginProvidersApiV1AuthProvidersGet>>,
+        TError,
+        TData
+      >
     >;
     request?: SecondParameter<typeof apiMutator>;
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getOidcLoginApiV1AuthOidcLoginGetQueryOptions(params, options);
+  const queryOptions = getListLoginProvidersApiV1AuthProvidersGetQueryOptions(options);
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -1215,34 +1237,40 @@ export function useOidcLoginApiV1AuthOidcLoginGet<
 }
 
 /**
- * @summary Oidc Callback
+ * Begin the relying-party flow for one provider. The platform provider's
+ * slug is ``oidc``, so the pre-generalization ``/auth/oidc/login`` URL is
+ * this same route.
+ * @summary Provider Login
  */
-export const oidcCallbackApiV1AuthOidcCallbackGet = (
-  params?: OidcCallbackApiV1AuthOidcCallbackGetParams,
+export const providerLoginApiV1AuthProviderSlugLoginGet = (
+  providerSlug: string,
+  params?: ProviderLoginApiV1AuthProviderSlugLoginGetParams,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
   return apiMutator<unknown>(
-    { url: `/api/v1/auth/oidc/callback`, method: "GET", params, signal },
+    { url: `/api/v1/auth/${providerSlug}/login`, method: "GET", params, signal },
     options
   );
 };
 
-export const getOidcCallbackApiV1AuthOidcCallbackGetQueryKey = (
-  params?: OidcCallbackApiV1AuthOidcCallbackGetParams
+export const getProviderLoginApiV1AuthProviderSlugLoginGetQueryKey = (
+  providerSlug: string,
+  params?: ProviderLoginApiV1AuthProviderSlugLoginGetParams
 ) => {
-  return [`/api/v1/auth/oidc/callback`, ...(params ? [params] : [])] as const;
+  return [`/api/v1/auth/${providerSlug}/login`, ...(params ? [params] : [])] as const;
 };
 
-export const getOidcCallbackApiV1AuthOidcCallbackGetQueryOptions = <
-  TData = Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+export const getProviderLoginApiV1AuthProviderSlugLoginGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  params?: OidcCallbackApiV1AuthOidcCallbackGetParams,
+  providerSlug: string,
+  params?: ProviderLoginApiV1AuthProviderSlugLoginGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+        Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
         TError,
         TData
       >
@@ -1253,42 +1281,50 @@ export const getOidcCallbackApiV1AuthOidcCallbackGetQueryOptions = <
   const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey =
-    queryOptions?.queryKey ?? getOidcCallbackApiV1AuthOidcCallbackGetQueryKey(params);
+    queryOptions?.queryKey ??
+    getProviderLoginApiV1AuthProviderSlugLoginGetQueryKey(providerSlug, params);
 
   const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>
-  > = ({ signal }) => oidcCallbackApiV1AuthOidcCallbackGet(params, requestOptions, signal);
+    Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>
+  > = ({ signal }) =>
+    providerLoginApiV1AuthProviderSlugLoginGet(providerSlug, params, requestOptions, signal);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+  return {
+    queryKey,
+    queryFn,
+    enabled: providerSlug !== null && providerSlug !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData, TError> };
 };
 
-export type OidcCallbackApiV1AuthOidcCallbackGetQueryResult = NonNullable<
-  Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>
+export type ProviderLoginApiV1AuthProviderSlugLoginGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>
 >;
-export type OidcCallbackApiV1AuthOidcCallbackGetQueryError = ErrorType<HTTPValidationError>;
+export type ProviderLoginApiV1AuthProviderSlugLoginGetQueryError = ErrorType<HTTPValidationError>;
 
-export function useOidcCallbackApiV1AuthOidcCallbackGet<
-  TData = Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+export function useProviderLoginApiV1AuthProviderSlugLoginGet<
+  TData = Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  params: undefined | OidcCallbackApiV1AuthOidcCallbackGetParams,
+  providerSlug: string,
+  params: undefined | ProviderLoginApiV1AuthProviderSlugLoginGetParams,
   options: {
     query: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+        Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
         TError,
         TData
       >
     > &
       Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+          Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
           TError,
-          Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>
+          Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>
         >,
         "initialData"
       >;
@@ -1296,24 +1332,25 @@ export function useOidcCallbackApiV1AuthOidcCallbackGet<
   },
   queryClient?: QueryClient
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useOidcCallbackApiV1AuthOidcCallbackGet<
-  TData = Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+export function useProviderLoginApiV1AuthProviderSlugLoginGet<
+  TData = Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  params?: OidcCallbackApiV1AuthOidcCallbackGetParams,
+  providerSlug: string,
+  params?: ProviderLoginApiV1AuthProviderSlugLoginGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+        Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
         TError,
         TData
       >
     > &
       Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+          Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
           TError,
-          Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>
+          Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>
         >,
         "initialData"
       >;
@@ -1321,15 +1358,16 @@ export function useOidcCallbackApiV1AuthOidcCallbackGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useOidcCallbackApiV1AuthOidcCallbackGet<
-  TData = Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+export function useProviderLoginApiV1AuthProviderSlugLoginGet<
+  TData = Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  params?: OidcCallbackApiV1AuthOidcCallbackGetParams,
+  providerSlug: string,
+  params?: ProviderLoginApiV1AuthProviderSlugLoginGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+        Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
         TError,
         TData
       >
@@ -1339,18 +1377,19 @@ export function useOidcCallbackApiV1AuthOidcCallbackGet<
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
- * @summary Oidc Callback
+ * @summary Provider Login
  */
 
-export function useOidcCallbackApiV1AuthOidcCallbackGet<
-  TData = Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+export function useProviderLoginApiV1AuthProviderSlugLoginGet<
+  TData = Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  params?: OidcCallbackApiV1AuthOidcCallbackGetParams,
+  providerSlug: string,
+  params?: ProviderLoginApiV1AuthProviderSlugLoginGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof oidcCallbackApiV1AuthOidcCallbackGet>>,
+        Awaited<ReturnType<typeof providerLoginApiV1AuthProviderSlugLoginGet>>,
         TError,
         TData
       >
@@ -1359,7 +1398,187 @@ export function useOidcCallbackApiV1AuthOidcCallbackGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getOidcCallbackApiV1AuthOidcCallbackGetQueryOptions(params, options);
+  const queryOptions = getProviderLoginApiV1AuthProviderSlugLoginGetQueryOptions(
+    providerSlug,
+    params,
+    options
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * Complete the relying-party flow for one provider (see provider_login:
+ * the platform provider's slug is ``oidc``, so the URL operators registered
+ * at their IdP is this same route).
+ * @summary Provider Callback
+ */
+export const providerCallbackApiV1AuthProviderSlugCallbackGet = (
+  providerSlug: string,
+  params?: ProviderCallbackApiV1AuthProviderSlugCallbackGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<unknown>(
+    { url: `/api/v1/auth/${providerSlug}/callback`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getProviderCallbackApiV1AuthProviderSlugCallbackGetQueryKey = (
+  providerSlug: string,
+  params?: ProviderCallbackApiV1AuthProviderSlugCallbackGetParams
+) => {
+  return [`/api/v1/auth/${providerSlug}/callback`, ...(params ? [params] : [])] as const;
+};
+
+export const getProviderCallbackApiV1AuthProviderSlugCallbackGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  providerSlug: string,
+  params?: ProviderCallbackApiV1AuthProviderSlugCallbackGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getProviderCallbackApiV1AuthProviderSlugCallbackGetQueryKey(providerSlug, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>
+  > = ({ signal }) =>
+    providerCallbackApiV1AuthProviderSlugCallbackGet(providerSlug, params, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: providerSlug !== null && providerSlug !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ProviderCallbackApiV1AuthProviderSlugCallbackGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>
+>;
+export type ProviderCallbackApiV1AuthProviderSlugCallbackGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useProviderCallbackApiV1AuthProviderSlugCallbackGet<
+  TData = Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  providerSlug: string,
+  params: undefined | ProviderCallbackApiV1AuthProviderSlugCallbackGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+          TError,
+          Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useProviderCallbackApiV1AuthProviderSlugCallbackGet<
+  TData = Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  providerSlug: string,
+  params?: ProviderCallbackApiV1AuthProviderSlugCallbackGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+          TError,
+          Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useProviderCallbackApiV1AuthProviderSlugCallbackGet<
+  TData = Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  providerSlug: string,
+  params?: ProviderCallbackApiV1AuthProviderSlugCallbackGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Provider Callback
+ */
+
+export function useProviderCallbackApiV1AuthProviderSlugCallbackGet<
+  TData = Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  providerSlug: string,
+  params?: ProviderCallbackApiV1AuthProviderSlugCallbackGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof providerCallbackApiV1AuthProviderSlugCallbackGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getProviderCallbackApiV1AuthProviderSlugCallbackGetQueryOptions(
+    providerSlug,
+    params,
+    options
+  );
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1783,6 +1783,22 @@ export interface LeaveGuildRequest {
   project_deletions?: number[];
 }
 
+/**
+ * One sign-in provider offered on the login page (non-secret metadata).
+ */
+export interface LoginProviderEntry {
+  slug: string;
+  display_name: string;
+  kind: string;
+  login_url: string;
+  icon: string | null;
+  button_style: string | null;
+}
+
+export interface LoginProvidersResponse {
+  providers: LoginProviderEntry[];
+}
+
 export type MentionEntityType = (typeof MentionEntityType)[keyof typeof MentionEntityType];
 
 export const MentionEntityType = {
@@ -3736,12 +3752,12 @@ export type BootstrapStatusApiV1AuthBootstrapGet200 = { [key: string]: boolean }
 
 export type OidcStatusApiV1AuthOidcStatusGet200 = { [key: string]: unknown };
 
-export type OidcLoginApiV1AuthOidcLoginGetParams = {
+export type ProviderLoginApiV1AuthProviderSlugLoginGetParams = {
   mobile?: boolean;
   device_name?: string;
 };
 
-export type OidcCallbackApiV1AuthOidcCallbackGetParams = {
+export type ProviderCallbackApiV1AuthProviderSlugCallbackGetParams = {
   code?: string | null;
   state?: string | null;
 };


### PR DESCRIPTION
## Problem

Phase 1 of the auth design (multi-provider, operator-global) needs per-provider login routes and a provider listing for the login page. Today the RP flow is hardwired to the single platform provider at `/auth/oidc/login|callback`, configured straight from `app_settings`.

## Changes

**Stacked on #925** — base is `feature/login-session-cutover`; retarget to `dev` after that merges.

- `/auth/{slug}/login` and `/auth/{slug}/callback` replace the hardwired routes. The platform provider's slug is literally `oidc`, so the pre-generalization URLs — including the redirect URIs operators registered at their IdPs — are byte-identical instances of the new routes. No alias window needed; every existing OIDC test passes unchanged through the generalized handlers.
- Slug resolution goes through the provider registry: the platform slug keeps `app_settings` as its config surface (reconciled into the registry row on every resolve, exactly as the callback already did); any other slug resolves to an enabled operator-global registry row, its client built from the row + the app_admin-only secret companion (`None` = PKCE-only client). Unknown/disabled/config-incomplete slugs 404 with `OIDC_NOT_ENABLED`; the guild posture keeps all operator-global providers dormant server-side.
- `GET /auth/providers` returns the login-ready providers (slug, display name, kind, icon/button_style, per-slug login URL — non-secret metadata only, read on the system engine) for the upcoming login-page provider loop. `/auth/oidc/status` stays until the SPA switches, then goes per §14.1.
- Claim-to-role sync reads `role_claim_path` from the resolved provider row (reconciled, so unchanged for the platform provider).

No changelog entry: user-visible multi-provider login lands with the provider CRUD + login-page loop slices; until then registry rows can only exist by hand.

## Schema / env

None (API addition only; generated types regenerated).

## Testing

```
cd backend && uv run pytest app/api/v1/platform_endpoints/auth_test.py   # 69 passed
cd backend && uv run ruff check app
```

New tests: per-slug 404s (unknown, disabled, config-incomplete), `/auth/providers` shapes across postures (platform configured, extra registry row, guild posture, unconfigured), and a full end-to-end login against a registry-row provider asserting the federated identity and session bind to that provider (`amr=["oidc:corp"]`, `sat=[row.id]`).