### PR TITLE
Window calendar tasks to the visible range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Import surfaces: each tool's list page (documents, projects, queues, counter groups, calendar) gained an "Import from file" action — an overflow menu on the header and a button in the empty state — for importing that tool's JSON export. The backup import runs through a wizard in guild settings: pick a zip and it's previewed locally (nothing uploaded until you continue), then uploaded, planned, and confirmed.
 - Guild settings **Data** tab: the former Export tab now hosts both directions — export and import — plus one activity table showing recent export and import jobs together, with re-download for finished exports and a report view for finished imports. The old `/settings/export` URL redirects here.
 
+### Fixed
+
+- The calendar no longer drops tasks. It asked for the first 100 tasks in the initiative with no date filter at all, so a busy initiative could silently leave in-window tasks off the calendar entirely, while still transferring tasks from years you weren't looking at. It now fetches exactly the dates the current view shows (day, week, month, year, or list) and pages through all of them. The project filter's options now come from the initiative's projects, so they no longer appear and disappear as you move between months.
+
 ### Changed
 
 - The document and task pickers on queue items, and the project's "attach existing document" picker, now search as you type on the server instead of downloading every document and task in the initiative when the dialog opens. Opening a picker shows the most recent entries and typing narrows them; large initiatives no longer stall these dialogs. Project document cards now load only the documents actually attached (API: `GET /documents/` gained an `ids` filter, max 100 per request).

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -16,12 +16,13 @@ from app.db.query import (
     apply_sorting,
     build_paginated_response,
     extract_condition_value,
+    iter_leaf_conditions,
     paginate_sequence,
     paginated_query,
     parse_conditions,
     parse_sort_fields,
 )
-from app.schemas.query import FilterOp, SortDir
+from app.schemas.query import FilterCondition, FilterOp, SortDir
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import (
@@ -1257,21 +1258,32 @@ async def _parse_task_list_query(
 
     tz = _validate_tz(tz)
 
-    property_value_conditions = [
-        cond for cond in user_conditions if cond.field == "property_values"
+    # Every property_values leaf, wherever it sits, so its definition is loaded
+    # and the limit counts what the query actually compiles.
+    property_value_leaves = [
+        cond
+        for cond in iter_leaf_conditions(user_conditions)
+        if cond.field == "property_values"
     ]
-    if len(property_value_conditions) > properties_service.MAX_PROPERTY_FILTERS:
+    if len(property_value_leaves) > properties_service.MAX_PROPERTY_FILTERS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=QueryMessages.INVALID_CONDITIONS,
         )
     property_ids_needed: list[int] = []
-    for cond in property_value_conditions:
+    for cond in property_value_leaves:
         if isinstance(cond.value, dict):
             try:
                 property_ids_needed.append(int(cond.value.get("property_id")))
             except (TypeError, ValueError):
                 continue
+    # The cross-guild path AND-s these into its statement by hand, so it can
+    # only take top-level leaves — a grouped one isn't an unconditional filter.
+    property_value_conditions = [
+        cond
+        for cond in user_conditions
+        if isinstance(cond, FilterCondition) and cond.field == "property_values"
+    ]
     property_definitions_map = await properties_service.load_definitions_by_ids(
         session,
         property_ids_needed,
@@ -1548,10 +1560,12 @@ async def list_tasks(
     conditions: Optional[str] = Query(
         default=None,
         description=(
-            "JSON list of filter conditions. Each object: "
+            "JSON list of filter conditions, AND-ed together. Each object: "
             '{"field": "<column>", "op": "<operator>", "value": <val>}. '
             "Any Task column is valid plus virtual fields: "
-            "status_category, assignee_ids, tag_ids, initiative_ids."
+            "status_category, assignee_ids, tag_ids, initiative_ids. "
+            'An object with a "conditions" key is an AND/OR group: '
+            '{"logic": "or", "conditions": [...]}.'
         ),
     ),
     include_archived: bool = Query(default=False, description="Include archived tasks"),

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -1066,3 +1066,101 @@ async def test_rolling_recurrence_spring_forward_preserves_wall_clock_time(
     assert new_due_la.minute == 30
     new_due_utc = new_task.due_date.astimezone(timezone.utc)
     assert new_due_utc == datetime(2026, 3, 9, 9, 30, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.integration
+async def test_filter_tasks_by_date_window_group(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """An OR group windows tasks by start_date OR due_date.
+
+    The shape the calendar sends: a task belongs on screen if either of its
+    dates lands in the visible range, so a task due in-window but started
+    before it must still come back.
+    """
+    from datetime import datetime, timezone
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+
+    async def _dated(title, start, due):
+        task = await _create_task(session, a.project, title)
+        task.start_date = start
+        task.due_date = due
+        session.add(task)
+        await session.commit()
+        return task
+
+    def _at(day):
+        return datetime(2026, 6, day, 12, 0, tzinfo=timezone.utc)
+
+    # Window is June 2026; each task is named for why it should/shouldn't match.
+    both_inside = await _dated("both inside", _at(10), _at(11))
+    due_only = await _dated("due only", None, _at(12))
+    start_only = await _dated("start only", _at(13), None)
+    # Starts in May, due in June: the due marker is on screen.
+    straddles = await _dated(
+        "straddles", datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc), _at(14)
+    )
+    outside = await _dated(
+        "outside",
+        datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc),
+        datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc),
+    )
+    undated = await _create_task(session, a.project, "undated")
+
+    window_start = "2026-06-01T00:00:00+00:00"
+    window_end = "2026-06-30T23:59:59+00:00"
+    conditions = json.dumps(
+        [
+            {
+                "logic": "or",
+                "conditions": [
+                    {
+                        "logic": "and",
+                        "conditions": [
+                            {"field": field, "op": "gte", "value": window_start},
+                            {"field": field, "op": "lte", "value": window_end},
+                        ],
+                    }
+                    for field in ("start_date", "due_date")
+                ],
+            }
+        ]
+    )
+
+    # params= rather than an f-string URL: the "+" in a UTC offset is a space
+    # once the query string is decoded.
+    response = await client.get(
+        a.g("/tasks/"),
+        params={"conditions": conditions, "page_size": 0},
+        headers=a.headers,
+    )
+
+    assert response.status_code == 200
+    returned = {t["id"] for t in response.json()["items"]}
+    assert returned == {both_inside.id, due_only.id, start_only.id, straddles.id}
+    assert outside.id not in returned
+    assert undated.id not in returned
+
+
+@pytest.mark.integration
+async def test_list_tasks_rejects_conditions_nested_too_deeply(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    conditions = json.dumps(
+        [
+            {
+                "conditions": [
+                    {"conditions": [{"conditions": [{"field": "id", "value": 1}]}]}
+                ]
+            }
+        ]
+    )
+
+    response = await client.get(
+        a.g(f"/tasks/?conditions={conditions}"), headers=a.headers
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "QUERY_INVALID_CONDITIONS"

--- a/backend/app/db/query.py
+++ b/backend/app/db/query.py
@@ -297,10 +297,18 @@ def _coerce_value(col: Any, value: Any) -> Any:
     if py_type not in (datetime, date) or not isinstance(value, str):
         return value
     try:
-        # date columns take a plain date; a datetime column reads either form.
         return py_type.fromisoformat(value)
     except ValueError:
-        return value
+        pass
+    if py_type is date:
+        # A date column narrowed with a full timestamp — the shape JS
+        # toISOString() produces, which date.fromisoformat() won't read. The
+        # caller means the calendar day, so take it.
+        try:
+            return datetime.fromisoformat(value).date()
+        except ValueError:
+            pass
+    return value
 
 
 def _build_filter_clause(col: Any, op: FilterOp, value: Any):

--- a/backend/app/db/query.py
+++ b/backend/app/db/query.py
@@ -1,7 +1,7 @@
 """Reusable query utilities for filtering, sorting, and pagination.
 
 Provides composable functions that transform SQLAlchemy Select statements:
-- parse_conditions: safely parses a JSON string into FilterCondition list
+- parse_conditions: safely parses a JSON string into a FilterCondition/FilterGroup list
 - apply_filters: adds WHERE clauses from FilterCondition/FilterGroup lists
 - apply_sorting: adds ORDER BY clauses from SortField list or comma-separated strings
 - apply_pagination: adds OFFSET/LIMIT
@@ -11,6 +11,8 @@ Provides composable functions that transform SQLAlchemy Select statements:
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from datetime import date, datetime
 from typing import Any
 
 from pydantic import ValidationError
@@ -24,6 +26,51 @@ from app.schemas.query import FilterCondition, FilterGroup, FilterOp, SortField,
 _MAX_CONDITIONS = 50
 _MAX_SORT_FIELDS = 10
 _MAX_RAW_LENGTH = 10_000
+# How deeply groups may nest. A group counts as one level, so the default
+# admits ``or_(and_(a, b), and_(c, d))`` — the shape a two-field date window
+# needs — without letting a payload nest arbitrarily.
+_MAX_GROUP_DEPTH = 3
+
+
+def iter_leaf_conditions(
+    conditions: list[FilterCondition | FilterGroup],
+) -> Iterator[FilterCondition]:
+    """Yield every :class:`FilterCondition` in *conditions*, groups included.
+
+    For callers that need to see each leaf wherever it sits (loading the
+    property definitions a filter references, counting against a limit).
+    Callers that read a value to *narrow* a query must not use this — see
+    :func:`extract_condition_value`.
+    """
+    for cond in conditions:
+        if isinstance(cond, FilterGroup):
+            yield from iter_leaf_conditions(cond.conditions)
+        else:
+            yield cond
+
+
+def _parse_condition_item(item: Any) -> FilterCondition | FilterGroup:
+    """Build a condition or group from one raw JSON item.
+
+    A ``conditions`` key marks a group; anything else is a leaf comparison.
+    """
+    if not isinstance(item, dict):
+        raise TypeError("condition must be an object")
+    if "conditions" in item:
+        return FilterGroup(**item)
+    return FilterCondition(**item)
+
+
+def _check_group_depth(
+    conditions: list[FilterCondition | FilterGroup],
+    max_depth: int,
+    depth: int = 1,
+) -> None:
+    for cond in conditions:
+        if isinstance(cond, FilterGroup):
+            if depth >= max_depth:
+                raise ValueError(f"conditions nested too deeply (max {max_depth})")
+            _check_group_depth(cond.conditions, max_depth, depth + 1)
 
 
 def parse_conditions(
@@ -31,11 +78,21 @@ def parse_conditions(
     *,
     max_conditions: int = _MAX_CONDITIONS,
     max_length: int = _MAX_RAW_LENGTH,
-) -> list[FilterCondition]:
+    max_depth: int = _MAX_GROUP_DEPTH,
+) -> list[FilterCondition | FilterGroup]:
     """Safely parse a JSON-encoded list of filter conditions.
 
     Designed for use with query parameters that carry structured filters as a
     JSON string.  Applies size and count limits before parsing the payload.
+
+    Items are flat :class:`FilterCondition` comparisons (implicitly AND-ed) or
+    :class:`FilterGroup` objects for explicit AND/OR logic, which
+    :func:`apply_filters` resolves recursively.  A group is any item carrying a
+    ``conditions`` key::
+
+        [{"logic": "or", "conditions": [
+            {"field": "start_date", "op": "gte", "value": "..."},
+            {"field": "due_date", "op": "gte", "value": "..."}]}]
 
     Returns an empty list when *raw* is ``None`` or empty.
 
@@ -60,9 +117,20 @@ def parse_conditions(
         raise ValueError(f"too many conditions (max {max_conditions})")
 
     try:
-        return [FilterCondition(**item) for item in items]
+        parsed = [_parse_condition_item(item) for item in items]
     except (ValidationError, TypeError) as exc:
         raise ValueError("invalid condition structure") from exc
+
+    # Depth and leaf count are checked after parsing: the payload limit above
+    # only bounds the top level, and a group's leaves cost the same to compile
+    # as top-level ones.
+    _check_group_depth(parsed, max_depth)
+
+    leaf_count = sum(1 for _ in iter_leaf_conditions(parsed))
+    if leaf_count > max_conditions:
+        raise ValueError(f"too many conditions (max {max_conditions})")
+
+    return parsed
 
 
 def parse_sort_fields(
@@ -102,11 +170,20 @@ def parse_sort_fields(
 
 
 def extract_condition_value(
-    conditions: list[FilterCondition],
+    conditions: list[FilterCondition | FilterGroup],
     field: str,
 ) -> Any:
-    """Return the ``value`` for the first condition matching *field*, or ``None``."""
+    """Return the ``value`` for the first top-level condition matching *field*,
+    or ``None``.
+
+    Deliberately does not descend into groups: callers use the returned value as
+    a guaranteed narrowing of the result set (which projects to check access on,
+    which initiatives to query), and only a top-level condition is AND-ed into
+    every row. A field inside an ``or`` group holds for some rows, not all.
+    """
     for cond in conditions:
+        if isinstance(cond, FilterGroup):
+            continue
         if cond.field == field:
             return cond.value
     return None
@@ -196,12 +273,49 @@ def _resolve_group(
     return not_(combined) if group.negate else combined
 
 
+def _column_python_type(col: Any) -> type | None:
+    """The Python type *col* stores, or ``None`` if it doesn't declare one."""
+    try:
+        return col.type.python_type
+    except (AttributeError, NotImplementedError):
+        return None
+
+
+def _coerce_value(col: Any, value: Any) -> Any:
+    """Parse an ISO-8601 string into the date/datetime *col* expects.
+
+    Conditions arrive as JSON, which has no date type, so a caller can only
+    send a string. SQLAlchemy binds a Python ``str`` as VARCHAR even when it is
+    compared against a timestamp column, which Postgres then refuses to compare
+    — so the parse has to happen here.
+
+    Anything that isn't an ISO string for a date/datetime column is passed
+    through untouched: a value this can't read is one the caller shouldn't
+    quietly have filtered away.
+    """
+    py_type = _column_python_type(col)
+    if py_type not in (datetime, date) or not isinstance(value, str):
+        return value
+    try:
+        # date columns take a plain date; a datetime column reads either form.
+        return py_type.fromisoformat(value)
+    except ValueError:
+        return value
+
+
 def _build_filter_clause(col: Any, op: FilterOp, value: Any):
     """Return a single WHERE clause for *col* with the given operator.
 
     Negation is handled by the caller via ``FilterCondition.negate``,
     not by separate operators.
     """
+    if op not in (FilterOp.is_null, FilterOp.ilike):
+        value = (
+            [_coerce_value(col, v) for v in value]
+            if op == FilterOp.in_ and isinstance(value, (list, tuple))
+            else _coerce_value(col, value)
+        )
+
     if op == FilterOp.eq:
         return col == value
     if op == FilterOp.lt:

--- a/backend/app/db/query_test.py
+++ b/backend/app/db/query_test.py
@@ -1,7 +1,19 @@
 """Unit tests for the reusable query utility functions."""
 
+from datetime import date, datetime, timezone
+
 import pytest
-from sqlalchemy import Column, Integer, MetaData, String, Boolean, Float, Table
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    Integer,
+    MetaData,
+    String,
+    Table,
+)
 from sqlmodel import select
 
 from app.db.query import (
@@ -11,6 +23,7 @@ from app.db.query import (
     apply_pagination,
     build_paginated_response,
     extract_condition_value,
+    iter_leaf_conditions,
     parse_conditions,
     parse_sort_fields,
 )
@@ -30,6 +43,8 @@ _dummy_table = Table(
     Column("priority", String(20)),
     Column("score", Float),
     Column("is_active", Boolean),
+    Column("due_at", DateTime(timezone=True)),
+    Column("due_on", Date),
 )
 
 
@@ -41,6 +56,8 @@ class _DummyModel:
     priority = _dummy_table.c.priority
     score = _dummy_table.c.score
     is_active = _dummy_table.c.is_active
+    due_at = _dummy_table.c.due_at
+    due_on = _dummy_table.c.due_on
 
 
 # ---------------------------------------------------------------------------
@@ -542,6 +559,95 @@ class TestCallableFilterHandler:
         assert received["value"] == [10, 20]
 
 
+class TestDateValueCoercion:
+    """ISO strings in conditions must reach the DB as real dates.
+
+    JSON has no date type, so a date filter can only arrive as a string, and
+    SQLAlchemy binds a str as VARCHAR even against a timestamp column —
+    Postgres then refuses to compare the two.
+    """
+
+    def test_iso_string_binds_as_timestamp_not_varchar(self):
+        stmt = select(_dummy_table)
+        conditions = [
+            FilterCondition(
+                field="due_at", op=FilterOp.gte, value="2026-06-01T00:00:00+00:00"
+            )
+        ]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        bind = list(result.whereclause.get_children())[1]
+        assert isinstance(bind.type, DateTime)
+        assert bind.value == datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    def test_parses_z_suffix(self):
+        """The shape JS toISOString() produces."""
+        stmt = select(_dummy_table)
+        conditions = [
+            FilterCondition(
+                field="due_at", op=FilterOp.lte, value="2026-06-30T23:59:59.999Z"
+            )
+        ]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        bind = list(result.whereclause.get_children())[1]
+        assert bind.value.tzinfo is not None
+        assert bind.value.year == 2026
+
+    def test_date_column_gets_a_date(self):
+        stmt = select(_dummy_table)
+        conditions = [
+            FilterCondition(field="due_on", op=FilterOp.eq, value="2026-06-01")
+        ]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        bind = list(result.whereclause.get_children())[1]
+        assert bind.value == date(2026, 6, 1)
+
+    def test_coerces_each_value_of_an_in_list(self):
+        stmt = select(_dummy_table)
+        conditions = [
+            FilterCondition(
+                field="due_on", op=FilterOp.in_, value=["2026-06-01", "2026-06-02"]
+            )
+        ]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        sql = str(result.compile(compile_kwargs={"literal_binds": True}))
+        # Rendered as dates, not quoted strings needing a cast.
+        assert "'2026-06-01'" in sql
+
+    def test_datetime_column_accepts_a_date_only_string(self):
+        stmt = select(_dummy_table)
+        conditions = [
+            FilterCondition(field="due_at", op=FilterOp.gte, value="2026-06-01")
+        ]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        bind = list(result.whereclause.get_children())[1]
+        assert bind.value == datetime(2026, 6, 1)
+
+    def test_unparseable_string_is_left_alone(self):
+        """Passed through rather than dropped: silently ignoring a filter the
+        caller asked for would widen the result set."""
+        stmt = select(_dummy_table)
+        conditions = [
+            FilterCondition(field="due_at", op=FilterOp.gte, value="whenever")
+        ]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        bind = list(result.whereclause.get_children())[1]
+        assert bind.value == "whenever"
+
+    def test_non_date_columns_are_untouched(self):
+        stmt = select(_dummy_table)
+        conditions = [FilterCondition(field="name", op=FilterOp.eq, value="2026-06-01")]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        bind = list(result.whereclause.get_children())[1]
+        assert bind.value == "2026-06-01"
+
+    def test_is_null_value_is_not_coerced(self):
+        """is_null reads its value as a boolean flag, not a comparand."""
+        stmt = select(_dummy_table)
+        conditions = [FilterCondition(field="due_at", op=FilterOp.is_null, value=True)]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        assert "IS NULL" in str(result.compile()).upper()
+
+
 # ---------------------------------------------------------------------------
 # apply_sorting
 # ---------------------------------------------------------------------------
@@ -1002,6 +1108,68 @@ class TestParseConditions:
         result = parse_conditions(json.dumps(items))
         assert len(result) == 50
 
+    def test_parses_group(self):
+        raw = (
+            '[{"logic": "or", "conditions": ['
+            '{"field": "start_date", "op": "gte", "value": "2026-01-01"},'
+            '{"field": "due_date", "op": "gte", "value": "2026-01-01"}]}]'
+        )
+        result = parse_conditions(raw)
+        assert len(result) == 1
+        group = result[0]
+        assert isinstance(group, FilterGroup)
+        assert group.logic == "or"
+        assert [c.field for c in group.conditions] == ["start_date", "due_date"]
+
+    def test_parses_group_alongside_flat_conditions(self):
+        raw = (
+            '[{"field": "priority", "op": "in_", "value": ["high"]},'
+            '{"logic": "or", "conditions": [{"field": "a", "value": 1}]}]'
+        )
+        result = parse_conditions(raw)
+        assert isinstance(result[0], FilterCondition)
+        assert isinstance(result[1], FilterGroup)
+
+    def test_group_logic_defaults_to_and(self):
+        result = parse_conditions('[{"conditions": [{"field": "a", "value": 1}]}]')
+        assert result[0].logic == "and"
+
+    def test_parses_nested_group(self):
+        raw = (
+            '[{"logic": "or", "conditions": ['
+            '{"logic": "and", "conditions": ['
+            '{"field": "start_date", "op": "gte", "value": "a"},'
+            '{"field": "start_date", "op": "lte", "value": "b"}]}]}]'
+        )
+        result = parse_conditions(raw)
+        assert isinstance(result[0].conditions[0], FilterGroup)
+
+    def test_rejects_group_nested_too_deeply(self):
+        raw = (
+            '[{"conditions": [{"conditions": [{"conditions": ['
+            '{"field": "a", "value": 1}]}]}]}]'
+        )
+        with pytest.raises(ValueError, match="nested too deeply"):
+            parse_conditions(raw)
+
+    def test_custom_max_depth(self):
+        raw = '[{"conditions": [{"conditions": [{"field": "a", "value": 1}]}]}]'
+        assert parse_conditions(raw)  # depth 2 is fine by default
+        with pytest.raises(ValueError, match="nested too deeply"):
+            parse_conditions(raw, max_depth=1)
+
+    def test_rejects_too_many_conditions_inside_a_group(self):
+        """The count is of leaves, so a group can't smuggle past the limit."""
+        import json
+
+        items = [{"conditions": [{"field": "f", "value": i} for i in range(51)]}]
+        with pytest.raises(ValueError, match="too many conditions"):
+            parse_conditions(json.dumps(items))
+
+    def test_rejects_invalid_structure_inside_a_group(self):
+        with pytest.raises(ValueError, match="invalid condition structure"):
+            parse_conditions('[{"conditions": [{"bad_key": "value"}]}]')
+
 
 # ---------------------------------------------------------------------------
 # extract_condition_value
@@ -1028,6 +1196,54 @@ class TestExtractConditionValue:
     def test_returns_none_when_not_found(self):
         conditions = [FilterCondition(field="name", value="test")]
         assert extract_condition_value(conditions, "missing") is None
+
+    def test_ignores_values_inside_groups(self):
+        """A grouped field doesn't hold for every row, so it must not be read
+        as a narrowing of the result set."""
+        conditions = [
+            FilterGroup(
+                logic="or",
+                conditions=[FilterCondition(field="project_id", value=7)],
+            )
+        ]
+        assert extract_condition_value(conditions, "project_id") is None
+
+    def test_finds_top_level_match_past_a_group(self):
+        conditions = [
+            FilterGroup(conditions=[FilterCondition(field="a", value=1)]),
+            FilterCondition(field="project_id", value=7),
+        ]
+        assert extract_condition_value(conditions, "project_id") == 7
+
+
+# ---------------------------------------------------------------------------
+# iter_leaf_conditions
+# ---------------------------------------------------------------------------
+
+
+class TestIterLeafConditions:
+    def test_yields_flat_conditions(self):
+        conditions = [
+            FilterCondition(field="a", value=1),
+            FilterCondition(field="b", value=2),
+        ]
+        assert [c.field for c in iter_leaf_conditions(conditions)] == ["a", "b"]
+
+    def test_descends_into_nested_groups(self):
+        conditions = [
+            FilterCondition(field="a", value=1),
+            FilterGroup(
+                logic="or",
+                conditions=[
+                    FilterCondition(field="b", value=2),
+                    FilterGroup(conditions=[FilterCondition(field="c", value=3)]),
+                ],
+            ),
+        ]
+        assert [c.field for c in iter_leaf_conditions(conditions)] == ["a", "b", "c"]
+
+    def test_empty(self):
+        assert list(iter_leaf_conditions([])) == []
 
     def test_empty_list_returns_none(self):
         assert extract_condition_value([], "anything") is None

--- a/backend/app/db/query_test.py
+++ b/backend/app/db/query_test.py
@@ -601,6 +601,19 @@ class TestDateValueCoercion:
         bind = list(result.whereclause.get_children())[1]
         assert bind.value == date(2026, 6, 1)
 
+    def test_date_column_narrowed_by_a_full_timestamp_takes_the_day(self):
+        """date.fromisoformat() won't read a time component, but a caller
+        windowing a date column sends exactly that (JS toISOString())."""
+        stmt = select(_dummy_table)
+        conditions = [
+            FilterCondition(
+                field="due_on", op=FilterOp.gte, value="2026-06-01T12:30:00.000Z"
+            )
+        ]
+        result = apply_filters(stmt, _DummyModel, conditions)
+        bind = list(result.whereclause.get_children())[1]
+        assert bind.value == date(2026, 6, 1)
+
     def test_coerces_each_value_of_an_in_list(self):
         stmt = select(_dummy_table)
         conditions = [

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -478,6 +478,7 @@ def _inject_query_schemas(openapi_schema: dict) -> None:
     # ``string`` that FastAPI infers from the endpoint signature.  The Axios
     # paramsSerializer on the frontend JSON-encodes arrays of objects automatically.
     fc_ref = {"$ref": "#/components/schemas/FilterCondition"}
+    fg_ref = {"$ref": "#/components/schemas/FilterGroup"}
     sf_ref = {"$ref": "#/components/schemas/SortField"}
     for path_item in openapi_schema.get("paths", {}).values():
         for operation in path_item.values():
@@ -485,7 +486,11 @@ def _inject_query_schemas(openapi_schema: dict) -> None:
                 continue
             for param in operation.get("parameters", []):
                 if param.get("name") == "conditions" and param.get("in") == "query":
-                    param["schema"] = {"type": "array", "items": fc_ref}
+                    # An item is either a leaf comparison or an AND/OR group.
+                    param["schema"] = {
+                        "type": "array",
+                        "items": {"anyOf": [fc_ref, fg_ref]},
+                    }
                     param.pop("anyOf", None)
                 if param.get("name") == "sorting" and param.get("in") == "query":
                     param["schema"] = {"type": "array", "items": sf_ref}

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3845,9 +3845,9 @@ export type ProjectActivityFeedApiV1GGuildIdProjectsProjectIdActivityGetParams =
 
 export type ListTasksApiV1GGuildIdTasksGetParams = {
   /**
-   * JSON list of filter conditions. Each object: {"field": "<column>", "op": "<operator>", "value": <val>}. Any Task column is valid plus virtual fields: status_category, assignee_ids, tag_ids, initiative_ids.
+   * JSON list of filter conditions, AND-ed together. Each object: {"field": "<column>", "op": "<operator>", "value": <val>}. Any Task column is valid plus virtual fields: status_category, assignee_ids, tag_ids, initiative_ids. An object with a "conditions" key is an AND/OR group: {"logic": "or", "conditions": [...]}.
    */
-  conditions?: FilterCondition[];
+  conditions?: (FilterCondition | FilterGroup)[];
   /**
    * Include archived tasks
    */
@@ -3958,7 +3958,7 @@ export type ExportTasksApiV1GGuildIdExportsTasksGetParams = {
   /**
    * Same JSON filter conditions as the task list
    */
-  conditions?: FilterCondition[];
+  conditions?: (FilterCondition | FilterGroup)[];
   /**
    * Same JSON sort fields as the task list
    */
@@ -4265,7 +4265,7 @@ export type SyncDocumentContentApiV1GGuildIdCollaborationDocumentsDocumentIdSync
   };
 
 export type ListMyTasksApiV1MeTasksGetParams = {
-  conditions?: FilterCondition[];
+  conditions?: (FilterCondition | FilterGroup)[];
   /**
    * Include archived tasks
    */
@@ -4284,7 +4284,7 @@ export type ListMyTasksApiV1MeTasksGetParams = {
 };
 
 export type ListMyCreatedTasksApiV1MeTasksCreatedGetParams = {
-  conditions?: FilterCondition[];
+  conditions?: (FilterCondition | FilterGroup)[];
   /**
    * Include archived tasks
    */

--- a/frontend/src/components/calendar/index.ts
+++ b/frontend/src/components/calendar/index.ts
@@ -7,3 +7,5 @@ export type {
 } from "./CalendarView";
 export { CALENDAR_VIEW_MODE_KEY, CalendarView } from "./CalendarView";
 export { buildTaskCalendarEntries } from "./taskCalendarEntries";
+export type { CalendarVisibleRange } from "./visibleRange";
+export { calendarVisibleRange } from "./visibleRange";

--- a/frontend/src/components/calendar/taskCalendarEntries.test.ts
+++ b/frontend/src/components/calendar/taskCalendarEntries.test.ts
@@ -64,6 +64,27 @@ describe("buildTaskCalendarEntries", () => {
     expect(due?.meta).toMatchObject({ type: "task", taskId: 9, kind: "due" });
   });
 
+  it("keeps each marker on its own day rather than spanning start → due", () => {
+    // Load-bearing for the calendar's fetch: EventsPage windows tasks on
+    // "start_date OR due_date in the visible range", which is only complete
+    // because a task occupies those two days and nothing in between. A task
+    // straddling the whole window renders nothing inside it, so fetching it
+    // would be pointless. If tasks ever render as a bar across the two dates,
+    // that window has to widen to match — or spanning tasks vanish.
+    const task = buildTask({
+      id: 11,
+      start_date: "2026-01-15T09:00:00",
+      due_date: "2026-03-20T17:00:00",
+    });
+
+    const entries = buildTaskCalendarEntries(task, COLOR);
+
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      expect(entry.startAt).toBe(entry.endAt);
+    }
+  });
+
   it("renders a single start marker when only start_date is set", () => {
     const task = buildTask({ id: 10, start_date: "2026-01-15T09:00:00", due_date: undefined });
     const entries = buildTaskCalendarEntries(task, COLOR);

--- a/frontend/src/components/calendar/visibleRange.test.ts
+++ b/frontend/src/components/calendar/visibleRange.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { calendarVisibleRange } from "./visibleRange";
+
+// Local-time construction throughout: the range feeds a query window that the
+// user reads in their own timezone.
+const FOCUS = new Date(2026, 1, 11, 13, 30); // Wed 11 Feb 2026, mid-afternoon
+
+const iso = (d: Date) => `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+
+describe("calendarVisibleRange", () => {
+  it("day view covers the focus day only", () => {
+    const { start, end } = calendarVisibleRange(FOCUS, "day");
+    expect(iso(start)).toBe("2026-2-11");
+    expect(iso(end)).toBe("2026-2-11");
+    expect(start.getHours()).toBe(0);
+    expect(end.getHours()).toBe(23);
+  });
+
+  it("week view covers the surrounding week", () => {
+    const { start, end } = calendarVisibleRange(FOCUS, "week");
+    expect(iso(start)).toBe("2026-2-8"); // Sunday
+    expect(iso(end)).toBe("2026-2-14"); // Saturday
+  });
+
+  it("week view honors weekStartsOn", () => {
+    const { start, end } = calendarVisibleRange(FOCUS, "week", 1);
+    expect(iso(start)).toBe("2026-2-9"); // Monday
+    expect(iso(end)).toBe("2026-2-15"); // Sunday
+  });
+
+  it("month view covers whole weeks only, when the month aligns to them", () => {
+    // Feb 2026 happens to run Sun 1 → Sat 28: a grid with no padding at all.
+    const { start, end } = calendarVisibleRange(FOCUS, "month");
+    expect(iso(start)).toBe("2026-2-1");
+    expect(iso(end)).toBe("2026-2-28");
+  });
+
+  it("month view pads to whole weeks, so adjacent-month days are covered", () => {
+    // Jan 2026 runs Thu 1 → Sat 31, so its grid opens on Sun 28 Dec 2025 and
+    // closes on Sat 31 Jan. Those December days are on screen and their tasks
+    // have to be fetched.
+    const { start, end } = calendarVisibleRange(new Date(2026, 0, 15), "month");
+    expect(iso(start)).toBe("2025-12-28");
+    expect(iso(end)).toBe("2026-1-31");
+  });
+
+  it("year view covers the focus year", () => {
+    const { start, end } = calendarVisibleRange(FOCUS, "year");
+    expect(iso(start)).toBe("2026-1-1");
+    expect(iso(end)).toBe("2026-12-31");
+  });
+
+  it("list view covers the focus month exactly, without week padding", () => {
+    const { start, end } = calendarVisibleRange(FOCUS, "list");
+    expect(iso(start)).toBe("2026-2-1");
+    expect(iso(end)).toBe("2026-2-28");
+  });
+
+  it("end is inclusive of the final day", () => {
+    const { end } = calendarVisibleRange(FOCUS, "month");
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+  });
+});

--- a/frontend/src/components/calendar/visibleRange.ts
+++ b/frontend/src/components/calendar/visibleRange.ts
@@ -1,0 +1,52 @@
+import {
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+} from "date-fns";
+
+import type { CalendarViewMode } from "./CalendarView";
+
+export interface CalendarVisibleRange {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * The span of dates a calendar view actually renders for a given focus date.
+ *
+ * Mirrors what each view builds internally: the month grid pads out to whole
+ * weeks (so late-January days show in the February grid), the list view shows
+ * the focus month exactly, and week/day track the focus date. Callers use this
+ * to fetch only the entries a view can display — keep it in step with
+ * ``CalendarView`` if a view's span ever changes, or entries will be fetched
+ * that the grid never shows (or worse, shown days will come up empty).
+ */
+export function calendarVisibleRange(
+  focusDate: Date,
+  viewMode: CalendarViewMode,
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0
+): CalendarVisibleRange {
+  switch (viewMode) {
+    case "day":
+      return { start: startOfDay(focusDate), end: endOfDay(focusDate) };
+    case "week":
+      return {
+        start: startOfWeek(focusDate, { weekStartsOn }),
+        end: endOfWeek(focusDate, { weekStartsOn }),
+      };
+    case "month":
+      return {
+        start: startOfWeek(startOfMonth(focusDate), { weekStartsOn }),
+        end: endOfWeek(endOfMonth(focusDate), { weekStartsOn }),
+      };
+    case "year":
+      return { start: startOfYear(focusDate), end: endOfYear(focusDate) };
+    case "list":
+      return { start: startOfMonth(focusDate), end: endOfMonth(focusDate) };
+  }
+}

--- a/frontend/src/pages/initiativeTools/events/EventsPage.test.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.test.tsx
@@ -1,0 +1,191 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { endOfMonth, startOfMonth } from "date-fns";
+import { HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { buildProject, buildTask } from "@/__tests__/factories";
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { createTestQueryClient, renderPage } from "@/__tests__/helpers/render";
+import type { FilterCondition, FilterGroup } from "@/api/generated/initiativeAPI.schemas";
+import { CALENDAR_VIEW_MODE_KEY } from "@/components/calendar";
+import { VIEW_PREFERENCES_QUERY_KEY } from "@/hooks/useViewPreference";
+
+import { EventsView } from "./EventsPage";
+
+const INITIATIVE_ID = 1;
+const PROJECT_ID = 1;
+
+/** A day comfortably inside the focus month, so it lands in every view. */
+const inFocusMonth = (dayOffset: number) => {
+  const d = startOfMonth(new Date());
+  d.setDate(d.getDate() + dayOffset);
+  d.setHours(12, 0, 0, 0);
+  return d.toISOString();
+};
+
+/**
+ * Render the calendar in list view — the list renders a row per entry, so a
+ * task either appears or it doesn't. The month grid collapses a busy day into
+ * "+N more", which would hide the very thing these tests check for.
+ */
+function renderEvents() {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(VIEW_PREFERENCES_QUERY_KEY, {
+    items: { [CALENDAR_VIEW_MODE_KEY]: "list" },
+  });
+  const Page = () => <EventsView fixedInitiativeId={INITIATIVE_ID} canCreate={false} />;
+  return renderPage(Page, { queryClient });
+}
+
+/** Capture the params of every GET /tasks/ and serve `pages` in order. */
+function stubTaskPages(
+  pages: { items: unknown[]; has_next: boolean }[],
+  projects = [buildProject({ id: PROJECT_ID, initiative_id: INITIATIVE_ID, name: "Apollo" })]
+) {
+  const requests: URLSearchParams[] = [];
+  server.use(
+    guildHttp.get("/calendar-events/", () =>
+      HttpResponse.json({
+        items: [],
+        total_count: 0,
+        page: 1,
+        page_size: 0,
+        has_next: false,
+        has_prev: false,
+      })
+    ),
+    guildHttp.get("/projects/", () =>
+      HttpResponse.json({
+        items: projects,
+        total_count: projects.length,
+        page: 1,
+        page_size: 0,
+        has_next: false,
+      })
+    ),
+    guildHttp.get("/tasks/", ({ request }) => {
+      const params = new URL(request.url).searchParams;
+      requests.push(params);
+      const page = Number(params.get("page") ?? 1);
+      const body = pages[page - 1] ?? { items: [], has_next: false };
+      return HttpResponse.json({
+        ...body,
+        total_count: pages.reduce((n, p) => n + p.items.length, 0),
+        page,
+        page_size: 0,
+        has_prev: page > 1,
+        sorting: null,
+      });
+    })
+  );
+  return requests;
+}
+
+const parseConditions = (params: URLSearchParams) =>
+  JSON.parse(params.get("conditions") ?? "[]") as (FilterCondition | FilterGroup)[];
+
+const isGroup = (c: FilterCondition | FilterGroup): c is FilterGroup => "conditions" in c;
+
+describe("EventsView tasks query", () => {
+  it("windows the tasks query to the dates the view renders", async () => {
+    const requests = stubTaskPages([{ items: [], has_next: false }]);
+
+    renderEvents();
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+
+    const group = parseConditions(requests[0]).find(isGroup);
+    expect(group).toBeDefined();
+    expect(group?.logic).toBe("or");
+
+    // A task sits on the calendar by its start_date, its due_date, or both, so
+    // the window must match either — not both at once.
+    const legs = (group?.conditions ?? []).filter(isGroup);
+    expect(legs).toHaveLength(2);
+    const fields = legs.map((leg) => (leg.conditions[0] as FilterCondition).field);
+    expect(fields).toEqual(["start_date", "due_date"]);
+
+    // List view shows the focus month exactly.
+    const now = new Date();
+    for (const leg of legs) {
+      const [gte, lte] = leg.conditions as FilterCondition[];
+      expect(leg.logic).toBe("and");
+      expect(gte.op).toBe("gte");
+      expect(gte.value).toBe(startOfMonth(now).toISOString());
+      expect(lte.op).toBe("lte");
+      expect(lte.value).toBe(endOfMonth(now).toISOString());
+    }
+  });
+
+  it("renders every in-window task when the results span more than one page", async () => {
+    // The old query asked for a flat page_size=100 and took page 1 only, so
+    // anything past the hundredth in-window task silently vanished.
+    const page1 = Array.from({ length: 100 }, (_, i) =>
+      buildTask({
+        id: i + 1,
+        title: `Task ${i + 1}`,
+        project_id: PROJECT_ID,
+        due_date: inFocusMonth(i % 27),
+      })
+    );
+    const page2 = [
+      buildTask({
+        id: 101,
+        title: "Hundred and first task",
+        project_id: PROJECT_ID,
+        due_date: inFocusMonth(3),
+      }),
+    ];
+    const requests = stubTaskPages([
+      { items: page1, has_next: true },
+      { items: page2, has_next: false },
+    ]);
+
+    renderEvents();
+
+    // The task beyond the old cap is on the calendar.
+    expect(await screen.findByText("Hundred and first task")).toBeInTheDocument();
+    expect(screen.getByText("Task 1")).toBeInTheDocument();
+
+    // page_size=0 asks for whole windows, and both were walked.
+    await waitFor(() => expect(requests).toHaveLength(2));
+    expect(requests[0].get("page_size")).toBe("0");
+    expect(requests.map((r) => r.get("page"))).toEqual(["1", "2"]);
+  });
+
+  it("offers the initiative's projects as filter options, whatever the window holds", async () => {
+    // No task in the window belongs to Apollo — its option has to survive
+    // anyway, or the filter would vanish on any month the project is quiet.
+    stubTaskPages(
+      [{ items: [], has_next: false }],
+      [
+        buildProject({ id: PROJECT_ID, initiative_id: INITIATIVE_ID, name: "Apollo" }),
+        buildProject({ id: 2, initiative_id: INITIATIVE_ID, name: "Zeus" }),
+        buildProject({
+          id: 3,
+          initiative_id: INITIATIVE_ID,
+          name: "A template",
+          is_template: true,
+        }),
+        buildProject({ id: 4, initiative_id: 99, name: "Another initiative's" }),
+      ]
+    );
+
+    const user = userEvent.setup();
+    renderEvents();
+
+    // The label isn't bound to the Radix trigger, so scope by their shared row.
+    const label = await screen.findByText("Project");
+    const trigger = within(label.parentElement as HTMLElement).getByRole("combobox");
+    await user.click(trigger);
+
+    expect(await screen.findByText("Apollo")).toBeInTheDocument();
+    expect(screen.getByText("Zeus")).toBeInTheDocument();
+    // Templates are held out of the calendar's tasks, and other initiatives
+    // aren't in scope at all.
+    expect(screen.queryByText("A template")).toBeNull();
+    expect(screen.queryByText("Another initiative's")).toBeNull();
+  });
+});

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import type {
   CalendarEventSummary,
   FilterCondition,
+  FilterGroup,
   ListTasksApiV1GGuildIdTasksGetParams,
   TaskPriority,
   TaskStatusCategory,
@@ -23,6 +24,7 @@ import {
   type CalendarEntryReschedule,
   CalendarView,
   type CalendarViewMode,
+  calendarVisibleRange,
 } from "@/components/calendar";
 import { BulkExportButton } from "@/components/exports/BulkExportButton";
 import { ExportButton } from "@/components/exports/ExportButton";
@@ -45,6 +47,7 @@ import { useCalendarEventsList, useRescheduleCalendarEvent } from "@/hooks/useCa
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
 import { useGridSelection } from "@/hooks/useGridSelection";
 import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
+import { useProjects } from "@/hooks/useProjects";
 import { useTasks, useUpdateTask } from "@/hooks/useTasks";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { exportFilenameStem } from "@/lib/exportDownload";
@@ -180,6 +183,12 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     );
   }, [showEvents, showTasks, statusFilters, priorityFilters, projectFilters, propertyFilters]);
 
+  // The span the current view renders — the window the tasks query fetches.
+  const visibleRange = useMemo(
+    () => calendarVisibleRange(focusDate, viewMode, weekStartsOn),
+    [focusDate, viewMode, weekStartsOn]
+  );
+
   // Serialize property filters into the query-param shape the backend
   // expects. Empty list drops the param entirely so the URL stays clean.
   const propertyFiltersParam = useMemo(() => {
@@ -202,7 +211,22 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
 
   const tasksParams = useMemo((): ListTasksApiV1GGuildIdTasksGetParams | null => {
     if (!showTasks) return null;
-    const conditions: FilterCondition[] = [];
+    const conditions: (FilterCondition | FilterGroup)[] = [];
+
+    // Fetch only the tasks the current view can render. A task is placed by its
+    // start_date, its due_date, or both (see buildTaskCalendarEntries), so the
+    // window has to match either one — a task due in-window but started before
+    // it still belongs on the calendar.
+    conditions.push({
+      logic: "or",
+      conditions: (["start_date", "due_date"] as const).map((field) => ({
+        logic: "and" as const,
+        conditions: [
+          { field, op: "gte", value: visibleRange.start.toISOString() },
+          { field, op: "lte", value: visibleRange.end.toISOString() },
+        ],
+      })),
+    });
 
     // If initiativeId is specified, filter by that initiative; otherwise show all guild tasks
     if (initiativeId) {
@@ -232,13 +256,16 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
       });
     }
     return {
-      conditions: conditions.length > 0 ? conditions : undefined,
+      conditions,
       page: 1,
-      page_size: 100,
+      // The calendar must render every in-window task, so take the whole
+      // window: page_size=0 makes useTasks walk the server's pages.
+      page_size: 0,
       tz: userTimezone,
     };
   }, [
     showTasks,
+    visibleRange,
     initiativeId,
     statusFilters,
     priorityFilters,
@@ -247,11 +274,14 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     userTimezone,
   ]);
 
-  const defaultTaskParams: ListTasksApiV1GGuildIdTasksGetParams = { page: 1, page_size: 100 };
+  const defaultTaskParams: ListTasksApiV1GGuildIdTasksGetParams = { page: 1, page_size: 0 };
   const tasksQuery = useTasks(tasksParams ?? defaultTaskParams, {
     enabled: !!tasksParams,
     placeholderData: keepPreviousData,
   });
+
+  // Same param shape the sidebar and dashboard use, so this shares their cache.
+  const projectsQuery = useProjects(undefined, { enabled: showTasks, staleTime: 30_000 });
 
   const canCreateEvents = useMemo(() => {
     if (canCreate !== undefined) return canCreate;
@@ -440,20 +470,23 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     [t]
   );
 
-  // Derive unique projects from task results for the project filter dropdown
+  // Options for the project filter. Sourced from the projects list rather than
+  // the task rows those filters produce: the rows only cover the visible date
+  // window, so deriving from them would drop a project from the dropdown on
+  // every month it happens to have no task in — including the one currently
+  // selected.
   const projectOptions = useMemo(() => {
-    const tasks = tasksQuery.data?.items ?? [];
-    const seen = new Map<number, string>();
-    tasks.forEach((task) => {
-      if (!seen.has(task.project_id)) {
-        seen.set(task.project_id, task.project_name ?? String(task.project_id));
-      }
-    });
-    return Array.from(seen.entries()).map(([id, name]) => ({
-      value: String(id),
-      label: name,
-    }));
-  }, [tasksQuery.data]);
+    const projects = projectsQuery.data?.items ?? [];
+    return projects
+      .filter(
+        (project) =>
+          // Template projects are held out of the calendar's tasks, so an
+          // option for one would filter to nothing.
+          !project.is_template && (initiativeId === null || project.initiative_id === initiativeId)
+      )
+      .map((project) => ({ value: String(project.id), label: project.name }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [projectsQuery.data, initiativeId]);
 
   const isLoading = eventsQuery.isLoading && !eventsQuery.data;
 

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -217,6 +217,12 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
     // start_date, its due_date, or both (see buildTaskCalendarEntries), so the
     // window has to match either one — a task due in-window but started before
     // it still belongs on the calendar.
+    //
+    // A task that straddles the whole window (starts before, due after) matches
+    // neither arm, which is correct: its two markers sit on days outside the
+    // window and it renders nothing inside it. That holds only while markers
+    // are single days rather than a bar spanning start → due — pinned by a test
+    // in taskCalendarEntries.test.ts.
     conditions.push({
       logic: "or",
       conditions: (["start_date", "due_date"] as const).map((field) => ({


### PR DESCRIPTION
Fixes #860.

## Problem

`EventsPage` fetched calendar events with a ±1yr window but fetched tasks with a flat `page_size: 100` and **no date range at all**. That was simultaneously an overfetch (tasks from years outside the visible calendar were transferred) and a correctness bug: an initiative with more than 100 tasks silently lost the rest from the calendar, with nothing on screen to say so.

Two things surfaced while fixing it that the issue didn't anticipate:

**The window needs an OR, so it wasn't frontend-only.** A task is placed on the calendar by its `start_date`, its `due_date`, or both (`buildTaskCalendarEntries`), so the window has to match *either* — a task due in-window but started before it still belongs on screen. `parse_conditions` only ever built flat, AND-ed `FilterCondition`s. `FilterGroup` and the OR logic already existed in the schema and in `apply_filters`; they just couldn't arrive through the query param.

**Date filtering through `conditions` had never worked.** Found by the endpoint test: SQLAlchemy binds a Python `str` as VARCHAR even when compared against a timestamp column, and Postgres refuses (`operator does not exist: timestamp with time zone >= character varying`). Any date condition 500'd. The frontend test couldn't catch this — MSW mocks the API.

## Changes

**Backend**
- `parse_conditions` accepts AND/OR groups (any item with a `conditions` key), bounded by a nesting-depth cap and a leaf count, so a group can't smuggle past the existing condition limit.
- `extract_condition_value` deliberately **does not** descend into groups: callers read it as a guaranteed narrowing of the result set (which projects to check access on, which initiatives to query), and a field inside an `or` group holds for some rows, not all.
- `_build_filter_clause` parses ISO strings into the column's own date/datetime type. An unparseable value is passed through rather than dropped — silently ignoring a filter would widen the result set.
- `_parse_task_list_query` collects `property_values` leaves from inside groups too (so their definitions load), while the cross-guild path keeps taking top-level leaves only, since it AND-s them in by hand.
- OpenAPI `conditions` param is now `(FilterCondition | FilterGroup)[]`; generated types regenerated.

**Frontend**
- New tested `calendarVisibleRange(focusDate, viewMode, weekStartsOn)` helper returning the span each view actually renders (the month grid pads to whole weeks; list is the focus month exactly).
- `EventsPage` windows the tasks query to that range and passes `page_size: 0`, so the existing `fetchAllPages` walks every page — the calendar renders every in-window task regardless of count.
- Project filter options now come from the projects list instead of the returned task rows. **Forced by the narrower window**: deriving options from in-window rows would drop a project from the dropdown on every month it happened to have no task in, including the currently selected one. Also fixes a pre-existing bug where selecting a project collapsed the options to just that project. Template projects are excluded (they're held out of the calendar's tasks, so the option would filter to nothing).

## Testing

```
cd backend && pytest          # 1974 passed, 11 failed
cd backend && ruff check app && ruff format --check app
cd frontend && pnpm test:run  # 905 passed
cd frontend && pnpm typecheck && pnpm lint
```

The 11 backend failures are **identical to dev's** and fail on a clean checkout (OIDC discovery reaching a live host, `security_invariants`, `ws_auth`, `config`). Verified by running the full suite on a clean baseline and diffing the failure sets — no regression, +23 new backend tests. Note the suite shares one test database and can't be run concurrently.

New tests, each verified to fail without its fix:
- `tasks_test.py` — an OR window returns both-dated, due-only, start-only, and straddling tasks, and excludes out-of-window and undated ones; nesting cap returns 400.
- `query_test.py` — group parsing, depth/leaf limits, `extract_condition_value` ignoring groups, and date coercion (`Z` suffix, date columns, `in_` lists, unparseable passthrough).
- `EventsPage.test.tsx` — the request carries the OR window and `page_size: 0`; a task past the old 100 cap renders (fails if `page_size` goes back to 100); project options survive an empty window.
- `visibleRange.test.ts` — each view mode's span, including month-grid padding into adjacent months.

Worth a manual pass: page across months in each view mode, especially a due-date-only task and one starting in the previous month — the cases the OR group exists for.

## Follow-ups filed

- #930 — the **events** query on this same page has the identical >100 silent drop. Left out to keep this reviewable.
- #931 — `/me/tasks` silently ignores any condition it doesn't extract by name, including these groups. A live trap for whoever windows `MyCalendarPage` next (called out as lower-concern in #860).