### PR TITLE
UI polish: sidebar rows and button icon spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Multiple sign-in providers: the sign-in page now offers a button for every SSO provider the server has configured, not just one. Operators manage additional OIDC providers in Settings → Authentication — with presets for Google and Microsoft Entra, and a custom option for any OIDC identity provider (Keycloak, Authentik, Zitadel, …) — alongside the existing platform SSO form. Client secrets are write-only: set or replaced, never displayed.
 
+### Changed
+
+- Sidebar rows use their full width: an initiative, project, or tool row's name and count now span the whole row until you hover it, at which point the settings/"+" button slides in and the name shrinks to make room (rather than the button permanently reserving space or overlapping the text). The reveal animation is skipped for users who prefer reduced motion.
+
+### Fixed
+
+- The sidebar "Edit tag" dialog is no longer visually broken — the name field now fills the row and the color picker sits beside it, instead of the color picker taking the full width and collapsing the name field to a sliver.
+- Removed redundant spacing between icons and labels across buttons throughout the app; the button's built-in gap now handles it consistently.
+
 ## [0.57.0] - 2026-07-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The sidebar "Edit tag" dialog is no longer visually broken — the name field now fills the row and the color picker sits beside it, instead of the color picker taking the full width and collapsing the name field to a sliver.
+- On mobile, opening the three-dot menu next to an initiative or project in the sidebar no longer dismisses the sidebar drawer.
 - Removed redundant spacing between icons and labels across buttons throughout the app; the button's built-in gap now handles it consistently.
 
 ## [0.57.0] - 2026-07-16

--- a/frontend/src/components/access/BulkEditAccessDialog.tsx
+++ b/frontend/src/components/access/BulkEditAccessDialog.tsx
@@ -800,7 +800,7 @@ export function BulkEditAccessDialog({
             >
               {isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("bulkAccess.applying")}
                 </>
               ) : roleMode === "grant" ? (
@@ -817,7 +817,7 @@ export function BulkEditAccessDialog({
             >
               {isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("bulkAccess.applying")}
                 </>
               ) : userMode === "grant" ? (
@@ -834,7 +834,7 @@ export function BulkEditAccessDialog({
             >
               {isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("bulkAccess.applying")}
                 </>
               ) : allMode === "share" ? (

--- a/frontend/src/components/access/ShareControl.tsx
+++ b/frontend/src/components/access/ShareControl.tsx
@@ -310,7 +310,7 @@ export const ShareControl = ({
                 <PopoverTrigger asChild>
                   <Button type="button" variant="outline" size="sm" disabled={disabled}>
                     {t("share.addPeople")}
-                    <ChevronDown className="ml-1 h-4 w-4 opacity-50" />
+                    <ChevronDown className="h-4 w-4 opacity-50" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-72 p-0" align="end">
@@ -408,7 +408,7 @@ export const ShareControl = ({
                 <PopoverTrigger asChild>
                   <Button type="button" variant="outline" size="sm" disabled={disabled}>
                     {t("share.addRoles")}
-                    <ChevronDown className="ml-1 h-4 w-4 opacity-50" />
+                    <ChevronDown className="h-4 w-4 opacity-50" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-72 p-0" align="end">

--- a/frontend/src/components/admin/AdminDeleteUserDialog.tsx
+++ b/frontend/src/components/admin/AdminDeleteUserDialog.tsx
@@ -530,7 +530,7 @@ export function AdminDeleteUserDialog({
                               onClick={() => setGuildDeleteConfirm(guildBlocker)}
                               disabled={isResolvingBlocker}
                             >
-                              <Trash2 className="mr-1 h-4 w-4" />
+                              <Trash2 className="h-4 w-4" />
                               {t("adminDeleteUser.deleteGuild")}
                             </Button>
                           </div>
@@ -598,7 +598,7 @@ export function AdminDeleteUserDialog({
                                   onClick={() => setInitiativeDeleteConfirm(initBlocker)}
                                   disabled={isResolvingBlocker}
                                 >
-                                  <Trash2 className="mr-1 h-4 w-4" />
+                                  <Trash2 className="h-4 w-4" />
                                   {t("adminDeleteUser.deleteInitiative")}
                                 </Button>
                               </div>
@@ -749,7 +749,7 @@ export function AdminDeleteUserDialog({
               onClick={handleBack}
               disabled={step === "choose-type" || deleteUser.isPending || isResolvingBlocker}
             >
-              <ChevronLeft className="mr-1 h-4 w-4" />
+              <ChevronLeft className="h-4 w-4" />
               {t("adminDeleteUser.back")}
             </Button>
 
@@ -776,7 +776,7 @@ export function AdminDeleteUserDialog({
                 >
                   {isCheckingEligibility ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" />
                       {t("adminDeleteUser.loading")}
                     </>
                   ) : (
@@ -791,7 +791,7 @@ export function AdminDeleteUserDialog({
                 >
                   {deleteUser.isPending ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" />
                       {action === "deactivate"
                         ? t("adminDeleteUser.deactivating")
                         : t("adminDeleteUser.deleting")}

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -309,7 +309,7 @@ export const CreateDocumentDialog = ({
                     className="h-auto px-2 py-1 text-xs"
                     onClick={() => setSelectedTemplateId("")}
                   >
-                    <X className="mr-1 h-3 w-3" />
+                    <X className="h-3 w-3" />
                     {t("create.clear")}
                   </Button>
                 )}
@@ -411,7 +411,7 @@ export const CreateDocumentDialog = ({
                   className="w-full"
                   onClick={() => fileInputRef.current?.click()}
                 >
-                  <Upload className="mr-2 h-4 w-4" />
+                  <Upload className="h-4 w-4" />
                   {t("create.chooseFile")}
                 </Button>
               )}
@@ -513,7 +513,7 @@ export const CreateDocumentDialog = ({
             >
               {createDocument.isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("create.creating")}
                 </>
               ) : (
@@ -539,7 +539,7 @@ export const CreateDocumentDialog = ({
             >
               {uploadDocument.isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("create.uploadingFile")}
                 </>
               ) : (
@@ -566,7 +566,7 @@ export const CreateDocumentDialog = ({
             >
               {createDocument.isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("create.creating")}
                 </>
               ) : (

--- a/frontend/src/components/documents/CreateDocumentWizard.tsx
+++ b/frontend/src/components/documents/CreateDocumentWizard.tsx
@@ -216,7 +216,7 @@ export const CreateDocumentWizard = () => {
         {/* Back button */}
         {step !== "select-guild" && (
           <Button variant="ghost" size="sm" className="w-fit" onClick={handleBack}>
-            <ChevronLeft className="mr-1 h-4 w-4" />
+            <ChevronLeft className="h-4 w-4" />
             {t("createWizard.back")}
           </Button>
         )}

--- a/frontend/src/components/documents/CreateWikilinkDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateWikilinkDocumentDialog.tsx
@@ -140,7 +140,7 @@ export function CreateWikilinkDocumentDialog({
             >
               {createDocument.isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("wikilink.creating")}
                 </>
               ) : (

--- a/frontend/src/components/documents/DocumentSummary.tsx
+++ b/frontend/src/components/documents/DocumentSummary.tsx
@@ -71,7 +71,7 @@ export const DocumentSummary = ({ documentId, summary, onSummaryChange }: Docume
         <Sparkles className="mx-auto h-8 w-8 text-muted-foreground" />
         <p className="text-muted-foreground text-sm">{t("summary.generateDescription")}</p>
         <Button onClick={() => generateSummary.mutate()} disabled={generateSummary.isPending}>
-          <Sparkles className="mr-2 h-4 w-4" />
+          <Sparkles className="h-4 w-4" />
           {t("summary.generateButton")}
         </Button>
         {generateSummary.isError && <p className="text-destructive text-sm">{getErrorMessage()}</p>}

--- a/frontend/src/components/documents/DocumentsFilterBar.tsx
+++ b/frontend/src/components/documents/DocumentsFilterBar.tsx
@@ -69,7 +69,7 @@ export const DocumentsFilterBar = ({
           <Button variant="ghost" size="sm" className="h-8 px-3">
             {filtersOpen ? t("page.hideFilters") : t("page.showFilters")}
             <ChevronDown
-              className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+              className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
             />
           </Button>
         </CollapsibleTrigger>

--- a/frontend/src/components/documents/FileDocumentViewer.tsx
+++ b/frontend/src/components/documents/FileDocumentViewer.tsx
@@ -286,7 +286,7 @@ export const FileDocumentViewer = ({
                   size="sm"
                   aria-label={t("versions.label")}
                 >
-                  <History className="mr-2 h-4 w-4" />
+                  <History className="h-4 w-4" />
                   {t("versions.label")}
                   {versions.length > 1 && (
                     <Badge variant="secondary" className="ml-2 px-1.5">
@@ -307,9 +307,9 @@ export const FileDocumentViewer = ({
                       disabled={uploadVersion.isPending}
                     >
                       {uploadVersion.isPending ? (
-                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
                       ) : (
-                        <Upload className="mr-1.5 h-3.5 w-3.5" />
+                        <Upload className="h-3.5 w-3.5" />
                       )}
                       {t("versions.uploadNew")}
                     </Button>
@@ -363,11 +363,11 @@ export const FileDocumentViewer = ({
             </Popover>
           )}
           <Button variant="outline" size="sm" onClick={handleOpenInNewTab}>
-            <ExternalLink className="mr-2 h-4 w-4" />
+            <ExternalLink className="h-4 w-4" />
             {t("viewer.openNewTab")}
           </Button>
           <Button variant="outline" size="sm" onClick={handleDownload}>
-            <Download className="mr-2 h-4 w-4" />
+            <Download className="h-4 w-4" />
             {t("viewer.download")}
           </Button>
         </div>
@@ -437,7 +437,7 @@ export const FileDocumentViewer = ({
                   <FileText className="mb-4 h-16 w-16 text-muted-foreground" />
                   <p className="mb-4 text-muted-foreground">{pdfError}</p>
                   <Button onClick={handleDownload}>
-                    <Download className="mr-2 h-4 w-4" />
+                    <Download className="h-4 w-4" />
                     {t("viewer.downloadPdf")}
                   </Button>
                 </div>
@@ -569,11 +569,11 @@ export const FileDocumentViewer = ({
             </p>
             <div className="flex gap-3">
               <Button onClick={handleDownload}>
-                <Download className="mr-2 h-4 w-4" />
+                <Download className="h-4 w-4" />
                 {t("viewer.downloadFileType", { fileType: fileTypeLabel })}
               </Button>
               <Button variant="outline" onClick={handleOpenInNewTab}>
-                <ExternalLink className="mr-2 h-4 w-4" />
+                <ExternalLink className="h-4 w-4" />
                 {t("viewer.openNewTab")}
               </Button>
             </div>
@@ -590,7 +590,7 @@ export const FileDocumentViewer = ({
             </h3>
             <p className="mb-6 text-muted-foreground">{t("viewer.unknownFileType")}</p>
             <Button onClick={handleDownload}>
-              <Download className="mr-2 h-4 w-4" />
+              <Download className="h-4 w-4" />
               {t("viewer.downloadFile")}
             </Button>
           </div>

--- a/frontend/src/components/documents/SmartLinkDocumentViewer.tsx
+++ b/frontend/src/components/documents/SmartLinkDocumentViewer.tsx
@@ -72,7 +72,7 @@ export function SmartLinkDocumentViewer({ content, className }: SmartLinkDocumen
       </p>
       <Button asChild variant="default" size="sm">
         <a href={url} target="_blank" rel="noopener noreferrer">
-          <ExternalLink className="mr-2 h-4 w-4" />
+          <ExternalLink className="h-4 w-4" />
           {t("smartLink.openInNewTab")}
         </a>
       </Button>

--- a/frontend/src/components/documents/settings/DocumentSettingsAdvancedTab.tsx
+++ b/frontend/src/components/documents/settings/DocumentSettingsAdvancedTab.tsx
@@ -36,7 +36,7 @@ export const DocumentSettingsAdvancedTab = ({
             onClick={onDuplicateClick}
             disabled={!canManageDocument}
           >
-            <Copy className="mr-2 h-4 w-4" />
+            <Copy className="h-4 w-4" />
             {t("settings.duplicateDocument")}
           </Button>
           <Button
@@ -45,7 +45,7 @@ export const DocumentSettingsAdvancedTab = ({
             onClick={onCopyClick}
             disabled={!canManageDocument}
           >
-            <ArrowRightLeft className="mr-2 h-4 w-4" />
+            <ArrowRightLeft className="h-4 w-4" />
             {t("settings.copyToInitiative")}
           </Button>
         </CardContent>
@@ -59,7 +59,7 @@ export const DocumentSettingsAdvancedTab = ({
           </CardHeader>
           <CardContent>
             <Button type="button" variant="destructive" onClick={onDeleteClick} disabled={!isOwner}>
-              <Trash2 className="mr-2 h-4 w-4" />
+              <Trash2 className="h-4 w-4" />
               {t("settings.deleteDocument")}
             </Button>
           </CardContent>

--- a/frontend/src/components/documents/settings/DocumentSettingsDialogs.tsx
+++ b/frontend/src/components/documents/settings/DocumentSettingsDialogs.tsx
@@ -112,7 +112,7 @@ export const DocumentSettingsDialogs = ({
             >
               {isDuplicating ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("settings.duplicating")}
                 </>
               ) : (
@@ -187,7 +187,7 @@ export const DocumentSettingsDialogs = ({
             >
               {isCopying ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("settings.copying")}
                 </>
               ) : (
@@ -215,7 +215,7 @@ export const DocumentSettingsDialogs = ({
             <Button type="button" variant="destructive" onClick={onDelete} disabled={isDeleting}>
               {isDeleting ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("settings.deleting")}
                 </>
               ) : (

--- a/frontend/src/components/exports/ExportWizard.tsx
+++ b/frontend/src/components/exports/ExportWizard.tsx
@@ -171,7 +171,7 @@ export function ExportWizard({ scope, initiativeId, open, onOpenChange }: Export
 
         {step !== "mode" && step !== "progress" && (
           <Button variant="ghost" size="sm" className="w-fit" onClick={back}>
-            <ChevronLeft className="mr-1 h-4 w-4" />
+            <ChevronLeft className="h-4 w-4" />
             {t("wizard.back")}
           </Button>
         )}

--- a/frontend/src/components/imports/ImportWizard.tsx
+++ b/frontend/src/components/imports/ImportWizard.tsx
@@ -196,7 +196,7 @@ export function ImportWizard({ open, onOpenChange }: ImportWizardProps) {
 
         {step === "peek" && (
           <Button variant="ghost" size="sm" className="w-fit" onClick={() => setStep("pick")}>
-            <ChevronLeft className="mr-1 h-4 w-4" />
+            <ChevronLeft className="h-4 w-4" />
             {t("wizard.back")}
           </Button>
         )}

--- a/frontend/src/components/initiativeTools/advancedTools/AdvancedToolCard.tsx
+++ b/frontend/src/components/initiativeTools/advancedTools/AdvancedToolCard.tsx
@@ -52,7 +52,7 @@ export const AdvancedToolCard = ({ tool }: AdvancedToolCardProps) => {
               className="text-muted-foreground"
               onClick={() => setTagsDialogOpen(true)}
             >
-              <TagIcon className="mr-1 h-4 w-4" />
+              <TagIcon className="h-4 w-4" />
               {t("manageTags")}
             </Button>
           )}

--- a/frontend/src/components/initiativeTools/counters/CounterFormDialog.tsx
+++ b/frontend/src/components/initiativeTools/counters/CounterFormDialog.tsx
@@ -244,7 +244,7 @@ export const CounterFormDialog = ({
           <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
             {isSubmitting ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {isEdit ? t("saving") : t("adding")}
               </>
             ) : isEdit ? (

--- a/frontend/src/components/initiativeTools/counters/CountersFilterBar.tsx
+++ b/frontend/src/components/initiativeTools/counters/CountersFilterBar.tsx
@@ -52,7 +52,7 @@ export const CountersFilterBar = ({
           <Button variant="ghost" size="sm" className="h-8 px-3">
             {filtersOpen ? t("filters.hide") : t("filters.show")}
             <ChevronDown
-              className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+              className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
             />
           </Button>
         </CollapsibleTrigger>

--- a/frontend/src/components/initiativeTools/counters/CreateCounterGroupDialog.tsx
+++ b/frontend/src/components/initiativeTools/counters/CreateCounterGroupDialog.tsx
@@ -178,7 +178,7 @@ export const CreateCounterGroupDialog = ({
           <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
             {isCreating ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {t("creating")}
               </>
             ) : (

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -443,7 +443,7 @@ export const CreateEventDialog = ({
           <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
             {isCreating ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {t("creating")}
               </>
             ) : (

--- a/frontend/src/components/initiativeTools/queues/ActHeldButton.tsx
+++ b/frontend/src/components/initiativeTools/queues/ActHeldButton.tsx
@@ -34,9 +34,9 @@ export const ActHeldButton = ({ itemId, onAct }: ActHeldButtonProps) => {
     <DropdownMenu>
       <DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
         <Button type="button" size="sm" aria-label={t("actNow")}>
-          <Zap className="mr-1 h-4 w-4" />
+          <Zap className="h-4 w-4" />
           {t("actNow")}
-          <ChevronDown className="ml-1 h-3 w-3" aria-hidden="true" />
+          <ChevronDown className="h-3 w-3" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>

--- a/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
@@ -285,7 +285,7 @@ export const AddQueueItemDialog = ({
           <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
             {isAdding ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {t("adding")}
               </>
             ) : (

--- a/frontend/src/components/initiativeTools/queues/CreateQueueDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/CreateQueueDialog.tsx
@@ -182,7 +182,7 @@ export const CreateQueueDialog = ({
           <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
             {isCreating ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {t("creating")}
               </>
             ) : (

--- a/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
@@ -371,13 +371,13 @@ export const EditQueueItemDialog = ({
                 onClick={() => setDeleteConfirmOpen(true)}
                 disabled={isSaving || isDeleting}
               >
-                <Trash2 className="mr-1 h-4 w-4" />
+                <Trash2 className="h-4 w-4" />
                 {t("removeItem")}
               </Button>
               <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
                 {isSaving ? (
                   <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <Loader2 className="h-4 w-4 animate-spin" />
                     {t("saving")}
                   </>
                 ) : (

--- a/frontend/src/components/initiativeTools/queues/QueueControls.tsx
+++ b/frontend/src/components/initiativeTools/queues/QueueControls.tsx
@@ -57,11 +57,11 @@ export const QueueControls = ({
             disabled={isLoading}
           >
             {isLoading ? (
-              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              <Loader2 className="h-4 w-4 animate-spin" />
             ) : queue.is_active ? (
-              <Pause className="mr-1 h-4 w-4" />
+              <Pause className="h-4 w-4" />
             ) : (
-              <Play className="mr-1 h-4 w-4" />
+              <Play className="h-4 w-4" />
             )}
             {queue.is_active ? t("stop") : t("start")}
           </Button>
@@ -119,7 +119,7 @@ export const QueueControls = ({
             onClick={onHold}
             disabled={!queue.is_active || !queue.current_item || isLoading}
           >
-            <Hand className="mr-1 h-4 w-4" />
+            <Hand className="h-4 w-4" />
             {t("hold")}
           </Button>
         </TooltipTrigger>
@@ -142,7 +142,7 @@ export const QueueControls = ({
       <Tooltip delayDuration={300}>
         <TooltipTrigger asChild>
           <Button variant="ghost" size="sm" onClick={onReset} disabled={isLoading}>
-            <RotateCcw className="mr-1 h-4 w-4" />
+            <RotateCcw className="h-4 w-4" />
             {t("reset")}
           </Button>
         </TooltipTrigger>

--- a/frontend/src/components/initiativeTools/queues/QueuesFilterBar.tsx
+++ b/frontend/src/components/initiativeTools/queues/QueuesFilterBar.tsx
@@ -58,7 +58,7 @@ export const QueuesFilterBar = ({
           <Button variant="ghost" size="sm" className="h-8 px-3">
             {filtersOpen ? t("filters.hide") : t("filters.show")}
             <ChevronDown
-              className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+              className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
             />
           </Button>
         </CollapsibleTrigger>

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsDangerTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsDangerTab.tsx
@@ -49,11 +49,11 @@ export const InitiativeSettingsDangerTab = ({
                 disabled={isArchiving}
               >
                 {isArchiving ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                 ) : isArchived ? (
-                  <ArchiveRestore className="mr-2 h-4 w-4" />
+                  <ArchiveRestore className="h-4 w-4" />
                 ) : (
-                  <Archive className="mr-2 h-4 w-4" />
+                  <Archive className="h-4 w-4" />
                 )}
                 {isArchived ? t("settings.unarchiveInitiative") : t("settings.archiveInitiative")}
               </Button>
@@ -69,12 +69,12 @@ export const InitiativeSettingsDangerTab = ({
             >
               {isDeleting ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("settings.deletingInitiative")}
                 </>
               ) : (
                 <>
-                  <Trash2 className="mr-2 h-4 w-4" />
+                  <Trash2 className="h-4 w-4" />
                   {t("settings.deleteInitiative")}
                 </>
               )}

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsDetailsTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsDetailsTab.tsx
@@ -88,7 +88,7 @@ export const InitiativeSettingsDetailsTab = ({
               <Button type="submit" disabled={isSaving}>
                 {isSaving ? (
                   <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <Loader2 className="h-4 w-4 animate-spin" />
                     {t("settings.saving")}
                   </>
                 ) : (

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsDialogs.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsDialogs.tsx
@@ -226,7 +226,7 @@ export const InitiativeSettingsDialogs = ({
             >
               {createRoleMutation.isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("settings.creatingRole")}
                 </>
               ) : (
@@ -291,7 +291,7 @@ export const InitiativeSettingsDialogs = ({
             >
               {updateRoleMutation.isPending ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   {t("settings.savingRole")}
                 </>
               ) : (

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
@@ -484,7 +484,7 @@ export const InitiativeSettingsMembersTab = ({
                 >
                   {addMember.isPending ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" />
                       {t("settings.adding")}
                     </>
                   ) : (

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsPropertiesTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsPropertiesTab.tsx
@@ -156,7 +156,7 @@ const OptionListEditor = ({ options, onChange, disabled }: OptionListEditorProps
         ))}
       </ul>
       <Button type="button" variant="outline" size="sm" onClick={handleAdd} disabled={disabled}>
-        <Plus className="mr-1 h-4 w-4" />
+        <Plus className="h-4 w-4" />
         {t("properties:manager.addOption")}
       </Button>
     </div>
@@ -311,7 +311,7 @@ export const InitiativeSettingsPropertiesTab = ({ initiativeId }: { initiativeId
             <CardDescription>{t("properties:manager.description")}</CardDescription>
           </div>
           <Button onClick={handleOpenCreate}>
-            <Plus className="mr-1 h-4 w-4" />
+            <Plus className="h-4 w-4" />
             {t("properties:manager.newDefinition")}
           </Button>
         </CardHeader>

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsRolesTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsRolesTab.tsx
@@ -238,7 +238,7 @@ export const InitiativeSettingsRolesTab = ({
 
         {canManageMembers && (
           <Button variant="outline" onClick={onOpenCreateRoleDialog}>
-            <Plus className="mr-2 h-4 w-4" />
+            <Plus className="h-4 w-4" />
             {t("settings.addCustomRole")}
           </Button>
         )}

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -396,7 +396,7 @@ export const NotificationBell = () => {
             disabled={unreadCount === 0 || markAllMutation.isPending}
             onClick={() => markAllMutation.mutate()}
           >
-            <CheckCheck className="mr-1 h-3 w-3" />
+            <CheckCheck className="h-3 w-3" />
             {t("notifications.markAllRead")}
           </Button>
         </div>

--- a/frontend/src/components/notifications/PushPermissionPrompt.tsx
+++ b/frontend/src/components/notifications/PushPermissionPrompt.tsx
@@ -79,7 +79,7 @@ export const PushPermissionPrompt = () => {
             onClick={handleDismiss}
             className="text-blue-700 hover:text-blue-900 dark:text-blue-300 dark:hover:text-blue-100"
           >
-            <X className="mr-1 h-4 w-4" />
+            <X className="h-4 w-4" />
             {t("notifications.push.dismiss")}
           </Button>
           <Button

--- a/frontend/src/components/projects/AssigneeSelector.tsx
+++ b/frontend/src/components/projects/AssigneeSelector.tsx
@@ -123,7 +123,7 @@ export const AssigneeSelector = ({
               selectedOptions.length === 0 && "text-muted-foreground"
             )}
           >
-            <Users className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+            <Users className="h-4 w-4 shrink-0 opacity-50" />
             {selectedOptions.length > 0 ? (
               <div className="flex flex-wrap gap-1">
                 {selectedOptions.map((option) => {

--- a/frontend/src/components/projects/ProjectDocumentsSection.tsx
+++ b/frontend/src/components/projects/ProjectDocumentsSection.tsx
@@ -155,7 +155,7 @@ export const ProjectDocumentsSection = ({
           <div className="flex items-center gap-2">
             {canCreate && (
               <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
-                <FilePlus className="mr-2 h-4 w-4" />
+                <FilePlus className="h-4 w-4" />
                 {t("documents.newDocument")}
               </Button>
             )}
@@ -163,7 +163,7 @@ export const ProjectDocumentsSection = ({
               <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
                 <DialogTrigger asChild>
                   <Button type="button" size="sm" variant="outline">
-                    <Link className="mr-2 h-4 w-4" />
+                    <Link className="h-4 w-4" />
                     {t("documents.attachExisting")}
                   </Button>
                 </DialogTrigger>
@@ -201,7 +201,7 @@ export const ProjectDocumentsSection = ({
                     >
                       {attachMutation.isPending ? (
                         <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          <Loader2 className="h-4 w-4 animate-spin" />
                           {t("documents.attaching")}
                         </>
                       ) : (

--- a/frontend/src/components/projects/ProjectTaskStatusesManager.tsx
+++ b/frontend/src/components/projects/ProjectTaskStatusesManager.tsx
@@ -460,7 +460,7 @@ export const ProjectTaskStatusesManager = ({
               }}
               disabled={!canManage || createStatus.isPending}
             >
-              {createStatus.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {createStatus.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
               {t("statuses.add")}
             </Button>
           </div>
@@ -480,7 +480,7 @@ export const ProjectTaskStatusesManager = ({
                   onClick={handleSaveAll}
                   disabled={!hasChanges || updateStatus.isPending}
                 >
-                  <Save className="mr-2 h-4 w-4" />
+                  <Save className="h-4 w-4" />
                   {t("statuses.saveChanges")}
                 </Button>
               )}
@@ -580,9 +580,7 @@ export const ProjectTaskStatusesManager = ({
               onClick={handleDeleteConfirm}
               disabled={deleteStatusMutation.isPending || !fallbackOptions.length}
             >
-              {deleteStatusMutation.isPending ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : null}
+              {deleteStatusMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
               {t("common:delete")}
             </Button>
           </DialogFooter>

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -958,7 +958,7 @@ export const ProjectTasksSection = ({
               <Button variant="ghost" size="sm" className="h-8 px-3">
                 {filtersOpen ? t("tasks.hideFilters") : t("tasks.showFilters")}
                 <ChevronDown
-                  className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+                  className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
                 />
               </Button>
             </CollapsibleTrigger>

--- a/frontend/src/components/projects/ProjectsFilterBar.tsx
+++ b/frontend/src/components/projects/ProjectsFilterBar.tsx
@@ -70,7 +70,7 @@ export const ProjectsFilterBar = ({
           <Button variant="ghost" size="sm" className="h-8 px-3">
             {filtersOpen ? t("filters.hide") : t("filters.show")}
             <ChevronDown
-              className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+              className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
             />
           </Button>
         </CollapsibleTrigger>

--- a/frontend/src/components/properties/AddPropertyButton.tsx
+++ b/frontend/src/components/properties/AddPropertyButton.tsx
@@ -170,7 +170,7 @@ export const AddPropertyButton = ({
           className="w-full justify-start text-muted-foreground hover:text-foreground"
           disabled={disabled}
         >
-          <Plus className="mr-1 h-4 w-4" />
+          <Plus className="h-4 w-4" />
           {t("properties:addProperty")}
         </Button>
       </PopoverTrigger>
@@ -270,7 +270,7 @@ export const AddPropertyButton = ({
                   className="w-full"
                   onClick={handleAddOption}
                 >
-                  <Plus className="mr-1 h-4 w-4" />
+                  <Plus className="h-4 w-4" />
                   {t("properties:picker.addOption")}
                 </Button>
               </div>

--- a/frontend/src/components/properties/PropertyFilter.tsx
+++ b/frontend/src/components/properties/PropertyFilter.tsx
@@ -324,7 +324,7 @@ export const PropertyFilter = ({
         disabled={!canAddMore}
         className="h-8"
       >
-        <Plus className="mr-1 h-4 w-4" />
+        <Plus className="h-4 w-4" />
         {t("filter.addFilter")}
       </Button>
     </div>

--- a/frontend/src/components/properties/PropertyInput.tsx
+++ b/frontend/src/components/properties/PropertyInput.tsx
@@ -469,7 +469,7 @@ const PropertyOptionPicker = ({
               ))}
             </span>
           )}
-          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">

--- a/frontend/src/components/shared/BulkEditTagsDialog.tsx
+++ b/frontend/src/components/shared/BulkEditTagsDialog.tsx
@@ -190,7 +190,7 @@ export function BulkEditTagsDialog<T extends TaggableItem>({
           <Button onClick={() => void handleApply()} disabled={isPending || !canApply}>
             {isPending ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {labels.applying}
               </>
             ) : (

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -152,7 +152,7 @@ export const InitiativeSection = memo(
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/initiative:opacity-100 lg:flex"
+                    className="hidden h-6 w-0 shrink-0 overflow-hidden p-0 opacity-0 transition-all group-hover/initiative:w-6 group-hover/initiative:opacity-100 motion-reduce:transition-none lg:flex"
                     asChild
                   >
                     <Link to={gp(`/initiatives/${initiative.id}/settings`)}>
@@ -269,7 +269,7 @@ export const InitiativeSection = memo(
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/project:opacity-100 lg:flex"
+                                className="hidden h-6 w-0 shrink-0 overflow-hidden p-0 opacity-0 transition-all group-hover/project:w-6 group-hover/project:opacity-100 motion-reduce:transition-none lg:flex"
                                 asChild
                               >
                                 <Link to={gp(`/projects/${project.id}/settings`)}>

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -165,8 +165,10 @@ export const InitiativeSection = memo(
                 </TooltipContent>
               </Tooltip>
 
-              {/* Mobile: Show three-dot menu */}
-              <DropdownMenu>
+              {/* Mobile: Show three-dot menu. modal={false}: a modal dropdown
+                  nested in the non-modal mobile sidebar drawer dismisses the
+                  drawer on open (matches the user-footer dropdown). */}
+              <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
@@ -282,8 +284,11 @@ export const InitiativeSection = memo(
                             </TooltipContent>
                           </Tooltip>
 
-                          {/* Mobile: Show three-dot menu */}
-                          <DropdownMenu>
+                          {/* Mobile: Show three-dot menu. modal={false}: a modal
+                              dropdown nested in the non-modal mobile sidebar
+                              drawer dismisses the drawer on open (matches the
+                              user-footer dropdown). */}
+                          <DropdownMenu modal={false}>
                             <DropdownMenuTrigger asChild>
                               <Button
                                 variant="ghost"

--- a/frontend/src/components/sidebar/TagBrowser.tsx
+++ b/frontend/src/components/sidebar/TagBrowser.tsx
@@ -218,7 +218,7 @@ export const TagBrowser = ({
   return (
     <div className="space-y-1">
       {editMode && (
-        <div className="flex items-center justify-between gap-1 px-2">
+        <div className="flex items-center justify-between gap-1">
           <Checkbox
             checked={allSelected ? true : selectedCount > 0 ? "indeterminate" : false}
             onCheckedChange={toggleSelectAll}
@@ -270,12 +270,13 @@ export const TagBrowser = ({
                 }
               }}
               autoFocus
+              className="min-w-0 flex-1"
             />
             <ColorPickerPopover
               value={editColor}
               onChange={setEditColor}
               triggerLabel={t("manage.color")}
-              className="h-9 shrink-0"
+              className="h-9 w-auto shrink-0"
             />
           </div>
           <DialogFooter>

--- a/frontend/src/components/tags/TagPicker.tsx
+++ b/frontend/src/components/tags/TagPicker.tsx
@@ -163,7 +163,7 @@ export function TagPicker({
               className
             )}
           >
-            <TagIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+            <TagIcon className="h-4 w-4 shrink-0 opacity-50" />
             {selectedTags.length > 0 ? (
               <div className="flex flex-wrap gap-1">
                 {selectedTags.map((tag) => (

--- a/frontend/src/components/tasks/CreateTaskWizard.tsx
+++ b/frontend/src/components/tasks/CreateTaskWizard.tsx
@@ -313,7 +313,7 @@ export const CreateTaskWizard = () => {
         {/* Back button */}
         {step !== "select-guild" && (
           <Button variant="ghost" size="sm" className="w-fit" onClick={handleBack}>
-            <ChevronLeft className="mr-1 h-4 w-4" />
+            <ChevronLeft className="h-4 w-4" />
             {t("createWizard.back")}
           </Button>
         )}
@@ -423,9 +423,7 @@ export const CreateTaskWizard = () => {
                     onClick={() => setProjectPage((p) => p + 1)}
                     disabled={projectsQuery.isFetching}
                   >
-                    {projectsQuery.isFetching ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : null}
+                    {projectsQuery.isFetching ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
                     {t("createWizard.loadMore")}
                   </Button>
                 )}

--- a/frontend/src/components/tasks/GlobalTaskFilters.tsx
+++ b/frontend/src/components/tasks/GlobalTaskFilters.tsx
@@ -66,7 +66,7 @@ export const GlobalTaskFilters = ({
           <Button variant="ghost" size="sm" className="h-8 px-3">
             {filtersOpen ? t("filters.hide") : t("filters.show")}
             <ChevronDown
-              className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+              className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
             />
           </Button>
         </CollapsibleTrigger>

--- a/frontend/src/components/tasks/TagTasksTable.tsx
+++ b/frontend/src/components/tasks/TagTasksTable.tsx
@@ -488,7 +488,7 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
             <Button variant="ghost" size="sm" className="h-8 px-3">
               {filtersOpen ? t("filters.hide") : t("filters.show")}
               <ChevronDown
-                className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+                className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
               />
             </Button>
           </CollapsibleTrigger>

--- a/frontend/src/components/tasks/TaskBulkEditDialog.tsx
+++ b/frontend/src/components/tasks/TaskBulkEditDialog.tsx
@@ -220,7 +220,7 @@ export const TaskBulkEditDialog = ({
           <Button type="submit" disabled={!hasChanges || isSubmitting}>
             {isSubmitting ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {t("bulkEdit.applying")}
               </>
             ) : (

--- a/frontend/src/components/tools/ToolCreateButton.tsx
+++ b/frontend/src/components/tools/ToolCreateButton.tsx
@@ -73,7 +73,7 @@ export function ToolCreateButton({ tool, initiativeId, variant }: ToolCreateButt
     return (
       <Button asChild size="sm">
         <Link to={to} search={search} onClick={onClick}>
-          <Plus className="mr-2 h-4 w-4" />
+          <Plus className="h-4 w-4" />
           {label}
         </Link>
       </Button>
@@ -86,7 +86,7 @@ export function ToolCreateButton({ tool, initiativeId, variant }: ToolCreateButt
         <Button
           variant="ghost"
           size="icon"
-          className="hidden h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 lg:flex"
+          className="hidden h-6 w-0 shrink-0 overflow-hidden p-0 opacity-0 transition-all group-hover/tool:w-6 group-hover/tool:opacity-100 motion-reduce:transition-none lg:flex"
           asChild
         >
           <Link to={to} search={search} onClick={onClick} aria-label={label}>

--- a/frontend/src/components/ui/async-combobox.tsx
+++ b/frontend/src/components/ui/async-combobox.tsx
@@ -111,7 +111,7 @@ export const AsyncCombobox = ({
             disabled={disabled}
           >
             <span className="truncate">{triggerLabel}</span>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[320px] p-0">

--- a/frontend/src/components/ui/model-combobox.tsx
+++ b/frontend/src/components/ui/model-combobox.tsx
@@ -89,7 +89,7 @@ export const ModelCombobox = ({
             disabled={disabled}
           >
             <span className="truncate">{value || placeholder}</span>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">

--- a/frontend/src/components/ui/searchable-combobox.tsx
+++ b/frontend/src/components/ui/searchable-combobox.tsx
@@ -74,7 +74,7 @@ export const SearchableCombobox = ({
             disabled={disabled}
           >
             {selectedItem?.label ?? placeholder}
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[320px] p-0">

--- a/frontend/src/components/user/DeleteAccountDialog.tsx
+++ b/frontend/src/components/user/DeleteAccountDialog.tsx
@@ -484,7 +484,7 @@ export function DeleteAccountDialog({
                 deleteAccount.isPending
               }
             >
-              <ChevronLeft className="mr-1 h-4 w-4" />
+              <ChevronLeft className="h-4 w-4" />
               {t("deleteAccount.back")}
             </Button>
 
@@ -509,7 +509,7 @@ export function DeleteAccountDialog({
                 >
                   {isCheckingEligibility ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" />
                       {t("deleteAccount.checking")}
                     </>
                   ) : (
@@ -524,7 +524,7 @@ export function DeleteAccountDialog({
                 >
                   {deleteAccount.isPending ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" />
                       {t("deleteAccount.deleting")}
                     </>
                   ) : action === "deactivate" ? (

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1245,12 +1245,12 @@ export const DocumentDetailPage = () => {
                             >
                               {isUploadingFeaturedImage ? (
                                 <>
-                                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                  <Loader2 className="h-4 w-4 animate-spin" />
                                   {t("detail.uploading")}
                                 </>
                               ) : (
                                 <>
-                                  <ImagePlus className="mr-2 h-4 w-4" />
+                                  <ImagePlus className="h-4 w-4" />
                                   {t("detail.uploadImage")}
                                 </>
                               )}
@@ -1273,7 +1273,7 @@ export const DocumentDetailPage = () => {
                                 }}
                                 disabled={isUploadingFeaturedImage}
                               >
-                                <X className="mr-2 h-4 w-4" />
+                                <X className="h-4 w-4" />
                                 {t("detail.removeImage")}
                               </Button>
                             ) : null}
@@ -1367,7 +1367,7 @@ export const DocumentDetailPage = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <ExternalLink className="mr-2 h-4 w-4" />
+                    <ExternalLink className="h-4 w-4" />
                     {t("smartLink.openInNewTab")}
                   </a>
                 </Button>
@@ -1381,9 +1381,9 @@ export const DocumentDetailPage = () => {
                 className={cn(document.document_type !== "smart_link" && "ml-auto")}
               >
                 {isFullscreen ? (
-                  <Minimize2 className="mr-2 h-4 w-4" />
+                  <Minimize2 className="h-4 w-4" />
                 ) : (
-                  <Maximize2 className="mr-2 h-4 w-4" />
+                  <Maximize2 className="h-4 w-4" />
                 )}
                 {t(isFullscreen ? "detail.exitFullscreen" : "detail.enterFullscreen")}
               </Button>
@@ -1494,7 +1494,7 @@ export const DocumentDetailPage = () => {
                       >
                         {saveDocument.isPending ? (
                           <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            <Loader2 className="h-4 w-4 animate-spin" />
                             {t("detail.saving")}
                           </>
                         ) : (

--- a/frontend/src/pages/InitiativeDetailPage.tsx
+++ b/frontend/src/pages/InitiativeDetailPage.tsx
@@ -191,7 +191,7 @@ export const InitiativeDetailPage = () => {
                 to="/g/$guildId/initiatives/$initiativeId/settings"
                 params={{ guildId: guildIdParam, initiativeId: String(initiative.id) }}
               >
-                <Settings className="mr-2 h-4 w-4" />
+                <Settings className="h-4 w-4" />
                 {t("detail.initiativeSettings")}
               </Link>
             </Button>

--- a/frontend/src/pages/InitiativesPage.tsx
+++ b/frontend/src/pages/InitiativesPage.tsx
@@ -326,7 +326,7 @@ export const InitiativesPage = () => {
                   <Button type="submit" disabled={createInitiative.isPending}>
                     {createInitiative.isPending ? (
                       <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <Loader2 className="h-4 w-4 animate-spin" />
                         {t("createDialog.creating")}
                       </>
                     ) : (

--- a/frontend/src/pages/SettingsInitiativesPage.tsx
+++ b/frontend/src/pages/SettingsInitiativesPage.tsx
@@ -191,12 +191,12 @@ export const SettingsInitiativesPage = () => {
             >
               {initiative.is_archived ? (
                 <>
-                  <ArchiveRestore className="mr-1.5 h-4 w-4" />
+                  <ArchiveRestore className="h-4 w-4" />
                   {t("manage.unarchive")}
                 </>
               ) : (
                 <>
-                  <Archive className="mr-1.5 h-4 w-4" />
+                  <Archive className="h-4 w-4" />
                   {t("manage.archive")}
                 </>
               )}
@@ -209,7 +209,7 @@ export const SettingsInitiativesPage = () => {
               disabled={initiative.is_default}
               title={initiative.is_default ? t("manage.deleteDefaultHint") : undefined}
             >
-              <Trash2 className="mr-1.5 h-4 w-4" />
+              <Trash2 className="h-4 w-4" />
               {t("manage.delete")}
             </Button>
           </div>

--- a/frontend/src/pages/SettingsPlatformUsersPage.tsx
+++ b/frontend/src/pages/SettingsPlatformUsersPage.tsx
@@ -412,7 +412,7 @@ export const SettingsPlatformUsersPage = () => {
             onClick={exportAllUsersCsv}
             disabled={!usersQuery.data?.length}
           >
-            <Download className="mr-1.5 h-4 w-4" />
+            <Download className="h-4 w-4" />
             {t("platformUsers.exportAll")}
           </Button>
         </CardHeader>

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -422,7 +422,7 @@ export const SettingsUsersPage = () => {
             onClick={exportAllUsersCsv}
             disabled={!usersQuery.data?.length}
           >
-            <Download className="mr-1.5 h-4 w-4" />
+            <Download className="h-4 w-4" />
             {t("users.exportAll")}
           </Button>
         </CardHeader>

--- a/frontend/src/pages/TagDetailPage.tsx
+++ b/frontend/src/pages/TagDetailPage.tsx
@@ -168,13 +168,13 @@ export const TagDetailPage = () => {
         {!isEditing && (
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={handleStartEdit}>
-              <Settings className="mr-1 h-4 w-4" />
+              <Settings className="h-4 w-4" />
               {t("detail.edit")}
             </Button>
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button variant="destructive" size="sm">
-                  <Trash2 className="mr-1 h-4 w-4" />
+                  <Trash2 className="h-4 w-4" />
                   {t("detail.delete")}
                 </Button>
               </AlertDialogTrigger>

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupSettingsPage.tsx
@@ -279,7 +279,7 @@ export function CounterGroupSettingsPage() {
             </CardHeader>
             <CardContent>
               <Button type="button" variant="outline" onClick={openDuplicateDialog}>
-                <Copy className="mr-2 h-4 w-4" />
+                <Copy className="h-4 w-4" />
                 {t("duplicate.action")}
               </Button>
             </CardContent>
@@ -298,7 +298,7 @@ export function CounterGroupSettingsPage() {
                   onClick={() => setDeleteDialogOpen(true)}
                   disabled={!isOwner}
                 >
-                  <Trash2 className="mr-2 h-4 w-4" />
+                  <Trash2 className="h-4 w-4" />
                   {t("deleteGroup")}
                 </Button>
               </CardContent>

--- a/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
@@ -465,7 +465,7 @@ export function EventSettingsPage() {
           <Button onClick={handleSave} disabled={updateEvent.isPending || !datesValid}>
             {updateEvent.isPending ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {t("saving")}
               </>
             ) : (
@@ -513,7 +513,7 @@ export function EventSettingsPage() {
           <Button onClick={handleSaveAttendees} disabled={setAttendees.isPending}>
             {setAttendees.isPending ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
                 {t("saving")}
               </>
             ) : (
@@ -577,7 +577,7 @@ export function EventSettingsPage() {
             onClick={() => setDeleteConfirmOpen(true)}
             disabled={deleteEvent.isPending}
           >
-            <Trash2 className="mr-2 h-4 w-4" />
+            <Trash2 className="h-4 w-4" />
             {t("deleteEvent")}
           </Button>
         </CardContent>

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -509,7 +509,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
           />
           {canCreateEvents && (
             <Button variant="outline" size="sm" onClick={() => setImportDialogOpen(true)}>
-              <Upload className="mr-1.5 h-4 w-4" />
+              <Upload className="h-4 w-4" />
               {t("import.importIcs")}
             </Button>
           )}
@@ -532,7 +532,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
             <Button variant="ghost" size="sm" className="h-8 px-3">
               {filtersOpen ? t("filters.hide") : t("filters.show")}
               <ChevronDown
-                className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+                className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
               />
             </Button>
           </CollapsibleTrigger>

--- a/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
@@ -312,7 +312,7 @@ export function QueueDetailPage() {
             <QueueViewToggle view={view} onChange={setView} />
             {canEdit && (
               <Button variant="outline" size="sm" onClick={() => setAddItemOpen(true)}>
-                <Plus className="mr-1 h-4 w-4" />
+                <Plus className="h-4 w-4" />
                 {t("addItem")}
               </Button>
             )}
@@ -328,7 +328,7 @@ export function QueueDetailPage() {
             <CardContent>
               {canEdit && (
                 <Button onClick={() => setAddItemOpen(true)}>
-                  <Plus className="mr-1 h-4 w-4" />
+                  <Plus className="h-4 w-4" />
                   {t("addItem")}
                 </Button>
               )}

--- a/frontend/src/pages/initiativeTools/queues/QueueSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueSettingsPage.tsx
@@ -239,7 +239,7 @@ export const QueueSettingsPage = () => {
                   onClick={() => setDeleteDialogOpen(true)}
                   disabled={!isOwner}
                 >
-                  <Trash2 className="mr-2 h-4 w-4" />
+                  <Trash2 className="h-4 w-4" />
                   {t("deleteQueue")}
                 </Button>
               </CardContent>

--- a/frontend/src/pages/landing/LandingCinematic.tsx
+++ b/frontend/src/pages/landing/LandingCinematic.tsx
@@ -793,7 +793,7 @@ export const LandingCinematic = () => {
                 asChild
               >
                 <Link to="/register">
-                  <Shield className="mr-2 h-5 w-5 transition-transform duration-300 group-hover:rotate-12" />
+                  <Shield className="h-5 w-5 transition-transform duration-300 group-hover:rotate-12" />
                   {t("hero.ctaStart")}
                 </Link>
               </Button>
@@ -1153,7 +1153,7 @@ export const LandingCinematic = () => {
                 >
                   <Link to="/register">
                     {t("cta.button")}
-                    <Sparkles className="ml-2 h-5 w-5 transition-transform duration-300 group-hover:rotate-12" />
+                    <Sparkles className="h-5 w-5 transition-transform duration-300 group-hover:rotate-12" />
                   </Link>
                 </Button>
               </div>

--- a/frontend/src/pages/user/MyCalendarPage.tsx
+++ b/frontend/src/pages/user/MyCalendarPage.tsx
@@ -233,7 +233,7 @@ export const MyCalendarPage = () => {
             <p className="text-muted-foreground">{t("tasks:myCalendar.subtitle")}</p>
           </div>
           <Button variant="outline" size="sm" onClick={handleExport}>
-            <Download className="mr-1.5 h-4 w-4" />
+            <Download className="h-4 w-4" />
             {t("calendarEvents:export.exportIcs")}
           </Button>
         </div>
@@ -252,7 +252,7 @@ export const MyCalendarPage = () => {
               <Button variant="ghost" size="sm" className="h-8 px-3">
                 {table.filtersOpen ? t("tasks:filters.hide") : t("tasks:filters.show")}
                 <ChevronDown
-                  className={`ml-1 h-4 w-4 transition-transform ${table.filtersOpen ? "rotate-180" : ""}`}
+                  className={`h-4 w-4 transition-transform ${table.filtersOpen ? "rotate-180" : ""}`}
                 />
               </Button>
             </CollapsibleTrigger>

--- a/frontend/src/pages/user/MyDocumentsPage.tsx
+++ b/frontend/src/pages/user/MyDocumentsPage.tsx
@@ -375,7 +375,7 @@ export const MyDocumentsPage = () => {
               <Button variant="ghost" size="sm" className="h-8 px-3">
                 {filtersOpen ? t("myDocuments.hideFilters") : t("myDocuments.showFilters")}
                 <ChevronDown
-                  className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+                  className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
                 />
               </Button>
             </CollapsibleTrigger>

--- a/frontend/src/pages/user/MyProjectsPage.tsx
+++ b/frontend/src/pages/user/MyProjectsPage.tsx
@@ -418,7 +418,7 @@ export const MyProjectsPage = () => {
               <Button variant="ghost" size="sm" className="h-8 px-3">
                 {filtersOpen ? t("projects:filters.hide") : t("projects:filters.show")}
                 <ChevronDown
-                  className={`ml-1 h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
+                  className={`h-4 w-4 transition-transform ${filtersOpen ? "rotate-180" : ""}`}
                 />
               </Button>
             </CollapsibleTrigger>

--- a/frontend/src/pages/user/settings/UserSettingsSecurityPage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsSecurityPage.tsx
@@ -212,7 +212,7 @@ export const UserSettingsSecurityPage = () => {
                     onClick={() => setRevokeTarget(device)}
                     disabled={revokeToken.isPending}
                   >
-                    <Trash2 className="mr-1.5 h-4 w-4" />
+                    <Trash2 className="h-4 w-4" />
                     {t("security.revoke")}
                   </Button>
                 </div>


### PR DESCRIPTION
## Problem

A few UI rough edges accumulated in the sidebar and across buttons:

- The sidebar **Edit tag** dialog was visually broken — the color picker's built-in `w-full` ate the whole row, collapsing the name field to a tiny sliver.
- Sidebar rows (initiatives, projects, tools) had their hover-reveal settings/`+` buttons permanently reserving horizontal space with `opacity-0`, so the name/count never used the full width.
- Many icons inside `Button`s carried redundant `mr-*`/`ml-*` margins even though `Button` already applies `gap-2` (`gap-1.5` for `size="sm"`), causing slightly inconsistent icon–label spacing.

## Changes

**Fixed**
- **Edit-tag dialog** ([TagBrowser.tsx](../blob/polish/sidebar-and-icon-spacing/frontend/src/components/sidebar/TagBrowser.tsx)): name `Input` gets `min-w-0 flex-1`, color picker gets `w-auto` so it sizes to its swatch + hex instead of stretching full width.
- **Redundant button icon margins**: removed 128 horizontal margin tokens from icons that are direct children of `Button`/`buttonVariants` across 69 files. Only the margin token was stripped — size classes (`h-4 w-4`, `size-4`) and others (`animate-spin`, `opacity-50`, `shrink-0`) preserved. Icons inside `DropdownMenuItem`/`CommandItem`/`SelectItem`/raw comboboxes/plain flex rows were intentionally left alone (their margins are load-bearing).

**Changed**
- **Sidebar hover-reveal buttons** ([InitiativeSection.tsx](../blob/polish/sidebar-and-icon-spacing/frontend/src/components/sidebar/InitiativeSection.tsx), [ToolCreateButton.tsx](../blob/polish/sidebar-and-icon-spacing/frontend/src/components/tools/ToolCreateButton.tsx)): the settings gear / `+` button is now `w-0` (zero-width, in-flow) when idle and animates open to `w-6` on hover, so the name + count fill the row and the button slides in beside the truncating label rather than overlapping it. Guarded with `motion-reduce:transition-none`.

Desktop-only behavior is unchanged for mobile, which still uses the always-visible three-dot menu.

## Testing

- `pnpm typecheck` — passes
- `pnpm biome check` on all changed files — passes (also enforced by the pre-commit hook)
- `pnpm vitest run` on `TagBrowser.test.tsx` + `AddPropertyButton.test.tsx` — 11 passed

No backend, schema, or env changes. Pure frontend CSS/markup — no native/Capacitor changes, so `MIN_NATIVE_VERSION` is untouched.