### PR TITLE
Fix 500 on My Tasks page when filtered by a property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The "My Tasks" page no longer returns a 500 error when filtered by a custom property. The cross-guild task views load property definitions per guild schema now, instead of querying a table that isn't visible on that request's connection.
+
 ### Added
 
 - Multiple sign-in providers: the sign-in page now offers a button for every SSO provider the server has configured, not just one. Operators manage additional OIDC providers in Settings → Authentication — with presets for Google and Microsoft Entra, and a custom option for any OIDC identity provider (Keycloak, Authentik, Zitadel, …) — alongside the existing platform SSO form. Client secrets are write-only: set or replaced, never displayed.

--- a/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
@@ -438,3 +438,78 @@ async def test_list_my_tasks_property_value_is_null_filter(
     task_ids = {t["id"] for t in response.json()["items"]}
     assert without_value.id in task_ids
     assert with_value.id not in task_ids
+
+
+@pytest.mark.integration
+async def test_list_my_tasks_property_filter_spans_guilds(
+    client: AsyncClient, session: AsyncSession
+):
+    """GET /me/tasks applies a property_values filter across EVERY guild.
+
+    ``_load_property_definitions_across_guilds`` routes into each guild's schema
+    to resolve the definition, then the compiled ``property_id`` predicate runs
+    per-guild. A definition id is unique only within a schema, so two guilds
+    typically both assign the same id to their first definition; the loader
+    merges first-id-wins and the filter must still resolve correctly in both.
+    """
+    from app.models.tenant.property import PropertyType
+    from app.testing.factories import (
+        create_property_definition,
+        create_task_property_value,
+    )
+
+    user = await create_user(session, email="user@example.com")
+    guild1, initiative1, project1 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 1"
+    )
+    guild2, initiative2, project2 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 2"
+    )
+
+    def1 = await create_property_definition(
+        session, initiative1, name="Note", type=PropertyType.text
+    )
+    def2 = await create_property_definition(
+        session, initiative2, name="Note", type=PropertyType.text
+    )
+    # Per-schema sequences: the first definition in each guild shares an id. The
+    # filter carries one property_id, so this collision is what makes a single
+    # cross-guild filter meaningful (and exercises the first-id-wins merge).
+    assert def1.id == def2.id
+
+    # Build each guild's rows fully before moving on: the assign/value writes
+    # route the session's ROLE into that guild, so interleaving would leave a
+    # write pointed at the wrong guild's schema.
+    g1_has = await _create_task(session, project1, "g1 has", created_by_id=user.id)
+    g1_empty = await _create_task(session, project1, "g1 empty", created_by_id=user.id)
+    await _assign(session, g1_has, user.id)
+    await _assign(session, g1_empty, user.id)
+    await create_task_property_value(session, g1_has, def1, value_text="x")
+
+    g2_has = await _create_task(session, project2, "g2 has", created_by_id=user.id)
+    g2_empty = await _create_task(session, project2, "g2 empty", created_by_id=user.id)
+    await _assign(session, g2_has, user.id)
+    await _assign(session, g2_empty, user.id)
+    await create_task_property_value(session, g2_has, def2, value_text="y")
+
+    headers = get_auth_headers(user)
+    conditions = json.dumps(
+        [
+            {
+                "field": "property_values",
+                "op": "is_null",
+                "value": {"property_id": def1.id, "value": True},
+            }
+        ]
+    )
+    response = await client.get(
+        f"/api/v1/me/tasks?conditions={conditions}", headers=headers
+    )
+
+    assert response.status_code == 200, response.text
+    # Key by (guild_id, id): ids collide across schemas.
+    found = {(t["guild_id"], t["id"]) for t in response.json()["items"]}
+    assert (guild1.id, g1_empty.id) in found
+    assert (guild2.id, g2_empty.id) in found
+    assert (guild1.id, g1_has.id) not in found
+    assert (guild2.id, g2_has.id) not in found

--- a/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
@@ -381,3 +381,60 @@ async def test_list_my_tasks_priority_sorted_desc_across_guilds(
     assert response.status_code == 200, response.text
     titles = [t["title"] for t in response.json()["items"]]
     assert titles == ["urgent", "high", "medium", "low"]
+
+
+@pytest.mark.integration
+async def test_list_my_tasks_property_value_is_null_filter(
+    client: AsyncClient, session: AsyncSession
+):
+    """GET /me/tasks filters by a custom property value.
+
+    Regression: the property definition needed to compile the filter lives in
+    the guild schema, but the /me session runs in the ``public`` search_path.
+    Loading definitions off that un-routed session raised
+    ``UndefinedTableError: relation "property_definitions" does not exist`` and
+    the endpoint 500'd; definitions must be loaded per-guild.
+    """
+    from app.models.tenant.property import PropertyType
+    from app.testing.factories import (
+        create_property_definition,
+        create_task_property_value,
+    )
+
+    user = await create_user(session, email="user@example.com")
+    guild, initiative, project = await _setup_guild_with_project(session, user)
+
+    definition = await create_property_definition(
+        session, initiative, name="Owner note", type=PropertyType.text
+    )
+
+    with_value = await _create_task(
+        session, project, "Has value", created_by_id=user.id
+    )
+    without_value = await _create_task(
+        session, project, "No value", created_by_id=user.id
+    )
+    await _assign(session, with_value, user.id)
+    await _assign(session, without_value, user.id)
+    await create_task_property_value(
+        session, with_value, definition, value_text="something"
+    )
+
+    headers = get_auth_headers(user)
+    conditions = json.dumps(
+        [
+            {
+                "field": "property_values",
+                "op": "is_null",
+                "value": {"property_id": definition.id, "value": True},
+            }
+        ]
+    )
+    response = await client.get(
+        f"/api/v1/me/tasks?conditions={conditions}", headers=headers
+    )
+
+    assert response.status_code == 200, response.text
+    task_ids = {t["id"] for t in response.json()["items"]}
+    assert without_value.id in task_ids
+    assert with_value.id not in task_ids

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -1218,6 +1218,9 @@ class _TaskListQuery:
     guild_ids: Optional[list]
     property_value_conditions: list
     property_definitions: dict
+    # Every property_values leaf's definition id (nested groups included), so the
+    # deferred cross-guild loader resolves exactly what the limit check counted.
+    property_ids_needed: list[int]
 
 
 async def _parse_task_list_query(
@@ -1299,6 +1302,7 @@ async def _parse_task_list_query(
         guild_ids=extract_condition_value(user_conditions, "guild_ids"),
         property_value_conditions=property_value_conditions,
         property_definitions=property_definitions_map,
+        property_ids_needed=property_ids_needed,
     )
 
 
@@ -1317,13 +1321,7 @@ async def _load_property_definitions_across_guilds(
     needs the definition's *type* (which typed column to compare), so the first
     guild that resolves an id wins and its type is reused for every guild's
     schema-local ``property_id`` predicate."""
-    needed: list[int] = []
-    for cond in q.property_value_conditions:
-        if isinstance(cond.value, dict):
-            try:
-                needed.append(int(cond.value.get("property_id")))
-            except (TypeError, ValueError):
-                continue
+    needed = q.property_ids_needed
     if not needed:
         return {}
 

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -1225,9 +1225,17 @@ async def _parse_task_list_query(
     conditions: Optional[str],
     sorting: Optional[str],
     tz: Optional[str],
+    *,
+    defer_property_definitions: bool = False,
 ) -> _TaskListQuery:
     """Validate + extract task list query params (conditions, sort, tz,
-    property-value filters). Raises 400 on malformed input."""
+    property-value filters). Raises 400 on malformed input.
+
+    ``defer_property_definitions`` leaves ``property_definitions`` empty for
+    the cross-guild ``/me`` paths, whose session runs in the ``public``
+    search_path and cannot see any guild's ``property_definitions`` table.
+    Those callers load the definitions per-guild afterwards via
+    :func:`_load_property_definitions_across_guilds`."""
     try:
         user_conditions = parse_conditions(conditions)
     except ValueError:
@@ -1272,10 +1280,13 @@ async def _parse_task_list_query(
         for cond in user_conditions
         if isinstance(cond, FilterCondition) and cond.field == "property_values"
     ]
-    property_definitions_map = await properties_service.load_definitions_by_ids(
-        session,
-        property_ids_needed,
-    )
+    if defer_property_definitions:
+        property_definitions_map: dict[int, PropertyDefinition] = {}
+    else:
+        property_definitions_map = await properties_service.load_definitions_by_ids(
+            session,
+            property_ids_needed,
+        )
 
     return _TaskListQuery(
         user_conditions=user_conditions,
@@ -1289,6 +1300,48 @@ async def _parse_task_list_query(
         property_value_conditions=property_value_conditions,
         property_definitions=property_definitions_map,
     )
+
+
+async def _load_property_definitions_across_guilds(
+    session,
+    current_user: User,
+    q: _TaskListQuery,
+) -> dict[int, PropertyDefinition]:
+    """Load the property definitions a cross-guild ``/me`` list needs, routing
+    into each of the user's guild schemas.
+
+    The ``/me`` session runs in the ``public`` search_path and cannot see any
+    guild's ``property_definitions`` table, so the definitions must be loaded
+    under the same per-guild routing the aggregate list itself uses. A property
+    definition id is unique per guild schema; the compiled filter clause only
+    needs the definition's *type* (which typed column to compare), so the first
+    guild that resolves an id wins and its type is reused for every guild's
+    schema-local ``property_id`` predicate."""
+    needed: list[int] = []
+    for cond in q.property_value_conditions:
+        if isinstance(cond.value, dict):
+            try:
+                needed.append(int(cond.value.get("property_id")))
+            except (TypeError, ValueError):
+                continue
+    if not needed:
+        return {}
+
+    target_guilds = await member_guild_ids(
+        session, current_user.id, restrict_to=q.guild_ids
+    )
+
+    async def _fetch(guild_session, _guild_id: int):
+        defs = await properties_service.load_definitions_by_ids(guild_session, needed)
+        return list(defs.values())
+
+    definitions = await gather_across_guilds(
+        session, current_user.id, target_guilds, _fetch
+    )
+    merged: dict[int, PropertyDefinition] = {}
+    for defn in definitions:
+        merged.setdefault(defn.id, defn)
+    return merged
 
 
 async def _guild_task_query_builder(
@@ -1472,7 +1525,12 @@ async def list_my_tasks(
 
     An optional ``guild_ids`` conditions entry narrows to a subset of guilds.
     """
-    q = await _parse_task_list_query(session, conditions, sorting, tz)
+    q = await _parse_task_list_query(
+        session, conditions, sorting, tz, defer_property_definitions=True
+    )
+    q.property_definitions = await _load_property_definitions_across_guilds(
+        session, current_user, q
+    )
     items, total_count, actual_page = await _list_global_tasks(
         session,
         current_user,
@@ -1512,7 +1570,12 @@ async def list_my_created_tasks(
     tz: Optional[str] = Query(default=None),
 ) -> TaskListResponse:
     """Tasks created by the current user across every guild they belong to."""
-    q = await _parse_task_list_query(session, conditions, sorting, tz)
+    q = await _parse_task_list_query(
+        session, conditions, sorting, tz, defer_property_definitions=True
+    )
+    q.property_definitions = await _load_property_definitions_across_guilds(
+        session, current_user, q
+    )
     items, total_count, actual_page = await _list_global_created_tasks(
         session,
         current_user,


### PR DESCRIPTION
## Problem

Filtering the **My Tasks** page (`GET /api/v1/me/tasks`) by a custom property returned a 500:

```
asyncpg.exceptions.UndefinedTableError: relation "property_definitions" does not exist
```

`/me/tasks` and `/me/tasks/created` are cross-guild aggregates that run on a `UserSessionDep` session — `platform_<tier>` role, `search_path = public`. But `_parse_task_list_query` unconditionally loaded property definitions off that session, and `property_definitions` only exists inside each per-guild schema (`guild_<id>`). Any request carrying a `property_values` filter therefore faulted. The guild-scoped list/export paths were unaffected because their session is already routed into a guild schema.

## Changes

- `_parse_task_list_query` gained a `defer_property_definitions` flag so the `/me` callers skip the definition load on the un-routed session.
- New `_load_property_definitions_across_guilds` loads the needed definitions **inside** each guild's routed context via the existing `gather_across_guilds` helper (the same machinery the aggregate list already uses), merging first-id-wins. The compiled filter clause only needs the definition's *type*, and the `property_id` predicate is schema-local, so this is correct across guilds.
- Both `/me/tasks` and `/me/tasks/created` now parse with the flag, then populate `property_definitions` from the cross-guild loader.
- Changelog entry under `[Unreleased] › Fixed`.

## Testing

- Added `test_list_my_tasks_property_value_is_null_filter` reproducing the exact failing request shape (a `property_values` `is_null` filter); it 500'd before the fix and now asserts a correct 200.
- `pytest app/api/v1/tenant_endpoints/me_tasks_test.py` — 9 passed
- `pytest app/api/v1/tenant_endpoints/me_tasks_created_test.py` — 7 passed
- `ruff check` — clean