### PR TITLE
Add slim searchable member endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Member pickers no longer download the entire guild roster: a new slim, searchable, paginated endpoint serves member typeaheads (guild-wide and per-initiative), returning just id, name, avatar, and status for a bounded page of results instead of every member's full profile. This is the backend groundwork for server-side member search in the assignee and mention pickers.
 - Multiple sign-in providers: the sign-in page now offers a button for every SSO provider the server has configured, not just one. Operators manage additional OIDC providers in Settings → Authentication — with presets for Google and Microsoft Entra, and a custom option for any OIDC identity provider (Keycloak, Authentik, Zitadel, …) — alongside the existing platform SSO form. Client secrets are write-only: set or replaced, never displayed.
 
 ### Changed

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Annotated, List, Optional, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from sqlalchemy import func
 from sqlmodel import select
 
 from app.api.deps import (
@@ -45,6 +46,8 @@ from app.schemas.platform.user import (
     UserGuildMember,
     UserRead,
     UserSelfUpdate,
+    UserSummary,
+    UserSummaryListResponse,
     UserUpdate,
     AccountDeletionRequest,
     AccountDeletionResponse,
@@ -73,6 +76,7 @@ from app.services.platform import csv_export
 from app.services.tenant import stats_service
 from app.services.platform import user_tokens as user_tokens_service
 from app.services.tenant import recent_views as recent_views_service
+from app.db.query import page_has_next, paginated_query
 
 # Allowed values for the optional "task completion visual feedback" effect.
 # Mirrored on the frontend in src/lib/taskCompletionVisualFeedback.ts; keep
@@ -165,6 +169,51 @@ async def list_users(
         member.initiative_roles = getattr(user, "initiative_roles", [])
         response.append(member)
     return response
+
+
+@guild_router.get("/search", response_model=UserSummaryListResponse)
+async def search_users(
+    session: RLSSessionDep,
+    _current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+    search: Optional[str] = Query(
+        default=None,
+        description="Case-insensitive substring match on the member's name.",
+    ),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=0, le=100),
+) -> UserSummaryListResponse:
+    """Slim, searchable, paginated roster for typeahead/pickers.
+
+    Same authorization as the full member list (``RLSSessionDep`` +
+    ``GuildContextDep``, membership re-validated per request): the new params
+    are additive filters on an already-RLS-gated query, so they only ever
+    narrow the row set. Returns :class:`UserSummary` (no email, roles, or
+    ``initiative_roles`` enrichment) instead of the heavy ``UserGuildMember``.
+    """
+    base = (
+        select(User)
+        .join(GuildMembership, GuildMembership.user_id == User.id)
+        .where(GuildMembership.guild_id == guild_context.guild_id)
+    )
+    if search and (term := search.strip()):
+        base = base.where(User.full_name.ilike(f"%{term}%"))
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    data_stmt = base.order_by(User.full_name.asc(), User.id.asc())
+
+    users, total_count, actual_page = await paginated_query(
+        session, data_stmt, count_stmt, page=page, page_size=page_size
+    )
+
+    return UserSummaryListResponse(
+        items=[UserSummary.model_validate(user) for user in users],
+        total_count=total_count,
+        page=actual_page,
+        page_size=page_size,
+        has_next=page_has_next(actual_page, page_size, total_count),
+        has_prev=actual_page > 1,
+    )
 
 
 _GUILD_CSV_HEADERS = [

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -118,6 +118,90 @@ async def test_list_users_in_guild(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.integration
+async def test_search_users_returns_slim_paginated_envelope(
+    client: AsyncClient, session: AsyncSession
+):
+    """The slim search endpoint returns a UserSummary envelope (no email /
+    role / initiative_roles) and honours page_size."""
+    guild = await create_guild(session)
+    caller = await create_user(session, email="caller@example.com", full_name="Aaa")
+    other = await create_user(session, email="other@example.com", full_name="Bbb")
+    third = await create_user(session, email="third@example.com", full_name="Ccc")
+    for user in (caller, other, third):
+        await create_guild_membership(session, user=user, guild=guild)
+
+    headers = get_auth_headers(caller)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/search",
+        headers=headers,
+        params={"page_size": 2, "page": 1},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 3
+    assert body["page"] == 1
+    assert body["page_size"] == 2
+    assert body["has_next"] is True
+    assert body["has_prev"] is False
+    assert len(body["items"]) == 2
+    # Ordered by full_name — the first two of Aaa/Bbb/Ccc.
+    assert [item["full_name"] for item in body["items"]] == ["Aaa", "Bbb"]
+    # Slim projection: no email, no platform role, no initiative_roles.
+    summary = body["items"][0]
+    assert set(summary.keys()) == {
+        "id",
+        "full_name",
+        "avatar_base64",
+        "avatar_url",
+        "status",
+    }
+
+
+@pytest.mark.integration
+async def test_search_users_filters_by_name(client: AsyncClient, session: AsyncSession):
+    """The `search` param is a case-insensitive substring match on the name."""
+    guild = await create_guild(session)
+    caller = await create_user(
+        session, email="caller@example.com", full_name="Alice Smith"
+    )
+    bob = await create_user(session, email="bob@example.com", full_name="Bob Jones")
+    for user in (caller, bob):
+        await create_guild_membership(session, user=user, guild=guild)
+
+    headers = get_auth_headers(caller)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/search",
+        headers=headers,
+        params={"search": "smith"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["full_name"] for item in body["items"]] == ["Alice Smith"]
+
+
+@pytest.mark.integration
+async def test_search_users_requires_membership(
+    client: AsyncClient, session: AsyncSession
+):
+    """A non-member cannot reach the guild's slim roster (path is a selector,
+    not a trust boundary)."""
+    guild = await create_guild(session)
+    outsider = await create_user(session, email="outsider@example.com")
+    # No guild membership for the outsider.
+
+    headers = get_auth_headers(outsider)
+
+    response = await client.get(f"/api/v1/g/{guild.id}/users/search", headers=headers)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
 async def test_update_user_by_id_as_admin(client: AsyncClient, session: AsyncSession):
     """Test that guild admin can update other users."""
     guild = await create_guild(session)

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -1,6 +1,6 @@
-from typing import Annotated, List, Sequence
+from typing import Annotated, List, Optional, Sequence
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 from sqlmodel import select, delete
@@ -49,7 +49,12 @@ from app.schemas.tenant.initiative import (
     serialize_initiative,
     serialize_role,
 )
-from app.schemas.platform.user import UserPublic
+from app.schemas.platform.user import (
+    UserPublic,
+    UserSummary,
+    UserSummaryListResponse,
+)
+from app.db.query import page_has_next, paginated_query
 from app.services import notifications as notifications_service
 from app.services.tenant import initiatives as initiatives_service
 from app.services.platform import guilds as guilds_service
@@ -884,6 +889,69 @@ async def get_initiative_members(
     )
     result = await session.exec(stmt)
     return result.all()
+
+
+@router.get("/{initiative_id}/members/search", response_model=UserSummaryListResponse)
+async def search_initiative_members(
+    initiative_id: int,
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+    search: Optional[str] = Query(
+        default=None,
+        description="Case-insensitive substring match on the member's name.",
+    ),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=0, le=100),
+) -> UserSummaryListResponse:
+    """Slim, searchable, paginated roster of an initiative's members.
+
+    Same authorization as :func:`get_initiative_members` (member, guild
+    admin, or PAM/break-glass grantee); the search/pagination params are
+    additive filters on the already-RLS-gated query. Returns
+    :class:`UserSummary` for typeahead/picker surfaces instead of the full
+    ``UserPublic`` roster.
+    """
+    await _get_initiative_or_404(initiative_id, session, guild_context.guild_id)
+
+    membership = await initiatives_service.get_initiative_membership(
+        session,
+        initiative_id=initiative_id,
+        user_id=current_user.id,
+    )
+    if (
+        not membership
+        and not guild_context.is_pam
+        and not rls_service.is_guild_admin(guild_context.role)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=InitiativeMessages.NOT_A_MEMBER,
+        )
+
+    base = (
+        select(User)
+        .join(InitiativeMember, InitiativeMember.user_id == User.id)
+        .where(InitiativeMember.initiative_id == initiative_id)
+    )
+    if search and (term := search.strip()):
+        base = base.where(User.full_name.ilike(f"%{term}%"))
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    data_stmt = base.order_by(User.full_name.asc(), User.id.asc())
+
+    users, total_count, actual_page = await paginated_query(
+        session, data_stmt, count_stmt, page=page, page_size=page_size
+    )
+
+    return UserSummaryListResponse(
+        items=[UserSummary.model_validate(user) for user in users],
+        total_count=total_count,
+        page=actual_page,
+        page_size=page_size,
+        has_next=page_has_next(actual_page, page_size, total_count),
+        has_prev=actual_page > 1,
+    )
 
 
 @router.post(

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -412,6 +412,77 @@ async def test_get_initiative_members(
 
 
 @pytest.mark.integration
+async def test_search_initiative_members_slim_and_filtered(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The slim members search returns a UserSummary envelope and filters by
+    name, with the same membership gate as the full roster."""
+    admin = await acting_user(guild_role=GuildRole.admin, full_name="Zed Admin")
+    initiative = await create_initiative(
+        session, admin.guild, admin.user, name="Search Initiative"
+    )
+    await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative,
+        initiative_role="member",
+        email="alice@example.com",
+        full_name="Alice Wonderland",
+    )
+    await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative,
+        initiative_role="member",
+        email="bob@example.com",
+        full_name="Bob Builder",
+    )
+
+    # Unfiltered: slim envelope over every member (creator + 2).
+    response = await client.get(
+        admin.g(f"/initiatives/{initiative.id}/members/search"),
+        headers=admin.headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 3
+    assert set(body["items"][0].keys()) == {
+        "id",
+        "full_name",
+        "avatar_base64",
+        "avatar_url",
+        "status",
+    }
+
+    # Filtered by name.
+    response = await client.get(
+        admin.g(f"/initiatives/{initiative.id}/members/search"),
+        headers=admin.headers,
+        params={"search": "wonder"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert body["items"][0]["full_name"] == "Alice Wonderland"
+
+
+@pytest.mark.integration
+async def test_search_initiative_members_as_nonmember_forbidden(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A plain guild member outside the initiative is locked out of the slim
+    roster, mirroring the full members endpoint."""
+    creator = await acting_user(guild_role=GuildRole.member, initiative=True)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
+
+    response = await client.get(
+        outsider.g(f"/initiatives/{creator.initiative.id}/members/search"),
+        headers=outsider.headers,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
 async def test_get_initiative_members_as_nonmember_guild_admin(
     client: AsyncClient, session: AsyncSession, acting_user
 ):

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -130,6 +130,41 @@ class UserGuildMember(UserPublic):
     initiative_roles: List["UserInitiativeRole"] = Field(default_factory=list)
 
 
+class UserSummary(SanitizedBaseModel):
+    """Slim user projection for typeahead and picker surfaces.
+
+    Drops the fields pickers never read — email, platform/guild role,
+    ``initiative_roles`` (an N+1 enrichment on the full roster), and
+    timestamps — while keeping the avatar so members still render with a
+    face. The payload is bounded by pagination on the endpoints that serve
+    it, not by dropping the avatar.
+    """
+
+    model_config = ConfigDict(
+        from_attributes=True, json_schema_serialization_defaults_required=True
+    )
+
+    id: int
+    full_name: Optional[str] = None
+    # Response schema — uncapped for the same legacy-row reason as UserPublic.
+    avatar_base64: Optional[RawTextStr] = None
+    avatar_url: Optional[str] = None
+    status: UserStatus = UserStatus.active
+
+
+class UserSummaryListResponse(SanitizedBaseModel):
+    """Paginated envelope for the slim user search/typeahead endpoints."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    items: List[UserSummary]
+    total_count: int
+    page: int
+    page_size: int
+    has_next: bool
+    has_prev: bool
+
+
 class UserRead(UserBase):
     model_config = ConfigDict(
         from_attributes=True, json_schema_serialization_defaults_required=True

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3575,6 +3575,35 @@ export interface UserStatsResponse {
   guild_breakdown: GuildTaskBreakdown[];
 }
 
+/**
+ * Slim user projection for typeahead and picker surfaces.
+ *
+ * Drops the fields pickers never read — email, platform/guild role,
+ * ``initiative_roles`` (an N+1 enrichment on the full roster), and
+ * timestamps — while keeping the avatar so members still render with a
+ * face. The payload is bounded by pagination on the endpoints that serve
+ * it, not by dropping the avatar.
+ */
+export interface UserSummary {
+  id: number;
+  full_name: string | null;
+  avatar_base64: string | null;
+  avatar_url: string | null;
+  status: UserStatus;
+}
+
+/**
+ * Paginated envelope for the slim user search/typeahead endpoints.
+ */
+export interface UserSummaryListResponse {
+  items: UserSummary[];
+  total_count: number;
+  page: number;
+  page_size: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
 export interface UserUpdate {
   full_name?: string | null;
   role?: UserRole | null;
@@ -4027,6 +4056,22 @@ export type SearchMentionablesApiV1GGuildIdCommentsMentionsSearchGetParams = {
   q?: string;
 };
 
+export type SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams = {
+  /**
+   * Case-insensitive substring match on the member's name.
+   */
+  search?: string | null;
+  /**
+   * @minimum 1
+   */
+  page?: number;
+  /**
+   * @minimum 0
+   * @maximum 100
+   */
+  page_size?: number;
+};
+
 export type GetDocumentCountsApiV1GGuildIdDocumentsCountsGetParams = {
   initiative_id?: number | null;
   search?: string | null;
@@ -4370,6 +4415,22 @@ export type ListAdvancedToolsApiV1GGuildIdAdvancedToolsGetParams = {
 
 export type ListPropertyDefinitionsApiV1GGuildIdPropertyDefinitionsGetParams = {
   initiative_id?: number | null;
+};
+
+export type SearchUsersApiV1GGuildIdUsersSearchGetParams = {
+  /**
+   * Case-insensitive substring match on the member's name.
+   */
+  search?: string | null;
+  /**
+   * @minimum 1
+   */
+  page?: number;
+  /**
+   * @minimum 0
+   * @maximum 100
+   */
+  page_size?: number;
 };
 
 export type ExportUsersCsvApiV1GGuildIdUsersExportCsvGetParams = {

--- a/frontend/src/api/generated/initiatives/initiatives.ts
+++ b/frontend/src/api/generated/initiatives/initiatives.ts
@@ -32,7 +32,9 @@ import type {
   InitiativeRoleUpdate,
   InitiativeUpdate,
   MyInitiativePermissions,
+  SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams,
   UserPublic,
+  UserSummaryListResponse,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -1935,6 +1937,278 @@ export const useAddInitiativeMemberApiV1GGuildIdInitiativesInitiativeIdMembersPo
     queryClient
   );
 };
+/**
+ * Slim, searchable, paginated roster of an initiative's members.
+ *
+ * Same authorization as :func:`get_initiative_members` (member, guild
+ * admin, or PAM/break-glass grantee); the search/pagination params are
+ * additive filters on the already-RLS-gated query. Returns
+ * :class:`UserSummary` for typeahead/picker surfaces instead of the full
+ * ``UserPublic`` roster.
+ * @summary Search Initiative Members
+ */
+export const searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet = (
+  guildId: number,
+  initiativeId: number,
+  params?: SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<UserSummaryListResponse>(
+    {
+      url: `/api/v1/g/${guildId}/initiatives/${initiativeId}/members/search`,
+      method: "GET",
+      params,
+      signal,
+    },
+    options
+  );
+};
+
+export const getSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetQueryKey =
+  (
+    guildId: number,
+    initiativeId: number,
+    params?: SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams
+  ) => {
+    return [
+      `/api/v1/g/${guildId}/initiatives/${initiativeId}/members/search`,
+      ...(params ? [params] : []),
+    ] as const;
+  };
+
+export const getSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetQueryOptions =
+  <
+    TData = Awaited<
+      ReturnType<typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet>
+    >,
+    TError = ErrorType<HTTPValidationError>,
+  >(
+    guildId: number,
+    initiativeId: number,
+    params?: SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams,
+    options?: {
+      query?: Partial<
+        UseQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+            >
+          >,
+          TError,
+          TData
+        >
+      >;
+      request?: SecondParameter<typeof apiMutator>;
+    }
+  ) => {
+    const { query: queryOptions, request: requestOptions } = options ?? {};
+
+    const queryKey =
+      queryOptions?.queryKey ??
+      getSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetQueryKey(
+        guildId,
+        initiativeId,
+        params
+      );
+
+    const queryFn: QueryFunction<
+      Awaited<
+        ReturnType<
+          typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+        >
+      >
+    > = ({ signal }) =>
+      searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet(
+        guildId,
+        initiativeId,
+        params,
+        requestOptions,
+        signal
+      );
+
+    return {
+      queryKey,
+      queryFn,
+      enabled:
+        guildId !== null &&
+        guildId !== undefined &&
+        initiativeId !== null &&
+        initiativeId !== undefined,
+      ...queryOptions,
+    } as UseQueryOptions<
+      Awaited<
+        ReturnType<
+          typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+        >
+      >,
+      TError,
+      TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+  };
+
+export type SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetQueryResult =
+  NonNullable<
+    Awaited<
+      ReturnType<typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet>
+    >
+  >;
+export type SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet<
+  TData = Awaited<
+    ReturnType<typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  initiativeId: number,
+  params:
+    | undefined
+    | SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+          >
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet<
+  TData = Awaited<
+    ReturnType<typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  initiativeId: number,
+  params?: SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+          >
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet<
+  TData = Awaited<
+    ReturnType<typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  initiativeId: number,
+  params?: SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+          >
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Search Initiative Members
+ */
+
+export function useSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet<
+  TData = Awaited<
+    ReturnType<typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  initiativeId: number,
+  params?: SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet
+          >
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions =
+    getSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGetQueryOptions(
+      guildId,
+      initiativeId,
+      params,
+      options
+    );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
 /**
  * Remove a member from an initiative.
  * @summary Remove Initiative Member

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -33,12 +33,14 @@ import type {
   GuildRemovalEligibilityResponse,
   GuildRemovalRequest,
   HTTPValidationError,
+  SearchUsersApiV1GGuildIdUsersSearchGetParams,
   UserCreate,
   UserGuildMember,
   UserPublic,
   UserRead,
   UserSelfUpdate,
   UserStatsResponse,
+  UserSummaryListResponse,
   UserUpdate,
 } from "../initiativeAPI.schemas";
 
@@ -1256,6 +1258,184 @@ export const useCreateUserApiV1GGuildIdUsersPost = <
 > => {
   return useMutation(getCreateUserApiV1GGuildIdUsersPostMutationOptions(options), queryClient);
 };
+/**
+ * Slim, searchable, paginated roster for typeahead/pickers.
+ *
+ * Same authorization as the full member list (``RLSSessionDep`` +
+ * ``GuildContextDep``, membership re-validated per request): the new params
+ * are additive filters on an already-RLS-gated query, so they only ever
+ * narrow the row set. Returns :class:`UserSummary` (no email, roles, or
+ * ``initiative_roles`` enrichment) instead of the heavy ``UserGuildMember``.
+ * @summary Search Users
+ */
+export const searchUsersApiV1GGuildIdUsersSearchGet = (
+  guildId: number,
+  params?: SearchUsersApiV1GGuildIdUsersSearchGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<UserSummaryListResponse>(
+    { url: `/api/v1/g/${guildId}/users/search`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getSearchUsersApiV1GGuildIdUsersSearchGetQueryKey = (
+  guildId: number,
+  params?: SearchUsersApiV1GGuildIdUsersSearchGetParams
+) => {
+  return [`/api/v1/g/${guildId}/users/search`, ...(params ? [params] : [])] as const;
+};
+
+export const getSearchUsersApiV1GGuildIdUsersSearchGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: SearchUsersApiV1GGuildIdUsersSearchGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getSearchUsersApiV1GGuildIdUsersSearchGetQueryKey(guildId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>
+  > = ({ signal }) =>
+    searchUsersApiV1GGuildIdUsersSearchGet(guildId, params, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: guildId !== null && guildId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type SearchUsersApiV1GGuildIdUsersSearchGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>
+>;
+export type SearchUsersApiV1GGuildIdUsersSearchGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useSearchUsersApiV1GGuildIdUsersSearchGet<
+  TData = Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: undefined | SearchUsersApiV1GGuildIdUsersSearchGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+          TError,
+          Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useSearchUsersApiV1GGuildIdUsersSearchGet<
+  TData = Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: SearchUsersApiV1GGuildIdUsersSearchGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+          TError,
+          Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useSearchUsersApiV1GGuildIdUsersSearchGet<
+  TData = Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: SearchUsersApiV1GGuildIdUsersSearchGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Search Users
+ */
+
+export function useSearchUsersApiV1GGuildIdUsersSearchGet<
+  TData = Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: SearchUsersApiV1GGuildIdUsersSearchGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof searchUsersApiV1GGuildIdUsersSearchGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getSearchUsersApiV1GGuildIdUsersSearchGetQueryOptions(
+    guildId,
+    params,
+    options
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
 /**
  * Export guild members as a CSV file. Pass `user_id` one or more times to
  * restrict the export to a subset. Without `user_id`, all visible members are


### PR DESCRIPTION
## Problem

`GET /g/{guild_id}/users/` returned the entire guild membership as heavy `UserGuildMember` rows (each carrying `avatar_base64`, `initiative_roles[]`, email, timestamps) with no search, pagination, or slim projection — the single largest overfetch in the app, backing hot paths like the assignee/mention pickers. The per-initiative `GET /.../initiatives/{id}/members` roster had the same gap. Closes #855.

## Changes

- **New slim schema** (`schemas/platform/user.py`): `UserSummary` (`id`, `full_name`, `avatar_base64`, `avatar_url`, `status`) + `UserSummaryListResponse` paginated envelope. It drops email, platform/guild role, `initiative_roles` (an N+1 enrichment on the full roster), and timestamps, but **keeps the avatar** so pickers still render a face — the payload is bounded by pagination, not by dropping the avatar.
- **Two new endpoints**, both reusing the existing `paginated_query` / `page_has_next` helpers:
  - `GET /g/{guild_id}/users/search` (`RLSSessionDep` + `GuildContextDep`)
  - `GET /g/{guild_id}/initiatives/{initiative_id}/members/search` (member / guild-admin / PAM gate, same as the full roster)
  - Params: `search` (case-insensitive `ILIKE` on `full_name`), `page` (≥1), `page_size` (0–100), ordered by name.
- **Non-breaking**: the existing full-roster endpoints (`list_users`, `get_initiative_members`) are untouched, so current consumers keep working. The frontend picker rewire is the sibling issue #856.
- **Orval client regenerated & committed** (`searchUsers…`, `searchInitiativeMembers…`, `UserSummary`, `UserSummaryListResponse`).

## Authorization

Same gates as the full-roster siblings — the new params are additive filters on an already-RLS-gated query, so they only ever narrow the row set. Membership is re-validated per request; a non-member gets 403.

## Testing

- `cd backend && pytest app/api/v1/platform_endpoints/users_test.py app/api/v1/tenant_endpoints/initiatives_test.py` → **85 passed** (5 new: slim envelope + pagination, name filtering, non-member 403 for each endpoint)
- `ruff check app/` → clean
- `cd frontend && pnpm typecheck` → clean; `pnpm biome check src/api/generated` → clean

## Notes

- Blocks/pairs with #856 (frontend server-side typeahead picker conversion).
