### PR TITLE
Fix stale users-DELETE RLS test after migration 0144

### DIFF
--- a/backend/app/db/platform_role_rls_test.py
+++ b/backend/app/db/platform_role_rls_test.py
@@ -96,16 +96,19 @@ async def test_support_cannot_update_others_but_moderator_can(session):
 
 
 async def test_no_tier_can_delete_users(session):
-    """``users_no_delete`` (RESTRICTIVE) keeps DELETE denied even for owner; user
-    deletion stays on the admin engine."""
+    """DELETE on ``public.users`` is revoked from every request-path floor
+    (migration 0144); user rows are removed only on the admin/system engine.
+    An owner-tier request-path DELETE is therefore denied at the grant level
+    (insufficient-privilege), not merely filtered to 0 rows."""
     actor = await create_user(session)
     target = await create_user(session)
     await _assume(session, "owner", actor.id)
-    res = await session.exec(
-        text("DELETE FROM users WHERE id = :id"), params={"id": target.id}
-    )
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(
+                text("DELETE FROM users WHERE id = :id"), params={"id": target.id}
+            )
     await _reset(session)
-    assert res.rowcount == 0
 
 
 # --- access_grants --------------------------------------------------------


### PR DESCRIPTION
## Problem

The full backend suite fails on `app/db/platform_role_rls_test.py::test_no_tier_can_delete_users`:

```
sqlalchemy.exc.ProgrammingError: InsufficientPrivilegeError: permission denied for table users
[SQL: DELETE FROM users WHERE id = $1]
```

## Cause

Migration **`20260717_0144_users_role_column_scope.py`** (already on `dev`) column-scopes the request-path write access on `public.users` and, per its own docstring, **revokes DELETE from the request floors**:

```sql
REVOKE UPDATE, DELETE ON TABLE public.users FROM app_guild_base
REVOKE INSERT, UPDATE, DELETE ON TABLE public.users FROM "platform_base"
```

The test still asserted the *old* model — DELETE granted but neutralized by a RESTRICTIVE policy, so `res.rowcount == 0`. Now DELETE is denied at the **grant** level, so the statement raises `InsufficientPrivilegeError` instead of returning rowcount 0. The migration changed the mechanism but didn't update this test.

## Fix

Assert the raised denial, mirroring the owner-only `app_settings` write test already in this file (`begin_nested()` savepoint + `pytest.raises(DBAPIError)`):

```python
await _assume(session, "owner", actor.id)
with pytest.raises(DBAPIError):
    async with session.begin_nested():
        await session.exec(text("DELETE FROM users WHERE id = :id"), params={"id": target.id})
await _reset(session)
```

No production code changes — test-only, matching the current (post-0144) grant model.

## Verification

- `test_no_tier_can_delete_users` now passes (isolation and file run).
- File-run went from **2 failed → 1 failed**; the remaining `test_access_grants_self_vs_admin` failure is **pre-existing and unrelated** — it fails only in isolated/file-only runs (RLS visibility depends on prior-test DB state) and **passes in the full suite** (confirmed: the full-suite run reports only the DELETE test failing). Deterministic ordering (no pytest-randomly), so CI (full suite) is unaffected. Left as a separate, lower-priority test-isolation cleanup.

## Note for the 0144 author (@LeeJMorel?)

Flagging in case there was an intended `users_no_delete` RESTRICTIVE-policy approach that the grant-revoke superseded — the test docstring referenced it, but no such policy is created by 0144.
