### PR TITLE
Finish platform admin→operator rename; register storage backfill grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A database created or restored in a Postgres cluster where the platform "admin" → "operator" role rename had already run no longer loses its platform-staff row-security coverage: a repair migration finishes the rename by re-binding the affected policies (access-grant queue, platform user list/management) to the operator role and removing the leftover one. Without it, operators and owners saw only their own rows in the access-grant queue and the platform user list on such databases.
 - The sidebar "Edit tag" dialog is no longer visually broken — the name field now fills the row and the color picker sits beside it, instead of the color picker taking the full width and collapsing the name field to a sliver.
 - On mobile, opening the three-dot menu next to an initiative or project in the sidebar no longer dismisses the sidebar drawer.
 - Removed redundant spacing between icons and labels across buttons throughout the app; the button's built-in gap now handles it consistently.

--- a/backend/alembic/versions/20260718_0148_finish_platform_operator_rename.py
+++ b/backend/alembic/versions/20260718_0148_finish_platform_operator_rename.py
@@ -92,13 +92,12 @@ def upgrade() -> None:
         return
 
     # Both roles exist: re-point this database's policies at the operator role.
-    # OID 0 in polroles is the PUBLIC pseudo-role (no pg_roles row), so it is
-    # carried as a separate flag and re-emitted as the keyword — resolving names
-    # alone would silently drop it from the rebound TO list.
+    # Resolving polroles to names is lossless here: Postgres normalizes any TO
+    # list containing PUBLIC to exactly {0}, so a policy matched by the
+    # old-role predicate below can only ever name real roles.
     bindings = connection.execute(
         text(
             "SELECT n.nspname AS sch, c.relname AS tbl, p.polname AS pol, "
-            "0 = ANY(p.polroles) AS has_public, "
             "ARRAY(SELECT r.rolname FROM pg_roles r "
             "      WHERE r.oid = ANY(p.polroles)) AS roles "
             "FROM pg_policy p "
@@ -108,16 +107,13 @@ def upgrade() -> None:
         ),
         {"oid": old_oid},
     ).all()
-    for sch, tbl, pol, has_public, roles in bindings:
+    for sch, tbl, pol, roles in bindings:
         rebound: list[str] = []
         for role in roles:
             target = new if role == old else role
             if target not in rebound:
                 rebound.append(target)
-        parts = [f'"{_safe_ident(r)}"' for r in rebound]
-        if has_public:
-            parts.append("PUBLIC")
-        to_clause = ", ".join(parts)
+        to_clause = ", ".join(f'"{_safe_ident(r)}"' for r in rebound)
         connection.execute(
             text(
                 f'ALTER POLICY "{_safe_ident(pol)}" '

--- a/backend/alembic/versions/20260718_0148_finish_platform_operator_rename.py
+++ b/backend/alembic/versions/20260718_0148_finish_platform_operator_rename.py
@@ -1,0 +1,142 @@
+"""Finish the platform ``admin`` -> ``operator`` rename when 0139 no-opped.
+
+Migration 20260710_0139 renames the cluster-global role ``platform_admin`` to
+``platform_operator`` only while the target name is still free. Roles are
+cluster-global but databases are not: when a database is (re)created in a
+cluster where the rename already happened — a rebuilt test database, or a
+restore into an existing cluster — the frozen baseline re-creates
+``platform_admin`` from its frozen tier list and binds three policies to it
+(``access_grants_admin``, ``users_platform_manage``, ``users_platform_read``),
+and 0139's guarded rename then finds ``platform_operator`` already taken and
+does nothing. That database is left with those policies bound to a role no
+request ever assumes, so operator/owner platform reads fail closed (admins see
+only their own rows).
+
+This migration converges either state at apply time:
+
+* old role exists, target free -> plain ``ALTER ROLE ... RENAME`` (as 0139);
+* both roles exist -> re-bind every policy in THIS database that names the old
+  role onto the new one, then drop the old role unless something elsewhere in
+  the cluster still depends on it (that database's own upgrade finishes it).
+
+A database whose policies already bind ``platform_operator`` is untouched, so
+re-running is a no-op.
+
+Revision ID: 20260718_0148
+Revises: 20260718_0147
+Create Date: 2026-07-18
+"""
+
+from __future__ import annotations
+
+import string
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "20260718_0148"
+down_revision = "20260718_0147"
+branch_labels = None
+depends_on = None
+
+
+# Prefix defense-in-depth (operator/test config, never user input): an explicit
+# allow-list of role-name characters so a stray quote can't break out of DDL.
+# Frozen copy of the baseline helper — migrations are immutable records and must
+# not drift if the prefix logic ever changes.
+_ALLOWED_IDENT_CHARS = frozenset(string.ascii_letters + string.digits + "_")
+
+
+def _platform_prefix() -> str:
+    """The platform-role prefix, read from settings at APPLY time (the test
+    suite sets it before running migrations; empty in prod/dev)."""
+    from app.core.config import settings
+
+    prefix = settings.PLATFORM_ROLE_PREFIX
+    if not set(prefix) <= _ALLOWED_IDENT_CHARS:
+        raise ValueError(f"unsafe PLATFORM_ROLE_PREFIX for role DDL: {prefix!r}")
+    return prefix
+
+
+def _safe_ident(name: str) -> str:
+    """Guard an identifier before it lands in an f-string DDL sink. Everything
+    this migration renders comes from the catalog or hardcoded literals, held
+    to the same allow-list as the prefix."""
+    if not name or not set(name) <= _ALLOWED_IDENT_CHARS:
+        raise ValueError(f"unsafe identifier for DDL: {name!r}")
+    return name
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    prefix = _platform_prefix()
+    old = f"{prefix}platform_admin"
+    new = f"{prefix}platform_operator"
+
+    old_oid = connection.execute(
+        text("SELECT oid FROM pg_roles WHERE rolname = :r"), {"r": old}
+    ).scalar()
+    if old_oid is None:
+        return
+
+    new_exists = connection.execute(
+        text("SELECT 1 FROM pg_roles WHERE rolname = :r"), {"r": new}
+    ).scalar()
+    if not new_exists:
+        # 0139 never ran against this cluster state; the plain rename still
+        # works and carries every grant and policy binding with it.
+        connection.execute(
+            text(f'ALTER ROLE "{_safe_ident(old)}" RENAME TO "{_safe_ident(new)}"')
+        )
+        return
+
+    # Both roles exist: re-point this database's policies at the operator role.
+    bindings = connection.execute(
+        text(
+            "SELECT n.nspname AS sch, c.relname AS tbl, p.polname AS pol, "
+            "ARRAY(SELECT r.rolname FROM pg_roles r "
+            "      WHERE r.oid = ANY(p.polroles)) AS roles "
+            "FROM pg_policy p "
+            "JOIN pg_class c ON c.oid = p.polrelid "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE :oid = ANY(p.polroles)"
+        ),
+        {"oid": old_oid},
+    ).all()
+    for sch, tbl, pol, roles in bindings:
+        rebound: list[str] = []
+        for role in roles:
+            target = new if role == old else role
+            if target not in rebound:
+                rebound.append(target)
+        to_clause = ", ".join(f'"{_safe_ident(r)}"' for r in rebound)
+        connection.execute(
+            text(
+                f'ALTER POLICY "{_safe_ident(pol)}" '
+                f'ON "{_safe_ident(sch)}"."{_safe_ident(tbl)}" TO {to_clause}'
+            )
+        )
+
+    # The old role should now be unreferenced; drop it so the ladder has one
+    # role per tier again. Another database in the same cluster may still bind
+    # policies to it — leave it for that database's own upgrade in that case.
+    connection.execute(
+        text(
+            f"""
+            DO $$ BEGIN
+                BEGIN
+                    DROP ROLE "{_safe_ident(old)}";
+                EXCEPTION WHEN dependent_objects_still_exist THEN
+                    NULL;
+                END;
+            END $$;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Convergence repair only — there is no meaningful prior state to restore.
+    # Reverting the rename itself is 20260710_0139's downgrade.
+    pass

--- a/backend/alembic/versions/20260718_0148_finish_platform_operator_rename.py
+++ b/backend/alembic/versions/20260718_0148_finish_platform_operator_rename.py
@@ -92,9 +92,13 @@ def upgrade() -> None:
         return
 
     # Both roles exist: re-point this database's policies at the operator role.
+    # OID 0 in polroles is the PUBLIC pseudo-role (no pg_roles row), so it is
+    # carried as a separate flag and re-emitted as the keyword — resolving names
+    # alone would silently drop it from the rebound TO list.
     bindings = connection.execute(
         text(
             "SELECT n.nspname AS sch, c.relname AS tbl, p.polname AS pol, "
+            "0 = ANY(p.polroles) AS has_public, "
             "ARRAY(SELECT r.rolname FROM pg_roles r "
             "      WHERE r.oid = ANY(p.polroles)) AS roles "
             "FROM pg_policy p "
@@ -104,13 +108,16 @@ def upgrade() -> None:
         ),
         {"oid": old_oid},
     ).all()
-    for sch, tbl, pol, roles in bindings:
+    for sch, tbl, pol, has_public, roles in bindings:
         rebound: list[str] = []
         for role in roles:
             target = new if role == old else role
             if target not in rebound:
                 rebound.append(target)
-        to_clause = ", ".join(f'"{_safe_ident(r)}"' for r in rebound)
+        parts = [f'"{_safe_ident(r)}"' for r in rebound]
+        if has_public:
+            parts.append("PUBLIC")
+        to_clause = ", ".join(parts)
         connection.execute(
             text(
                 f'ALTER POLICY "{_safe_ident(pol)}" '

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -12,7 +12,11 @@ TEST_SECRET_KEY = "f2d8a1c4b7e90365d4a2f8c1b6e3079a5c8d2e4f6a1b3c5d7e9f0a2b4c6d8
 def _settings(**overrides) -> Settings:
     overrides.setdefault("APP_URL", "https://app.example.com")
     overrides.setdefault("SECRET_KEY", TEST_SECRET_KEY)
+    # _env_file=None keeps these unit tests hermetic: without it, a developer's
+    # real backend/.env (e.g. a legitimately-set JWT_SIGNING_KEY) leaks into
+    # every Settings field the test didn't explicitly override.
     return Settings(
+        _env_file=None,
         DATABASE_URL_APP="postgresql+asyncpg://app:app@localhost/app",
         DATABASE_URL_ADMIN="postgresql+asyncpg://admin:admin@localhost/app",
         **overrides,

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pydantic import ValidationError
+from pydantic_settings import SettingsConfigDict
 
 from app.core.config import CAPACITOR_NATIVE_ORIGINS, Settings
 
@@ -9,14 +10,18 @@ from app.core.config import CAPACITOR_NATIVE_ORIGINS, Settings
 TEST_SECRET_KEY = "f2d8a1c4b7e90365d4a2f8c1b6e3079a5c8d2e4f6a1b3c5d7e9f0a2b4c6d8e1f"
 
 
+class _HermeticSettings(Settings):
+    """``Settings`` without the dotenv source: keeps these unit tests hermetic —
+    otherwise a developer's real backend/.env (e.g. a legitimately-set
+    JWT_SIGNING_KEY) leaks into every field the test didn't override."""
+
+    model_config = SettingsConfigDict(env_file=None)
+
+
 def _settings(**overrides) -> Settings:
     overrides.setdefault("APP_URL", "https://app.example.com")
     overrides.setdefault("SECRET_KEY", TEST_SECRET_KEY)
-    # _env_file=None keeps these unit tests hermetic: without it, a developer's
-    # real backend/.env (e.g. a legitimately-set JWT_SIGNING_KEY) leaks into
-    # every Settings field the test didn't explicitly override.
-    return Settings(
-        _env_file=None,
+    return _HermeticSettings(
         DATABASE_URL_APP="postgresql+asyncpg://app:app@localhost/app",
         DATABASE_URL_ADMIN="postgresql+asyncpg://admin:admin@localhost/app",
         **overrides,

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -47,9 +47,22 @@ _RLS_SHARED_TABLES = {
     "guild_memberships",
     "guilds",
     "oidc_claim_mappings",
+    "storage_backfill_state",
     "user_view_preferences",
     "users",
 }
+
+
+@pytest.fixture(autouse=True)
+async def _materialize_lazy_shared_tables():
+    """``storage_backfill_state`` is created lazily at runtime, not by a
+    migration — without this the catalog assertions below would depend on
+    whether a storage test happened to run first. Creating it here also
+    converges a table left behind by an earlier build on the current grant
+    set (the create path is revoke-then-grant, idempotent)."""
+    from app.services.storage_backfill import _ensure_table
+
+    await _ensure_table()
 
 
 def _app_role_family() -> list[str]:

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -47,7 +47,12 @@ __all__ = [
 # Public tables that carry no SQLModel (so they're absent from ``SHARED_TABLES``,
 # which derives from model metadata) yet still exist in ``public`` and so still
 # need an explicit "grant it nothing" decision for the login roles.
-NON_MODEL_SHARED_TABLES: frozenset[str] = frozenset({"alembic_version"})
+# ``storage_backfill_state`` is created lazily at runtime (see
+# app.services.storage_backfill), not by a migration; its entry below is what
+# the service's own GRANT renders from.
+NON_MODEL_SHARED_TABLES: frozenset[str] = frozenset(
+    {"alembic_version", "storage_backfill_state"}
+)
 
 # Every ``public`` table that requires a per-role grant decision.
 GRANTABLE_SHARED_TABLES: frozenset[str] = SHARED_TABLES | NON_MODEL_SHARED_TABLES
@@ -113,6 +118,11 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     "billing_jti_blocklist": frozenset({"SELECT", "DELETE"}),
     # migrations-only bookkeeping (the provisioning role owns it)
     "alembic_version": None,
+    # lazily-created UNLOGGED backfill status singleton: read, seeded idle, and
+    # claimed/updated on the system engine; rows are never deleted (the claim
+    # UPDATE recycles the singleton). The service grants exactly this set at
+    # table creation (app.services.storage_backfill._ensure_table).
+    "storage_backfill_state": frozenset({"SELECT", "INSERT", "UPDATE"}),
 }
 
 
@@ -156,6 +166,8 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     "billing_event_log": None,
     "billing_jti_blocklist": None,
     "alembic_version": None,
+    # system-engine-only status singleton; no request role reads it
+    "storage_backfill_state": None,
 }
 
 

--- a/backend/app/services/storage_backfill.py
+++ b/backend/app/services/storage_backfill.py
@@ -68,6 +68,16 @@ CREATE UNLOGGED TABLE IF NOT EXISTS storage_backfill_state (
 # lazily-created table follows the same "decide it explicitly" discipline as the
 # migrated ones (security_invariants_test compares the live catalog to it).
 _ADMIN_GRANT = grant_sql(SHARED_TABLE_SYSTEM_GRANTS["storage_backfill_state"])
+if _ADMIN_GRANT is None:
+    # Every read/write in this module runs on the system engine; a registry
+    # entry of "no access" would leave the service unable to operate at all,
+    # so fail at import with a pointer to the decision rather than emitting a
+    # malformed GRANT at first use.
+    raise RuntimeError(
+        "app.db.system_grants gives the system engine no access to "
+        "storage_backfill_state; the storage backfill service requires "
+        "SELECT/INSERT/UPDATE"
+    )
 
 _table_lock = asyncio.Lock()
 _table_ready = False

--- a/backend/app/services/storage_backfill.py
+++ b/backend/app/services/storage_backfill.py
@@ -38,6 +38,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.db.backfill_uploads_to_s3 import BackfillSummary, backfill_uploads_to_s3
 from app.db import session as db_session
 from app.db.session import AdminSessionLocal
+from app.db.system_grants import SHARED_TABLE_SYSTEM_GRANTS, grant_sql
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,11 @@ CREATE UNLOGGED TABLE IF NOT EXISTS storage_backfill_state (
     heartbeat timestamptz
 )
 """
+
+# The system engine's verbs come from the audited shared-table registry, so the
+# lazily-created table follows the same "decide it explicitly" discipline as the
+# migrated ones (security_invariants_test compares the live catalog to it).
+_ADMIN_GRANT = grant_sql(SHARED_TABLE_SYSTEM_GRANTS["storage_backfill_state"])
 
 _table_lock = asyncio.Lock()
 _table_ready = False
@@ -97,7 +103,14 @@ async def _ensure_table() -> None:
             await conn.execute(
                 text("ALTER TABLE storage_backfill_state FORCE ROW LEVEL SECURITY")
             )
-            await conn.execute(text("GRANT ALL ON storage_backfill_state TO app_admin"))
+            # Revoke-then-grant so a table created by an earlier build (which
+            # granted ALL) converges on the registry's verb set.
+            await conn.execute(
+                text("REVOKE ALL ON storage_backfill_state FROM app_admin")
+            )
+            await conn.execute(
+                text(f"GRANT {_ADMIN_GRANT} ON storage_backfill_state TO app_admin")
+            )
         _table_ready = True
 
 


### PR DESCRIPTION
## Problem

Eight backend tests fail on any database whose Postgres cluster has lived through a rebuild — and two of the underlying causes are real bugs that could bite production, not test dirt.

1. **Platform staff policies bound to a retired role.** Migration `20260710_0139` renames the cluster-global role `platform_admin` → `platform_operator` only while the target name is free. Roles are cluster-global but databases are not: a database (re)created in a cluster where the rename already ran (rebuilt test DB, restore into an existing cluster) gets `platform_admin` re-created by the frozen baseline with `access_grants_admin`, `users_platform_read`, and `users_platform_manage` bound to it, and 0139's guarded rename silently no-ops. Operators/owners then see only their own rows in the access-grant queue and the platform user list (4 test failures: `test_access_grants_self_vs_admin`, 3× CSV export).
2. **Unregistered shared table.** The lazily-created `storage_backfill_state` table had no entry in the shared-table grant registry, so `security_invariants_test` failed whenever the table existed — CI only stays green by test ordering (2 failures).
3. **Non-hermetic config tests.** `Settings` reads `backend/.env`, so a developer's real `JWT_SIGNING_KEY`/`PREVIOUS_SECRET_KEY` leaked into the tests that assert defaults (2 failures).

## Changes

- **New migration `20260718_0148`** converges either state: plain `ALTER ROLE … RENAME` when the target is free; otherwise re-binds every policy in the database that names the old role onto `platform_operator` and drops the leftover role once nothing in the cluster depends on it. Idempotent; no-op on healthy databases.
- **`storage_backfill_state` registered** in `NON_MODEL_SHARED_TABLES` + both grant matrices (`SELECT, INSERT, UPDATE` for the system engine, nothing for the bare login role). The service now grants exactly the registry's verb set (revoke-then-grant, so tables created by earlier builds converge off `GRANT ALL`), and the invariant tests materialize the lazy table so the catalog assertions are deterministic instead of order-dependent.
- **Config tests construct `Settings` with `_env_file=None`** so local dotfiles can't leak in. No production config behavior changed — per review, blank/default JWT key semantics are deliberately left for the auth rework PR.

## Schema/env updates

- One new Alembic migration (`20260718_0148_finish_platform_operator_rename.py`). Repair-only: no tables or columns change; downgrade is a documented no-op (0139 owns the rename reversal). No env changes.

## Testing

```bash
cd backend && pytest app/db/platform_role_rls_test.py::test_access_grants_self_vs_admin \
  app/api/v1/platform_endpoints/admin_test.py app/db/security_invariants_test.py \
  app/db/system_grants_test.py app/db/tenancy_test.py app/services/storage_backfill_test.py \
  app/core/config_test.py --no-cov          # all pass, previously 8 failures
cd backend && ruff check app alembic        # clean
cd backend && pytest -n auto --no-cov       # full suite
```

Verified against a polluted cluster (both `test_master_platform_admin` and `_operator` present): after `alembic upgrade head` the three policies bind `platform_operator` and the stale role is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)