### PR TITLE
Per-initiative grouped counts for sidebar and landing badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The sidebar and the initiatives landing page no longer download every document (and, on the landing page, every project) just to show per-initiative count badges. A new grouped-counts endpoint returns the per-initiative totals in one query, honoring the same visibility rules as the lists — so the badges stay accurate while large guilds stop transferring their whole corpus on every page.
 - Sidebar rows use their full width: an initiative, project, or tool row's name and count now span the whole row until you hover it, at which point the settings/"+" button slides in and the name shrinks to make room (rather than the button permanently reserving space or overlapping the text). The reveal animation is skipped for users who prefer reduced motion.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The sidebar and the initiatives landing page no longer download every document (and, on the landing page, every project) just to show per-initiative count badges. A new grouped-counts endpoint returns the per-initiative totals in one query, honoring the same visibility rules as the lists — so the badges stay accurate while large guilds stop transferring their whole corpus on every page.
+- The sidebar and the initiatives landing page no longer download every document (and, on the landing page, every project) just to show per-initiative count badges. New grouped-counts endpoints return the per-initiative totals in one query, honoring the same visibility rules as the lists — so the badges stay accurate while large guilds stop transferring their whole corpus on every page. The sidebar's queue and counter-group badges use the same endpoints now too, replacing capped list fetches that silently undercounted past 100 items and dragged each item's full sharing state along.
 - Sidebar rows use their full width: an initiative, project, or tool row's name and count now span the whole row until you hover it, at which point the settings/"+" button slides in and the name shrinks to make room (rather than the button permanently reserving space or overlapping the text). The reveal animation is skipped for users who prefer reduced motion.
 
 ### Fixed

--- a/backend/app/api/v1/tenant_endpoints/counters.py
+++ b/backend/app/api/v1/tenant_endpoints/counters.py
@@ -42,6 +42,7 @@ from app.models.tenant.initiative import (
 )
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.platform.user import User
+from app.schemas.tenant.initiative import InitiativeGroupedCountsResponse
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.schemas.tenant.counter import (
     CounterCreate,
@@ -293,6 +294,42 @@ async def list_counter_groups(
         page=page,
         page_size=page_size,
         has_next=has_next,
+    )
+
+
+@router.get("/counts/by-initiative", response_model=InitiativeGroupedCountsResponse)
+async def get_counter_group_counts_by_initiative(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> InitiativeGroupedCountsResponse:
+    """Visible counter-group counts grouped by initiative.
+
+    Lightweight endpoint for the sidebar badges — same visibility rules
+    as the counter-group list (counters-enabled initiatives, DAC), one
+    GROUP BY instead of a capped list page.
+    """
+    conditions = [
+        CounterGroup.guild_id == guild_context.guild_id,
+        CounterGroup.initiative_id.in_(
+            select(Initiative.id).where(Initiative.counter_groups_enabled == True)  # noqa: E712
+        ),
+    ]
+    if not rls_service.is_guild_admin(guild_context.role) and not guild_context.is_pam:
+        conditions.append(
+            CounterGroup.id.in_(
+                counters_service.visible_counter_group_ids_subquery(current_user.id)
+            )
+        )
+
+    statement = (
+        select(CounterGroup.initiative_id, func.count(CounterGroup.id))
+        .where(*conditions)
+        .group_by(CounterGroup.initiative_id)
+    )
+    rows = (await session.exec(statement)).all()
+    return InitiativeGroupedCountsResponse(
+        counts={initiative_id: count for initiative_id, count in rows}
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/counters_test.py
+++ b/backend/app/api/v1/tenant_endpoints/counters_test.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
-from app.testing import Actor
+from app.testing import Actor, create_counter_group, create_initiative
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -787,3 +787,45 @@ async def test_delete_counter_group_still_emits_group_deleted(
     resp = await client.delete(a.g(f"/counter-groups/{group['id']}"), headers=a.headers)
     assert resp.status_code == 204, resp.text
     assert (a.guild.id, "counter_group", group["id"], "group_deleted") in emitted
+
+
+@pytest.mark.integration
+async def test_counter_group_counts_by_initiative(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Grouped counts mirror the list: DAC-visible groups in counters-enabled
+    initiatives only, with no entry for unjoined initiatives."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    other_initiative = await create_initiative(session, admin.guild, admin.user)
+    disabled_initiative = await create_initiative(
+        session, admin.guild, admin.user, counter_groups_enabled=False
+    )
+
+    await create_counter_group(session, admin.initiative, member.user)
+    await create_counter_group(session, admin.initiative, admin.user)
+    await create_counter_group(session, other_initiative, admin.user)
+    await create_counter_group(session, disabled_initiative, admin.user)
+
+    # Guild admin: every group in counters-enabled initiatives, grouped.
+    response = await client.get(
+        admin.g("/counter-groups/counts/by-initiative"), headers=admin.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {
+        str(admin.initiative.id): 2,
+        str(other_initiative.id): 1,
+    }
+
+    # Member: only groups shared with them, and no entry for initiatives
+    # they are not in.
+    response = await client.get(
+        member.g("/counter-groups/counts/by-initiative"), headers=member.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {str(admin.initiative.id): 1}

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -78,6 +78,7 @@ from app.schemas.tenant.document import (
     serialize_document_file_versions,
     serialize_document_summary,
 )
+from app.schemas.tenant.initiative import InitiativeGroupedCountsResponse
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.schemas.ai_generation import GenerateDocumentSummaryResponse
 from app.schemas.tenant.property import PropertyValuesSetRequest
@@ -567,6 +568,31 @@ async def get_document_counts(
         total_count=total_count,
         untagged_count=untagged_count,
         tag_counts=tag_counts,
+    )
+
+
+@router.get("/counts/by-initiative", response_model=InitiativeGroupedCountsResponse)
+async def get_document_counts_by_initiative(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> InitiativeGroupedCountsResponse:
+    """Visible-document counts grouped by initiative.
+
+    Lightweight endpoint for the sidebar and initiative landing-card
+    badges — same visibility filters as the document list, one GROUP BY
+    instead of walking the full corpus.
+    """
+    conditions = _build_visible_docs_filters(guild_context.guild_id, current_user.id)
+    statement = (
+        select(Document.initiative_id, func.count(Document.id))
+        .join(Document.initiative)
+        .where(*conditions)
+        .group_by(Document.initiative_id)
+    )
+    rows = (await session.exec(statement)).all()
+    return InitiativeGroupedCountsResponse(
+        counts={initiative_id: count for initiative_id, count in rows}
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_test.py
@@ -964,3 +964,41 @@ async def test_autocomplete_documents_honors_limit(
 
     assert response.status_code == 200
     assert len(response.json()) == 2
+
+
+@pytest.mark.integration
+async def test_document_counts_by_initiative(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Grouped counts follow the same visibility rules as the document list."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    other_initiative = await create_initiative(session, admin.guild, admin.user)
+
+    await create_document(session, admin.initiative, member.user)
+    await create_document(session, admin.initiative, member.user)
+    await create_document(session, admin.initiative, admin.user)
+    await create_document(session, other_initiative, admin.user)
+
+    # Guild admin sees every document, grouped by initiative.
+    response = await client.get(
+        admin.g("/documents/counts/by-initiative"), headers=admin.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {
+        str(admin.initiative.id): 3,
+        str(other_initiative.id): 1,
+    }
+
+    # A member counts only documents shared with them, and gets no entry
+    # at all for initiatives they are not in.
+    response = await client.get(
+        member.g("/documents/counts/by-initiative"), headers=member.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {str(admin.initiative.id): 2}

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -71,7 +71,10 @@ from app.schemas.tenant.project import (
 )
 from app.schemas.platform.user import UserSummary, UserSummaryListResponse
 from app.schemas.tenant.comment import CommentAuthor
-from app.schemas.tenant.initiative import serialize_initiative
+from app.schemas.tenant.initiative import (
+    InitiativeGroupedCountsResponse,
+    serialize_initiative,
+)
 from app.schemas.tenant.document import (
     ProjectDocumentSummary,
     serialize_project_document_link,
@@ -905,6 +908,44 @@ async def list_writable_projects(
         session,
         current_user,
         writable_projects,
+    )
+
+
+@router.get("/counts/by-initiative", response_model=InitiativeGroupedCountsResponse)
+async def get_project_counts_by_initiative(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> InitiativeGroupedCountsResponse:
+    """Visible-project counts grouped by initiative.
+
+    Lightweight endpoint for initiative landing-card badges — same
+    visibility rules as the default project list (non-archived,
+    non-template), one GROUP BY instead of walking the full corpus.
+    """
+    conditions = [
+        Initiative.guild_id == guild_context.guild_id,
+        Project.is_archived.is_(False),
+        Project.is_template.is_(False),
+    ]
+    if not has_active_grant(
+        guild_context.guild_id
+    ) and not permissions_service.is_request_guild_admin(guild_context.guild_id):
+        conditions.append(
+            Project.id.in_(
+                permissions_service.visible_project_ids_subquery(current_user.id)
+            )
+        )
+
+    statement = (
+        select(Project.initiative_id, func.count(Project.id))
+        .join(Project.initiative)
+        .where(*conditions)
+        .group_by(Project.initiative_id)
+    )
+    rows = (await session.exec(statement)).all()
+    return InitiativeGroupedCountsResponse(
+        counts={initiative_id: count for initiative_id, count in rows}
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -1141,3 +1141,47 @@ async def test_project_shows_all_members_document_to_member(
     assert r.status_code == 200, r.text
     doc_ids = [d["document_id"] for d in r.json()["documents"]]
     assert doc.id in doc_ids
+
+
+@pytest.mark.integration
+async def test_project_counts_by_initiative(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Grouped counts mirror the default list: visible, non-archived,
+    non-template projects only, with no entry for unjoined initiatives."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    other_initiative = await create_initiative(session, admin.guild, admin.user)
+
+    await create_project(session, admin.initiative, member.user, name="Member project")
+    await create_project(session, admin.initiative, admin.user, name="Admin project")
+    await create_project(
+        session, admin.initiative, admin.user, name="Archived", is_archived=True
+    )
+    await create_project(
+        session, admin.initiative, admin.user, name="Template", is_template=True
+    )
+    await create_project(session, other_initiative, admin.user, name="Other project")
+
+    # Guild admin: every non-archived, non-template project, grouped.
+    response = await client.get(
+        admin.g("/projects/counts/by-initiative"), headers=admin.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {
+        str(admin.initiative.id): 2,
+        str(other_initiative.id): 1,
+    }
+
+    # Member: only projects shared with them, and no entry for
+    # initiatives they are not in.
+    response = await client.get(
+        member.g("/projects/counts/by-initiative"), headers=member.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {str(admin.initiative.id): 1}

--- a/backend/app/api/v1/tenant_endpoints/queues.py
+++ b/backend/app/api/v1/tenant_endpoints/queues.py
@@ -44,6 +44,7 @@ from app.models.tenant.initiative import (
 )
 from app.models.platform.user import User
 from app.core.messages import QueueMessages, InitiativeMessages
+from app.schemas.tenant.initiative import InitiativeGroupedCountsResponse
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.schemas.tenant.queue import (
     QueueCreate,
@@ -295,6 +296,40 @@ async def list_queues(
         page=page,
         page_size=page_size,
         has_next=has_next,
+    )
+
+
+@router.get("/counts/by-initiative", response_model=InitiativeGroupedCountsResponse)
+async def get_queue_counts_by_initiative(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> InitiativeGroupedCountsResponse:
+    """Visible-queue counts grouped by initiative.
+
+    Lightweight endpoint for the sidebar badges — same visibility rules
+    as the queue list (queues-enabled initiatives, DAC), one GROUP BY
+    instead of a capped list page.
+    """
+    conditions = [
+        Queue.guild_id == guild_context.guild_id,
+        Queue.initiative_id.in_(
+            select(Initiative.id).where(Initiative.queues_enabled == True)  # noqa: E712
+        ),
+    ]
+    if not rls_service.is_guild_admin(guild_context.role) and not guild_context.is_pam:
+        conditions.append(
+            Queue.id.in_(queues_service.visible_queue_ids_subquery(current_user.id))
+        )
+
+    statement = (
+        select(Queue.initiative_id, func.count(Queue.id))
+        .where(*conditions)
+        .group_by(Queue.initiative_id)
+    )
+    rows = (await session.exec(statement)).all()
+    return InitiativeGroupedCountsResponse(
+        counts={initiative_id: count for initiative_id, count in rows}
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/queues_test.py
+++ b/backend/app/api/v1/tenant_endpoints/queues_test.py
@@ -9,7 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
 from app.models.tenant.initiative import InitiativeRoleModel
-from app.testing import Actor
+from app.testing import Actor, create_initiative, create_queue
 
 
 # ---------------------------------------------------------------------------
@@ -947,3 +947,45 @@ async def test_delete_queue_still_emits_queue_deleted(
     resp = await client.delete(a.g(f"/queues/{queue['id']}"), headers=a.headers)
     assert resp.status_code == 204, resp.text
     assert (a.guild.id, "queue", queue["id"], "queue_deleted") in emitted
+
+
+@pytest.mark.integration
+async def test_queue_counts_by_initiative(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Grouped counts mirror the list: DAC-visible queues in queues-enabled
+    initiatives only, with no entry for unjoined initiatives."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    other_initiative = await create_initiative(session, admin.guild, admin.user)
+    disabled_initiative = await create_initiative(
+        session, admin.guild, admin.user, queues_enabled=False
+    )
+
+    await create_queue(session, admin.initiative, member.user, name="Member queue")
+    await create_queue(session, admin.initiative, admin.user, name="Admin queue")
+    await create_queue(session, other_initiative, admin.user, name="Other queue")
+    await create_queue(session, disabled_initiative, admin.user, name="Hidden queue")
+
+    # Guild admin: every queue in queues-enabled initiatives, grouped.
+    response = await client.get(
+        admin.g("/queues/counts/by-initiative"), headers=admin.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {
+        str(admin.initiative.id): 2,
+        str(other_initiative.id): 1,
+    }
+
+    # Member: only queues shared with them, and no entry for initiatives
+    # they are not in.
+    response = await client.get(
+        member.g("/queues/counts/by-initiative"), headers=member.headers
+    )
+    assert response.status_code == 200
+    assert response.json()["counts"] == {str(admin.initiative.id): 1}

--- a/backend/app/schemas/tenant/initiative.py
+++ b/backend/app/schemas/tenant/initiative.py
@@ -136,6 +136,18 @@ class MyInitiativePermissions(SanitizedBaseModel):
     advanced_tools_enabled: bool = False
 
 
+class InitiativeGroupedCountsResponse(SanitizedBaseModel):
+    """Per-initiative resource counts (initiative_id -> visible count).
+
+    Shared response shape for the documents/projects grouped-count
+    endpoints that back sidebar and landing-card badges.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    counts: Dict[int, int] = Field(default_factory=dict)
+
+
 # Member schemas - updated to work with role_id
 class InitiativeMemberAdd(SanitizedBaseModel):
     """Add a member to an initiative."""

--- a/frontend/src/__tests__/helpers/handlers/document.handlers.ts
+++ b/frontend/src/__tests__/helpers/handlers/document.handlers.ts
@@ -14,4 +14,7 @@ export const documentHandlers = [
       sort_dir: null,
     });
   }),
+  guildHttp.get("/documents/counts/by-initiative", () => {
+    return HttpResponse.json({ counts: {} });
+  }),
 ];

--- a/frontend/src/__tests__/helpers/handlers/project.handlers.ts
+++ b/frontend/src/__tests__/helpers/handlers/project.handlers.ts
@@ -9,6 +9,10 @@ export const projectHandlers = [
     return HttpResponse.json([buildProject()]);
   }),
 
+  guildHttp.get("/projects/counts/by-initiative", () => {
+    return HttpResponse.json({ counts: {} });
+  }),
+
   guildHttp.post("/projects/", () => {
     return HttpResponse.json(buildProject());
   }),

--- a/frontend/src/api/generated/counters/counters.ts
+++ b/frontend/src/api/generated/counters/counters.ts
@@ -32,6 +32,7 @@ import type {
   CounterSortRequest,
   CounterUpdate,
   HTTPValidationError,
+  InitiativeGroupedCountsResponse,
   ListCounterGroupsApiV1GGuildIdCounterGroupsGetParams,
   RecentViewWrite,
   ResourceGrantSchema,
@@ -308,6 +309,252 @@ export const useCreateCounterGroupApiV1GGuildIdCounterGroupsPost = <
     queryClient
   );
 };
+/**
+ * Visible counter-group counts grouped by initiative.
+ *
+ * Lightweight endpoint for the sidebar badges — same visibility rules
+ * as the counter-group list (counters-enabled initiatives, DAC), one
+ * GROUP BY instead of a capped list page.
+ * @summary Get Counter Group Counts By Initiative
+ */
+export const getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet = (
+  guildId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<InitiativeGroupedCountsResponse>(
+    { url: `/api/v1/g/${guildId}/counter-groups/counts/by-initiative`, method: "GET", signal },
+    options
+  );
+};
+
+export const getGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryKey =
+  (guildId: number) => {
+    return [`/api/v1/g/${guildId}/counter-groups/counts/by-initiative`] as const;
+  };
+
+export const getGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryOptions =
+  <
+    TData = Awaited<
+      ReturnType<
+        typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+      >
+    >,
+    TError = ErrorType<HTTPValidationError>,
+  >(
+    guildId: number,
+    options?: {
+      query?: Partial<
+        UseQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          TData
+        >
+      >;
+      request?: SecondParameter<typeof apiMutator>;
+    }
+  ) => {
+    const { query: queryOptions, request: requestOptions } = options ?? {};
+
+    const queryKey =
+      queryOptions?.queryKey ??
+      getGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryKey(
+        guildId
+      );
+
+    const queryFn: QueryFunction<
+      Awaited<
+        ReturnType<
+          typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+        >
+      >
+    > = ({ signal }) =>
+      getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet(
+        guildId,
+        requestOptions,
+        signal
+      );
+
+    return {
+      queryKey,
+      queryFn,
+      enabled: guildId !== null && guildId !== undefined,
+      ...queryOptions,
+    } as UseQueryOptions<
+      Awaited<
+        ReturnType<
+          typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+        >
+      >,
+      TError,
+      TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+  };
+
+export type GetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryResult =
+  NonNullable<
+    Awaited<
+      ReturnType<
+        typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+      >
+    >
+  >;
+export type GetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<
+      typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+    >
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<
+      typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+    >
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<
+      typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+    >
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Get Counter Group Counts By Initiative
+ */
+
+export function useGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<
+      typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+    >
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions =
+    getGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryOptions(
+      guildId,
+      options
+    );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
 /**
  * Access enforced by resource_dependency before the body runs.
  * @summary Read Counter Group

--- a/frontend/src/api/generated/documents/documents.ts
+++ b/frontend/src/api/generated/documents/documents.ts
@@ -38,6 +38,7 @@ import type {
   GenerateDocumentSummaryResponse,
   GetDocumentCountsApiV1GGuildIdDocumentsCountsGetParams,
   HTTPValidationError,
+  InitiativeGroupedCountsResponse,
   ListDocumentsApiV1GGuildIdDocumentsGetParams,
   ListMyDocumentsApiV1MeDocumentsGetParams,
   PropertyValuesSetRequest,
@@ -219,6 +220,235 @@ export function useGetDocumentCountsApiV1GGuildIdDocumentsCountsGet<
     params,
     options
   );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * Visible-document counts grouped by initiative.
+ *
+ * Lightweight endpoint for the sidebar and initiative landing-card
+ * badges — same visibility filters as the document list, one GROUP BY
+ * instead of walking the full corpus.
+ * @summary Get Document Counts By Initiative
+ */
+export const getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet = (
+  guildId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<InitiativeGroupedCountsResponse>(
+    { url: `/api/v1/g/${guildId}/documents/counts/by-initiative`, method: "GET", signal },
+    options
+  );
+};
+
+export const getGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryKey = (
+  guildId: number
+) => {
+  return [`/api/v1/g/${guildId}/documents/counts/by-initiative`] as const;
+};
+
+export const getGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryOptions =
+  <
+    TData = Awaited<
+      ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+    >,
+    TError = ErrorType<HTTPValidationError>,
+  >(
+    guildId: number,
+    options?: {
+      query?: Partial<
+        UseQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          TData
+        >
+      >;
+      request?: SecondParameter<typeof apiMutator>;
+    }
+  ) => {
+    const { query: queryOptions, request: requestOptions } = options ?? {};
+
+    const queryKey =
+      queryOptions?.queryKey ??
+      getGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryKey(guildId);
+
+    const queryFn: QueryFunction<
+      Awaited<
+        ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+      >
+    > = ({ signal }) =>
+      getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet(
+        guildId,
+        requestOptions,
+        signal
+      );
+
+    return {
+      queryKey,
+      queryFn,
+      enabled: guildId !== null && guildId !== undefined,
+      ...queryOptions,
+    } as UseQueryOptions<
+      Awaited<
+        ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+      >,
+      TError,
+      TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+  };
+
+export type GetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryResult =
+  NonNullable<
+    Awaited<
+      ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+    >
+  >;
+export type GetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Get Document Counts By Initiative
+ */
+
+export function useGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet
+          >
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions =
+    getGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryOptions(
+      guildId,
+      options
+    );
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1751,6 +1751,18 @@ export interface InitiativeCreate {
   color?: string | null;
 }
 
+export type InitiativeGroupedCountsResponseCounts = { [key: string]: number };
+
+/**
+ * Per-initiative resource counts (initiative_id -> visible count).
+ *
+ * Shared response shape for the documents/projects grouped-count
+ * endpoints that back sidebar and landing-card badges.
+ */
+export interface InitiativeGroupedCountsResponse {
+  counts: InitiativeGroupedCountsResponseCounts;
+}
+
 /**
  * Add a member to an initiative.
  */

--- a/frontend/src/api/generated/projects/projects.ts
+++ b/frontend/src/api/generated/projects/projects.ts
@@ -22,6 +22,7 @@ import type {
 
 import type {
   HTTPValidationError,
+  InitiativeGroupedCountsResponse,
   ListMyProjectsApiV1MeProjectsGetParams,
   ListProjectsApiV1GGuildIdProjectsGetParams,
   ProjectActivityFeedApiV1GGuildIdProjectsProjectIdActivityGetParams,
@@ -462,6 +463,227 @@ export function useListWritableProjectsApiV1GGuildIdProjectsWritableGet<
     guildId,
     options
   );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * Visible-project counts grouped by initiative.
+ *
+ * Lightweight endpoint for initiative landing-card badges — same
+ * visibility rules as the default project list (non-archived,
+ * non-template), one GROUP BY instead of walking the full corpus.
+ * @summary Get Project Counts By Initiative
+ */
+export const getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet = (
+  guildId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<InitiativeGroupedCountsResponse>(
+    { url: `/api/v1/g/${guildId}/projects/counts/by-initiative`, method: "GET", signal },
+    options
+  );
+};
+
+export const getGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryKey = (
+  guildId: number
+) => {
+  return [`/api/v1/g/${guildId}/projects/counts/by-initiative`] as const;
+};
+
+export const getGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryOptions =
+  <
+    TData = Awaited<
+      ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+    >,
+    TError = ErrorType<HTTPValidationError>,
+  >(
+    guildId: number,
+    options?: {
+      query?: Partial<
+        UseQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          TData
+        >
+      >;
+      request?: SecondParameter<typeof apiMutator>;
+    }
+  ) => {
+    const { query: queryOptions, request: requestOptions } = options ?? {};
+
+    const queryKey =
+      queryOptions?.queryKey ??
+      getGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryKey(guildId);
+
+    const queryFn: QueryFunction<
+      Awaited<
+        ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+      >
+    > = ({ signal }) =>
+      getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet(
+        guildId,
+        requestOptions,
+        signal
+      );
+
+    return {
+      queryKey,
+      queryFn,
+      enabled: guildId !== null && guildId !== undefined,
+      ...queryOptions,
+    } as UseQueryOptions<
+      Awaited<
+        ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+      >,
+      TError,
+      TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+  };
+
+export type GetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryResult =
+  NonNullable<
+    Awaited<
+      ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+    >
+  >;
+export type GetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet
+            >
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Get Project Counts By Initiative
+ */
+
+export function useGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions =
+    getGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryOptions(
+      guildId,
+      options
+    );
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;

--- a/frontend/src/api/generated/queues/queues.ts
+++ b/frontend/src/api/generated/queues/queues.ts
@@ -22,6 +22,7 @@ import type {
 
 import type {
   HTTPValidationError,
+  InitiativeGroupedCountsResponse,
   ListQueuesApiV1GGuildIdQueuesGetParams,
   QueueCreate,
   QueueItemCreate,
@@ -284,6 +285,210 @@ export const useCreateQueueApiV1GGuildIdQueuesPost = <
 > => {
   return useMutation(getCreateQueueApiV1GGuildIdQueuesPostMutationOptions(options), queryClient);
 };
+/**
+ * Visible-queue counts grouped by initiative.
+ *
+ * Lightweight endpoint for the sidebar badges — same visibility rules
+ * as the queue list (queues-enabled initiatives, DAC), one GROUP BY
+ * instead of a capped list page.
+ * @summary Get Queue Counts By Initiative
+ */
+export const getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet = (
+  guildId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<InitiativeGroupedCountsResponse>(
+    { url: `/api/v1/g/${guildId}/queues/counts/by-initiative`, method: "GET", signal },
+    options
+  );
+};
+
+export const getGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryKey = (
+  guildId: number
+) => {
+  return [`/api/v1/g/${guildId}/queues/counts/by-initiative`] as const;
+};
+
+export const getGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryOptions = <
+  TData = Awaited<
+    ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryKey(guildId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>>
+  > = ({ signal }) =>
+    getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet(
+      guildId,
+      requestOptions,
+      signal
+    );
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: guildId !== null && guildId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryResult =
+  NonNullable<
+    Awaited<ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>>
+  >;
+export type GetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<
+            ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+          >,
+          TError,
+          Awaited<
+            ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<
+            ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+          >,
+          TError,
+          Awaited<
+            ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Get Queue Counts By Initiative
+ */
+
+export function useGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet<
+  TData = Awaited<
+    ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions =
+    getGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryOptions(
+      guildId,
+      options
+    );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
 /**
  * Get a queue; access enforced by resource_dependency before the body runs.
  * @summary Read Queue

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -44,7 +44,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useAutoCloseSidebar } from "@/hooks/useAutoCloseSidebar";
 import { useCounterGroupsList } from "@/hooks/useCounters";
 import { compareVersions, useDockerHubVersion } from "@/hooks/useDockerHubVersion";
-import { useAllDocumentIds } from "@/hooks/useDocuments";
+import { useDocumentCountsByInitiative } from "@/hooks/useDocuments";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
@@ -111,7 +111,10 @@ export const AppSidebar = () => {
     staleTime: 60_000,
   });
 
-  const documentsQuery = useAllDocumentIds({ enabled: guildTreeEnabled, staleTime: 60_000 });
+  const documentCountsQuery = useDocumentCountsByInitiative({
+    enabled: guildTreeEnabled,
+    staleTime: 60_000,
+  });
 
   const projectsByInitiative = useMemo(() => {
     const map = new Map<number, ProjectRead[]>();
@@ -127,13 +130,11 @@ export const AppSidebar = () => {
 
   const documentCountsByInitiative = useMemo(() => {
     const map = new Map<number, number>();
-    const documents = Array.isArray(documentsQuery.data) ? documentsQuery.data : [];
-    documents.forEach((doc) => {
-      const count = map.get(doc.initiative_id) ?? 0;
-      map.set(doc.initiative_id, count + 1);
+    Object.entries(documentCountsQuery.data?.counts ?? {}).forEach(([initiativeId, count]) => {
+      map.set(Number(initiativeId), count);
     });
     return map;
-  }, [documentsQuery.data]);
+  }, [documentCountsQuery.data]);
 
   // Fetch queues for counts (lightweight list query)
   const queuesQuery = useQueuesList(

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -42,14 +42,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAuth } from "@/hooks/useAuth";
 import { useAutoCloseSidebar } from "@/hooks/useAutoCloseSidebar";
-import { useCounterGroupsList } from "@/hooks/useCounters";
+import { useCounterGroupCountsByInitiative } from "@/hooks/useCounters";
 import { compareVersions, useDockerHubVersion } from "@/hooks/useDockerHubVersion";
 import { useDocumentCountsByInitiative } from "@/hooks/useDocuments";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useFavoriteProjects, useProjects } from "@/hooks/useProjects";
-import { useQueuesList } from "@/hooks/useQueues";
+import { useQueueCountsByInitiative } from "@/hooks/useQueues";
 import { useTags } from "@/hooks/useTags";
 import { guildPath } from "@/lib/guildUrl";
 import { getInitials } from "@/lib/initials";
@@ -136,36 +136,30 @@ export const AppSidebar = () => {
     return map;
   }, [documentCountsQuery.data]);
 
-  // Fetch queues for counts (lightweight list query)
-  const queuesQuery = useQueuesList(
-    { page: 1, page_size: 100 },
-    { enabled: guildTreeEnabled, staleTime: 60_000 }
-  );
+  const queueCountsQuery = useQueueCountsByInitiative({
+    enabled: guildTreeEnabled,
+    staleTime: 60_000,
+  });
 
   const queueCountsByInitiative = useMemo(() => {
     const map = new Map<number, number>();
-    const queues = queuesQuery.data?.items ?? [];
-    queues.forEach((queue) => {
-      const count = map.get(queue.initiative_id) ?? 0;
-      map.set(queue.initiative_id, count + 1);
+    Object.entries(queueCountsQuery.data?.counts ?? {}).forEach(([initiativeId, count]) => {
+      map.set(Number(initiativeId), count);
     });
     return map;
-  }, [queuesQuery.data]);
+  }, [queueCountsQuery.data]);
 
-  // Fetch counter groups for counts
-  const counterGroupsQuery = useCounterGroupsList(
-    { page: 1, page_size: 100 },
-    { enabled: guildTreeEnabled, staleTime: 60_000 }
-  );
+  const counterGroupCountsQuery = useCounterGroupCountsByInitiative({
+    enabled: guildTreeEnabled,
+    staleTime: 60_000,
+  });
   const counterGroupCountsByInitiative = useMemo(() => {
     const map = new Map<number, number>();
-    const groups = counterGroupsQuery.data?.items ?? [];
-    groups.forEach((group) => {
-      const count = map.get(group.initiative_id) ?? 0;
-      map.set(group.initiative_id, count + 1);
+    Object.entries(counterGroupCountsQuery.data?.counts ?? {}).forEach(([initiativeId, count]) => {
+      map.set(Number(initiativeId), count);
     });
     return map;
-  }, [counterGroupsQuery.data]);
+  }, [counterGroupCountsQuery.data]);
 
   const visibleInitiatives = useMemo(
     () => filterVisible(Array.isArray(initiativesQuery.data) ? initiativesQuery.data : []),

--- a/frontend/src/hooks/useCounters.ts
+++ b/frontend/src/hooks/useCounters.ts
@@ -8,6 +8,8 @@ import {
   deleteCounterApiV1GGuildIdCounterGroupsGroupIdCountersCounterIdDelete,
   deleteCounterGroupApiV1GGuildIdCounterGroupsGroupIdDelete,
   duplicateCounterGroupApiV1GGuildIdCounterGroupsGroupIdDuplicatePost,
+  getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet,
+  getGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryKey,
   getListCounterGroupsApiV1GGuildIdCounterGroupsGetQueryKey,
   getReadCounterGroupApiV1GGuildIdCounterGroupsGroupIdGetQueryKey,
   incrementCounterApiV1GGuildIdCounterGroupsGroupIdCountersCounterIdIncrementPost,
@@ -32,6 +34,7 @@ import type {
   CounterSetCountRequest,
   CounterSortRequest,
   CounterUpdate,
+  InitiativeGroupedCountsResponse,
   ListCounterGroupsApiV1GGuildIdCounterGroupsGetParams,
   ResourceGrantSchema,
 } from "@/api/generated/initiativeAPI.schemas";
@@ -104,6 +107,23 @@ export const useCounterGroupsList = (
         params
       ) as unknown as Promise<CounterGroupListResponse>,
     placeholderData: keepPreviousData,
+    ...options,
+  });
+};
+
+export const useCounterGroupCountsByInitiative = (
+  options?: QueryOpts<InitiativeGroupedCountsResponse>
+) => {
+  const guildId = useActiveGuildId();
+  return useQuery<InitiativeGroupedCountsResponse>({
+    queryKey:
+      getGetCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGetQueryKey(
+        guildId
+      ),
+    queryFn: () =>
+      getCounterGroupCountsByInitiativeApiV1GGuildIdCounterGroupsCountsByInitiativeGet(
+        guildId
+      ) as unknown as Promise<InitiativeGroupedCountsResponse>,
     ...options,
   });
 };

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -10,8 +10,10 @@ import {
   generateSummaryApiV1GGuildIdDocumentsDocumentIdAiSummaryPost,
   getBacklinksApiV1GGuildIdDocumentsDocumentIdBacklinksGet,
   getDocumentCountsApiV1GGuildIdDocumentsCountsGet,
+  getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet,
   getGetBacklinksApiV1GGuildIdDocumentsDocumentIdBacklinksGetQueryKey,
   getGetDocumentCountsApiV1GGuildIdDocumentsCountsGetQueryKey,
+  getGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryKey,
   getListDocumentsApiV1GGuildIdDocumentsGetQueryKey,
   getListDocumentVersionsApiV1GGuildIdDocumentsDocumentIdVersionsGetQueryKey,
   getReadDocumentApiV1GGuildIdDocumentsDocumentIdGetQueryKey,
@@ -36,6 +38,7 @@ import type {
   DocumentUpdate,
   GenerateDocumentSummaryResponse,
   GetDocumentCountsApiV1GGuildIdDocumentsCountsGetParams,
+  InitiativeGroupedCountsResponse,
   ListDocumentsApiV1GGuildIdDocumentsGetParams,
   ResourceGrantSchema,
 } from "@/api/generated/initiativeAPI.schemas";
@@ -97,6 +100,21 @@ export const useDocumentCounts = (
         guildId,
         params
       ) as unknown as Promise<DocumentCountsResponse>,
+    ...options,
+  });
+};
+
+export const useDocumentCountsByInitiative = (
+  options?: QueryOpts<InitiativeGroupedCountsResponse>
+) => {
+  const guildId = useActiveGuildId();
+  return useQuery<InitiativeGroupedCountsResponse>({
+    queryKey:
+      getGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryKey(guildId),
+    queryFn: () =>
+      getDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGet(
+        guildId
+      ) as unknown as Promise<InitiativeGroupedCountsResponse>,
     ...options,
   });
 };

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type {
+  InitiativeGroupedCountsResponse,
   ListMyProjectsApiV1MeProjectsGetParams,
   ListProjectsApiV1GGuildIdProjectsGetParams,
   ProjectActivityFeedApiV1GGuildIdProjectsProjectIdActivityGetParams,
@@ -24,10 +25,12 @@ import {
   favoriteProjectApiV1GGuildIdProjectsProjectIdFavoritePost,
   favoriteProjectsApiV1GGuildIdProjectsFavoritesGet,
   getFavoriteProjectsApiV1GGuildIdProjectsFavoritesGetQueryKey,
+  getGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryKey,
   getListMyProjectsApiV1MeProjectsGetQueryKey,
   getListProjectsApiV1GGuildIdProjectsGetQueryKey,
   getListWritableProjectsApiV1GGuildIdProjectsWritableGetQueryKey,
   getProjectActivityFeedApiV1GGuildIdProjectsProjectIdActivityGetQueryKey,
+  getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet,
   getReadProjectApiV1GGuildIdProjectsProjectIdGetQueryKey,
   listMyProjectsApiV1MeProjectsGet,
   listProjectsApiV1GGuildIdProjectsGet,
@@ -76,6 +79,21 @@ export const useProjects = (
         guildId,
         params
       ) as unknown as Promise<ProjectListResponse>,
+    ...options,
+  });
+};
+
+export const useProjectCountsByInitiative = (
+  options?: QueryOpts<InitiativeGroupedCountsResponse>
+) => {
+  const guildId = useActiveGuildId();
+  return useQuery<InitiativeGroupedCountsResponse>({
+    queryKey:
+      getGetProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGetQueryKey(guildId),
+    queryFn: () =>
+      getProjectCountsByInitiativeApiV1GGuildIdProjectsCountsByInitiativeGet(
+        guildId
+      ) as unknown as Promise<InitiativeGroupedCountsResponse>,
     ...options,
   });
 };

--- a/frontend/src/hooks/useQueues.ts
+++ b/frontend/src/hooks/useQueues.ts
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-query";
 
 import type {
+  InitiativeGroupedCountsResponse,
   ListQueuesApiV1GGuildIdQueuesGetParams,
   QueueCreate,
   QueueItemCreate,
@@ -24,7 +25,9 @@ import {
   createQueueApiV1GGuildIdQueuesPost,
   deleteQueueApiV1GGuildIdQueuesQueueIdDelete,
   deleteQueueItemApiV1GGuildIdQueuesQueueIdItemsItemIdDelete,
+  getGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryKey,
   getListQueuesApiV1GGuildIdQueuesGetQueryKey,
+  getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet,
   getReadQueueApiV1GGuildIdQueuesQueueIdGetQueryKey,
   holdCurrentTurnApiV1GGuildIdQueuesQueueIdHoldPost,
   listQueuesApiV1GGuildIdQueuesGet,
@@ -62,6 +65,21 @@ export const useQueuesList = (
     queryFn: () =>
       listQueuesApiV1GGuildIdQueuesGet(guildId, params) as unknown as Promise<QueueListResponse>,
     placeholderData: keepPreviousData,
+    ...options,
+  });
+};
+
+export const useQueueCountsByInitiative = (
+  options?: QueryOpts<InitiativeGroupedCountsResponse>
+) => {
+  const guildId = useActiveGuildId();
+  return useQuery<InitiativeGroupedCountsResponse>({
+    queryKey:
+      getGetQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGetQueryKey(guildId),
+    queryFn: () =>
+      getQueueCountsByInitiativeApiV1GGuildIdQueuesCountsByInitiativeGet(
+        guildId
+      ) as unknown as Promise<InitiativeGroupedCountsResponse>,
     ...options,
   });
 };

--- a/frontend/src/pages/InitiativesPage.tsx
+++ b/frontend/src/pages/InitiativesPage.tsx
@@ -37,11 +37,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/hooks/useAuth";
-import { useDocumentsList } from "@/hooks/useDocuments";
+import { useDocumentCountsByInitiative } from "@/hooks/useDocuments";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useCreateInitiative, useInitiatives } from "@/hooks/useInitiatives";
-import { useProjects } from "@/hooks/useProjects";
+import { useProjectCountsByInitiative } from "@/hooks/useProjects";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
@@ -67,12 +67,15 @@ export const InitiativesPage = () => {
 
   const initiativesQuery = useInitiatives({ enabled: Boolean(activeGuild) });
 
-  const projectsQuery = useProjects(undefined, {
+  const projectCountsQuery = useProjectCountsByInitiative({
     enabled: Boolean(activeGuild),
     staleTime: 30_000,
   });
 
-  const documentsListQuery = useDocumentsList({ page_size: 0 });
+  const documentCountsQuery = useDocumentCountsByInitiative({
+    enabled: Boolean(activeGuild),
+    staleTime: 30_000,
+  });
 
   const visibleInitiatives = useMemo(
     () => filterVisible(initiativesQuery.data),
@@ -81,21 +84,19 @@ export const InitiativesPage = () => {
 
   const projectCounts = useMemo(() => {
     const counts = new Map<number, number>();
-    const projects = projectsQuery.data?.items ?? [];
-    projects.forEach((project) => {
-      counts.set(project.initiative_id, (counts.get(project.initiative_id) ?? 0) + 1);
+    Object.entries(projectCountsQuery.data?.counts ?? {}).forEach(([initiativeId, count]) => {
+      counts.set(Number(initiativeId), count);
     });
     return counts;
-  }, [projectsQuery.data]);
+  }, [projectCountsQuery.data]);
 
   const documentCounts = useMemo(() => {
     const counts = new Map<number, number>();
-    const documents = documentsListQuery.data?.items ?? [];
-    documents.forEach((document) => {
-      counts.set(document.initiative_id, (counts.get(document.initiative_id) ?? 0) + 1);
+    Object.entries(documentCountsQuery.data?.counts ?? {}).forEach(([initiativeId, count]) => {
+      counts.set(Number(initiativeId), count);
     });
     return counts;
-  }, [documentsListQuery.data]);
+  }, [documentCountsQuery.data]);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newName, setNewName] = useState("");
@@ -223,13 +224,15 @@ export const InitiativesPage = () => {
                       <p>
                         {t("projectsLabel")}{" "}
                         <span className="font-semibold">
-                          {projectsQuery.isLoading ? "…" : (projectCounts.get(initiative.id) ?? 0)}
+                          {projectCountsQuery.isLoading
+                            ? "…"
+                            : (projectCounts.get(initiative.id) ?? 0)}
                         </span>
                       </p>
                       <p>
                         {t("documentsLabel")}{" "}
                         <span className="font-semibold">
-                          {documentsListQuery.isLoading
+                          {documentCountsQuery.isLoading
                             ? "…"
                             : (documentCounts.get(initiative.id) ?? 0)}
                         </span>


### PR DESCRIPTION
Closes #858 (and extends the same fix to the queue/counter badges).

## Problem

Two hot surfaces fetched the entire guild document (and project) corpus just to derive per-initiative count badges:

- `AppSidebar` used `useAllDocumentIds({ page_size: 0 })` — walking every heavy `DocumentSummary` on every authenticated route — only to build a `Map<initiative_id, count>`.
- `InitiativesPage` did the same with `useDocumentsList({ page_size: 0 })` plus a full `useProjects()` fetch, only for the landing-card count badges.

The sidebar's queue and counter-group badges had the same pattern in a milder form: one list page capped at 100 items, counted client-side — which silently undercounts once a guild exceeds 100 visible queues/counter groups, and each summary item drags its tags and its **full `resource_grants` list** along just to be tallied.

## Changes

**Backend** — four grouped-count endpoints sharing one response schema (`InitiativeGroupedCountsResponse`, `counts: {initiative_id: count}`), each a single `GROUP BY initiative_id` under `RLSSessionDep` + `GuildContextDep`:

- `GET /g/{guild_id}/documents/counts/by-initiative` — reuses `_build_visible_docs_filters` (identical visibility to the document list: DAC visible-ids subquery, guild-admin and PAM legs).
- `GET /g/{guild_id}/projects/counts/by-initiative` — mirrors the default project list semantics (non-archived, non-template, same conditions as `_visible_projects`).
- `GET /g/{guild_id}/queues/counts/by-initiative` and `GET /g/{guild_id}/counter-groups/counts/by-initiative` — mirror their lists: only queues-/counters-enabled initiatives, same DAC narrowing, same guild-admin/PAM handling.

An initiative the caller is not in contributes no key at all. Tests for all four cover grouping, the guild-admin view, DAC filtering (a member only counts resources shared with them), archived/template exclusion (projects), tool-disabled initiative exclusion (queues/counters), and that unjoined initiatives return no entry.

**Frontend**

- New hooks: `useDocumentCountsByInitiative`, `useProjectCountsByInitiative`, `useQueueCountsByInitiative`, `useCounterGroupCountsByInitiative`; regenerated Orval types (committed).
- `AppSidebar` drops its document corpus walk and both capped queue/counter list fetches for the count queries (it keeps `useProjects` — the tree renders actual project rows).
- `InitiativesPage` drops both its full document-list and full project-list fetches for the count queries.
- Default MSW handlers added for the new document/project routes.

Not removed: `useAllDocumentIds` itself — the two template-picker dialogs still use it; tracked separately in #958. `useQueuesList`/`useCounterGroupsList` keep their legitimate consumers (queues/counters pages, tool palette).

## Schema/env updates

No DB migrations and no env changes — the endpoints are read-only queries over existing tables. OpenAPI/generated types regenerated and committed.

## Testing

```
cd backend && pytest app/api/v1/tenant_endpoints/documents_test.py app/api/v1/tenant_endpoints/projects_test.py app/api/v1/tenant_endpoints/queues_test.py app/api/v1/tenant_endpoints/counters_test.py
cd backend && ruff check app
cd frontend && pnpm typecheck && pnpm lint
cd frontend && pnpm test:run   # 920 passed
```

No visual changes — the badges render the same numbers from the new endpoints (and the queue/counter badges become *correct* past 100 items, where the old capped fetch undercounted).
