### PR TITLE
Fix urgent tasks sorting last on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On mobile, opening the three-dot menu next to an initiative or project in the sidebar no longer dismisses the sidebar drawer.
 - Removed redundant spacing between icons and labels across buttons throughout the app; the button's built-in gap now handles it consistently.
 - The "My Tasks" page no longer returns a 500 error when filtered by a custom property. The cross-guild task views load property definitions per guild schema now, instead of querying a table that isn't visible on that request's connection.
+- The dashboard's "Upcoming tasks" list no longer sorts urgent tasks last. It sorted by a hand-rolled priority map that omitted `urgent` (and invented unused `critical`/`none` keys), so every urgent task fell into the fallback bucket and sorted after lower-priority ones. Priority ordering now flows from a single source of truth in `lib/sorting.ts`, derived from the backend `TaskPriority` enum, that every priority-list UI shares — so it can't drift again.
 
 ## [0.57.0] - 2026-07-16
 

--- a/frontend/src/components/dashboard/UpcomingTasksList.tsx
+++ b/frontend/src/components/dashboard/UpcomingTasksList.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGuildPath } from "@/lib/guildUrl";
+import { priorityRank } from "@/lib/sorting";
 
 interface UpcomingTasksListProps {
   tasks: TaskListRead[];
@@ -34,14 +35,6 @@ function getDueBadgeLabelKey(dueDate: string | null | undefined): string | null 
   return "upcomingTasks.upcoming";
 }
 
-const priorityOrder: Record<string, number> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-  none: 4,
-};
-
 export function UpcomingTasksList({ tasks, isLoading }: UpcomingTasksListProps) {
   const { t } = useTranslation("dashboard");
   const gp = useGuildPath();
@@ -51,7 +44,8 @@ export function UpcomingTasksList({ tasks, isLoading }: UpcomingTasksListProps) 
     const aDate = a.due_date ? parseISO(a.due_date).getTime() : Infinity;
     const bDate = b.due_date ? parseISO(b.due_date).getTime() : Infinity;
     if (aDate !== bDate) return aDate - bDate;
-    return (priorityOrder[a.priority] ?? 4) - (priorityOrder[b.priority] ?? 4);
+    // Higher priority first (urgent → low) as the due-date tiebreaker.
+    return (priorityRank[b.priority] ?? -1) - (priorityRank[a.priority] ?? -1);
   });
 
   return (

--- a/frontend/src/components/tasks/GlobalTaskFilters.tsx
+++ b/frontend/src/components/tasks/GlobalTaskFilters.tsx
@@ -13,8 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
-
-const priorityOrder: TaskPriority[] = ["low", "medium", "high", "urgent"];
+import { PRIORITY_ORDER } from "@/lib/sorting";
 
 interface GlobalTaskFiltersProps {
   statusFilters: TaskStatusCategory[];
@@ -101,7 +100,7 @@ export const GlobalTaskFilters = ({
               </Label>
               <MultiSelect
                 selectedValues={priorityFilters}
-                options={priorityOrder.map((priority) => ({
+                options={PRIORITY_ORDER.map((priority) => ({
                   value: priority,
                   label: t(`priority.${priority}` as never),
                 }))}

--- a/frontend/src/components/tasks/TagTasksTable.tsx
+++ b/frontend/src/components/tasks/TagTasksTable.tsx
@@ -32,7 +32,7 @@ import { usePrefetchTasks, useTasks, useUpdateTask } from "@/hooks/useTasks";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
-import { dateSortingFn, prioritySortingFn } from "@/lib/sorting";
+import { dateSortingFn, PRIORITY_ORDER, prioritySortingFn } from "@/lib/sorting";
 
 const statusFallbackOrder: Record<TaskStatusCategory, TaskStatusCategory[]> = {
   backlog: ["backlog"],
@@ -40,8 +40,6 @@ const statusFallbackOrder: Record<TaskStatusCategory, TaskStatusCategory[]> = {
   in_progress: ["in_progress", "todo", "backlog"],
   done: ["done", "in_progress", "todo", "backlog"],
 };
-
-const priorityOrder: TaskPriority[] = ["low", "medium", "high", "urgent"];
 
 const DEFAULT_STATUS_FILTERS: TaskStatusCategory[] = ["backlog", "todo", "in_progress"];
 
@@ -516,7 +514,7 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
               </Label>
               <MultiSelect
                 selectedValues={priorityFilters}
-                options={priorityOrder.map((priority) => ({
+                options={PRIORITY_ORDER.map((priority) => ({
                   value: priority,
                   label: t(`priority.${priority}`),
                 }))}

--- a/frontend/src/lib/sorting.test.ts
+++ b/frontend/src/lib/sorting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { TaskPriority } from "@/api/generated/initiativeAPI.schemas";
+
+import { PRIORITY_ORDER, priorityRank } from "./sorting";
+
+describe("priority ordering", () => {
+  it("ranks every backend priority low → urgent", () => {
+    expect(priorityRank.low).toBeLessThan(priorityRank.medium);
+    expect(priorityRank.medium).toBeLessThan(priorityRank.high);
+    expect(priorityRank.high).toBeLessThan(priorityRank.urgent);
+  });
+
+  it("covers every value of the generated TaskPriority enum", () => {
+    // Guards against drift from the backend: a newly added priority must
+    // appear here (and get ranked) or these assertions fail.
+    const enumValues = Object.values(TaskPriority);
+    expect(new Set(PRIORITY_ORDER)).toEqual(new Set(enumValues));
+    expect(Object.keys(priorityRank).sort()).toEqual([...enumValues].sort());
+  });
+
+  it("orders PRIORITY_ORDER ascending by rank", () => {
+    expect(PRIORITY_ORDER).toEqual(["low", "medium", "high", "urgent"]);
+    const ranks = PRIORITY_ORDER.map((p) => priorityRank[p]);
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+  });
+
+  it("sorts urgent ahead of low when used descending (dashboard tiebreaker)", () => {
+    // Regression for #863: urgent tasks must not sort last.
+    const byUrgentFirst = [TaskPriority.low, TaskPriority.urgent, TaskPriority.medium].sort(
+      (a, b) => priorityRank[b] - priorityRank[a]
+    );
+    expect(byUrgentFirst[0]).toBe(TaskPriority.urgent);
+  });
+});

--- a/frontend/src/lib/sorting.ts
+++ b/frontend/src/lib/sorting.ts
@@ -1,6 +1,6 @@
 import type { Row } from "@tanstack/react-table";
 
-import type { TaskPriority } from "@/api/generated/initiativeAPI.schemas";
+import { TaskPriority } from "@/api/generated/initiativeAPI.schemas";
 
 const toTimestamp = (value: unknown): number | null => {
   if (!value) {
@@ -42,12 +42,26 @@ export const dateSortingFn = <TData>(rowA: Row<TData>, rowB: Row<TData>, columnI
   return valueA - valueB;
 };
 
-const priorityRank: Record<TaskPriority, number> = {
+/**
+ * Canonical task-priority ranking, low → urgent. Keyed by `TaskPriority` so
+ * adding a priority to the backend enum surfaces as a compile error here until
+ * it is ranked — this is the single source of truth for priority ordering.
+ */
+export const priorityRank: Record<TaskPriority, number> = {
   low: 0,
   medium: 1,
   high: 2,
   urgent: 3,
 };
+
+/**
+ * Task priorities in ascending order (low → urgent). Derived from the generated
+ * `TaskPriority` enum so it always covers every backend value, sorted by
+ * `priorityRank`. Route all "ordered priority list" UIs through this.
+ */
+export const PRIORITY_ORDER: TaskPriority[] = (Object.values(TaskPriority) as TaskPriority[]).sort(
+  (a, b) => priorityRank[a] - priorityRank[b]
+);
 
 /**
  * Sorts by task priority (low to urgent)

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -87,14 +87,13 @@ import { toast } from "@/lib/chesterToast";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
 import { queryClient } from "@/lib/queryClient";
+import { PRIORITY_ORDER } from "@/lib/sorting";
 import {
   getAvatarSrc,
   getInitialsForUser,
   getUserDisplayName,
   isAnonymizedUser,
 } from "@/lib/userDisplay";
-
-const priorityOrder: TaskPriority[] = ["low", "medium", "high", "urgent"];
 
 const toLocalInputValue = (value?: string | null) => {
   if (!value) {
@@ -761,7 +760,7 @@ export const TaskEditPage = () => {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {priorityOrder.map((value) => (
+                      {PRIORITY_ORDER.map((value) => (
                         <SelectItem key={value} value={value}>
                           {t(`priority.${value}` as never)}
                         </SelectItem>

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -53,13 +53,13 @@ import { useViewPreference } from "@/hooks/useViewPreference";
 import { exportFilenameStem } from "@/lib/exportDownload";
 import { useGuildPath } from "@/lib/guildUrl";
 import { getProjectColor } from "@/lib/projectColor";
+import { PRIORITY_ORDER } from "@/lib/sorting";
 import { getItem, setItem } from "@/lib/storage";
 import { toolExportEndpoint } from "@/lib/tools";
 
 const STORAGE_KEY = "initiative-events-prefs";
 
 const STATUS_CATEGORIES: TaskStatusCategory[] = ["backlog", "todo", "in_progress", "done"];
-const PRIORITY_ORDER: TaskPriority[] = ["low", "medium", "high", "urgent"];
 
 interface StoredPrefs {
   showEvents: boolean;

--- a/frontend/src/pages/user/MyCalendarPage.tsx
+++ b/frontend/src/pages/user/MyCalendarPage.tsx
@@ -31,6 +31,7 @@ import { useViewPreference } from "@/hooks/useViewPreference";
 import { toast } from "@/lib/chesterToast";
 import { guildPath, useGuildPath } from "@/lib/guildUrl";
 import { getProjectColor } from "@/lib/projectColor";
+import { PRIORITY_ORDER } from "@/lib/sorting";
 
 const STORAGE_KEY = "initiative-my-calendar-prefs";
 
@@ -70,8 +71,6 @@ const sanitizeStoredPrefs = (raw: unknown): StoredPrefs => {
     guildFilters: Array.isArray(v.guildFilters) ? v.guildFilters : PREFS_DEFAULTS.guildFilters,
   };
 };
-
-const priorityOrder: TaskPriority[] = ["low", "medium", "high", "urgent"];
 
 const getDefaultFiltersVisibility = () =>
   typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches;
@@ -331,7 +330,7 @@ export const MyCalendarPage = () => {
                 </Label>
                 <MultiSelect
                   selectedValues={priorityFilters}
-                  options={priorityOrder.map((p) => ({
+                  options={PRIORITY_ORDER.map((p) => ({
                     value: p,
                     label: t(`tasks:priority.${p}` as never),
                   }))}


### PR DESCRIPTION
## Problem

`UpcomingTasksList` on the dashboard sorted by a hand-rolled priority map with the wrong keys — it invented `critical`/`none` (never emitted) and **omitted `urgent`**. Every urgent task fell into the `?? 4` fallback bucket and sorted **last** instead of first. Fixes #863.

The ordered priority set was also duplicated across 6+ files, so it could drift from the backend `TaskPriority` enum.

## Changes

- **Single source of truth** in [`lib/sorting.ts`](frontend/src/lib/sorting.ts): export `priorityRank` and a new `PRIORITY_ORDER`, derived from the generated `TaskPriority` enum and sorted by rank. `priorityRank` is typed `Record<TaskPriority, number>`, so adding a backend priority becomes a compile error until it's ranked (one-file change).
- **Fixed the bug**: `UpcomingTasksList` now uses shared `priorityRank` (descending — urgent-first as the due-date tiebreaker), deleting the local map.
- **Routed the 5 duplicate ordered lists** through `PRIORITY_ORDER`: `GlobalTaskFilters`, `TagTasksTable`, `TaskEditPage`, `MyCalendarPage`, `EventsPage`. (`priorityVariant` stays in `projectTasksConfig.ts`.)
- Added `lib/sorting.test.ts` — regression test for ordering + enum-coverage drift guard.
- CHANGELOG entry under `[Unreleased] → Fixed`.

## Testing

- `pnpm typecheck` — clean
- `pnpm biome check` on changed files — clean
- `pnpm test:run src/lib/sorting.test.ts` — 4/4 pass