### PR TITLE
Route useGlobalDocuments through apiMutator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed redundant spacing between icons and labels across buttons throughout the app; the button's built-in gap now handles it consistently.
 - The "My Tasks" page no longer returns a 500 error when filtered by a custom property. The cross-guild task views load property definitions per guild schema now, instead of querying a table that isn't visible on that request's connection.
 - The dashboard's "Upcoming tasks" list no longer sorts urgent tasks last. It sorted by a hand-rolled priority map that omitted `urgent` (and invented unused `critical`/`none` keys), so every urgent task fell into the fallback bucket and sorted after lower-priority ones. Priority ordering now flows from a single source of truth in `lib/sorting.ts`, derived from the backend `TaskPriority` enum, that every priority-list UI shares — so it can't drift again.
+- The "My Documents" page's data fetching now routes through the shared API client wrapper like its sibling "My Projects"/"My Calendar" views, instead of a hand-rolled fetcher that bypassed it — so native (Capacitor) base-URL rewriting and request handling apply consistently.
 
 ## [0.57.0] - 2026-07-16
 

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -16,9 +16,11 @@ import {
   getGetDocumentCountsByInitiativeApiV1GGuildIdDocumentsCountsByInitiativeGetQueryKey,
   getListDocumentsApiV1GGuildIdDocumentsGetQueryKey,
   getListDocumentVersionsApiV1GGuildIdDocumentsDocumentIdVersionsGetQueryKey,
+  getListMyDocumentsApiV1MeDocumentsGetQueryKey,
   getReadDocumentApiV1GGuildIdDocumentsDocumentIdGetQueryKey,
   listDocumentsApiV1GGuildIdDocumentsGet,
   listDocumentVersionsApiV1GGuildIdDocumentsDocumentIdVersionsGet,
+  listMyDocumentsApiV1MeDocumentsGet,
   readDocumentApiV1GGuildIdDocumentsDocumentIdGet,
   setDocumentGrantsApiV1GGuildIdDocumentsDocumentIdGrantsPut,
   updateDocumentApiV1GGuildIdDocumentsDocumentIdPatch,
@@ -41,6 +43,7 @@ import type {
   GetDocumentCountsApiV1GGuildIdDocumentsCountsGetParams,
   InitiativeGroupedCountsResponse,
   ListDocumentsApiV1GGuildIdDocumentsGetParams,
+  ListMyDocumentsApiV1MeDocumentsGetParams,
   ResourceGrantSchema,
 } from "@/api/generated/initiativeAPI.schemas";
 import { attachProjectDocumentApiV1GGuildIdProjectsProjectIdDocumentsDocumentIdPost } from "@/api/generated/projects/projects";
@@ -230,34 +233,25 @@ export const useSetDocumentCache = () => {
 
 // ── Global (cross-guild) queries ────────────────────────────────────────────
 
-import { apiClient } from "@/api/client";
-
-export const GLOBAL_DOCUMENTS_QUERY_KEY = "/api/v1/me/documents" as const;
-
-export const globalDocumentsQueryFn = async (
-  params: Record<string, string | string[] | number | number[]>
-) => {
-  const response = await apiClient.get<DocumentListResponse>("/me/documents", { params });
-  return response.data;
-};
-
 export const useGlobalDocuments = (
-  params: Record<string, string | string[] | number | number[]>,
+  params?: ListMyDocumentsApiV1MeDocumentsGetParams,
   options?: QueryOpts<DocumentListResponse>
 ) => {
   return useQuery<DocumentListResponse>({
-    queryKey: [GLOBAL_DOCUMENTS_QUERY_KEY, params],
-    queryFn: () => globalDocumentsQueryFn(params),
+    queryKey: getListMyDocumentsApiV1MeDocumentsGetQueryKey(params),
+    queryFn: () =>
+      listMyDocumentsApiV1MeDocumentsGet(params) as unknown as Promise<DocumentListResponse>,
     ...options,
   });
 };
 
 export const usePrefetchGlobalDocuments = () => {
   const qc = useQueryClient();
-  return (params: Record<string, string | string[] | number | number[]>) => {
+  return (params?: ListMyDocumentsApiV1MeDocumentsGetParams) => {
     return qc.prefetchQuery({
-      queryKey: [GLOBAL_DOCUMENTS_QUERY_KEY, params],
-      queryFn: () => globalDocumentsQueryFn(params),
+      queryKey: getListMyDocumentsApiV1MeDocumentsGetQueryKey(params),
+      queryFn: () =>
+        listMyDocumentsApiV1MeDocumentsGet(params) as unknown as Promise<DocumentListResponse>,
       staleTime: 30_000,
     });
   };

--- a/frontend/src/pages/user/MyDocumentsPage.tsx
+++ b/frontend/src/pages/user/MyDocumentsPage.tsx
@@ -6,7 +6,10 @@ import { ChevronDown, Filter, Loader2, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { DocumentSummary } from "@/api/generated/initiativeAPI.schemas";
+import type {
+  DocumentSummary,
+  ListMyDocumentsApiV1MeDocumentsGetParams,
+} from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllDocuments } from "@/api/query-keys";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import { SortIcon } from "@/components/SortIcon";
@@ -165,7 +168,7 @@ export const MyDocumentsPage = () => {
   }, [guildFilters, debouncedSearch, setPage]);
 
   const documentsGlobalParams = useMemo(() => {
-    const params: Record<string, string | string[] | number | number[]> = {};
+    const params: ListMyDocumentsApiV1MeDocumentsGetParams = {};
     if (guildFilters.length > 0) params.guild_ids = guildFilters;
     if (debouncedSearch.trim()) params.search = debouncedSearch.trim();
     if (sortBy) params.sort_by = sortBy;

--- a/frontend/src/routes/_serverRequired/_authenticated/my-documents.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/my-documents.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-import { apiClient } from "@/api/client";
-import type { UserViewPreferencesMap } from "@/api/generated/initiativeAPI.schemas";
+import {
+  getListMyDocumentsApiV1MeDocumentsGetQueryKey,
+  listMyDocumentsApiV1MeDocumentsGet,
+} from "@/api/generated/documents/documents";
+import type {
+  ListMyDocumentsApiV1MeDocumentsGetParams,
+  UserViewPreferencesMap,
+} from "@/api/generated/initiativeAPI.schemas";
 import { VIEW_PREFERENCES_QUERY_KEY } from "@/hooks/useViewPreference";
 import { getItem } from "@/lib/storage";
 
@@ -53,7 +59,7 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/my-documen
     const { queryClient } = context;
     const { guildFilters } = readPrefetchFilters(queryClient);
 
-    const params: Record<string, string | string[] | number | number[]> = {
+    const params: ListMyDocumentsApiV1MeDocumentsGetParams = {
       page: 1,
       page_size: PAGE_SIZE,
     };
@@ -62,8 +68,8 @@ export const Route = createFileRoute("/_serverRequired/_authenticated/my-documen
     try {
       await queryClient.ensureQueryData({
         // Key + params mirror useGlobalDocuments so the prefetch warms the page query.
-        queryKey: ["/api/v1/me/documents", params],
-        queryFn: () => apiClient.get("/me/documents", { params }).then((r) => r.data),
+        queryKey: getListMyDocumentsApiV1MeDocumentsGetQueryKey(params),
+        queryFn: () => listMyDocumentsApiV1MeDocumentsGet(params),
         staleTime: 30_000,
       });
     } catch {


### PR DESCRIPTION
## Problem

`useGlobalDocuments` hand-rolled its fetcher and query key with `apiClient.get(...)` directly, **bypassing `apiMutator`** ([api/mutator.ts](frontend/src/api/mutator.ts)) — so Capacitor/native base-URL rewriting and FormData handling didn't apply — and used a loose `Record<string, ...>` params type instead of the generated `ListMyDocumentsApiV1MeDocumentsGetParams`. Its sibling hooks `useGlobalProjects` and `useGlobalCalendarEventsList` already use the generated helpers.

## Changes

- [useDocuments.ts](frontend/src/hooks/useDocuments.ts): removed `GLOBAL_DOCUMENTS_QUERY_KEY`, `globalDocumentsQueryFn`, and the `apiClient` import; `useGlobalDocuments`/`usePrefetchGlobalDocuments` now use the generated `listMyDocumentsApiV1MeDocumentsGet` + `getListMyDocumentsApiV1MeDocumentsGetQueryKey` with the proper param type — matching `useGlobalProjects`/`useGlobalCalendarEventsList`.
- [MyDocumentsPage.tsx](frontend/src/pages/user/MyDocumentsPage.tsx): typed `documentsGlobalParams` as `ListMyDocumentsApiV1MeDocumentsGetParams`.
- [my-documents.tsx](frontend/src/routes/_serverRequired/_authenticated/my-documents.tsx): the route loader prefetch mirrored the old key and *also* bypassed the mutator via `apiClient.get`; switched it to the same generated helper so key + fetcher stay aligned.

Invalidation is unchanged: `getListMyDocumentsApiV1MeDocumentsGetQueryKey(params)` returns `["/api/v1/me/documents", params]`, so `invalidatePersonalPrefix("/api/v1/me/documents")` still matches.

## Testing

- `pnpm typecheck` — pass
- `pnpm biome check` on the 3 changed files — pass
- `./scripts/test-changed.sh` — 932 tests pass (69 files)

Fixes #865