### PR TITLE
Stop OIDC callback looping on itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Signing in through single sign-on no longer sends the app into a request storm: the sign-in callback finished, updated the session, and then re-ran itself off its own update, re-fetching the current user, the guild list, and access grants dozens of times before settling. The callback is now consumed exactly once, and the guild list no longer reloads every time the current user is refreshed.
 - Comment, document-summary, and guild-list error messages now route through the shared error-message helper: the user sees a localized message (and rate-limit errors are surfaced as such) instead of an untranslated backend error code.
 - A database created or restored in a Postgres cluster where the platform "admin" → "operator" role rename had already run no longer loses its platform-staff row-security coverage: a repair migration finishes the rename by re-binding the affected policies (access-grant queue, platform user list/management) to the operator role and removing the leftover one. Without it, operators and owners saw only their own rows in the access-grant queue and the platform user list on such databases.
 - The sidebar "Edit tag" dialog is no longer visually broken — the name field now fills the row and the color picker sits beside it, instead of the color picker taking the full width and collapsing the name field to a sliver.

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -182,20 +182,26 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return response.data;
   };
 
-  const completeOidcLogin = async (accessToken?: string, isDevice = false) => {
-    if (isDevice && accessToken) {
-      // Native: store device token in persistent storage
-      setAuthToken(accessToken, true);
-      setItem(TOKEN_STORAGE_KEY, accessToken);
-      setItem(DEVICE_TOKEN_KEY, "true");
-      setTokenState(accessToken);
-      setIsDeviceToken(true);
-    }
-    // Web: cookie was already set by the backend redirect — just fetch the user
-    const me = await apiClient.get<UserRead>("/users/me");
-    setUser(me.data);
-    markJustSignedIn();
-  };
+  // Memoized: the OIDC callback page calls this from an effect, and this
+  // function also sets the user it depends on. An unstable identity would make
+  // that effect re-run on every render it causes — an endless /users/me loop.
+  const completeOidcLogin = useCallback(
+    async (accessToken?: string, isDevice = false) => {
+      if (isDevice && accessToken) {
+        // Native: store device token in persistent storage
+        setAuthToken(accessToken, true);
+        setItem(TOKEN_STORAGE_KEY, accessToken);
+        setItem(DEVICE_TOKEN_KEY, "true");
+        setTokenState(accessToken);
+        setIsDeviceToken(true);
+      }
+      // Web: cookie was already set by the backend redirect — just fetch the user
+      const me = await apiClient.get<UserRead>("/users/me");
+      setUser(me.data);
+      markJustSignedIn();
+    },
+    [setUser]
+  );
 
   const logout = useCallback(async () => {
     // Fire the POST *first*, while the bearer token and cookie are still

--- a/frontend/src/hooks/useGuilds.tsx
+++ b/frontend/src/hooks/useGuilds.tsx
@@ -135,6 +135,11 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
   // a module var is per-JS-context (see query-keys.ts).
   setInvalidationGuild(activeGuildId);
 
+  // Key guild loading on the user's *id*, not the user object: `refreshUser()`
+  // always returns a fresh object, so an object-identity dep would refetch the
+  // guild list and access grants on every profile refresh.
+  const userId = user?.id ?? null;
+
   const canCreateGuilds = user?.can_create_guilds ?? true;
 
   // Persist this tab's guild as the fresh-tab default (read once at mount).
@@ -165,7 +170,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const refreshGuilds = useCallback(async () => {
-    if (!user) {
+    if (userId === null) {
       setGuilds([]);
       setActiveGuildId(null);
       setError(null);
@@ -215,7 +220,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
     } finally {
       setLoading(false);
     }
-  }, [user, applyGuildState]);
+  }, [userId, applyGuildState]);
 
   const flushPendingOrder = useCallback(async () => {
     if (!pendingOrderRef.current) {
@@ -265,7 +270,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
   }, [flushPendingOrder]);
 
   useEffect(() => {
-    if (!user) {
+    if (userId === null) {
       setGuilds([]);
       setActiveGuildId(null);
       setError(null);
@@ -274,7 +279,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
     void refreshGuilds();
-  }, [user, refreshGuilds]);
+  }, [userId, refreshGuilds]);
 
   const switchGuild = useCallback(
     async (guildId: number) => {
@@ -282,14 +287,14 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
       // route layout calls syncGuildFromUrl. Here we just move this tab's local
       // state and drop the previous guild's now-wrong cached query data. No
       // server context — per-tab only, so two tabs can hold different guilds.
-      if (!user || guildId === activeGuildIdRef.current) {
+      if (userId === null || guildId === activeGuildIdRef.current) {
         return;
       }
       setActiveGuildId(guildId);
       await resetGuildScopedQueries();
       await Promise.all([refreshGuilds(), refreshUser()]);
     },
-    [user, refreshGuilds, refreshUser]
+    [userId, refreshGuilds, refreshUser]
   );
 
   /**
@@ -356,7 +361,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
 
   const createGuild = useCallback(
     async ({ name, description }: { name: string; description?: string }) => {
-      if (!user) {
+      if (userId === null) {
         throw new Error("You must be signed in to create a guild.");
       }
       if (!canCreateGuilds) {
@@ -377,7 +382,7 @@ export const GuildProvider = ({ children }: { children: ReactNode }) => {
 
       return response.data;
     },
-    [user, canCreateGuilds, refreshGuilds, refreshUser]
+    [userId, canCreateGuilds, refreshGuilds, refreshUser]
   );
 
   const updateGuildInState = useCallback((guild: GuildRead) => {

--- a/frontend/src/pages/GuildInvitePage.tsx
+++ b/frontend/src/pages/GuildInvitePage.tsx
@@ -9,6 +9,7 @@ import { LogoIcon } from "@/components/LogoIcon";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/hooks/useAuth";
+import { useGuilds } from "@/hooks/useGuilds";
 import { getErrorMessage } from "@/lib/errorMessage";
 
 export const GuildInvitePage = () => {
@@ -19,6 +20,7 @@ export const GuildInvitePage = () => {
     [normalizedCode]
   );
   const { user, refreshUser } = useAuth();
+  const { refreshGuilds } = useGuilds();
   const { t } = useTranslation(["guilds", "common"]);
   const [status, setStatus] = useState<GuildInviteStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -74,7 +76,11 @@ export const GuildInvitePage = () => {
     try {
       await apiClient.post("/guilds/invite/accept", { code: normalizedCode });
       setAccepted(true);
-      await refreshUser();
+      // Refresh both explicitly: joining changes the user's guild list, and the
+      // switcher only reloads when asked to. (It deliberately does not key off
+      // the user object's identity — refreshUser() always returns a fresh one,
+      // which would refetch every guild on any profile change.)
+      await Promise.all([refreshUser(), refreshGuilds()]);
     } catch (err) {
       setAcceptError(getErrorMessage(err, "guilds:invite.unableToAccept"));
     } finally {

--- a/frontend/src/pages/OidcCallbackPage.tsx
+++ b/frontend/src/pages/OidcCallbackPage.tsx
@@ -1,6 +1,6 @@
 import { Browser } from "@capacitor/browser";
 import { useRouter, useSearch } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -19,6 +19,10 @@ export const OidcCallbackPage = () => {
   const { completeOidcLogin } = useAuth();
   const { isNativePlatform } = useServer();
   const [status, setStatus] = useState(t("oidcCallback.finishing"));
+  // The exchange is a one-shot side effect that also changes auth state, which
+  // re-renders this page. Guard it so the callback is only ever consumed once,
+  // however the effect's dependencies churn.
+  const startedRef = useRef(false);
 
   useEffect(() => {
     const error = searchParams.error;
@@ -26,6 +30,10 @@ export const OidcCallbackPage = () => {
       setStatus(t("oidcCallback.failedWithError", { error }));
       return;
     }
+    if (startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
     const run = async () => {
       try {
         // token is present for native (device_token); undefined for web (cookie was set by backend)


### PR DESCRIPTION
## Problem

Signing in through OIDC sent the app into a request storm — dozens of repeats of `GET /users/me`, `GET /guilds/`, and `GET /access-grants/?mine=true` before it settled.

`completeOidcLogin` was the only auth function declared as a bare arrow function in the `AuthProvider` body — `refreshUser` and `logout` next to it are both `useCallback`'d — so it got a fresh identity on every provider render. [OidcCallbackPage.tsx](frontend/src/pages/OidcCallbackPage.tsx) lists it in its effect deps, and calling it does `setUser(...)`, which re-renders the provider, which mints a new `completeOidcLogin`, which re-runs the effect. Each turn of that loop:

- refetched `/users/me` (from `completeOidcLogin` itself), and
- handed `useGuilds` a new `user` object identity, whose effect deps were `[user, refreshGuilds]` → `/guilds/` then `/access-grants/?mine=true`.

The trailing `guilds`+`access-grants` pairs with no `users/me` in the reported logs are the queued `refreshGuilds` calls draining after `router.navigate` finally unmounted the page.

Password login never hit this because it runs from a submit handler, not an effect — which is why it only surfaced once a real OIDC provider was configured.

## Changes

- [useAuth.tsx](frontend/src/hooks/useAuth.tsx) — `completeOidcLogin` is now `useCallback([setUser])`, giving it the stable identity its siblings already had.
- [OidcCallbackPage.tsx](frontend/src/pages/OidcCallbackPage.tsx) — guard the exchange behind a one-shot `startedRef`. The auth code is single-use, so re-entry was never valid regardless of what churns in the deps.
- [useGuilds.tsx](frontend/src/hooks/useGuilds.tsx) — remove the amplifier: key on `user?.id` rather than the `user` object. `refreshUser()` always returns a fresh object, so *any* profile refresh was re-fetching the full guild list plus access grants. `switchGuild`/`createGuild` moved to the same key (they only null-checked `user`).
- `CHANGELOG.md` entry under `[Unreleased] → Fixed`.

## Testing

- `cd frontend && pnpm typecheck` — clean.
- `cd frontend && pnpm biome check src/hooks/useAuth.tsx src/hooks/useGuilds.tsx src/pages/OidcCallbackPage.tsx` — clean (3 files, no fixes applied).
- `cd frontend && pnpm lint` — no warnings in touched files; the 4 remaining are pre-existing (`styles.css`, an unrelated document hook).
- `cd frontend && ./scripts/test-changed.sh` — ran the full suite (shared test infra in the changed set): **69 files, 932 tests passed**.

No backend changes, so no schema/type regeneration needed.