### PR TITLE
Align new task dialog with task editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The new-task dialog now matches the task editor: both are built on a single shared task form, so creating a task exposes the same fields as editing one. You can now set the **status**, attach **tags**, and fill in **custom properties** while creating a task — all saved in the single create request instead of only becoming available after the task exists.
+
+### Changed
+
+- In the task editor, tags and custom properties now save with the rest of the form when you click **Save** (previously they saved immediately on change). The editor warns before you navigate away with unsaved changes, and the new-task dialog no longer closes if you click outside it (use Escape or Cancel).
+
 ## [0.58.0] - 2026-07-21
 
 ### Security

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -1921,7 +1921,9 @@ async def create_task(
             session, project.id
         )
 
-    task_data = task_in.model_dump(exclude={"assignee_ids", "task_status_id"})
+    task_data = task_in.model_dump(
+        exclude={"assignee_ids", "task_status_id", "tag_ids", "property_values"}
+    )
 
     # Serialize recurrence to JSON if present
     if task_data.get("recurrence") is not None:
@@ -1951,6 +1953,36 @@ async def create_task(
                 project_name=project.name,
                 guild_id=guild_context.guild_id,
             )
+
+    # Attach tags and custom properties in the same transaction. Both services
+    # mutate the session without committing; a raised HTTPException (invalid
+    # tag/property) rolls back so no orphan task is persisted.
+    try:
+        if task_in.tag_ids:
+            await tags_service.set_entity_tags(
+                session,
+                tags_service.TAG_LINKS["task"],
+                guild_id=guild_context.guild_id,
+                entity_id=task.id,
+                tag_ids=task_in.tag_ids,
+            )
+        if task_in.property_values:
+            initiative_id = project.initiative_id if project else None
+            if initiative_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=TaskMessages.NOT_FOUND,
+                )
+            await properties_service.set_task_property_values(
+                session,
+                task,
+                task_in.property_values,
+                initiative_id,
+            )
+    except HTTPException:
+        await session.rollback()
+        raise
+
     await _touch_project(session, task_in.project_id)
     await session.commit()
     task = await _fetch_task(session, task.id, guild_context.guild_id)
@@ -2023,6 +2055,8 @@ async def update_task(
 
     update_data = task_in.model_dump(exclude_unset=True)
     assignee_ids = update_data.pop("assignee_ids", None)
+    tag_ids = update_data.pop("tag_ids", None)
+    property_values = update_data.pop("property_values", None)
     previous_status_category = task.task_status.category if task.task_status else None
     new_status_id = update_data.pop("task_status_id", None)
 
@@ -2087,10 +2121,51 @@ async def update_task(
                 project_name=project.name,
                 guild_id=guild_context.guild_id,
             )
+
+    # Replace tags/properties when the client sent them (PATCH semantics:
+    # absent/None = leave unchanged; a list = replace-all). Both services
+    # mutate the session without committing; roll back on validation errors.
+    try:
+        if tag_ids is not None:
+            await tags_service.set_entity_tags(
+                session,
+                tags_service.TAG_LINKS["task"],
+                guild_id=guild_context.guild_id,
+                entity_id=task.id,
+                tag_ids=tag_ids,
+            )
+        if property_values is not None:
+            initiative_id = task.project.initiative_id if task.project else None
+            if initiative_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=TaskMessages.NOT_FOUND,
+                )
+            await properties_service.set_task_property_values(
+                session,
+                task,
+                task_in.property_values or [],
+                initiative_id,
+            )
+    except HTTPException:
+        await session.rollback()
+        raise
+
+    # The services above issue bulk DELETEs on the junction/value rows, leaving
+    # the ORM-loaded collections stale. Expire them so ``session.add(task)``
+    # below doesn't cascade the now-deleted instances (they reload fresh in the
+    # populate_existing fetch that builds the response).
+    if tag_ids is not None:
+        session.expire(task, ["tag_links"])
+    if property_values is not None:
+        session.expire(task, ["property_values"])
+
     await _touch_project(session, task.project_id, timestamp=now)
     session.add(task)
     await session.commit()
-    task = await _fetch_task(session, task.id, guild_context.guild_id)
+    task = await _fetch_task(
+        session, task.id, guild_context.guild_id, populate_existing=True
+    )
     if task is None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -138,6 +138,207 @@ async def test_create_task(client: AsyncClient, session: AsyncSession, acting_us
 
 
 @pytest.mark.integration
+async def test_create_task_with_status(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A non-default ``task_status_id`` is honored on create."""
+    from app.services.tenant import task_statuses as task_statuses_service
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    await task_statuses_service.ensure_default_statuses(session, a.project.id)
+    statuses = await task_statuses_service.list_statuses(session, a.project.id)
+    default_status = await task_statuses_service.get_default_status(
+        session, a.project.id
+    )
+    await session.commit()
+    non_default = next(s for s in statuses if s.id != default_status.id)
+
+    response = await client.post(
+        a.g("/tasks/"),
+        headers=a.headers,
+        json={
+            "title": "Statused Task",
+            "project_id": a.project.id,
+            "task_status_id": non_default.id,
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["task_status_id"] == non_default.id
+
+
+@pytest.mark.integration
+async def test_create_task_with_tags(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """``tag_ids`` on create attaches the tags in the same request."""
+    from app.testing.factories import create_tag
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    tag1 = await create_tag(session, a.guild, name="urgent")
+    tag2 = await create_tag(session, a.guild, name="backend")
+
+    response = await client.post(
+        a.g("/tasks/"),
+        headers=a.headers,
+        json={
+            "title": "Tagged Task",
+            "project_id": a.project.id,
+            "tag_ids": [tag1.id, tag2.id],
+        },
+    )
+
+    assert response.status_code == 201
+    returned_tag_ids = {t["id"] for t in response.json()["tags"]}
+    assert returned_tag_ids == {tag1.id, tag2.id}
+
+
+@pytest.mark.integration
+async def test_create_task_with_properties(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """``property_values`` on create attaches custom property values."""
+    from app.testing.factories import create_property_definition
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    text_defn = await create_property_definition(session, a.initiative, name="Notes")
+
+    response = await client.post(
+        a.g("/tasks/"),
+        headers=a.headers,
+        json={
+            "title": "Task with props",
+            "project_id": a.project.id,
+            "property_values": [{"property_id": text_defn.id, "value": "hello"}],
+        },
+    )
+
+    assert response.status_code == 201
+    props = {p["property_id"]: p["value"] for p in response.json()["properties"]}
+    assert props[text_defn.id] == "hello"
+
+
+@pytest.mark.integration
+async def test_create_task_with_invalid_tag_id_rolls_back(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """An invalid tag id fails the create and persists no task."""
+    from sqlmodel import func, select
+
+    from app.models.tenant.task import Task
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+
+    response = await client.post(
+        a.g("/tasks/"),
+        headers=a.headers,
+        json={
+            "title": "Should Not Exist",
+            "project_id": a.project.id,
+            "tag_ids": [999999],
+        },
+    )
+
+    assert response.status_code in (400, 404)
+    count = (
+        await session.exec(
+            select(func.count())
+            .select_from(Task)
+            .where(Task.title == "Should Not Exist")
+        )
+    ).one()
+    assert count == 0
+
+
+@pytest.mark.integration
+async def test_create_task_with_invalid_property_rolls_back(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A property from another initiative fails the create and persists no task."""
+    from sqlmodel import func, select
+
+    from app.models.tenant.task import Task
+    from app.testing.factories import create_initiative, create_property_definition
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    # A definition scoped to a DIFFERENT initiative in the same guild.
+    other_initiative = await create_initiative(session, a.guild, a.user)
+    foreign_defn = await create_property_definition(
+        session, other_initiative, name="Foreign"
+    )
+
+    response = await client.post(
+        a.g("/tasks/"),
+        headers=a.headers,
+        json={
+            "title": "Bad Prop Task",
+            "project_id": a.project.id,
+            "property_values": [{"property_id": foreign_defn.id, "value": "x"}],
+        },
+    )
+
+    assert response.status_code in (400, 404)
+    count = (
+        await session.exec(
+            select(func.count()).select_from(Task).where(Task.title == "Bad Prop Task")
+        )
+    ).one()
+    assert count == 0
+
+
+@pytest.mark.integration
+async def test_update_task_with_tags_and_properties(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """PATCH replaces tags/properties; omitting the keys leaves them unchanged."""
+    from app.testing.factories import create_property_definition, create_tag
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    task = await _create_task(session, a.project)
+    tag = await create_tag(session, a.guild, name="review")
+    defn = await create_property_definition(session, a.initiative, name="Estimate")
+
+    # Set tags + a property value via PATCH.
+    response = await client.patch(
+        a.g(f"/tasks/{task.id}"),
+        headers=a.headers,
+        json={
+            "tag_ids": [tag.id],
+            "property_values": [{"property_id": defn.id, "value": "later"}],
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert {t["id"] for t in body["tags"]} == {tag.id}
+    assert {p["property_id"]: p["value"] for p in body["properties"]}[
+        defn.id
+    ] == "later"
+
+    # A PATCH that omits the keys must leave tags/properties intact.
+    response = await client.patch(
+        a.g(f"/tasks/{task.id}"),
+        headers=a.headers,
+        json={"title": "Renamed"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["title"] == "Renamed"
+    assert {t["id"] for t in body["tags"]} == {tag.id}
+    assert {p["property_id"] for p in body["properties"]} == {defn.id}
+
+    # An explicit empty list clears them.
+    response = await client.patch(
+        a.g(f"/tasks/{task.id}"),
+        headers=a.headers,
+        json={"tag_ids": [], "property_values": []},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tags"] == []
+    assert body["properties"] == []
+
+
+@pytest.mark.integration
 async def test_create_task_requires_project_access(
     client: AsyncClient, session: AsyncSession, acting_user
 ):

--- a/backend/app/schemas/tenant/task.py
+++ b/backend/app/schemas/tenant/task.py
@@ -10,7 +10,7 @@ from app.schemas.tenant.task_status import TaskStatusRead
 from app.schemas.platform.guild import GuildSummary
 from app.schemas.tenant.subtask import TaskSubtaskProgress
 from app.schemas.tenant.tag import TagSummary
-from app.schemas.tenant.property import PropertySummary
+from app.schemas.tenant.property import PropertySummary, PropertyValueInput
 
 from app.models.tenant.task import TaskPriority
 from app.models.platform.user import UserStatus
@@ -131,6 +131,8 @@ class TaskCreate(TaskBase):
     project_id: int
     assignee_ids: List[int] = Field(default_factory=list)
     task_status_id: Optional[int] = None
+    tag_ids: List[int] = Field(default_factory=list, max_length=100)
+    property_values: List[PropertyValueInput] = Field(default_factory=list)
 
 
 class TaskUpdate(SanitizedBaseModel):
@@ -144,6 +146,9 @@ class TaskUpdate(SanitizedBaseModel):
     recurrence: Optional[TaskRecurrence | None] = None
     recurrence_strategy: Optional[Literal["fixed", "rolling"]] = None
     is_archived: Optional[bool] = None
+    # PATCH semantics: None = "leave unchanged"; a list (incl. []) = replace-all.
+    tag_ids: Optional[List[int]] = Field(default=None, max_length=100)
+    property_values: Optional[List[PropertyValueInput]] = None
 
 
 class TaskMoveRequest(SanitizedBaseModel):

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -112,7 +112,11 @@
     "descriptionGenerated": "Beschreibung generiert",
     "generateDescriptionError": "Beschreibung konnte nicht generiert werden",
     "commentsError": "Kommentare können derzeit nicht geladen werden.",
-    "taskStatusRequired": "Aufgabenstatus ist erforderlich"
+    "taskStatusRequired": "Aufgabenstatus ist erforderlich",
+    "unsavedTitle": "Nicht gespeicherte Änderungen verwerfen?",
+    "unsavedBody": "Sie haben nicht gespeicherte Änderungen an dieser Aufgabe. Wenn Sie jetzt gehen, gehen sie verloren.",
+    "unsavedLeave": "Verlassen",
+    "unsavedStay": "Bleiben"
   },
   "myTasks": {
     "title": "Meine Aufgaben",
@@ -251,5 +255,21 @@
     "selected_other": "{{count}} Aufgaben ausgewählt",
     "editTags": "Tags bearbeiten",
     "archiving": "Wird archiviert…"
+  },
+  "taskForm": {
+    "titleLabel": "Titel",
+    "titlePlaceholder": "Aufgabentitel",
+    "descriptionLabel": "Beschreibung",
+    "descriptionPlaceholder": "Weitere Details hinzufügen (optional)",
+    "advancedDetails": "Erweiterte Details",
+    "statusLabel": "Status",
+    "selectStatus": "Status auswählen",
+    "priorityLabel": "Priorität",
+    "assigneesLabel": "Zuständige",
+    "assigneesEmptyMessage": "Keine Mitglieder gefunden",
+    "startDateLabel": "Startdatum",
+    "dueDateLabel": "Fälligkeitsdatum",
+    "tagsLabel": "Tags",
+    "tagsPlaceholder": "Tags hinzufügen"
   }
 }

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -112,7 +112,11 @@
     "descriptionGenerated": "Description generated",
     "generateDescriptionError": "Unable to generate description",
     "commentsError": "Unable to load comments right now.",
-    "taskStatusRequired": "Task status is required"
+    "taskStatusRequired": "Task status is required",
+    "unsavedTitle": "Discard unsaved changes?",
+    "unsavedBody": "You have unsaved changes to this task. If you leave now, they will be lost.",
+    "unsavedLeave": "Leave",
+    "unsavedStay": "Stay"
   },
   "myTasks": {
     "title": "My Tasks",
@@ -251,5 +255,21 @@
     "selected_other": "{{count}} tasks selected",
     "editTags": "Edit Tags",
     "archiving": "Archiving…"
+  },
+  "taskForm": {
+    "titleLabel": "Title",
+    "titlePlaceholder": "Task title",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Add more details (optional)",
+    "advancedDetails": "Advanced details",
+    "statusLabel": "Status",
+    "selectStatus": "Select status",
+    "priorityLabel": "Priority",
+    "assigneesLabel": "Assignees",
+    "assigneesEmptyMessage": "No members found",
+    "startDateLabel": "Start date",
+    "dueDateLabel": "Due date",
+    "tagsLabel": "Tags",
+    "tagsPlaceholder": "Add tags"
   }
 }

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -112,7 +112,11 @@
     "descriptionGenerated": "Descripción generada",
     "generateDescriptionError": "No se pudo generar la descripción",
     "commentsError": "No se pudieron cargar los comentarios en este momento.",
-    "taskStatusRequired": "El estado de la tarea es obligatorio"
+    "taskStatusRequired": "El estado de la tarea es obligatorio",
+    "unsavedTitle": "¿Descartar los cambios sin guardar?",
+    "unsavedBody": "Tienes cambios sin guardar en esta tarea. Si sales ahora, se perderán.",
+    "unsavedLeave": "Salir",
+    "unsavedStay": "Quedarme"
   },
   "myTasks": {
     "title": "Mis tareas",
@@ -251,5 +255,21 @@
     "selected_other": "{{count}} tareas seleccionadas",
     "editTags": "Editar etiquetas",
     "archiving": "Archivando…"
+  },
+  "taskForm": {
+    "titleLabel": "Título",
+    "titlePlaceholder": "Título de la tarea",
+    "descriptionLabel": "Descripción",
+    "descriptionPlaceholder": "Añade más detalles (opcional)",
+    "advancedDetails": "Detalles avanzados",
+    "statusLabel": "Estado",
+    "selectStatus": "Seleccionar estado",
+    "priorityLabel": "Prioridad",
+    "assigneesLabel": "Asignados",
+    "assigneesEmptyMessage": "No se encontraron miembros",
+    "startDateLabel": "Fecha de inicio",
+    "dueDateLabel": "Fecha de vencimiento",
+    "tagsLabel": "Etiquetas",
+    "tagsPlaceholder": "Añadir etiquetas"
   }
 }

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -112,7 +112,11 @@
     "descriptionGenerated": "Description générée",
     "generateDescriptionError": "Impossible de générer la description",
     "commentsError": "Impossible de charger les commentaires pour l'instant.",
-    "taskStatusRequired": "Le statut de la tâche est requis"
+    "taskStatusRequired": "Le statut de la tâche est requis",
+    "unsavedTitle": "Abandonner les modifications non enregistrées ?",
+    "unsavedBody": "Vous avez des modifications non enregistrées sur cette tâche. Si vous partez maintenant, elles seront perdues.",
+    "unsavedLeave": "Quitter",
+    "unsavedStay": "Rester"
   },
   "myTasks": {
     "title": "Mes tâches",
@@ -251,5 +255,21 @@
     "selected_other": "{{count}} tâches sélectionnées",
     "editTags": "Modifier les étiquettes",
     "archiving": "Archivage…"
+  },
+  "taskForm": {
+    "titleLabel": "Titre",
+    "titlePlaceholder": "Titre de la tâche",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Ajouter plus de détails (facultatif)",
+    "advancedDetails": "Détails avancés",
+    "statusLabel": "Statut",
+    "selectStatus": "Sélectionner un statut",
+    "priorityLabel": "Priorité",
+    "assigneesLabel": "Assignés",
+    "assigneesEmptyMessage": "Aucun membre trouvé",
+    "startDateLabel": "Date de début",
+    "dueDateLabel": "Date d'échéance",
+    "tagsLabel": "Étiquettes",
+    "tagsPlaceholder": "Ajouter des étiquettes"
   }
 }

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3214,6 +3214,9 @@ export interface TaskCreate {
   project_id: number;
   assignee_ids?: number[];
   task_status_id?: number | null;
+  /** @maxItems 100 */
+  tag_ids?: number[];
+  property_values?: PropertyValueInput[];
 }
 
 export interface TaskListResponse {
@@ -3353,6 +3356,8 @@ export interface TaskUpdate {
   recurrence?: TaskRecurrenceInput | null;
   recurrence_strategy?: TaskUpdateRecurrenceStrategy;
   is_archived?: boolean | null;
+  tag_ids?: number[] | null;
+  property_values?: PropertyValueInput[] | null;
 }
 
 /**

--- a/frontend/src/components/projects/ProjectTaskComposer.tsx
+++ b/frontend/src/components/projects/ProjectTaskComposer.tsx
@@ -17,6 +17,8 @@ interface ProjectTaskComposerProps {
   isArchived: boolean;
   isSubmitting: boolean;
   hasError: boolean;
+  /** When true, a backdrop click won't close the dialog (unsaved input). */
+  isDirty: boolean;
   onSubmit: () => void;
   onCancel?: () => void;
 }
@@ -27,6 +29,7 @@ export const ProjectTaskComposer = ({
   isArchived,
   isSubmitting,
   hasError,
+  isDirty,
   onSubmit,
   onCancel,
 }: ProjectTaskComposerProps) => {
@@ -39,9 +42,12 @@ export const ProjectTaskComposer = ({
   return (
     <DialogContent
       className="max-h-screen overflow-y-auto bg-card"
-      // Don't let an accidental backdrop click discard an in-progress task.
-      // Escape and the explicit Cancel button still close the dialog.
-      onInteractOutside={(event) => event.preventDefault()}
+      // Only block a backdrop click while there's unsaved input, so a stray
+      // click can't discard an in-progress task. When the form is untouched,
+      // clicking outside closes it as usual. Escape and Cancel always close.
+      onInteractOutside={(event) => {
+        if (isDirty) event.preventDefault();
+      }}
     >
       <DialogHeader>
         <DialogTitle>{t("taskComposer.title")}</DialogTitle>

--- a/frontend/src/components/projects/ProjectTaskComposer.tsx
+++ b/frontend/src/components/projects/ProjectTaskComposer.tsx
@@ -1,101 +1,48 @@
 import type { FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 
-import type {
-  TaskListReadRecurrenceStrategy,
-  TaskPriority,
-  TaskRecurrenceOutput,
-} from "@/api/generated/initiativeAPI.schemas";
-import { MemberMultiSelect } from "@/components/members/MemberSearchSelect";
-import { TaskRecurrenceSelector } from "@/components/projects/TaskRecurrenceSelector";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
+import { TaskForm, type TaskFormProps } from "@/components/tasks/TaskForm";
 import { Button } from "@/components/ui/button";
-import { DateTimePicker } from "@/components/ui/date-time-picker";
 import {
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { useAuth } from "@/hooks/useAuth";
 
 interface ProjectTaskComposerProps {
-  title: string;
-  description: string;
-  priority: TaskPriority;
-  assigneeIds: number[];
-  startDate: string;
-  dueDate: string;
-  recurrence: TaskRecurrenceOutput | null;
-  recurrenceStrategy: TaskListReadRecurrenceStrategy;
+  /** Controlled field set forwarded to the shared TaskForm (layout is fixed). */
+  form: Omit<TaskFormProps, "layout">;
   canWrite: boolean;
   isArchived: boolean;
   isSubmitting: boolean;
   hasError: boolean;
-  projectId: number;
-  onTitleChange: (value: string) => void;
-  onDescriptionChange: (value: string) => void;
-  onPriorityChange: (value: TaskPriority) => void;
-  onAssigneesChange: (value: number[]) => void;
-  onStartDateChange: (value: string) => void;
-  onDueDateChange: (value: string) => void;
-  onRecurrenceChange: (value: TaskRecurrenceOutput | null) => void;
-  onRecurrenceStrategyChange: (value: TaskListReadRecurrenceStrategy) => void;
   onSubmit: () => void;
   onCancel?: () => void;
-  autoFocusTitle?: boolean;
 }
 
 export const ProjectTaskComposer = ({
-  title,
-  description,
-  priority,
-  assigneeIds,
-  startDate,
-  dueDate,
-  recurrence,
-  recurrenceStrategy,
+  form,
   canWrite,
   isArchived,
   isSubmitting,
   hasError,
-  projectId,
-  onTitleChange,
-  onDescriptionChange,
-  onPriorityChange,
-  onAssigneesChange,
-  onStartDateChange,
-  onDueDateChange,
-  onRecurrenceChange,
-  onRecurrenceStrategyChange,
   onSubmit,
   onCancel,
-  autoFocusTitle = false,
 }: ProjectTaskComposerProps) => {
   const { t } = useTranslation(["projects", "common"]);
-  const { user: currentUser } = useAuth();
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit();
   };
 
   return (
-    <DialogContent className="max-h-screen overflow-y-auto bg-card">
+    <DialogContent
+      className="max-h-screen overflow-y-auto bg-card"
+      // Don't let an accidental backdrop click discard an in-progress task.
+      // Escape and the explicit Cancel button still close the dialog.
+      onInteractOutside={(event) => event.preventDefault()}
+    >
       <DialogHeader>
         <DialogTitle>{t("taskComposer.title")}</DialogTitle>
         <DialogDescription>{t("taskComposer.description")}</DialogDescription>
@@ -105,104 +52,7 @@ export const ProjectTaskComposer = ({
           <p className="text-muted-foreground text-sm">{t("taskComposer.archivedMessage")}</p>
         ) : canWrite ? (
           <form className="space-y-4" onSubmit={handleSubmit}>
-            <div className="space-y-2">
-              <Label htmlFor="task-title">{t("taskComposer.titleLabel")}</Label>
-              <Input
-                id="task-title"
-                value={title}
-                onChange={(event) => onTitleChange(event.target.value)}
-                placeholder={t("taskComposer.titlePlaceholder")}
-                required
-                autoFocus={autoFocusTitle}
-              />
-            </div>
-            <Accordion type="single" collapsible>
-              <AccordionItem value="advanced">
-                <AccordionTrigger>{t("taskComposer.advancedDetails")}</AccordionTrigger>
-                <AccordionContent className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="task-description">{t("taskComposer.descriptionLabel")}</Label>
-                    <Textarea
-                      id="task-description"
-                      rows={3}
-                      value={description}
-                      onChange={(event) => onDescriptionChange(event.target.value)}
-                      placeholder={t("taskComposer.descriptionPlaceholder")}
-                    />
-                  </div>
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="task-priority">{t("taskComposer.priorityLabel")}</Label>
-                      <Select
-                        value={priority}
-                        onValueChange={(value) => onPriorityChange(value as TaskPriority)}
-                      >
-                        <SelectTrigger id="task-priority">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="low">{t("taskComposer.priorityLow")}</SelectItem>
-                          <SelectItem value="medium">{t("taskComposer.priorityMedium")}</SelectItem>
-                          <SelectItem value="high">{t("taskComposer.priorityHigh")}</SelectItem>
-                          <SelectItem value="urgent">{t("taskComposer.priorityUrgent")}</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>{t("taskComposer.assigneesLabel")}</Label>
-                      <MemberMultiSelect
-                        scope={{ type: "project", projectId }}
-                        selectedIds={assigneeIds}
-                        onChange={onAssigneesChange}
-                        disabled={isSubmitting}
-                        emptyMessage={t("taskComposer.assigneesEmptyMessage")}
-                        currentUserId={currentUser?.id}
-                      />
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="task-start-date">{t("taskComposer.startDateLabel")}</Label>
-                    <DateTimePicker
-                      id="task-start-date"
-                      value={startDate}
-                      onChange={onStartDateChange}
-                      disabled={isSubmitting}
-                      placeholder={t("taskComposer.optional")}
-                      calendarProps={{
-                        hidden: {
-                          after: new Date(dueDate),
-                        },
-                      }}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="task-due-date">{t("taskComposer.dueDateLabel")}</Label>
-                    <DateTimePicker
-                      id="task-due-date"
-                      value={dueDate}
-                      onChange={onDueDateChange}
-                      disabled={isSubmitting}
-                      placeholder={t("taskComposer.optional")}
-                      calendarProps={{
-                        hidden: {
-                          before: new Date(startDate),
-                        },
-                      }}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <TaskRecurrenceSelector
-                      recurrence={recurrence}
-                      onChange={onRecurrenceChange}
-                      strategy={recurrenceStrategy}
-                      onStrategyChange={onRecurrenceStrategyChange}
-                      disabled={isSubmitting}
-                      referenceDate={dueDate || startDate}
-                    />
-                  </div>
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
+            <TaskForm {...form} layout="dialog" />
             <div className="flex flex-wrap gap-2">
               <Button type="submit" disabled={isSubmitting}>
                 {isSubmitting ? t("taskComposer.saving") : t("taskComposer.createTask")}

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -26,9 +26,6 @@ import type {
   FilterCondition,
   ListTasksApiV1GGuildIdTasksGetParams,
   TaskListRead,
-  TaskListReadRecurrenceStrategy,
-  TaskPriority,
-  TaskRecurrenceOutput,
   TaskReorderRequest,
   TaskStatusRead,
 } from "@/api/generated/initiativeAPI.schemas";
@@ -58,6 +55,7 @@ import { BulkEditTaskTagsDialog } from "@/components/tasks/BulkEditTaskTagsDialo
 import { ExportTasksButton } from "@/components/tasks/ExportTasksButton";
 import { TaskBulkEditDialog } from "@/components/tasks/TaskBulkEditDialog";
 import { TaskBulkEditPanel } from "@/components/tasks/TaskBulkEditPanel";
+import { emptyTaskFormValue, type TaskFormValue } from "@/components/tasks/TaskForm";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -209,15 +207,11 @@ export const ProjectTasksSection = ({
       return a.position - b.position;
     });
   }, [taskStatuses]);
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [priority, setPriority] = useState<TaskPriority>("medium");
-  const [assigneeIds, setAssigneeIds] = useState<number[]>([]);
-  const [startDate, setStartDate] = useState<string>("");
-  const [dueDate, setDueDate] = useState<string>("");
-  const [recurrence, setRecurrence] = useState<TaskRecurrenceOutput | null>(null);
-  const [recurrenceStrategy, setRecurrenceStrategy] =
-    useState<TaskListReadRecurrenceStrategy>("fixed");
+  // Single source of truth for the aligned create dialog's fields (title,
+  // description, status, priority, assignees, dates, recurrence, tags, and
+  // custom properties). TaskForm mutates it via onChange; submit batches it
+  // all into one create POST.
+  const [composerValue, setComposerValue] = useState<TaskFormValue>(() => emptyTaskFormValue());
   const filterStorageKey = `project:${projectId}:view-filters`;
   const [storedFilters, setStoredFilters, { isLoaded: filtersLoaded }] =
     useViewPreference<StoredFilters>(filterStorageKey, DEFAULT_FILTERS);
@@ -445,19 +439,22 @@ export const ProjectTasksSection = ({
 
   const createTask = useCreateTask({
     onSuccess: (newTask) => {
-      setTitle("");
-      setDescription("");
-      setPriority("medium");
-      setAssigneeIds([]);
-      setStartDate("");
-      setDueDate("");
-      setRecurrence(null);
-      setRecurrenceStrategy("fixed");
+      setComposerValue(emptyTaskFormValue({ statusId: defaultStatusId }));
       setIsComposerOpen(false);
       setLocalOverride((prev) => [...(prev ?? projectTasks), newTask]);
       toast.success(t("tasks.taskCreated"));
     },
   });
+
+  // Seed the composer's status from the project default whenever it opens so
+  // the user starts at the default but can override it.
+  useEffect(() => {
+    if (isComposerOpen) {
+      setComposerValue((prev) =>
+        prev.statusId == null ? { ...prev, statusId: defaultStatusId } : prev
+      );
+    }
+  }, [isComposerOpen, defaultStatusId]);
 
   // Patch the locally-overridden task list with a server-confirmed update so
   // the board/calendar reflects it immediately (and drop the task if it no
@@ -1085,46 +1082,47 @@ export const ProjectTasksSection = ({
         <>
           <Dialog open={isComposerOpen} onOpenChange={setIsComposerOpen}>
             <ProjectTaskComposer
-              title={title}
-              description={description}
-              priority={priority}
-              assigneeIds={assigneeIds}
-              startDate={startDate}
-              dueDate={dueDate}
-              recurrence={recurrence}
-              recurrenceStrategy={recurrenceStrategy}
               canWrite={canWriteProject}
               isArchived={projectIsArchived}
               isSubmitting={createTask.isPending}
               hasError={Boolean(createTask.isError)}
-              projectId={projectId}
-              onTitleChange={setTitle}
-              onDescriptionChange={setDescription}
-              onPriorityChange={setPriority}
-              onAssigneesChange={setAssigneeIds}
-              onStartDateChange={setStartDate}
-              onDueDateChange={setDueDate}
-              onRecurrenceChange={setRecurrence}
-              onRecurrenceStrategyChange={setRecurrenceStrategy}
+              form={{
+                value: composerValue,
+                onChange: setComposerValue,
+                statuses: sortedTaskStatuses,
+                projectId,
+                initiativeId,
+                currentUserId: user?.id,
+                autoFocusTitle: true,
+              }}
               onSubmit={() => {
-                if (!defaultStatusId) {
+                const selectedStatusId = composerValue.statusId ?? defaultStatusId;
+                if (!selectedStatusId) {
                   toast.error(t("tasks.createError"));
                   return;
                 }
                 const payload: Record<string, unknown> = {
                   project_id: projectId,
-                  title,
-                  description,
-                  priority,
-                  assignee_ids: assigneeIds,
-                  start_date: startDate ? new Date(startDate).toISOString() : null,
-                  due_date: dueDate ? new Date(dueDate).toISOString() : null,
-                  recurrence: recurrence,
-                  task_status_id: defaultStatusId,
+                  title: composerValue.title,
+                  description: composerValue.description,
+                  priority: composerValue.priority,
+                  assignee_ids: composerValue.assigneeIds,
+                  start_date: composerValue.startDate
+                    ? new Date(composerValue.startDate).toISOString()
+                    : null,
+                  due_date: composerValue.dueDate
+                    ? new Date(composerValue.dueDate).toISOString()
+                    : null,
+                  task_status_id: selectedStatusId,
+                  tag_ids: composerValue.tags.map((tg) => tg.id),
+                  property_values: composerValue.properties.map((property) => ({
+                    property_id: property.property_id,
+                    value: composerValue.propertyValues[property.property_id] ?? null,
+                  })),
                 };
-                if (recurrence) {
-                  payload.recurrence = recurrence;
-                  payload.recurrence_strategy = recurrenceStrategy;
+                if (composerValue.recurrence) {
+                  payload.recurrence = composerValue.recurrence;
+                  payload.recurrence_strategy = composerValue.recurrenceStrategy;
                 } else {
                   payload.recurrence = null;
                   payload.recurrence_strategy = "fixed";
@@ -1132,7 +1130,6 @@ export const ProjectTasksSection = ({
                 createTask.mutate(payload as never);
               }}
               onCancel={() => setIsComposerOpen(false)}
-              autoFocusTitle
             />
           </Dialog>
           <Dialog open={isBulkEditDialogOpen} onOpenChange={setIsBulkEditDialogOpen}>

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -469,6 +469,12 @@ export const ProjectTasksSection = ({
     [composerValue, defaultStatusId]
   );
 
+  // Close and discard the composer draft so reopening starts fresh.
+  const closeComposer = useCallback(() => {
+    setComposerValue(emptyTaskFormValue({ statusId: defaultStatusId }));
+    setIsComposerOpen(false);
+  }, [defaultStatusId]);
+
   // Patch the locally-overridden task list with a server-confirmed update so
   // the board/calendar reflects it immediately (and drop the task if it no
   // longer matches the active status filter).
@@ -1093,7 +1099,10 @@ export const ProjectTasksSection = ({
 
       {canEditTaskDetails ? (
         <>
-          <Dialog open={isComposerOpen} onOpenChange={setIsComposerOpen}>
+          <Dialog
+            open={isComposerOpen}
+            onOpenChange={(open) => (open ? setIsComposerOpen(true) : closeComposer())}
+          >
             <ProjectTaskComposer
               canWrite={canWriteProject}
               isArchived={projectIsArchived}
@@ -1143,7 +1152,7 @@ export const ProjectTasksSection = ({
                 }
                 createTask.mutate(payload as never);
               }}
-              onCancel={() => setIsComposerOpen(false)}
+              onCancel={closeComposer}
             />
           </Dialog>
           <Dialog open={isBulkEditDialogOpen} onOpenChange={setIsBulkEditDialogOpen}>

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -55,7 +55,11 @@ import { BulkEditTaskTagsDialog } from "@/components/tasks/BulkEditTaskTagsDialo
 import { ExportTasksButton } from "@/components/tasks/ExportTasksButton";
 import { TaskBulkEditDialog } from "@/components/tasks/TaskBulkEditDialog";
 import { TaskBulkEditPanel } from "@/components/tasks/TaskBulkEditPanel";
-import { emptyTaskFormValue, type TaskFormValue } from "@/components/tasks/TaskForm";
+import {
+  emptyTaskFormValue,
+  serializeTaskFormValue,
+  type TaskFormValue,
+} from "@/components/tasks/TaskForm";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -455,6 +459,15 @@ export const ProjectTasksSection = ({
       );
     }
   }, [isComposerOpen, defaultStatusId]);
+
+  // Dirty = the composer differs from a fresh form seeded at the default
+  // status. Used to keep a backdrop click from discarding in-progress input.
+  const composerDirty = useMemo(
+    () =>
+      serializeTaskFormValue(composerValue) !==
+      serializeTaskFormValue(emptyTaskFormValue({ statusId: defaultStatusId })),
+    [composerValue, defaultStatusId]
+  );
 
   // Patch the locally-overridden task list with a server-confirmed update so
   // the board/calendar reflects it immediately (and drop the task if it no
@@ -1086,6 +1099,7 @@ export const ProjectTasksSection = ({
               isArchived={projectIsArchived}
               isSubmitting={createTask.isPending}
               hasError={Boolean(createTask.isError)}
+              isDirty={composerDirty}
               form={{
                 value: composerValue,
                 onChange: setComposerValue,

--- a/frontend/src/components/properties/PropertyFields.tsx
+++ b/frontend/src/components/properties/PropertyFields.tsx
@@ -1,0 +1,154 @@
+import { X } from "lucide-react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  type PropertyDefinitionRead,
+  type PropertySummary,
+  PropertyType,
+} from "@/api/generated/initiativeAPI.schemas";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+import { PropertyInput } from "./PropertyInput";
+import { iconForPropertyType } from "./propertyTypeIcons";
+
+export interface PropertyFieldsProps {
+  /** Attached property rows — real server rows or locally-added stubs. */
+  properties: PropertySummary[];
+  /** Current value keyed by ``property_id``. Fully controlled by the parent. */
+  values: Record<number, unknown>;
+  onChange: (propertyId: number, value: unknown) => void;
+  onRemove: (propertyId: number) => void;
+  disabled?: boolean;
+  /** Initiative that scopes any ``user_reference`` picker in the list. */
+  initiativeId?: number | null;
+  className?: string;
+}
+
+/** Build a stub ``PropertySummary`` from a definition the user just picked but
+ *  hasn't given a value yet, so it can render alongside real attached rows. */
+export const propertyStubFromDefinition = (
+  definition: PropertyDefinitionRead
+): PropertySummary => ({
+  property_id: definition.id,
+  name: definition.name,
+  type: definition.type,
+  options: definition.options ?? null,
+  value: null,
+});
+
+/** Convert a server ``PropertySummary.value`` into the shape the controlled
+ *  ``values`` map expects: ``user_reference`` collapses to its numeric id
+ *  (``PropertyInput`` round-trips the id), everything else passes through. */
+export const normalizePropertyValue = (property: PropertySummary): unknown => {
+  if (property.type === PropertyType.user_reference) {
+    if (
+      property.value &&
+      typeof property.value === "object" &&
+      "id" in property.value &&
+      typeof (property.value as { id: unknown }).id === "number"
+    ) {
+      return (property.value as { id: number }).id;
+    }
+    return null;
+  }
+  return property.value ?? null;
+};
+
+/** Pull the ``{id, full_name}`` a ``user_reference`` value carries so the
+ *  picker can render the selected name without a search round-trip. */
+const userReferenceValue = (
+  property: PropertySummary
+): { id: number; full_name?: string | null } | null => {
+  if (property.type !== PropertyType.user_reference) return null;
+  const raw = property.value;
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "id" in raw &&
+    typeof (raw as { id: unknown }).id === "number"
+  ) {
+    return raw as { id: number; full_name?: string | null };
+  }
+  return null;
+};
+
+/**
+ * Presentational, fully-controlled list of custom property inputs. It owns no
+ * persistence, debounce, or draft state — the parent holds the values and
+ * decides when/how to save (immediate PUT vs batch into a create/update
+ * request). ``PropertyList`` wraps this for the autosaving document/event flow.
+ */
+export const PropertyFields = ({
+  properties,
+  values,
+  onChange,
+  onRemove,
+  disabled = false,
+  initiativeId,
+  className,
+}: PropertyFieldsProps) => {
+  const { t } = useTranslation(["properties", "common"]);
+
+  const sorted = useMemo(
+    () => [...properties].sort((a, b) => a.name.localeCompare(b.name)),
+    [properties]
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <p className={cn("text-muted-foreground text-sm", className)}>
+        {t("properties:noProperties")}
+      </p>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <ul className="space-y-2">
+        {sorted.map((property) => {
+          const inputId = `property-field-${property.property_id}`;
+          const Icon = iconForPropertyType(property.type);
+          return (
+            <li
+              key={property.property_id}
+              className="grid grid-cols-[minmax(0,8rem)_1fr_auto] items-center gap-2"
+            >
+              <Label
+                htmlFor={inputId}
+                className="flex min-w-0 items-center gap-1.5 font-normal text-muted-foreground text-xs"
+                title={property.name}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <span className="truncate">{property.name}</span>
+              </Label>
+              <div id={inputId} className="min-w-0">
+                <PropertyInput
+                  definition={property}
+                  value={values[property.property_id]}
+                  onChange={(next) => onChange(property.property_id, next)}
+                  disabled={disabled}
+                  initiativeId={initiativeId}
+                  selectedUser={userReferenceValue(property)}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground"
+                onClick={() => onRemove(property.property_id)}
+                disabled={disabled}
+                aria-label={t("properties:remove")}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/src/components/properties/index.ts
+++ b/frontend/src/components/properties/index.ts
@@ -1,5 +1,7 @@
 export type { AddPropertyButtonProps } from "./AddPropertyButton";
 export { AddPropertyButton } from "./AddPropertyButton";
+export type { PropertyFieldsProps } from "./PropertyFields";
+export { PropertyFields, propertyStubFromDefinition } from "./PropertyFields";
 export type { PropertyFilterCondition, PropertyFilterProps } from "./PropertyFilter";
 export { opsForType, PropertyFilter } from "./PropertyFilter";
 export type { PropertyInputProps } from "./PropertyInput";

--- a/frontend/src/components/tasks/TaskForm.tsx
+++ b/frontend/src/components/tasks/TaskForm.tsx
@@ -1,0 +1,351 @@
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import type {
+  PropertyDefinitionRead,
+  PropertySummary,
+  TagSummary,
+  TaskListReadRecurrenceStrategy,
+  TaskPriority,
+  TaskRecurrenceOutput,
+  TaskStatusRead,
+} from "@/api/generated/initiativeAPI.schemas";
+import { type MemberLike, MemberMultiSelect } from "@/components/members/MemberSearchSelect";
+import { TaskRecurrenceSelector } from "@/components/projects/TaskRecurrenceSelector";
+import { AddPropertyButton } from "@/components/properties/AddPropertyButton";
+import { PropertyFields, propertyStubFromDefinition } from "@/components/properties/PropertyFields";
+import { TagPicker } from "@/components/tags";
+import { statusTriggerStyle, TaskStatusOption } from "@/components/tasks/TaskStatusOption";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { DateTimePicker } from "@/components/ui/date-time-picker";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { PRIORITY_ORDER } from "@/lib/sorting";
+
+/** The full editable state of a task form, owned by the parent so it can
+ *  build a create/update payload, compare against a snapshot for dirty
+ *  tracking, and reset on success. TaskForm mutates it only via ``onChange``. */
+export interface TaskFormValue {
+  title: string;
+  description: string;
+  statusId: number | null;
+  priority: TaskPriority;
+  assigneeIds: number[];
+  startDate: string;
+  dueDate: string;
+  recurrence: TaskRecurrenceOutput | null;
+  recurrenceStrategy: TaskListReadRecurrenceStrategy;
+  tags: TagSummary[];
+  /** Attached property rows — real server rows or locally-added stubs. */
+  properties: PropertySummary[];
+  /** Current value keyed by ``property_id``. */
+  propertyValues: Record<number, unknown>;
+}
+
+/** A blank value for a fresh task form. */
+export const emptyTaskFormValue = (overrides: Partial<TaskFormValue> = {}): TaskFormValue => ({
+  title: "",
+  description: "",
+  statusId: null,
+  priority: "medium",
+  assigneeIds: [],
+  startDate: "",
+  dueDate: "",
+  recurrence: null,
+  recurrenceStrategy: "fixed",
+  tags: [],
+  properties: [],
+  propertyValues: {},
+  ...overrides,
+});
+
+export interface TaskFormProps {
+  value: TaskFormValue;
+  onChange: (value: TaskFormValue) => void;
+
+  statuses: TaskStatusRead[];
+  projectId: number | null;
+  initiativeId: number | null;
+  currentUserId?: number;
+  /** Pre-known assignee users so the picker renders names without a search. */
+  selectedAssignees?: MemberLike[];
+  disabled?: boolean;
+
+  /** Override the plain description textarea (e.g. the editor's markdown/AI block). */
+  descriptionSlot?: ReactNode;
+  /** Reference date for the recurrence "occurs on" preview. */
+  recurrenceReferenceDate?: string | null;
+
+  /** ``dialog`` tucks everything but the title into a collapsible section;
+   *  ``page`` renders every field flat. */
+  layout?: "dialog" | "page";
+  autoFocusTitle?: boolean;
+}
+
+/**
+ * Shared task field set used by both the create dialog and the edit page. The
+ * parent owns the ``value`` (for submit / dirty-tracking / reset); TaskForm
+ * owns the interaction logic — including adding, editing, and removing tags and
+ * custom properties — and reports every change through a single ``onChange``.
+ * It renders no ``<form>``, submit buttons, or surrounding chrome.
+ */
+export const TaskForm = ({
+  value,
+  onChange,
+  statuses,
+  projectId,
+  initiativeId,
+  currentUserId,
+  selectedAssignees,
+  disabled = false,
+  descriptionSlot,
+  recurrenceReferenceDate,
+  layout = "page",
+  autoFocusTitle = false,
+}: TaskFormProps) => {
+  const { t } = useTranslation(["tasks", "properties", "common"]);
+
+  const set = (patch: Partial<TaskFormValue>) => onChange({ ...value, ...patch });
+
+  const currentStatus = value.statusId
+    ? (statuses.find((status) => status.id === value.statusId) ?? null)
+    : null;
+  const currentPropertyIds = value.properties.map((property) => property.property_id);
+
+  const handlePropertyAdd = (definition: PropertyDefinitionRead) => {
+    if (value.properties.some((p) => p.property_id === definition.id)) return;
+    set({
+      properties: [...value.properties, propertyStubFromDefinition(definition)],
+      propertyValues: { ...value.propertyValues, [definition.id]: null },
+    });
+  };
+
+  const handlePropertyChange = (propertyId: number, next: unknown) => {
+    set({ propertyValues: { ...value.propertyValues, [propertyId]: next } });
+  };
+
+  const handlePropertyRemove = (propertyId: number) => {
+    const nextValues = { ...value.propertyValues };
+    delete nextValues[propertyId];
+    set({
+      properties: value.properties.filter((p) => p.property_id !== propertyId),
+      propertyValues: nextValues,
+    });
+  };
+
+  const statusPriority = (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-2">
+        <Label>{t("taskForm.statusLabel")}</Label>
+        <Select
+          value={value.statusId ? String(value.statusId) : undefined}
+          onValueChange={(selected) => {
+            const parsed = Number(selected);
+            if (Number.isFinite(parsed)) {
+              set({ statusId: parsed });
+            }
+          }}
+          disabled={disabled || statuses.length === 0}
+        >
+          <SelectTrigger
+            className="border-2"
+            style={currentStatus ? statusTriggerStyle(currentStatus) : undefined}
+            disabled={disabled || statuses.length === 0}
+          >
+            {currentStatus ? (
+              <SelectValue asChild>
+                <TaskStatusOption status={currentStatus} />
+              </SelectValue>
+            ) : (
+              <SelectValue placeholder={t("taskForm.selectStatus")} />
+            )}
+          </SelectTrigger>
+          <SelectContent>
+            {statuses.map((status) => (
+              <SelectItem key={status.id} value={String(status.id)}>
+                <TaskStatusOption status={status} />
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label>{t("taskForm.priorityLabel")}</Label>
+        <Select
+          value={value.priority}
+          onValueChange={(selected) => set({ priority: selected as TaskPriority })}
+          disabled={disabled}
+        >
+          <SelectTrigger disabled={disabled}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PRIORITY_ORDER.map((option) => (
+              <SelectItem key={option} value={option}>
+                {t(`priority.${option}` as never)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+
+  const dates = (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-2">
+        <Label htmlFor="task-start-date">{t("taskForm.startDateLabel")}</Label>
+        <DateTimePicker
+          id="task-start-date"
+          value={value.startDate}
+          onChange={(next) => set({ startDate: next })}
+          disabled={disabled}
+          placeholder={t("common:optional")}
+          calendarProps={{ hidden: { after: new Date(value.dueDate) } }}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="task-due-date">{t("taskForm.dueDateLabel")}</Label>
+        <DateTimePicker
+          id="task-due-date"
+          value={value.dueDate}
+          onChange={(next) => set({ dueDate: next })}
+          disabled={disabled}
+          placeholder={t("common:optional")}
+          calendarProps={{ hidden: { before: new Date(value.startDate) } }}
+        />
+      </div>
+    </div>
+  );
+
+  const assigneesTags = (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-2">
+        <Label>{t("taskForm.assigneesLabel")}</Label>
+        <MemberMultiSelect
+          scope={{ type: "project", projectId: projectId ?? null }}
+          selectedIds={value.assigneeIds}
+          selectedUsers={selectedAssignees}
+          onChange={(ids) => set({ assigneeIds: ids })}
+          disabled={disabled}
+          emptyMessage={t("taskForm.assigneesEmptyMessage")}
+          currentUserId={currentUserId}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>{t("taskForm.tagsLabel")}</Label>
+        <TagPicker
+          selectedTags={value.tags}
+          onChange={(tags) => set({ tags })}
+          disabled={disabled}
+          placeholder={t("taskForm.tagsPlaceholder")}
+        />
+      </div>
+    </div>
+  );
+
+  const recurrenceField = (
+    <TaskRecurrenceSelector
+      recurrence={value.recurrence}
+      onChange={(recurrence) => set({ recurrence })}
+      strategy={value.recurrenceStrategy}
+      onStrategyChange={(recurrenceStrategy) => set({ recurrenceStrategy })}
+      disabled={disabled}
+      referenceDate={recurrenceReferenceDate ?? value.dueDate ?? value.startDate}
+    />
+  );
+
+  const propertiesField = (
+    <section className="space-y-2">
+      <Label>{t("properties:title")}</Label>
+      <PropertyFields
+        properties={value.properties}
+        values={value.propertyValues}
+        onChange={handlePropertyChange}
+        onRemove={handlePropertyRemove}
+        disabled={disabled}
+        initiativeId={initiativeId}
+      />
+      <AddPropertyButton
+        initiativeId={initiativeId ?? 0}
+        currentPropertyIds={currentPropertyIds}
+        onAdd={handlePropertyAdd}
+        disabled={disabled || !initiativeId}
+      />
+    </section>
+  );
+
+  const descriptionField = descriptionSlot ?? (
+    <div className="space-y-2">
+      <Label htmlFor="task-description">{t("taskForm.descriptionLabel")}</Label>
+      <Textarea
+        id="task-description"
+        rows={3}
+        value={value.description}
+        onChange={(event) => set({ description: event.target.value })}
+        placeholder={t("taskForm.descriptionPlaceholder")}
+        disabled={disabled}
+      />
+    </div>
+  );
+
+  const titleField = (
+    <div className="space-y-2">
+      <Label htmlFor="task-title">{t("taskForm.titleLabel")}</Label>
+      <Input
+        id="task-title"
+        value={value.title}
+        onChange={(event) => set({ title: event.target.value })}
+        placeholder={t("taskForm.titlePlaceholder")}
+        required
+        disabled={disabled}
+        autoFocus={autoFocusTitle}
+      />
+    </div>
+  );
+
+  const advancedFields = (
+    <>
+      {descriptionField}
+      {statusPriority}
+      {dates}
+      {assigneesTags}
+      {recurrenceField}
+      {propertiesField}
+    </>
+  );
+
+  if (layout === "dialog") {
+    return (
+      <div className="space-y-4">
+        {titleField}
+        <Accordion type="single" collapsible>
+          <AccordionItem value="advanced">
+            <AccordionTrigger>{t("taskForm.advancedDetails")}</AccordionTrigger>
+            <AccordionContent className="space-y-4">{advancedFields}</AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {titleField}
+      {advancedFields}
+    </div>
+  );
+};

--- a/frontend/src/components/tasks/TaskForm.tsx
+++ b/frontend/src/components/tasks/TaskForm.tsx
@@ -55,6 +55,26 @@ export interface TaskFormValue {
   propertyValues: Record<number, unknown>;
 }
 
+/** Order-stable projection of a form value, for equality / dirty comparison. */
+export const serializeTaskFormValue = (value: TaskFormValue): string =>
+  JSON.stringify({
+    title: value.title,
+    description: value.description,
+    statusId: value.statusId,
+    priority: value.priority,
+    assigneeIds: [...value.assigneeIds].sort((a, b) => a - b),
+    startDate: value.startDate,
+    dueDate: value.dueDate,
+    recurrence: value.recurrence,
+    recurrenceStrategy: value.recurrenceStrategy,
+    tags: value.tags.map((tag) => tag.id).sort((a, b) => a - b),
+    properties: value.properties.map((p) => p.property_id).sort((a, b) => a - b),
+    propertyValues: Object.keys(value.propertyValues)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((id) => [id, value.propertyValues[id] ?? null]),
+  });
+
 /** A blank value for a fresh task form. */
 export const emptyTaskFormValue = (overrides: Partial<TaskFormValue> = {}): TaskFormValue => ({
   title: "",

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -183,6 +183,10 @@ export const TaskEditPage = () => {
   // Lets the delete/move/duplicate flows navigate without tripping the
   // unsaved-changes guard.
   const bypassGuardRef = useRef(false);
+  // Track which task the form was last seeded from, and whether it currently
+  // holds unsaved edits, so a background refetch doesn't overwrite them.
+  const seededTaskIdRef = useRef<number | null>(null);
+  const isDirtyRef = useRef(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [moveContext, setMoveContext] = useState<MoveTaskVariables | null>(null);
@@ -221,6 +225,14 @@ export const TaskEditPage = () => {
   useEffect(() => {
     if (taskQuery.data) {
       const task = taskQuery.data;
+      // Don't clobber unsaved edits: a background refetch of the same task
+      // must not overwrite pending field/tag/property changes. Only reseed
+      // when this is a different task, or the form has no unsaved edits.
+      const isNewTask = seededTaskIdRef.current !== task.id;
+      if (!isNewTask && isDirtyRef.current) {
+        return;
+      }
+      seededTaskIdRef.current = task.id;
       setTitle(task.title);
       setDescription(task.description ?? "");
       setStatusId(task.task_status_id);
@@ -486,6 +498,9 @@ export const TaskEditPage = () => {
     propertyValues,
   });
   const isDirty = !isReadOnly && savedSnapshot !== null && currentSnapshot !== savedSnapshot;
+  // Mirror into a ref so the task-load effect can read the latest dirtiness
+  // without adding it to the effect's dependency list.
+  isDirtyRef.current = isDirty;
 
   // Block in-app navigation while there are unsaved edits (unless a delete /
   // move / duplicate flow explicitly opted out via bypassGuardRef).

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -36,7 +36,7 @@ import { normalizePropertyValue } from "@/components/properties/PropertyFields";
 import { StatusMessage } from "@/components/StatusMessage";
 import { MoveTaskDialog } from "@/components/tasks/MoveTaskDialog";
 import { TaskChecklist } from "@/components/tasks/TaskChecklist";
-import { TaskForm, type TaskFormValue } from "@/components/tasks/TaskForm";
+import { serializeTaskFormValue, TaskForm, type TaskFormValue } from "@/components/tasks/TaskForm";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -133,26 +133,6 @@ const formValueFromTask = (task: TaskFormSource): TaskFormValue => ({
   properties: task.properties ?? [],
   propertyValues: seedPropertyValues(task.properties ?? []),
 });
-
-/** Order-stable projection of a form value for dirty comparison. */
-const serializeFormValue = (value: TaskFormValue): string =>
-  JSON.stringify({
-    title: value.title,
-    description: value.description,
-    statusId: value.statusId,
-    priority: value.priority,
-    assigneeIds: [...value.assigneeIds].sort((a, b) => a - b),
-    startDate: value.startDate,
-    dueDate: value.dueDate,
-    recurrence: value.recurrence,
-    recurrenceStrategy: value.recurrenceStrategy,
-    tags: value.tags.map((tag) => tag.id).sort((a, b) => a - b),
-    properties: value.properties.map((p) => p.property_id).sort((a, b) => a - b),
-    propertyValues: Object.keys(value.propertyValues)
-      .map(Number)
-      .sort((a, b) => a - b)
-      .map((id) => [id, value.propertyValues[id] ?? null]),
-  });
 
 type MoveTaskVariables = {
   targetProjectId: number;
@@ -253,7 +233,7 @@ export const TaskEditPage = () => {
       setTags(task.tags ?? []);
       setAttachedProperties(task.properties ?? []);
       setPropertyValues(seedPropertyValues(task.properties ?? []));
-      setSavedSnapshot(serializeFormValue(formValueFromTask(task)));
+      setSavedSnapshot(serializeTaskFormValue(formValueFromTask(task)));
     }
   }, [taskQuery.data]);
 
@@ -275,7 +255,7 @@ export const TaskEditPage = () => {
       setTags(updatedTask.tags ?? []);
       setAttachedProperties(updatedTask.properties ?? []);
       setPropertyValues(seedPropertyValues(updatedTask.properties ?? []));
-      setSavedSnapshot(serializeFormValue(formValueFromTask(updatedTask)));
+      setSavedSnapshot(serializeTaskFormValue(formValueFromTask(updatedTask)));
       toast.success(t("edit.taskUpdated"));
     },
   });
@@ -491,7 +471,7 @@ export const TaskEditPage = () => {
   // values against the last-saved snapshot. Computed from the individual
   // states + effective* fallbacks (kept before the early returns so the
   // guard hooks below run unconditionally).
-  const currentSnapshot = serializeFormValue({
+  const currentSnapshot = serializeTaskFormValue({
     title,
     description,
     statusId: statusId ?? task?.task_status_id ?? null,

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams, useRouter } from "@tanstack/react-router";
+import { Link, useBlocker, useParams, useRouter } from "@tanstack/react-router";
 import { format, formatDistanceToNow } from "date-fns";
 import {
   AlertCircle,
@@ -14,33 +14,29 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { getListCommentsApiV1GGuildIdCommentsGetQueryKey } from "@/api/generated/comments/comments";
 import type {
   CommentRead,
-  PropertyDefinitionRead,
   PropertySummary,
   TagSummary,
   TaskListRead,
   TaskListReadRecurrenceStrategy,
   TaskPriority,
+  TaskRead,
   TaskRecurrenceOutput,
 } from "@/api/generated/initiativeAPI.schemas";
 import { getReadTaskApiV1GGuildIdTasksTaskIdGetQueryKey } from "@/api/generated/tasks/tasks";
 import { invalidateProject, invalidateProjectTaskStatuses } from "@/api/query-keys";
 import { CommentSection } from "@/components/comments/CommentSection";
 import { Markdown } from "@/components/Markdown";
-import { MemberMultiSelect } from "@/components/members/MemberSearchSelect";
-import { TaskRecurrenceSelector } from "@/components/projects/TaskRecurrenceSelector";
-import { AddPropertyButton } from "@/components/properties/AddPropertyButton";
-import { PropertyList } from "@/components/properties/PropertyList";
+import { normalizePropertyValue } from "@/components/properties/PropertyFields";
 import { StatusMessage } from "@/components/StatusMessage";
-import { TagPicker } from "@/components/tags";
 import { MoveTaskDialog } from "@/components/tasks/MoveTaskDialog";
 import { TaskChecklist } from "@/components/tasks/TaskChecklist";
-import { statusTriggerStyle, TaskStatusOption } from "@/components/tasks/TaskStatusOption";
+import { TaskForm, type TaskFormValue } from "@/components/tasks/TaskForm";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -54,16 +50,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import { DateTimePicker } from "@/components/ui/date-time-picker";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
@@ -73,8 +60,6 @@ import { useComments } from "@/hooks/useComments";
 import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useProject, useProjectTaskStatuses, useWritableProjects } from "@/hooks/useProjects";
-import { useSetTaskProperties } from "@/hooks/useProperties";
-import { useSetTaskTags } from "@/hooks/useTags";
 import {
   useDeleteTask,
   useDuplicateTask,
@@ -87,7 +72,6 @@ import { toast } from "@/lib/chesterToast";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
 import { queryClient } from "@/lib/queryClient";
-import { PRIORITY_ORDER } from "@/lib/sorting";
 import {
   getAvatarSrc,
   getInitialsForUser,
@@ -106,6 +90,69 @@ const toLocalInputValue = (value?: string | null) => {
   const pad = (segment: number) => segment.toString().padStart(2, "0");
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
+
+/** Build the controlled ``propertyValues`` map from the task's server rows. */
+const seedPropertyValues = (properties: PropertySummary[]): Record<number, unknown> => {
+  const seeded: Record<number, unknown> = {};
+  for (const property of properties) {
+    seeded[property.property_id] = normalizePropertyValue(property);
+  }
+  return seeded;
+};
+
+/** The subset of a task read the form seeds from (shared by TaskRead / TaskListRead). */
+type TaskFormSource = Omit<
+  Pick<
+    TaskRead,
+    | "title"
+    | "description"
+    | "task_status_id"
+    | "priority"
+    | "start_date"
+    | "due_date"
+    | "recurrence"
+    | "recurrence_strategy"
+    | "tags"
+    | "properties"
+  >,
+  "assignees"
+> & { assignees?: { id: number }[] | null };
+
+/** The canonical form value for a loaded/saved task. */
+const formValueFromTask = (task: TaskFormSource): TaskFormValue => ({
+  title: task.title,
+  description: task.description ?? "",
+  statusId: task.task_status_id,
+  priority: task.priority,
+  assigneeIds: task.assignees?.map((assignee) => assignee.id) ?? [],
+  startDate: toLocalInputValue(task.start_date),
+  dueDate: toLocalInputValue(task.due_date),
+  recurrence: task.recurrence ?? null,
+  recurrenceStrategy: task.recurrence_strategy ?? "fixed",
+  tags: task.tags ?? [],
+  properties: task.properties ?? [],
+  propertyValues: seedPropertyValues(task.properties ?? []),
+});
+
+/** Order-stable projection of a form value for dirty comparison. */
+const serializeFormValue = (value: TaskFormValue): string =>
+  JSON.stringify({
+    title: value.title,
+    description: value.description,
+    statusId: value.statusId,
+    priority: value.priority,
+    assigneeIds: [...value.assigneeIds].sort((a, b) => a - b),
+    startDate: value.startDate,
+    dueDate: value.dueDate,
+    recurrence: value.recurrence,
+    recurrenceStrategy: value.recurrenceStrategy,
+    tags: value.tags.map((tag) => tag.id).sort((a, b) => a - b),
+    properties: value.properties.map((p) => p.property_id).sort((a, b) => a - b),
+    propertyValues: Object.keys(value.propertyValues)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((id) => [id, value.propertyValues[id] ?? null]),
+  });
 
 type MoveTaskVariables = {
   targetProjectId: number;
@@ -145,11 +192,17 @@ export const TaskEditPage = () => {
   const [recurrenceStrategy, setRecurrenceStrategy] =
     useState<TaskListReadRecurrenceStrategy | null>(null);
   const [tags, setTags] = useState<TagSummary[]>([]);
-  // Locally-added property definitions that don't yet have a persisted value.
-  // Rendered alongside `task.properties` as empty-valued stubs so the user
-  // can fill them in; PropertyList's PUT persists them once a value is set.
-  const [pendingProperties, setPendingProperties] = useState<PropertyDefinitionRead[]>([]);
-  const setTaskPropertiesMutation = useSetTaskProperties();
+  // Attached property rows (real server rows + locally-added stubs) and their
+  // controlled values. Both seed from the task and are batched into the main
+  // Save (PATCH) rather than saved immediately.
+  const [attachedProperties, setAttachedProperties] = useState<PropertySummary[]>([]);
+  const [propertyValues, setPropertyValues] = useState<Record<number, unknown>>({});
+  // Serialized snapshot of the last-saved form value; dirty state is a diff
+  // against it. Set whenever the form is seeded (task load / save success).
+  const [savedSnapshot, setSavedSnapshot] = useState<string | null>(null);
+  // Lets the delete/move/duplicate flows navigate without tripping the
+  // unsaved-changes guard.
+  const bypassGuardRef = useRef(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [moveContext, setMoveContext] = useState<MoveTaskVariables | null>(null);
@@ -169,8 +222,6 @@ export const TaskEditPage = () => {
   const commentsQuery = useComments(commentsQueryParams, {
     enabled: Number.isFinite(parsedTaskId),
   });
-
-  const setTaskTagsMutation = useSetTaskTags();
 
   // Aliased early so handleSubmit / effective* derivations both see it.
   // The duplicate declaration further down was kept until this fix; the
@@ -200,6 +251,9 @@ export const TaskEditPage = () => {
       setRecurrence(task.recurrence ?? null);
       setRecurrenceStrategy(task.recurrence_strategy ?? "fixed");
       setTags(task.tags ?? []);
+      setAttachedProperties(task.properties ?? []);
+      setPropertyValues(seedPropertyValues(task.properties ?? []));
+      setSavedSnapshot(serializeFormValue(formValueFromTask(task)));
     }
   }, [taskQuery.data]);
 
@@ -218,6 +272,10 @@ export const TaskEditPage = () => {
       setDueDate(toLocalInputValue(updatedTask.due_date));
       setRecurrence(updatedTask.recurrence ?? null);
       setRecurrenceStrategy(updatedTask.recurrence_strategy ?? "fixed");
+      setTags(updatedTask.tags ?? []);
+      setAttachedProperties(updatedTask.properties ?? []);
+      setPropertyValues(seedPropertyValues(updatedTask.properties ?? []));
+      setSavedSnapshot(serializeFormValue(formValueFromTask(updatedTask)));
       toast.success(t("edit.taskUpdated"));
     },
   });
@@ -225,6 +283,7 @@ export const TaskEditPage = () => {
   const duplicateTask = useDuplicateTask({
     onSuccess: (newTask) => {
       toast.success(t("edit.taskDuplicated"));
+      bypassGuardRef.current = true;
       router.navigate({ to: gp(`/tasks/${newTask.id}`) });
     },
   });
@@ -232,6 +291,7 @@ export const TaskEditPage = () => {
   const deleteTask = useDeleteTask({
     onSuccess: () => {
       toast.success(t("edit.taskDeleted"));
+      bypassGuardRef.current = true;
       router.navigate({ to: gp(`/projects/${projectId}`) });
     },
   });
@@ -298,6 +358,11 @@ export const TaskEditPage = () => {
       due_date: dueDate ? new Date(dueDate).toISOString() : null,
       recurrence: effectiveRecurrence,
       recurrence_strategy: effectiveRecurrence ? effectiveRecurrenceStrategy : "fixed",
+      tag_ids: tags.map((tag) => tag.id),
+      property_values: attachedProperties.map((property) => ({
+        property_id: property.property_id,
+        value: propertyValues[property.property_id] ?? null,
+      })),
     };
     updateTask.mutate({ taskId: parsedTaskId, data: payload as never });
   };
@@ -367,59 +432,6 @@ export const TaskEditPage = () => {
       }
     : null;
 
-  // Combine server-attached properties with locally-added stubs (definitions
-  // the user just picked but hasn't given a value yet). Drop any pending
-  // entries that the server has since returned as attached.
-  const serverProperties = useMemo<PropertySummary[]>(() => task?.properties ?? [], [task]);
-  const serverPropertyIds = useMemo(
-    () => new Set(serverProperties.map((p) => p.property_id)),
-    [serverProperties]
-  );
-  const combinedProperties = useMemo<PropertySummary[]>(() => {
-    const stubs: PropertySummary[] = pendingProperties
-      .filter((def) => !serverPropertyIds.has(def.id))
-      .map((def) => ({
-        property_id: def.id,
-        name: def.name,
-        type: def.type,
-        options: def.options ?? null,
-        value: null,
-      }));
-    return [...serverProperties, ...stubs];
-  }, [serverProperties, pendingProperties, serverPropertyIds]);
-  const combinedPropertyIds = useMemo(
-    () => combinedProperties.map((p) => p.property_id),
-    [combinedProperties]
-  );
-
-  useEffect(() => {
-    if (pendingProperties.length === 0) return;
-    setPendingProperties((prev) => prev.filter((def) => !serverPropertyIds.has(def.id)));
-  }, [serverPropertyIds, pendingProperties.length]);
-
-  const handleAddProperty = (definition: PropertyDefinitionRead) => {
-    setPendingProperties((prev) =>
-      prev.some((def) => def.id === definition.id) ? prev : [...prev, definition]
-    );
-    // Persist the attached-but-empty row immediately so the property
-    // survives a refresh before the user enters a value.
-    if (!Number.isFinite(parsedTaskId) || serverPropertyIds.has(definition.id)) return;
-    const values = [
-      ...serverProperties.map((p) => ({
-        property_id: p.property_id,
-        value:
-          p.type === "user_reference" && p.value && typeof p.value === "object" && "id" in p.value
-            ? (p.value as { id: number }).id
-            : (p.value ?? null),
-      })),
-      { property_id: definition.id, value: null },
-    ];
-    setTaskPropertiesMutation.mutate({
-      taskId: parsedTaskId,
-      values: { values },
-    });
-  };
-
   // Pure DAC: permissions inherited from project. Server-computed — already
   // capped at "read" when the guild's content is frozen (read_only status).
   const myLevel = project?.my_permission_level;
@@ -475,14 +487,43 @@ export const TaskEditPage = () => {
     }
   }, [isReadOnly]);
 
-  const handleTagsChange = (newTags: TagSummary[]) => {
-    setTags(newTags);
-    // Save tags immediately via separate endpoint
-    setTaskTagsMutation.mutate({
-      taskId: parsedTaskId,
-      tagIds: newTags.map((t) => t.id),
-    });
-  };
+  // Dirty tracking for the unsaved-changes guard: compare the current field
+  // values against the last-saved snapshot. Computed from the individual
+  // states + effective* fallbacks (kept before the early returns so the
+  // guard hooks below run unconditionally).
+  const currentSnapshot = serializeFormValue({
+    title,
+    description,
+    statusId: statusId ?? task?.task_status_id ?? null,
+    priority: effectivePriority,
+    assigneeIds,
+    startDate,
+    dueDate,
+    recurrence: effectiveRecurrence,
+    recurrenceStrategy: effectiveRecurrenceStrategy,
+    tags,
+    properties: attachedProperties,
+    propertyValues,
+  });
+  const isDirty = !isReadOnly && savedSnapshot !== null && currentSnapshot !== savedSnapshot;
+
+  // Block in-app navigation while there are unsaved edits (unless a delete /
+  // move / duplicate flow explicitly opted out via bypassGuardRef).
+  const blocker = useBlocker({
+    shouldBlockFn: () => isDirty && !bypassGuardRef.current,
+    withResolver: true,
+  });
+
+  // Guard full-page unloads (reload / tab close) while dirty.
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
 
   const handleBackClick = () => {
     router.history.back();
@@ -562,7 +603,95 @@ export const TaskEditPage = () => {
   const currentStatus =
     taskStatuses.find((item) => item.id === effectiveStatusId) ??
     (task && task.task_status_id === effectiveStatusId ? task.task_status : null);
-  const statusSelectDisabled = isReadOnly || taskStatuses.length === 0;
+
+  // Assemble the shared TaskForm value from the page's individual states. The
+  // effective* fallbacks keep the form from flashing defaults during the
+  // one-render gap between "task loaded" and "load effect ran".
+  const formValue: TaskFormValue = {
+    title,
+    description,
+    statusId: effectiveStatusId,
+    priority: effectivePriority,
+    assigneeIds,
+    startDate,
+    dueDate,
+    recurrence: effectiveRecurrence,
+    recurrenceStrategy: effectiveRecurrenceStrategy,
+    tags,
+    properties: attachedProperties,
+    propertyValues,
+  };
+
+  const handleFormChange = (next: TaskFormValue) => {
+    setTitle(next.title);
+    setDescription(next.description);
+    setStatusId(next.statusId);
+    setPriority(next.priority);
+    setAssigneeIds(next.assigneeIds);
+    setStartDate(next.startDate);
+    setDueDate(next.dueDate);
+    setRecurrence(next.recurrence);
+    setRecurrenceStrategy(next.recurrenceStrategy);
+    setTags(next.tags);
+    setAttachedProperties(next.properties);
+    setPropertyValues(next.propertyValues);
+  };
+
+  // The editor's richer description block (markdown preview + AI generate +
+  // edit/preview toggle), passed to TaskForm as its description slot.
+  const descriptionSlot = (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Label htmlFor="task-description">{t("edit.descriptionLabel")}</Label>
+        {!isReadOnly ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 text-xs"
+            onClick={() => setIsEditingDescription((prev) => !prev)}
+          >
+            {isEditingDescription ? t("edit.preview") : t("common:edit")}
+          </Button>
+        ) : null}
+        {!isReadOnly && aiEnabled ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 text-xs"
+            onClick={() => generateDescription.mutate(parsedTaskId)}
+            disabled={generateDescription.isPending}
+          >
+            {generateDescription.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Sparkles className="h-3 w-3" />
+            )}
+            {t("edit.aiGenerate")}
+          </Button>
+        ) : null}
+      </div>
+      {isEditingDescription && !isReadOnly ? (
+        <Textarea
+          id="task-description"
+          rows={6}
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder={t("edit.descriptionPlaceholder")}
+          disabled={isReadOnly}
+        />
+      ) : description ? (
+        <div className="rounded-md border border-border/70 border-dashed bg-muted/40 px-3 py-2">
+          <Markdown content={description} />
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-sm italic">
+          {isReadOnly ? t("edit.noDescriptionReadOnly") : t("edit.noDescription")}
+        </p>
+      )}
+    </div>
+  );
 
   return (
     <div className="space-y-6">
@@ -650,208 +779,19 @@ export const TaskEditPage = () => {
               </p>
             ) : null}
             <form className="space-y-6" onSubmit={handleSubmit}>
-              <div className="space-y-2">
-                <Label htmlFor="task-title">{t("edit.titleLabel")}</Label>
-                <Input
-                  id="task-title"
-                  value={title}
-                  onChange={(event) => setTitle(event.target.value)}
-                  placeholder={t("edit.titlePlaceholder")}
-                  required
-                  disabled={isReadOnly}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <Label htmlFor="task-description">{t("edit.descriptionLabel")}</Label>
-                  {!isReadOnly ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-8 px-2 text-xs"
-                      onClick={() => setIsEditingDescription((prev) => !prev)}
-                    >
-                      {isEditingDescription ? t("edit.preview") : t("common:edit")}
-                    </Button>
-                  ) : null}
-                  {!isReadOnly && aiEnabled ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-8 px-2 text-xs"
-                      onClick={() => generateDescription.mutate(parsedTaskId)}
-                      disabled={generateDescription.isPending}
-                    >
-                      {generateDescription.isPending ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <Sparkles className="h-3 w-3" />
-                      )}
-                      {t("edit.aiGenerate")}
-                    </Button>
-                  ) : null}
-                </div>
-                {isEditingDescription && !isReadOnly ? (
-                  <Textarea
-                    id="task-description"
-                    rows={6}
-                    value={description}
-                    onChange={(event) => setDescription(event.target.value)}
-                    placeholder={t("edit.descriptionPlaceholder")}
-                    disabled={isReadOnly}
-                  />
-                ) : description ? (
-                  <div className="rounded-md border border-border/70 border-dashed bg-muted/40 px-3 py-2">
-                    <Markdown content={description} />
-                  </div>
-                ) : (
-                  <p className="text-muted-foreground text-sm italic">
-                    {isReadOnly ? t("edit.noDescriptionReadOnly") : t("edit.noDescription")}
-                  </p>
-                )}
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <Label>{t("edit.statusLabel")}</Label>
-                  <Select
-                    value={effectiveStatusId ? String(effectiveStatusId) : undefined}
-                    onValueChange={(value) => {
-                      const parsed = Number(value);
-                      if (Number.isFinite(parsed)) {
-                        setStatusId(parsed);
-                      }
-                    }}
-                    disabled={statusSelectDisabled}
-                  >
-                    <SelectTrigger
-                      className="border-2"
-                      style={currentStatus ? statusTriggerStyle(currentStatus) : undefined}
-                      disabled={statusSelectDisabled}
-                    >
-                      {currentStatus ? (
-                        <SelectValue asChild>
-                          <TaskStatusOption status={currentStatus} />
-                        </SelectValue>
-                      ) : (
-                        <SelectValue placeholder={t("edit.selectStatus")} />
-                      )}
-                    </SelectTrigger>
-                    <SelectContent>
-                      {taskStatuses.map((value) => (
-                        <SelectItem key={value.id} value={String(value.id)}>
-                          <TaskStatusOption status={value} />
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label>{t("edit.priorityLabel")}</Label>
-                  <Select
-                    value={effectivePriority}
-                    onValueChange={(value) => setPriority(value as TaskPriority)}
-                    disabled={isReadOnly}
-                  >
-                    <SelectTrigger disabled={isReadOnly}>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {PRIORITY_ORDER.map((value) => (
-                        <SelectItem key={value} value={value}>
-                          {t(`priority.${value}` as never)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="task-start-date">{t("edit.startDateLabel")}</Label>
-                  <DateTimePicker
-                    id="task-start-date"
-                    value={startDate}
-                    onChange={setStartDate}
-                    disabled={isReadOnly}
-                    placeholder={t("common:optional")}
-                    calendarProps={{
-                      hidden: {
-                        after: new Date(dueDate),
-                      },
-                    }}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="task-due-date">{t("edit.dueDateLabel")}</Label>
-                  <DateTimePicker
-                    id="task-due-date"
-                    value={dueDate}
-                    onChange={setDueDate}
-                    disabled={isReadOnly}
-                    placeholder={t("common:optional")}
-                    calendarProps={{
-                      hidden: {
-                        before: new Date(startDate),
-                      },
-                    }}
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <Label>{t("edit.assigneesLabel")}</Label>
-                  <MemberMultiSelect
-                    scope={{ type: "project", projectId: projectId ?? null }}
-                    selectedIds={assigneeIds}
-                    selectedUsers={task?.assignees}
-                    onChange={setAssigneeIds}
-                    disabled={isReadOnly}
-                    emptyMessage={t("edit.assigneesEmptyMessage")}
-                    currentUserId={currentUser?.id}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>{t("edit.tagsLabel")}</Label>
-                  <TagPicker
-                    selectedTags={tags}
-                    onChange={handleTagsChange}
-                    disabled={isReadOnly}
-                    placeholder={t("edit.tagsPlaceholder")}
-                  />
-                </div>
-              </div>
-
-              <TaskRecurrenceSelector
-                recurrence={effectiveRecurrence}
-                onChange={setRecurrence}
-                strategy={effectiveRecurrenceStrategy}
-                onStrategyChange={setRecurrenceStrategy}
+              <TaskForm
+                layout="page"
                 disabled={isReadOnly}
-                referenceDate={dueDate || startDate || task?.due_date || task?.start_date}
+                value={formValue}
+                onChange={handleFormChange}
+                statuses={taskStatuses}
+                projectId={projectId ?? null}
+                initiativeId={project?.initiative_id ?? null}
+                currentUserId={currentUser?.id}
+                selectedAssignees={task?.assignees}
+                descriptionSlot={descriptionSlot}
+                recurrenceReferenceDate={dueDate || startDate || task?.due_date || task?.start_date}
               />
-
-              <section className="space-y-2">
-                <Label>{t("properties:title")}</Label>
-                <PropertyList
-                  entityKind="task"
-                  entityId={parsedTaskId}
-                  properties={combinedProperties}
-                  disabled={isReadOnly}
-                  initiativeId={project?.initiative_id}
-                />
-                <AddPropertyButton
-                  initiativeId={project?.initiative_id ?? 0}
-                  currentPropertyIds={combinedPropertyIds}
-                  onAdd={handleAddProperty}
-                  disabled={isReadOnly || !project?.initiative_id}
-                />
-              </section>
 
               <div className="flex flex-wrap gap-3">
                 <Button type="submit" disabled={updateTask.isPending || isReadOnly}>
@@ -968,6 +908,19 @@ export const TaskEditPage = () => {
           setShowDeleteConfirm(false);
         }}
         isLoading={deleteTask.isPending}
+        destructive
+      />
+
+      <ConfirmDialog
+        open={blocker.status === "blocked"}
+        onOpenChange={(open) => {
+          if (!open) blocker.reset?.();
+        }}
+        title={t("edit.unsavedTitle")}
+        description={t("edit.unsavedBody")}
+        confirmLabel={t("edit.unsavedLeave")}
+        cancelLabel={t("edit.unsavedStay")}
+        onConfirm={() => blocker.proceed?.()}
         destructive
       />
     </div>


### PR DESCRIPTION
## Problem

The new-task dialog and the task editor were separate implementations of the same
form, and task creation couldn't set **status**, **tags**, or **custom properties** —
those only became available after the task already existed (via per-change PUTs).
Task #1983 asked to align the two flows and make tags/properties settable on create
(which needs backend changes).

## Changes

- **Shared form.** New [`TaskForm`](frontend/src/components/tasks/TaskForm.tsx) is one
  fully-controlled field set used by both the create dialog and the editor, driven by a
  single `value`/`onChange` object. Extracted [`PropertyFields`](frontend/src/components/properties/PropertyFields.tsx)
  as the controlled property core (the autosaving `PropertyList` stays for docs/events).
- **Backend.** `TaskCreate`/`TaskUpdate` gain `tag_ids` + `property_values`; [`create_task` and `update_task`](backend/app/api/v1/tenant_endpoints/tasks.py)
  attach them in the same transaction via the existing tag/property services, rolling
  back so an invalid tag/property leaves no orphan task. Regenerated Orval types.
- **Create flow.** The dialog now exposes a status picker (defaults to the project
  default), tags, and custom properties — all sent in one POST ([ProjectTaskComposer](frontend/src/components/projects/ProjectTaskComposer.tsx), [ProjectTasksSection](frontend/src/components/projects/ProjectTasksSection.tsx)).
- **Editor.** Tags/properties now save with the main **Save** (one PATCH) instead of
  immediately ([TaskEditPage](frontend/src/pages/TaskEditPage.tsx)). Added an
  unsaved-changes navigation guard (`useBlocker` + confirm + `beforeunload`).
- **Dialog UX.** The create dialog blocks a backdrop-click close only while it has
  unsaved input; an untouched dialog closes on outside click. Escape/Cancel always close.
- i18n: added `taskForm.*` and `edit.unsaved*` keys to en/de/es/fr.

## Testing

- Backend: `pytest app/api/v1/tenant_endpoints/tasks_test.py tasks_properties_test.py tags_test.py` → 70 passed (incl. new create/update-with-tags/properties/status + rollback tests); `ruff check app` clean.
- Frontend: `pnpm typecheck` clean; `pnpm biome check` clean on changed files; `./scripts/test-changed.sh` → 932 passed; locale-parity test passes.

Fixes #1983