### PR TITLE
Live-update relative times without reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In the task editor, tags and custom properties now save with the rest of the form when you click **Save** (previously they saved immediately on change). The editor warns before you navigate away with unsaved changes, and the new-task dialog no longer closes if you click outside it (use Escape or Cancel).
 
+### Fixed
+
+- Relative timestamps across the app (e.g. "2 minutes ago" on task start/due dates, document cards and detail pages, comments, project activity, trash, import/export jobs, and the My Projects / My Documents lists) now refresh in place as time passes, instead of only updating on a page reload. A single shared clock drives every label, and each one re-renders only when its displayed text actually changes, so even large tables stay fast.
+
 ## [0.58.0] - 2026-07-21
 
 ### Security

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -1,11 +1,10 @@
-import { formatDistanceToNow } from "date-fns";
 import { Pencil, Reply, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { useDateLocale } from "@/hooks/useDateLocale";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { resolveUploadUrl } from "@/lib/uploadUrl";
 import { getInitialsForUser, getUserDisplayName, isAnonymizedUser } from "@/lib/userDisplay";
 
@@ -49,7 +48,7 @@ export const CommentThread = ({
   projectNames = new Map(),
 }: CommentThreadProps) => {
   const { t } = useTranslation(["documents", "common"]);
-  const dateLocale = useDateLocale();
+  const relativeCreatedAt = useRelativeTime(comment.created_at);
   const [isReplying, setIsReplying] = useState(false);
   const [replyContent, setReplyContent] = useState("");
   const [isEditing, setIsEditing] = useState(false);
@@ -100,10 +99,7 @@ export const CommentThread = ({
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-xs">
               <span className="font-medium text-foreground">{displayName}</span>
               <span className="whitespace-nowrap">
-                {formatDistanceToNow(new Date(comment.created_at), {
-                  addSuffix: true,
-                  locale: dateLocale,
-                })}
+                {relativeCreatedAt}
                 {isEdited && (
                   <span className="ml-1 text-muted-foreground">{t("comments.edited")}</span>
                 )}

--- a/frontend/src/components/dashboard/RecentCommentsList.tsx
+++ b/frontend/src/components/dashboard/RecentCommentsList.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router";
-import { formatDistanceToNow, parseISO } from "date-fns";
 import { MessageSquare } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -7,6 +6,7 @@ import type { RecentActivityEntry } from "@/api/generated/initiativeAPI.schemas"
 import { CommentContent } from "@/components/comments/CommentContent";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGuildPath } from "@/lib/guildUrl";
 import { getInitials } from "@/lib/initials";
@@ -89,9 +89,10 @@ export function RecentCommentsList({ comments, isLoading }: RecentCommentsListPr
                       <span className="truncate font-medium text-sm">
                         {getUserDisplayName(entry.author, "Unknown")}
                       </span>
-                      <span className="shrink-0 text-muted-foreground text-xs">
-                        {formatDistanceToNow(parseISO(entry.created_at), { addSuffix: true })}
-                      </span>
+                      <RelativeTime
+                        date={entry.created_at}
+                        className="shrink-0 text-muted-foreground text-xs"
+                      />
                     </div>
                     {contextParts.length > 0 && (
                       <p className="truncate text-muted-foreground text-xs">

--- a/frontend/src/components/documents/DocumentBacklinks.tsx
+++ b/frontend/src/components/documents/DocumentBacklinks.tsx
@@ -1,12 +1,11 @@
 import { Link } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
 import { ChevronDown, ChevronRight, FileText, Link2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { useDateLocale } from "@/hooks/useDateLocale";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { useDocumentBacklinks } from "@/hooks/useDocuments";
 import { useGuildPath } from "@/lib/guildUrl";
 
@@ -16,7 +15,6 @@ interface DocumentBacklinksProps {
 
 export function DocumentBacklinks({ documentId }: DocumentBacklinksProps) {
   const { t } = useTranslation("documents");
-  const dateLocale = useDateLocale();
   const [isOpen, setIsOpen] = useState(true);
   const gp = useGuildPath();
 
@@ -67,12 +65,10 @@ export function DocumentBacklinks({ documentId }: DocumentBacklinksProps) {
                   <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
                   <div className="flex-1 truncate">
                     <span className="text-sm group-hover:underline">{backlink.title}</span>
-                    <span className="ml-2 text-muted-foreground text-xs">
-                      {formatDistanceToNow(new Date(backlink.updated_at), {
-                        addSuffix: true,
-                        locale: dateLocale,
-                      })}
-                    </span>
+                    <RelativeTime
+                      date={backlink.updated_at}
+                      className="ml-2 text-muted-foreground text-xs"
+                    />
                   </div>
                 </Link>
               </li>

--- a/frontend/src/components/documents/DocumentCard.tsx
+++ b/frontend/src/components/documents/DocumentCard.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
 import { useTranslation } from "react-i18next";
 
 import type { DocumentSummary } from "@/api/generated/initiativeAPI.schemas";
@@ -8,7 +7,7 @@ import { nonEmptyPropertySummaries } from "@/components/properties/propertyHelpe
 import { TagBadge } from "@/components/tags/TagBadge";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useDateLocale } from "@/hooks/useDateLocale";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { getDocumentIcon, getDocumentIconColor, getFileTypeLabel } from "@/lib/fileUtils";
 import { useGuildPath } from "@/lib/guildUrl";
 import { matchSmartLinkProvider } from "@/lib/smartLinkProviders";
@@ -22,7 +21,7 @@ interface DocumentCardProps {
 
 export const DocumentCard = ({ document, className }: DocumentCardProps) => {
   const { t } = useTranslation("documents");
-  const dateLocale = useDateLocale();
+  const relativeUpdatedAt = useRelativeTime(document.updated_at);
   const gp = useGuildPath();
   const projectCount = document.projects.length;
   const commentCount = document.comment_count ?? 0;
@@ -115,12 +114,7 @@ export const DocumentCard = ({ document, className }: DocumentCardProps) => {
             </TooltipProvider>
           </div>
           <p className="text-muted-foreground text-xs">
-            {t("card.updated", {
-              date: formatDistanceToNow(new Date(document.updated_at), {
-                addSuffix: true,
-                locale: dateLocale,
-              }),
-            })}
+            {t("card.updated", { date: relativeUpdatedAt })}
           </p>
           {document.tags && document.tags.length > 0 ? (
             <div className="flex flex-wrap gap-1">

--- a/frontend/src/components/documents/DocumentsListView.tsx
+++ b/frontend/src/components/documents/DocumentsListView.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@tanstack/react-router";
 import type { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
-import { formatDistanceToNow } from "date-fns";
 import { FileSpreadsheet, FileText, Presentation } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -13,7 +12,7 @@ import { TagBadge } from "@/components/tags/TagBadge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
-import { useDateLocale } from "@/hooks/useDateLocale";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
 import { useProperties } from "@/hooks/useProperties";
 import { getFileTypeLabel } from "@/lib/fileUtils";
@@ -97,7 +96,6 @@ export const DocumentsListView = ({
   onSortingChange,
 }: DocumentsListViewProps) => {
   const { t } = useTranslation(["documents", "common"]);
-  const dateLocale = useDateLocale();
 
   const { data: allPropertyDefinitions = [] } = useProperties();
   const propertyColumns = useMemo(
@@ -148,16 +146,11 @@ export const DocumentsListView = ({
             </div>
           );
         },
-        cell: ({ row }) => {
-          const updatedAt = new Date(row.original.updated_at);
-          return (
-            <div className="min-w-[100px] sm:min-w-0">
-              <span className="text-muted-foreground">
-                {formatDistanceToNow(updatedAt, { addSuffix: true, locale: dateLocale })}
-              </span>
-            </div>
-          );
-        },
+        cell: ({ row }) => (
+          <div className="min-w-[100px] sm:min-w-0">
+            <RelativeTime date={row.original.updated_at} className="text-muted-foreground" />
+          </div>
+        ),
         sortingFn: dateSortingFn,
       },
       {
@@ -225,7 +218,7 @@ export const DocumentsListView = ({
         },
       },
     ],
-    [t, dateLocale]
+    [t]
   );
 
   const columnsWithProperties = useMemo<ColumnDef<DocumentSummary>[]>(() => {

--- a/frontend/src/components/documents/FileDocumentViewer.tsx
+++ b/frontend/src/components/documents/FileDocumentViewer.tsx
@@ -1,4 +1,3 @@
-import { formatDistanceToNow } from "date-fns";
 import {
   Download,
   ExternalLink,
@@ -23,12 +22,12 @@ import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { useDateLocale } from "@/hooks/useDateLocale";
 import {
   useDeleteDocumentVersion,
   useDocumentVersions,
   useUploadDocumentVersion,
 } from "@/hooks/useDocuments";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { toast } from "@/lib/chesterToast";
 import { formatBytes, getFileExtension, getFileTypeLabel } from "@/lib/fileUtils";
 import { resolveDocumentDownloadUrl, resolveDocumentVersionDownloadUrl } from "@/lib/uploadUrl";
@@ -66,6 +65,16 @@ interface FileDocumentViewerProps {
   isOwner?: boolean;
 }
 
+/**
+ * Live "Version N · M ago" label for one version row. A component (not an inline
+ * hook) so `useRelativeTime` can run per row inside the versions map.
+ */
+const VersionLabel = ({ number, createdAt }: { number: number; createdAt: string }) => {
+  const { t } = useTranslation(["documents", "common"]);
+  const relative = useRelativeTime(createdAt);
+  return <>{t("versions.versionLabel", { number, date: relative })}</>;
+};
+
 export const FileDocumentViewer = ({
   documentId,
   guildId,
@@ -77,7 +86,6 @@ export const FileDocumentViewer = ({
   isOwner = false,
 }: FileDocumentViewerProps) => {
   const { t } = useTranslation(["documents", "common"]);
-  const dateLocale = useDateLocale();
 
   // ── Version history ─────────────────────────────────────────────────────
   const { data: versions } = useDocumentVersions(documentId);
@@ -262,9 +270,6 @@ export const FileDocumentViewer = ({
   const OfficeIcon = isExcel ? FileSpreadsheet : isPowerPoint ? Presentation : FileText;
   const iconColor = isExcel ? "text-green-600" : isPowerPoint ? "text-orange-500" : "text-blue-600";
 
-  const formatVersionDate = (createdAt: string) =>
-    formatDistanceToNow(new Date(createdAt), { addSuffix: true, locale: dateLocale });
-
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -332,10 +337,7 @@ export const FileDocumentViewer = ({
                           className="flex flex-1 items-center gap-2 rounded px-1.5 py-1.5 text-left text-sm hover:bg-accent"
                         >
                           <span className="flex-1 truncate">
-                            {t("versions.versionLabel", {
-                              number: v.version_number,
-                              date: formatVersionDate(v.created_at),
-                            })}
+                            <VersionLabel number={v.version_number} createdAt={v.created_at} />
                           </span>
                           {v.is_current && (
                             <Badge variant="outline" className="shrink-0">

--- a/frontend/src/components/imports/DataJobsTable.tsx
+++ b/frontend/src/components/imports/DataJobsTable.tsx
@@ -1,4 +1,3 @@
-import { formatDistanceToNow } from "date-fns";
 import { Download, FileText, Loader2, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -14,6 +13,7 @@ import { ImportReport } from "@/components/imports/ImportReport";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { RelativeTime } from "@/components/ui/relative-time";
 import {
   Table,
   TableBody,
@@ -23,7 +23,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
-import { useDateLocale } from "@/hooks/useDateLocale";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { downloadExportArtifact } from "@/lib/exportDownload";
@@ -68,7 +67,6 @@ function exportDisplayStatus(job: ExportJobRead): string {
 export function DataJobsTable() {
   const { t } = useTranslation(["imports", "exports"]);
   const guildId = useActiveGuildId();
-  const dateLocale = useDateLocale();
   const [reportJob, setReportJob] = useState<ImportJobRead | null>(null);
 
   const exportsQuery = useListExportJobsApiV1GGuildIdExportsGet(guildId, {
@@ -176,10 +174,7 @@ export function DataJobsTable() {
                   </Badge>
                 </TableCell>
                 <TableCell className="hidden text-muted-foreground text-sm sm:table-cell">
-                  {formatDistanceToNow(new Date(row.job.created_at), {
-                    addSuffix: true,
-                    locale: dateLocale,
-                  })}
+                  <RelativeTime date={row.job.created_at} />
                 </TableCell>
                 <TableCell className="text-right">
                   {row.direction === "export" && status === "done" && (

--- a/frontend/src/components/projects/ProjectActivitySidebar.tsx
+++ b/frontend/src/components/projects/ProjectActivitySidebar.tsx
@@ -1,6 +1,5 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
 import { ChevronRight, MessageSquare } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -14,8 +13,8 @@ import {
   projectActivityFeedApiV1GGuildIdProjectsProjectIdActivityGet,
 } from "@/api/generated/projects/projects";
 import { Button } from "@/components/ui/button";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
-import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
 import { guildPath } from "@/lib/guildUrl";
 import { cn } from "@/lib/utils";
@@ -28,7 +27,6 @@ export const ProjectActivitySidebar = ({ projectId }: ProjectActivitySidebarProp
   const { activeGuildId } = useGuilds();
   const guildId = useActiveGuildId();
   const { t } = useTranslation(["projects", "common"]);
-  const dateLocale = useDateLocale();
   const [collapsed, setCollapsed] = useState(true);
   const isEnabled = Boolean(projectId && !collapsed);
 
@@ -133,12 +131,7 @@ export const ProjectActivitySidebar = ({ projectId }: ProjectActivitySidebarProp
                     >
                       <div className="flex items-center justify-between text-muted-foreground text-xs">
                         <span className="font-medium text-foreground">{authorName}</span>
-                        <span>
-                          {formatDistanceToNow(new Date(entry.created_at), {
-                            addSuffix: true,
-                            locale: dateLocale,
-                          })}
-                        </span>
+                        <RelativeTime date={entry.created_at} showTitle={false} />
                       </div>
                       <p className="text-foreground text-sm">
                         {t("activitySidebar.commentedOn")}{" "}

--- a/frontend/src/components/projects/ProjectDocumentsSection.tsx
+++ b/frontend/src/components/projects/ProjectDocumentsSection.tsx
@@ -1,4 +1,3 @@
-import { formatDistanceToNow } from "date-fns";
 import { ChevronDown, ChevronUp, FilePlus, Link, Loader2, Unlink } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -29,9 +28,9 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
-import { useDateLocale } from "@/hooks/useDateLocale";
 import { useDocumentAutocomplete, useDocumentsList } from "@/hooks/useDocuments";
 import { useAttachProjectDocument, useDetachProjectDocument } from "@/hooks/useProjects";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { toast } from "@/lib/chesterToast";
 import { MAX_DOCUMENT_IDS } from "@/lib/documentUtils";
 import { getItem, setItem } from "@/lib/storage";
@@ -44,6 +43,17 @@ type ProjectDocumentsSectionProps = {
   canAttach: boolean;
 };
 
+/**
+ * Live "Attached N ago" label for one attached document. A component (not an
+ * inline hook) so `useRelativeTime` can run per row inside the documents map.
+ * `addSuffix` is off because the "ago" wording lives in the translation string.
+ */
+const AttachedDocumentTime = ({ attachedAt }: { attachedAt: string }) => {
+  const { t } = useTranslation("projects");
+  const relative = useRelativeTime(attachedAt, { addSuffix: false });
+  return <>{t("documents.attachedAgo", { time: relative })}</>;
+};
+
 export const ProjectDocumentsSection = ({
   projectId,
   initiativeId,
@@ -52,7 +62,6 @@ export const ProjectDocumentsSection = ({
   canAttach,
 }: ProjectDocumentsSectionProps) => {
   const { t } = useTranslation("projects");
-  const dateLocale = useDateLocale();
   const guildId = useActiveGuildId();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -265,11 +274,7 @@ export const ProjectDocumentsSection = ({
                         ) : null}
                       </div>
                       <div className="text-muted-foreground text-xs">
-                        {t("documents.attachedAgo", {
-                          time: formatDistanceToNow(new Date(doc.attached_at), {
-                            locale: dateLocale,
-                          }),
-                        })}
+                        <AttachedDocumentTime attachedAt={doc.attached_at} />
                       </div>
                     </div>
                   </CarouselItem>

--- a/frontend/src/components/tasks/TaskDateCell.tsx
+++ b/frontend/src/components/tasks/TaskDateCell.tsx
@@ -1,8 +1,9 @@
-import { formatDistance, isPast } from "date-fns";
+import { formatDistance } from "date-fns";
 import { memo, useMemo } from "react";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDateLocale } from "@/hooks/useDateLocale";
+import { useLiveClockValue } from "@/hooks/useRelativeTime";
 
 type DateCellProps = {
   date: string | null | undefined;
@@ -11,21 +12,36 @@ type DateCellProps = {
 };
 
 /**
- * Memoized date cell to avoid re-computing formatDistance on every render
+ * Memoized date cell for task tables. The relative label and its past-due
+ * styling both refresh in place as time passes (via the shared clock in
+ * `useLiveClockValue`) without a page reload, while the absolute tooltip date is
+ * memoized since it never changes.
  */
 export const DateCell = memo(({ date, isPastVariant, isDone }: DateCellProps) => {
   const dateLocale = useDateLocale();
-  const dateObj = useMemo(() => (date ? new Date(date) : null), [date]);
-  const isPastDate = useMemo(() => (dateObj ? isPast(dateObj) : false), [dateObj]);
-  const relativeDate = useMemo(
-    () =>
-      dateObj ? formatDistance(dateObj, new Date(), { addSuffix: true, locale: dateLocale }) : null,
-    [dateObj, dateLocale]
-  );
+  const time = useMemo(() => {
+    if (!date) {
+      return null;
+    }
+    const parsed = new Date(date).getTime();
+    return Number.isNaN(parsed) ? null : parsed;
+  }, [date]);
+
+  // A single snapshot string encodes both the label and whether the date is in
+  // the past, so the cell re-renders exactly when either changes (and never when
+  // neither does). "1|2 minutes ago" → past, "0|in 3 days" → future.
+  const snapshot = useLiveClockValue((now) => {
+    if (time == null) {
+      return null;
+    }
+    const relative = formatDistance(time, now, { addSuffix: true, locale: dateLocale });
+    return `${time < now ? "1" : "0"}|${relative}`;
+  });
+
   const formattedDate = useMemo(
     () =>
-      dateObj
-        ? dateObj.toLocaleString(dateLocale.code, {
+      time != null
+        ? new Date(time).toLocaleString(dateLocale.code, {
             weekday: "long",
             year: "numeric",
             month: "long",
@@ -34,12 +50,15 @@ export const DateCell = memo(({ date, isPastVariant, isDone }: DateCellProps) =>
             minute: "2-digit",
           })
         : null,
-    [dateObj, dateLocale]
+    [time, dateLocale]
   );
 
-  if (!relativeDate) {
+  if (snapshot == null) {
     return <span className="text-muted-foreground">—</span>;
   }
+
+  const isPastDate = snapshot[0] === "1";
+  const relativeDate = snapshot.slice(2);
 
   const className = (() => {
     if (!isPastDate || !isPastVariant) {

--- a/frontend/src/components/trash/TrashTable.tsx
+++ b/frontend/src/components/trash/TrashTable.tsx
@@ -1,4 +1,3 @@
-import { formatDistanceToNow } from "date-fns";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -10,6 +9,7 @@ import type {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { RelativeTime } from "@/components/ui/relative-time";
 import {
   Table,
   TableBody,
@@ -42,14 +42,6 @@ interface TrashTableProps {
   // would always 403.
   showPurgeAction: boolean;
 }
-
-const formatRelative = (iso: string): string => {
-  try {
-    return formatDistanceToNow(new Date(iso), { addSuffix: true });
-  } catch {
-    return iso;
-  }
-};
 
 export const TrashTable = ({ variant, showPurgeAction }: TrashTableProps) => {
   const { t } = useTranslation("trash");
@@ -175,10 +167,14 @@ export const TrashTable = ({ variant, showPurgeAction }: TrashTableProps) => {
                 <TableCell className="font-medium">{item.name || `#${item.entity_id}`}</TableCell>
                 <TableCell className="text-muted-foreground">{item.deleted_by_display}</TableCell>
                 <TableCell className="text-muted-foreground">
-                  {formatRelative(item.deleted_at)}
+                  <RelativeTime date={item.deleted_at} fallback={item.deleted_at} />
                 </TableCell>
                 <TableCell className="text-muted-foreground">
-                  {item.purge_at ? formatRelative(item.purge_at) : t("neverPurges")}
+                  {item.purge_at ? (
+                    <RelativeTime date={item.purge_at} fallback={item.purge_at} />
+                  ) : (
+                    t("neverPurges")
+                  )}
                 </TableCell>
                 <TableCell>
                   <div className="flex justify-end gap-2">

--- a/frontend/src/components/ui/relative-time.tsx
+++ b/frontend/src/components/ui/relative-time.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+import { useDateLocale } from "@/hooks/useDateLocale";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
+
+type RelativeTimeProps = {
+  /** Timestamp to describe relative to now. */
+  date: Date | string | number | null | undefined;
+  /** Append/prepend "ago"/"in" (date-fns `addSuffix`). Defaults to `true`. */
+  addSuffix?: boolean;
+  /** Rendered when `date` is nullish or unparseable. */
+  fallback?: React.ReactNode;
+  className?: string;
+  /**
+   * Show the absolute date in a native tooltip on hover. Defaults to `true`.
+   * Set `false` inside cells that provide their own richer tooltip.
+   */
+  showTitle?: boolean;
+};
+
+/**
+ * A relative timestamp ("2 minutes ago") that refreshes in place as time passes,
+ * without a page reload. Backed by the shared clock in `useRelativeTime`, so it
+ * only re-renders when its displayed text changes. Drop-in replacement for
+ * inline `formatDistanceToNow(...)` calls in tables and lists.
+ */
+export const RelativeTime = ({
+  date,
+  addSuffix = true,
+  fallback = null,
+  className,
+  showTitle = true,
+}: RelativeTimeProps) => {
+  const locale = useDateLocale();
+  const text = useRelativeTime(date, { addSuffix, locale });
+
+  const title = useMemo(() => {
+    if (!showTitle || date == null) {
+      return undefined;
+    }
+    const parsed = typeof date === "object" ? date : new Date(date);
+    return Number.isNaN(parsed.getTime())
+      ? undefined
+      : parsed.toLocaleString(locale.code, {
+          weekday: "long",
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+        });
+  }, [showTitle, date, locale]);
+
+  if (text == null) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <span className={className} title={title}>
+      {text}
+    </span>
+  );
+};

--- a/frontend/src/hooks/useRelativeTime.test.tsx
+++ b/frontend/src/hooks/useRelativeTime.test.tsx
@@ -1,0 +1,68 @@
+import { act, render, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CLOCK_TICK_MS } from "@/lib/relativeTimeClock";
+
+import { useRelativeTime } from "./useRelativeTime";
+
+/**
+ * Anchor "now" so the relative labels are deterministic. `toFake: ["Date",
+ * "setInterval", ...]` lets the shared clock's interval advance under
+ * `vi.advanceTimersByTime` while `Date.now()` moves in lockstep.
+ */
+const NOW = new Date("2026-07-22T12:00:00.000Z");
+
+beforeEach(() => {
+  vi.useFakeTimers({ now: NOW });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useRelativeTime", () => {
+  it("formats a past timestamp with a suffix", () => {
+    const twoMinutesAgo = new Date(NOW.getTime() - 2 * 60_000).toISOString();
+    const { result } = renderHook(() => useRelativeTime(twoMinutesAgo));
+    expect(result.current).toBe("2 minutes ago");
+  });
+
+  it("returns null for nullish or unparseable input", () => {
+    const { result: nullResult } = renderHook(() => useRelativeTime(null));
+    expect(nullResult.current).toBeNull();
+
+    const { result: badResult } = renderHook(() => useRelativeTime("not-a-date"));
+    expect(badResult.current).toBeNull();
+  });
+
+  it("advances in place as the shared clock ticks", () => {
+    const start = new Date(NOW.getTime() - 60_000).toISOString();
+    const { result } = renderHook(() => useRelativeTime(start));
+    expect(result.current).toBe("1 minute ago");
+
+    // Advance real time by two ticks worth so the label crosses into the next
+    // minute bucket, then let the clock's interval fire.
+    act(() => {
+      vi.advanceTimersByTime(2 * CLOCK_TICK_MS);
+    });
+    expect(result.current).toBe("2 minutes ago");
+  });
+
+  it("only re-renders when the displayed string changes", () => {
+    // A timestamp years in the past never changes label, so ticking the clock
+    // must not re-render the consumer.
+    const longAgo = new Date(NOW.getTime() - 3 * 365 * 24 * 60 * 60_000).toISOString();
+    let renders = 0;
+    const Probe = () => {
+      renders += 1;
+      return <span>{useRelativeTime(longAgo)}</span>;
+    };
+    render(<Probe />);
+    const initialRenders = renders;
+
+    act(() => {
+      vi.advanceTimersByTime(10 * CLOCK_TICK_MS);
+    });
+    expect(renders).toBe(initialRenders);
+  });
+});

--- a/frontend/src/hooks/useRelativeTime.ts
+++ b/frontend/src/hooks/useRelativeTime.ts
@@ -1,0 +1,58 @@
+import { formatDistance, type Locale } from "date-fns";
+import { useSyncExternalStore } from "react";
+
+import { useDateLocale } from "@/hooks/useDateLocale";
+import { getClockNow, subscribeToClock } from "@/lib/relativeTimeClock";
+
+/**
+ * Subscribe to the shared clock and derive a value from the current time,
+ * re-rendering only when that value changes.
+ *
+ * `compute` MUST return a primitive (string/number/boolean). React compares the
+ * snapshot with `Object.is`, so a primitive that is unchanged between ticks
+ * suppresses the re-render — a "3 hours ago" label costs one function call per
+ * tick but no re-render until the hour rolls over. Returning an object would
+ * defeat this (a fresh reference every tick forces a re-render every tick).
+ */
+export const useLiveClockValue = <T extends string | number | boolean | null>(
+  compute: (now: number) => T
+): T => {
+  return useSyncExternalStore(
+    subscribeToClock,
+    () => compute(getClockNow()),
+    () => compute(getClockNow())
+  );
+};
+
+type RelativeTimeOptions = {
+  addSuffix?: boolean;
+  /** Override the locale; defaults to the app's current i18n locale. */
+  locale?: Locale;
+};
+
+/**
+ * A live-updating relative time string ("2 minutes ago") backed by the shared
+ * clock. Recomputes on every tick but only triggers a re-render when the
+ * formatted string actually changes, so it stays cheap in large tables.
+ *
+ * The locale defaults to the app's current i18n locale, so callers don't need
+ * to plumb it through. Returns `null` when `date` is nullish so callers can
+ * render a placeholder.
+ */
+export const useRelativeTime = (
+  date: Date | string | number | null | undefined,
+  options?: RelativeTimeOptions
+): string | null => {
+  const currentLocale = useDateLocale();
+  const addSuffix = options?.addSuffix ?? true;
+  const locale = options?.locale ?? currentLocale;
+  const time =
+    date == null ? null : typeof date === "object" ? date.getTime() : new Date(date).getTime();
+
+  return useLiveClockValue((now) => {
+    if (time == null || Number.isNaN(time)) {
+      return null;
+    }
+    return formatDistance(time, now, { addSuffix, locale });
+  });
+};

--- a/frontend/src/lib/relativeTimeClock.ts
+++ b/frontend/src/lib/relativeTimeClock.ts
@@ -1,0 +1,96 @@
+/**
+ * A single, app-wide clock that relative-time labels ("2 minutes ago") subscribe
+ * to so they refresh in place without a page reload.
+ *
+ * Why one shared clock instead of a timer per label: a table can render dozens of
+ * relative timestamps, and one `setInterval` per cell would mean dozens of wakeups
+ * firing at staggered moments. Here every subscriber is driven by the same tick,
+ * so updates batch into a single render pass and the interval only runs while at
+ * least one label is mounted.
+ *
+ * Re-render suppression is the caller's job: `getClockNow()` only advances on a
+ * tick, so a `useSyncExternalStore` snapshot derived from it stays referentially
+ * stable between ticks, and React skips re-rendering any label whose formatted
+ * string did not actually change (see `useRelativeTime`).
+ */
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Cached "now" shared by every subscriber. Only advances on a tick so snapshots
+ * stay stable between ticks (required for `useSyncExternalStore` to bail out of
+ * re-rendering unchanged labels).
+ */
+let now = Date.now();
+
+/**
+ * 30s keeps minute-granularity labels ("2 minutes ago") within half a minute of
+ * accurate while keeping wakeups cheap. Coarser labels ("3 hours ago", "2 days
+ * ago") never re-render on most ticks because their formatted string is
+ * unchanged — the tick still fires, but React bails out.
+ */
+export const CLOCK_TICK_MS = 30_000;
+
+const notify = (): void => {
+  now = Date.now();
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+const handleVisibilityChange = (): void => {
+  // A backgrounded tab throttles (or pauses) `setInterval`, so labels can be
+  // badly stale by the time it returns to the foreground. Tick immediately on
+  // becoming visible so they snap to the current time.
+  if (typeof document !== "undefined" && document.visibilityState === "visible") {
+    notify();
+  }
+};
+
+const start = (): void => {
+  if (intervalId !== null) {
+    return;
+  }
+  now = Date.now();
+  intervalId = setInterval(notify, CLOCK_TICK_MS);
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+  }
+};
+
+const stop = (): void => {
+  if (intervalId === null) {
+    return;
+  }
+  clearInterval(intervalId);
+  intervalId = null;
+  if (typeof document !== "undefined") {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }
+};
+
+/**
+ * The shared "now", in epoch milliseconds. Stable between ticks so callers can
+ * derive a referentially-stable snapshot from it.
+ */
+export const getClockNow = (): number => now;
+
+/**
+ * Subscribe to the shared clock. Returns an unsubscribe function. The interval
+ * runs only while at least one subscriber is registered. Shaped for direct use
+ * as the `subscribe` argument of `useSyncExternalStore`.
+ */
+export const subscribeToClock = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  start();
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      stop();
+    }
+  };
+};

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,5 +1,4 @@
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
 import type { SerializedEditorState } from "lexical";
 import {
   ChevronDown,
@@ -107,9 +106,9 @@ import { Label } from "@/components/ui/label";
 import { useAIEnabled } from "@/hooks/useAIEnabled";
 import { useAuth } from "@/hooks/useAuth";
 import { useCollaboration } from "@/hooks/useCollaboration";
-import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { uploadAttachment } from "@/lib/attachmentUtils";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
@@ -120,9 +119,18 @@ import { resolveHeaderlessApiUrl, resolveUploadUrl } from "@/lib/uploadUrl";
 import { getUserDisplayName } from "@/lib/userDisplay";
 import { cn } from "@/lib/utils";
 
+/**
+ * Live "Attached N ago" label for one attached-project row. A component (not an
+ * inline hook) so `useRelativeTime` can run per row inside the projects map.
+ */
+const AttachedProjectTime = ({ attachedAt }: { attachedAt: string }) => {
+  const { t } = useTranslation("documents");
+  const relative = useRelativeTime(attachedAt);
+  return <>{t("detail.attached", { date: relative })}</>;
+};
+
 export const DocumentDetailPage = () => {
   const { t } = useTranslation(["documents", "properties", "common"]);
-  const dateLocale = useDateLocale();
   const { guildId: guildIdParam, documentId } = useParams({ strict: false }) as {
     guildId: string;
     documentId: string;
@@ -235,6 +243,7 @@ export const DocumentDetailPage = () => {
   });
 
   const document = documentQuery.data;
+  const relativeUpdatedAt = useRelativeTime(document?.updated_at);
 
   // Track recently viewed documents so the layout header tabs bar can surface
   // them. Mirrors the pattern in ProjectDetailPage.
@@ -1151,14 +1160,7 @@ export const DocumentDetailPage = () => {
               {document.initiative.name}
             </Link>
           ) : null}
-          <span>
-            {t("detail.updated", {
-              date: formatDistanceToNow(new Date(document.updated_at), {
-                addSuffix: true,
-                locale: dateLocale,
-              }),
-            })}
-          </span>
+          <span>{t("detail.updated", { date: relativeUpdatedAt })}</span>
           {document.is_template ? <Badge variant="outline">{t("detail.template")}</Badge> : null}
         </div>
       </div>
@@ -1552,12 +1554,7 @@ export const DocumentDetailPage = () => {
                         {link.project_name ?? t("detail.projectFallback", { id: link.project_id })}
                       </Link>
                       <p className="text-muted-foreground text-xs">
-                        {t("detail.attached", {
-                          date: formatDistanceToNow(new Date(link.attached_at), {
-                            addSuffix: true,
-                            locale: dateLocale,
-                          }),
-                        })}
+                        <AttachedProjectTime attachedAt={link.attached_at} />
                       </p>
                     </div>
                   </div>

--- a/frontend/src/pages/DocumentSettingsPage.tsx
+++ b/frontend/src/pages/DocumentSettingsPage.tsx
@@ -1,5 +1,4 @@
 import { Link, useParams, useRouter } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
 import { Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,7 +19,6 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
-import { useDateLocale } from "@/hooks/useDateLocale";
 import {
   useCopyDocumentToInitiative,
   useDeleteDocument,
@@ -30,6 +28,7 @@ import {
   useUpdateDocument,
 } from "@/hooks/useDocuments";
 import { useInitiatives } from "@/hooks/useInitiatives";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { useSetToolTags } from "@/hooks/useToolTags";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
@@ -39,7 +38,6 @@ import { Capability, hasCapability } from "@/lib/permissions";
 
 export const DocumentSettingsPage = () => {
   const { t } = useTranslation(["documents", "common"]);
-  const dateLocale = useDateLocale();
   const { documentId } = useParams({ strict: false }) as { documentId: string };
   const parsedId = Number(documentId);
   const router = useRouter();
@@ -61,6 +59,7 @@ export const DocumentSettingsPage = () => {
   const documentQuery = useDocument(Number.isFinite(parsedId) ? parsedId : null);
 
   const document = documentQuery.data;
+  const relativeUpdatedAt = useRelativeTime(document?.updated_at);
 
   const initiativesQuery = useInitiatives({ enabled: Boolean(document) && Boolean(user) });
 
@@ -264,14 +263,7 @@ export const DocumentSettingsPage = () => {
         </div>
         <div className="flex flex-col items-end gap-2 text-right text-muted-foreground text-sm">
           <p className="font-medium">{document.title}</p>
-          <p>
-            {t("detail.updated", {
-              date: formatDistanceToNow(new Date(document.updated_at), {
-                addSuffix: true,
-                locale: dateLocale,
-              }),
-            })}
-          </p>
+          <p>{t("detail.updated", { date: relativeUpdatedAt })}</p>
           {document.initiative ? (
             <span className="inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs">
               <InitiativeColorDot color={document.initiative.color} />

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -1,5 +1,4 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { formatDistanceToNow } from "date-fns";
 import { Copy, Download, RefreshCcw, Trash2 } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -28,8 +27,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useAuth } from "@/hooks/useAuth";
-import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import {
   useApproveUser,
   useExportGuildUsersCsv,
@@ -46,10 +45,32 @@ const inviteLinkForCode = (code: string) => {
   return `${normalizedBase}/invite/${encodeURIComponent(code)}`;
 };
 
+/**
+ * Live "N uses · expires M" line for one invite. A component (not an inline
+ * hook) so `useRelativeTime` can run per invite inside the invites map.
+ */
+const InviteUsesLine = ({
+  uses,
+  maxUses,
+  expiresAt,
+}: {
+  uses: number;
+  maxUses: number | null;
+  expiresAt: string | null;
+}) => {
+  const { t } = useTranslation("guilds");
+  const relativeExpiry = useRelativeTime(expiresAt);
+  const expires = expiresAt != null ? relativeExpiry : t("users.neverExpires");
+  return (
+    <p className="text-muted-foreground">
+      {t("users.usesFormat", { uses, max: maxUses ?? "∞", expires })}
+    </p>
+  );
+};
+
 export const SettingsUsersPage = () => {
   const { user } = useAuth();
   const { t } = useTranslation("guilds");
-  const dateLocale = useDateLocale();
 
   const { activeGuild } = useGuilds();
   // Guild admin check is based on guild membership role only (independent from platform role)
@@ -367,13 +388,6 @@ export const SettingsUsersPage = () => {
           <div className="space-y-3">
             {inviteRows.map((invite) => {
               const link = inviteLinkForCode(invite.code);
-              const expires =
-                invite.expires_at != null
-                  ? formatDistanceToNow(new Date(invite.expires_at), {
-                      addSuffix: true,
-                      locale: dateLocale,
-                    })
-                  : t("users.neverExpires");
               return (
                 <div
                   key={invite.id}
@@ -381,13 +395,11 @@ export const SettingsUsersPage = () => {
                 >
                   <div>
                     <p className="font-medium">{link}</p>
-                    <p className="text-muted-foreground">
-                      {t("users.usesFormat", {
-                        uses: invite.uses,
-                        max: invite.max_uses ?? "\u221e",
-                        expires,
-                      })}
-                    </p>
+                    <InviteUsesLine
+                      uses={invite.uses}
+                      maxUses={invite.max_uses ?? null}
+                      expiresAt={invite.expires_at ?? null}
+                    />
                   </div>
                   <div className="flex gap-2">
                     <Button

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -1,5 +1,5 @@
 import { Link, useBlocker, useParams, useRouter } from "@tanstack/react-router";
-import { format, formatDistanceToNow } from "date-fns";
+import { format } from "date-fns";
 import {
   AlertCircle,
   Archive,
@@ -60,6 +60,7 @@ import { useComments } from "@/hooks/useComments";
 import { useDateLocale } from "@/hooks/useDateLocale";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useProject, useProjectTaskStatuses, useWritableProjects } from "@/hooks/useProjects";
+import { useRelativeTime } from "@/hooks/useRelativeTime";
 import {
   useDeleteTask,
   useDuplicateTask,
@@ -402,24 +403,13 @@ export const TaskEditPage = () => {
     };
   }, [task?.created_at, task?.created_by_id, creator]);
 
-  // Tick once a minute so the "N ago" label stays fresh while the page is
-  // open — ``formatDistanceToNow`` reads ``Date.now()`` at call time, so a
-  // bare state update is enough to re-render with a current value.
-  const [, setRelativeTick] = useState(0);
-  useEffect(() => {
-    if (!creationContext) return;
-    const id = setInterval(() => setRelativeTick((n) => n + 1), 60_000);
-    return () => clearInterval(id);
-  }, [creationContext]);
-
-  // Computed each render (cheap) so the tick above actually shows up.
+  // The relative "N ago" label refreshes in place via the shared clock; the
+  // absolute date never changes so it's formatted inline.
+  const relativeCreatedAt = useRelativeTime(creationContext?.createdAt);
   const creationMeta = creationContext
     ? {
         ...creationContext,
-        relative: formatDistanceToNow(creationContext.createdAt, {
-          addSuffix: true,
-          locale: dateLocale,
-        }),
+        relative: relativeCreatedAt,
         absolute: format(creationContext.createdAt, "PPpp", { locale: dateLocale }),
       }
     : null;

--- a/frontend/src/pages/user/MyDocumentsPage.tsx
+++ b/frontend/src/pages/user/MyDocumentsPage.tsx
@@ -1,7 +1,6 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { Link, useRouter, useSearch } from "@tanstack/react-router";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { formatDistanceToNow } from "date-fns";
 import { ChevronDown, Filter, Loader2, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -21,7 +20,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
-import { useDateLocale } from "@/hooks/useDateLocale";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { useGlobalDocuments, usePrefetchGlobalDocuments } from "@/hooks/useDocuments";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useViewPreference } from "@/hooks/useViewPreference";
@@ -76,7 +75,6 @@ export const MyDocumentsPage = () => {
   const { guilds, activeGuildId } = useGuilds();
   const prefetchGlobalDocuments = usePrefetchGlobalDocuments();
   const router = useRouter();
-  const dateLocale = useDateLocale();
   const searchParams = useSearch({ strict: false }) as { page?: number };
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
@@ -316,16 +314,12 @@ export const MyDocumentsPage = () => {
           if (!updatedAt || Number.isNaN(updatedAt.getTime())) {
             return <span className="text-muted-foreground text-sm">&mdash;</span>;
           }
-          return (
-            <span className="text-muted-foreground text-sm">
-              {formatDistanceToNow(updatedAt, { addSuffix: true, locale: dateLocale })}
-            </span>
-          );
+          return <RelativeTime date={updatedAt} className="text-muted-foreground text-sm" />;
         },
         enableSorting: true,
       },
     ],
-    [t, guilds, docGuildPath, dateLocale]
+    [t, guilds, docGuildPath]
   );
 
   // Responsive filter visibility

--- a/frontend/src/pages/user/MyProjectsPage.tsx
+++ b/frontend/src/pages/user/MyProjectsPage.tsx
@@ -1,7 +1,6 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { Link, useRouter, useSearch } from "@tanstack/react-router";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { formatDistanceToNow } from "date-fns";
 import { ChevronDown, Filter, Loader2, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,7 +19,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
-import { useDateLocale } from "@/hooks/useDateLocale";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useGlobalProjects, usePrefetchGlobalProjects } from "@/hooks/useProjects";
 import { useViewPreference } from "@/hooks/useViewPreference";
@@ -75,7 +74,6 @@ export const MyProjectsPage = () => {
   const { t } = useTranslation(["projects", "common"]);
   const { guilds } = useGuilds();
   const prefetchGlobalProjects = usePrefetchGlobalProjects();
-  const dateLocale = useDateLocale();
   const router = useRouter();
   const searchParams = useSearch({ strict: false }) as { page?: number };
   const searchParamsRef = useRef(searchParams);
@@ -357,15 +355,11 @@ export const MyProjectsPage = () => {
           if (!updatedAt) {
             return <span className="text-muted-foreground text-sm">&mdash;</span>;
           }
-          return (
-            <span className="text-muted-foreground text-sm">
-              {formatDistanceToNow(new Date(updatedAt), { addSuffix: true, locale: dateLocale })}
-            </span>
-          );
+          return <RelativeTime date={updatedAt} className="text-muted-foreground text-sm" />;
         },
       },
     ],
-    [t, getGuildName, getProjectGuildId, dateLocale]
+    [t, getGuildName, getProjectGuildId]
   );
 
   // Responsive filter collapsible


### PR DESCRIPTION
## Problem
Relative timestamps ("2 minutes ago") were computed once and never refreshed as wall-clock time advanced — so they only updated on a full page reload or an incidental re-render. Closes the FR "Relative times within tables should update without refreshing the page" (and extends the fix app-wide).

## Changes
- Add a single app-wide clock, [relativeTimeClock.ts](frontend/src/lib/relativeTimeClock.ts): one `setInterval` (30s) that runs only while at least one label is mounted, with a `visibilitychange` catch-up so a backgrounded tab snaps to the current time on return.
- Add [useRelativeTime.ts](frontend/src/hooks/useRelativeTime.ts) (+ `useLiveClockValue`) built on `useSyncExternalStore`: the snapshot is a primitive string, so a label recomputes every tick but **re-renders only when its displayed text actually changes** — a "3 years ago" label costs one function call per tick, zero re-renders. Locale is auto-resolved from i18n so call sites don't plumb it.
- Add a reusable [`<RelativeTime>`](frontend/src/components/ui/relative-time.tsx) component (with an absolute-date tooltip).
- Refactor [TaskDateCell](frontend/src/components/tasks/TaskDateCell.tsx) (task tables) to a single snapshot encoding both the label and past-due styling, so both go live.
- Convert every remaining relative-time site: tables ([DocumentsListView](frontend/src/components/documents/DocumentsListView.tsx), [TrashTable](frontend/src/components/trash/TrashTable.tsx), [DataJobsTable](frontend/src/components/imports/DataJobsTable.tsx)), cards/detail/list views ([DocumentCard](frontend/src/components/documents/DocumentCard.tsx), [DocumentDetailPage](frontend/src/pages/DocumentDetailPage.tsx), [DocumentSettingsPage](frontend/src/pages/DocumentSettingsPage.tsx), [FileDocumentViewer](frontend/src/components/documents/FileDocumentViewer.tsx), [DocumentBacklinks](frontend/src/components/documents/DocumentBacklinks.tsx), [ProjectDocumentsSection](frontend/src/components/projects/ProjectDocumentsSection.tsx), [ProjectActivitySidebar](frontend/src/components/projects/ProjectActivitySidebar.tsx), [RecentCommentsList](frontend/src/components/dashboard/RecentCommentsList.tsx), [CommentThread](frontend/src/components/comments/CommentThread.tsx), [MyProjectsPage](frontend/src/pages/user/MyProjectsPage.tsx), [MyDocumentsPage](frontend/src/pages/user/MyDocumentsPage.tsx), [SettingsUsersPage](frontend/src/pages/SettingsUsersPage.tsx)).
- Replace the ad-hoc 60s `setInterval` ticker in [TaskEditPage](frontend/src/pages/TaskEditPage.tsx) with the shared clock.
- Translation strings are untouched: interpolated-into-a-sentence labels source the string from the hook (extracting a tiny per-row subcomponent where inside a `.map()`), so word order and localized suffixes stay correct.

## Testing
- `cd frontend && pnpm typecheck` — clean
- `pnpm biome check` on new/changed files — clean
- `pnpm lint` — only 4 pre-existing unrelated warnings, none in changed files
- `pnpm test:run` — 936 passed (70 files), incl. new [useRelativeTime.test.tsx](frontend/src/hooks/useRelativeTime.test.tsx) covering formatting, null handling, live advancement across ticks, and the no-re-render guarantee