### PR TITLE
Strip base64 fields from MCP payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The in-app MCP server now strips base64 image blobs (avatar and guild-icon data URIs) from every tool result. These `*_base64` fields carried no information an MCP client could act on yet often dwarfed the rest of a payload — a single guild icon was frequently larger than an entire task read — so filtering them out reclaims that context for the fields that matter.
 - Relative timestamps across the app (e.g. "2 minutes ago" on task start/due dates, document cards and detail pages, comments, project activity, trash, import/export jobs, and the My Projects / My Documents lists) now refresh in place as time passes, instead of only updating on a page reload. A single shared clock drives every label, and each one re-renders only when its displayed text actually changes, so even large tables stay fast.
 
 ## [0.58.0] - 2026-07-21

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -17,16 +17,21 @@ See ``history/mcp-server-design.md``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Any
 
 import httpx
 from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_http_headers
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.server.providers.openapi import MCPType, RouteMap
+from fastmcp.tools.base import ToolResult
+from mcp.types import TextContent
 
 from app.core.config import PROJECT_NAME
 
 if TYPE_CHECKING:
+    import mcp.types as mt
     from fastapi import FastAPI
 
 # Read surface: every GET route carrying these FastAPI tags becomes a tool.
@@ -58,6 +63,80 @@ _ROUTE_MAPS = [
 ]
 
 
+# Base64 image blobs (avatar/guild icons) can dwarf the useful part of a
+# payload — a single guild ``icon_base64`` is often larger than the rest of a
+# task read combined. They're never actionable to an MCP client, so strip any
+# ``*_base64`` field before the result reaches the caller, keeping the context
+# they consume for the fields that matter.
+_BASE64_SUFFIX = "_base64"
+
+
+def _strip_base64(value: Any) -> Any:
+    """Recursively drop any dict key ending in ``_base64``.
+
+    Returns a new structure; the input is left untouched. Matching by suffix
+    (not a fixed name list) means a future base64 field is filtered by
+    construction, without another edit here.
+    """
+    if isinstance(value, dict):
+        return {
+            k: _strip_base64(v)
+            for k, v in value.items()
+            if not (isinstance(k, str) and k.endswith(_BASE64_SUFFIX))
+        }
+    if isinstance(value, list):
+        return [_strip_base64(v) for v in value]
+    return value
+
+
+class Base64FilterMiddleware(Middleware):
+    """Strip ``*_base64`` fields from every tool result.
+
+    Route-backed tools return the raw route JSON, which carries avatar/guild
+    icon data URIs. Filtering here — after the route (and its RLS gates) have
+    run — is purely cosmetic to the payload: it removes only inert image blobs,
+    never anything a caller acts on.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        result = await call_next(context)
+
+        structured = result.structured_content
+        if structured is not None:
+            structured = _strip_base64(structured)
+
+        content: list[Any] = []
+        for block in result.content:
+            # Text blocks hold the JSON body for route-backed tools; strip the
+            # parsed form and re-serialize. Non-JSON text and non-text blocks
+            # pass through untouched.
+            if isinstance(block, TextContent):
+                try:
+                    parsed = json.loads(block.text)
+                except (ValueError, TypeError):
+                    content.append(block)
+                    continue
+                content.append(
+                    TextContent(
+                        type="text",
+                        text=json.dumps(_strip_base64(parsed), default=str),
+                    )
+                )
+            else:
+                content.append(block)
+
+        return ToolResult(
+            content=content,
+            structured_content=structured,
+            meta=result.meta,
+            is_error=result.is_error,
+        )
+
+
 async def _forward_authorization(request: httpx.Request) -> None:
     """Forward the caller's PAT to the in-process upstream route call.
 
@@ -75,9 +154,11 @@ def build_mcp_server(app: "FastAPI") -> FastMCP:
 
     The app must already have its routers included so the RouteMap can see them.
     """
-    return FastMCP.from_fastapi(
+    server = FastMCP.from_fastapi(
         app=app,
         name=PROJECT_NAME,
         route_maps=_ROUTE_MAPS,
         httpx_client_kwargs={"event_hooks": {"request": [_forward_authorization]}},
     )
+    server.add_middleware(Base64FilterMiddleware())
+    return server

--- a/backend/app/mcp_server_test.py
+++ b/backend/app/mcp_server_test.py
@@ -6,10 +6,14 @@ asserts the RouteMap curation holds: tools cover only projects/tasks/initiatives
 no destructive, bulk, AI-generation, or property/tag mutations leak through.
 """
 
+import json
+
 import pytest
+from fastmcp.tools.base import ToolResult
+from mcp.types import TextContent
 
 from app.main import app
-from app.mcp_server import build_mcp_server
+from app.mcp_server import Base64FilterMiddleware, _strip_base64, build_mcp_server
 
 # A tool is a "write" if its operationId begins with one of these verbs.
 _WRITE_PREFIXES = (
@@ -71,3 +75,55 @@ async def test_mcp_write_tools_are_the_curated_safe_set():
     # Exactly the safe set — no delete/archive-all/reorder/duplicate/AI/property
     # mutation may appear.
     assert writes == _SAFE_WRITES, f"write surface changed: {sorted(writes)}"
+
+
+@pytest.mark.unit
+def test_strip_base64_removes_suffixed_keys_recursively():
+    payload = {
+        "title": "t",
+        "guild": {"id": 3, "name": "g", "icon_base64": "AAAA"},
+        "assignees": [
+            {"id": 1, "email": "a@example.com", "avatar_base64": "BBBB"},
+            {"id": 2, "email": "b@example.com", "avatar_base64": None},
+        ],
+        "count_base64_ish": "kept",  # only an exact suffix match is stripped
+    }
+    stripped = _strip_base64(payload)
+
+    assert "icon_base64" not in stripped["guild"]
+    assert all("avatar_base64" not in a for a in stripped["assignees"])
+    # Non-base64 fields (including a lookalike key) are preserved.
+    assert stripped["guild"] == {"id": 3, "name": "g"}
+    assert stripped["assignees"][0] == {"id": 1, "email": "a@example.com"}
+    assert stripped["count_base64_ish"] == "kept"
+    # Input is not mutated.
+    assert "icon_base64" in payload["guild"]
+
+
+@pytest.mark.unit
+async def test_base64_filter_middleware_strips_content_and_structured():
+    payload = {"guild": {"icon_base64": "AAAA", "name": "g"}}
+    result = ToolResult(
+        content=[TextContent(type="text", text=json.dumps(payload))],
+        structured_content=payload,
+    )
+
+    async def call_next(_context):
+        return result
+
+    out = await Base64FilterMiddleware().on_call_tool(None, call_next)
+
+    assert out.structured_content == {"guild": {"name": "g"}}
+    assert json.loads(out.content[0].text) == {"guild": {"name": "g"}}
+
+
+@pytest.mark.unit
+async def test_base64_filter_middleware_passes_through_non_json_text():
+    result = ToolResult(content=[TextContent(type="text", text="plain not json")])
+
+    async def call_next(_context):
+        return result
+
+    out = await Base64FilterMiddleware().on_call_tool(None, call_next)
+
+    assert out.content[0].text == "plain not json"


### PR DESCRIPTION
## Problem

The in-app MCP server exposes route-backed tools, so each tool result is the raw JSON from the underlying FastAPI route. That JSON carries base64 image data URIs — `guild.icon_base64`, `creator.avatar_base64`, `assignees[].avatar_base64` — which are inert to an MCP client but often dwarf the rest of the payload. A single guild `icon_base64` blob was frequently larger than an entire `read_task` response combined, wasting the client's context on data it can't use.

## Changes

- [mcp_server.py](backend/app/mcp_server.py): add `_strip_base64()` — recursively drops any dict key ending in `_base64` (suffix match, not a fixed list, so future base64 fields are filtered by construction) — and `Base64FilterMiddleware`, a FastMCP `on_call_tool` middleware that strips base64 from **both** the structured content and the JSON in text content blocks of every tool result. Registered via `add_middleware` in `build_mcp_server`. It runs after the route's RLS gates, so it only removes image blobs, never anything a caller acts on.
- [mcp_server_test.py](backend/app/mcp_server_test.py): tests for recursive stripping (incl. a `count_base64_ish` lookalike that must be kept, and input non-mutation), middleware stripping both content channels, and non-JSON text pass-through.
- [CHANGELOG.md](CHANGELOG.md): Fixed entry under `[Unreleased]`.

## Design notes

- All current base64 fields (`avatar_base64`, `icon_base64`) are `Optional`/non-required in the schemas, so removing them from structured content stays valid against each tool's output schema.
- Middleware chosen over an httpx response hook because it operates on the parsed `ToolResult` — cleaner than mutating a streamed body, and it covers structured + text output uniformly.

## Testing

- `cd backend && .venv/bin/python -m pytest app/mcp_server_test.py` — 5 passed
- `cd backend && .venv/bin/ruff check app` — All checks passed