### PR TITLE
Include task statuses in project read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The new-task dialog now matches the task editor: both are built on a single shared task form, so creating a task exposes the same fields as editing one. You can now set the **status**, attach **tags**, and fill in **custom properties** while creating a task — all saved in the single create request instead of only becoming available after the task exists.
+- The single-project read (`GET /projects/{id}`) now includes the project's `task_statuses` (ordered by position), so a client has the status ids it needs to place or move a task without a second call or hunting through existing tasks. List responses stay lean and omit them. The MCP server also exposes the existing per-project task-status listing as a read tool.
 
 ### Changed
 

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -3,6 +3,7 @@ from typing import Annotated, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import and_, case, func
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -74,6 +75,7 @@ from app.schemas.tenant.project import (
     ProjectActivityEntry,
     ProjectActivityResponse,
 )
+from app.schemas.tenant.task_status import TaskStatusRead
 from app.schemas.platform.user import UserSummary, UserSummaryListResponse
 from app.schemas.tenant.comment import CommentAuthor
 from app.schemas.tenant.initiative import (
@@ -205,6 +207,7 @@ async def _get_project_or_404(
                 selectinload(Document.initiative).selectinload(Initiative.memberships),
             ),
             selectinload(Project.tag_links).selectinload(ProjectTag.tag),
+            selectinload(Project.task_statuses),
         )
     )
     if populate_existing:
@@ -715,6 +718,20 @@ async def _projects_by_ids(
     return {project.id: project for project in projects if project.id is not None}
 
 
+def _project_task_statuses(project: Project) -> List[TaskStatusRead]:
+    """Serialize the project's task statuses (ordered by position).
+
+    Returns an empty list when the relationship wasn't eager-loaded — the slim
+    and list projections don't load it, so this must never trigger a lazy load
+    on the async session (which would raise). Detail reads load it via
+    ``_get_project_or_404``.
+    """
+    if "task_statuses" in sa_inspect(project).unloaded:
+        return []
+    statuses = sorted(project.task_statuses, key=lambda s: (s.position, s.id or 0))
+    return [TaskStatusRead.model_validate(status) for status in statuses]
+
+
 def _build_project_payload(
     project: Project,
     *,
@@ -738,6 +755,7 @@ def _build_project_payload(
             "last_viewed_at": view_map.get(project_id),
             "documents": _project_documents(project, user_id=user_id),
             "task_summary": summary,
+            "task_statuses": _project_task_statuses(project),
             "tags": tags_service.tag_summaries(project.tag_links),
             "grants": permissions_service.serialize_grants(project),
             "my_permission_level": my_permission_level,

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -20,11 +20,13 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.platform.guild import GuildRole
 from app.models.tenant.document import Document, DocumentType, ProjectDocument
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
+from app.models.tenant.task import TaskStatusCategory
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
     create_initiative,
     create_project,
+    create_task_status,
 )
 
 
@@ -444,6 +446,53 @@ async def test_get_project_by_id(
     data = response.json()
     assert data["id"] == project.id
     assert data["name"] == project.name
+
+
+@pytest.mark.integration
+async def test_get_project_includes_task_statuses(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The detail read carries the project's task statuses, ordered by position."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    project = await create_project(session, admin.initiative, admin.user)
+    done = await create_task_status(
+        session, project, name="Done", category=TaskStatusCategory.done, position=1
+    )
+    backlog = await create_task_status(
+        session,
+        project,
+        name="Backlog",
+        category=TaskStatusCategory.backlog,
+        position=0,
+    )
+
+    response = await client.get(
+        admin.g(f"/projects/{project.id}"), headers=admin.headers
+    )
+
+    assert response.status_code == 200
+    statuses = response.json()["task_statuses"]
+    # Ordered by position: backlog (0) before done (1).
+    assert [s["id"] for s in statuses] == [backlog.id, done.id]
+    assert [s["category"] for s in statuses] == ["backlog", "done"]
+
+
+@pytest.mark.integration
+async def test_list_projects_omits_task_statuses(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The list projection stays lean — statuses are a detail-read enrichment."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    project = await create_project(session, admin.initiative, admin.user)
+    await create_task_status(
+        session, project, name="Done", category=TaskStatusCategory.done
+    )
+
+    response = await client.get(admin.g("/projects/"), headers=admin.headers)
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert items and all(item["task_statuses"] == [] for item in items)
 
 
 @pytest.mark.integration

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -35,7 +35,10 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
 # Read surface: every GET route carrying these FastAPI tags becomes a tool.
-READ_TAGS = ("projects", "tasks", "initiatives")
+# ``task-statuses`` exposes only its GET (list a project's statuses) — its
+# POST/PATCH/reorder routes aren't in the write allow-list, so they stay
+# excluded — giving a caller the status ids needed to place or move a task.
+READ_TAGS = ("projects", "tasks", "initiatives", "task-statuses")
 
 # Curated safe writes: an explicit allow-list matched by exact path *shape* so
 # only these four mutations are exposed — create a task (``POST /tasks/``), edit a

--- a/backend/app/schemas/tenant/project.py
+++ b/backend/app/schemas/tenant/project.py
@@ -11,6 +11,7 @@ from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.schemas.tenant.initiative import InitiativeRead
 from app.schemas.tenant.document import ProjectDocumentSummary
 from app.schemas.tenant.tag import TagSummary
+from app.schemas.tenant.task_status import TaskStatusRead
 from app.schemas.platform.user import UserPublic
 from app.schemas.tenant.comment import CommentAuthor
 
@@ -75,6 +76,16 @@ class ProjectRead(ProjectBase):
     last_viewed_at: Optional[datetime] = None
     documents: List[ProjectDocumentSummary] = Field(default_factory=list)
     task_summary: ProjectTaskSummary = Field(default_factory=ProjectTaskSummary)
+    # The project's task statuses (ordered by position). Populated on the
+    # single-project detail read and mutation responses so a caller has the
+    # status ids it needs to place or move a task; left empty in list
+    # projections, which stay lean. The ``validation_alias`` (an attribute the
+    # ORM row never has) stops ``model_validate(project)`` from auto-pulling the
+    # relationship — which would lazy-load and fail on the paths that don't
+    # eager-load it; the value is set explicitly in ``_build_project_payload``.
+    task_statuses: List[TaskStatusRead] = Field(
+        default_factory=list, validation_alias="task_statuses_source"
+    )
     tags: List[TagSummary] = Field(default_factory=list)
     # The current user's effective level on this resource (what *I* can do).
     my_permission_level: Optional[str] = None

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2450,6 +2450,7 @@ export interface ProjectRead {
   last_viewed_at: string | null;
   documents: ProjectDocumentSummary[];
   task_summary: ProjectTaskSummary;
+  task_statuses: TaskStatusRead[];
   tags: TagSummary[];
   my_permission_level: string | null;
   grants: ResourceGrantSchema[];


### PR DESCRIPTION
## Problem

To move or place a task you need the destination status id, but nothing in the project read exposed the project's statuses — you had to scan an existing task in the right category to discover the id (exactly the friction hit while moving task 1989 to Done). There *is* a `GET /projects/{id}/task-statuses` endpoint, but it's tagged `task-statuses`, which wasn't in the MCP read surface, so it wasn't reachable as a tool either.

Follow-up to #985 (same MCP-payload-quality theme).

## Changes

- [project.py](backend/app/schemas/tenant/project.py): add `task_statuses: List[TaskStatusRead]` to `ProjectRead`. A `validation_alias` (an attribute the ORM row never has) stops `model_validate(project)` from auto-pulling the relationship — which would lazy-load and raise on the paths that don't eager-load it (this is why the field name can match the relationship yet stay manually populated).
- [projects.py](backend/app/api/v1/tenant_endpoints/projects.py): eager-load `Project.task_statuses` in `_get_project_or_404` (detail + mutation responses), and populate the field in `_build_project_payload` via a guarded serializer (`_project_task_statuses`) that returns `[]` when the relationship isn't loaded. List/slim projections stay lean and omit statuses.
- [mcp_server.py](backend/app/mcp_server.py): add `task-statuses` to `READ_TAGS` so the existing per-project status listing (GET only) becomes an MCP read tool. Its POST/PATCH/reorder routes aren't in the write allow-list, so they stay excluded.
- Regenerated `initiativeAPI.schemas.ts` (one field added to `ProjectRead`).
- Tests: statuses present + ordered on detail read, absent on list; CHANGELOG entry.

## Design note

Detail-only by intent — statuses are a per-project detail enrichment (4 small objects), and keeping them out of list responses honors the payload-slimming goal that motivated #985. The MCP `read_project` tool now carries everything needed to operate on a project's tasks in one call.

## Testing

- `cd backend && .venv/bin/python -m pytest app/api/v1/tenant_endpoints/projects_test.py app/api/v1/tenant_endpoints/task_statuses_test.py app/mcp_server_test.py app/schemas` — 84 passed
- `cd backend && .venv/bin/ruff check app` — All checks passed
- `cd frontend && pnpm typecheck` — clean