### PR TITLE
Fix MCP task-listing base64, query params, and cross-guild task filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The in-app MCP server's base64 filter now **nulls** `*_base64` fields instead of dropping the keys. Removing the keys made a tool's structured output violate its own (schema-required) shape, so every task or user-bearing listing failed with `'avatar_base64' is a required property`. The image blob is still stripped from the payload; the field is just kept as `null`.
+- MCP list tools (tasks, `/me` tasks) now present their `conditions` and `sorting` parameters as JSON strings, so filtering and sorting through the MCP server work. They were typed as arrays (for the frontend), which the MCP request builder serialized with Python `str()` — single-quoted, invalid JSON — so every filtered or sorted list call was rejected with `QUERY_INVALID_CONDITIONS` / `QUERY_INVALID_SORT_FIELDS`.
+
 ## [0.58.1] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The in-app MCP server's base64 filter now **nulls** `*_base64` fields instead of dropping the keys. Removing the keys made a tool's structured output violate its own (schema-required) shape, so every task or user-bearing listing failed with `'avatar_base64' is a required property`. The image blob is still stripped from the payload; the field is just kept as `null`.
 - MCP list tools (tasks, `/me` tasks) now present their `conditions` and `sorting` parameters as JSON strings, so filtering and sorting through the MCP server work. They were typed as arrays (for the frontend), which the MCP request builder serialized with Python `str()` — single-quoted, invalid JSON — so every filtered or sorted list call was rejected with `QUERY_INVALID_CONDITIONS` / `QUERY_INVALID_SORT_FIELDS`.
+- The cross-guild **My Tasks** / **Created Tasks** lists (`/me/tasks`, `/me/tasks/created`) now honor every `conditions` field — `due_date`, `title`, and the rest — instead of only a fixed handful (`project_id`, `priority`, `status_category`, `initiative_ids`, `guild_ids`, property values). Any other filter was silently ignored, so e.g. filtering "my tasks" by due date returned the full assigned list. The aggregate now applies the same filter set as the guild-scoped list, per guild.
 
 ## [0.58.1] - 2026-07-22
 

--- a/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
@@ -208,6 +208,63 @@ async def test_list_my_tasks_priority_filter(
 
 
 @pytest.mark.integration
+async def test_list_my_tasks_due_date_filter_across_guilds(
+    client: AsyncClient, session: AsyncSession
+):
+    """GET /me/tasks honors a due_date condition across every guild.
+
+    Regression: the cross-guild aggregate only applied a fixed whitelist of
+    extracted scalars and silently dropped every other field, so a ``due_date``
+    filter returned the caller's entire assigned set. The aggregate now applies
+    the full condition set per guild via apply_filters, matching the
+    guild-scoped list.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    overdue = now - timedelta(days=2)
+    upcoming = now + timedelta(days=10)
+
+    user = await create_user(session, email="user@example.com")
+    guild1, _, project1 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 1"
+    )
+    _guild2, _, project2 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 2"
+    )
+
+    # One overdue + one upcoming in each guild, so a working filter must reach
+    # across guilds and cannot pass by only matching one guild's rows.
+    g1_overdue = await _create_task(
+        session, project1, "g1 overdue", created_by_id=user.id, due_date=overdue
+    )
+    g1_upcoming = await _create_task(
+        session, project1, "g1 upcoming", created_by_id=user.id, due_date=upcoming
+    )
+    g2_overdue = await _create_task(
+        session, project2, "g2 overdue", created_by_id=user.id, due_date=overdue
+    )
+    g2_upcoming = await _create_task(
+        session, project2, "g2 upcoming", created_by_id=user.id, due_date=upcoming
+    )
+    for task in (g1_overdue, g1_upcoming, g2_overdue, g2_upcoming):
+        await _assign(session, task, user.id)
+
+    headers = get_auth_headers(user)
+    conditions = json.dumps(
+        [{"field": "due_date", "op": "lt", "value": now.isoformat()}]
+    )
+    # Pass via params so httpx URL-encodes the "+" in the ISO offset.
+    response = await client.get(
+        "/api/v1/me/tasks", params={"conditions": conditions}, headers=headers
+    )
+
+    assert response.status_code == 200, response.text
+    task_ids = {t["id"] for t in response.json()["items"]}
+    assert task_ids == {g1_overdue.id, g2_overdue.id}
+
+
+@pytest.mark.integration
 async def test_list_my_tasks_guild_ids_filter(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -22,7 +22,7 @@ from app.db.query import (
     parse_conditions,
     parse_sort_fields,
 )
-from app.schemas.query import FilterCondition, FilterOp, SortDir
+from app.schemas.query import FilterOp, SortDir
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import (
@@ -986,39 +986,6 @@ async def _allowed_project_ids(
     return {pid for pid in result.all() if pid is not None}
 
 
-def _property_value_filter_clauses(
-    property_value_conditions: list,
-    property_definitions: dict,
-) -> list:
-    """Compile ``property_values`` conditions to SA WHERE clauses for tasks.
-
-    Shared between the global and non-global list paths so the global
-    paths also honor custom-property filters. Task conditions arrive with
-    ``{"property_id": pid, "value": raw}`` payloads — unwrap that and
-    delegate to :func:`properties_service.build_single_property_clause`
-    so the compiled predicate stays in lockstep with docs/events.
-    """
-    clauses = []
-    for cond in property_value_conditions:
-        if not isinstance(cond.value, dict):
-            continue
-        pid_raw = cond.value.get("property_id")
-        raw_value = cond.value.get("value")
-        try:
-            pid = int(pid_raw)
-        except (TypeError, ValueError):
-            continue
-        defn = property_definitions.get(pid)
-        if defn is None:
-            continue
-        clause = properties_service.build_single_property_clause(
-            "task", pid, cond.op, raw_value, defn
-        )
-        if clause is not None:
-            clauses.append(clause)
-    return clauses
-
-
 def _global_task_options():
     return (
         selectinload(Task.project)
@@ -1051,6 +1018,9 @@ async def _gather_global_task_reads(
     ``(Task, date_group)`` rows *without* ORDER BY and the merged set is sorted
     once, globally, by :func:`_sort_global_task_reads` before pagination.
     Annotation + conversion happen inside each guild's routed context.
+
+    ``build_query`` receives the guild id so it can compile the guild-local
+    filter fields (tag/property subqueries resolve against that guild's schema).
     """
     target_guilds = await member_guild_ids(
         session, current_user.id, restrict_to=guild_ids
@@ -1059,7 +1029,7 @@ async def _gather_global_task_reads(
     async def _fetch(
         guild_session: AsyncSession, _guild_id: int
     ) -> list[tuple[TaskListRead, int]]:
-        rows = list((await guild_session.exec(build_query())).all())
+        rows = list((await guild_session.exec(build_query(_guild_id))).all())
         tasks = [row[0] for row in rows]
         await _annotate_tasks(guild_session, tasks)
         tags_service.annotate_tags(tasks)
@@ -1084,12 +1054,8 @@ async def _list_global_tasks(
     session: SessionDep,
     current_user: User,
     *,
-    project_id: Optional[int],
-    priorities: Optional[List[TaskPriority]],
-    status_category: Optional[List[TaskStatusCategory]],
-    initiative_ids: Optional[List[int]],
+    user_conditions: list,
     guild_ids: Optional[List[int]],
-    property_value_conditions: list | None = None,
     property_definitions: dict | None = None,
     include_archived: bool = False,
     page: int = 1,
@@ -1101,33 +1067,26 @@ async def _list_global_tasks(
 ) -> tuple[list[TaskListRead], int, int]:
     """Tasks assigned to the user, across every guild they belong to.
 
-    ``start_after``/``start_before`` window the set to tasks whose start or due
-    date falls inside — used by the ``/me`` calendar aggregate (the global path
-    ignores arbitrary ``conditions``, so the window travels as explicit params).
+    ``user_conditions`` are applied per guild via :func:`apply_filters` using the
+    same field set as the guild-scoped list, so any Task field — ``due_date``,
+    ``title``, ``priority``, ``status_category``, property values, … — filters
+    here too. ``start_after``/``start_before`` window the set to tasks whose
+    start or due date falls inside — used by the ``/me`` calendar aggregate (the
+    window travels as explicit params so a caller never has to encode it in
+    ``conditions``).
     """
-    conditions = [
+    base_conditions = [
         TaskAssignee.user_id == current_user.id,
         Project.is_archived.is_(False),
         Project.is_template.is_(False),
     ]
     if not include_archived:
-        conditions.append(Task.is_archived.is_(False))
-    if project_id is not None:
-        conditions.append(Task.project_id == project_id)
-    if priorities:
-        conditions.append(Task.priority.in_(tuple(priorities)))
-    if initiative_ids:
-        conditions.append(Project.initiative_id.in_(tuple(initiative_ids)))
+        base_conditions.append(Task.is_archived.is_(False))
     window = _task_calendar_window_clause(start_after, start_before)
     if window is not None:
-        conditions.append(window)
-    conditions.extend(
-        _property_value_filter_clauses(
-            property_value_conditions or [], property_definitions or {}
-        )
-    )
+        base_conditions.append(window)
 
-    def _build():
+    def _build(guild_id: int):
         # Carry the SQL-computed date_group out for the cross-guild sort; ORDER
         # BY is omitted because _sort_global_task_reads orders the merged set.
         stmt = (
@@ -1135,12 +1094,19 @@ async def _list_global_tasks(
             .join(TaskAssignee, TaskAssignee.task_id == Task.id)
             .join(Task.project)
             .join(Project.initiative)
+            .where(*base_conditions)
+            .options(*_global_task_options())
         )
-        if status_category:
-            stmt = stmt.join(TaskStatus, Task.task_status_id == TaskStatus.id).where(
-                TaskStatus.category.in_(tuple(status_category))
-            )
-        return stmt.where(*conditions).options(*_global_task_options())
+        return apply_filters(
+            stmt,
+            Task,
+            user_conditions,
+            allowed_fields=_build_task_filter_fields(
+                guild_id=guild_id,
+                current_user_id=current_user.id,
+                property_definitions=property_definitions or {},
+            ),
+        )
 
     return await _gather_global_task_reads(
         session,
@@ -1157,12 +1123,8 @@ async def _list_global_created_tasks(
     session: SessionDep,
     current_user: User,
     *,
-    project_id: Optional[int],
-    priorities: Optional[List[TaskPriority]],
-    status_category: Optional[List[TaskStatusCategory]],
-    initiative_ids: Optional[List[int]],
+    user_conditions: list,
     guild_ids: Optional[List[int]],
-    property_value_conditions: list | None = None,
     property_definitions: dict | None = None,
     include_archived: bool = False,
     page: int = 1,
@@ -1170,39 +1132,39 @@ async def _list_global_created_tasks(
     sort_fields: list | None = None,
     tz: str | None = None,
 ) -> tuple[list[TaskListRead], int, int]:
-    """Tasks created by the user, across every guild they belong to."""
-    conditions = [
+    """Tasks created by the user, across every guild they belong to.
+
+    ``user_conditions`` are applied per guild via :func:`apply_filters` (same
+    field set as the guild-scoped list), so any Task field filters here too.
+    """
+    base_conditions = [
         Task.created_by_id == current_user.id,
         Project.is_archived.is_(False),
         Project.is_template.is_(False),
     ]
     if not include_archived:
-        conditions.append(Task.is_archived.is_(False))
-    if project_id is not None:
-        conditions.append(Task.project_id == project_id)
-    if priorities:
-        conditions.append(Task.priority.in_(tuple(priorities)))
-    if initiative_ids:
-        conditions.append(Project.initiative_id.in_(tuple(initiative_ids)))
-    conditions.extend(
-        _property_value_filter_clauses(
-            property_value_conditions or [], property_definitions or {}
-        )
-    )
+        base_conditions.append(Task.is_archived.is_(False))
 
-    def _build():
+    def _build(guild_id: int):
         # Carry the SQL-computed date_group out for the cross-guild sort; ORDER
         # BY is omitted because _sort_global_task_reads orders the merged set.
         stmt = (
             select(Task, _date_group_expression(tz).label("date_group"))
             .join(Task.project)
             .join(Project.initiative)
+            .where(*base_conditions)
+            .options(*_global_task_options())
         )
-        if status_category:
-            stmt = stmt.join(TaskStatus, Task.task_status_id == TaskStatus.id).where(
-                TaskStatus.category.in_(tuple(status_category))
-            )
-        return stmt.where(*conditions).options(*_global_task_options())
+        return apply_filters(
+            stmt,
+            Task,
+            user_conditions,
+            allowed_fields=_build_task_filter_fields(
+                guild_id=guild_id,
+                current_user_id=current_user.id,
+                property_definitions=property_definitions or {},
+            ),
+        )
 
     return await _gather_global_task_reads(
         session,
@@ -1223,12 +1185,11 @@ class _TaskListQuery:
     user_conditions: list
     sort_fields: Optional[list]
     tz: Optional[str]
+    # project_id narrows which projects the guild path checks access on; guild_ids
+    # restricts the cross-guild fan-out. Every other field filters through
+    # ``user_conditions`` via apply_filters, so no other scalar is extracted here.
     project_id: Optional[int]
-    priorities: Optional[list]
-    status_category: Optional[list]
-    initiative_ids: Optional[list]
     guild_ids: Optional[list]
-    property_value_conditions: list
     property_definitions: dict
     # Every property_values leaf's definition id (nested groups included), so the
     # deferred cross-guild loader resolves exactly what the limit check counted.
@@ -1288,13 +1249,6 @@ async def _parse_task_list_query(
                 property_ids_needed.append(int(cond.value.get("property_id")))
             except (TypeError, ValueError):
                 continue
-    # The cross-guild path AND-s these into its statement by hand, so it can
-    # only take top-level leaves — a grouped one isn't an unconditional filter.
-    property_value_conditions = [
-        cond
-        for cond in user_conditions
-        if isinstance(cond, FilterCondition) and cond.field == "property_values"
-    ]
     if defer_property_definitions:
         property_definitions_map: dict[int, PropertyDefinition] = {}
     else:
@@ -1308,11 +1262,7 @@ async def _parse_task_list_query(
         sort_fields=sort_fields,
         tz=tz,
         project_id=extract_condition_value(user_conditions, "project_id"),
-        priorities=extract_condition_value(user_conditions, "priority"),
-        status_category=extract_condition_value(user_conditions, "status_category"),
-        initiative_ids=extract_condition_value(user_conditions, "initiative_ids"),
         guild_ids=extract_condition_value(user_conditions, "guild_ids"),
-        property_value_conditions=property_value_conditions,
         property_definitions=property_definitions_map,
         property_ids_needed=property_ids_needed,
     )
@@ -1544,12 +1494,8 @@ async def list_my_tasks(
     items, total_count, actual_page = await _list_global_tasks(
         session,
         current_user,
-        project_id=q.project_id,
-        priorities=q.priorities,
-        status_category=q.status_category,
-        initiative_ids=q.initiative_ids,
+        user_conditions=q.user_conditions,
         guild_ids=q.guild_ids,
-        property_value_conditions=q.property_value_conditions,
         property_definitions=q.property_definitions,
         include_archived=include_archived,
         page=page,
@@ -1589,12 +1535,8 @@ async def list_my_created_tasks(
     items, total_count, actual_page = await _list_global_created_tasks(
         session,
         current_user,
-        project_id=q.project_id,
-        priorities=q.priorities,
-        status_category=q.status_category,
-        initiative_ids=q.initiative_ids,
+        user_conditions=q.user_conditions,
         guild_ids=q.guild_ids,
-        property_value_conditions=q.property_value_conditions,
         property_definitions=q.property_definitions,
         include_archived=include_archived,
         page=page,
@@ -1727,12 +1669,8 @@ async def query_my_tasks_list(
     items, _total, _page = await _list_global_tasks(
         session,
         current_user,
-        project_id=q.project_id,
-        priorities=q.priorities,
-        status_category=q.status_category,
-        initiative_ids=q.initiative_ids,
+        user_conditions=q.user_conditions,
         guild_ids=q.guild_ids,
-        property_value_conditions=q.property_value_conditions,
         property_definitions=q.property_definitions,
         include_archived=include_archived,
         page=1,

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -68,37 +68,49 @@ _ROUTE_MAPS = [
 
 # Base64 image blobs (avatar/guild icons) can dwarf the useful part of a
 # payload — a single guild ``icon_base64`` is often larger than the rest of a
-# task read combined. They're never actionable to an MCP client, so strip any
+# task read combined. They're never actionable to an MCP client, so redact any
 # ``*_base64`` field before the result reaches the caller, keeping the context
 # they consume for the fields that matter.
+#
+# We null the value rather than *drop the key*: a tool's structured output is
+# validated against the tool's output schema, and these fields are declared
+# there (``json_schema_serialization_defaults_required=True`` even lists them as
+# required — nullable, but present). Removing the key makes the structured
+# content violate its own schema, which the client rejects ("'avatar_base64' is
+# a required property"); nulling keeps it schema-valid while dropping the blob.
 _BASE64_SUFFIX = "_base64"
 
 
-def _strip_base64(value: Any) -> Any:
-    """Recursively drop any dict key ending in ``_base64``.
+def _redact_base64(value: Any) -> Any:
+    """Recursively null any dict value whose key ends in ``_base64``.
 
     Returns a new structure; the input is left untouched. Matching by suffix
-    (not a fixed name list) means a future base64 field is filtered by
-    construction, without another edit here.
+    (not a fixed name list) means a future base64 field is redacted by
+    construction, without another edit here. The key is kept (set to ``None``)
+    so the result still satisfies the tool's output schema.
     """
     if isinstance(value, dict):
         return {
-            k: _strip_base64(v)
+            k: (
+                None
+                if isinstance(k, str) and k.endswith(_BASE64_SUFFIX)
+                else _redact_base64(v)
+            )
             for k, v in value.items()
-            if not (isinstance(k, str) and k.endswith(_BASE64_SUFFIX))
         }
     if isinstance(value, list):
-        return [_strip_base64(v) for v in value]
+        return [_redact_base64(v) for v in value]
     return value
 
 
 class Base64FilterMiddleware(Middleware):
-    """Strip ``*_base64`` fields from every tool result.
+    """Redact ``*_base64`` fields (to ``null``) from every tool result.
 
     Route-backed tools return the raw route JSON, which carries avatar/guild
     icon data URIs. Filtering here — after the route (and its RLS gates) have
-    run — is purely cosmetic to the payload: it removes only inert image blobs,
-    never anything a caller acts on.
+    run — is purely cosmetic to the payload: it nulls only inert image blobs,
+    never anything a caller acts on, and leaves the keys present so structured
+    output stays valid against the tool's schema.
     """
 
     async def on_call_tool(
@@ -110,11 +122,11 @@ class Base64FilterMiddleware(Middleware):
 
         structured = result.structured_content
         if structured is not None:
-            structured = _strip_base64(structured)
+            structured = _redact_base64(structured)
 
         content: list[Any] = []
         for block in result.content:
-            # Text blocks hold the JSON body for route-backed tools; strip the
+            # Text blocks hold the JSON body for route-backed tools; redact the
             # parsed form and re-serialize. Non-JSON text and non-text blocks
             # pass through untouched.
             if isinstance(block, TextContent):
@@ -126,7 +138,7 @@ class Base64FilterMiddleware(Middleware):
                 content.append(
                     TextContent(
                         type="text",
-                        text=json.dumps(_strip_base64(parsed), default=str),
+                        text=json.dumps(_redact_base64(parsed), default=str),
                     )
                 )
             else:
@@ -152,6 +164,53 @@ async def _forward_authorization(request: httpx.Request) -> None:
         request.headers["authorization"] = auth
 
 
+# The list endpoints take ``conditions``/``sorting`` as a JSON *string* query
+# param, but ``main._inject_query_schemas`` retypes them to arrays-of-objects in
+# the OpenAPI so the frontend's axios serializer JSON-encodes them. The MCP
+# request builder doesn't do that JSON-encoding: handed an array argument it
+# serializes each item with Python ``str()`` (single-quoted, e.g.
+# ``{'field': 'due_date'}``), which the backend's ``json.loads`` rejects — every
+# filtered/sorted list call 400s. Presenting the param to the model as a plain
+# JSON string instead makes it send a string the builder forwards verbatim (valid
+# JSON the backend parses). This touches only the MCP tool surface; the REST +
+# Orval types keep the rich array schema.
+_JSON_STRING_PARAMS = {
+    "conditions": (
+        "JSON-encoded array of filter conditions, AND-ed together. Each item: "
+        '{"field": "<column>", "op": '
+        '"eq"|"lt"|"lte"|"gt"|"gte"|"in_"|"ilike"|"is_null", "value": <val>}. '
+        'An item with a "conditions" key is a group: '
+        '{"logic": "and"|"or", "conditions": [...]}. '
+        'Example: [{"field": "due_date", "op": "lt", "value": "2026-07-22"}]'
+    ),
+    "sorting": (
+        "JSON-encoded array of sort fields. Each item: "
+        '{"field": "<column>", "dir": "asc"|"desc"}. '
+        'Example: [{"field": "due_date", "dir": "asc"}]'
+    ),
+}
+
+
+def _stringify_json_query_params(route: object, component: object) -> None:
+    """Retype array ``conditions``/``sorting`` tool params to JSON strings.
+
+    A FastMCP ``mcp_component_fn`` (build-time): mutates each tool's input schema
+    in place so the model passes a JSON string the request builder forwards as
+    valid JSON, rather than an array it would mis-serialize. See the note on
+    ``_JSON_STRING_PARAMS``.
+    """
+    params = getattr(component, "parameters", None)
+    if not isinstance(params, dict):
+        return
+    props = params.get("properties")
+    if not isinstance(props, dict):
+        return
+    for name, description in _JSON_STRING_PARAMS.items():
+        schema = props.get(name)
+        if isinstance(schema, dict) and schema.get("type") == "array":
+            props[name] = {"type": "string", "description": description}
+
+
 def build_mcp_server(app: "FastAPI") -> FastMCP:
     """Build the route-backed, read-only MCP server from the FastAPI ``app``.
 
@@ -161,6 +220,7 @@ def build_mcp_server(app: "FastAPI") -> FastMCP:
         app=app,
         name=PROJECT_NAME,
         route_maps=_ROUTE_MAPS,
+        mcp_component_fn=_stringify_json_query_params,
         httpx_client_kwargs={"event_hooks": {"request": [_forward_authorization]}},
     )
     server.add_middleware(Base64FilterMiddleware())

--- a/backend/app/mcp_server_test.py
+++ b/backend/app/mcp_server_test.py
@@ -13,7 +13,7 @@ from fastmcp.tools.base import ToolResult
 from mcp.types import TextContent
 
 from app.main import app
-from app.mcp_server import Base64FilterMiddleware, _strip_base64, build_mcp_server
+from app.mcp_server import Base64FilterMiddleware, _redact_base64, build_mcp_server
 
 # A tool is a "write" if its operationId begins with one of these verbs.
 _WRITE_PREFIXES = (
@@ -78,7 +78,7 @@ async def test_mcp_write_tools_are_the_curated_safe_set():
 
 
 @pytest.mark.unit
-def test_strip_base64_removes_suffixed_keys_recursively():
+def test_redact_base64_nulls_suffixed_keys_recursively():
     payload = {
         "title": "t",
         "guild": {"id": 3, "name": "g", "icon_base64": "AAAA"},
@@ -86,22 +86,23 @@ def test_strip_base64_removes_suffixed_keys_recursively():
             {"id": 1, "email": "a@example.com", "avatar_base64": "BBBB"},
             {"id": 2, "email": "b@example.com", "avatar_base64": None},
         ],
-        "count_base64_ish": "kept",  # only an exact suffix match is stripped
+        "count_base64_ish": "kept",  # only an exact suffix match is redacted
     }
-    stripped = _strip_base64(payload)
+    redacted = _redact_base64(payload)
 
-    assert "icon_base64" not in stripped["guild"]
-    assert all("avatar_base64" not in a for a in stripped["assignees"])
-    # Non-base64 fields (including a lookalike key) are preserved.
-    assert stripped["guild"] == {"id": 3, "name": "g"}
-    assert stripped["assignees"][0] == {"id": 1, "email": "a@example.com"}
-    assert stripped["count_base64_ish"] == "kept"
+    # Keys are kept but nulled — so the structured output still satisfies a
+    # schema that declares (and may require) these fields.
+    assert redacted["guild"] == {"id": 3, "name": "g", "icon_base64": None}
+    assert [a["avatar_base64"] for a in redacted["assignees"]] == [None, None]
+    # Non-base64 fields (including a lookalike key) keep their values.
+    assert redacted["assignees"][0]["email"] == "a@example.com"
+    assert redacted["count_base64_ish"] == "kept"
     # Input is not mutated.
-    assert "icon_base64" in payload["guild"]
+    assert payload["guild"]["icon_base64"] == "AAAA"
 
 
 @pytest.mark.unit
-async def test_base64_filter_middleware_strips_content_and_structured():
+async def test_base64_filter_middleware_redacts_content_and_structured():
     payload = {"guild": {"icon_base64": "AAAA", "name": "g"}}
     result = ToolResult(
         content=[TextContent(type="text", text=json.dumps(payload))],
@@ -113,8 +114,31 @@ async def test_base64_filter_middleware_strips_content_and_structured():
 
     out = await Base64FilterMiddleware().on_call_tool(None, call_next)
 
-    assert out.structured_content == {"guild": {"name": "g"}}
-    assert json.loads(out.content[0].text) == {"guild": {"name": "g"}}
+    assert out.structured_content == {"guild": {"icon_base64": None, "name": "g"}}
+    assert json.loads(out.content[0].text) == {
+        "guild": {"icon_base64": None, "name": "g"}
+    }
+
+
+@pytest.mark.unit
+async def test_list_tools_expose_conditions_and_sorting_as_json_strings():
+    # main._inject_query_schemas retypes these to arrays for the REST/Orval
+    # surface; the MCP tool must present them as JSON strings instead, or the
+    # request builder serializes an array via Python str() (single-quoted) and
+    # the backend's json.loads rejects it. Assert every tool that has them uses
+    # a string schema.
+    tools = await build_mcp_server(app).list_tools()
+    seen = 0
+    for tool in tools:
+        props = (tool.parameters or {}).get("properties", {})
+        for name in ("conditions", "sorting"):
+            schema = props.get(name)
+            if schema is not None:
+                seen += 1
+                assert schema.get("type") == "string", (
+                    f"{tool.name}.{name} should be a JSON string, got {schema}"
+                )
+    assert seen, "expected at least one tool exposing conditions/sorting"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

Fetching tasks through the deployed MCP server failed several ways (reported after #985/#986 shipped):

1. **`'avatar_base64' is a required property`** on *every* task- or user-bearing listing (even `page_size: 1`). Regression from #985: MCP output schemas use `json_schema_serialization_defaults_required=True`, so `avatar_base64`/`icon_base64` are **required** (nullable) — but the base64 middleware *deleted* the keys, making structured output violate its own schema.
2. **`QUERY_INVALID_CONDITIONS`** — a `conditions` filter was rejected.
3. **`QUERY_INVALID_SORT_FIELDS`** — a `sorting` field was rejected.
4. **Cross-guild filters were silently ignored.** Even with valid JSON conditions, filtering **My Tasks** / **Created Tasks** by `due_date` (or any field outside a fixed whitelist) returned the caller's entire assigned list instead of a filtered set — so "what's overdue across my guilds?" was unanswerable through the MCP tools.

Root cause of #2/#3: [`main._inject_query_schemas`](backend/app/main.py#L469-L489) retypes `conditions`/`sorting` to arrays-of-objects in OpenAPI (so the frontend's axios serializer JSON-encodes them). FastMCP's request builder doesn't do that — handed an array it serializes each item with Python `str()`, producing single-quoted `conditions={'field': 'due_date'}` which the backend's `json.loads` rejects.

Root cause of #4: the cross-guild `/me/tasks` and `/me/tasks/created` aggregates only extracted a fixed whitelist of scalar filters (`project_id`, `priority`, `status_category`, `initiative_ids`, `guild_ids`, property values) and dropped every other `conditions` field. The guild-scoped `/g/{id}/tasks` list applies the full condition set via `apply_filters`; the aggregate didn't, because it fans out across each guild's schema.

## Changes

- [mcp_server.py](backend/app/mcp_server.py) — `Base64FilterMiddleware` now **nulls** `*_base64` values (`_redact_base64`) instead of dropping keys, so the blob is gone but the key stays present and schema-valid. *(This is why the middleware exists at all: `OpenAPITool.run()` returns the raw body and there's no native field-redaction hook — response post-processing is done via middleware, the same pattern as FastMCP's built-in `ResponseLimitingMiddleware`.)*
- [mcp_server.py](backend/app/mcp_server.py) — an `mcp_component_fn` (`_stringify_json_query_params`) retypes the `conditions`/`sorting` **tool** params to JSON strings with example-bearing descriptions. The model now sends a string the request builder forwards verbatim as valid JSON. REST/Orval types keep the rich array schema — this touches only the MCP tool surface.
- [tasks.py](backend/app/api/v1/tenant_endpoints/tasks.py) — the cross-guild `/me/tasks` and `/me/tasks/created` aggregates now apply the **full** `user_conditions` per guild through the same `apply_filters` + `_build_task_filter_fields` path the guild-scoped list uses (each guild query still runs RLS-scoped in its own routed session). Any Task field — `due_date`, `title`, … — now filters correctly. Removed the now-dead scalar extraction, the orphaned `_property_value_filter_clauses` helper, and unused `_TaskListQuery` fields (net −118 lines in that file).
- Tests: redaction keeps keys as null (structured + text channels); conditions/sorting are strings on the tools; new `test_list_my_tasks_due_date_filter_across_guilds` proves a `due_date` filter reaches across guilds.
- CHANGELOG.

## Testing

- `cd backend && .venv/bin/python -m pytest app/mcp_server_test.py` — passed
- `cd backend && .venv/bin/python -m pytest app/api/v1/tenant_endpoints/me_tasks_test.py app/api/v1/tenant_endpoints/me_tasks_created_test.py app/api/v1/tenant_endpoints/tasks_test.py app/api/v1/tenant_endpoints/tasks_properties_test.py app/api/v1/tenant_endpoints/calendar_entries_test.py` — 84 passed (calendar-entries shares the `/me` aggregate)
- `cd backend && .venv/bin/ruff check app` — clean
- Verified end-to-end against local dev: `due_date < today` on `/me/tasks` now returns **0** (correctly, nothing overdue) instead of the full assigned list, and a `< today+3d` bound returns exactly the matching task.
