### PR TITLE
Reset task composer status on project switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The new-task dialog's **Status** dropdown now resets when you switch projects. Because the task section is reused as you move between projects, a status you had picked (or the previous project's default) could linger and be submitted against the new project, whose statuses have different ids. The composer now drops any status that doesn't belong to the active project and falls back to that project's default.
+
 ## [0.58.2] - 2026-07-22
 
 ### Fixed

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -451,14 +451,24 @@ export const ProjectTasksSection = ({
   });
 
   // Seed the composer's status from the project default whenever it opens so
-  // the user starts at the default but can override it.
+  // the user starts at the default but can override it. Also reset a status
+  // that belongs to a different project — this section instance is reused when
+  // navigating between projects, so a status id picked in the previous project
+  // would otherwise linger and be submitted against the new one.
   useEffect(() => {
     if (isComposerOpen) {
-      setComposerValue((prev) =>
-        prev.statusId == null ? { ...prev, statusId: defaultStatusId } : prev
-      );
+      setComposerValue((prev) => {
+        if (prev.statusId == null) {
+          return { ...prev, statusId: defaultStatusId };
+        }
+        const belongsToProject = sortedTaskStatuses.some((status) => status.id === prev.statusId);
+        if (!belongsToProject && sortedTaskStatuses.length > 0) {
+          return { ...prev, statusId: defaultStatusId };
+        }
+        return prev;
+      });
     }
-  }, [isComposerOpen, defaultStatusId]);
+  }, [isComposerOpen, defaultStatusId, sortedTaskStatuses]);
 
   // Dirty = the composer differs from a fresh form seeded at the default
   // status. Used to keep a backdrop click from discarding in-progress input.


### PR DESCRIPTION
## Problem

Reported in guild task [#2008](https://initiative.morels.me/g/3/tasks/2008): sometimes when creating a task the **Status** dropdown doesn't reset when switching from one project to another. The composer keeps a stale `task_status_id` from the previously-selected project, and each project has its own distinct status ids.

## Root cause

[ProjectTasksSection](frontend/src/components/projects/ProjectTasksSection.tsx) owns the create-task composer state in a `useState`, and the section is reused (not remounted with a `key`) when navigating between project detail pages. The status-seeding effect only filled in the status when it was `null`, so a status id picked in a prior project lingered and could be submitted against the new project.

## Changes

- [ProjectTasksSection.tsx](frontend/src/components/projects/ProjectTasksSection.tsx): the seeding effect now also drops any `statusId` that isn't part of the active project's status set, falling back to that project's default. A guard on `sortedTaskStatuses.length > 0` avoids clobbering the selection during a transient empty/loading state; a valid in-project override the user picked is preserved.
- `CHANGELOG.md`: entry under `[Unreleased] → Fixed`.

## Testing

- `cd frontend && pnpm typecheck` — passes
- `cd frontend && pnpm biome check src/components/projects/ProjectTasksSection.tsx` — clean
- `./scripts/test-changed.sh` — no test files cover this component