### PR TITLE
Reject backup asset keys with path components on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The new-task dialog's **Status** dropdown now resets when you switch projects. Because the task section is reused as you move between projects, a status you had picked (or the previous project's default) could linger and be submitted against the new project, whose statuses have different ids. The composer now drops any status that doesn't belong to the active project and falls back to that project's default.
 
+### Security
+
+- Backup import now validates every upload asset key as a flat filename and uses one canonical key for its database lookup, uniqueness check, and storage write. A backup whose asset key carried path components is rejected as malformed, keeping an imported upload's database record and the stored file it points at in agreement.
+
 ## [0.58.2] - 2026-07-22
 
 ### Fixed

--- a/backend/app/api/v1/tenant_endpoints/imports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/imports_test.py
@@ -905,6 +905,117 @@ async def test_backup_rejects_invalid_and_bomb_zips(
     assert unsupported.json()["detail"] == "IMPORT_SCHEMA_VERSION_UNSUPPORTED"
 
 
+async def test_backup_rejects_asset_key_with_path_components(
+    client, acting_user, session
+):
+    """An asset storage_key is both the uploads-row identity and the storage
+    write target; the backends key by basename. A backup whose key carries path
+    components is rejected whole at upload, leaving an existing blob of the same
+    basename untouched and creating no second uploads row."""
+    from sqlmodel import select
+
+    from app.models.tenant.upload import Upload
+    from app.testing import route_session_to_guild
+    from app.testing.factories import create_upload
+
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    original = b"%PDF-original"
+    get_guild_storage(a.guild.id).write(
+        "keep.pdf", original, content_type="application/pdf"
+    )
+    await create_upload(
+        session,
+        a.guild,
+        a.user,
+        filename="keep.pdf",
+        size_bytes=len(original),
+        content_type="application/pdf",
+    )
+
+    manifest = _minimal_manifest(
+        assets=[
+            {
+                "path": "assets/nested/keep.pdf",
+                "storage_key": "nested/keep.pdf",
+                "original_filename": "keep.pdf",
+                "content_type": "application/pdf",
+                "size_bytes": len(original),
+                "referenced_by": [],
+            }
+        ],
+    )
+    zip_bytes = _make_backup_zip(
+        manifest, {"assets/nested/keep.pdf": b"REPLACED-BYTES"}
+    )
+    resp = await _upload_backup(client, a, zip_bytes)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "IMPORT_ZIP_INVALID"
+
+    blob = get_guild_storage(a.guild.id).open_readable("keep.pdf")
+    assert blob is not None and blob.path.read_bytes() == original
+    await route_session_to_guild(session, a.guild.id)
+    rows = (
+        await session.exec(select(Upload).where(Upload.guild_id == a.guild.id))
+    ).all()
+    assert [u.filename for u in rows] == ["keep.pdf"]
+
+
+def test_reject_non_flat_asset_keys_unit():
+    """The one choke point both plan and apply funnel through: flat keys pass;
+    a storage_key or file-entry asset with path components raises."""
+    from app.schemas.tenant.backup_export import (
+        BackupManifest,
+        ManifestAsset,
+        ManifestEntry,
+    )
+    from app.services.import_engine.backup import _reject_non_flat_asset_keys
+    from app.services.import_engine.contract import ImportEngineError
+
+    def _manifest(assets=None, entries=None):
+        return BackupManifest(
+            type="initiative-backup",
+            schema_version=1,
+            app_version="0.0.0-test",
+            exported_at="2026-07-15T00:00:00+00:00",
+            guild={"id": 1, "name": "g"},
+            include_uploads=True,
+            initiatives=[],
+            entries=entries or [],
+            assets=assets or [],
+            skipped=[],
+        )
+
+    def _asset(storage_key):
+        return ManifestAsset(path=f"assets/{storage_key}", storage_key=storage_key)
+
+    def _file_entry(asset_ref):
+        return ManifestEntry(
+            path=asset_ref,
+            tool="document",
+            type="file",
+            entity_id=1,
+            title="f",
+            initiative_id=1,
+            asset=asset_ref,
+        )
+
+    # Flat keys pass (a legit export only ever emits these).
+    _reject_non_flat_asset_keys(_manifest(assets=[_asset("abc123.pdf")]))
+    _reject_non_flat_asset_keys(_manifest(entries=[_file_entry("assets/abc123.pdf")]))
+
+    # Path components in the asset key (incl. self-collision spellings) reject.
+    for bad in ("nested/keep.pdf", "a/b/keep.pdf", "./keep.pdf"):
+        with pytest.raises(ImportEngineError) as exc:
+            _reject_non_flat_asset_keys(_manifest(assets=[_asset(bad)]))
+        assert exc.value.code == "IMPORT_ZIP_INVALID"
+
+    # And in a file entry's asset reference.
+    with pytest.raises(ImportEngineError):
+        _reject_non_flat_asset_keys(
+            _manifest(entries=[_file_entry("assets/nested/keep.pdf")])
+        )
+
+
 async def test_backup_confirm_include_map_skips_tools(
     client, acting_user, session, monkeypatch, role_session
 ):

--- a/backend/app/services/import_engine/backup.py
+++ b/backend/app/services/import_engine/backup.py
@@ -115,7 +115,25 @@ def read_manifest(archive: zipfile.ZipFile) -> BackupManifest:
         MIN_SUPPORTED_IMPORT_VERSION <= manifest.schema_version <= BACKUP_SCHEMA_VERSION
     ):
         raise ImportEngineError(ImportEngineMessages.IMPORT_SCHEMA_VERSION_UNSUPPORTED)
+    _reject_non_flat_asset_keys(manifest)
     return manifest
+
+
+def _reject_non_flat_asset_keys(manifest: BackupManifest) -> None:
+    """A backup asset key is both the ``uploads`` row identity and the storage
+    write target; the storage backends reduce it to ``Path(key).name``, so it
+    must already be flat for the two to match. Legit exports only ever emit flat
+    keys, so a key with path components is a malformed backup — reject it."""
+    from app.services.storage import is_flat_storage_key
+
+    for asset in manifest.assets:
+        if not is_flat_storage_key(asset.storage_key):
+            raise ImportEngineError(ImportEngineMessages.IMPORT_ZIP_INVALID)
+    for entry in manifest.entries:
+        if entry.asset is not None and not is_flat_storage_key(
+            entry.asset.removeprefix("assets/")
+        ):
+            raise ImportEngineError(ImportEngineMessages.IMPORT_ZIP_INVALID)
 
 
 def plan_backup(

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -52,6 +52,14 @@ _STREAM_CHUNK = 64 * 1024
 _S3_MISSING_CODES = {"404", "NoSuchKey", "NoSuchBucket", "NotFound"}
 
 
+def is_flat_storage_key(key: str) -> bool:
+    """True if ``key`` has no path components — it already equals its own
+    basename. Both backends key objects by ``Path(key).name``, so a value used
+    as both a stored identity and a storage key must be flat for the two to
+    refer to the same object."""
+    return bool(key) and Path(key).name == key
+
+
 def content_disposition_attachment(filename: str) -> str:
     """Build a safe ``attachment`` Content-Disposition value.
 


### PR DESCRIPTION
## Problem

Backup import used the **full** manifest asset key as the `uploads` row identity and uniqueness check (`Upload.filename == storage_key`), while the storage backends key objects by `Path(key).name`. When an asset key carried path components (e.g. `nested/keep.pdf`), those two values diverged: the uniqueness check saw a "new" key and created a fresh `uploads` row, but the physical write landed on the existing basename (`keep.pdf`) and replaced its bytes. The same divergence let two keys in one backup (`alpha/collision.txt`, `beta/collision.txt`) produce two DB rows mapping to a single stored object.

Import is meant to only ever *create* new initiatives, never mutate existing stored content. A legitimately-exported backup only ever emits flat keys (`file_url.split("/")[-1]`), so a non-flat key is a malformed backup.

## Fix

Validate every asset key as a flat filename at the one choke point both plan and apply funnel through, using a single predicate in the storage seam:

- **`storage.py`** — `is_flat_storage_key(key)`: true only when `key` already equals `Path(key).name`. One home for the "flat basename" rule that the backends' key handling implies.
- **`import_engine/backup.py`** — `read_manifest` now calls `_reject_non_flat_asset_keys`, checking every `asset.storage_key` and every file-entry `asset` reference. A non-flat key fails the whole backup with `IMPORT_ZIP_INVALID`, mirroring the existing zip-traversal guard. Covers the self-collision case for free.

No schema change. Confirmed the export side only emits flat keys, so there are zero false positives on real backups.

## Notable changes

- `backend/app/services/storage.py` — add `is_flat_storage_key`.
- `backend/app/services/import_engine/backup.py` — enforce flat asset keys in `read_manifest`.
- `backend/app/api/v1/tenant_endpoints/imports_test.py` — regression tests.
- `CHANGELOG.md` — `### Security` entry under `[Unreleased]`.

## Testing

```
cd backend && pytest app/api/v1/tenant_endpoints/imports_test.py -k "backup or reject_non_flat"
# 14 passed
```

- `test_backup_rejects_asset_key_with_path_components` — end-to-end: a pre-existing blob + a backup keyed `nested/keep.pdf` → 400 `IMPORT_ZIP_INVALID`, original bytes intact, no second `uploads` row.
- `test_reject_non_flat_asset_keys_unit` — flat keys pass; asset keys and file-entry references with path components (incl. `./` spellings) raise.
- `ruff check` clean; `ruff format` applied.
