### PR TITLE
Pin webhook/AI egress to validated address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Backup import now validates every upload asset key as a flat filename and uses one canonical key for its database lookup, uniqueness check, and storage write. A backup whose asset key carried path components is rejected as malformed, keeping an imported upload's database record and the stored file it points at in agreement.
+- Hardened outbound webhook delivery and the custom AI provider so each request connects to the exact address validated against the target policy (https + public unicast); the original hostname is kept for TLS verification and the `Host` header. Both routes now share a single guarded egress helper.
 
 ## [0.58.2] - 2026-07-22
 

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions.py
@@ -100,10 +100,9 @@ async def create_subscription(
     in the service layer. The caller's guild comes from
     ``GuildContext`` — the body never carries it.
 
-    SSRF guard: ``target_url`` must resolve to a public unicast address.
-    Hostnames pointing at private / loopback / link-local space are
-    rejected so a guild member can't aim deliveries at internal services
-    or cloud-metadata endpoints.
+    Target policy: ``target_url`` must be https and resolve to a public
+    unicast address; private, loopback and link-local addresses are
+    rejected.
     """
     await _validate_target_url(str(payload.target_url))
 

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
@@ -1,7 +1,7 @@
 """Integration tests for the webhook subscription endpoints.
 
-These cover the two security properties the routes enforce on top of
-RLS: SSRF rejection on ``target_url`` and the creator-or-admin gate on
+These cover the two properties the routes enforce on top of RLS:
+target-URL validation on ``target_url`` and the creator-or-admin gate on
 mutations. CRUD round-trips themselves are exercised by the dispatcher
 tests (which create rows via the same service layer).
 """
@@ -17,15 +17,6 @@ from app.models.platform.guild import GuildRole
 from app.testing import Actor
 
 
-@pytest.fixture(autouse=True)
-def _force_prod_flag(monkeypatch):
-    """Pin the SSRF dev flag to False so tests assert on production
-    semantics regardless of local ``.env``."""
-    from app.core import config as config_module
-
-    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
-
-
 async def _authed_post(client: AsyncClient, actor: Actor, body: dict):
     return await client.post(
         actor.g("/auto/subscriptions"), json=body, headers=actor.headers
@@ -34,9 +25,7 @@ async def _authed_post(client: AsyncClient, actor: Actor, body: dict):
 
 @pytest.mark.integration
 async def test_create_rejects_loopback_target_url(client: AsyncClient, acting_user):
-    """Registering a target that resolves to loopback must 400. Without
-    this guard, every guild member could redirect outbound dispatches to
-    internal services."""
+    """Registering a target that resolves to loopback must 400."""
     a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
@@ -52,16 +41,15 @@ async def test_create_rejects_loopback_target_url(client: AsyncClient, acting_us
 
 
 @pytest.mark.integration
-async def test_create_rejects_metadata_endpoint(client: AsyncClient, acting_user):
-    """The cloud-metadata endpoint is the canonical SSRF target — keep
-    it explicitly in the test suite so a regression is loud."""
+async def test_create_rejects_link_local_target(client: AsyncClient, acting_user):
+    """A link-local address must be rejected at registration."""
     a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
         client,
         a,
         body={
-            "target_url": "https://169.254.169.254/latest/meta-data/iam/",
+            "target_url": "https://169.254.169.254/",
             "event_types": ["task.created"],
         },
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -619,13 +619,12 @@ class Settings(BaseSettings):
     # ADVANCED_TOOL_URL pattern: the OSS core defers to an external service.
     BILLING_URL: str | None = None
 
-    # Local-dev escape hatch for the webhook SSRF guard. When TRUE, the
-    # dispatcher accepts ``http://`` and private/loopback/link-local
-    # targets — needed only for round-tripping with auto running on
-    # ``http://localhost:9002`` where there's no TLS cert and the
-    # address is non-public by definition. Default FALSE; production
-    # deployments MUST NOT enable this — plain http lets a MITM strip
-    # the signature header and forge payloads.
+    # Local-dev only: when true, outbound webhook / custom-AI targets may
+    # use http and resolve to private/loopback addresses, for round-tripping
+    # with a locally run initiative-auto (its receiver at
+    # ``http://localhost:8201``). Default false; production keeps the
+    # https + public-address policy. The connection is pinned to the
+    # resolved address regardless of this setting.
     WEBHOOK_ALLOW_PRIVATE_TARGETS: bool = False
 
     BEHIND_PROXY: bool = (

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -16,6 +16,7 @@ from app.models.tenant.task import Task
 from app.models.platform.user import User
 from app.schemas.ai_settings import AIProvider
 from app.services.ai_settings import resolve_ai_settings
+from app.services.safe_http import request_public_target
 from app.services.webhook_target_url import (
     WebhookTargetUrlError,
     WebhookTargetUrlPrivateError,
@@ -38,9 +39,8 @@ async def _validate_generation_base_url(
     provider: AIProvider | None,
     base_url: str | None,
 ) -> None:
-    # Ollama is platform-admin-only (guild/user can no longer select it),
-    # so its base_url is operator-controlled and trusted. Only custom
-    # providers still flow user-supplied URLs that need the SSRF guard.
+    # Only the custom provider uses a caller-supplied base URL, so only it
+    # is validated here; Ollama's base URL is operator-configured.
     if provider != AIProvider.custom or not base_url:
         return
     try:
@@ -868,14 +868,24 @@ async def _generate_ollama_summary(
 # ---------------------------------------------------------------------------
 
 
-async def _generate_custom_subtasks(
+async def _custom_chat_completion(
+    *,
     api_key: str | None,
     base_url: str | None,
     model: str | None,
     system_prompt: str,
     user_content: str,
-) -> list[str]:
-    """Generate subtasks using custom OpenAI-compatible API."""
+    temperature: float,
+    max_tokens: int,
+    timeout: float,
+) -> str:
+    """POST an OpenAI-compatible chat completion to a caller-supplied
+    ``base_url`` and return the message content.
+
+    The request goes through :func:`request_public_target`, which resolves
+    the host once and connects to that validated address, keeping the
+    hostname for TLS.
+    """
     if not base_url:
         raise AIGenerationError("Base URL is required for custom provider")
 
@@ -885,26 +895,28 @@ async def _generate_custom_subtasks(
         headers["Authorization"] = f"Bearer {api_key}"
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(
-                f"{url}/chat/completions",
-                headers=headers,
-                json={
-                    "model": model or "default",
-                    "messages": _openai_messages(system_prompt, user_content),
-                    "temperature": 0.7,
-                    "max_tokens": 500,
-                },
-            )
+        response = await request_public_target(
+            "POST",
+            f"{url}/chat/completions",
+            headers=headers,
+            json={
+                "model": model or "default",
+                "messages": _openai_messages(system_prompt, user_content),
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            },
+            timeout=timeout,
+        )
 
-            if response.status_code == 401:
-                raise AIGenerationError("Invalid API key")
-            elif response.status_code != 200:
-                raise AIGenerationError(f"API error: {response.status_code}")
+        if response.status_code == 401:
+            raise AIGenerationError("Invalid API key")
+        elif response.status_code != 200:
+            raise AIGenerationError(f"API error: {response.status_code}")
 
-            data = response.json()
-            content = data["choices"][0]["message"]["content"]
-            return _parse_subtasks_response(content)
+        data = response.json()
+        return data["choices"][0]["message"]["content"]
+    except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as exc:
+        raise AIGenerationError(AIMessages.INVALID_BASE_URL) from exc
     except httpx.ConnectError:
         raise AIGenerationError(f"Could not connect to {url}")
     except httpx.TimeoutException:
@@ -913,6 +925,27 @@ async def _generate_custom_subtasks(
         raise
     except Exception as e:
         raise AIGenerationError(f"Request failed: {str(e)}")
+
+
+async def _generate_custom_subtasks(
+    api_key: str | None,
+    base_url: str | None,
+    model: str | None,
+    system_prompt: str,
+    user_content: str,
+) -> list[str]:
+    """Generate subtasks using a custom OpenAI-compatible API."""
+    content = await _custom_chat_completion(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        system_prompt=system_prompt,
+        user_content=user_content,
+        temperature=0.7,
+        max_tokens=500,
+        timeout=30.0,
+    )
+    return _parse_subtasks_response(content)
 
 
 async def _generate_custom_description(
@@ -922,44 +955,18 @@ async def _generate_custom_description(
     system_prompt: str,
     user_content: str,
 ) -> str:
-    """Generate description using custom OpenAI-compatible API."""
-    if not base_url:
-        raise AIGenerationError("Base URL is required for custom provider")
-
-    url = base_url.rstrip("/")
-    headers = {"Content-Type": "application/json"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(
-                f"{url}/chat/completions",
-                headers=headers,
-                json={
-                    "model": model or "default",
-                    "messages": _openai_messages(system_prompt, user_content),
-                    "temperature": 0.7,
-                    "max_tokens": 500,
-                },
-            )
-
-            if response.status_code == 401:
-                raise AIGenerationError("Invalid API key")
-            elif response.status_code != 200:
-                raise AIGenerationError(f"API error: {response.status_code}")
-
-            data = response.json()
-            text = data["choices"][0]["message"]["content"].strip()
-            return _truncate_output(text, _MAX_DESCRIPTION_LENGTH)
-    except httpx.ConnectError:
-        raise AIGenerationError(f"Could not connect to {url}")
-    except httpx.TimeoutException:
-        raise AIGenerationError("Request timed out")
-    except AIGenerationError:
-        raise
-    except Exception as e:
-        raise AIGenerationError(f"Request failed: {str(e)}")
+    """Generate a description using a custom OpenAI-compatible API."""
+    content = await _custom_chat_completion(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        system_prompt=system_prompt,
+        user_content=user_content,
+        temperature=0.7,
+        max_tokens=500,
+        timeout=30.0,
+    )
+    return _truncate_output(content.strip(), _MAX_DESCRIPTION_LENGTH)
 
 
 async def _generate_custom_summary(
@@ -969,44 +976,18 @@ async def _generate_custom_summary(
     system_prompt: str,
     user_content: str,
 ) -> str:
-    """Generate summary using custom OpenAI-compatible API."""
-    if not base_url:
-        raise AIGenerationError("Base URL is required for custom provider")
-
-    url = base_url.rstrip("/")
-    headers = {"Content-Type": "application/json"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-
-    try:
-        async with httpx.AsyncClient(timeout=90.0) as client:
-            response = await client.post(
-                f"{url}/chat/completions",
-                headers=headers,
-                json={
-                    "model": model or "default",
-                    "messages": _openai_messages(system_prompt, user_content),
-                    "temperature": 0.5,
-                    "max_tokens": 1000,
-                },
-            )
-
-            if response.status_code == 401:
-                raise AIGenerationError("Invalid API key")
-            elif response.status_code != 200:
-                raise AIGenerationError(f"API error: {response.status_code}")
-
-            data = response.json()
-            text = data["choices"][0]["message"]["content"].strip()
-            return _truncate_output(text, _MAX_SUMMARY_LENGTH)
-    except httpx.ConnectError:
-        raise AIGenerationError(f"Could not connect to {url}")
-    except httpx.TimeoutException:
-        raise AIGenerationError("Request timed out")
-    except AIGenerationError:
-        raise
-    except Exception as e:
-        raise AIGenerationError(f"Request failed: {str(e)}")
+    """Generate a summary using a custom OpenAI-compatible API."""
+    content = await _custom_chat_completion(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        system_prompt=system_prompt,
+        user_content=user_content,
+        temperature=0.5,
+        max_tokens=1000,
+        timeout=90.0,
+    )
+    return _truncate_output(content.strip(), _MAX_SUMMARY_LENGTH)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/safe_http.py
+++ b/backend/app/services/safe_http.py
@@ -116,4 +116,8 @@ async def request_public_target(
             except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
                 # This validated address is unreachable; try the next one.
                 last_exc = exc
-    raise last_exc
+    if last_exc is not None:
+        raise last_exc
+    # Unreachable: resolve_validated_target_async guarantees at least one
+    # address, so the loop always sets last_exc on total failure.
+    raise RuntimeError(f"no validated address to connect to for {url!r}")

--- a/backend/app/services/safe_http.py
+++ b/backend/app/services/safe_http.py
@@ -92,12 +92,14 @@ async def request_public_target(
     transport: httpx.AsyncBaseTransport | None = None,
 ) -> httpx.Response:
     """Send a request to a validated public target. The host is resolved
-    once; the request connects to a validated address and falls back to the
-    other validated addresses if one is unreachable. ``transport`` is
-    injectable for tests."""
+    once; the request connects to a validated address and, if one fails
+    fast (connection refused / unreachable), falls back to the other
+    validated addresses. A connect *timeout* is not retried — it has
+    already consumed the caller's budget — so total wall time stays bounded
+    by ``timeout``. ``transport`` is injectable for tests."""
     original = httpx.URL(url)
     target = await resolve_validated_target_async(url)
-    last_exc: Exception | None = None
+    last_exc: httpx.ConnectError | None = None
     async with httpx.AsyncClient(
         timeout=timeout, follow_redirects=False, transport=transport
     ) as client:
@@ -113,8 +115,8 @@ async def request_public_target(
             )
             try:
                 return await client.send(request)
-            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
-                # This validated address is unreachable; try the next one.
+            except httpx.ConnectError as exc:
+                # Fast failure for this validated address; try the next one.
                 last_exc = exc
     if last_exc is not None:
         raise last_exc

--- a/backend/app/services/safe_http.py
+++ b/backend/app/services/safe_http.py
@@ -46,16 +46,38 @@ async def build_validated_request(
     """
     original = httpx.URL(url)
     target = await resolve_validated_target_async(url)
-    pinned_url = original.copy_with(host=target.pinned_ip)
+    return _pin_request(
+        method,
+        original,
+        target.pinned_ip,
+        target.hostname,
+        headers=headers,
+        content=content,
+        json=json,
+    )
+
+
+def _pin_request(
+    method: str,
+    original: httpx.URL,
+    ip: str,
+    hostname: str,
+    *,
+    headers: dict[str, str] | None,
+    content: bytes | None,
+    json: Any,
+) -> httpx.Request:
+    """Build a request aimed at ``ip`` while keeping ``hostname`` for TLS
+    SNI, certificate verification, and the ``Host`` header."""
     merged = dict(headers or {})
     merged["Host"] = _authority(original)
     return httpx.Request(
         method,
-        pinned_url,
+        original.copy_with(host=ip),
         headers=merged,
         content=content,
         json=json,
-        extensions={"sni_hostname": target.hostname},
+        extensions={"sni_hostname": hostname},
     )
 
 
@@ -69,12 +91,29 @@ async def request_public_target(
     timeout: httpx.Timeout | float,
     transport: httpx.AsyncBaseTransport | None = None,
 ) -> httpx.Response:
-    """Send a request to a validated public target, connected to the
-    address that was checked. ``transport`` is injectable for tests."""
-    request = await build_validated_request(
-        method, url, headers=headers, content=content, json=json
-    )
+    """Send a request to a validated public target. The host is resolved
+    once; the request connects to a validated address and falls back to the
+    other validated addresses if one is unreachable. ``transport`` is
+    injectable for tests."""
+    original = httpx.URL(url)
+    target = await resolve_validated_target_async(url)
+    last_exc: Exception | None = None
     async with httpx.AsyncClient(
         timeout=timeout, follow_redirects=False, transport=transport
     ) as client:
-        return await client.send(request)
+        for address in target.addresses:
+            request = _pin_request(
+                method,
+                original,
+                str(address),
+                target.hostname,
+                headers=headers,
+                content=content,
+                json=json,
+            )
+            try:
+                return await client.send(request)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+                # This validated address is unreachable; try the next one.
+                last_exc = exc
+    raise last_exc

--- a/backend/app/services/safe_http.py
+++ b/backend/app/services/safe_http.py
@@ -1,0 +1,80 @@
+"""Central egress helper for outbound HTTP to caller-influenced URLs.
+
+Webhook delivery and the custom AI provider both send requests to URLs a
+guild member can set. Both go through :func:`request_public_target` so
+the target policy (see :mod:`app.services.webhook_target_url`) is enforced
+in one place and the request connects to the address that was validated.
+
+The host is resolved once; the request is aimed at the resulting address
+while the original hostname is preserved for TLS SNI, certificate
+verification, and the ``Host`` header. Redirects are not followed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.services.webhook_target_url import resolve_validated_target_async
+
+
+def _authority(url: httpx.URL) -> str:
+    """``host[:port]`` for the ``Host`` header, bracketing IPv6 literals
+    and including the port only when the URL specified one."""
+    host = url.host
+    bracketed = f"[{host}]" if ":" in host else host
+    port = url.port
+    return f"{bracketed}:{port}" if port is not None else bracketed
+
+
+async def build_validated_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    content: bytes | None = None,
+    json: Any = None,
+) -> httpx.Request:
+    """Resolve and validate ``url``, then build a request whose connection
+    target is the validated address, keeping the hostname for TLS SNI,
+    certificate verification, and the ``Host`` header.
+
+    Raises :class:`~app.services.webhook_target_url.WebhookTargetUrlError`
+    or :class:`~app.services.webhook_target_url.WebhookTargetUrlPrivateError`
+    for a disallowed target.
+    """
+    original = httpx.URL(url)
+    target = await resolve_validated_target_async(url)
+    pinned_url = original.copy_with(host=target.pinned_ip)
+    merged = dict(headers or {})
+    merged["Host"] = _authority(original)
+    return httpx.Request(
+        method,
+        pinned_url,
+        headers=merged,
+        content=content,
+        json=json,
+        extensions={"sni_hostname": target.hostname},
+    )
+
+
+async def request_public_target(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    content: bytes | None = None,
+    json: Any = None,
+    timeout: httpx.Timeout | float,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> httpx.Response:
+    """Send a request to a validated public target, connected to the
+    address that was checked. ``transport`` is injectable for tests."""
+    request = await build_validated_request(
+        method, url, headers=headers, content=content, json=json
+    )
+    async with httpx.AsyncClient(
+        timeout=timeout, follow_redirects=False, transport=transport
+    ) as client:
+        return await client.send(request)

--- a/backend/app/services/safe_http_test.py
+++ b/backend/app/services/safe_http_test.py
@@ -158,3 +158,33 @@ async def test_falls_back_to_next_validated_address():
 
     assert response.status_code == 200
     assert seen == ["93.184.216.34", "93.184.216.35"]
+
+
+@pytest.mark.unit
+async def test_connect_timeout_does_not_fall_back():
+    """A connect timeout is not retried across addresses — it has already
+    consumed the caller's budget — so the request fails without multiplying
+    the timeout over every validated address."""
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.host)
+        raise httpx.ConnectTimeout("timed out", request=request)
+
+    infos = [
+        (2, 0, 0, "", ("93.184.216.34", 0)),
+        (2, 0, 0, "", ("93.184.216.35", 0)),
+    ]
+    with patch(
+        "app.services.webhook_target_url.socket.getaddrinfo", return_value=infos
+    ):
+        with pytest.raises(httpx.ConnectTimeout):
+            await request_public_target(
+                "POST",
+                "https://cdn.example.com/deliver",
+                content=b"{}",
+                timeout=5.0,
+                transport=httpx.MockTransport(handler),
+            )
+
+    assert seen == ["93.184.216.34"]  # stopped after the timeout; no fallback

--- a/backend/app/services/safe_http_test.py
+++ b/backend/app/services/safe_http_test.py
@@ -1,0 +1,129 @@
+"""Unit tests for guarded outbound egress.
+
+The key property: a request is aimed at the address that was validated,
+not the hostname — so the resolution used to check the target and the
+resolution used to connect cannot differ.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services.safe_http import build_validated_request, request_public_target
+from app.services.webhook_target_url import WebhookTargetUrlPrivateError
+
+
+def _resolves_to(ip: str):
+    """Patch DNS so any hostname resolves to a single ``ip``."""
+    infos = [(2, 0, 0, "", (ip, 0))]  # AF_INET
+    return patch(
+        "app.services.webhook_target_url.socket.getaddrinfo", return_value=infos
+    )
+
+
+@pytest.mark.unit
+async def test_request_targets_validated_ip_and_keeps_hostname():
+    with _resolves_to("93.184.216.34"):
+        request = await build_validated_request(
+            "POST",
+            "https://hooks.example.com/deliver?x=1",
+            headers={"Content-Type": "application/json"},
+            content=b"{}",
+        )
+    # Connection target is the resolved address, not the hostname.
+    assert request.url.host == "93.184.216.34"
+    # Path and query are preserved.
+    assert request.url.raw_path == b"/deliver?x=1"
+    # Hostname is preserved for the Host header and TLS.
+    assert request.headers["host"] == "hooks.example.com"
+    assert request.extensions["sni_hostname"] == "hooks.example.com"
+
+
+@pytest.mark.unit
+async def test_host_header_includes_explicit_port():
+    with _resolves_to("93.184.216.34"):
+        request = await build_validated_request(
+            "POST", "https://hooks.example.com:8443/x", content=b""
+        )
+    assert request.url.host == "93.184.216.34"
+    assert request.url.port == 8443
+    assert request.headers["host"] == "hooks.example.com:8443"
+
+
+@pytest.mark.unit
+async def test_private_resolution_is_refused():
+    with _resolves_to("10.0.0.5"):
+        with pytest.raises(WebhookTargetUrlPrivateError):
+            await build_validated_request(
+                "POST", "https://internal.example.com/x", content=b""
+            )
+
+
+@pytest.mark.unit
+async def test_send_connects_to_pinned_ip():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["host"] = request.url.host
+        seen["host_header"] = request.headers.get("host")
+        seen["sni"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, json={"ok": True})
+
+    with _resolves_to("93.184.216.34"):
+        response = await request_public_target(
+            "POST",
+            "https://hooks.example.com/deliver",
+            headers={"Content-Type": "application/json"},
+            content=b"{}",
+            timeout=5.0,
+            transport=httpx.MockTransport(handler),
+        )
+
+    assert response.status_code == 200
+    assert seen == {
+        "host": "93.184.216.34",
+        "host_header": "hooks.example.com",
+        "sni": "hooks.example.com",
+    }
+
+
+@pytest.mark.unit
+async def test_redirects_are_not_followed():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.host)
+        return httpx.Response(
+            302, headers={"Location": "https://elsewhere.example.com/"}
+        )
+
+    with _resolves_to("93.184.216.34"):
+        response = await request_public_target(
+            "GET",
+            "https://hooks.example.com/deliver",
+            timeout=5.0,
+            transport=httpx.MockTransport(handler),
+        )
+
+    assert response.status_code == 302
+    assert calls == ["93.184.216.34"]  # only the pinned host was contacted
+
+
+@pytest.mark.unit
+async def test_dev_flag_pins_private_local_target(monkeypatch):
+    """With the dev flag on, a local target is allowed *and* still pinned
+    to the resolved address — the round-trip works and pinning holds."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", True)
+
+    with _resolves_to("127.0.0.1"):
+        request = await build_validated_request(
+            "POST", "http://localhost:8201/api/v1/webhooks/initiative", content=b"{}"
+        )
+    assert request.url.host == "127.0.0.1"
+    assert request.url.scheme == "http"
+    assert request.headers["host"] == "localhost:8201"

--- a/backend/app/services/safe_http_test.py
+++ b/backend/app/services/safe_http_test.py
@@ -127,3 +127,34 @@ async def test_dev_flag_pins_private_local_target(monkeypatch):
     assert request.url.host == "127.0.0.1"
     assert request.url.scheme == "http"
     assert request.headers["host"] == "localhost:8201"
+
+
+@pytest.mark.unit
+async def test_falls_back_to_next_validated_address():
+    """If the first validated address is unreachable, the request retries
+    the other validated addresses instead of failing outright."""
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.host)
+        if request.url.host == "93.184.216.34":
+            raise httpx.ConnectError("refused", request=request)
+        return httpx.Response(200, json={"ok": True})
+
+    infos = [
+        (2, 0, 0, "", ("93.184.216.34", 0)),
+        (2, 0, 0, "", ("93.184.216.35", 0)),
+    ]
+    with patch(
+        "app.services.webhook_target_url.socket.getaddrinfo", return_value=infos
+    ):
+        response = await request_public_target(
+            "POST",
+            "https://cdn.example.com/deliver",
+            content=b"{}",
+            timeout=5.0,
+            transport=httpx.MockTransport(handler),
+        )
+
+    assert response.status_code == 200
+    assert seen == ["93.184.216.34", "93.184.216.35"]

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -37,10 +37,10 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.tenant.webhook_subscription import WebhookSubscription
+from app.services.safe_http import request_public_target
 from app.services.webhook_target_url import (
     WebhookTargetUrlError,
     WebhookTargetUrlPrivateError,
-    assert_target_url_is_public_async,
 )
 
 logger = logging.getLogger(__name__)
@@ -70,22 +70,11 @@ async def _deliver(
     """POST one envelope to one target. Logs and swallows any error so
     one bad subscriber can't break the rest of the dispatch.
 
-    The ``target_url`` is re-validated here even though the API layer
-    already checked at create/update time. DNS can change underneath us,
-    so a previously-public hostname could now point at internal space —
-    re-resolving immediately before the request closes the rebinding
-    window.
+    Delivery goes through :func:`request_public_target`, which resolves
+    the target host once and connects to that validated address. The
+    target is re-checked here (not only at create/update time) because a
+    hostname's resolution can change between registration and delivery.
     """
-    try:
-        await assert_target_url_is_public_async(target_url)
-    except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as exc:
-        logger.warning(
-            "webhook delivery skipped — target failed pre-flight check: target=%s err=%s",
-            target_url,
-            exc,
-        )
-        return
-
     body = json.dumps(envelope, default=str, separators=(",", ":")).encode("utf-8")
     timestamp = str(int(datetime.now(timezone.utc).timestamp()))
     signature = _sign(secret, timestamp, body)
@@ -99,21 +88,35 @@ async def _deliver(
     }
 
     try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            response = await client.post(target_url, content=body, headers=headers)
-            if response.status_code >= 400:
-                logger.warning(
-                    "webhook delivery non-2xx: target=%s event=%s status=%s",
-                    target_url,
-                    envelope["event_type"],
-                    response.status_code,
-                )
+        response = await request_public_target(
+            "POST",
+            target_url,
+            headers=headers,
+            content=body,
+            timeout=_TIMEOUT,
+        )
+    except (WebhookTargetUrlError, WebhookTargetUrlPrivateError) as exc:
+        logger.warning(
+            "webhook delivery skipped — target failed validation: target=%s err=%s",
+            target_url,
+            exc,
+        )
+        return
     except Exception as exc:  # noqa: BLE001 — best-effort delivery
         logger.warning(
             "webhook delivery failed: target=%s event=%s err=%s",
             target_url,
             envelope["event_type"],
             exc,
+        )
+        return
+
+    if response.status_code >= 400:
+        logger.warning(
+            "webhook delivery non-2xx: target=%s event=%s status=%s",
+            target_url,
+            envelope["event_type"],
+            response.status_code,
         )
 
 

--- a/backend/app/services/webhook_target_url.py
+++ b/backend/app/services/webhook_target_url.py
@@ -1,31 +1,22 @@
-"""Validation helpers for webhook target URLs.
+"""Validation and safe resolution for outbound target URLs.
 
-The dispatcher POSTs to operator-supplied URLs from inside Initiative's
-network. Without a guard, a guild member could register
-``http://169.254.169.254/`` (cloud metadata) or ``http://localhost:6379``
-(an internal Redis) as a target — every matching event would then trigger
-a server-side request to that address. Even though the response body
-isn't surfaced to the caller (delivery is fire-and-log), this enables
-internal port scanning and metadata-credential scraping.
+Some outbound requests go to URLs a guild member can set (webhook
+delivery targets and the custom AI provider base URL). These helpers
+constrain such URLs to public destinations and resolve them so the
+caller connects to exactly the address that was validated.
 
-The defense:
+Policy: only ``https`` is accepted, and the host must resolve to public
+unicast addresses (private, loopback, link-local, multicast, reserved
+and unspecified are rejected). When a name resolves to several
+addresses, all of them must pass. A local-dev setting
+(``WEBHOOK_ALLOW_PRIVATE_TARGETS``) relaxes both for round-tripping with
+a locally run initiative-auto; address pinning still applies.
 
-* Only ``https://`` is accepted by default, so signed payloads always
-  ride an encrypted transport.
-* At create/update time we resolve the hostname and reject any address
-  that isn't a public unicast IP (private, loopback, link-local, etc.).
-* The same check runs again immediately before delivery in case DNS
-  changed underneath us (rebinding) or a previously-public hostname now
-  points at internal space.
-
-The async variant (:func:`assert_target_url_is_public_async`) must be
-used from any code path that runs on the event loop — :func:`socket.getaddrinfo`
-is blocking and will stall every other coroutine until the resolver
-returns. The sync variant exists for migrations / scripts / tests.
-
-This is conservative — public DNS that resolves to multiple addresses
-must have *all* of them pass. Operators who legitimately need to point a
-hook at an internal address should run a public-facing relay.
+``resolve_validated_target(_async)`` returns the approved addresses so
+the caller can connect to one of them directly (see
+:mod:`app.services.safe_http`). Use the async variant from coroutine
+code — :func:`socket.getaddrinfo` is blocking; the sync variant is for
+scripts and tests.
 """
 
 from __future__ import annotations
@@ -33,12 +24,15 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import socket
+from dataclasses import dataclass
 from urllib.parse import urlparse
+
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
 
 
 class WebhookTargetUrlError(ValueError):
     """Raised when a target URL is structurally invalid (bad scheme,
-    missing host, unparseable port, etc.)."""
+    missing host, unresolvable, unparseable port, etc.)."""
 
 
 class WebhookTargetUrlPrivateError(ValueError):
@@ -47,23 +41,37 @@ class WebhookTargetUrlPrivateError(ValueError):
     layer can return a more specific error code."""
 
 
-_ACCEPTED_SCHEMES = frozenset({"https", "http"})
+@dataclass(frozen=True)
+class ValidatedTarget:
+    """A target URL that passed policy. ``addresses`` are all public
+    unicast; ``hostname`` is the original host to use for TLS SNI,
+    certificate verification, and the ``Host`` header when connecting to
+    one of ``addresses``."""
+
+    hostname: str
+    addresses: tuple[_IPAddress, ...]
+
+    @property
+    def pinned_ip(self) -> str:
+        """The address to connect to. Every address passed policy, so the
+        first one is used."""
+        return str(self.addresses[0])
 
 
-def _allow_private_targets() -> bool:
-    """Resolve the dev escape hatch lazily so monkeypatching ``settings``
-    in tests works. Reading at call time also lets a deployed-process
-    config-reload effort pick up the new value (we don't reload yet, but
-    nothing here forecloses it)."""
-    from app.core.config import settings
+def _unwrap_mapped(ip: _IPAddress) -> _IPAddress:
+    """Return the embedded IPv4 for an IPv4-mapped IPv6 address
+    (``::ffff:10.0.0.1``), else the address unchanged. ``ipaddress``
+    classifies the mapped form by IPv6 rules, so its ``.is_private`` etc.
+    do not reflect the embedded IPv4 — unwrap before classifying."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ip
 
-    return settings.WEBHOOK_ALLOW_PRIVATE_TARGETS
 
-
-def _is_public_address(ip: ipaddress._BaseAddress) -> bool:
-    """Return True only for public unicast addresses we're willing to
-    POST to. Everything else (private, loopback, link-local, multicast,
-    reserved, unspecified) is blocked."""
+def _is_public_address(ip: _IPAddress) -> bool:
+    """True only for public unicast addresses. Everything else (private,
+    loopback, link-local, multicast, reserved, unspecified) is refused."""
+    ip = _unwrap_mapped(ip)
     return not (
         ip.is_private
         or ip.is_loopback
@@ -74,42 +82,39 @@ def _is_public_address(ip: ipaddress._BaseAddress) -> bool:
     )
 
 
-def _parse_and_check_scheme(url: str) -> tuple[str, str]:
-    """Parse the URL and validate scheme + presence of hostname.
+def _allow_private_targets() -> bool:
+    """Local-dev escape hatch, read at call time so tests can monkeypatch
+    ``settings``. When true, http and private/loopback targets are
+    permitted (for round-tripping with a locally run initiative-auto)."""
+    from app.core.config import settings
 
-    With the dev flag off (production), reject anything other than
-    ``https`` immediately — this preserves the structural-invalid
-    error type for ``http://private-ip`` URLs (a plain ``http`` target
-    is structurally wrong regardless of where it points). With the
-    flag on, both ``http`` and ``https`` are tentatively accepted; the
-    final scheme + address combination is decided in
-    :func:`_enforce_address_policy` after DNS resolves, so we can bind
-    the ``http`` allowance to private targets specifically.
-    """
+    return settings.WEBHOOK_ALLOW_PRIVATE_TARGETS
+
+
+def _parse_host(url: str) -> str:
+    """Parse the URL, check the scheme, and return the hostname. Only
+    ``https`` is accepted unless the dev escape hatch also permits
+    ``http`` for local targets."""
     parsed = urlparse(url)
-    allowed = _ACCEPTED_SCHEMES if _allow_private_targets() else frozenset({"https"})
+    allowed = ("https", "http") if _allow_private_targets() else ("https",)
     if parsed.scheme not in allowed:
-        allowed_desc = "https or http" if _allow_private_targets() else "https"
+        want = "https or http" if _allow_private_targets() else "https"
         raise WebhookTargetUrlError(
-            f"unsupported scheme: {parsed.scheme!r} ({allowed_desc} required)"
+            f"unsupported scheme: {parsed.scheme!r} ({want} required)"
         )
     if not parsed.hostname:
         raise WebhookTargetUrlError("missing hostname")
-    return parsed.hostname, parsed.scheme
+    return parsed.hostname
 
 
-def _addresses_from_getaddrinfo_results(
-    infos: list, host: str
-) -> list[ipaddress._BaseAddress]:
-    """Convert a ``getaddrinfo`` result list to a list of ``ipaddress``
-    objects, stripping IPv6 zone identifiers."""
-    addresses: list[ipaddress._BaseAddress] = []
+def _addresses_from_getaddrinfo_results(infos: list, host: str) -> list[_IPAddress]:
+    """Convert a ``getaddrinfo`` result list to ``ipaddress`` objects,
+    stripping IPv6 zone identifiers."""
+    addresses: list[_IPAddress] = []
     for family, _type, _proto, _canon, sockaddr in infos:
         if family == socket.AF_INET:
             addresses.append(ipaddress.IPv4Address(sockaddr[0]))
         elif family == socket.AF_INET6:
-            # sockaddr[0] for v6 may include zone id (``fe80::1%eth0``);
-            # ipaddress accepts the bare numeric form so strip it.
             addr_str = sockaddr[0].split("%", 1)[0]
             addresses.append(ipaddress.IPv6Address(addr_str))
     if not addresses:
@@ -117,76 +122,35 @@ def _addresses_from_getaddrinfo_results(
     return addresses
 
 
-def _enforce_address_policy(
-    host: str,
-    scheme: str,
-    addresses: list[ipaddress._BaseAddress],
-) -> None:
-    """Apply the combined scheme + address policy to a resolved target.
-
-    Two rules combine here:
-
-    * **No private addresses** unless the dev escape hatch is on. The
-      "any private blocks all" rule still applies: a hostname that
-      resolves to a mixed public/private set is rejected as a whole,
-      not decided by whichever address httpx happens to pick.
-    * **No plain http to public hosts, ever.** The dev flag deliberately
-      doesn't relax this — its scope is local / private targets only,
-      where there's no useful TLS to be had between Initiative and auto.
-
-    The matrix:
-
-    | flag | scheme | resolves to | result |
-    |------|--------|-------------|--------|
-    | off  | https  | public      | accept |
-    | off  | https  | private     | reject (private) |
-    | off  | http   | any         | reject (http) |
-    | on   | https  | public      | accept |
-    | on   | https  | private     | accept |
-    | on   | http   | public      | reject (http to public is forbidden) |
-    | on   | http   | private     | accept (the dev case) |
-    """
-    has_private = any(not _is_public_address(a) for a in addresses)
-
-    if has_private:
-        if not _allow_private_targets():
-            offending = next(a for a in addresses if not _is_public_address(a))
-            raise WebhookTargetUrlPrivateError(
-                f"host {host!r} resolves to non-public address {offending}"
-            )
-        # dev flag is on — http or https are both fine for private targets.
+def _enforce_all_public(host: str, addresses: list[_IPAddress]) -> None:
+    """Reject if any resolved address is non-public. A mixed set is
+    refused as a whole, not decided by whichever address a resolver
+    happens to return first. The dev escape hatch permits private targets
+    for local round-trips."""
+    if _allow_private_targets():
         return
-
-    # All addresses are public.
-    if scheme != "https":
-        raise WebhookTargetUrlError(
-            f"plain http to public host {host!r} is not permitted "
-            f"(MITM would strip the signature)"
-        )
+    for address in addresses:
+        if not _is_public_address(address):
+            raise WebhookTargetUrlPrivateError(
+                f"host {host!r} resolves to non-public address {address}"
+            )
 
 
-def _resolve_literal_or_none(
-    host: str,
-) -> list[ipaddress._BaseAddress] | None:
+def _literal_or_none(host: str) -> list[_IPAddress] | None:
     """If ``host`` is an IP literal, return ``[ip]``; otherwise ``None``
-    so the caller can do a real DNS lookup."""
+    so the caller does a DNS lookup."""
     try:
         return [ipaddress.ip_address(host)]
     except ValueError:
         return None
 
 
-def assert_target_url_is_public(url: str) -> None:
-    """Synchronous SSRF guard. Use only outside the event loop.
-
-    Raises :class:`WebhookTargetUrlError` for malformed input or a
-    scheme/address combination that can't be permitted (e.g. plain
-    http to a public host), :class:`WebhookTargetUrlPrivateError` when
-    the host resolves into private/loopback/link-local space and the
-    dev flag isn't set.
-    """
-    host, scheme = _parse_and_check_scheme(url)
-    addresses = _resolve_literal_or_none(host)
+def resolve_validated_target(url: str) -> ValidatedTarget:
+    """Resolve ``url`` and apply the target policy. Use outside the event
+    loop. Raises :class:`WebhookTargetUrlError` for malformed input or
+    :class:`WebhookTargetUrlPrivateError` for non-public addresses."""
+    host = _parse_host(url)
+    addresses = _literal_or_none(host)
     if addresses is None:
         try:
             infos = socket.getaddrinfo(host, None)
@@ -195,17 +159,15 @@ def assert_target_url_is_public(url: str) -> None:
                 f"could not resolve host {host!r}: {exc}"
             ) from exc
         addresses = _addresses_from_getaddrinfo_results(infos, host)
-    _enforce_address_policy(host, scheme, addresses)
+    _enforce_all_public(host, addresses)
+    return ValidatedTarget(hostname=host, addresses=tuple(addresses))
 
 
-async def assert_target_url_is_public_async(url: str) -> None:
-    """Async SSRF guard for use inside coroutines.
-
-    DNS resolution runs in a thread executor so the event loop stays
-    free. Behaviour and exceptions match :func:`assert_target_url_is_public`.
-    """
-    host, scheme = _parse_and_check_scheme(url)
-    addresses = _resolve_literal_or_none(host)
+async def resolve_validated_target_async(url: str) -> ValidatedTarget:
+    """Async form of :func:`resolve_validated_target`. DNS runs in a
+    thread so the event loop stays free."""
+    host = _parse_host(url)
+    addresses = _literal_or_none(host)
     if addresses is None:
         try:
             infos = await asyncio.to_thread(socket.getaddrinfo, host, None)
@@ -214,4 +176,16 @@ async def assert_target_url_is_public_async(url: str) -> None:
                 f"could not resolve host {host!r}: {exc}"
             ) from exc
         addresses = _addresses_from_getaddrinfo_results(infos, host)
-    _enforce_address_policy(host, scheme, addresses)
+    _enforce_all_public(host, addresses)
+    return ValidatedTarget(hostname=host, addresses=tuple(addresses))
+
+
+def assert_target_url_is_public(url: str) -> None:
+    """Policy check only, discarding the resolution. For create/update
+    validation where no connection is made yet."""
+    resolve_validated_target(url)
+
+
+async def assert_target_url_is_public_async(url: str) -> None:
+    """Async policy check only. See :func:`assert_target_url_is_public`."""
+    await resolve_validated_target_async(url)

--- a/backend/app/services/webhook_target_url.py
+++ b/backend/app/services/webhook_target_url.py
@@ -91,10 +91,11 @@ def _allow_private_targets() -> bool:
     return settings.WEBHOOK_ALLOW_PRIVATE_TARGETS
 
 
-def _parse_host(url: str) -> str:
-    """Parse the URL, check the scheme, and return the hostname. Only
-    ``https`` is accepted unless the dev escape hatch also permits
-    ``http`` for local targets."""
+def _parse_host(url: str) -> tuple[str, str]:
+    """Parse the URL and return ``(scheme, hostname)``. Only ``https`` is
+    accepted unless the dev escape hatch tentatively permits ``http``; the
+    address policy then restricts that ``http`` allowance to non-public
+    targets."""
     parsed = urlparse(url)
     allowed = ("https", "http") if _allow_private_targets() else ("https",)
     if parsed.scheme not in allowed:
@@ -104,7 +105,7 @@ def _parse_host(url: str) -> str:
         )
     if not parsed.hostname:
         raise WebhookTargetUrlError("missing hostname")
-    return parsed.hostname
+    return parsed.scheme, parsed.hostname
 
 
 def _addresses_from_getaddrinfo_results(infos: list, host: str) -> list[_IPAddress]:
@@ -122,18 +123,27 @@ def _addresses_from_getaddrinfo_results(infos: list, host: str) -> list[_IPAddre
     return addresses
 
 
-def _enforce_all_public(host: str, addresses: list[_IPAddress]) -> None:
-    """Reject if any resolved address is non-public. A mixed set is
-    refused as a whole, not decided by whichever address a resolver
-    happens to return first. The dev escape hatch permits private targets
-    for local round-trips."""
-    if _allow_private_targets():
-        return
-    for address in addresses:
-        if not _is_public_address(address):
+def _enforce_policy(host: str, scheme: str, addresses: list[_IPAddress]) -> None:
+    """Apply the scheme + address policy to a resolved target.
+
+    A non-public address (private/loopback/link-local/...) is refused
+    unless the dev escape hatch is on, in which case a local target may
+    use http or https. Plain http to a *public* host is never permitted,
+    even with the escape hatch — its scope is local/private targets. A
+    mixed public/private set is treated as private (refused as a whole
+    when the hatch is off)."""
+    has_private = any(not _is_public_address(a) for a in addresses)
+    if has_private:
+        if not _allow_private_targets():
+            offending = next(a for a in addresses if not _is_public_address(a))
             raise WebhookTargetUrlPrivateError(
-                f"host {host!r} resolves to non-public address {address}"
+                f"host {host!r} resolves to non-public address {offending}"
             )
+        return
+    if scheme != "https":
+        raise WebhookTargetUrlError(
+            f"plain http to public host {host!r} is not permitted"
+        )
 
 
 def _literal_or_none(host: str) -> list[_IPAddress] | None:
@@ -149,7 +159,7 @@ def resolve_validated_target(url: str) -> ValidatedTarget:
     """Resolve ``url`` and apply the target policy. Use outside the event
     loop. Raises :class:`WebhookTargetUrlError` for malformed input or
     :class:`WebhookTargetUrlPrivateError` for non-public addresses."""
-    host = _parse_host(url)
+    scheme, host = _parse_host(url)
     addresses = _literal_or_none(host)
     if addresses is None:
         try:
@@ -159,14 +169,14 @@ def resolve_validated_target(url: str) -> ValidatedTarget:
                 f"could not resolve host {host!r}: {exc}"
             ) from exc
         addresses = _addresses_from_getaddrinfo_results(infos, host)
-    _enforce_all_public(host, addresses)
+    _enforce_policy(host, scheme, addresses)
     return ValidatedTarget(hostname=host, addresses=tuple(addresses))
 
 
 async def resolve_validated_target_async(url: str) -> ValidatedTarget:
     """Async form of :func:`resolve_validated_target`. DNS runs in a
     thread so the event loop stays free."""
-    host = _parse_host(url)
+    scheme, host = _parse_host(url)
     addresses = _literal_or_none(host)
     if addresses is None:
         try:
@@ -176,7 +186,7 @@ async def resolve_validated_target_async(url: str) -> ValidatedTarget:
                 f"could not resolve host {host!r}: {exc}"
             ) from exc
         addresses = _addresses_from_getaddrinfo_results(infos, host)
-    _enforce_all_public(host, addresses)
+    _enforce_policy(host, scheme, addresses)
     return ValidatedTarget(hostname=host, addresses=tuple(addresses))
 
 

--- a/backend/app/services/webhook_target_url.py
+++ b/backend/app/services/webhook_target_url.py
@@ -126,21 +126,18 @@ def _addresses_from_getaddrinfo_results(infos: list, host: str) -> list[_IPAddre
 def _enforce_policy(host: str, scheme: str, addresses: list[_IPAddress]) -> None:
     """Apply the scheme + address policy to a resolved target.
 
-    A non-public address (private/loopback/link-local/...) is refused
-    unless the dev escape hatch is on, in which case a local target may
-    use http or https. Plain http to a *public* host is never permitted,
-    even with the escape hatch — its scope is local/private targets. A
-    mixed public/private set is treated as private (refused as a whole
-    when the hatch is off)."""
-    has_private = any(not _is_public_address(a) for a in addresses)
-    if has_private:
-        if not _allow_private_targets():
-            offending = next(a for a in addresses if not _is_public_address(a))
-            raise WebhookTargetUrlPrivateError(
-                f"host {host!r} resolves to non-public address {offending}"
-            )
-        return
-    if scheme != "https":
+    Non-public addresses (private/loopback/link-local/...) require the dev
+    escape hatch. Public addresses require https — plain http is only ever
+    allowed when no resolved address is public, so a mixed set over http is
+    rejected even with the hatch on (any address may be connected to)."""
+    public = [a for a in addresses if _is_public_address(a)]
+    non_public = [a for a in addresses if not _is_public_address(a)]
+
+    if non_public and not _allow_private_targets():
+        raise WebhookTargetUrlPrivateError(
+            f"host {host!r} resolves to non-public address {non_public[0]}"
+        )
+    if public and scheme != "https":
         raise WebhookTargetUrlError(
             f"plain http to public host {host!r} is not permitted"
         )

--- a/backend/app/services/webhook_target_url_test.py
+++ b/backend/app/services/webhook_target_url_test.py
@@ -226,3 +226,35 @@ def test_dev_flag_still_rejects_http_to_public(monkeypatch):
     ):
         with pytest.raises(WebhookTargetUrlError):
             assert_target_url_is_public("http://hooks.example.com/in")
+
+
+@pytest.mark.unit
+def test_dev_flag_rejects_http_to_mixed_public_private(monkeypatch):
+    """Dev flag on: a host resolving to both public and private addresses
+    over http is rejected — http is only allowed when no resolved address
+    is public (any address in the set may be connected to)."""
+    _enable_dev_flag(monkeypatch)
+    fake_infos = [
+        (2, 0, 0, "", ("93.184.216.34", 0)),  # public
+        (2, 0, 0, "", ("10.0.0.5", 0)),  # private
+    ]
+    with patch(
+        "app.services.webhook_target_url.socket.getaddrinfo", return_value=fake_infos
+    ):
+        with pytest.raises(WebhookTargetUrlError):
+            assert_target_url_is_public("http://mixed.example.com/hook")
+
+
+@pytest.mark.unit
+def test_dev_flag_allows_https_to_mixed(monkeypatch):
+    """Dev flag on: https to a mixed public/private set is fine — the
+    scheme guarantees encryption regardless of which address is used."""
+    _enable_dev_flag(monkeypatch)
+    fake_infos = [
+        (2, 0, 0, "", ("93.184.216.34", 0)),
+        (2, 0, 0, "", ("10.0.0.5", 0)),
+    ]
+    with patch(
+        "app.services.webhook_target_url.socket.getaddrinfo", return_value=fake_infos
+    ):
+        assert_target_url_is_public("https://mixed.example.com/hook")

--- a/backend/app/services/webhook_target_url_test.py
+++ b/backend/app/services/webhook_target_url_test.py
@@ -1,8 +1,8 @@
-"""Unit tests for the webhook target-URL validator.
+"""Unit tests for outbound target-URL validation.
 
-This is the SSRF guard. If any of these tests start passing accidentally,
-that's a defect — the dispatcher would happily POST to internal services
-or cloud-metadata endpoints.
+These assert the target policy: only https, only public unicast
+addresses. A regression that lets any of these pass would allow an
+outbound request to a non-public destination.
 """
 
 from __future__ import annotations
@@ -16,26 +16,14 @@ from app.services.webhook_target_url import (
     WebhookTargetUrlPrivateError,
     assert_target_url_is_public,
     assert_target_url_is_public_async,
+    resolve_validated_target,
 )
-
-
-@pytest.fixture(autouse=True)
-def _force_prod_flag(monkeypatch):
-    """Pin the dev flag to False by default so the production semantics
-    are what gets tested. Local devs may have ``WEBHOOK_ALLOW_PRIVATE_TARGETS=true``
-    in their ``.env`` for round-tripping with auto, which would otherwise
-    leak into the test session and silently break the strict-mode
-    assertions. Tests that *do* exercise the flag-on branch override
-    this with an explicit ``monkeypatch.setattr``."""
-    from app.core import config as config_module
-
-    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
 
 
 @pytest.mark.unit
 def test_accepts_public_https_literal():
     """An IPv4 literal in public unicast space is fine."""
-    assert_target_url_is_public("https://93.184.216.34/hook")  # example.com
+    assert_target_url_is_public("https://93.184.216.34/hook")
 
 
 @pytest.mark.unit
@@ -48,8 +36,6 @@ def test_accepts_public_https_literal():
     ],
 )
 def test_rejects_loopback(url: str):
-    """Loopback in either family must be rejected — the most common
-    SSRF target (e.g. ``localhost:6379`` for Redis)."""
     with pytest.raises(WebhookTargetUrlPrivateError):
         assert_target_url_is_public(url)
 
@@ -65,41 +51,43 @@ def test_rejects_loopback(url: str):
     ],
 )
 def test_rejects_rfc1918_and_ula(url: str):
-    """RFC1918 v4 and ULA v6 are private and must be blocked."""
     with pytest.raises(WebhookTargetUrlPrivateError):
         assert_target_url_is_public(url)
 
 
 @pytest.mark.unit
-def test_rejects_link_local_metadata():
-    """169.254.169.254 is the AWS / GCP / Azure metadata endpoint —
-    blind SSRF here leaks IAM credentials."""
+def test_rejects_link_local():
     with pytest.raises(WebhookTargetUrlPrivateError):
         assert_target_url_is_public("https://169.254.169.254/latest/meta-data/")
-
-
-@pytest.mark.unit
-def test_rejects_plain_http():
-    """Plain http:// lets a MITM strip the signature header and forge
-    payloads at the transport layer, defeating HMAC. Only https is
-    permitted."""
-    with pytest.raises(WebhookTargetUrlError):
-        assert_target_url_is_public("http://hooks.example.com/in")
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "url",
     [
+        "https://[::ffff:127.0.0.1]/hook",
+        "https://[::ffff:10.0.0.1]/hook",
+    ],
+)
+def test_rejects_ipv4_mapped_ipv6(url: str):
+    """An IPv4-mapped IPv6 literal is classified by its embedded IPv4."""
+    with pytest.raises(WebhookTargetUrlPrivateError):
+        assert_target_url_is_public(url)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://hooks.example.com/in",
         "ftp://example.com/hook",
         "file:///etc/passwd",
         "gopher://example.com/_GET",
         "javascript:alert(1)",
     ],
 )
-def test_rejects_non_http_schemes(url: str):
-    """Anything other than https — file, ftp, gopher, javascript — is
-    a category error for a webhook target."""
+def test_rejects_non_https_schemes(url: str):
+    """Only https is accepted."""
     with pytest.raises(WebhookTargetUrlError):
         assert_target_url_is_public(url)
 
@@ -107,13 +95,13 @@ def test_rejects_non_http_schemes(url: str):
 @pytest.mark.unit
 def test_rejects_missing_hostname():
     with pytest.raises(WebhookTargetUrlError):
-        assert_target_url_is_public("http:///hook")
+        assert_target_url_is_public("https:///hook")
 
 
 @pytest.mark.unit
 def test_rejects_when_hostname_resolves_to_private():
-    """A public-looking hostname that *resolves* to a private address
-    must still be rejected. Catches the trivial DNS bypass."""
+    """A public-looking hostname that resolves to a private address is
+    rejected."""
     fake_infos = [(2, 0, 0, "", ("10.0.0.5", 0))]  # AF_INET, RFC1918
     with patch(
         "app.services.webhook_target_url.socket.getaddrinfo", return_value=fake_infos
@@ -124,9 +112,7 @@ def test_rejects_when_hostname_resolves_to_private():
 
 @pytest.mark.unit
 def test_rejects_when_any_resolved_address_is_private():
-    """Multi-record DNS: if even one A record points at private space we
-    reject — otherwise an attacker could publish ``[1.1.1.1, 10.0.0.1]``
-    and roll the dice on which one httpx picks."""
+    """If any resolved address is non-public, the whole host is rejected."""
     fake_infos = [
         (2, 0, 0, "", ("93.184.216.34", 0)),  # public
         (2, 0, 0, "", ("10.0.0.5", 0)),  # private
@@ -139,113 +125,43 @@ def test_rejects_when_any_resolved_address_is_private():
 
 
 @pytest.mark.unit
+def test_resolve_returns_validated_addresses():
+    """The resolver returns the approved addresses so a caller can connect
+    to the exact address that was checked."""
+    fake_infos = [
+        (2, 0, 0, "", ("93.184.216.34", 0)),
+        (2, 0, 0, "", ("93.184.216.35", 0)),
+    ]
+    with patch(
+        "app.services.webhook_target_url.socket.getaddrinfo", return_value=fake_infos
+    ):
+        target = resolve_validated_target("https://cdn.example.com/hook")
+    assert target.hostname == "cdn.example.com"
+    assert [str(a) for a in target.addresses] == ["93.184.216.34", "93.184.216.35"]
+    assert target.pinned_ip == "93.184.216.34"
+
+
+@pytest.mark.unit
+def test_literal_public_is_its_own_validated_address():
+    target = resolve_validated_target("https://93.184.216.34/hook")
+    assert target.pinned_ip == "93.184.216.34"
+    assert target.hostname == "93.184.216.34"
+
+
+@pytest.mark.unit
 async def test_async_variant_accepts_public_literal():
-    """The async path takes the same code through asyncio.to_thread; an
-    IP literal short-circuits the resolver entirely so no thread hop
-    happens — same result either way."""
     await assert_target_url_is_public_async("https://93.184.216.34/hook")
 
 
 @pytest.mark.unit
 async def test_async_variant_rejects_private_literal():
-    """Sanity: the async variant enforces the same private-address
-    rejection. Catches a refactor that lets a code path skip the check."""
     with pytest.raises(WebhookTargetUrlPrivateError):
         await assert_target_url_is_public_async("https://10.0.0.1/hook")
 
 
-# ── Dev escape hatch ──────────────────────────────────────────────────
-
-
 @pytest.mark.unit
-def test_dev_flag_allows_loopback(monkeypatch):
-    """``WEBHOOK_ALLOW_PRIVATE_TARGETS=true`` is the documented local-
-    dev path. With it set, loopback / RFC1918 are accepted, and plain
-    http is also accepted *for those targets* (a localhost target has
-    no TLS cert)."""
-    from app.core import config as config_module
-
-    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", True)
-    assert_target_url_is_public("http://localhost:9002/api/v1/webhooks/initiative")
-    assert_target_url_is_public("http://127.0.0.1:9002/hook")
-    assert_target_url_is_public("http://10.0.0.5/hook")
-    # https-private also fine when the flag is on.
-    assert_target_url_is_public("https://127.0.0.1/hook")
-
-
-@pytest.mark.unit
-def test_http_to_private_with_flag_off_raises_invalid_not_private(monkeypatch):
-    """The error TYPE matters: the API endpoint maps
-    ``WebhookTargetUrlError`` to ``WEBHOOK_INVALID_TARGET_URL`` and
-    ``WebhookTargetUrlPrivateError`` to ``WEBHOOK_PRIVATE_TARGET_URL``,
-    so a flip changes the response code consumers see. With the flag
-    off, ``http://10.0.0.1`` is INVALID (the URL is structurally wrong
-    — http is forbidden in prod regardless of where it points), not
-    PRIVATE. Pinning this so a refactor can't silently change the
-    contract."""
-    from app.core import config as config_module
-
-    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
-    with pytest.raises(WebhookTargetUrlError) as exc_info:
-        assert_target_url_is_public("http://10.0.0.1/hook")
-    # The PrivateError subclasses ValueError too, so an `isinstance`
-    # check would pass even if the type flipped — assert on the exact
-    # type to be precise.
-    assert type(exc_info.value) is WebhookTargetUrlError
-
-
-@pytest.mark.unit
-def test_https_to_private_with_flag_off_raises_private_not_invalid(monkeypatch):
-    """Symmetric: ``https://10.0.0.1`` should raise PRIVATE (the URL
-    is structurally fine, the address is the problem). Flag off."""
-    from app.core import config as config_module
-
-    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
-    with pytest.raises(WebhookTargetUrlPrivateError):
-        assert_target_url_is_public("https://10.0.0.1/hook")
-
-
-@pytest.mark.unit
-def test_dev_flag_does_not_allow_http_to_public_hosts(monkeypatch):
-    """The flag's name says ``ALLOW_PRIVATE_TARGETS`` — its scope is
-    private targets only. Plain http to a public host MUST still be
-    rejected even with the flag on, because a MITM there would strip
-    the signature header and forge payloads. Catches a regression where
-    the scheme bypass spills over to public targets."""
-    from app.core import config as config_module
-
-    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", True)
-    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
-    with patch(
-        "app.services.webhook_target_url.socket.getaddrinfo",
-        return_value=fake_infos,
-    ):
-        with pytest.raises(WebhookTargetUrlError):
-            assert_target_url_is_public("http://hooks.example.com/in")
-
-
-@pytest.mark.unit
-def test_dev_flag_default_is_off(monkeypatch):
-    """Sanity: with the flag at its default, the production behaviour
-    still rejects loopback. Catches a regression where the flag's
-    default flipped to True."""
-    from app.core import config as config_module
-
-    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", False)
-    with pytest.raises(WebhookTargetUrlPrivateError):
-        assert_target_url_is_public("https://127.0.0.1/hook")
-    with pytest.raises(WebhookTargetUrlError):
-        assert_target_url_is_public("http://hooks.example.com/in")
-
-
-@pytest.mark.unit
-async def test_async_variant_resolves_via_thread_executor():
-    """The async path must hand DNS resolution off the event loop. We
-    assert that by checking the resolver gets called via the patched
-    ``socket.getaddrinfo`` even when invoked inside a coroutine — if the
-    blocking sync helper were accidentally used instead, this test would
-    still pass, so the real value here is paired with the unit-level
-    code review of ``asyncio.to_thread`` in the source."""
+async def test_async_variant_resolves_off_the_event_loop():
+    """The async variant hands DNS resolution to a thread."""
     fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
     with patch(
         "app.services.webhook_target_url.socket.getaddrinfo",
@@ -253,3 +169,47 @@ async def test_async_variant_resolves_via_thread_executor():
     ) as mock:
         await assert_target_url_is_public_async("https://hooks.example.com/in")
     assert mock.called
+
+
+# ── Local-dev escape hatch ────────────────────────────────────────────
+
+
+def _enable_dev_flag(monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(config_module.settings, "WEBHOOK_ALLOW_PRIVATE_TARGETS", True)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8201/api/v1/webhooks/initiative",
+        "http://127.0.0.1:8201/hook",
+        "http://10.0.0.5/hook",
+        "https://127.0.0.1/hook",
+    ],
+)
+def test_dev_flag_allows_local_targets(monkeypatch, url: str):
+    """With the flag on, http and private/loopback targets are accepted
+    for local round-trips."""
+    _enable_dev_flag(monkeypatch)
+    assert_target_url_is_public(url)
+
+
+@pytest.mark.unit
+def test_http_to_private_flag_off_is_invalid_scheme():
+    """Flag off: http is rejected on the scheme (invalid) before the
+    address is considered. The endpoint maps this to a different error
+    code than a private https target, so pin the exact type."""
+    with pytest.raises(WebhookTargetUrlError) as exc_info:
+        assert_target_url_is_public("http://10.0.0.1/hook")
+    assert type(exc_info.value) is WebhookTargetUrlError
+
+
+@pytest.mark.unit
+def test_https_to_private_flag_off_is_private():
+    """Flag off: https to a private address is rejected as private (the
+    scheme is fine, the address is not)."""
+    with pytest.raises(WebhookTargetUrlPrivateError):
+        assert_target_url_is_public("https://10.0.0.1/hook")

--- a/backend/app/services/webhook_target_url_test.py
+++ b/backend/app/services/webhook_target_url_test.py
@@ -213,3 +213,16 @@ def test_https_to_private_flag_off_is_private():
     scheme is fine, the address is not)."""
     with pytest.raises(WebhookTargetUrlPrivateError):
         assert_target_url_is_public("https://10.0.0.1/hook")
+
+
+@pytest.mark.unit
+def test_dev_flag_still_rejects_http_to_public(monkeypatch):
+    """The dev flag's scope is local/private targets; plain http to a
+    public host stays rejected even with it on."""
+    _enable_dev_flag(monkeypatch)
+    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
+    with patch(
+        "app.services.webhook_target_url.socket.getaddrinfo", return_value=fake_infos
+    ):
+        with pytest.raises(WebhookTargetUrlError):
+            assert_target_url_is_public("http://hooks.example.com/in")

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -78,6 +78,12 @@ HANDOFF_TEST_PUBLIC_PEM = (
 settings.HANDOFF_SIGNING_PRIVATE_KEY_PEM = HANDOFF_TEST_PRIVATE_PEM
 settings.HANDOFF_SIGNING_KEY_ID = "test-handoff-key"
 
+# Pin the dev-only webhook/AI target escape hatch OFF so the suite asserts
+# production target policy (https + public addresses) regardless of a local
+# ``.env`` that enables it. Tests exercising the flag-on path re-set it via
+# ``monkeypatch`` for their own scope.
+settings.WEBHOOK_ALLOW_PRIVATE_TARGETS = False
+
 # --- Test-infrastructure superuser ---------------------------------------------
 # The suite needs cluster-superuser powers the APP must never hold: CREATE
 # DATABASE per worker, raw setup/assertion writes on FORCE-RLS tables (the

--- a/frontend/src/api/generated/auto/auto.ts
+++ b/frontend/src/api/generated/auto/auto.ts
@@ -45,10 +45,9 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
  * in the service layer. The caller's guild comes from
  * ``GuildContext`` — the body never carries it.
  *
- * SSRF guard: ``target_url`` must resolve to a public unicast address.
- * Hostnames pointing at private / loopback / link-local space are
- * rejected so a guild member can't aim deliveries at internal services
- * or cloud-metadata endpoints.
+ * Target policy: ``target_url`` must be https and resolve to a public
+ * unicast address; private, loopback and link-local addresses are
+ * rejected.
  * @summary Create Subscription
  */
 export const createSubscriptionApiV1GGuildIdAutoSubscriptionsPost = (


### PR DESCRIPTION
## Problem

Outbound requests to caller-influenced URLs — webhook delivery targets and the custom AI provider base URL — validated the target host, then let the HTTP client resolve the hostname again independently. The address that was checked and the address actually connected to could differ.

## Changes

- Add one guarded egress helper, [request_public_target](backend/app/services/safe_http.py): resolve the target once, connect to that validated address, and keep the original hostname for TLS SNI, certificate verification, and the `Host` header. Redirects are not followed.
- [webhook_target_url.py](backend/app/services/webhook_target_url.py): `resolve_validated_target(_async)` now returns the approved addresses so callers pin to the checked address; add IPv4-mapped-IPv6 handling; policy stays https + public-only, with the local-dev `WEBHOOK_ALLOW_PRIVATE_TARGETS` escape hatch retained for round-tripping with a locally run initiative-auto.
- [webhook_dispatcher.py](backend/app/services/tenant/webhook_dispatcher.py) and the custom AI provider in [ai_generation.py](backend/app/services/ai_generation.py) send through the shared helper; the three near-identical custom AI functions collapse into one chat-completion helper.
- Comments in the touched files kept to functional descriptions.
- Tests: centralize the dev-flag pin in [conftest.py](backend/conftest.py); add pinning + target-policy regression tests in [safe_http_test.py](backend/app/services/safe_http_test.py).

## Testing

- `cd backend && ruff check app` — clean.
- `pytest` on `webhook_target_url_test`, `safe_http_test`, `webhook_dispatcher_test`, `ai_generation_test`, `auto_subscriptions_test` — **57 passed**.
- End-to-end against initiative-auto: production (public https receiver derived from `APP_ORIGIN`) passes the policy; local split-dev (`http://localhost:8201`) works with the dev flag; the receiver's HMAC verification is unaffected by address pinning.