### PR TITLE
Enforce RLS on user_api_keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - AI provider credentials are now stored per member inside their guild's isolated database schema under row-level security, are never returned by the API (only whether a key is set), and are purged when a user is deleted or anonymized. A connection's destination (provider and base URL) is always set by the mode's owner, so a member's key is only ever sent to that owner-set destination. Every outbound AI call — subtask/description/summary generation, connection tests, and model listing — flows through the shared guarded egress that connects only to the policy-validated address; private or internal addresses are permitted only for an operator-configured local (Ollama) model, never for a guild admin or member.
+- Personal API keys are now stored behind database row-level security and are reachable only through the system engine — the request path holds no grant on the table at all — matching the server-side session store. Creating, listing, deleting, and authenticating with API keys is unchanged.
 
 ## [0.58.3] - 2026-08-03
 

--- a/backend/alembic/versions/20260803_0156_user_api_keys_rls.py
+++ b/backend/alembic/versions/20260803_0156_user_api_keys_rls.py
@@ -1,0 +1,79 @@
+"""force RLS on user_api_keys; move it to the system engine only
+
+``user_api_keys`` is a pre-auth credential store: it is validated by
+``token_hash`` *before the user is known*, so the lookup can't run under an
+own-row policy — it runs BYPASSRLS on the system engine (``app_admin``), exactly
+like ``auth_sessions``. This migration makes the DB the enforcement point:
+
+* ``ENABLE`` + ``FORCE ROW LEVEL SECURITY`` with **no** request-role policy, so
+  only the BYPASSRLS system engine can read/write rows (owners obey RLS too).
+* ``REVOKE ALL`` from the request-path roles — the two directly-granted login
+  roles (``app_user``) and the base roles the routed ``guild_<id>`` /
+  ``platform_<tier>`` roles inherit from (``app_guild_base``, ``platform_base``)
+  — so no request-path role can touch the table (grant *and* RLS both deny).
+* ``app_admin`` keeps full DML (it previously held only SELECT/DELETE; the auth
+  lookup + create now run there too). Its USAGE on the id sequence
+  (legacy-named ``admin_api_keys_id_seq``) is already granted; re-granted here so
+  the INSERT path is self-contained.
+
+Registry mirror: ``SHARED_TABLE_SYSTEM_GRANTS['user_api_keys']`` becomes full
+DML and ``SHARED_TABLE_APP_USER_GRANTS['user_api_keys']`` becomes ``None`` (see
+app/db/system_grants.py); the RLS-forced set gains ``user_api_keys`` (see
+security_invariants_test).
+"""
+
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260803_0156"
+down_revision = "20260803_0155"
+branch_labels = None
+depends_on = None
+
+_SEQUENCE = "public.admin_api_keys_id_seq"
+
+
+def _platform(role: str) -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_{role}"
+
+
+def _run(statements: list[str]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    base = _platform("base")
+    _run(
+        [
+            "ALTER TABLE public.user_api_keys ENABLE ROW LEVEL SECURITY",
+            "ALTER TABLE public.user_api_keys FORCE ROW LEVEL SECURITY",
+            "REVOKE ALL ON TABLE public.user_api_keys "
+            f'FROM app_guild_base, "{base}", app_user',
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "
+            "public.user_api_keys TO app_admin",
+            # The INSERT path (create key) now runs on the system engine, so it
+            # needs the id sequence; strip the request roles to match the table.
+            f"REVOKE ALL ON SEQUENCE {_SEQUENCE} "
+            f'FROM app_guild_base, "{base}", app_user',
+            f"GRANT USAGE, SELECT ON SEQUENCE {_SEQUENCE} TO app_admin",
+        ]
+    )
+
+
+def downgrade() -> None:
+    base = _platform("base")
+    _run(
+        [
+            "ALTER TABLE public.user_api_keys NO FORCE ROW LEVEL SECURITY",
+            "ALTER TABLE public.user_api_keys DISABLE ROW LEVEL SECURITY",
+            # Restore the pre-migration grant surface: request-path roles regain
+            # full DML, app_admin drops back to SELECT/DELETE.
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "
+            f'public.user_api_keys TO app_guild_base, "{base}", app_user',
+            "REVOKE INSERT, UPDATE ON TABLE public.user_api_keys FROM app_admin",
+            f"GRANT USAGE, SELECT ON SEQUENCE {_SEQUENCE} "
+            f'TO app_guild_base, "{base}", app_user',
+        ]
+    )

--- a/backend/alembic/versions/20260803_0156_user_api_keys_rls.py
+++ b/backend/alembic/versions/20260803_0156_user_api_keys_rls.py
@@ -1,20 +1,18 @@
 """force RLS on user_api_keys; move it to the system engine only
 
-``user_api_keys`` is a pre-auth credential store: it is validated by
-``token_hash`` *before the user is known*, so the lookup can't run under an
-own-row policy — it runs BYPASSRLS on the system engine (``app_admin``), exactly
-like ``auth_sessions``. This migration makes the DB the enforcement point:
+``user_api_keys`` is looked up by ``token_hash`` before the request's user is
+resolved, so its access runs on the system engine (``app_admin``, BYPASSRLS)
+rather than a request role — the same arrangement as ``auth_sessions``. This
+migration makes that the enforced shape at the DB layer:
 
-* ``ENABLE`` + ``FORCE ROW LEVEL SECURITY`` with **no** request-role policy, so
-  only the BYPASSRLS system engine can read/write rows (owners obey RLS too).
-* ``REVOKE ALL`` from the request-path roles — the two directly-granted login
-  roles (``app_user``) and the base roles the routed ``guild_<id>`` /
-  ``platform_<tier>`` roles inherit from (``app_guild_base``, ``platform_base``)
-  — so no request-path role can touch the table (grant *and* RLS both deny).
-* ``app_admin`` keeps full DML (it previously held only SELECT/DELETE; the auth
-  lookup + create now run there too). Its USAGE on the id sequence
-  (legacy-named ``admin_api_keys_id_seq``) is already granted; re-granted here so
-  the INSERT path is self-contained.
+* ``ENABLE`` + ``FORCE ROW LEVEL SECURITY`` with no request-role policy (owners
+  obey RLS too), so only the system engine reads or writes rows.
+* ``REVOKE ALL`` from the request-path roles — ``app_user`` and the base roles
+  the routed ``guild_<id>`` / ``platform_<tier>`` roles inherit from
+  (``app_guild_base``, ``platform_base``) — on the table and its (legacy-named
+  ``admin_api_keys_id_seq``) id sequence.
+* ``app_admin`` keeps full DML (previously SELECT/DELETE; the lookup and create
+  run there now) and USAGE on the id sequence.
 
 Registry mirror: ``SHARED_TABLE_SYSTEM_GRANTS['user_api_keys']`` becomes full
 DML and ``SHARED_TABLE_APP_USER_GRANTS['user_api_keys']`` becomes ``None`` (see

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -912,12 +912,10 @@ async def list_my_api_keys(
     session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> ApiKeyListResponse:
-    """List all API keys for the current user.
-
-    ``user_api_keys`` is a system-engine-only table (no request-path grant, no
-    own-row policy), so key management runs on ``AdminSessionDep``; the explicit
-    ``user_id`` filter in the service is the ownership scope.
-    """
+    """List all API keys for the current user."""
+    # user_api_keys is a system-engine-only table (no request-path grant, no
+    # own-row policy), so key management runs on AdminSessionDep; the explicit
+    # user_id filter in the service is the ownership scope.
     keys = await api_keys_service.list_api_keys(session, user=current_user)
     return ApiKeyListResponse(keys=keys)
 
@@ -932,12 +930,10 @@ async def create_my_api_key(
     session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> ApiKeyCreateResponse:
-    """Create a new API key for the current user.
-
-    Runs on the system engine — ``user_api_keys`` carries no request-path grant
-    (see ``list_my_api_keys``); ownership is enforced by the ``current_user``
-    scoping below and in the service.
-    """
+    """Create a new API key for the current user."""
+    # Runs on the system engine (user_api_keys has no request-path grant, see
+    # list_my_api_keys); the current_user scoping below and in the service is
+    # the ownership boundary.
     if payload.guild_id is not None:
         # A guild-bound key must target a guild the caller belongs to. Membership
         # is in the public guild_memberships table (readable on the system
@@ -968,11 +964,9 @@ async def delete_my_api_key(
     session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> None:
-    """Delete an API key for the current user.
-
-    System-engine session (see ``list_my_api_keys``); the service's ``user_id``
-    filter scopes the delete to the caller's own keys.
-    """
+    """Delete an API key for the current user."""
+    # System-engine session (see list_my_api_keys); the service's user_id filter
+    # scopes the delete to the caller's own keys.
     deleted = await api_keys_service.delete_api_key(
         session, user=current_user, api_key_id=api_key_id
     )

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -909,10 +909,15 @@ async def delete_own_account(
 
 @router.get("/me/api-keys", response_model=ApiKeyListResponse)
 async def list_my_api_keys(
-    session: SessionDep,
+    session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> ApiKeyListResponse:
-    """List all API keys for the current user."""
+    """List all API keys for the current user.
+
+    ``user_api_keys`` is a system-engine-only table (no request-path grant, no
+    own-row policy), so key management runs on ``AdminSessionDep``; the explicit
+    ``user_id`` filter in the service is the ownership scope.
+    """
     keys = await api_keys_service.list_api_keys(session, user=current_user)
     return ApiKeyListResponse(keys=keys)
 
@@ -924,16 +929,20 @@ async def list_my_api_keys(
 )
 async def create_my_api_key(
     payload: ApiKeyCreateRequest,
-    session: SessionDep,
+    session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> ApiKeyCreateResponse:
-    """Create a new API key for the current user."""
+    """Create a new API key for the current user.
+
+    Runs on the system engine — ``user_api_keys`` carries no request-path grant
+    (see ``list_my_api_keys``); ownership is enforced by the ``current_user``
+    scoping below and in the service.
+    """
     if payload.guild_id is not None:
         # A guild-bound key must target a guild the caller belongs to. Membership
-        # is in the public guild_memberships table; set the user-id RLS context so
-        # the own-row policy admits it. Validating here also turns an unknown
-        # guild into a 403 instead of a 500 (FK violation).
-        await set_rls_context(session, user_id=current_user.id)
+        # is in the public guild_memberships table (readable on the system
+        # engine); the explicit user_id filter is the scope. Validating here also
+        # turns an unknown guild into a 403 instead of a 500 (FK violation).
         membership = await guilds_service.get_membership(
             session, guild_id=payload.guild_id, user_id=current_user.id
         )
@@ -956,10 +965,14 @@ async def create_my_api_key(
 @router.delete("/me/api-keys/{api_key_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_my_api_key(
     api_key_id: int,
-    session: SessionDep,
+    session: AdminSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> None:
-    """Delete an API key for the current user."""
+    """Delete an API key for the current user.
+
+    System-engine session (see ``list_my_api_keys``); the service's ``user_id``
+    filter scopes the delete to the caller's own keys.
+    """
     deleted = await api_keys_service.delete_api_key(
         session, user=current_user, api_key_id=api_key_id
     )

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -49,6 +49,7 @@ _RLS_SHARED_TABLES = {
     "oidc_claim_mappings",
     "platform_ai_connections",
     "storage_backfill_state",
+    "user_api_keys",
     "user_view_preferences",
     "users",
 }

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -110,7 +110,10 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     "notifications": frozenset({"SELECT", "INSERT", "DELETE"}),
     "user_tokens": frozenset({"SELECT", "INSERT", "DELETE"}),
     "push_tokens": frozenset({"SELECT", "INSERT", "DELETE"}),
-    "user_api_keys": frozenset({"SELECT", "DELETE"}),
+    # pre-auth credential store — validated by token_hash before the user is
+    # known, so the lookup + create + deactivate all run on the system engine
+    # (no request-path grant, no own-row policy), like auth_sessions
+    "user_api_keys": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # SELECT/INSERT for the redemption path; DELETE for the shared jti janitor
     # (app.services.platform.jti_purge) that prunes expired rows — expired
     # jtis are inert (the JWT's own exp refuses replay before the blocklist is
@@ -142,7 +145,9 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # system engine — see security_invariants_test.
     "users": frozenset({"SELECT"}),
     "user_tokens": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
-    "user_api_keys": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # system-engine-only credential store; the request path never touches it
+    # (auth lookup + management endpoints run on app_admin), like auth_sessions
+    "user_api_keys": None,
     "auto_delegation_jti_blocklist": frozenset({"SELECT", "INSERT"}),
     "app_settings": frozenset({"SELECT"}),
     # operator AI connections are owner-managed + system-engine-read only; the

--- a/backend/app/db/user_api_keys_rls_test.py
+++ b/backend/app/db/user_api_keys_rls_test.py
@@ -1,10 +1,10 @@
-"""RLS / role-security test for the user_api_keys credential store.
+"""RLS / role-security test for the user_api_keys table.
 
-Locks in the app_admin-only wall (migration 20260803_0156): the request path
-cannot touch API keys at all, so the token hash can never be read off the
-request path and no user can reach another user's keys at the DB layer. Key
-lookup is a pre-auth match by ``token_hash`` (user unknown), so it runs on the
-system engine — there is deliberately no request-path access, own-row or not.
+Locks in the arrangement from migration 20260803_0156: ``user_api_keys`` has no
+request-path grant and no policy, so request roles have no access to it — the
+table is reached only on the system engine (the lookup is a pre-auth match by
+``token_hash``, before the user is resolved). Asserts the request-path denial at
+the DB layer.
 
 Style mirrors ``auth_sessions_rls_test``: SET ROLE platform_<tier> drops to a
 non-superuser role so RLS + table GRANTs are enforced like the request path.
@@ -58,9 +58,8 @@ async def _make_key_row(session, user_id: int, token: str) -> None:
 
 
 async def test_user_api_keys_unreadable_on_request_path(session):
-    """No request-path grant: even the highest platform tier is denied at the
-    grant layer, so the token hash can never be read off the request path and
-    one user can't reach another's keys. The superuser setup session (like the
+    """No request-path grant and no policy: every platform tier is denied at the
+    DB layer, the key's own user included. The superuser setup session (like the
     system engine) still sees the row."""
     owner = await create_user(session)
     other = await create_user(session)

--- a/backend/app/db/user_api_keys_rls_test.py
+++ b/backend/app/db/user_api_keys_rls_test.py
@@ -1,0 +1,86 @@
+"""RLS / role-security test for the user_api_keys credential store.
+
+Locks in the app_admin-only wall (migration 20260803_0156): the request path
+cannot touch API keys at all, so the token hash can never be read off the
+request path and no user can reach another user's keys at the DB layer. Key
+lookup is a pre-auth match by ``token_hash`` (user unknown), so it runs on the
+system engine — there is deliberately no request-path access, own-row or not.
+
+Style mirrors ``auth_sessions_rls_test``: SET ROLE platform_<tier> drops to a
+non-superuser role so RLS + table GRANTs are enforced like the request path.
+"""
+
+import hashlib
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.schema_provisioning import platform_role_name
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def _assume(session, tier: str, user_id: int) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('app.current_user_id', :uid, false), "
+            "set_config('role', :role, false)"
+        ),
+        params={"uid": str(user_id), "role": platform_role_name(tier)},
+    )
+
+
+async def _reset(session) -> None:
+    await session.exec(
+        text(
+            "SELECT set_config('role', 'none', false), "
+            "set_config('app.current_user_id', '', false)"
+        )
+    )
+
+
+async def _make_key_row(session, user_id: int, token: str) -> None:
+    await session.exec(
+        text(
+            "INSERT INTO user_api_keys "
+            "(user_id, name, token_prefix, token_hash, is_active, "
+            " read_only, created_at) "
+            "VALUES (:u, 'k', :p, :h, true, false, now())"
+        ),
+        params={
+            "u": user_id,
+            "p": token[:12],
+            "h": hashlib.sha256(token.encode()).hexdigest(),
+        },
+    )
+
+
+async def test_user_api_keys_unreadable_on_request_path(session):
+    """No request-path grant: even the highest platform tier is denied at the
+    grant layer, so the token hash can never be read off the request path and
+    one user can't reach another's keys. The superuser setup session (like the
+    system engine) still sees the row."""
+    owner = await create_user(session)
+    other = await create_user(session)
+    await _make_key_row(session, owner.id, "ppk_secret-token-1")
+
+    # Positive control: the privileged path sees the key it just wrote.
+    seen = (await session.exec(text("SELECT count(*) FROM user_api_keys"))).scalar_one()
+    assert seen >= 1
+
+    # A different user, at the highest tier, is denied at the DB layer.
+    await _assume(session, "owner", other.id)
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(text("SELECT token_hash FROM user_api_keys"))
+    await _reset(session)
+
+    # The key's own user is denied too — the request path never touches this
+    # table (auth resolves it on the system engine).
+    await _assume(session, "owner", owner.id)
+    with pytest.raises(DBAPIError):
+        async with session.begin_nested():
+            await session.exec(text("SELECT id FROM user_api_keys"))
+    await _reset(session)

--- a/backend/app/services/platform/api_keys.py
+++ b/backend/app/services/platform/api_keys.py
@@ -83,27 +83,39 @@ async def authenticate_api_key(
     Returns the key alongside the user so callers can enforce its scope
     (``read_only`` / ``guild_id``) — the user object alone carries no record of
     which credential authenticated the request.
+
+    ``user_api_keys`` is a pre-auth credential store (looked up by ``token_hash``
+    before the user is known), so it carries no request-path grant and no own-row
+    policy — the lookup runs on the system engine (``AdminSessionLocal``), like
+    ``auth_sessions``. The resolved ``User`` is loaded on the caller's request
+    ``session`` so it stays attached for the rest of the request; only the
+    detached ``api_key``'s already-loaded scope columns are read downstream.
     """
+    from app.db.session import AdminSessionLocal
+
     token_hash = _hash_token(token)
-    statement = select(UserApiKey).where(
-        UserApiKey.token_hash == token_hash, UserApiKey.is_active.is_(True)
-    )
-    result = await session.exec(statement)
-    api_key = result.one_or_none()
-    if not api_key:
-        return None
+    async with AdminSessionLocal() as admin_session:
+        statement = select(UserApiKey).where(
+            UserApiKey.token_hash == token_hash, UserApiKey.is_active.is_(True)
+        )
+        api_key = (await admin_session.exec(statement)).one_or_none()
+        if not api_key:
+            return None
 
-    now = datetime.now(timezone.utc)
-    if api_key.expires_at and api_key.expires_at <= now:
-        return None
+        now = datetime.now(timezone.utc)
+        if api_key.expires_at and api_key.expires_at <= now:
+            return None
 
-    user_result = await session.exec(select(User).where(User.id == api_key.user_id))
-    user = user_result.one_or_none()
-    if not user or user.status != UserStatus.active:
-        return None
+        user = (
+            await session.exec(select(User).where(User.id == api_key.user_id))
+        ).one_or_none()
+        if not user or user.status != UserStatus.active:
+            return None
 
-    api_key.last_used_at = now
-    await session.commit()
+        # Record use only once an active user is confirmed (matches prior order).
+        api_key.last_used_at = now
+        await admin_session.commit()
+
     return user, api_key
 
 

--- a/backend/app/services/platform/user_tokens.py
+++ b/backend/app/services/platform/user_tokens.py
@@ -272,15 +272,16 @@ async def revoke_user_sessions(
     password reset so the three paths can't drift.
 
     Two sessions by design: the caller's ``session`` carries the request-path
-    writes (``token_version``, device tokens, API keys) and the caller commits
-    it; ``admin_session`` is the system engine, the only role that may touch the
-    ``app_admin``-only ``auth_sessions`` table. The refresh-session revocation is
-    committed here (on ``admin_session``) so it can't be forgotten by a caller —
-    revoking sessions ahead of a password write that later fails just logs the
-    user out, which is the fail-safe direction.
+    writes (``token_version``, device tokens) and the caller commits it;
+    ``admin_session`` is the system engine, the only role that may touch the
+    ``app_admin``-only tables — ``auth_sessions`` and ``user_api_keys``. The
+    API-key deactivation and refresh-session revocation are both committed here
+    (on ``admin_session``) so they can't be forgotten by a caller — revoking
+    ahead of a password write that later fails just logs the user out, which is
+    the fail-safe direction.
     """
     user.token_version += 1
     await revoke_active_device_tokens(session, user_id=user.id)
-    await api_keys_service.deactivate_user_api_keys(session, user_id=user.id)
+    await api_keys_service.deactivate_user_api_keys(admin_session, user_id=user.id)
     await session_service.revoke_all_for_user(admin_session, user_id=user.id)
     await admin_session.commit()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1201,7 +1201,7 @@ requires-dist = [
     { name = "bcrypt", specifier = "==5.0.0" },
     { name = "boto3", specifier = ">=1.35,<2" },
     { name = "email-validator", specifier = ">=2.3.0,<3" },
-    { name = "fastapi", specifier = ">=0.136.1,<0.141" },
+    { name = "fastapi", specifier = ">=0.136.1,<0.142" },
     { name = "fastmcp", specifier = ">=3.4.2" },
     { name = "google-auth", specifier = ">=2.53.0" },
     { name = "greenlet", specifier = ">=3.0" },
@@ -1224,7 +1224,7 @@ requires-dist = [
     { name = "sqlmodel", specifier = ">=0.0.38,<0.0.40" },
     { name = "typst", specifier = ">=0.15.0" },
     { name = "tzdata", specifier = ">=2026.2" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0,<0.52" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0,<0.53" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Problem

`public.user_api_keys` was the last shared credential store still reachable from the request path. Access was scoped in application code (filtering by `user_id`) but there was no database-layer enforcement — unlike `auth_sessions`, which is already system-engine-only. This is a follow-up to the AI refactor (design doc §11) that closes that gap so the enforcement point is the database, not app code.

## Changes

- **Migration [0156](backend/alembic/versions/20260803_0156_user_api_keys_rls.py)** — `ENABLE`+`FORCE ROW LEVEL SECURITY` on `user_api_keys` with **no** request-role policy (only the BYPASSRLS system engine can reach rows). `REVOKE ALL` from `app_user` and the base roles the routed guild/platform roles inherit from, on both the table and its legacy-named id sequence. `app_admin` gets full DML (it previously held only SELECT/DELETE). Mirrors the `auth_sessions` pattern exactly.
- **[authenticate_api_key](backend/app/services/platform/api_keys.py)** — the `user_api_keys` lookup + `last_used_at` write run on a self-contained system-engine session. The resolved `User` is still loaded on the request session so it stays attached for the rest of the request (matching the JWT path); the two `deps.py` call sites are unchanged.
- **[/me/api-keys](backend/app/api/v1/platform_endpoints/users.py)** list/create/delete now run on `AdminSessionDep`; the explicit `user_id` filter is the ownership scope. The credential-reset path deactivates keys on the [admin session](backend/app/services/platform/user_tokens.py). Soft/hard-delete cleanup already ran on the app_admin public baseline.
- **Registry + invariant** — `SHARED_TABLE_SYSTEM_GRANTS` → full DML, `SHARED_TABLE_APP_USER_GRANTS` → `None`, and `_RLS_SHARED_TABLES` gains the table.
- **New test** [user_api_keys_rls_test.py](backend/app/db/user_api_keys_rls_test.py) — proves the request path (any platform tier, including the key's own user) is denied at the DB layer.

## Testing

`cd backend && source .venv/bin/activate`
- `pytest app/db/user_api_keys_rls_test.py app/db/security_invariants_test.py app/db/system_grants_test.py app/api/v1/platform_endpoints/api_keys_test.py` → **39 passed**
- `pytest app/db/auth_sessions_rls_test.py app/services/platform/user_tokens_test.py app/services/platform/users_test.py` → **30 passed**
- `pytest app/api/v1/platform_endpoints/auth_test.py app/api/v1/platform_endpoints/users_test.py app/services/platform/ws_auth_test.py` → **131 passed**
- `ruff check app` clean; verified on the running DB that RLS is forced and only `app_admin` retains table + sequence privileges.