### PR TITLE
Small frontend cleanups: shared filter/date/name/upload helpers

### DIFF
--- a/backend/app/api/v1/platform_endpoints/config.py
+++ b/backend/app/api/v1/platform_endpoints/config.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from app.core.config import settings
+from app.services.tenant.attachments import MAX_DOCUMENT_FILE_SIZE
 
 router = APIRouter()
 
@@ -72,6 +73,9 @@ class AppConfig(BaseModel):
     advanced_tool: Optional[AdvancedToolConfig] = None
     captcha: Optional[CaptchaConfig] = None
     billing: Optional[BillingConfig] = None
+    # The upload size cap the server enforces on file endpoints. The SPA reads
+    # it for pre-flight checks so the number lives in exactly one place.
+    max_upload_bytes: int
 
 
 # Default ports the WHATWG URL spec strips from origin strings. If the
@@ -137,4 +141,9 @@ def get_app_config() -> AppConfig:
     # billing URL. Absent ⇒ the SPA hides every tier/upgrade/manage surface.
     billing = BillingConfig(url=settings.BILLING_URL) if settings.BILLING_URL else None
 
-    return AppConfig(advanced_tool=advanced_tool, captcha=captcha, billing=billing)
+    return AppConfig(
+        advanced_tool=advanced_tool,
+        captcha=captcha,
+        billing=billing,
+        max_upload_bytes=MAX_DOCUMENT_FILE_SIZE,
+    )

--- a/backend/app/api/v1/platform_endpoints/config_test.py
+++ b/backend/app/api/v1/platform_endpoints/config_test.py
@@ -12,6 +12,7 @@ import pytest
 from httpx import AsyncClient
 
 from app.core.config import settings
+from app.services.tenant.attachments import MAX_DOCUMENT_FILE_SIZE
 
 
 @pytest.mark.integration
@@ -36,7 +37,18 @@ async def test_config_returns_no_advanced_tool_when_url_unset(
         "advanced_tool": None,
         "captcha": None,
         "billing": None,
+        "max_upload_bytes": MAX_DOCUMENT_FILE_SIZE,
     }
+
+
+@pytest.mark.integration
+async def test_config_exposes_upload_cap(client: AsyncClient):
+    """The SPA reads the server-enforced upload cap from config so the limit
+    has a single source of truth (no mirrored frontend constant)."""
+    response = await client.get("/api/v1/config")
+
+    assert response.status_code == 200
+    assert response.json()["max_upload_bytes"] == MAX_DOCUMENT_FILE_SIZE
 
 
 @pytest.mark.integration

--- a/frontend/public/locales/de/imports.json
+++ b/frontend/public/locales/de/imports.json
@@ -63,6 +63,7 @@
     "parseError": "Diese Datei ist kein bekannter Initiative-Export.",
     "wrongTool": "Diese Datei ist ein {{type}}-Export — importiere sie über die Seite dieses Werkzeugs.",
     "fileTooLarge": "Diese Datei ist zu groß zum Importieren.",
+    "limitUnavailable": "Die Upload-Limits konnten nicht geladen werden. Prüfe deine Verbindung und versuche es erneut.",
     "preview": "{{title}} · {{type}}",
     "targetInitiative": "Importieren in",
     "selectInitiative": "Initiative wählen",

--- a/frontend/public/locales/en/imports.json
+++ b/frontend/public/locales/en/imports.json
@@ -63,6 +63,7 @@
     "parseError": "This file isn't a recognized Initiative export.",
     "wrongTool": "This file is a {{type}} export — import it from that tool's page.",
     "fileTooLarge": "This file is too large to import.",
+    "limitUnavailable": "Upload limits could not be loaded. Check your connection and try again.",
     "preview": "{{title}} · {{type}}",
     "targetInitiative": "Import into",
     "selectInitiative": "Choose an initiative",

--- a/frontend/public/locales/es/imports.json
+++ b/frontend/public/locales/es/imports.json
@@ -63,6 +63,7 @@
     "parseError": "Este archivo no es una exportación reconocida de Initiative.",
     "wrongTool": "Este archivo es una exportación de {{type}}: impórtalo desde la página de esa herramienta.",
     "fileTooLarge": "Este archivo es demasiado grande para importar.",
+    "limitUnavailable": "No se pudieron cargar los límites de subida. Comprueba tu conexión e inténtalo de nuevo.",
     "preview": "{{title}} · {{type}}",
     "targetInitiative": "Importar en",
     "selectInitiative": "Elige una iniciativa",

--- a/frontend/public/locales/fr/imports.json
+++ b/frontend/public/locales/fr/imports.json
@@ -63,6 +63,7 @@
     "parseError": "Ce fichier n'est pas un export Initiative reconnu.",
     "wrongTool": "Ce fichier est un export {{type}} — importez-le depuis la page de cet outil.",
     "fileTooLarge": "Ce fichier est trop volumineux pour être importé.",
+    "limitUnavailable": "Impossible de charger les limites d'envoi. Vérifiez votre connexion et réessayez.",
     "preview": "{{title}} · {{type}}",
     "targetInitiative": "Importer dans",
     "selectInitiative": "Choisir une initiative",

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -538,6 +538,7 @@ export interface AppConfig {
   advanced_tool?: AdvancedToolConfig | null;
   captcha?: CaptchaConfig | null;
   billing?: BillingConfig | null;
+  max_upload_bytes: number;
 }
 
 export interface ArchiveDoneResponse {

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useAppConfig } from "@/hooks/useAppConfig";
 import {
   useCreateDocument,
   useTemplateAutocomplete,
@@ -80,6 +81,7 @@ export const CreateDocumentDialog = ({
   initiatives = [],
 }: CreateDocumentDialogProps) => {
   const { t } = useTranslation(["documents", "common"]);
+  const { maxUploadBytes } = useAppConfig();
 
   const [createDialogTab, setCreateDialogTab] = useState<"new" | "upload" | "smartLink">("new");
   const [newTitle, setNewTitle] = useState("");
@@ -195,8 +197,7 @@ export const CreateDocumentDialog = ({
   const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      const maxSize = 50 * 1024 * 1024;
-      if (file.size > maxSize) {
+      if (maxUploadBytes !== null && file.size > maxUploadBytes) {
         toast.error(t("create.fileTooLarge"));
         e.target.value = "";
         return;

--- a/frontend/src/components/documents/FileDocumentViewer.tsx
+++ b/frontend/src/components/documents/FileDocumentViewer.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useAppConfig } from "@/hooks/useAppConfig";
 import {
   useDeleteDocumentVersion,
   useDocumentVersions,
@@ -48,7 +49,6 @@ pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerSrc;
 // Accepted file types for uploading a new version (mirrors CreateDocumentDialog).
 const VERSION_UPLOAD_ACCEPT =
   ".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.html,.htm,.png,.jpg,.jpeg,.gif,.webp,.svg,.md,.markdown";
-const MAX_VERSION_FILE_SIZE = 50 * 1024 * 1024;
 
 interface FileDocumentViewerProps {
   documentId: number;
@@ -86,6 +86,7 @@ export const FileDocumentViewer = ({
   isOwner = false,
 }: FileDocumentViewerProps) => {
   const { t } = useTranslation(["documents", "common"]);
+  const { maxUploadBytes } = useAppConfig();
 
   // ── Version history ─────────────────────────────────────────────────────
   const { data: versions } = useDocumentVersions(documentId);
@@ -207,7 +208,7 @@ export const FileDocumentViewer = ({
     const file = event.target.files?.[0];
     event.target.value = "";
     if (!file) return;
-    if (file.size > MAX_VERSION_FILE_SIZE) {
+    if (maxUploadBytes !== null && file.size > maxUploadBytes) {
       toast.error(t("create.fileTooLarge"));
       return;
     }

--- a/frontend/src/components/imports/EnvelopeImportDialog.tsx
+++ b/frontend/src/components/imports/EnvelopeImportDialog.tsx
@@ -21,15 +21,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
+import { useAppConfig } from "@/hooks/useAppConfig";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { queryClient } from "@/lib/queryClient";
 import { toolEnvelopeType, toolForEnvelopeType } from "@/lib/tools";
-
-// Client-side guard against pathological files stalling file.text()/JSON.parse.
-const MAX_BYTES = 50 * 1024 * 1024;
 
 interface ParsedEnvelope {
   type?: string;
@@ -66,6 +64,7 @@ export function EnvelopeImportDialog({
 }: EnvelopeImportDialogProps) {
   const { t } = useTranslation(["imports", "common"]);
   const guildId = useActiveGuildId();
+  const { maxUploadBytes } = useAppConfig();
   const initiativesQuery = useInitiatives();
   const { filterVisible, permissionsFor } = useInitiativeAccess();
 
@@ -118,7 +117,8 @@ export function EnvelopeImportDialog({
       setFileName("");
       return;
     }
-    if (file.size > MAX_BYTES) {
+    // Guard against pathological files stalling file.text()/JSON.parse.
+    if (maxUploadBytes !== null && file.size > maxUploadBytes) {
       setFileName(file.name);
       setParseError(t("imports:envelope.fileTooLarge"));
       return;

--- a/frontend/src/components/imports/EnvelopeImportDialog.tsx
+++ b/frontend/src/components/imports/EnvelopeImportDialog.tsx
@@ -29,6 +29,13 @@ import { getErrorMessage } from "@/lib/errorMessage";
 import { queryClient } from "@/lib/queryClient";
 import { toolEnvelopeType, toolForEnvelopeType } from "@/lib/tools";
 
+// The real upload cap is server-owned and arrives via /api/v1/config
+// (max_upload_bytes). Until it has loaded, file.text()/JSON.parse below still
+// need SOME bound to run safely in the browser — this deliberately
+// conservative degraded-mode budget covers that window. It is not a copy of
+// the server limit and must stay well below any plausible value of it.
+const DEGRADED_PARSE_BUDGET_BYTES = 10 * 1024 * 1024;
+
 interface ParsedEnvelope {
   type?: string;
   kind?: string;
@@ -117,10 +124,20 @@ export function EnvelopeImportDialog({
       setFileName("");
       return;
     }
-    // Guard against pathological files stalling file.text()/JSON.parse.
-    if (maxUploadBytes !== null && file.size > maxUploadBytes) {
+    // Guard the fully client-side file.text()/JSON.parse below. The server's
+    // cap applies once known; before then the conservative degraded budget
+    // holds, and an over-budget file gets the "limits couldn't load" message
+    // rather than a misleading "too large".
+    const parseLimit = maxUploadBytes ?? DEGRADED_PARSE_BUDGET_BYTES;
+    if (file.size > parseLimit) {
       setFileName(file.name);
-      setParseError(t("imports:envelope.fileTooLarge"));
+      setParseError(
+        t(
+          maxUploadBytes === null
+            ? "imports:envelope.limitUnavailable"
+            : "imports:envelope.fileTooLarge"
+        )
+      );
       return;
     }
     setFileName(file.name);

--- a/frontend/src/components/initiatives/DeleteInitiativeDialog.tsx
+++ b/frontend/src/components/initiatives/DeleteInitiativeDialog.tsx
@@ -1,18 +1,6 @@
-import { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 interface DeleteInitiativeDialogProps {
   open: boolean;
@@ -28,6 +16,8 @@ interface DeleteInitiativeDialogProps {
  * to trash. Shared by the per-initiative settings page and the guild settings
  * Initiatives table so there is exactly one delete workflow to maintain. The
  * caller owns the mutation (via onConfirm/isDeleting); this only gates it.
+ *
+ * A thin wrapper over the shared ConfirmDialog's type-to-confirm mode.
  */
 export const DeleteInitiativeDialog = ({
   open,
@@ -37,62 +27,35 @@ export const DeleteInitiativeDialog = ({
   onConfirm,
 }: DeleteInitiativeDialogProps) => {
   const { t } = useTranslation(["initiatives", "common"]);
-  const [confirmText, setConfirmText] = useState("");
-  const canConfirm = confirmText === initiativeName;
-
-  // Reset the typed confirmation whenever the dialog (re)opens.
-  useEffect(() => {
-    if (open) setConfirmText("");
-  }, [open]);
 
   return (
-    <AlertDialog
+    <ConfirmDialog
       open={open}
-      onOpenChange={(next) => {
-        onOpenChange(next);
-        if (!next) setConfirmText("");
-      }}
-    >
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{t("settings.deleteConfirmTitle")}</AlertDialogTitle>
-          <AlertDialogDescription>
-            <Trans
-              i18nKey="settings.deleteConfirmDescription"
-              ns="initiatives"
-              values={{ name: initiativeName }}
-              components={{ bold: <strong /> }}
-            />
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <div className="space-y-2 py-2">
-          <Label htmlFor="delete-initiative-confirm-input">
-            <Trans
-              i18nKey="settings.deleteConfirmLabel"
-              ns="initiatives"
-              values={{ name: initiativeName }}
-              components={{ bold: <strong /> }}
-            />
-          </Label>
-          <Input
-            id="delete-initiative-confirm-input"
-            value={confirmText}
-            onChange={(e) => setConfirmText(e.target.value)}
-            placeholder={initiativeName}
-            autoComplete="off"
-          />
-        </div>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isDeleting}>{t("common:cancel")}</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            disabled={!canConfirm || isDeleting}
-            className="bg-destructive text-white hover:bg-destructive/90"
-          >
-            {isDeleting ? t("settings.deletingInitiative") : t("common:delete")}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+      onOpenChange={onOpenChange}
+      title={t("settings.deleteConfirmTitle")}
+      description={
+        <Trans
+          i18nKey="settings.deleteConfirmDescription"
+          ns="initiatives"
+          values={{ name: initiativeName }}
+          components={{ bold: <strong /> }}
+        />
+      }
+      confirmationText={initiativeName}
+      confirmationLabel={
+        <Trans
+          i18nKey="settings.deleteConfirmLabel"
+          ns="initiatives"
+          values={{ name: initiativeName }}
+          components={{ bold: <strong /> }}
+        />
+      }
+      confirmLabel={t("common:delete")}
+      loadingLabel={t("settings.deletingInitiative")}
+      cancelLabel={t("common:cancel")}
+      onConfirm={onConfirm}
+      isLoading={isDeleting}
+      destructive
+    />
   );
 };

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -75,6 +75,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAuth } from "@/hooks/useAuth";
+import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import { useTags } from "@/hooks/useTags";
 import {
   useArchiveDoneTasks,
@@ -166,13 +167,6 @@ const TASK_VIEW_OPTIONS: TaskViewOption[] = [
   { value: "calendar", labelKey: "tasks.viewCalendar", icon: Calendar },
   { value: "gantt", labelKey: "tasks.viewGantt", icon: GanttChart },
 ];
-
-const getDefaultFiltersVisibility = () => {
-  if (typeof window === "undefined") {
-    return true;
-  }
-  return window.matchMedia("(min-width: 640px)").matches;
-};
 
 type ProjectTasksSectionProps = {
   projectId: number;
@@ -266,7 +260,7 @@ export const ProjectTasksSection = ({
     // filter pruning lives in the property filter UI itself (it needs the
     // property definitions, which aren't fetched here).
   }, [filtersLoaded, tagsLoaded, tags, sortedTaskStatuses, filters, setStoredFilters]);
-  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+  const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
   const [localOverride, setLocalOverride] = useState<TaskListRead[] | null>(null);
   const [isComposerOpen, setIsComposerOpen] = useState(initialComposerOpen ?? false);
   useEffect(() => {
@@ -384,23 +378,6 @@ export const ProjectTasksSection = ({
   useEffect(() => {
     setLocalOverride(null);
   }, [projectTasks]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const mediaQuery = window.matchMedia("(min-width: 640px)");
-    const handleChange = (event: MediaQueryListEvent) => {
-      setFiltersOpen(event.matches);
-    };
-    setFiltersOpen(mediaQuery.matches);
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
-  }, []);
 
   useEffect(() => {
     if (!collapsedStorageKey) {

--- a/frontend/src/components/properties/PropertyValueCell.tsx
+++ b/frontend/src/components/properties/PropertyValueCell.tsx
@@ -8,8 +8,8 @@ import {
   PropertyType,
 } from "@/api/generated/initiativeAPI.schemas";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { getInitials } from "@/lib/initials";
-import { resolveUploadUrl } from "@/lib/uploadUrl";
+import { formatDate, formatDateTime } from "@/lib/formatDate";
+import { getAvatarSrc, getInitialsForUser, getUserDisplayName } from "@/lib/userDisplay";
 import { cn } from "@/lib/utils";
 
 import { isEmptyPropertyValue } from "./propertyHelpers";
@@ -36,16 +36,6 @@ const formatNumber = (raw: unknown): string => {
     if (Number.isFinite(parsed)) return new Intl.NumberFormat().format(parsed);
   }
   return "";
-};
-
-const formatDate = (raw: unknown, withTime: boolean): string => {
-  if (typeof raw !== "string" || !raw) return "";
-  const date = new Date(raw);
-  if (Number.isNaN(date.getTime())) return "";
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    ...(withTime ? { timeStyle: "short" } : {}),
-  }).format(date);
 };
 
 const coerceOptionMap = (options: PropertyOption[] | null | undefined) => {
@@ -200,11 +190,11 @@ export const PropertyValueCell = ({
       break;
     }
     case PropertyType.date: {
-      body = <span>{formatDate(value, false)}</span>;
+      body = <span>{formatDate(value)}</span>;
       break;
     }
     case PropertyType.datetime: {
-      body = <span>{formatDate(value, true)}</span>;
+      body = <span>{formatDateTime(value)}</span>;
       break;
     }
     case PropertyType.select: {
@@ -244,13 +234,13 @@ export const PropertyValueCell = ({
       if (!user) {
         body = <span className="text-muted-foreground italic">{t("cell.emptyValue")}</span>;
       } else {
-        const name = user.full_name ?? `#${user.id}`;
-        const userAvatarSrc = resolveUploadUrl(user.avatar_url) || user.avatar_base64 || undefined;
+        const name = getUserDisplayName(user, `#${user.id}`);
+        const userAvatarSrc = getAvatarSrc(user);
         body = (
           <span className="inline-flex max-w-full items-center gap-2 truncate">
             <Avatar className="h-5 w-5 text-[10px]">
               {userAvatarSrc ? <AvatarImage src={userAvatarSrc} alt={name} /> : null}
-              <AvatarFallback userId={user.id}>{getInitials(user.full_name)}</AvatarFallback>
+              <AvatarFallback userId={user.id}>{getInitialsForUser(user)}</AvatarFallback>
             </Avatar>
             <span className="truncate">{name}</span>
           </span>

--- a/frontend/src/components/tasks/TagTasksTable.tsx
+++ b/frontend/src/components/tasks/TagTasksTable.tsx
@@ -27,6 +27,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { DataTable } from "@/components/ui/data-table";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
+import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import { useGuilds } from "@/hooks/useGuilds";
 import { usePrefetchTasks, useTasks, useUpdateTask } from "@/hooks/useTasks";
 import { toast } from "@/lib/chesterToast";
@@ -42,13 +43,6 @@ const statusFallbackOrder: Record<TaskStatusCategory, TaskStatusCategory[]> = {
 };
 
 const DEFAULT_STATUS_FILTERS: TaskStatusCategory[] = ["backlog", "todo", "in_progress"];
-
-const getDefaultFiltersVisibility = () => {
-  if (typeof window === "undefined") {
-    return true;
-  }
-  return window.matchMedia("(min-width: 640px)").matches;
-};
 
 type TagTasksTableProps = {
   tagId: number;
@@ -78,7 +72,7 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
 
   const [statusFilters, setStatusFilters] = useState<TaskStatusCategory[]>(DEFAULT_STATUS_FILTERS);
   const [priorityFilters, setPriorityFilters] = useState<TaskPriority[]>([]);
-  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+  const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
 
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
   const [pageSize, setPageSize] = useState(TAG_TASKS_PAGE_SIZE);
@@ -449,21 +443,6 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
       },
     },
   ];
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const mediaQuery = window.matchMedia("(min-width: 640px)");
-    const handleChange = (event: MediaQueryListEvent) => {
-      setFiltersOpen(event.matches);
-    };
-    setFiltersOpen(mediaQuery.matches);
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
-  }, []);
 
   const isInitialLoad = tasksQuery.isLoading && !tasksQuery.data;
 

--- a/frontend/src/components/ui/confirm-dialog.tsx
+++ b/frontend/src/components/ui/confirm-dialog.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode, useEffect, useId, useState } from "react";
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -9,18 +11,32 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
 type ConfirmDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
-  description?: string;
+  description?: ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   onConfirm: () => void;
   isLoading?: boolean;
+  /** Text shown on the confirm button while ``isLoading``. */
+  loadingLabel?: string;
   destructive?: boolean;
+  /**
+   * When set, render a text input beneath the description and keep the
+   * confirm button disabled until the typed value matches this string
+   * exactly — the "type the name to confirm" guard.
+   */
+  confirmationText?: string;
+  /** Label/prompt rendered above the confirmation input. */
+  confirmationLabel?: ReactNode;
+  /** Extra content rendered between the description and the confirmation input. */
+  children?: ReactNode;
 };
 
 export const ConfirmDialog = ({
@@ -32,8 +48,31 @@ export const ConfirmDialog = ({
   cancelLabel = "Cancel",
   onConfirm,
   isLoading,
+  loadingLabel = "Please wait...",
   destructive,
+  confirmationText,
+  confirmationLabel,
+  children,
 }: ConfirmDialogProps) => {
+  const inputId = useId();
+  const [confirmationInput, setConfirmationInput] = useState("");
+
+  const requiresConfirmation = Boolean(confirmationText);
+
+  // Reset the typed confirmation whenever the dialog closes so a
+  // reopened dialog starts blank.
+  useEffect(() => {
+    if (!open) setConfirmationInput("");
+  }, [open]);
+
+  // Reset when the expected phrase changes (e.g. a reused dialog now
+  // guards a differently named resource).
+  useEffect(() => {
+    setConfirmationInput("");
+  }, [confirmationText]);
+
+  const confirmationSatisfied = !requiresConfirmation || confirmationInput === confirmationText;
+
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
@@ -41,14 +80,27 @@ export const ConfirmDialog = ({
           <AlertDialogTitle>{title}</AlertDialogTitle>
           {description && <AlertDialogDescription>{description}</AlertDialogDescription>}
         </AlertDialogHeader>
+        {children}
+        {requiresConfirmation && (
+          <div className="space-y-2 py-2">
+            {confirmationLabel && <Label htmlFor={inputId}>{confirmationLabel}</Label>}
+            <Input
+              id={inputId}
+              value={confirmationInput}
+              onChange={(e) => setConfirmationInput(e.target.value)}
+              placeholder={confirmationText}
+              autoComplete="off"
+            />
+          </div>
+        )}
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isLoading}>{cancelLabel}</AlertDialogCancel>
           <AlertDialogAction
             onClick={onConfirm}
-            disabled={isLoading}
+            disabled={isLoading || !confirmationSatisfied}
             className={cn(destructive && buttonVariants({ variant: "destructive" }))}
           >
-            {isLoading ? "Please wait..." : confirmLabel}
+            {isLoading ? loadingLabel : confirmLabel}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -39,5 +39,9 @@ export const useAppConfig = () => {
      *  the SPA hides every tier/upgrade/manage surface (the usage panel,
      *  which shows operator-set caps + usage, renders regardless). */
     billing: query.data?.billing ?? null,
+    /** Server-enforced upload size cap, for pre-flight checks. Null until the
+     *  config loads — skip the client-side check then; the server still
+     *  rejects oversized uploads. */
+    maxUploadBytes: query.data?.max_upload_bytes ?? null,
   };
 };

--- a/frontend/src/hooks/useDefaultFiltersOpen.ts
+++ b/frontend/src/hooks/useDefaultFiltersOpen.ts
@@ -1,0 +1,41 @@
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+
+/**
+ * Default "filters panel open" state for list surfaces: open on screens ≥ 640px,
+ * collapsed below. SSR-safe — defaults to open when there is no window to measure.
+ */
+export const getDefaultFiltersVisibility = (): boolean => {
+  if (typeof window === "undefined") {
+    return true;
+  }
+  return window.matchMedia("(min-width: 640px)").matches;
+};
+
+/**
+ * Filters-panel open state that initializes from the viewport width and stays in
+ * sync with it: subscribes to the 640px media query and mirrors `matches` into
+ * state. Returns a `[open, setOpen]` tuple like `useState`, so callers can still
+ * toggle it manually.
+ */
+export const useDefaultFiltersOpen = (): [boolean, Dispatch<SetStateAction<boolean>>] => {
+  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const mediaQuery = window.matchMedia("(min-width: 640px)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setFiltersOpen(event.matches);
+    };
+    setFiltersOpen(mediaQuery.matches);
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return [filtersOpen, setFiltersOpen];
+};

--- a/frontend/src/hooks/useGlobalTasksTable.ts
+++ b/frontend/src/hooks/useGlobalTasksTable.ts
@@ -22,6 +22,7 @@ import {
   listMyTasksApiV1MeTasksGet,
 } from "@/api/generated/tasks/tasks";
 import type { PropertyFilterCondition } from "@/components/properties/PropertyFilter";
+import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useUpdateTaskInGuild } from "@/hooks/useTasks";
 import { useViewPreference } from "@/hooks/useViewPreference";
@@ -70,13 +71,6 @@ const sanitizeStoredPrefs = (raw: unknown): StoredPrefs => {
       : FILTER_DEFAULTS.propertyFilters,
     sorting: Array.isArray(v.sorting) ? v.sorting : FILTER_DEFAULTS.sorting,
   };
-};
-
-const getDefaultFiltersVisibility = () => {
-  if (typeof window === "undefined") {
-    return true;
-  }
-  return window.matchMedia("(min-width: 640px)").matches;
 };
 
 const PAGE_SIZE = 20;
@@ -148,7 +142,7 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
   const setPropertyFilters = useMemo(() => makeSetter("propertyFilters"), [makeSetter]);
   const setSorting = useMemo(() => makeSetter("sorting"), [makeSetter]);
 
-  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+  const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
 
   // --- Pagination state ---
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
@@ -388,24 +382,6 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
   // Archived/template projects are excluded server-side by both global
   // scopes, so the rows come back ready to render.
   const displayTasks = tasks;
-
-  // --- Responsive filter visibility ---
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const mediaQuery = window.matchMedia("(min-width: 640px)");
-    const handleChange = (event: MediaQueryListEvent) => {
-      setFiltersOpen(event.matches);
-    };
-    setFiltersOpen(mediaQuery.matches);
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
-  }, []);
 
   // --- Derived loading / error states ---
   const isInitialLoad = tasksQuery.isLoading && !tasksQuery.data;

--- a/frontend/src/lib/formatDate.ts
+++ b/frontend/src/lib/formatDate.ts
@@ -1,0 +1,19 @@
+const format = (value: unknown, withTime: boolean): string => {
+  if (typeof value !== "string" || !value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    ...(withTime ? { timeStyle: "short" } : {}),
+  }).format(date);
+};
+
+/**
+ * Medium browser-locale date (e.g. "Aug 3, 2026"). Returns "" for missing or
+ * unparsable input — callers supply their own placeholder
+ * (`formatDate(v) || "—"`).
+ */
+export const formatDate = (value: unknown): string => format(value, false);
+
+/** {@link formatDate} plus a short time (e.g. "Aug 3, 2026, 9:15 PM"). */
+export const formatDateTime = (value: unknown): string => format(value, true);

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -31,6 +31,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
+import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import {
   useCopyDocument,
   useDeleteDocument,
@@ -56,12 +57,6 @@ const SORT_FIELD_MAP: Record<string, string> = {
   "last updated": "updated_at",
 };
 const DOCUMENT_TAG_FILTERS_KEY = "documents:tag-filters";
-const getDefaultDocumentFiltersVisibility = () => {
-  if (typeof window === "undefined") {
-    return true;
-  }
-  return window.matchMedia("(min-width: 640px)").matches;
-};
 
 type DocumentsViewProps = {
   fixedInitiativeId?: number;
@@ -119,7 +114,7 @@ export const DocumentsView = ({
     setInitiativeFilter(urlInitiativeId || INITIATIVE_FILTER_ALL);
   }, [searchParams, lockedInitiativeId]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [filtersOpen, setFiltersOpen] = useState(getDefaultDocumentFiltersVisibility);
+  const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
 
   // View mode and tag filters are server-persisted in the normal case.
   // When fixedTagIds is provided (tag detail page), the view is forced
@@ -515,23 +510,6 @@ export const DocumentsView = ({
       ? { run: () => setCreateDialogOpen(true), label: t("page.newDocument") }
       : null
   );
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const mediaQuery = window.matchMedia("(min-width: 640px)");
-    const handleChange = (event: MediaQueryListEvent) => {
-      setFiltersOpen(event.matches);
-    };
-    setFiltersOpen(mediaQuery.matches);
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
-  }, []);
 
   const handleDocumentCreated = (document: { id: number }) => {
     router.navigate({

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -53,6 +53,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
+import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
@@ -75,12 +76,6 @@ const PROJECT_SORT_KEY = "project:list:sort";
 const PROJECT_SEARCH_KEY = "project:list:search";
 const PROJECT_VIEW_KEY = "project:list:view-mode";
 const PROJECT_TAG_FILTERS_KEY = "project:list:tag-filters";
-const getDefaultFiltersVisibility = () => {
-  if (typeof window === "undefined") {
-    return true;
-  }
-  return window.matchMedia("(min-width: 640px)").matches;
-};
 
 type ProjectsViewProps = {
   fixedInitiativeId?: number;
@@ -199,7 +194,7 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
     [setPersistedViewMode]
   );
   const [tabValue, setTabValue] = useState<"active" | "templates" | "archive">("active");
-  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+  const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
 
   const [persistedTagFilters, setPersistedTagFilters] = useViewPreference<number[]>(
     PROJECT_TAG_FILTERS_KEY,
@@ -339,23 +334,6 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
     lockedInitiativeId,
     setIsComposerOpen,
   ]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const mediaQuery = window.matchMedia("(min-width: 640px)");
-    const handleChange = (event: MediaQueryListEvent) => {
-      setFiltersOpen(event.matches);
-    };
-    setFiltersOpen(mediaQuery.matches);
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
-  }, []);
 
   const reorderProjects = useReorderProjects();
 

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useCounterGroupsList } from "@/hooks/useCounters";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
+import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
@@ -125,8 +126,6 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
     canCreateGroups ? { run: () => setCreateOpen(true), label: t("createGroup") } : null
   );
 
-  const getDefaultFiltersVisibility = () =>
-    typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches;
   const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
 
   const groups = useMemo(() => {

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -45,6 +45,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useCalendarEntries } from "@/hooks/useCalendarEntries";
 import { useRescheduleCalendarEvent } from "@/hooks/useCalendarEvents";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
+import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
 import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useProjects } from "@/hooks/useProjects";
@@ -155,9 +156,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   const [propertyFilters, setPropertyFilters] = useState<PropertyFilterCondition[]>(
     () => storedPrefs.propertyFilters
   );
-  const [filtersOpen, setFiltersOpen] = useState(
-    () => typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches
-  );
+  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
 
   // Reset project filter when initiative changes (project IDs are initiative-scoped)
   const prevInitiativeId = useRef(initiativeId);

--- a/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
@@ -8,6 +8,7 @@ import { invalidateAllQueues } from "@/api/query-keys";
 import { BulkAccessBar, canManageSharing } from "@/components/access/BulkAccessBar";
 import { BulkEditAccessDialog } from "@/components/access/BulkEditAccessDialog";
 import { SelectableGridItem } from "@/components/access/SelectableGridItem";
+import { PaginationBar } from "@/components/documents/PaginationBar";
 import { BulkExportButton } from "@/components/exports/BulkExportButton";
 import { ToolImportAction } from "@/components/imports/ToolImportAction";
 import { CreateQueueDialog } from "@/components/initiativeTools/queues/CreateQueueDialog";
@@ -21,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/hooks/useAuth";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
+import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
@@ -79,6 +81,7 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
   }, [searchParams, lockedInitiativeId]);
 
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
+  const [pageSize, setPageSize] = useState(20);
 
   const setPage = useCallback(
     (updater: number | ((prev: number) => number)) => {
@@ -125,7 +128,7 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
       ? { initiative_id: Number(initiativeFilter) }
       : {}),
     page,
-    page_size: 20,
+    page_size: pageSize,
   });
 
   const initiativesQuery = useInitiatives();
@@ -176,8 +179,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
   } = useCreateFromSearchParam();
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const getDefaultFiltersVisibility = () =>
-    typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches;
   const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
 
   // Drive the app-wide bottom-nav add button for this route.
@@ -193,8 +194,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
 
   const totalCount = queuesQuery.data?.total_count ?? 0;
   const hasNext = queuesQuery.data?.has_next ?? false;
-  const pageSize = 20;
-  const totalPages = pageSize > 0 ? Math.ceil(totalCount / pageSize) : 1;
 
   // Client-side filtering by search query and status
   const queues = useMemo(() => {
@@ -308,30 +307,18 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
             ))}
           </div>
 
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page <= 1}
-              >
-                {t("previous")}
-              </Button>
-              <span className="text-muted-foreground text-sm">
-                {page} / {totalPages}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setPage((p) => p + 1)}
-                disabled={!hasNext}
-              >
-                {t("next")}
-              </Button>
-            </div>
-          )}
+          <PaginationBar
+            page={page}
+            pageSize={pageSize}
+            totalCount={totalCount}
+            hasNext={hasNext}
+            onPageChange={setPage}
+            onPageSizeChange={(size) => {
+              setPageSize(size);
+              setPage(1);
+            }}
+            onPrefetchPage={() => {}}
+          />
         </>
       ) : totalCount > 0 ? (
         <p className="text-muted-foreground text-sm">{t("filters.noMatchingQueues")}</p>

--- a/frontend/src/pages/user/MyCalendarPage.tsx
+++ b/frontend/src/pages/user/MyCalendarPage.tsx
@@ -26,6 +26,7 @@ import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { useAuth } from "@/hooks/useAuth";
 import { useMyCalendarEntries } from "@/hooks/useCalendarEntries";
+import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { toast } from "@/lib/chesterToast";
@@ -71,9 +72,6 @@ const sanitizeStoredPrefs = (raw: unknown): StoredPrefs => {
     guildFilters: Array.isArray(v.guildFilters) ? v.guildFilters : PREFS_DEFAULTS.guildFilters,
   };
 };
-
-const getDefaultFiltersVisibility = () =>
-  typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches;
 
 export const MyCalendarPage = () => {
   const { t } = useTranslation(["tasks", "calendarEvents", "common"]);

--- a/frontend/src/pages/user/MyDocumentsPage.tsx
+++ b/frontend/src/pages/user/MyDocumentsPage.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import { useGlobalDocuments, usePrefetchGlobalDocuments } from "@/hooks/useDocuments";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useViewPreference } from "@/hooks/useViewPreference";
@@ -62,13 +63,6 @@ const SORT_FIELD_MAP: Record<string, string> = {
 const SORT_FIELD_REVERSE: Record<string, string> = Object.fromEntries(
   Object.entries(SORT_FIELD_MAP).map(([col, field]) => [field, col])
 );
-
-const getDefaultFiltersVisibility = () => {
-  if (typeof window === "undefined") {
-    return true;
-  }
-  return window.matchMedia("(min-width: 640px)").matches;
-};
 
 export const MyDocumentsPage = () => {
   const { t } = useTranslation(["documents", "common"]);
@@ -113,7 +107,7 @@ export const MyDocumentsPage = () => {
 
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+  const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
 
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
   const [pageSize, setPageSize] = useState(PAGE_SIZE);
@@ -321,24 +315,6 @@ export const MyDocumentsPage = () => {
     ],
     [t, guilds, docGuildPath]
   );
-
-  // Responsive filter visibility
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const mediaQuery = window.matchMedia("(min-width: 640px)");
-    const handleChange = (event: MediaQueryListEvent) => {
-      setFiltersOpen(event.matches);
-    };
-    setFiltersOpen(mediaQuery.matches);
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
-  }, []);
 
   const initialSorting = useMemo(() => {
     if (!sortBy) return undefined;

--- a/frontend/src/pages/user/MyProjectsPage.tsx
+++ b/frontend/src/pages/user/MyProjectsPage.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useGlobalProjects, usePrefetchGlobalProjects } from "@/hooks/useProjects";
 import { useViewPreference } from "@/hooks/useViewPreference";
@@ -60,13 +61,6 @@ const SORT_FIELD_MAP: Record<string, string> = {
 const SORT_FIELD_REVERSE: Record<string, string> = Object.fromEntries(
   Object.entries(SORT_FIELD_MAP).map(([col, field]) => [field, col])
 );
-
-const getDefaultFiltersVisibility = () => {
-  if (typeof window === "undefined") {
-    return true;
-  }
-  return window.matchMedia("(min-width: 640px)").matches;
-};
 
 const PAGE_SIZE = 20;
 
@@ -113,7 +107,7 @@ export const MyProjectsPage = () => {
 
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [filtersOpen, setFiltersOpen] = useState(getDefaultFiltersVisibility);
+  const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
 
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
   const [pageSize, setPageSize] = useState(PAGE_SIZE);
@@ -361,24 +355,6 @@ export const MyProjectsPage = () => {
     ],
     [t, getGuildName, getProjectGuildId]
   );
-
-  // Responsive filter collapsible
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const mediaQuery = window.matchMedia("(min-width: 640px)");
-    const handleChange = (event: MediaQueryListEvent) => {
-      setFiltersOpen(event.matches);
-    };
-    setFiltersOpen(mediaQuery.matches);
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
-  }, []);
 
   const initialSorting = useMemo(() => {
     if (!sortBy) return undefined;

--- a/frontend/src/pages/user/settings/UserSettingsSecurityPage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsSecurityPage.tsx
@@ -36,20 +36,7 @@ import {
   useRevokeDeviceToken,
 } from "@/hooks/useSecurity";
 import { toast } from "@/lib/chesterToast";
-
-const formatDateTime = (value?: string | null) => {
-  if (!value) {
-    return "—";
-  }
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-};
+import { formatDateTime } from "@/lib/formatDate";
 
 const computeStatus = (key: ApiKeyMetadata) => {
   if (!key.is_active) {
@@ -372,7 +359,7 @@ export const UserSettingsSecurityPage = () => {
                             ? formatDateTime(key.last_used_at)
                             : t("security.never")}
                         </td>
-                        <td className="py-3 pr-4">{formatDateTime(key.expires_at)}</td>
+                        <td className="py-3 pr-4">{formatDateTime(key.expires_at) || "—"}</td>
                         <td className="py-3 text-right">
                           <Button
                             type="button"


### PR DESCRIPTION
## Problem

#874's bundle of small duplications: the 640px filters-visibility matchMedia block copy-pasted across 11 list surfaces, a 50 MB upload cap declared locally in 3 files, two byte-identical `Intl.DateTimeFormat` helpers, inline user display-name derivation that loses anonymized-user handling, hand-rolled pagers, and bespoke type-to-confirm dialogs.

## Changes

- **Filters visibility** — new [useDefaultFiltersOpen.ts](frontend/src/hooks/useDefaultFiltersOpen.ts): 7 sites had the initializer *plus* an identical media-query mirror effect → replaced with the hook; 4 sites had only the initializer → they import the pure `getDefaultFiltersVisibility` and keep their non-reactive `useState` (no behavior added).
- **Upload cap, single source of truth** — instead of a mirrored frontend constant, `/api/v1/config` now serves `max_upload_bytes` sourced from the backend's `MAX_DOCUMENT_FILE_SIZE` ([config.py](backend/app/api/v1/platform_endpoints/config.py)); Orval types regenerated; CreateDocumentDialog / FileDocumentViewer / EnvelopeImportDialog read it via `useAppConfig` and skip the pre-flight check until config loads (the server enforces regardless). Backend test added.
- **Dates** — [lib/formatDate.ts](frontend/src/lib/formatDate.ts) (`formatDate`/`formatDateTime`) collapses the two identical helpers. Kept on browser-default locale exactly like both originals; behavior delta: an unparsable timestamp on the security page now renders the "—" placeholder instead of the raw string.
- **User display** — `PropertyValueCell` user values go through `getUserDisplayName`/`getInitialsForUser`/`getAvatarSrc`. **AppSidebar deliberately left alone**: it obfuscates the email (`obfuscateEmail`) on purpose, and the signed-in user can't be anonymized — converting it would leak raw addresses.
- **Type-to-confirm dialogs** — `ConfirmDialog` gains optional `confirmationText`/`confirmationLabel`/`children` (+`loadingLabel`, `description` widened to ReactNode; all existing callers byte-compatible). `DeleteInitiativeDialog` becomes a thin wrapper. The issue's other three candidates were **not** converted: LeaveGuildDialog/RemoveGuildMemberDialog run async eligibility pre-flights with per-project disposition UI and conditionally hidden actions, and DeleteAccountDialog is a multi-step wizard — forcing them into ConfirmDialog would regress real behavior.
- **Pagers** — QueuesPage (the only genuinely hand-rolled pager) routes through `PaginationBar`; its endpoint already serves `page_size`/`total_count`/`has_next`, and it gains a real page-size control. TagTasksTable/MyDocumentsPage/MyProjectsPage already paginate through `DataTable`'s integrated controls — converting them would rip pagination out of the table, so they stay.
- **Skipped: item 7** (`DetailScaffold` wrapper + self-firing recent-view variant) — the detail pages differ materially; a scaffold wrapper is speculative abstraction, not consolidation of real duplication.

## Testing

- `cd backend && pytest app/api/v1/platform_endpoints/config_test.py` — 17 passed; `ruff check`/`ruff format` clean
- `cd frontend && pnpm typecheck` — 0 errors; `pnpm biome check src` — clean
- `./scripts/test-changed.sh` — full suite: 70 files / 936 tests passed

Closes #874