### PR TITLE
Adopt hasWriteAccess predicate for DAC level reads

### DIFF
--- a/frontend/src/components/access/BulkAccessBar.tsx
+++ b/frontend/src/components/access/BulkAccessBar.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
+import { hasWriteAccess } from "@/lib/permissions";
 
 interface BulkAccessBarProps {
   count: number;
@@ -55,8 +56,5 @@ export function BulkAccessBar({
 
 /** Selected items can have their sharing managed only by an owner/editor. */
 export function canManageSharing(items: { my_permission_level?: string | null }[]): boolean {
-  return (
-    items.length > 0 &&
-    items.every((i) => i.my_permission_level === "write" || i.my_permission_level === "owner")
-  );
+  return items.length > 0 && items.every((i) => hasWriteAccess(i.my_permission_level));
 }

--- a/frontend/src/components/import/TickTickImportDialog.tsx
+++ b/frontend/src/components/import/TickTickImportDialog.tsx
@@ -23,6 +23,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useImportFromTickTick, useParseTickTickCsv } from "@/hooks/useImports";
 import { useProjects, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { toast } from "@/lib/chesterToast";
+import { hasWriteAccess } from "@/lib/permissions";
 import type { DialogProps } from "@/types/dialog";
 
 interface TickTickColumn {
@@ -195,7 +196,7 @@ export const TickTickImportDialog = ({ open, onOpenChange }: TickTickImportDialo
   const activeProjects =
     projectsQuery.data?.items?.filter((p) => {
       if (p.is_archived || p.is_template) return false;
-      return p.my_permission_level === "owner" || p.my_permission_level === "write";
+      return hasWriteAccess(p.my_permission_level);
     }) ?? [];
   const statuses = taskStatusesQuery.data ?? [];
 

--- a/frontend/src/components/import/TodoistImportDialog.tsx
+++ b/frontend/src/components/import/TodoistImportDialog.tsx
@@ -23,6 +23,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useImportFromTodoist, useParseTodoistCsv } from "@/hooks/useImports";
 import { useProjects, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { toast } from "@/lib/chesterToast";
+import { hasWriteAccess } from "@/lib/permissions";
 import type { DialogProps } from "@/types/dialog";
 
 interface TodoistParseResult {
@@ -179,7 +180,7 @@ export const TodoistImportDialog = ({ open, onOpenChange }: TodoistImportDialogP
   const activeProjects =
     projectsQuery.data?.items?.filter((p) => {
       if (p.is_archived || p.is_template) return false;
-      return p.my_permission_level === "owner" || p.my_permission_level === "write";
+      return hasWriteAccess(p.my_permission_level);
     }) ?? [];
   const statuses = taskStatusesQuery.data ?? [];
 

--- a/frontend/src/components/import/VikunjaImportDialog.tsx
+++ b/frontend/src/components/import/VikunjaImportDialog.tsx
@@ -23,6 +23,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useImportFromVikunja, useParseVikunjaJson } from "@/hooks/useImports";
 import { useProjects, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { toast } from "@/lib/chesterToast";
+import { hasWriteAccess } from "@/lib/permissions";
 import type { DialogProps } from "@/types/dialog";
 
 interface VikunjaBucket {
@@ -203,7 +204,7 @@ export const VikunjaImportDialog = ({ open, onOpenChange }: VikunjaImportDialogP
   const activeProjects =
     projectsQuery.data?.items?.filter((p) => {
       if (p.is_archived || p.is_template) return false;
-      return p.my_permission_level === "owner" || p.my_permission_level === "write";
+      return hasWriteAccess(p.my_permission_level);
     }) ?? [];
   const statuses = taskStatusesQuery.data ?? [];
 

--- a/frontend/src/components/initiativeTools/advancedTools/AdvancedToolCard.tsx
+++ b/frontend/src/components/initiativeTools/advancedTools/AdvancedToolCard.tsx
@@ -7,6 +7,7 @@ import { TagBadge } from "@/components/tags/TagBadge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 
 import { EditAdvancedToolTagsDialog } from "./EditAdvancedToolTagsDialog";
 
@@ -19,7 +20,7 @@ export const AdvancedToolCard = ({ tool }: AdvancedToolCardProps) => {
   const gp = useGuildPath();
   const [tagsDialogOpen, setTagsDialogOpen] = useState(false);
 
-  const canWrite = tool.my_permission_level === "owner" || tool.my_permission_level === "write";
+  const canWrite = hasWriteAccess(tool.my_permission_level);
 
   return (
     <>

--- a/frontend/src/components/initiativeTools/queues/QueueControls.tsx
+++ b/frontend/src/components/initiativeTools/queues/QueueControls.tsx
@@ -5,6 +5,7 @@ import type { QueueRead } from "@/api/generated/initiativeAPI.schemas";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { hasWriteAccess } from "@/lib/permissions";
 
 interface QueueControlsProps {
   queue: QueueRead;
@@ -28,7 +29,7 @@ export const QueueControls = ({
   isLoading = false,
 }: QueueControlsProps) => {
   const { t } = useTranslation("queues");
-  const canControl = queue.my_permission_level === "owner" || queue.my_permission_level === "write";
+  const canControl = hasWriteAccess(queue.my_permission_level);
 
   if (!canControl) {
     return (

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -19,6 +19,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useAppConfig } from "@/hooks/useAppConfig";
 import type { InitiativeToolAccess } from "@/hooks/useInitiativeAccess";
 import { guildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 import { getItem, setItem } from "@/lib/storage";
 import {
   SIDEBAR_TOOLS,
@@ -64,8 +65,7 @@ export const InitiativeSection = memo(
     // Pure DAC: check if user has write access to a specific project
     const canManageProject = (project: ProjectRead): boolean => {
       if (!userId) return false;
-      const level = project.my_permission_level;
-      return level === "owner" || level === "write";
+      return hasWriteAccess(project.my_permission_level);
     };
 
     /** Whether a tool's row renders at all — the member can view it AND (for

--- a/frontend/src/components/tasks/CreateTaskWizard.tsx
+++ b/frontend/src/components/tasks/CreateTaskWizard.tsx
@@ -18,6 +18,7 @@ import { useInitiativesForGuild } from "@/hooks/useInitiatives";
 import { useGlobalProjects } from "@/hooks/useProjects";
 import { guildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
+import { hasWriteAccess } from "@/lib/permissions";
 import { getItem, removeItem, setItem } from "@/lib/storage";
 
 // ── Module-level opener (same pattern as CommandCenter) ─────────────────────
@@ -166,7 +167,7 @@ export const CreateTaskWizard = () => {
         (p) =>
           p.initiative_id === selectedInitiativeId &&
           !p.is_archived &&
-          (p.my_permission_level === "owner" || p.my_permission_level === "write")
+          hasWriteAccess(p.my_permission_level)
       ),
     [accumulatedProjects, selectedInitiativeId]
   );

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -74,3 +74,8 @@ export function canAccessAdminDashboard(user: WithCapabilities): boolean {
 export function canAccessPlatformAdmin(user: WithCapabilities): boolean {
   return canManagePlatformConfig(user) || canAccessAdminDashboard(user);
 }
+
+/** True when a server-computed per-resource permission level allows writing.
+ * Reads `my_permission_level` — never derive this client-side. */
+export const hasWriteAccess = (level: string | null | undefined): boolean =>
+  level === "owner" || level === "write";

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -114,6 +114,7 @@ import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
 import { findNewMentions } from "@/lib/mentionUtils";
+import { hasWriteAccess } from "@/lib/permissions";
 import { getItem, removeItem, setItem } from "@/lib/storage";
 import { resolveHeaderlessApiUrl, resolveUploadUrl } from "@/lib/uploadUrl";
 import { getUserDisplayName } from "@/lib/userDisplay";
@@ -398,8 +399,7 @@ export const DocumentDetailPage = () => {
     }
     // Server-computed: already capped at "read" when the guild's content is
     // frozen (read_only lifecycle status) or access is via a read-level grant.
-    const myLevel = document.my_permission_level;
-    return myLevel === "owner" || myLevel === "write";
+    return hasWriteAccess(document.my_permission_level);
   }, [document, user]);
   const isDirty =
     canEditDocument &&
@@ -416,8 +416,7 @@ export const DocumentDetailPage = () => {
       return false;
     }
     // Pure DAC: users with write or owner permission can moderate comments
-    const myLevel = document.my_permission_level;
-    return myLevel === "owner" || myLevel === "write";
+    return hasWriteAccess(document.my_permission_level);
   }, [document, user]);
 
   // Check if user can create documents in this initiative

--- a/frontend/src/pages/DocumentSettingsPage.tsx
+++ b/frontend/src/pages/DocumentSettingsPage.tsx
@@ -34,7 +34,7 @@ import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
-import { Capability, hasCapability } from "@/lib/permissions";
+import { Capability, hasCapability, hasWriteAccess } from "@/lib/permissions";
 
 export const DocumentSettingsPage = () => {
   const { t } = useTranslation(["documents", "common"]);
@@ -68,8 +68,7 @@ export const DocumentSettingsPage = () => {
     if (!document || !user) {
       return false;
     }
-    const myLevel = document.my_permission_level;
-    return myLevel === "owner" || myLevel === "write";
+    return hasWriteAccess(document.my_permission_level);
   }, [document, user]);
 
   // Pure DAC: only owners can delete/duplicate documents
@@ -78,15 +77,6 @@ export const DocumentSettingsPage = () => {
       return false;
     }
     return document.my_permission_level === "owner";
-  }, [document, user]);
-
-  // Pure DAC: check if user has write access
-  const hasWriteAccess = useMemo(() => {
-    if (!document || !user) {
-      return false;
-    }
-    const myLevel = document.my_permission_level;
-    return myLevel === "owner" || myLevel === "write";
   }, [document, user]);
 
   const manageableInitiatives = useMemo(() => {
@@ -286,8 +276,8 @@ export const DocumentSettingsPage = () => {
         <DocumentSettingsDetailsTab
           isTemplate={isTemplate}
           onTemplateToggle={handleTemplateToggle}
-          templateToggleDisabled={!hasWriteAccess || updateTemplate.isPending}
-          hasWriteAccess={hasWriteAccess}
+          templateToggleDisabled={!canManageDocument || updateTemplate.isPending}
+          hasWriteAccess={canManageDocument}
           documentTags={documentTags}
           onTagsChange={handleTagsChange}
         />

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -45,6 +45,7 @@ import { useInitiatives } from "@/hooks/useInitiatives";
 import { useTags } from "@/hooks/useTags";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 import { buildTagTree, collectDescendantTagIds, findNodeByPath } from "@/lib/tagTree";
 
 const INITIATIVE_FILTER_ALL = "all";
@@ -446,9 +447,7 @@ export const DocumentsView = ({
     if (!user || selectedDocuments.length === 0) {
       return false;
     }
-    return selectedDocuments.every(
-      (doc) => doc.my_permission_level === "owner" || doc.my_permission_level === "write"
-    );
+    return selectedDocuments.every((doc) => hasWriteAccess(doc.my_permission_level));
   }, [selectedDocuments, user]);
 
   const canEditSelectedDocuments = canDuplicateSelectedDocuments;

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -28,7 +28,7 @@ import { useProject, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { useRecordRecentView } from "@/hooks/useRecents";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
-import { Capability, hasCapability } from "@/lib/permissions";
+import { Capability, hasCapability, hasWriteAccess } from "@/lib/permissions";
 
 export const ProjectDetailPage = () => {
   const { t } = useTranslation("projects");
@@ -156,7 +156,7 @@ export const ProjectDetailPage = () => {
   const isInitiativePm = initiativeMembership?.role === "project_manager";
   const myLevel = project?.my_permission_level;
   // Pure DAC: write access requires owner or write permission level
-  const hasWritePermission = myLevel === "owner" || myLevel === "write";
+  const hasWritePermission = hasWriteAccess(myLevel);
 
   // Pure DAC: settings/write access based on permission level
   const canManageSettings = hasWritePermission;

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -19,6 +19,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useProject } from "@/hooks/useProjects";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 
 export const ProjectSettingsPage = () => {
   const { projectId } = useParams({ strict: false }) as { projectId: string };
@@ -51,13 +52,12 @@ export const ProjectSettingsPage = () => {
   }
 
   const isOwner = project.owner_id === user?.id;
-  const myLevel = project.my_permission_level;
   // Pure DAC: write access requires owner or write permission level
-  const hasWriteAccess = myLevel === "owner" || myLevel === "write";
+  const canWrite = hasWriteAccess(project.my_permission_level);
   // Pure DAC: write permission grants access to manage settings
-  const canManageTaskStatuses = hasWriteAccess;
-  const canManageAccess = hasWriteAccess;
-  const canWriteProject = hasWriteAccess;
+  const canManageTaskStatuses = canWrite;
+  const canManageAccess = canWrite;
+  const canWriteProject = canWrite;
 
   if (!canManageAccess && !canWriteProject) {
     return (

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -69,6 +69,7 @@ import {
 import { useTags } from "@/hooks/useTags";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 
 const INITIATIVE_FILTER_ALL = "all";
 const PROJECT_SORT_KEY = "project:list:sort";
@@ -306,7 +307,7 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   // Helper function for per-project DAC checks
   const hasProjectWritePermission = (project: ProjectRead): boolean => {
     if (!user) return false;
-    return project.my_permission_level === "owner" || project.my_permission_level === "write";
+    return hasWriteAccess(project.my_permission_level);
   };
 
   const templatesQuery = useTemplateProjects();

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -71,6 +71,7 @@ import {
 import { toast } from "@/lib/chesterToast";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 import { queryClient } from "@/lib/queryClient";
 import {
   getAvatarSrc,
@@ -415,8 +416,7 @@ export const TaskEditPage = () => {
 
   // Pure DAC: permissions inherited from project. Server-computed — already
   // capped at "read" when the guild's content is frozen (read_only status).
-  const myLevel = project?.my_permission_level;
-  const hasWritePermission = myLevel === "owner" || myLevel === "write";
+  const hasWritePermission = hasWriteAccess(project?.my_permission_level);
   const canWriteProject = hasWritePermission;
   const projectIsArchived = project?.is_archived ?? false;
   const isReadOnly = !canWriteProject || projectIsArchived;

--- a/frontend/src/pages/initiativeTools/counters/CounterDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterDetailPage.tsx
@@ -35,6 +35,7 @@ import { useCounterGroupRealtime } from "@/hooks/useResourceRealtime";
 import { getContrastingTextColor } from "@/lib/counter-color";
 import { isAtMax, isAtMin } from "@/lib/counter-math";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
 
 const SWIPE_THRESHOLD_PX = 60;
@@ -77,7 +78,7 @@ export function CounterDetailPage() {
   );
   const counter = currentIndex >= 0 ? counters[currentIndex] : null;
 
-  const canWrite = group?.my_permission_level === "owner" || group?.my_permission_level === "write";
+  const canWrite = hasWriteAccess(group?.my_permission_level);
 
   const goToCounter = (index: number) => {
     if (counters.length === 0 || !guildId || !groupId) return;

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
@@ -56,6 +56,7 @@ import { useCounterGroupRealtime } from "@/hooks/useResourceRealtime";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { exportFilenameStem } from "@/lib/exportDownload";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 import { toolExportEndpoint } from "@/lib/tools";
 
 const layoutStorageKey = (groupId: number) => `counter-group-${groupId}-layout`;
@@ -129,7 +130,7 @@ export function CounterGroupDetailPage() {
     recordViewMutation.mutate(viewedGroupId);
   }, [viewedGroupId, recordViewMutation.mutate]);
 
-  const canWrite = group?.my_permission_level === "owner" || group?.my_permission_level === "write";
+  const canWrite = hasWriteAccess(group?.my_permission_level);
   const canManage = group?.my_permission_level === "owner";
 
   // Drive the app-wide bottom-nav add button for this route.

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupSettingsPage.tsx
@@ -40,6 +40,7 @@ import {
 import { useSetToolTags } from "@/hooks/useToolTags";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 
 export function CounterGroupSettingsPage() {
   const { t } = useTranslation(["counterGroups", "common", "access"]);
@@ -53,8 +54,7 @@ export function CounterGroupSettingsPage() {
   const groupQuery = useCounterGroup(Number.isFinite(parsedId) ? parsedId : null);
   const group = groupQuery.data;
 
-  const canManage =
-    group?.my_permission_level === "owner" || group?.my_permission_level === "write";
+  const canManage = hasWriteAccess(group?.my_permission_level);
   const isOwner = group?.my_permission_level === "owner";
 
   // ── Details tab ────────────────────────────────────────────────────────

--- a/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
@@ -48,6 +48,7 @@ import { toast } from "@/lib/chesterToast";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { exportFilenameStem } from "@/lib/exportDownload";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 import { toolExportEndpoint } from "@/lib/tools";
 
 export function QueueDetailPage() {
@@ -141,7 +142,7 @@ export function QueueDetailPage() {
   const [addItemOpen, setAddItemOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<QueueItemRead | null>(null);
 
-  const canEdit = queue?.my_permission_level === "owner" || queue?.my_permission_level === "write";
+  const canEdit = hasWriteAccess(queue?.my_permission_level);
 
   // Drive the app-wide bottom-nav add button for this route.
   useRegisterPrimaryCreateAction(

--- a/frontend/src/pages/initiativeTools/queues/QueueSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueSettingsPage.tsx
@@ -26,6 +26,7 @@ import { useDeleteQueue, useQueue, useSetQueueGrants, useUpdateQueue } from "@/h
 import { useSetToolTags } from "@/hooks/useToolTags";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 
 export const QueueSettingsPage = () => {
   const { t } = useTranslation(["queues", "common", "access"]);
@@ -37,8 +38,7 @@ export const QueueSettingsPage = () => {
   const queueQuery = useQueue(Number.isFinite(parsedId) ? parsedId : null);
   const queue = queueQuery.data;
 
-  const canManage =
-    queue?.my_permission_level === "owner" || queue?.my_permission_level === "write";
+  const canManage = hasWriteAccess(queue?.my_permission_level);
   const isOwner = queue?.my_permission_level === "owner";
 
   // ── Details ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

#873: the server-computed `my_permission_level === "owner" || === "write"` disjunction was hand-typed at ~24 sites, and the same issue proposed `useGuildAdmin` / `useCreatableInitiatives` hooks for the guild-admin and PM-check reads.

## Changes

- New `hasWriteAccess(level)` in [lib/permissions.ts](frontend/src/lib/permissions.ts) — a pure read of the server-computed DAC level, per the repo's server-computed-permissions rule. Adopted at 22 sites (14 literal + 8 aliased `myLevel`/`level` variants), including `BulkAccessBar.canManageSharing` (the issue's exemplar). Owner-only checks (`=== "owner"`) are deliberately untouched. `DocumentSettingsPage` also drops a memo that was byte-identical to its `canManageDocument`.
- **Not added, deliberately** (recorded here for the issue):
  - `useGuildAdmin()` — plain `activeGuild?.role === "admin"` is a direct read of one server-computed field; a wrapper hook adds indirection without preventing any real drift.
  - `useCreatableInitiatives(tool)` — auditing every inline PM-check site against the already-centralized `useInitiativeAccess.canManage` showed **none are copies**: InitiativeSettings/InitiativeDetail add an `is_manager` leg `canManage` lacks; DocumentSettingsPage and ProjectDetailPage short-circuit on `data.bypass` rather than guild-admin; ICalImportDialog has **no** admin leg at all. Unifying these means choosing one semantic — a behavior decision, not a refactor. The divergences are itemized in a follow-up comment on #873.

## Testing

- `pnpm typecheck` — 0 errors; `pnpm biome check src` — clean
- `./scripts/test-changed.sh` — full suite: 70 files / 936 tests passed

Closes #873