### PR TITLE
Consolidate create dialogs and queue-item form

### DIFF
--- a/frontend/src/components/access/CreateAccessSection.tsx
+++ b/frontend/src/components/access/CreateAccessSection.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from "react-i18next";
+
+import type { ResourceGrantSchema } from "@/api/generated/initiativeAPI.schemas";
+import { ShareControl } from "@/components/access/ShareControl";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+export interface CreateAccessSectionProps {
+  initiativeId: number | null;
+  /** Full grant list for the resource being created. */
+  grants: ResourceGrantSchema[];
+  /** Called with the updated grant list to persist in the dialog's state. */
+  onChange: (grants: ResourceGrantSchema[]) => void;
+  /**
+   * Whether the "Advanced options" accordion starts expanded. Defaults to
+   * `true`; every create dialog opens it by default except the document dialog.
+   */
+  defaultOpen?: boolean;
+}
+
+/**
+ * The shared "Advanced options" access block used by every create dialog: an
+ * accordion wrapping the {@link ShareControl} grant editor. Kept byte-equal to
+ * the block each dialog previously inlined.
+ */
+export const CreateAccessSection = ({
+  initiativeId,
+  grants,
+  onChange,
+  defaultOpen = true,
+}: CreateAccessSectionProps) => {
+  const { t } = useTranslation("common");
+
+  return (
+    <Accordion type="single" collapsible defaultValue={defaultOpen ? "advanced" : undefined}>
+      <AccordionItem value="advanced" className="border-b-0">
+        <AccordionTrigger>{t("createAccess.advancedOptions")}</AccordionTrigger>
+        <AccordionContent>
+          <ShareControl initiativeId={initiativeId} grants={grants} onChange={onChange} />
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/frontend/src/components/access/grants.ts
+++ b/frontend/src/components/access/grants.ts
@@ -1,0 +1,14 @@
+import type { ResourceGrantSchema } from "@/api/generated/initiativeAPI.schemas";
+
+/**
+ * Default access grants for a newly created resource: every initiative member
+ * gets read access. Seeds the {@link ShareControl} in all create dialogs
+ * (project, queue, counter group, calendar event, document).
+ *
+ * This is a shared template — spread it (`[...DEFAULT_GRANTS]`) at each use site
+ * (initial state and reset-on-close) so every dialog owns an independent array
+ * and can never mutate a reference shared with another dialog.
+ */
+export const DEFAULT_GRANTS: ResourceGrantSchema[] = [
+  { all_initiative_members: true, level: "read" },
+];

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -18,13 +18,8 @@ import type {
   InitiativeRead,
   ResourceGrantSchema,
 } from "@/api/generated/initiativeAPI.schemas";
-import { ShareControl } from "@/components/access/ShareControl";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
+import { CreateAccessSection } from "@/components/access/CreateAccessSection";
+import { DEFAULT_GRANTS } from "@/components/access/grants";
 import { AsyncCombobox } from "@/components/ui/async-combobox";
 import { Button } from "@/components/ui/button";
 import {
@@ -100,9 +95,7 @@ export const CreateDocumentDialog = ({
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [smartLinkUrl, setSmartLinkUrl] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [grants, setGrants] = useState<ResourceGrantSchema[]>([
-    { all_initiative_members: true, level: "read" },
-  ]);
+  const [grants, setGrants] = useState<ResourceGrantSchema[]>([...DEFAULT_GRANTS]);
 
   // Determine effective initiative ID
   const effectiveInitiativeId =
@@ -161,7 +154,7 @@ export const CreateDocumentDialog = ({
       setSelectedFile(null);
       setSmartLinkUrl("");
       setCreateDialogTab("new");
-      setGrants([{ all_initiative_members: true, level: "read" }]);
+      setGrants([...DEFAULT_GRANTS]);
     }
   }, [open, defaultInitiativeId]);
 
@@ -482,18 +475,12 @@ export const CreateDocumentDialog = ({
           </TabsContent>
         </Tabs>
 
-        <Accordion type="single" collapsible>
-          <AccordionItem value="advanced" className="border-b-0">
-            <AccordionTrigger>{t("common:createAccess.advancedOptions")}</AccordionTrigger>
-            <AccordionContent>
-              <ShareControl
-                initiativeId={effectiveInitiativeId}
-                grants={grants}
-                onChange={setGrants}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+        <CreateAccessSection
+          initiativeId={effectiveInitiativeId}
+          grants={grants}
+          onChange={setGrants}
+          defaultOpen={false}
+        />
 
         <DialogFooter>
           {createDialogTab === "new" ? (

--- a/frontend/src/components/initiativeTools/counters/CreateCounterGroupDialog.tsx
+++ b/frontend/src/components/initiativeTools/counters/CreateCounterGroupDialog.tsx
@@ -1,36 +1,9 @@
-import { Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-
-import type { CounterGroupRead, ResourceGrantSchema } from "@/api/generated/initiativeAPI.schemas";
-import { ShareControl } from "@/components/access/ShareControl";
+import type { CounterGroupRead } from "@/api/generated/initiativeAPI.schemas";
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
+  type CreateToolConfig,
+  CreateToolDialog,
+} from "@/components/initiativeTools/shared/CreateToolDialog";
 import { useCreateCounterGroup } from "@/hooks/useCounters";
-import { useInitiatives } from "@/hooks/useInitiatives";
 import type { DialogProps } from "@/types/dialog";
 
 type CreateCounterGroupDialogProps = DialogProps & {
@@ -39,154 +12,14 @@ type CreateCounterGroupDialogProps = DialogProps & {
   onSuccess?: (group: CounterGroupRead) => void;
 };
 
-export const CreateCounterGroupDialog = ({
-  open,
-  onOpenChange,
-  initiativeId,
-  defaultInitiativeId,
-  onSuccess,
-}: CreateCounterGroupDialogProps) => {
-  const { t } = useTranslation(["counterGroups", "common"]);
-
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [selectedInitiativeId, setSelectedInitiativeId] = useState(
-    defaultInitiativeId ? String(defaultInitiativeId) : ""
-  );
-  const [grants, setGrants] = useState<ResourceGrantSchema[]>([
-    { all_initiative_members: true, level: "read" },
-  ]);
-
-  const initiativesQuery = useInitiatives();
-  const initiatives = initiativesQuery.data ?? [];
-
-  const effectiveInitiativeId =
-    initiativeId ?? (selectedInitiativeId ? Number(selectedInitiativeId) : null);
-
-  const lockedInitiative = initiativeId
-    ? (initiatives.find((i) => i.id === initiativeId) ?? null)
-    : null;
-
-  useEffect(() => {
-    if (open) {
-      if (defaultInitiativeId) {
-        setSelectedInitiativeId(String(defaultInitiativeId));
-      }
-    } else {
-      setName("");
-      setDescription("");
-      setSelectedInitiativeId(defaultInitiativeId ? String(defaultInitiativeId) : "");
-      setGrants([{ all_initiative_members: true, level: "read" }]);
-    }
-  }, [open, defaultInitiativeId]);
-
-  const createGroup = useCreateCounterGroup({
-    onSuccess: (group) => {
-      onOpenChange(false);
-      onSuccess?.(group);
-    },
-  });
-
-  const isCreating = createGroup.isPending;
-  const canSubmit = !!name.trim() && !!effectiveInitiativeId && !isCreating;
-
-  const handleSubmit = () => {
-    const trimmedName = name.trim();
-    if (!trimmedName || !effectiveInitiativeId) return;
-    createGroup.mutate({
-      name: trimmedName,
-      description: description.trim() || undefined,
-      initiative_id: effectiveInitiativeId,
-      grants,
-    });
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
-        <DialogHeader>
-          <DialogTitle>{t("createGroup")}</DialogTitle>
-          <DialogDescription>{t("noGroupsDescription")}</DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="create-counter-group-name">{t("name")}</Label>
-            <Input
-              id="create-counter-group-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t("namePlaceholder")}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && canSubmit) {
-                  e.preventDefault();
-                  handleSubmit();
-                }
-              }}
-              autoFocus
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="create-counter-group-description">{t("description")}</Label>
-            <Textarea
-              id="create-counter-group-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder={t("descriptionPlaceholder")}
-              rows={3}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="create-counter-group-initiative">{t("initiative")}</Label>
-            {initiativeId ? (
-              <div className="rounded-md border px-3 py-2 text-sm">
-                {lockedInitiative?.name ?? t("selectInitiative")}
-              </div>
-            ) : (
-              <Select value={selectedInitiativeId} onValueChange={setSelectedInitiativeId}>
-                <SelectTrigger id="create-counter-group-initiative">
-                  <SelectValue placeholder={t("selectInitiative")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {initiatives.map((initiative) => (
-                    <SelectItem key={initiative.id} value={String(initiative.id)}>
-                      {initiative.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          </div>
-
-          <Accordion type="single" collapsible defaultValue="advanced">
-            <AccordionItem value="advanced" className="border-b-0">
-              <AccordionTrigger>{t("common:createAccess.advancedOptions")}</AccordionTrigger>
-              <AccordionContent>
-                <ShareControl
-                  initiativeId={effectiveInitiativeId}
-                  grants={grants}
-                  onChange={setGrants}
-                />
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-
-        <DialogFooter>
-          <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
-            {isCreating ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {t("creating")}
-              </>
-            ) : (
-              t("createGroup")
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
+const COUNTER_GROUP_CONFIG: CreateToolConfig<CounterGroupRead> = {
+  namespace: "counterGroups",
+  titleKey: "createGroup",
+  descriptionKey: "noGroupsDescription",
+  idPrefix: "create-counter-group",
+  useCreate: useCreateCounterGroup,
 };
+
+export const CreateCounterGroupDialog = (props: CreateCounterGroupDialogProps) => (
+  <CreateToolDialog<CounterGroupRead> config={COUNTER_GROUP_CONFIG} {...props} />
+);

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -8,15 +8,10 @@ import type {
   TaskListReadRecurrenceStrategy,
   TaskRecurrenceOutput,
 } from "@/api/generated/initiativeAPI.schemas";
-import { ShareControl } from "@/components/access/ShareControl";
+import { CreateAccessSection } from "@/components/access/CreateAccessSection";
+import { DEFAULT_GRANTS } from "@/components/access/grants";
 import { MemberMultiSelect } from "@/components/members/MemberSearchSelect";
 import { TaskRecurrenceSelector } from "@/components/projects/TaskRecurrenceSelector";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
 import {
@@ -81,13 +76,11 @@ export const CreateEventDialog = ({
   const [recurrence, setRecurrence] = useState<TaskRecurrenceOutput | null>(null);
   const [recurrenceStrategy, setRecurrenceStrategy] =
     useState<TaskListReadRecurrenceStrategy>("fixed");
-  const [grants, setGrants] = useState<ResourceGrantSchema[]>([
-    { all_initiative_members: true, level: "read" },
-  ]);
+  const [grants, setGrants] = useState<ResourceGrantSchema[]>([...DEFAULT_GRANTS]);
 
   // Attendee candidates come from the initiative-scoped member typeahead
   // (MemberMultiSelect below) — every initiative member may attend. Event DAC
-  // (the ShareControl below) is a separate concern tracked in #948.
+  // (the access section below) is a separate concern tracked in #948.
 
   useEffect(() => {
     if (open) {
@@ -113,7 +106,7 @@ export const CreateEventDialog = ({
       setAttendeeIds([]);
       setRecurrence(null);
       setRecurrenceStrategy("fixed");
-      setGrants([{ all_initiative_members: true, level: "read" }]);
+      setGrants([...DEFAULT_GRANTS]);
     }
   }, [open, defaultStartDate, defaultStartTime, user]);
 
@@ -368,14 +361,7 @@ export const CreateEventDialog = ({
             referenceDate={referenceDate}
           />
 
-          <Accordion type="single" collapsible defaultValue="advanced">
-            <AccordionItem value="advanced" className="border-b-0">
-              <AccordionTrigger>{t("common:createAccess.advancedOptions")}</AccordionTrigger>
-              <AccordionContent>
-                <ShareControl initiativeId={initiativeId} grants={grants} onChange={setGrants} />
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
+          <CreateAccessSection initiativeId={initiativeId} grants={grants} onChange={setGrants} />
         </div>
 
         <DialogFooter>

--- a/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
@@ -1,13 +1,8 @@
 import { Loader2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { TagSummary } from "@/api/generated/initiativeAPI.schemas";
-import {
-  ENTITY_PICKER_PAGE_SIZE,
-  type LinkedEntity,
-  LinkedEntityPicker,
-} from "@/components/initiativeTools/queues/LinkedEntityPicker";
+import { LinkedEntityPicker } from "@/components/initiativeTools/queues/LinkedEntityPicker";
+import { useQueueItemForm } from "@/components/initiativeTools/queues/useQueueItemForm";
 import { TagPicker } from "@/components/tags/TagPicker";
 import { Button } from "@/components/ui/button";
 import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
@@ -24,13 +19,9 @@ import { Label } from "@/components/ui/label";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { useDocumentAutocomplete } from "@/hooks/useDocuments";
-import { useInitiativeMembers } from "@/hooks/useInitiatives";
 import { useCreateQueueItem } from "@/hooks/useQueues";
-import { useTaskAutocomplete } from "@/hooks/useTasks";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
-import { getUserDisplayName } from "@/lib/userDisplay";
 import type { DialogProps } from "@/types/dialog";
 
 type AddQueueItemDialogProps = DialogProps & {
@@ -49,69 +40,35 @@ export const AddQueueItemDialog = ({
   const { t } = useTranslation(["queues", "common"]);
   const gp = useGuildPath();
 
-  const [label, setLabel] = useState("");
-  const [position, setPosition] = useState("");
-  const [color, setColor] = useState("#6366F1");
-  const [notes, setNotes] = useState("");
-  const [isVisible, setIsVisible] = useState(true);
-  const [selectedTags, setSelectedTags] = useState<TagSummary[]>([]);
-  const [userId, setUserId] = useState<number | null>(null);
-  // Selections carry their titles: the typeahead only returns rows matching
-  // the live query, so a chip's label can't be looked up from the results.
-  const [selectedDocs, setSelectedDocs] = useState<LinkedEntity[]>([]);
-  const [selectedTasks, setSelectedTasks] = useState<LinkedEntity[]>([]);
-
-  const [docSearch, setDocSearch] = useState("");
-  const [docPickerOpen, setDocPickerOpen] = useState(false);
-  const [taskSearch, setTaskSearch] = useState("");
-  const [taskPickerOpen, setTaskPickerOpen] = useState(false);
-
-  // Reset form when dialog closes
-  useEffect(() => {
-    if (!open) {
-      setLabel("");
-      setPosition("");
-      setColor("#6366F1");
-      setNotes("");
-      setIsVisible(true);
-      setSelectedTags([]);
-      setUserId(null);
-      setSelectedDocs([]);
-      setSelectedTasks([]);
-    }
-  }, [open]);
-
-  // Fetch initiative members for user picker
-  const membersQuery = useInitiativeMembers(initiativeId);
-  const memberItems = useMemo(
-    () =>
-      (membersQuery.data ?? []).map((member) => ({
-        value: String(member.id),
-        label: getUserDisplayName(member),
-      })),
-    [membersQuery.data]
-  );
-
-  // Document picker — server typeahead, only while the picker is open.
-  const docsQuery = useDocumentAutocomplete(initiativeId, docSearch, {
-    enabled: open && docPickerOpen,
-    limit: ENTITY_PICKER_PAGE_SIZE,
-  });
-  const docResults = useMemo(
-    () => (docsQuery.data ?? []).map((doc) => ({ id: doc.id, title: doc.title })),
-    [docsQuery.data]
-  );
-
-  // Task picker — server typeahead over titles within this initiative.
-  const tasksQuery = useTaskAutocomplete(taskSearch, {
-    initiativeId,
-    enabled: open && taskPickerOpen,
-    limit: ENTITY_PICKER_PAGE_SIZE,
-  });
-  const taskResults = useMemo(
-    () => (tasksQuery.data ?? []).map((task) => ({ id: task.id, title: task.title })),
-    [tasksQuery.data]
-  );
+  const {
+    label,
+    setLabel,
+    position,
+    setPosition,
+    color,
+    setColor,
+    notes,
+    setNotes,
+    isVisible,
+    setIsVisible,
+    selectedTags,
+    setSelectedTags,
+    userId,
+    setUserId,
+    selectedDocs,
+    setSelectedDocs,
+    selectedTasks,
+    setSelectedTasks,
+    setDocSearch,
+    setDocPickerOpen,
+    setTaskSearch,
+    setTaskPickerOpen,
+    memberItems,
+    docResults,
+    docsLoading,
+    taskResults,
+    tasksLoading,
+  } = useQueueItemForm({ open, initiativeId });
 
   const createItem = useCreateQueueItem(queueId, {
     onSuccess: () => {
@@ -254,7 +211,7 @@ export const AddQueueItemDialog = ({
             selected={selectedDocs}
             onChange={setSelectedDocs}
             results={docResults}
-            loading={docsQuery.isFetching}
+            loading={docsLoading}
             onSearchChange={setDocSearch}
             onOpenChange={setDocPickerOpen}
             hrefFor={(id) => gp(`/documents/${id}`)}
@@ -267,7 +224,7 @@ export const AddQueueItemDialog = ({
             selected={selectedTasks}
             onChange={setSelectedTasks}
             results={taskResults}
-            loading={tasksQuery.isFetching}
+            loading={tasksLoading}
             onSearchChange={setTaskSearch}
             onOpenChange={setTaskPickerOpen}
             hrefFor={(id) => gp(`/tasks/${id}`)}

--- a/frontend/src/components/initiativeTools/queues/CreateQueueDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/CreateQueueDialog.tsx
@@ -1,35 +1,8 @@
-import { Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-
-import type { QueueRead, ResourceGrantSchema } from "@/api/generated/initiativeAPI.schemas";
-import { ShareControl } from "@/components/access/ShareControl";
+import type { QueueRead } from "@/api/generated/initiativeAPI.schemas";
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { useInitiatives } from "@/hooks/useInitiatives";
+  type CreateToolConfig,
+  CreateToolDialog,
+} from "@/components/initiativeTools/shared/CreateToolDialog";
 import { useCreateQueue } from "@/hooks/useQueues";
 import type { DialogProps } from "@/types/dialog";
 
@@ -42,155 +15,14 @@ type CreateQueueDialogProps = DialogProps & {
   onSuccess?: (queue: QueueRead) => void;
 };
 
-export const CreateQueueDialog = ({
-  open,
-  onOpenChange,
-  initiativeId,
-  defaultInitiativeId,
-  onSuccess,
-}: CreateQueueDialogProps) => {
-  const { t } = useTranslation(["queues", "common"]);
-
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [selectedInitiativeId, setSelectedInitiativeId] = useState(
-    defaultInitiativeId ? String(defaultInitiativeId) : ""
-  );
-  const [grants, setGrants] = useState<ResourceGrantSchema[]>([
-    { all_initiative_members: true, level: "read" },
-  ]);
-
-  const initiativesQuery = useInitiatives();
-  const initiatives = initiativesQuery.data ?? [];
-
-  const effectiveInitiativeId =
-    initiativeId ?? (selectedInitiativeId ? Number(selectedInitiativeId) : null);
-
-  const lockedInitiative = initiativeId
-    ? (initiatives.find((i) => i.id === initiativeId) ?? null)
-    : null;
-
-  // Reset form when dialog closes, set default initiative when dialog opens
-  useEffect(() => {
-    if (open) {
-      if (defaultInitiativeId) {
-        setSelectedInitiativeId(String(defaultInitiativeId));
-      }
-    } else {
-      setName("");
-      setDescription("");
-      setSelectedInitiativeId(defaultInitiativeId ? String(defaultInitiativeId) : "");
-      setGrants([{ all_initiative_members: true, level: "read" }]);
-    }
-  }, [open, defaultInitiativeId]);
-
-  const createQueue = useCreateQueue({
-    onSuccess: (queue) => {
-      onOpenChange(false);
-      onSuccess?.(queue);
-    },
-  });
-
-  const isCreating = createQueue.isPending;
-  const canSubmit = name.trim() && effectiveInitiativeId && !isCreating;
-
-  const handleSubmit = () => {
-    const trimmedName = name.trim();
-    if (!trimmedName || !effectiveInitiativeId) return;
-    createQueue.mutate({
-      name: trimmedName,
-      description: description.trim() || undefined,
-      initiative_id: effectiveInitiativeId,
-      grants,
-    });
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
-        <DialogHeader>
-          <DialogTitle>{t("createQueue")}</DialogTitle>
-          <DialogDescription>{t("noQueuesDescription")}</DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="create-queue-name">{t("name")}</Label>
-            <Input
-              id="create-queue-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t("namePlaceholder")}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && canSubmit) {
-                  e.preventDefault();
-                  handleSubmit();
-                }
-              }}
-              autoFocus
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="create-queue-description">{t("description")}</Label>
-            <Textarea
-              id="create-queue-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder={t("descriptionPlaceholder")}
-              rows={3}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="create-queue-initiative">{t("initiative")}</Label>
-            {initiativeId ? (
-              <div className="rounded-md border px-3 py-2 text-sm">
-                {lockedInitiative?.name ?? t("selectInitiative")}
-              </div>
-            ) : (
-              <Select value={selectedInitiativeId} onValueChange={setSelectedInitiativeId}>
-                <SelectTrigger id="create-queue-initiative">
-                  <SelectValue placeholder={t("selectInitiative")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {initiatives.map((initiative) => (
-                    <SelectItem key={initiative.id} value={String(initiative.id)}>
-                      {initiative.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          </div>
-
-          <Accordion type="single" collapsible defaultValue="advanced">
-            <AccordionItem value="advanced" className="border-b-0">
-              <AccordionTrigger>{t("common:createAccess.advancedOptions")}</AccordionTrigger>
-              <AccordionContent>
-                <ShareControl
-                  initiativeId={effectiveInitiativeId}
-                  grants={grants}
-                  onChange={setGrants}
-                />
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-
-        <DialogFooter>
-          <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
-            {isCreating ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {t("creating")}
-              </>
-            ) : (
-              t("createQueue")
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
+const QUEUE_CONFIG: CreateToolConfig<QueueRead> = {
+  namespace: "queues",
+  titleKey: "createQueue",
+  descriptionKey: "noQueuesDescription",
+  idPrefix: "create-queue",
+  useCreate: useCreateQueue,
 };
+
+export const CreateQueueDialog = (props: CreateQueueDialogProps) => (
+  <CreateToolDialog<QueueRead> config={QUEUE_CONFIG} {...props} />
+);

--- a/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
@@ -1,13 +1,10 @@
 import { Loader2, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { QueueItemRead, TagSummary } from "@/api/generated/initiativeAPI.schemas";
-import {
-  ENTITY_PICKER_PAGE_SIZE,
-  type LinkedEntity,
-  LinkedEntityPicker,
-} from "@/components/initiativeTools/queues/LinkedEntityPicker";
+import type { QueueItemRead } from "@/api/generated/initiativeAPI.schemas";
+import { LinkedEntityPicker } from "@/components/initiativeTools/queues/LinkedEntityPicker";
+import { useQueueItemForm } from "@/components/initiativeTools/queues/useQueueItemForm";
 import { TagPicker } from "@/components/tags/TagPicker";
 import { Button } from "@/components/ui/button";
 import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
@@ -25,8 +22,6 @@ import { Label } from "@/components/ui/label";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { useDocumentAutocomplete } from "@/hooks/useDocuments";
-import { useInitiativeMembers } from "@/hooks/useInitiatives";
 import {
   useDeleteQueueItem,
   useSetQueueItemDocuments,
@@ -34,10 +29,8 @@ import {
   useSetQueueItemTasks,
   useUpdateQueueItem,
 } from "@/hooks/useQueues";
-import { useTaskAutocomplete } from "@/hooks/useTasks";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
-import { getUserDisplayName } from "@/lib/userDisplay";
 import type { DialogProps } from "@/types/dialog";
 
 type EditQueueItemDialogProps = DialogProps & {
@@ -60,75 +53,37 @@ export const EditQueueItemDialog = ({
   const { t } = useTranslation(["queues", "common"]);
   const gp = useGuildPath();
 
-  const [label, setLabel] = useState(item.label);
-  const [position, setPosition] = useState(String(item.position));
-  const [color, setColor] = useState(item.color ?? "#6366F1");
-  const [notes, setNotes] = useState(item.notes ?? "");
-  const [isVisible, setIsVisible] = useState(item.is_visible);
-  const [selectedTags, setSelectedTags] = useState<TagSummary[]>(item.tags);
-  const [userId, setUserId] = useState<number | null>(item.user_id);
-  // Selections carry their titles: the typeahead only returns rows matching
-  // the live query, so a chip's label can't be looked up from the results.
-  // The item's own links already ship theirs.
-  const [selectedDocs, setSelectedDocs] = useState<LinkedEntity[]>(() =>
-    item.documents.map((d) => ({ id: d.document_id, title: d.title }))
-  );
-  const [selectedTasks, setSelectedTasks] = useState<LinkedEntity[]>(() =>
-    item.tasks.map((t) => ({ id: t.task_id, title: t.title }))
-  );
+  const {
+    label,
+    setLabel,
+    position,
+    setPosition,
+    color,
+    setColor,
+    notes,
+    setNotes,
+    isVisible,
+    setIsVisible,
+    selectedTags,
+    setSelectedTags,
+    userId,
+    setUserId,
+    selectedDocs,
+    setSelectedDocs,
+    selectedTasks,
+    setSelectedTasks,
+    setDocSearch,
+    setDocPickerOpen,
+    setTaskSearch,
+    setTaskPickerOpen,
+    memberItems,
+    docResults,
+    docsLoading,
+    taskResults,
+    tasksLoading,
+  } = useQueueItemForm({ open, initiativeId, item });
+
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-
-  const [docSearch, setDocSearch] = useState("");
-  const [docPickerOpen, setDocPickerOpen] = useState(false);
-  const [taskSearch, setTaskSearch] = useState("");
-  const [taskPickerOpen, setTaskPickerOpen] = useState(false);
-
-  // Sync state when item prop changes
-  useEffect(() => {
-    if (open) {
-      setLabel(item.label);
-      setPosition(String(item.position));
-      setColor(item.color ?? "#6366F1");
-      setNotes(item.notes ?? "");
-      setIsVisible(item.is_visible);
-      setSelectedTags(item.tags);
-      setUserId(item.user_id);
-      setSelectedDocs(item.documents.map((d) => ({ id: d.document_id, title: d.title })));
-      setSelectedTasks(item.tasks.map((tk) => ({ id: tk.task_id, title: tk.title })));
-    }
-  }, [open, item]);
-
-  // Fetch initiative members for user picker
-  const membersQuery = useInitiativeMembers(initiativeId);
-  const memberItems = useMemo(
-    () =>
-      (membersQuery.data ?? []).map((member) => ({
-        value: String(member.id),
-        label: getUserDisplayName(member),
-      })),
-    [membersQuery.data]
-  );
-
-  // Document picker — server typeahead, only while the picker is open.
-  const docsQuery = useDocumentAutocomplete(initiativeId, docSearch, {
-    enabled: open && docPickerOpen,
-    limit: ENTITY_PICKER_PAGE_SIZE,
-  });
-  const docResults = useMemo(
-    () => (docsQuery.data ?? []).map((doc) => ({ id: doc.id, title: doc.title })),
-    [docsQuery.data]
-  );
-
-  // Task picker — server typeahead over titles within this initiative.
-  const tasksQuery = useTaskAutocomplete(taskSearch, {
-    initiativeId,
-    enabled: open && taskPickerOpen,
-    limit: ENTITY_PICKER_PAGE_SIZE,
-  });
-  const taskResults = useMemo(
-    () => (tasksQuery.data ?? []).map((task) => ({ id: task.id, title: task.title })),
-    [tasksQuery.data]
-  );
 
   const setTags = useSetQueueItemTags(queueId);
   const setDocuments = useSetQueueItemDocuments(queueId);
@@ -333,7 +288,7 @@ export const EditQueueItemDialog = ({
               selected={selectedDocs}
               onChange={setSelectedDocs}
               results={docResults}
-              loading={docsQuery.isFetching}
+              loading={docsLoading}
               onSearchChange={setDocSearch}
               onOpenChange={setDocPickerOpen}
               hrefFor={(id) => gp(`/documents/${id}`)}
@@ -347,7 +302,7 @@ export const EditQueueItemDialog = ({
               selected={selectedTasks}
               onChange={setSelectedTasks}
               results={taskResults}
-              loading={tasksQuery.isFetching}
+              loading={tasksLoading}
               onSearchChange={setTaskSearch}
               onOpenChange={setTaskPickerOpen}
               hrefFor={(id) => gp(`/tasks/${id}`)}

--- a/frontend/src/components/initiativeTools/queues/useQueueItemForm.ts
+++ b/frontend/src/components/initiativeTools/queues/useQueueItemForm.ts
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from "react";
+
+import type { QueueItemRead, TagSummary } from "@/api/generated/initiativeAPI.schemas";
+import {
+  ENTITY_PICKER_PAGE_SIZE,
+  type LinkedEntity,
+} from "@/components/initiativeTools/queues/LinkedEntityPicker";
+import { useDocumentAutocomplete } from "@/hooks/useDocuments";
+import { useInitiativeMembers } from "@/hooks/useInitiatives";
+import { useTaskAutocomplete } from "@/hooks/useTasks";
+import { getUserDisplayName } from "@/lib/userDisplay";
+
+const DEFAULT_COLOR = "#6366F1";
+
+interface UseQueueItemFormArgs {
+  /** Whether the owning dialog is open (gates the picker typeaheads + reset). */
+  open: boolean;
+  /** Initiative the queue belongs to — scopes the member/doc/task pickers. */
+  initiativeId: number;
+  /**
+   * When provided, the form edits an existing item: fields initialize from it
+   * and re-sync whenever the dialog reopens. When omitted, the form is in
+   * "add" mode: fields start empty and reset to defaults on close.
+   */
+  item?: QueueItemRead;
+}
+
+/**
+ * Shared field state and picker option lists for the add/edit queue-item
+ * dialogs, which duplicated ~90% of their form wiring. The submit payload and
+ * any edit-only concerns (delete, change detection) stay in each dialog.
+ *
+ * The document and task pickers are server typeaheads (issue #857): they fetch
+ * only while the dialog is open and the picker is expanded, and never fetch the
+ * full list.
+ */
+export const useQueueItemForm = ({ open, initiativeId, item }: UseQueueItemFormArgs) => {
+  const [label, setLabel] = useState(item?.label ?? "");
+  const [position, setPosition] = useState(item ? String(item.position) : "");
+  const [color, setColor] = useState(item?.color ?? DEFAULT_COLOR);
+  const [notes, setNotes] = useState(item?.notes ?? "");
+  const [isVisible, setIsVisible] = useState(item?.is_visible ?? true);
+  const [selectedTags, setSelectedTags] = useState<TagSummary[]>(item?.tags ?? []);
+  const [userId, setUserId] = useState<number | null>(item?.user_id ?? null);
+  // Selections carry their titles: the typeahead only returns rows matching
+  // the live query, so a chip's label can't be looked up from the results.
+  // An edited item's own links already ship theirs.
+  const [selectedDocs, setSelectedDocs] = useState<LinkedEntity[]>(() =>
+    item ? item.documents.map((d) => ({ id: d.document_id, title: d.title })) : []
+  );
+  const [selectedTasks, setSelectedTasks] = useState<LinkedEntity[]>(() =>
+    item ? item.tasks.map((tk) => ({ id: tk.task_id, title: tk.title })) : []
+  );
+
+  const [docSearch, setDocSearch] = useState("");
+  const [docPickerOpen, setDocPickerOpen] = useState(false);
+  const [taskSearch, setTaskSearch] = useState("");
+  const [taskPickerOpen, setTaskPickerOpen] = useState(false);
+
+  // Edit mode: re-sync from the item on (re)open. Add mode: reset to defaults on
+  // close. In add mode `item` is always undefined, so the effect fires only on
+  // `open` changes — matching each dialog's original behavior.
+  useEffect(() => {
+    if (item) {
+      if (open) {
+        setLabel(item.label);
+        setPosition(String(item.position));
+        setColor(item.color ?? DEFAULT_COLOR);
+        setNotes(item.notes ?? "");
+        setIsVisible(item.is_visible);
+        setSelectedTags(item.tags);
+        setUserId(item.user_id);
+        setSelectedDocs(item.documents.map((d) => ({ id: d.document_id, title: d.title })));
+        setSelectedTasks(item.tasks.map((tk) => ({ id: tk.task_id, title: tk.title })));
+      }
+    } else if (!open) {
+      setLabel("");
+      setPosition("");
+      setColor(DEFAULT_COLOR);
+      setNotes("");
+      setIsVisible(true);
+      setSelectedTags([]);
+      setUserId(null);
+      setSelectedDocs([]);
+      setSelectedTasks([]);
+    }
+  }, [open, item]);
+
+  // Fetch initiative members for user picker
+  const membersQuery = useInitiativeMembers(initiativeId);
+  const memberItems = useMemo(
+    () =>
+      (membersQuery.data ?? []).map((member) => ({
+        value: String(member.id),
+        label: getUserDisplayName(member),
+      })),
+    [membersQuery.data]
+  );
+
+  // Document picker — server typeahead, only while the picker is open.
+  const docsQuery = useDocumentAutocomplete(initiativeId, docSearch, {
+    enabled: open && docPickerOpen,
+    limit: ENTITY_PICKER_PAGE_SIZE,
+  });
+  const docResults = useMemo(
+    () => (docsQuery.data ?? []).map((doc) => ({ id: doc.id, title: doc.title })),
+    [docsQuery.data]
+  );
+
+  // Task picker — server typeahead over titles within this initiative.
+  const tasksQuery = useTaskAutocomplete(taskSearch, {
+    initiativeId,
+    enabled: open && taskPickerOpen,
+    limit: ENTITY_PICKER_PAGE_SIZE,
+  });
+  const taskResults = useMemo(
+    () => (tasksQuery.data ?? []).map((task) => ({ id: task.id, title: task.title })),
+    [tasksQuery.data]
+  );
+
+  return {
+    // Field state
+    label,
+    setLabel,
+    position,
+    setPosition,
+    color,
+    setColor,
+    notes,
+    setNotes,
+    isVisible,
+    setIsVisible,
+    selectedTags,
+    setSelectedTags,
+    userId,
+    setUserId,
+    selectedDocs,
+    setSelectedDocs,
+    selectedTasks,
+    setSelectedTasks,
+    // Picker search/open setters
+    setDocSearch,
+    setDocPickerOpen,
+    setTaskSearch,
+    setTaskPickerOpen,
+    // Picker option lists
+    memberItems,
+    docResults,
+    docsLoading: docsQuery.isFetching,
+    taskResults,
+    tasksLoading: tasksQuery.isFetching,
+  };
+};

--- a/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
+++ b/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
@@ -1,0 +1,228 @@
+import type { FlatNamespace } from "i18next";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { ResourceGrantSchema } from "@/api/generated/initiativeAPI.schemas";
+import { CreateAccessSection } from "@/components/access/CreateAccessSection";
+import { DEFAULT_GRANTS } from "@/components/access/grants";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useInitiatives } from "@/hooks/useInitiatives";
+import type { DialogProps } from "@/types/dialog";
+import type { TranslateFn } from "@/types/i18n";
+import type { MutationOpts } from "@/types/mutation";
+
+/**
+ * The create payload shared by the simple initiative-tool create dialogs. Both
+ * `QueueCreate` and `CounterGroupCreate` are structurally this shape, so the
+ * dialog can build the payload once and hand it to either mutation hook.
+ */
+export type ToolCreatePayload = {
+  name: string;
+  description?: string | null;
+  initiative_id: number;
+  grants?: ResourceGrantSchema[];
+};
+
+/**
+ * The small, concrete bundle that distinguishes one tool's create dialog from
+ * another: its i18n namespace/keys, element-id prefix, and create-mutation hook.
+ */
+export interface CreateToolConfig<TRead> {
+  /** i18n namespace for this tool's strings (e.g. "queues"). */
+  namespace: FlatNamespace;
+  /** Key for the dialog title and the submit button label. */
+  titleKey: string;
+  /** Key for the dialog description. */
+  descriptionKey: string;
+  /** Prefix for field element ids, e.g. "create-queue" → "create-queue-name". */
+  idPrefix: string;
+  /** The domain create-mutation hook (e.g. `useCreateQueue`). */
+  useCreate: (options: MutationOpts<TRead, ToolCreatePayload>) => {
+    mutate: (payload: ToolCreatePayload) => void;
+    isPending: boolean;
+  };
+}
+
+export type CreateToolDialogProps<TRead> = DialogProps & {
+  /** If provided, the initiative is locked and cannot be changed. */
+  initiativeId?: number;
+  /** If provided, pre-selects this initiative (but the user can change it). */
+  defaultInitiativeId?: number;
+  /** Called after successful creation. */
+  onSuccess?: (result: TRead) => void;
+  config: CreateToolConfig<TRead>;
+};
+
+/**
+ * Shared implementation behind the queue and counter-group create dialogs,
+ * which were line-for-line twins apart from their i18n keys, element ids, and
+ * create-mutation hook. Each tool keeps a thin named wrapper with an unchanged
+ * public signature.
+ */
+export const CreateToolDialog = <TRead,>({
+  open,
+  onOpenChange,
+  initiativeId,
+  defaultInitiativeId,
+  onSuccess,
+  config,
+}: CreateToolDialogProps<TRead>) => {
+  const { namespace, titleKey, descriptionKey, idPrefix, useCreate } = config;
+  // The namespace and several keys are supplied by config (dynamic per tool), so
+  // use the loose translation signature rather than the statically-typed keys.
+  const { t: translate } = useTranslation(namespace);
+  const t = translate as TranslateFn;
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [selectedInitiativeId, setSelectedInitiativeId] = useState(
+    defaultInitiativeId ? String(defaultInitiativeId) : ""
+  );
+  const [grants, setGrants] = useState<ResourceGrantSchema[]>([...DEFAULT_GRANTS]);
+
+  const initiativesQuery = useInitiatives();
+  const initiatives = initiativesQuery.data ?? [];
+
+  const effectiveInitiativeId =
+    initiativeId ?? (selectedInitiativeId ? Number(selectedInitiativeId) : null);
+
+  const lockedInitiative = initiativeId
+    ? (initiatives.find((i) => i.id === initiativeId) ?? null)
+    : null;
+
+  // Reset form when dialog closes, set default initiative when dialog opens
+  useEffect(() => {
+    if (open) {
+      if (defaultInitiativeId) {
+        setSelectedInitiativeId(String(defaultInitiativeId));
+      }
+    } else {
+      setName("");
+      setDescription("");
+      setSelectedInitiativeId(defaultInitiativeId ? String(defaultInitiativeId) : "");
+      setGrants([...DEFAULT_GRANTS]);
+    }
+  }, [open, defaultInitiativeId]);
+
+  const createTool = useCreate({
+    onSuccess: (result) => {
+      onOpenChange(false);
+      onSuccess?.(result);
+    },
+  });
+
+  const isCreating = createTool.isPending;
+  const canSubmit = !!name.trim() && !!effectiveInitiativeId && !isCreating;
+
+  const handleSubmit = () => {
+    const trimmedName = name.trim();
+    if (!trimmedName || !effectiveInitiativeId) return;
+    createTool.mutate({
+      name: trimmedName,
+      description: description.trim() || undefined,
+      initiative_id: effectiveInitiativeId,
+      grants,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+        <DialogHeader>
+          <DialogTitle>{t(titleKey)}</DialogTitle>
+          <DialogDescription>{t(descriptionKey)}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-name`}>{t("name")}</Label>
+            <Input
+              id={`${idPrefix}-name`}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t("namePlaceholder")}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-description`}>{t("description")}</Label>
+            <Textarea
+              id={`${idPrefix}-description`}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("descriptionPlaceholder")}
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-initiative`}>{t("initiative")}</Label>
+            {initiativeId ? (
+              <div className="rounded-md border px-3 py-2 text-sm">
+                {lockedInitiative?.name ?? t("selectInitiative")}
+              </div>
+            ) : (
+              <Select value={selectedInitiativeId} onValueChange={setSelectedInitiativeId}>
+                <SelectTrigger id={`${idPrefix}-initiative`}>
+                  <SelectValue placeholder={t("selectInitiative")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {initiatives.map((initiative) => (
+                    <SelectItem key={initiative.id} value={String(initiative.id)}>
+                      {initiative.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          <CreateAccessSection
+            initiativeId={effectiveInitiativeId}
+            grants={grants}
+            onChange={setGrants}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
+            {isCreating ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t("creating")}
+              </>
+            ) : (
+              t(titleKey)
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/projects/CreateProjectDialog.tsx
+++ b/frontend/src/components/projects/CreateProjectDialog.tsx
@@ -2,14 +2,9 @@ import { type FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { InitiativeRead, ResourceGrantSchema } from "@/api/generated/initiativeAPI.schemas";
-import { ShareControl } from "@/components/access/ShareControl";
+import { CreateAccessSection } from "@/components/access/CreateAccessSection";
+import { DEFAULT_GRANTS } from "@/components/access/grants";
 import { EmojiPicker } from "@/components/EmojiPicker";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -62,9 +57,7 @@ export const CreateProjectDialog = ({
   const [initiativeId, setInitiativeId] = useState<string | null>(defaultInitiativeId);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>(NO_TEMPLATE_VALUE);
   const [isTemplateProject, setIsTemplateProject] = useState(false);
-  const [grants, setGrants] = useState<ResourceGrantSchema[]>([
-    { all_initiative_members: true, level: "read" },
-  ]);
+  const [grants, setGrants] = useState<ResourceGrantSchema[]>([...DEFAULT_GRANTS]);
 
   const templatesQuery = useTemplateProjects();
 
@@ -136,7 +129,7 @@ export const CreateProjectDialog = ({
             );
             setSelectedTemplateId(NO_TEMPLATE_VALUE);
             setIsTemplateProject(false);
-            setGrants([{ all_initiative_members: true, level: "read" }]);
+            setGrants([...DEFAULT_GRANTS]);
             onCreated();
           },
         }
@@ -273,18 +266,11 @@ export const CreateProjectDialog = ({
                 }}
               />
             </div>
-            <Accordion type="single" collapsible defaultValue="advanced">
-              <AccordionItem value="advanced" className="border-b-0">
-                <AccordionTrigger>{t("common:createAccess.advancedOptions")}</AccordionTrigger>
-                <AccordionContent>
-                  <ShareControl
-                    initiativeId={initiativeId ? Number(initiativeId) : null}
-                    grants={grants}
-                    onChange={setGrants}
-                  />
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
+            <CreateAccessSection
+              initiativeId={initiativeId ? Number(initiativeId) : null}
+              grants={grants}
+              onChange={setGrants}
+            />
             <div className="flex flex-wrap items-center gap-2">
               {createProject.isError ? (
                 <p className="text-destructive text-sm">{t("createDialog.createError")}</p>


### PR DESCRIPTION
## Problem

#870: the create-entity dialogs copy the same scaffold — the default-grant literal `[{ all_initiative_members: true, level: "read" }]` at 8 sites, the advanced-access Accordion + ShareControl block in all five create dialogs, CreateQueueDialog/CreateCounterGroupDialog as line-for-line twins, and Add/EditQueueItemDialog duplicating ~90% of their field state.

## Changes

- **[grants.ts](frontend/src/components/access/grants.ts)** exports `DEFAULT_GRANTS`; every site uses a fresh `[...DEFAULT_GRANTS]` (verified nothing mutates grants in place — ShareControl always emits new arrays/objects, so the spread is the minimal sufficient form).
- **[CreateAccessSection.tsx](frontend/src/components/access/CreateAccessSection.tsx)** replaces the copy-pasted access block in all five dialogs. One real outlier surfaced: CreateDocumentDialog's accordion starts collapsed while the other four start open — handled with a `defaultOpen` prop rather than silently changing either behavior.
- **Twins merged**: [CreateToolDialog.tsx](frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx) is the one dialog, parameterized by `{ namespace, titleKey, descriptionKey, idPrefix, useCreate }` — all concrete; `QueueCreate`/`CounterGroupCreate` are structurally identical so the injected hook needs no casts. `CreateQueueDialog`/`CreateCounterGroupDialog` stay as thin wrappers with unchanged public props.
- **[useQueueItemForm.ts](frontend/src/components/initiativeTools/queues/useQueueItemForm.ts)**: shared field state + picker option lists for both queue-item dialogs. The #857 server typeaheads are preserved verbatim (`enabled: open && pickerOpen` gating, `ENTITY_PICKER_PAGE_SIZE`); submit payload builders and edit-only state (delete confirm, change detection) stay per-dialog.

## Testing

- `pnpm typecheck` — 0 errors; `biome check src` — clean
- `vitest run` — full suite: 931 tests passed

Closes #870