### PR TITLE
Extract useInitiativeFilter + BulkAccessSection

### DIFF
--- a/frontend/src/components/access/BulkAccessSection.tsx
+++ b/frontend/src/components/access/BulkAccessSection.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { Tool } from "@/api/generated/initiativeAPI.schemas";
+import { BulkAccessBar, canManageSharing } from "@/components/access/BulkAccessBar";
+import {
+  type BulkAccessItem,
+  BulkEditAccessDialog,
+} from "@/components/access/BulkEditAccessDialog";
+import { BulkExportButton } from "@/components/exports/BulkExportButton";
+import { Button } from "@/components/ui/button";
+
+/** The slice of {@link useGridSelection} this section drives. */
+interface GridSelectionLike<T> {
+  active: boolean;
+  selectedItems: T[];
+  enter: () => void;
+  exit: () => void;
+}
+
+interface BulkAccessSectionProps<
+  T extends BulkAccessItem & { my_permission_level?: string | null },
+> {
+  /** The grid selection driving this page's cards. Its state stays on the page. */
+  selection: GridSelectionLike<T>;
+  /** The tool being listed — routes the bulk export and access endpoints. */
+  tool: Tool;
+  /** Invalidate the tool's list caches after a successful access change. */
+  invalidate: () => void;
+}
+
+/**
+ * The bulk edit-access toolbar shared by the standalone tool-list pages (queues,
+ * counter groups): a "Select" affordance that enters selection mode, the
+ * {@link BulkAccessBar} (with a bulk export action) shown while items are
+ * selected, and the {@link BulkEditAccessDialog} it opens. The per-card
+ * selection lives on the page and feeds the cards — this only renders the
+ * bar + dialog for the current selection.
+ */
+export function BulkAccessSection<
+  T extends BulkAccessItem & { my_permission_level?: string | null },
+>({ selection, tool, invalidate }: BulkAccessSectionProps<T>) {
+  const { t } = useTranslation("access");
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <>
+      {selection.active ? (
+        <BulkAccessBar
+          count={selection.selectedItems.length}
+          canManage={canManageSharing(selection.selectedItems)}
+          onEditAccess={() => setDialogOpen(true)}
+          onExit={selection.exit}
+        >
+          <BulkExportButton tool={tool} ids={selection.selectedItems.map((item) => item.id)} />
+        </BulkAccessBar>
+      ) : (
+        <div className="flex justify-end">
+          <Button variant="outline" size="sm" onClick={selection.enter}>
+            {t("bulkBar.select")}
+          </Button>
+        </div>
+      )}
+      <BulkEditAccessDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        items={selection.selectedItems}
+        resourceType={tool}
+        invalidate={invalidate}
+        onSuccess={selection.exit}
+      />
+    </>
+  );
+}

--- a/frontend/src/hooks/useInitiativeFilter.ts
+++ b/frontend/src/hooks/useInitiativeFilter.ts
@@ -1,0 +1,93 @@
+import { useSearch } from "@tanstack/react-router";
+import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
+
+import { useGuilds } from "@/hooks/useGuilds";
+
+/** Sentinel filter value meaning "no initiative filter — show every initiative". */
+export const INITIATIVE_FILTER_ALL = "all";
+
+interface UseInitiativeFilterOptions {
+  /**
+   * When a view is pinned to one initiative (e.g. an initiative detail page),
+   * pass its id. The filter is held at that initiative and the URL /
+   * guild-change effects are skipped. Pass `null` for the standalone tool-list
+   * pages that let the user pick an initiative.
+   */
+  lockedInitiativeId: number | null;
+  /**
+   * When true, clearing the `?initiativeId` search param resets the filter back
+   * to ALL — this matches the Documents page's "All documents" navigation,
+   * where arriving from an initiative-scoped view and then clearing the param
+   * must drop the pin. When false (the default) an empty param is a no-op and
+   * the current selection is kept.
+   */
+  resetOnParamCleared?: boolean;
+}
+
+interface UseInitiativeFilterResult {
+  /** The dropdown value: an initiative id as a string, or {@link INITIATIVE_FILTER_ALL}. */
+  initiativeFilter: string;
+  setInitiativeFilter: Dispatch<SetStateAction<string>>;
+  /** The active initiative id parsed for query/permission checks, or `null` for ALL. */
+  filteredInitiativeId: number | null;
+}
+
+/**
+ * The initiative-filter cluster shared by the tool-list pages (projects,
+ * documents, queues, counters). Owns the filter value plus the three effects
+ * that keep it coherent: consuming `?initiativeId` from the URL once, pinning to
+ * a locked initiative, and resetting when the active guild changes (initiative
+ * ids are guild-specific).
+ */
+export function useInitiativeFilter({
+  lockedInitiativeId,
+  resetOnParamCleared = false,
+}: UseInitiativeFilterOptions): UseInitiativeFilterResult {
+  const { activeGuildId } = useGuilds();
+  const searchParams = useSearch({ strict: false }) as { initiativeId?: string };
+
+  const [initiativeFilter, setInitiativeFilter] = useState<string>(
+    lockedInitiativeId ? String(lockedInitiativeId) : INITIATIVE_FILTER_ALL
+  );
+
+  const filteredInitiativeId =
+    initiativeFilter !== INITIATIVE_FILTER_ALL ? Number(initiativeFilter) : null;
+
+  const lastConsumedParams = useRef<string>("");
+  const prevGuildIdRef = useRef<number | null>(activeGuildId);
+
+  // Consume ?initiativeId from the URL once. A locked view ignores the URL, and
+  // an already-consumed value doesn't re-pin the filter (so the dropdown can
+  // override the URL selection). Whether a cleared param resets to ALL is
+  // controlled by resetOnParamCleared.
+  useEffect(() => {
+    if (lockedInitiativeId) return;
+    const urlInitiativeId = searchParams.initiativeId;
+    const paramKey = urlInitiativeId || "";
+    if (paramKey === lastConsumedParams.current) return;
+    if (!urlInitiativeId && !resetOnParamCleared) return;
+    lastConsumedParams.current = paramKey;
+    setInitiativeFilter(urlInitiativeId || INITIATIVE_FILTER_ALL);
+  }, [searchParams, lockedInitiativeId, resetOnParamCleared]);
+
+  // Keep the filter pinned to the locked initiative.
+  useEffect(() => {
+    if (lockedInitiativeId) {
+      const lockedValue = String(lockedInitiativeId);
+      setInitiativeFilter((prev) => (prev === lockedValue ? prev : lockedValue));
+    }
+  }, [lockedInitiativeId]);
+
+  // Reset the initiative filter when the active guild changes (initiative IDs
+  // are guild-specific), but not on initial mount.
+  useEffect(() => {
+    const prevGuildId = prevGuildIdRef.current;
+    prevGuildIdRef.current = activeGuildId;
+    if (prevGuildId !== null && prevGuildId !== activeGuildId && !lockedInitiativeId) {
+      setInitiativeFilter(INITIATIVE_FILTER_ALL);
+      lastConsumedParams.current = "";
+    }
+  }, [activeGuildId, lockedInitiativeId]);
+
+  return { initiativeFilter, setInitiativeFilter, filteredInitiativeId };
+}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -39,8 +39,8 @@ import {
   useDocumentsList,
   usePrefetchDocumentsList,
 } from "@/hooks/useDocuments";
-import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { INITIATIVE_FILTER_ALL, useInitiativeFilter } from "@/hooks/useInitiativeFilter";
 import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useTags } from "@/hooks/useTags";
@@ -48,7 +48,6 @@ import { useViewPreference } from "@/hooks/useViewPreference";
 import { useGuildPath } from "@/lib/guildUrl";
 import { buildTagTree, collectDescendantTagIds, findNodeByPath } from "@/lib/tagTree";
 
-const INITIATIVE_FILTER_ALL = "all";
 const DOCUMENT_VIEW_KEY = "documents:view-mode";
 
 /** Map DataTable column IDs to backend sort field names */
@@ -73,7 +72,6 @@ export const DocumentsView = ({
   const router = useRouter();
   const prefetchDocuments = usePrefetchDocumentsList();
   const { user } = useAuth();
-  const { activeGuildId } = useGuilds();
   // Shared access helper — honors guild-admin / PAM / membership so this page
   // never re-derives access from raw membership flags.
   const { filterVisible, permissionsFor, isGuildAdmin, isGrantGuild } = useInitiativeAccess();
@@ -84,35 +82,19 @@ export const DocumentsView = ({
     page?: number;
   };
   const lockedInitiativeId = typeof fixedInitiativeId === "number" ? fixedInitiativeId : null;
-  const [initiativeFilter, setInitiativeFilter] = useState<string>(
-    lockedInitiativeId ? String(lockedInitiativeId) : INITIATIVE_FILTER_ALL
-  );
-  // Parse the filtered initiative ID for permission checks
-  const filteredInitiativeId =
-    initiativeFilter !== INITIATIVE_FILTER_ALL ? Number(initiativeFilter) : null;
+  // The initiative filter consumes ?initiativeId — and, unlike the other tool
+  // lists, clearing the param (e.g. clicking "All Documents" from an
+  // initiative-scoped view) resets it back to ALL rather than staying pinned to
+  // the initiative we arrived from.
+  const { initiativeFilter, setInitiativeFilter, filteredInitiativeId } = useInitiativeFilter({
+    lockedInitiativeId,
+    resetOnParamCleared: true,
+  });
   const { data: filteredInitiativePermissions } = useMyInitiativePermissions(
     !lockedInitiativeId && filteredInitiativeId ? filteredInitiativeId : null
   );
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
-  const lastConsumedParams = useRef<string>("");
-  const prevGuildIdRef = useRef<number | null>(activeGuildId);
-
-  // Sync the initiative filter to the URL's ?initiativeId. A specific id filters
-  // to it; clearing the param — e.g. clicking "All Documents" from an
-  // initiative-scoped view — resets to ALL. Tracking lastConsumedParams lets the
-  // filter dropdown override the selection without the URL re-pinning it, while
-  // still resetting on real navigation. Without the reset the filter stayed
-  // pinned to the initiative we arrived from, so All Documents showed only that
-  // initiative's docs until a manual refresh.
-  useEffect(() => {
-    if (lockedInitiativeId) return;
-    const urlInitiativeId = searchParams.initiativeId;
-    const paramKey = urlInitiativeId || "";
-    if (paramKey === lastConsumedParams.current) return;
-    lastConsumedParams.current = paramKey;
-    setInitiativeFilter(urlInitiativeId || INITIATIVE_FILTER_ALL);
-  }, [searchParams, lockedInitiativeId]);
   const [searchQuery, setSearchQuery] = useState("");
   const [filtersOpen, setFiltersOpen] = useDefaultFiltersOpen();
 
@@ -255,24 +237,6 @@ export const DocumentsView = ({
       setTreeSelectedPaths(new Set());
     }
   }, [viewMode]);
-
-  useEffect(() => {
-    if (lockedInitiativeId) {
-      const lockedValue = String(lockedInitiativeId);
-      setInitiativeFilter((prev) => (prev === lockedValue ? prev : lockedValue));
-    }
-  }, [lockedInitiativeId]);
-
-  // Reset initiative filter when guild changes (initiative IDs are guild-specific)
-  useEffect(() => {
-    const prevGuildId = prevGuildIdRef.current;
-    prevGuildIdRef.current = activeGuildId;
-    // Only reset if guild actually changed (not on initial mount)
-    if (prevGuildId !== null && prevGuildId !== activeGuildId && !lockedInitiativeId) {
-      setInitiativeFilter(INITIATIVE_FILTER_ALL);
-      lastConsumedParams.current = "";
-    }
-  }, [activeGuildId, lockedInitiativeId]);
 
   // In tags view, the tree does its own client-side filtering, so skip backend tag filters
   // When fixedTagIds is provided, always use them regardless of view mode

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -1,14 +1,12 @@
-import { useRouter, useSearch } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { Loader2, Plus } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllCounterGroups } from "@/api/query-keys";
-import { BulkAccessBar, canManageSharing } from "@/components/access/BulkAccessBar";
-import { BulkEditAccessDialog } from "@/components/access/BulkEditAccessDialog";
+import { BulkAccessSection } from "@/components/access/BulkAccessSection";
 import { SelectableGridItem } from "@/components/access/SelectableGridItem";
-import { BulkExportButton } from "@/components/exports/BulkExportButton";
 import { ToolImportAction } from "@/components/imports/ToolImportAction";
 import { CounterGroupCard } from "@/components/initiativeTools/counters/CounterGroupCard";
 import { CountersFilterBar } from "@/components/initiativeTools/counters/CountersFilterBar";
@@ -20,13 +18,11 @@ import { useCounterGroupsList } from "@/hooks/useCounters";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
 import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
-import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { useInitiativeFilter } from "@/hooks/useInitiativeFilter";
 import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useGuildPath } from "@/lib/guildUrl";
-
-const INITIATIVE_FILTER_ALL = "all";
 
 type CountersViewProps = {
   fixedInitiativeId?: number;
@@ -37,53 +33,14 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
   const { t } = useTranslation(["counterGroups", "common", "access"]);
   const router = useRouter();
   const gp = useGuildPath();
-  const { activeGuildId } = useGuilds();
   const { permissionsFor } = useInitiativeAccess();
-  const searchParams = useSearch({ strict: false }) as {
-    initiativeId?: string;
-    create?: string;
-  };
 
   const lockedInitiativeId = typeof fixedInitiativeId === "number" ? fixedInitiativeId : null;
 
-  const [initiativeFilter, setInitiativeFilter] = useState<string>(
-    lockedInitiativeId ? String(lockedInitiativeId) : INITIATIVE_FILTER_ALL
-  );
-
-  const filteredInitiativeId =
-    initiativeFilter !== INITIATIVE_FILTER_ALL ? Number(initiativeFilter) : null;
+  const { initiativeFilter, setInitiativeFilter, filteredInitiativeId } = useInitiativeFilter({
+    lockedInitiativeId,
+  });
   const effectiveInitiativeId = lockedInitiativeId ?? filteredInitiativeId;
-
-  const lastConsumedParams = useRef<string>("");
-  const prevGuildIdRef = useRef<number | null>(activeGuildId);
-
-  // Consume ?initiativeId from the URL once.
-  useEffect(() => {
-    const urlInitiativeId = searchParams.initiativeId;
-    const paramKey = urlInitiativeId ?? "";
-    if (urlInitiativeId && !lockedInitiativeId && paramKey !== lastConsumedParams.current) {
-      lastConsumedParams.current = paramKey;
-      setInitiativeFilter(urlInitiativeId);
-    }
-  }, [searchParams, lockedInitiativeId]);
-
-  // Keep the filter pinned to the locked initiative.
-  useEffect(() => {
-    if (lockedInitiativeId) {
-      const lockedValue = String(lockedInitiativeId);
-      setInitiativeFilter((prev) => (prev === lockedValue ? prev : lockedValue));
-    }
-  }, [lockedInitiativeId]);
-
-  // Reset the initiative filter when the active guild changes.
-  useEffect(() => {
-    const prevGuildId = prevGuildIdRef.current;
-    prevGuildIdRef.current = activeGuildId;
-    if (prevGuildId !== null && prevGuildId !== activeGuildId && !lockedInitiativeId) {
-      setInitiativeFilter(INITIATIVE_FILTER_ALL);
-      lastConsumedParams.current = "";
-    }
-  }, [activeGuildId, lockedInitiativeId]);
 
   const { data: initiativePerms } = useMyInitiativePermissions(effectiveInitiativeId);
 
@@ -146,7 +103,6 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
   };
 
   const selection = useGridSelection<(typeof groups)[number]>();
-  const [bulkAccessOpen, setBulkAccessOpen] = useState(false);
 
   return (
     <div className="space-y-6">
@@ -203,25 +159,11 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
         <p className="text-destructive text-sm">{t("loadError")}</p>
       ) : groups.length > 0 ? (
         <>
-          {selection.active ? (
-            <BulkAccessBar
-              count={selection.selectedItems.length}
-              canManage={canManageSharing(selection.selectedItems)}
-              onEditAccess={() => setBulkAccessOpen(true)}
-              onExit={selection.exit}
-            >
-              <BulkExportButton
-                tool={Tool.counter_group}
-                ids={selection.selectedItems.map((g) => g.id)}
-              />
-            </BulkAccessBar>
-          ) : (
-            <div className="flex justify-end">
-              <Button variant="outline" size="sm" onClick={selection.enter}>
-                {t("access:bulkBar.select")}
-              </Button>
-            </div>
-          )}
+          <BulkAccessSection
+            selection={selection}
+            tool={Tool.counter_group}
+            invalidate={invalidateAllCounterGroups}
+          />
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {groups.map((group) => (
               <SelectableGridItem
@@ -267,15 +209,6 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
         initiativeId={lockedInitiativeId ?? undefined}
         defaultInitiativeId={effectiveInitiativeId ?? undefined}
         onSuccess={handleCreated}
-      />
-
-      <BulkEditAccessDialog
-        open={bulkAccessOpen}
-        onOpenChange={setBulkAccessOpen}
-        items={selection.selectedItems}
-        resourceType={Tool.counter_group}
-        invalidate={invalidateAllCounterGroups}
-        onSuccess={selection.exit}
       />
     </div>
   );

--- a/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
@@ -5,11 +5,9 @@ import { useTranslation } from "react-i18next";
 
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllQueues } from "@/api/query-keys";
-import { BulkAccessBar, canManageSharing } from "@/components/access/BulkAccessBar";
-import { BulkEditAccessDialog } from "@/components/access/BulkEditAccessDialog";
+import { BulkAccessSection } from "@/components/access/BulkAccessSection";
 import { SelectableGridItem } from "@/components/access/SelectableGridItem";
 import { PaginationBar } from "@/components/documents/PaginationBar";
-import { BulkExportButton } from "@/components/exports/BulkExportButton";
 import { ToolImportAction } from "@/components/imports/ToolImportAction";
 import { CreateQueueDialog } from "@/components/initiativeTools/queues/CreateQueueDialog";
 import { QueueCard } from "@/components/initiativeTools/queues/QueueCard";
@@ -24,14 +22,12 @@ import { useAuth } from "@/hooks/useAuth";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
 import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
-import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { INITIATIVE_FILTER_ALL, useInitiativeFilter } from "@/hooks/useInitiativeFilter";
 import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useQueuesList } from "@/hooks/useQueues";
 import { useGuildPath } from "@/lib/guildUrl";
-
-const INITIATIVE_FILTER_ALL = "all";
 
 type QueuesViewProps = {
   fixedInitiativeId?: number;
@@ -42,7 +38,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
   const { t } = useTranslation(["queues", "common", "access"]);
   const router = useRouter();
   const { user } = useAuth();
-  const { activeGuildId } = useGuilds();
   const { permissionsFor } = useInitiativeAccess();
   const gp = useGuildPath();
   const searchParams = useSearch({ strict: false }) as {
@@ -53,12 +48,9 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
 
   const lockedInitiativeId = typeof fixedInitiativeId === "number" ? fixedInitiativeId : null;
 
-  const [initiativeFilter, setInitiativeFilter] = useState<string>(
-    lockedInitiativeId ? String(lockedInitiativeId) : INITIATIVE_FILTER_ALL
-  );
-
-  const filteredInitiativeId =
-    initiativeFilter !== INITIATIVE_FILTER_ALL ? Number(initiativeFilter) : null;
+  const { initiativeFilter, setInitiativeFilter, filteredInitiativeId } = useInitiativeFilter({
+    lockedInitiativeId,
+  });
 
   const { data: filteredInitiativePermissions } = useMyInitiativePermissions(
     !lockedInitiativeId && filteredInitiativeId ? filteredInitiativeId : null
@@ -66,19 +58,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
 
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
-  const lastConsumedParams = useRef<string>("");
-  const prevGuildIdRef = useRef<number | null>(activeGuildId);
-
-  // Consume ?initiativeId from URL once
-  useEffect(() => {
-    const urlInitiativeId = searchParams.initiativeId;
-    const paramKey = urlInitiativeId || "";
-
-    if (urlInitiativeId && !lockedInitiativeId && paramKey !== lastConsumedParams.current) {
-      lastConsumedParams.current = paramKey;
-      setInitiativeFilter(urlInitiativeId);
-    }
-  }, [searchParams, lockedInitiativeId]);
 
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
   const [pageSize, setPageSize] = useState(20);
@@ -100,23 +79,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
     },
     [router]
   );
-
-  useEffect(() => {
-    if (lockedInitiativeId) {
-      const lockedValue = String(lockedInitiativeId);
-      setInitiativeFilter((prev) => (prev === lockedValue ? prev : lockedValue));
-    }
-  }, [lockedInitiativeId]);
-
-  // Reset initiative filter when guild changes
-  useEffect(() => {
-    const prevGuildId = prevGuildIdRef.current;
-    prevGuildIdRef.current = activeGuildId;
-    if (prevGuildId !== null && prevGuildId !== activeGuildId && !lockedInitiativeId) {
-      setInitiativeFilter(INITIATIVE_FILTER_ALL);
-      lastConsumedParams.current = "";
-    }
-  }, [activeGuildId, lockedInitiativeId]);
 
   // Reset to page 1 when filters change
   useEffect(() => {
@@ -214,7 +176,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
     : null;
 
   const selection = useGridSelection<(typeof queues)[number]>();
-  const [bulkAccessOpen, setBulkAccessOpen] = useState(false);
 
   return (
     <div className="space-y-6">
@@ -274,22 +235,11 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
         <p className="text-destructive text-sm">{t("loadError")}</p>
       ) : queues.length > 0 ? (
         <>
-          {selection.active ? (
-            <BulkAccessBar
-              count={selection.selectedItems.length}
-              canManage={canManageSharing(selection.selectedItems)}
-              onEditAccess={() => setBulkAccessOpen(true)}
-              onExit={selection.exit}
-            >
-              <BulkExportButton tool={Tool.queue} ids={selection.selectedItems.map((q) => q.id)} />
-            </BulkAccessBar>
-          ) : (
-            <div className="flex justify-end">
-              <Button variant="outline" size="sm" onClick={selection.enter}>
-                {t("access:bulkBar.select")}
-              </Button>
-            </div>
-          )}
+          <BulkAccessSection
+            selection={selection}
+            tool={Tool.queue}
+            invalidate={invalidateAllQueues}
+          />
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {queues.map((queue) => (
               <SelectableGridItem
@@ -350,15 +300,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
           initiativeFilter !== INITIATIVE_FILTER_ALL ? Number(initiativeFilter) : undefined
         }
         onSuccess={handleQueueCreated}
-      />
-
-      <BulkEditAccessDialog
-        open={bulkAccessOpen}
-        onOpenChange={setBulkAccessOpen}
-        items={selection.selectedItems}
-        resourceType={Tool.queue}
-        invalidate={invalidateAllQueues}
-        onSuccess={selection.exit}
       />
     </div>
   );


### PR DESCRIPTION
## Problem

#867 flagged ~200 lines of repeated filter/create/selection orchestration across the five tool-list View components and prescribed a `useToolListScaffold({...})` mega-hook returning ~10 values.

## Changes (re-scoped after design review)

- **The mega-hook is not built** — a config-object generic over independent concerns adds an idiom to learn and a layer to debug through. Also the ticket's `?create=true` bullet turned out to be already shipped (`useCreateFromSearchParam`, adopted by all five pages).
- **[useInitiativeFilter.ts](frontend/src/hooks/useInitiativeFilter.ts)** — the one genuinely cohesive concern: filter state + consume-`?initiativeId`-once + reset-on-guild-change + locked-initiative pin, with `INITIATIVE_FILTER_ALL` exported. Converted DocumentsPage, QueuesPage, CounterGroupsPage byte-for-byte (Documents' "clearing the param resets to All" variant is the hook's one boolean, `resetOnParamCleared`). Two pages left deliberately, with evidence in the hook adoption notes: **ProjectsPage**'s cluster also drives the create-dialog's default-initiative state (converting would drop those side effects — needs its own refactor), and **EventsPage** never had the cluster (it derives `initiativeId` directly).
- **[BulkAccessSection.tsx](frontend/src/components/access/BulkAccessSection.tsx)** — the identical `BulkAccessBar` + `BulkEditAccessDialog` block for Queues + Counters (`useGridSelection` and per-card props stay in each page per the issue's hot-path constraint). Events (view-mode-gated select toggle), Projects (conditional export child + different bar placement), and Documents (different bulk bar entirely) stay as they are.
- The five `canCreate<Tool>` memos were compared, not extracted: three distinct shapes (Projects/Documents/Queues family, Counters, Events) with different initiative-id sources — documented in the report for a future pass, not force-unified.

## Efficiency

Per the issue's constraint: no item `.map()`s, card prop construction, or memoization touched; no new context providers.

## Testing

- `pnpm typecheck` — 0 errors; `biome check src` — clean
- `vitest run` — full suite: 931 tests passed

Closes #867