### PR TITLE
Unify canCreate on server-computed create flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Create buttons and initiative pickers for projects, documents, events, queues, and counter groups now consistently follow your actual per-initiative create permission. Members whose custom role grants creation see the affordances everywhere they apply, and buttons or picker entries the server would reject no longer appear.
+- The Events calendar now offers event creation in the all-initiatives view when you can create events in at least one initiative — the create dialog gains an initiative picker to choose the target, matching the other tools.
+
 ## [0.59.0] - 2026-08-03
 
 ### Changed

--- a/frontend/src/components/initiativeTools/counters/CreateCounterGroupDialog.tsx
+++ b/frontend/src/components/initiativeTools/counters/CreateCounterGroupDialog.tsx
@@ -1,4 +1,5 @@
 import type { CounterGroupRead } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import {
   type CreateToolConfig,
   CreateToolDialog,
@@ -13,6 +14,7 @@ type CreateCounterGroupDialogProps = DialogProps & {
 };
 
 const COUNTER_GROUP_CONFIG: CreateToolConfig<CounterGroupRead> = {
+  tool: Tool.counter_group,
   namespace: "counterGroups",
   titleKey: "createGroup",
   descriptionKey: "noGroupsDescription",

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -8,6 +8,7 @@ import type {
   TaskListReadRecurrenceStrategy,
   TaskRecurrenceOutput,
 } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { CreateAccessSection } from "@/components/access/CreateAccessSection";
 import { DEFAULT_GRANTS } from "@/components/access/grants";
 import { MemberMultiSelect } from "@/components/members/MemberSearchSelect";
@@ -34,6 +35,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/hooks/useAuth";
 import { useCreateCalendarEvent } from "@/hooks/useCalendarEvents";
+import { useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import type { DialogProps } from "@/types/dialog";
 
 import {
@@ -47,7 +49,10 @@ import {
 } from "./eventDateTime";
 
 type CreateEventDialogProps = DialogProps & {
-  initiativeId: number;
+  /** If provided, the initiative is locked and the picker is hidden. */
+  initiativeId?: number;
+  /** If provided, pre-selects this initiative (but the user can change it). */
+  defaultInitiativeId?: number;
   defaultStartDate?: string;
   defaultStartTime?: string;
   onSuccess?: (event: CalendarEventRead) => void;
@@ -57,6 +62,7 @@ export const CreateEventDialog = ({
   open,
   onOpenChange,
   initiativeId,
+  defaultInitiativeId,
   defaultStartDate,
   defaultStartTime,
   onSuccess,
@@ -77,6 +83,16 @@ export const CreateEventDialog = ({
   const [recurrenceStrategy, setRecurrenceStrategy] =
     useState<TaskListReadRecurrenceStrategy>("fixed");
   const [grants, setGrants] = useState<ResourceGrantSchema[]>([...DEFAULT_GRANTS]);
+  const [selectedInitiativeId, setSelectedInitiativeId] = useState(
+    defaultInitiativeId ? String(defaultInitiativeId) : ""
+  );
+
+  // Initiatives the current user may create events in — backs the picker
+  // shown when no initiative is locked (the "All" calendar view).
+  const { creatableInitiatives } = useToolCreateAccess(Tool.calendar_event, { enabled: open });
+
+  const effectiveInitiativeId =
+    initiativeId ?? (selectedInitiativeId ? Number(selectedInitiativeId) : null);
 
   // Attendee candidates come from the initiative-scoped member typeahead
   // (MemberMultiSelect below) — every initiative member may attend. Event DAC
@@ -86,6 +102,9 @@ export const CreateEventDialog = ({
     if (open) {
       // The creator attends their own event by default.
       setAttendeeIds(user ? [user.id] : []);
+      if (defaultInitiativeId) {
+        setSelectedInitiativeId(String(defaultInitiativeId));
+      }
       if (defaultStartDate) {
         setStartDate(defaultStartDate);
         setEndDate(defaultStartDate);
@@ -107,8 +126,9 @@ export const CreateEventDialog = ({
       setRecurrence(null);
       setRecurrenceStrategy("fixed");
       setGrants([...DEFAULT_GRANTS]);
+      setSelectedInitiativeId(defaultInitiativeId ? String(defaultInitiativeId) : "");
     }
-  }, [open, defaultStartDate, defaultStartTime, user]);
+  }, [open, defaultInitiativeId, defaultStartDate, defaultStartTime, user]);
 
   // Apply a new start date/time, shifting the end so the event keeps its
   // current length (a 90-minute event stays 90 minutes; a multi-day event keeps
@@ -151,11 +171,11 @@ export const CreateEventDialog = ({
   });
 
   const isCreating = createEvent.isPending;
-  const canSubmit = title.trim() && datesValid && !isCreating;
+  const canSubmit = title.trim() && datesValid && !!effectiveInitiativeId && !isCreating;
 
   const handleSubmit = () => {
     const trimmedTitle = title.trim();
-    if (!trimmedTitle || !datesValid) return;
+    if (!trimmedTitle || !datesValid || !effectiveInitiativeId) return;
 
     let startISO: string;
     let endISO: string;
@@ -174,7 +194,7 @@ export const CreateEventDialog = ({
       start_at: startISO,
       end_at: endISO,
       all_day: allDay,
-      initiative_id: initiativeId,
+      initiative_id: effectiveInitiativeId,
       attendee_ids: attendeeIds.length > 0 ? attendeeIds : undefined,
       recurrence: recurrence
         ? {
@@ -242,6 +262,32 @@ export const CreateEventDialog = ({
               placeholder={t("locationPlaceholder")}
             />
           </div>
+
+          {initiativeId === undefined && (
+            <div className="space-y-2">
+              <Label htmlFor="create-event-initiative">{t("initiative")}</Label>
+              <Select
+                value={selectedInitiativeId}
+                onValueChange={(value) => {
+                  setSelectedInitiativeId(value);
+                  // Attendees are initiative members; a new target starts over
+                  // with just the creator.
+                  setAttendeeIds(user ? [user.id] : []);
+                }}
+              >
+                <SelectTrigger id="create-event-initiative">
+                  <SelectValue placeholder={t("selectInitiative")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {creatableInitiatives.map((initiative) => (
+                    <SelectItem key={initiative.id} value={String(initiative.id)}>
+                      {initiative.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           <div className="flex items-center gap-3">
             <Switch id="create-event-all-day" checked={allDay} onCheckedChange={setAllDay} />
@@ -338,19 +384,22 @@ export const CreateEventDialog = ({
             </div>
           )}
 
-          {/* Attendees */}
-          <div className="space-y-2">
-            <Label>{t("attendees")}</Label>
-            <MemberMultiSelect
-              scope={{ type: "initiative", initiativeId }}
-              selectedIds={attendeeIds}
-              selectedUsers={user ? [user] : undefined}
-              onChange={setAttendeeIds}
-              currentUserId={user?.id}
-              placeholder={t("addAttendee")}
-              emptyMessage={t("noAttendees")}
-            />
-          </div>
+          {/* Attendees — scoped to the target initiative's members, so wait
+              until one is chosen. */}
+          {effectiveInitiativeId != null && (
+            <div className="space-y-2">
+              <Label>{t("attendees")}</Label>
+              <MemberMultiSelect
+                scope={{ type: "initiative", initiativeId: effectiveInitiativeId }}
+                selectedIds={attendeeIds}
+                selectedUsers={user ? [user] : undefined}
+                onChange={setAttendeeIds}
+                currentUserId={user?.id}
+                placeholder={t("addAttendee")}
+                emptyMessage={t("noAttendees")}
+              />
+            </div>
+          )}
 
           {/* Recurrence */}
           <TaskRecurrenceSelector
@@ -361,7 +410,11 @@ export const CreateEventDialog = ({
             referenceDate={referenceDate}
           />
 
-          <CreateAccessSection initiativeId={initiativeId} grants={grants} onChange={setGrants} />
+          <CreateAccessSection
+            initiativeId={effectiveInitiativeId}
+            grants={grants}
+            onChange={setGrants}
+          />
         </div>
 
         <DialogFooter>

--- a/frontend/src/components/initiativeTools/events/ICalImportDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/ICalImportDialog.tsx
@@ -1,7 +1,8 @@
 import { AlertCircle, CheckCircle2, FileText, Upload } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { apiMutator } from "@/api/mutator";
 import { invalidateAllCalendarEvents } from "@/api/query-keys";
 import { Button } from "@/components/ui/button";
@@ -20,8 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useAuth } from "@/hooks/useAuth";
-import { useInitiatives } from "@/hooks/useInitiatives";
+import { useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { toast } from "@/lib/chesterToast";
 import type { DialogProps } from "@/types/dialog";
 
@@ -57,7 +57,6 @@ export const ICalImportDialog = ({
   fixedInitiativeId,
 }: ICalImportDialogProps) => {
   const { t } = useTranslation(["calendarEvents", "common"]);
-  const { user } = useAuth();
 
   const [step, setStep] = useState<Step>("upload");
   const [icsContent, setIcsContent] = useState("");
@@ -79,15 +78,10 @@ export const ICalImportDialog = ({
     }
   }, [open, fixedInitiativeId]);
 
-  const initiativesQuery = useInitiatives({ enabled: open });
-  const creatableInitiatives = useMemo(() => {
-    if (!user) return [];
-    return (initiativesQuery.data ?? []).filter(
-      (init) =>
-        init.calendar_events_enabled &&
-        init.members.some((m) => m.user.id === user.id && m.role === "project_manager")
-    );
-  }, [initiativesQuery.data, user]);
+  // Import creates events, so the target picker offers exactly the
+  // initiatives whose server-computed create flag is on (folds in the
+  // calendar master switch and the guild-admin / PAM legs).
+  const { creatableInitiatives } = useToolCreateAccess(Tool.calendar_event, { enabled: open });
 
   const MAX_ICS_SIZE = 2_000_000;
 

--- a/frontend/src/components/initiativeTools/queues/CreateQueueDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/CreateQueueDialog.tsx
@@ -1,4 +1,5 @@
 import type { QueueRead } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import {
   type CreateToolConfig,
   CreateToolDialog,
@@ -16,6 +17,7 @@ type CreateQueueDialogProps = DialogProps & {
 };
 
 const QUEUE_CONFIG: CreateToolConfig<QueueRead> = {
+  tool: Tool.queue,
   namespace: "queues",
   titleKey: "createQueue",
   descriptionKey: "noQueuesDescription",

--- a/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
+++ b/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
@@ -3,7 +3,7 @@ import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { ResourceGrantSchema } from "@/api/generated/initiativeAPI.schemas";
+import type { ResourceGrantSchema, Tool } from "@/api/generated/initiativeAPI.schemas";
 import { CreateAccessSection } from "@/components/access/CreateAccessSection";
 import { DEFAULT_GRANTS } from "@/components/access/grants";
 import { Button } from "@/components/ui/button";
@@ -25,6 +25,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import type { DialogProps } from "@/types/dialog";
 import type { TranslateFn } from "@/types/i18n";
@@ -47,6 +48,8 @@ export type ToolCreatePayload = {
  * another: its i18n namespace/keys, element-id prefix, and create-mutation hook.
  */
 export interface CreateToolConfig<TRead> {
+  /** The tool being created — drives the picker's creatable-initiative filter. */
+  tool: Tool;
   /** i18n namespace for this tool's strings (e.g. "queues"). */
   namespace: FlatNamespace;
   /** Key for the dialog title and the submit button label. */
@@ -86,7 +89,7 @@ export const CreateToolDialog = <TRead,>({
   onSuccess,
   config,
 }: CreateToolDialogProps<TRead>) => {
-  const { namespace, titleKey, descriptionKey, idPrefix, useCreate } = config;
+  const { tool, namespace, titleKey, descriptionKey, idPrefix, useCreate } = config;
   // The namespace and several keys are supplied by config (dynamic per tool), so
   // use the loose translation signature rather than the statically-typed keys.
   const { t: translate } = useTranslation(namespace);
@@ -101,6 +104,10 @@ export const CreateToolDialog = <TRead,>({
 
   const initiativesQuery = useInitiatives();
   const initiatives = initiativesQuery.data ?? [];
+
+  // The picker only offers initiatives the user may actually create this tool
+  // in (server-computed create flags; folds in the tool's master switch).
+  const { creatableInitiatives } = useToolCreateAccess(tool);
 
   const effectiveInitiativeId =
     initiativeId ?? (selectedInitiativeId ? Number(selectedInitiativeId) : null);
@@ -193,7 +200,7 @@ export const CreateToolDialog = <TRead,>({
                   <SelectValue placeholder={t("selectInitiative")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {initiatives.map((initiative) => (
+                  {creatableInitiatives.map((initiative) => (
                     <SelectItem key={initiative.id} value={String(initiative.id)}>
                       {initiative.name}
                     </SelectItem>

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -1,8 +1,9 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import type { InitiativeRead, Tool } from "@/api/generated/initiativeAPI.schemas";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import {
   isToolEnabled,
   TOOL_REGISTRY,
@@ -120,4 +121,44 @@ export function useInitiativeAccess() {
   );
 
   return { isGuildAdmin, isGrantGuild, grantReadWrite, filterVisible, permissionsFor, canManage };
+}
+
+/**
+ * Canonical "can the current user create <tool>" answer for pages and create
+ * dialogs. Creation always targets an initiative, so the answer has two
+ * shapes: with a specific initiative in context (a locked page or a filter
+ * selection) it is that initiative's server-computed create flag, read via
+ * `permissionsFor`; with none (an "All" view) it is "can create in at least
+ * one initiative" — the create dialog's initiative picker chooses the target.
+ *
+ * `creatableInitiatives` backs those pickers: the visible initiatives whose
+ * create flag is on for this tool. The flag already folds in the initiative's
+ * master switch, so initiatives with the tool disabled drop out.
+ */
+export function useToolCreateAccess(
+  tool: Tool,
+  { initiativeId, enabled }: { initiativeId?: number | null; enabled?: boolean } = {}
+) {
+  const { user } = useAuth();
+  const { filterVisible, permissionsFor } = useInitiativeAccess();
+  const initiativesQuery = useInitiatives(enabled === undefined ? undefined : { enabled });
+
+  const creatableInitiatives = useMemo(() => {
+    if (!user) return [];
+    return filterVisible(initiativesQuery.data).filter(
+      (initiative) => permissionsFor(initiative)[tool].create
+    );
+  }, [user, initiativesQuery.data, filterVisible, permissionsFor, tool]);
+
+  const canCreate = useMemo(() => {
+    if (initiativeId) {
+      const initiative = (initiativesQuery.data ?? []).find((item) => item.id === initiativeId);
+      // Unknown until the list loads — keep create affordances hidden rather
+      // than briefly offering a create the server would refuse.
+      return initiative ? permissionsFor(initiative)[tool].create : false;
+    }
+    return creatableInitiatives.length > 0;
+  }, [initiativeId, initiativesQuery.data, permissionsFor, tool, creatableInitiatives]);
+
+  return { canCreate, creatableInitiatives };
 }

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -107,6 +107,7 @@ import { useAIEnabled } from "@/hooks/useAIEnabled";
 import { useAuth } from "@/hooks/useAuth";
 import { useCollaboration } from "@/hooks/useCollaboration";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { uploadAttachment } from "@/lib/attachmentUtils";
@@ -141,6 +142,7 @@ export const DocumentDetailPage = () => {
   const setDocumentCache = useSetDocumentCache();
   const { user, token } = useAuth();
   const { activeGuildId } = useGuilds();
+  const { permissionsFor } = useInitiativeAccess();
   const guildId = Number(guildIdParam);
   const gp = useGuildPath();
   const sidePanel = useDocumentSidePanel();
@@ -419,19 +421,15 @@ export const DocumentDetailPage = () => {
     return hasWriteAccess(document.my_permission_level);
   }, [document, user]);
 
-  // Check if user can create documents in this initiative
+  // Whether the user can create documents in this document's initiative —
+  // via the shared access helper, so guild admins and PAM grantees are
+  // included regardless of any membership row.
   const canCreateDocuments = useMemo(() => {
-    if (!document?.initiative || !user) {
+    if (!document?.initiative) {
       return false;
     }
-    // Check if user has create_documents permission via their role
-    const membership = document.initiative.members?.find((m) => m.user?.id === user.id);
-    if (!membership) {
-      return false;
-    }
-    // can_create_documents is populated from the initiative membership role
-    return membership.can_create_documents ?? false;
-  }, [document?.initiative, user]);
+    return permissionsFor(document.initiative)[Tool.document].create;
+  }, [document?.initiative, permissionsFor]);
 
   // Wikilink navigation handler
   const handleWikilinkNavigate = useCallback(

--- a/frontend/src/pages/DocumentSettingsPage.tsx
+++ b/frontend/src/pages/DocumentSettingsPage.tsx
@@ -27,6 +27,7 @@ import {
   useSetDocumentCache,
   useUpdateDocument,
 } from "@/hooks/useDocuments";
+import { useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useRelativeTime } from "@/hooks/useRelativeTime";
 import { useSetToolTags } from "@/hooks/useToolTags";
@@ -34,7 +35,7 @@ import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
-import { Capability, hasCapability, hasWriteAccess } from "@/lib/permissions";
+import { hasWriteAccess } from "@/lib/permissions";
 
 export const DocumentSettingsPage = () => {
   const { t } = useTranslation(["documents", "common"]);
@@ -79,27 +80,19 @@ export const DocumentSettingsPage = () => {
     return document.my_permission_level === "owner";
   }, [document, user]);
 
-  const manageableInitiatives = useMemo(() => {
-    const initiatives = initiativesQuery.data ?? [];
-    if (!user) {
-      return [];
-    }
-    if (hasCapability(user, Capability.dataBypass)) {
-      return initiatives;
-    }
-    return initiatives.filter((initiative) =>
-      initiative.members.some(
-        (member) => member.user.id === user.id && member.role === "project_manager"
-      )
-    );
-  }, [initiativesQuery.data, user]);
+  // Copying creates a document in the target initiative, so the target list
+  // is the initiatives whose server-computed create flag is on — minus the
+  // one the document is already in.
+  const { creatableInitiatives } = useToolCreateAccess(Tool.document, {
+    enabled: Boolean(document) && Boolean(user),
+  });
 
   const copyableInitiatives = useMemo(() => {
     if (!document) {
       return [];
     }
-    return manageableInitiatives.filter((initiative) => initiative.id !== document.initiative_id);
-  }, [document, manageableInitiatives]);
+    return creatableInitiatives.filter((initiative) => initiative.id !== document.initiative_id);
+  }, [document, creatableInitiatives]);
 
   useEffect(() => {
     if (!document) {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -39,9 +39,8 @@ import {
   useDocumentsList,
   usePrefetchDocumentsList,
 } from "@/hooks/useDocuments";
-import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { useInitiativeAccess, useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { INITIATIVE_FILTER_ALL, useInitiativeFilter } from "@/hooks/useInitiativeFilter";
-import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useTags } from "@/hooks/useTags";
 import { useViewPreference } from "@/hooks/useViewPreference";
@@ -75,7 +74,7 @@ export const DocumentsView = ({
   const { user } = useAuth();
   // Shared access helper — honors guild-admin / PAM / membership so this page
   // never re-derives access from raw membership flags.
-  const { filterVisible, permissionsFor, isGuildAdmin, isGrantGuild } = useInitiativeAccess();
+  const { isGuildAdmin, isGrantGuild } = useInitiativeAccess();
   const gp = useGuildPath();
   const searchParams = useSearch({ strict: false }) as {
     initiativeId?: string;
@@ -91,9 +90,6 @@ export const DocumentsView = ({
     lockedInitiativeId,
     resetOnParamCleared: true,
   });
-  const { data: filteredInitiativePermissions } = useMyInitiativePermissions(
-    !lockedInitiativeId && filteredInitiativeId ? filteredInitiativeId : null
-  );
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
   const [searchQuery, setSearchQuery] = useState("");
@@ -341,16 +337,12 @@ export const DocumentsView = ({
 
   const initiativesQuery = useInitiatives();
 
-  // Initiatives the user can create documents in — resolved through the shared
-  // access helper so guild admins are included regardless of any membership row.
-  const creatableInitiatives = useMemo(() => {
-    if (!initiativesQuery.data || !user) {
-      return [];
-    }
-    return filterVisible(initiativesQuery.data).filter(
-      (initiative) => permissionsFor(initiative)[Tool.document].create
-    );
-  }, [initiativesQuery.data, user, filterVisible, permissionsFor]);
+  // Canonical create answer: the locked/filtered initiative's server-computed
+  // create flag, or (in the "All" view) whether any visible initiative grants
+  // it. `creatableInitiatives` feeds the create dialog's initiative picker.
+  const { canCreate: canCreateDerived, creatableInitiatives } = useToolCreateAccess(Tool.document, {
+    initiativeId: lockedInitiativeId ?? filteredInitiativeId,
+  });
 
   const [createDialogInitiativeId, setCreateDialogInitiativeId] = useState<number | undefined>(
     lockedInitiativeId ?? undefined
@@ -444,28 +436,9 @@ export const DocumentsView = ({
     isGrantGuild,
   ]);
 
-  // Use explicit canCreate prop if provided (from role permissions), otherwise check filtered initiative permissions
-  const canCreateDocuments = useMemo(() => {
-    // If explicit prop provided (e.g., from InitiativeDetailPage), use it
-    if (canCreate !== undefined) {
-      return canCreate;
-    }
-    // If a specific initiative is filtered, check permissions for that initiative
-    if (filteredInitiativeId && filteredInitiativePermissions) {
-      return canCreateTool(filteredInitiativePermissions, Tool.document);
-    }
-    // Fall back to legacy check (user is PM in any initiative)
-    if (lockedInitiativeId) {
-      return creatableInitiatives.some((initiative) => initiative.id === lockedInitiativeId);
-    }
-    return creatableInitiatives.length > 0;
-  }, [
-    canCreate,
-    filteredInitiativeId,
-    filteredInitiativePermissions,
-    lockedInitiativeId,
-    creatableInitiatives,
-  ]);
+  // An explicit canCreate prop (e.g. from InitiativeDetailPage) wins; otherwise
+  // use the canonical derivation above.
+  const canCreateDocuments = canCreate ?? canCreateDerived;
 
   // Drive the app-wide bottom-nav add button for this route.
   useRegisterPrimaryCreateAction(

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, SearchX, Settings, ShieldAlert } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import {
   invalidateAllTasks,
   invalidateProject,
@@ -23,12 +24,12 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
-import { useAuth } from "@/hooks/useAuth";
+import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useProject, useProjectTaskStatuses } from "@/hooks/useProjects";
 import { useRecordRecentView } from "@/hooks/useRecents";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
-import { Capability, hasCapability, hasWriteAccess } from "@/lib/permissions";
+import { hasWriteAccess } from "@/lib/permissions";
 
 export const ProjectDetailPage = () => {
   const { t } = useTranslation("projects");
@@ -37,7 +38,7 @@ export const ProjectDetailPage = () => {
     projectId: string;
   };
   const router = useRouter();
-  const { user } = useAuth();
+  const { permissionsFor } = useInitiativeAccess();
   const gp = useGuildPath();
   const searchParams = useSearch({ strict: false }) as { create?: string };
   const parsedProjectId = Number(projectId);
@@ -150,10 +151,6 @@ export const ProjectDetailPage = () => {
     );
   }
 
-  const initiativeMembership = project.initiative?.members?.find(
-    (member) => member.user.id === user?.id
-  );
-  const isInitiativePm = initiativeMembership?.role === "project_manager";
   const myLevel = project?.my_permission_level;
   // Pure DAC: write access requires owner or write permission level
   const hasWritePermission = hasWriteAccess(myLevel);
@@ -161,8 +158,11 @@ export const ProjectDetailPage = () => {
   // Pure DAC: settings/write access based on permission level
   const canManageSettings = hasWritePermission;
   const canWriteProject = hasWritePermission;
-  // Creating documents requires initiative PM role (backend requirement)
-  const canCreateDocuments = hasCapability(user, Capability.dataBypass) || isInitiativePm;
+  // Creating a document targets the project's initiative, so it follows that
+  // initiative's server-computed create flag.
+  const canCreateDocuments = project.initiative
+    ? permissionsFor(project.initiative)[Tool.document].create
+    : false;
   const canAttachDocuments = canWriteProject;
   // Pure DAC: any permission grants view access
   const canViewTaskDetails = Boolean(project && myLevel);

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -56,8 +56,7 @@ import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
 import { useDefaultFiltersOpen } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
 import { useGuilds } from "@/hooks/useGuilds";
-import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
-import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
+import { useInitiativeAccess, useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import {
   useArchivedProjects,
@@ -91,7 +90,7 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   // Single source of truth for "what can I do in each initiative" — honors
   // guild-admin / PAM / membership so this page never re-derives access from
   // raw membership flags (which would wrongly exclude guild admins).
-  const { filterVisible, permissionsFor, isGuildAdmin, isGrantGuild } = useInitiativeAccess();
+  const { isGuildAdmin, isGrantGuild } = useInitiativeAccess();
   const gp = useGuildPath();
   const searchParams = useSearch({ strict: false }) as { create?: string; initiativeId?: string };
   const lockedInitiativeId = typeof fixedInitiativeId === "number" ? fixedInitiativeId : null;
@@ -141,9 +140,6 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   // Parse the filtered initiative ID for permission checks
   const filteredInitiativeId =
     initiativeFilter !== INITIATIVE_FILTER_ALL ? Number(initiativeFilter) : null;
-  const { data: filteredInitiativePermissions } = useMyInitiativePermissions(
-    !lockedInitiativeId && filteredInitiativeId ? filteredInitiativeId : null
-  );
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const lastConsumedFilterParams = useRef<string>("");
   const prevGuildIdRef = useRef<number | null>(activeGuildId);
@@ -232,23 +228,18 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
   const projectsQuery = useProjects();
 
   // This is a guild-scoped page and the initiatives list is cheap + cached, so
-  // fetch it unconditionally. Manager state is derived below from the payload
-  // via the shared access helper (permissionsFor(...).canCreateProjects), which
-  // already honors guild-admin / PAM grants — no need to pre-gate on a claimed
-  // manager role from user.initiative_roles (the /users/me object no longer
-  // populates that field: initiative membership is guild-schema content).
+  // fetch it unconditionally. Create access is derived from the same payload
+  // by useToolCreateAccess, which already honors guild-admin / PAM grants — no
+  // need to pre-gate on a claimed manager role from user.initiative_roles (the
+  // /users/me object no longer populates that field: initiative membership is
+  // guild-schema content).
   const initiativesQuery = useInitiatives();
-  // Initiatives the user can create projects in — resolved through the shared
-  // access helper so guild admins are included regardless of any membership row.
-  const creatableInitiatives = useMemo(() => {
-    if (!initiativesQuery.data || !user) {
-      return [];
-    }
-    return filterVisible(initiativesQuery.data).filter(
-      (initiative) => permissionsFor(initiative)[Tool.project].create
-    );
-  }, [initiativesQuery.data, user, filterVisible, permissionsFor]);
-  const isProjectManager = creatableInitiatives.length > 0;
+  // Canonical create answer: the locked/filtered initiative's server-computed
+  // create flag, or (in the "All" view) whether any visible initiative grants
+  // it. `creatableInitiatives` feeds the create dialog's initiative picker.
+  const { canCreate: canCreateDerived, creatableInitiatives } = useToolCreateAccess(Tool.project, {
+    initiativeId: lockedInitiativeId ?? filteredInitiativeId,
+  });
 
   // Check if user can view projects for the filtered initiative
   const canViewProjects = useMemo(() => {
@@ -280,19 +271,9 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
     isGrantGuild,
   ]);
 
-  // Use explicit canCreate prop if provided (from role permissions), otherwise check filtered initiative permissions
-  const canCreateProjects = useMemo(() => {
-    // If explicit prop provided (e.g., from InitiativeDetailPage), use it
-    if (canCreate !== undefined) {
-      return canCreate;
-    }
-    // If a specific initiative is filtered, check permissions for that initiative
-    if (filteredInitiativeId && filteredInitiativePermissions) {
-      return canCreateTool(filteredInitiativePermissions, Tool.project);
-    }
-    // Fall back to legacy check (user is PM in any initiative)
-    return isProjectManager;
-  }, [canCreate, filteredInitiativeId, filteredInitiativePermissions, isProjectManager]);
+  // An explicit canCreate prop (e.g. from InitiativeDetailPage) wins; otherwise
+  // use the canonical derivation above.
+  const canCreateProjects = canCreate ?? canCreateDerived;
 
   // Drive the app-wide bottom-nav add button for this route.
   useRegisterPrimaryCreateAction(

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -18,9 +18,8 @@ import { useCounterGroupsList } from "@/hooks/useCounters";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
 import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
-import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiativeFilter } from "@/hooks/useInitiativeFilter";
-import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useGuildPath } from "@/lib/guildUrl";
 
@@ -33,7 +32,6 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
   const { t } = useTranslation(["counterGroups", "common", "access"]);
   const router = useRouter();
   const gp = useGuildPath();
-  const { permissionsFor } = useInitiativeAccess();
 
   const lockedInitiativeId = typeof fixedInitiativeId === "number" ? fixedInitiativeId : null;
 
@@ -41,8 +39,6 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
     lockedInitiativeId,
   });
   const effectiveInitiativeId = lockedInitiativeId ?? filteredInitiativeId;
-
-  const { data: initiativePerms } = useMyInitiativePermissions(effectiveInitiativeId);
 
   const groupsQuery = useCounterGroupsList({
     ...(effectiveInitiativeId ? { initiative_id: effectiveInitiativeId } : {}),
@@ -60,16 +56,13 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
     return map;
   }, [initiatives]);
 
-  const canCreateGroups = useMemo(() => {
-    if (canCreate !== undefined) return canCreate;
-    if (effectiveInitiativeId && initiativePerms) {
-      return canCreateTool(initiativePerms, Tool.counter_group);
-    }
-    // No initiative filter: creatable if the shared access helper allows
-    // creating in ANY counter-enabled initiative (honors guild-admin, PAM
-    // grants, and frozen read-only guilds).
-    return initiatives.some((initiative) => permissionsFor(initiative)[Tool.counter_group].create);
-  }, [canCreate, effectiveInitiativeId, initiativePerms, initiatives, permissionsFor]);
+  // Canonical create answer: the locked/filtered initiative's server-computed
+  // create flag, or (in the "All" view) whether any visible initiative grants
+  // it. An explicit canCreate prop (e.g. from InitiativeDetailPage) wins.
+  const { canCreate: canCreateDerived } = useToolCreateAccess(Tool.counter_group, {
+    initiativeId: effectiveInitiativeId,
+  });
+  const canCreateGroups = canCreate ?? canCreateDerived;
 
   const {
     open: createOpen,

--- a/frontend/src/pages/initiativeTools/events/EventsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventsPage.tsx
@@ -47,7 +47,8 @@ import { useRescheduleCalendarEvent } from "@/hooks/useCalendarEvents";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
 import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
-import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
+import { useInitiativeAccess, useToolCreateAccess } from "@/hooks/useInitiativeAccess";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { useProjects } from "@/hooks/useProjects";
 import { useUpdateTask } from "@/hooks/useTasks";
 import { useViewPreference } from "@/hooks/useViewPreference";
@@ -130,7 +131,8 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   const initiativeId =
     fixedInitiativeId ?? (searchParams.initiativeId ? Number(searchParams.initiativeId) : null);
 
-  const { data: initiativePermissions } = useMyInitiativePermissions(initiativeId);
+  const { permissionsFor } = useInitiativeAccess();
+  const initiativesQuery = useInitiatives();
 
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
@@ -263,25 +265,26 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   // Same param shape the sidebar and dashboard use, so this shares their cache.
   const projectsQuery = useProjects(undefined, { enabled: showTasks, staleTime: 30_000 });
 
-  const canCreateEvents = useMemo(() => {
-    if (canCreate !== undefined) return canCreate;
-    if (initiativeId && initiativePermissions) {
-      return canCreateTool(initiativePermissions, Tool.calendar_event);
-    }
-    return false;
-  }, [canCreate, initiativeId, initiativePermissions]);
+  // Canonical create answer: the selected initiative's server-computed create
+  // flag, or (in the "All" view) whether any visible initiative grants it —
+  // the create dialog's initiative picker chooses the target. An explicit
+  // canCreate prop (e.g. from InitiativeDetailPage) wins.
+  const { canCreate: canCreateDerived } = useToolCreateAccess(Tool.calendar_event, {
+    initiativeId,
+  });
+  const canCreateEvents = canCreate ?? canCreateDerived;
 
   // Tasks belong to projects; the precise per-project edit permission is
   // enforced by the backend on drop. Here we gate task-chip dragging on
   // project-create permission as a proxy, so users who can't manage project
   // content don't get draggable task chips. Decoupled from canCreateEvents so
-  // event-create and task-edit are judged independently.
+  // event-create and task-edit are judged independently. The "All" view keeps
+  // chips non-draggable — its tasks span initiatives with differing access.
   const canEditTasks = useMemo(() => {
-    if (initiativeId && initiativePermissions) {
-      return canCreateTool(initiativePermissions, Tool.project);
-    }
-    return false;
-  }, [initiativeId, initiativePermissions]);
+    if (!initiativeId) return false;
+    const initiative = initiativesQuery.data?.find((item) => item.id === initiativeId);
+    return initiative ? permissionsFor(initiative)[Tool.project].create : false;
+  }, [initiativeId, initiativesQuery.data, permissionsFor]);
 
   // --- Merge events + tasks into calendar entries ---
   const calendarEntries = useMemo<CalendarEntry[]>(() => {
@@ -373,7 +376,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
 
   // Drive the app-wide bottom-nav add button for this route.
   useRegisterPrimaryCreateAction(
-    canCreateEvents && initiativeId
+    canCreateEvents
       ? {
           run: () => {
             setCreateDefaultDate(null);
@@ -389,7 +392,7 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
   };
 
   const handleSlotClick = (date: Date) => {
-    if (!canCreateEvents || !initiativeId) return;
+    if (!canCreateEvents) return;
     setCreateDefaultDate(date);
     setCreateDialogOpen(true);
   };
@@ -643,15 +646,14 @@ export const EventsView = ({ fixedInitiativeId, canCreate }: EventsViewProps) =>
         </div>
       )}
 
-      {initiativeId && (
-        <CreateEventDialog
-          open={createDialogOpen}
-          onOpenChange={handleCreateDialogOpenChange}
-          initiativeId={initiativeId}
-          defaultStartDate={defaultStartDate}
-          onSuccess={handleEventCreated}
-        />
-      )}
+      <CreateEventDialog
+        open={createDialogOpen}
+        onOpenChange={handleCreateDialogOpenChange}
+        initiativeId={fixedInitiativeId}
+        defaultInitiativeId={initiativeId ?? undefined}
+        defaultStartDate={defaultStartDate}
+        onSuccess={handleEventCreated}
+      />
 
       <BulkEditAccessDialog
         open={bulkAccessOpen}

--- a/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
@@ -18,13 +18,11 @@ import {
 import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { useAuth } from "@/hooks/useAuth";
 import { useCreateFromSearchParam } from "@/hooks/useCreateFromSearchParam";
 import { getDefaultFiltersVisibility } from "@/hooks/useDefaultFiltersOpen";
 import { useGridSelection } from "@/hooks/useGridSelection";
-import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { INITIATIVE_FILTER_ALL, useInitiativeFilter } from "@/hooks/useInitiativeFilter";
-import { canCreateTool, useMyInitiativePermissions } from "@/hooks/useInitiativeRoles";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useQueuesList } from "@/hooks/useQueues";
 import { useGuildPath } from "@/lib/guildUrl";
@@ -37,8 +35,6 @@ type QueuesViewProps = {
 export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) => {
   const { t } = useTranslation(["queues", "common", "access"]);
   const router = useRouter();
-  const { user } = useAuth();
-  const { permissionsFor } = useInitiativeAccess();
   const gp = useGuildPath();
   const searchParams = useSearch({ strict: false }) as {
     initiativeId?: string;
@@ -51,10 +47,6 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
   const { initiativeFilter, setInitiativeFilter, filteredInitiativeId } = useInitiativeFilter({
     lockedInitiativeId,
   });
-
-  const { data: filteredInitiativePermissions } = useMyInitiativePermissions(
-    !lockedInitiativeId && filteredInitiativeId ? filteredInitiativeId : null
-  );
 
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
@@ -108,31 +100,13 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
     return map;
   }, [initiatives]);
 
-  // Initiatives the user can create queues in — resolved through the shared
-  // access helper so guild admins are included and frozen (read-only) guilds
-  // drop their create affordances.
-  const creatableInitiatives = useMemo(() => {
-    if (!user) return [];
-    return initiatives.filter((initiative) => permissionsFor(initiative)[Tool.queue].create);
-  }, [initiatives, user, permissionsFor]);
-
-  // Determine if user can create queues
-  const canCreateQueues = useMemo(() => {
-    if (canCreate !== undefined) return canCreate;
-    if (filteredInitiativeId && filteredInitiativePermissions) {
-      return canCreateTool(filteredInitiativePermissions, Tool.queue);
-    }
-    if (lockedInitiativeId) {
-      return creatableInitiatives.some((initiative) => initiative.id === lockedInitiativeId);
-    }
-    return creatableInitiatives.length > 0;
-  }, [
-    canCreate,
-    filteredInitiativeId,
-    filteredInitiativePermissions,
-    lockedInitiativeId,
-    creatableInitiatives,
-  ]);
+  // Canonical create answer: the locked/filtered initiative's server-computed
+  // create flag, or (in the "All" view) whether any visible initiative grants
+  // it. An explicit canCreate prop (e.g. from InitiativeDetailPage) wins.
+  const { canCreate: canCreateDerived } = useToolCreateAccess(Tool.queue, {
+    initiativeId: lockedInitiativeId ?? filteredInitiativeId,
+  });
+  const canCreateQueues = canCreate ?? canCreateDerived;
 
   const {
     open: createDialogOpen,


### PR DESCRIPTION
## Problem

Follow-up to the Part C audit (#876): the five tool list pages computed "can the user create this tool" five different ways, and a backend authorization audit showed the divergence is pre-permissions-rewrite drift, not design. All five create endpoints enforce the same rule — guild admin OR the caller's initiative role grants the `create_<tool>` PermissionKey — and the server already serializes the authoritative per-member answer (`can_create_{plural}` via `member_tool_flags`, plus `/my-permissions`). But the frontend still had:

- **ProjectDetailPage** — `canCreateDocuments = hasCapability(dataBypass) || isInitiativePm`: the `data.bypass` leg shows a button the backend 403s (it grants no standing create right), and the PM-string leg misses custom create-capable roles.
- **EventsPage** — hard `false` in the all-initiatives view, so users who can create events somewhere got no affordance at all.
- **ICalImportDialog** — target list from a `role === "project_manager"` string check (misses custom roles and guild admins).
- **CreateToolDialog** (queues/counters) — initiative picker listed **all** initiatives, including ones the user can't create in or where the tool is switched off.
- **DocumentDetailPage** — wikilink create read the raw membership flag, so guild admins / PAM grantees (no membership row) got `false`.
- **DocumentSettingsPage** — copy-to-initiative targets from `dataBypass || PM`, while the backend copy endpoint requires `create_documents` in the target initiative.

## Changes

- New [`useToolCreateAccess(tool, { initiativeId?, enabled? })`](frontend/src/hooks/useInitiativeAccess.ts) — the one canonical derivation, keyed by the `Tool` enum so a future tool gets it for free. Two branches, per the ticket: a specific initiative in context → `permissionsFor(initiative)[tool].create`; no initiative ("All" view) → "can create in at least one visible initiative". Also returns `creatableInitiatives` for the dialogs' pickers (create flags already fold in each tool's master switch).
- All five list pages ([ProjectsPage](frontend/src/pages/ProjectsPage.tsx), [DocumentsPage](frontend/src/pages/DocumentsPage.tsx), [EventsPage](frontend/src/pages/initiativeTools/events/EventsPage.tsx), [QueuesPage](frontend/src/pages/initiativeTools/queues/QueuesPage.tsx), [CounterGroupsPage](frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx)) adopt it and **drop their `useMyInitiativePermissions` fetch** — the initiatives payload they already load carries the same server-computed flags, so this removes one request per page/filter change. The explicit `canCreate` prop from InitiativeDetailPage/TagDetailPage still wins.
- [CreateEventDialog](frontend/src/components/initiativeTools/events/CreateEventDialog.tsx) gains the same optional-lock + initiative-picker shape as the shared CreateToolDialog (picker over creatable initiatives; attendees reset on target change since they're initiative members), enabling event creation from the all-initiatives calendar.
- [CreateToolDialog](frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx) config gains `tool: Tool` and its picker now offers only creatable initiatives; [ICalImportDialog](frontend/src/components/initiativeTools/events/ICalImportDialog.tsx), [ProjectDetailPage](frontend/src/pages/ProjectDetailPage.tsx), [DocumentDetailPage](frontend/src/pages/DocumentDetailPage.tsx), and [DocumentSettingsPage](frontend/src/pages/DocumentSettingsPage.tsx) all switch to the same seam.
- `EventsPage`'s task-chip drag proxy (`canEditTasks`) also moves to `permissionsFor`; the "All" view keeps chips non-draggable since its tasks span initiatives with differing access.

No client-side authorization decisions are added — every branch reads server-computed values (`member_tool_flags` + the guild-admin / PAM / content-frozen legs `permissionsFor` already mirrors from the backend). InitiativeDetailPage's tab pass-down (`/my-permissions`) is unchanged: it already matches the enforced rule and that endpoint is still needed for tab visibility.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `pnpm biome check <changed files>` — clean
- `./scripts/test-changed.sh` — shared infra changed, ran full suite: 70 files, 936 tests, all pass

Fixes #1030