### PR TITLE
Report no authoring for scoped PAM grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create buttons and initiative pickers for projects, documents, events, queues, and counter groups now consistently follow your actual per-initiative create permission. Members whose custom role grants creation see the affordances everywhere they apply, and buttons or picker entries the server would reject no longer appear.
 - The Events calendar now offers event creation in the all-initiatives view when you can create events in at least one initiative — the create dialog gains an initiative picker to choose the target, matching the other tools.
+- Platform staff acting in a guild through a scoped, time-bound access grant no longer see create buttons for new projects, documents, events, queues, or counter groups. Such a grant edits existing content only — the server already declined those creations, and the UI now reports the same answer instead of offering a dialog that fails on submit.
 
 ## [0.59.0] - 2026-08-03
 

--- a/backend/app/api/v1/platform_endpoints/access_grants_test.py
+++ b/backend/app/api/v1/platform_endpoints/access_grants_test.py
@@ -6,6 +6,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from datetime import datetime, timedelta, timezone
 
+from app.core.tools import Tool
 from app.models.platform.access_grant import AccessGrant
 from app.models.platform.user import UserRole
 from app.testing import (
@@ -449,6 +450,82 @@ async def test_grantee_sees_guild_content(client: AsyncClient, session: AsyncSes
         f"/api/v1/g/{guild.id}/projects/{project.id}/view", headers=headers
     )
     assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.integration
+async def test_scoped_read_write_grant_cannot_author_tools(
+    client: AsyncClient, session: AsyncSession
+):
+    """A scoped read_write grant edits *existing* content only. Authoring a
+    new top-level tool is an initiative-role permission a grantee never holds,
+    so ``my-permissions`` must report every create flag off (the UI keys its
+    create affordances on these flags) while view flags stay on — and an
+    actual create attempt is denied."""
+    owner = await create_user(
+        session, email="owner-scoped-rw@example.com", role=UserRole.owner
+    )
+    moderator = await create_user(
+        session, email="moderator-scoped-rw@example.com", role=UserRole.moderator
+    )
+    guild = await create_guild(session, creator=owner)
+    init = await create_initiative(session, guild, owner, name="Scoped Wing")
+    await _approved_read_grant(
+        session, user=moderator, guild=guild, owner=owner, level="read_write"
+    )
+
+    headers = get_auth_headers(moderator)
+
+    resp = await client.get(
+        f"/api/v1/g/{guild.id}/initiatives/{init.id}/my-permissions", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    perms = resp.json()
+    assert perms["is_manager"] is False
+    for tool in Tool:
+        assert perms["permissions"][tool.create_permission] is False, (
+            f"scoped read_write grant must not author {tool.plural}"
+        )
+    # View access is unaffected — core tools stay visible.
+    assert perms["permissions"]["projects_enabled"] is True
+    assert perms["permissions"]["documents_enabled"] is True
+
+    resp = await client.post(
+        f"/api/v1/g/{guild.id}/projects/",
+        headers=headers,
+        json={"name": "Grantee Project", "initiative_id": init.id},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.integration
+async def test_break_glass_grant_reports_admin_permissions(
+    client: AsyncClient, session: AsyncSession
+):
+    """A read_write grant held by a ``data.bypass`` user is break-glass: it is
+    answered from the guild-admin branch, so create flags stay on — the
+    distinction the scoped branch above must not blur."""
+    owner = await create_user(
+        session, email="owner-bg-perms@example.com", role=UserRole.owner
+    )
+    operator = await create_user(
+        session, email="operator-bg-perms@example.com", role=UserRole.operator
+    )
+    guild = await create_guild(session, creator=owner)
+    init = await create_initiative(session, guild, owner, name="Break Glass Wing")
+    await _approved_read_grant(
+        session, user=operator, guild=guild, owner=owner, level="read_write"
+    )
+
+    headers = get_auth_headers(operator)
+
+    resp = await client.get(
+        f"/api/v1/g/{guild.id}/initiatives/{init.id}/my-permissions", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    perms = resp.json()
+    assert perms["is_manager"] is True
+    assert perms["permissions"]["create_projects"] is True
+    assert perms["permissions"]["create_documents"] is True
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -25,7 +25,6 @@ from app.core.security import (
 )
 from app.core.config import settings
 from app.core.tools import CORE_TOOLS, TOGGLEABLE_TOOLS, Tool
-from app.models.platform.access_grant import AccessLevel
 from app.models.tenant.document import Document
 from app.models.tenant.project import Project
 from app.models.tenant.resource_grant import ResourceGrant, ResourceAccessLevel
@@ -666,23 +665,19 @@ async def get_my_initiative_permissions(
             advanced_tools_enabled=initiative.advanced_tools_enabled,
         )
 
-    # PAM grantee: time-bound, guild-wide access with no membership row. They
-    # can view every section (gated by the initiative's feature switches);
-    # create affordances follow the grant's access level. A grant never confers
-    # management.
+    # Scoped PAM grantee: time-bound, guild-wide access with no membership
+    # row. They can view every section (gated by the initiative's feature
+    # switches), and a read_write grant edits *existing* content only —
+    # authoring a new tool is an initiative-role permission a grantee never
+    # holds, so every create flag stays off. (Break-glass never reaches this
+    # branch: it is routed as a synthetic guild admin and answered above.)
+    # A grant never confers management.
     if guild_context.is_pam:
-        can_write = (
-            guild_context.grant is not None
-            and guild_context.grant.access_level == AccessLevel.read_write.value
-        )
         return MyInitiativePermissions(
             is_manager=False,
             permissions={
                 **{PermissionKey(t.view_permission): tool_available(t) for t in Tool},
-                **{
-                    PermissionKey(t.create_permission): tool_available(t) and can_write
-                    for t in Tool
-                },
+                **{PermissionKey(t.create_permission): False for t in Tool},
             },
             advanced_tools_enabled=initiative.advanced_tools_enabled,
         )

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -270,9 +270,11 @@ export const CreateEventDialog = ({
                 value={selectedInitiativeId}
                 onValueChange={(value) => {
                   setSelectedInitiativeId(value);
-                  // Attendees are initiative members; a new target starts over
-                  // with just the creator.
+                  // Attendees and access grants are initiative-scoped; a new
+                  // target starts over with just the creator and default
+                  // access.
                   setAttendeeIds(user ? [user.id] : []);
+                  setGrants([...DEFAULT_GRANTS]);
                 }}
               >
                 <SelectTrigger id="create-event-initiative">

--- a/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
+++ b/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
@@ -195,7 +195,15 @@ export const CreateToolDialog = <TRead,>({
                 {lockedInitiative?.name ?? t("selectInitiative")}
               </div>
             ) : (
-              <Select value={selectedInitiativeId} onValueChange={setSelectedInitiativeId}>
+              <Select
+                value={selectedInitiativeId}
+                onValueChange={(value) => {
+                  setSelectedInitiativeId(value);
+                  // Access grants are initiative-scoped; a new target starts
+                  // over with default access.
+                  setGrants([...DEFAULT_GRANTS]);
+                }}
+              >
                 <SelectTrigger id={`${idPrefix}-initiative`}>
                   <SelectValue placeholder={t("selectInitiative")} />
                 </SelectTrigger>

--- a/frontend/src/hooks/useInitiativeAccess.test.ts
+++ b/frontend/src/hooks/useInitiativeAccess.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { buildInitiative, buildUser } from "@/__tests__/factories";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
+import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+
+const mockUseAuth = vi.fn();
+const mockUseGuilds = vi.fn();
+
+vi.mock("@/hooks/useAuth", () => ({ useAuth: () => mockUseAuth() }));
+vi.mock("@/hooks/useGuilds", () => ({ useGuilds: () => mockUseGuilds() }));
+
+// A guild reached via a PAM grant rather than membership. Grant entries always
+// carry role "member" — the break-glass distinction must come from the grant
+// level + the holder's server-computed capabilities, never the role field.
+const grantGuild = (level: "read" | "read_write") => ({
+  id: 1,
+  role: "member",
+  accessType: "grant",
+  grantAccessLevel: level,
+});
+
+describe("useInitiativeAccess grant classification", () => {
+  it("gives a scoped read grant full view but no create", () => {
+    mockUseAuth.mockReturnValue({ user: buildUser({ role: "moderator" }) });
+    mockUseGuilds.mockReturnValue({ activeGuild: grantGuild("read") });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    const access = result.current.permissionsFor(buildInitiative());
+
+    expect(access[Tool.project]).toEqual({ view: true, create: false });
+    expect(access[Tool.document]).toEqual({ view: true, create: false });
+  });
+
+  it("gives a scoped read_write grant (no data.bypass) no create affordances", () => {
+    // The request→approve flow: a read_write grant edits existing content
+    // only — authoring new tools is denied server-side, so the UI must not
+    // offer it.
+    mockUseAuth.mockReturnValue({ user: buildUser({ role: "moderator" }) });
+    mockUseGuilds.mockReturnValue({ activeGuild: grantGuild("read_write") });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    const access = result.current.permissionsFor(buildInitiative());
+
+    expect(access[Tool.project]).toEqual({ view: true, create: false });
+    expect(access[Tool.document]).toEqual({ view: true, create: false });
+  });
+
+  it("gives a break-glass read_write grant (data.bypass holder) full create", () => {
+    // An operator's read_write grant is break-glass: the backend routes it as
+    // a synthetic guild admin, so create affordances stay on.
+    mockUseAuth.mockReturnValue({ user: buildUser({ role: "operator" }) });
+    mockUseGuilds.mockReturnValue({ activeGuild: grantGuild("read_write") });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    const access = result.current.permissionsFor(buildInitiative());
+
+    expect(access[Tool.project]).toEqual({ view: true, create: true });
+    expect(access[Tool.document]).toEqual({ view: true, create: true });
+  });
+
+  it("never lets a read grant create even for a data.bypass holder", () => {
+    // Break-glass requires read_write; an operator's read grant stays
+    // view-only.
+    mockUseAuth.mockReturnValue({ user: buildUser({ role: "operator" }) });
+    mockUseGuilds.mockReturnValue({ activeGuild: grantGuild("read") });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    const access = result.current.permissionsFor(buildInitiative());
+
+    expect(access[Tool.project]).toEqual({ view: true, create: false });
+  });
+});

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -4,6 +4,7 @@ import type { InitiativeRead, Tool } from "@/api/generated/initiativeAPI.schemas
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiatives } from "@/hooks/useInitiatives";
+import { Capability, hasCapability } from "@/lib/permissions";
 import {
   isToolEnabled,
   TOOL_REGISTRY,
@@ -63,6 +64,14 @@ export function useInitiativeAccess() {
   const isGuildAdmin = activeGuild?.role === "admin";
   const isGrantGuild = activeGuild?.accessType === "grant";
   const grantReadWrite = isGrantGuild && activeGuild?.grantAccessLevel === "read_write";
+  // A read_write grant is *break-glass* — the holder acts as a full guild
+  // admin for its window — only when held by a `data.bypass` user; the
+  // backend routes it as a synthetic guild admin. Any other grant (the
+  // request→approve flow) is scoped: it edits existing content only, so
+  // authoring new tools stays off. Both inputs are server-computed (the
+  // grant's access level and UserRead.capabilities), mirroring the backend's
+  // own break-glass rule.
+  const isBreakGlass = grantReadWrite && hasCapability(user, Capability.dataBypass);
   // Content writes are frozen server-side (read_only lifecycle status) for
   // real members — admins included. Grant entries never carry the flag (PAM /
   // break-glass override the status), so no accessType check is needed.
@@ -93,7 +102,7 @@ export function useInitiativeAccess() {
     (initiative: InitiativeRead): InitiativeToolAccess => {
       if (!user) return readOnlyDefault;
       if (isGuildAdmin) return fullAccess(initiative, !contentReadOnly);
-      if (isGrantGuild) return fullAccess(initiative, grantReadWrite);
+      if (isGrantGuild) return fullAccess(initiative, isBreakGlass);
       const membership = initiative.members.find((m) => m.user.id === user.id);
       if (!membership) return readOnlyDefault;
       return Object.fromEntries(
@@ -106,7 +115,7 @@ export function useInitiativeAccess() {
         ])
       ) as InitiativeToolAccess;
     },
-    [user, isGuildAdmin, isGrantGuild, grantReadWrite, contentReadOnly]
+    [user, isGuildAdmin, isGrantGuild, isBreakGlass, contentReadOnly]
   );
 
   /** Whether the user can manage (PM/admin) a specific initiative. A grant


### PR DESCRIPTION
## Problem

#881: as a moderator with a scoped PAM `read_write` grant (request→approve flow), the UI showed create buttons for all tools, but creating any top-level tool failed with a 403. The backend behavior is the documented design — a scoped grant edits *existing* content only; authoring requires an initiative-role `create_*` permission a grantee never holds, and only **break-glass** (a `read_write` grant held by a `data.bypass` user, routed as a synthetic guild admin) can author. The bug was that both frontend permission seams contradicted it, making the UI the source of truth instead of the server. This is Option A from the issue: align the UI with the enforced design.

## Changes

- **Backend** — [`GET /initiatives/{id}/my-permissions`](backend/app/api/v1/tenant_endpoints/initiatives.py) PAM branch now reports every `create_*` flag off. Only scoped grants reach this branch: break-glass carries a synthetic admin role and is answered from the guild-admin branch above it (verified in `deps.py` — `break_glass` ⇒ `GuildRole.admin`). View flags are unchanged.
- **Frontend** — [`useInitiativeAccess`](frontend/src/hooks/useInitiativeAccess.ts)'s grant branch now grants create affordances only for break-glass, derived exactly as the backend derives it — `grant.access_level === "read_write"` **and** the holder has the `data.bypass` capability — both server-computed inputs (`AccessGrantRead.access_level`, `UserRead.capabilities`). Scoped grantees keep full view access; every `create` flag is false, so all the affordances keyed on `permissionsFor` (list-page buttons, dialog pickers, bottom-nav create) disappear together.
- **Regression tests** ([access_grants_test.py](backend/app/api/v1/platform_endpoints/access_grants_test.py)): a scoped `read_write` grantee gets `create_* = False` for every tool from my-permissions, keeps view flags, and a real project create is denied; a break-glass holder (operator) gets the guild-admin answer (`is_manager`, create flags on) — pinning the branch distinction.

Note: PR #1032 (canCreate unification, #1030) also touches `useInitiativeAccess.ts` and the changelog in non-overlapping hunks; whichever merges second may need a trivial changelog-header resolution.

## Testing

- `cd backend && pytest app/api/v1/platform_endpoints/access_grants_test.py` — 14 passed (incl. the 2 new tests; the scoped-grant one fails against the old code)
- `pytest app/api/v1/tenant_endpoints/initiatives_test.py app/api/v1/tenant_endpoints/initiative_share_override_test.py app/api/guild_suspension_test.py` — 67 passed
- `ruff check app` clean; `ruff format app` no changes
- `cd frontend && pnpm typecheck` clean; `pnpm biome check src/hooks/useInitiativeAccess.ts` clean; `./scripts/test-changed.sh` ran the full suite: 936 tests pass

Fixes #881