### PR TITLE
Gate the global create wizards on permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create buttons and initiative pickers for projects, documents, events, queues, and counter groups now consistently follow your actual per-initiative create permission. Members whose custom role grants creation see the affordances everywhere they apply, and buttons or picker entries the server would reject no longer appear.
 - The Events calendar now offers event creation in the all-initiatives view when you can create events in at least one initiative — the create dialog gains an initiative picker to choose the target, matching the other tools.
 - Platform staff acting in a guild through a scoped, time-bound access grant no longer see create buttons for new projects, documents, events, queues, or counter groups. Such a grant edits existing content only — the server already declined those creations, and the UI now reports the same answer instead of offering a dialog that fails on submit.
+- The global "+" quick-create for documents and tasks (the bottom-bar menu and the command palette) now follows your create permission: its items hide when you can't create the thing in any of your guilds, and the wizards list only the guilds and initiatives you can actually create in — so you no longer walk through a wizard only to be refused on submit.
 
 ## [0.59.0] - 2026-08-03
 

--- a/frontend/public/locales/de/documents.json
+++ b/frontend/public/locales/de/documents.json
@@ -260,7 +260,7 @@
     "selectInitiative": "Wähle eine Initiative",
     "lastUsed": "Zuletzt verwendet",
     "back": "Zurück",
-    "noInitiatives": "Keine Initiativen in dieser Gilde gefunden."
+    "noInitiatives": "Keine Initiativen hier, zu denen du Dokumente hinzufügen kannst."
   },
   "viewer": {
     "loadError": "Dokument kann nicht geladen werden",

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -260,7 +260,7 @@
     "selectInitiative": "Select an initiative",
     "lastUsed": "Last used",
     "back": "Back",
-    "noInitiatives": "No initiatives found in this guild."
+    "noInitiatives": "No initiatives here you can add documents to."
   },
   "viewer": {
     "loadError": "Unable to load document",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -260,7 +260,7 @@
     "selectInitiative": "Selecciona una iniciativa",
     "lastUsed": "Último usado",
     "back": "Atrás",
-    "noInitiatives": "No se encontraron iniciativas en este gremio."
+    "noInitiatives": "No hay iniciativas aquí a las que puedas añadir documentos."
   },
   "viewer": {
     "loadError": "No se pudo cargar el documento",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -260,7 +260,7 @@
     "selectInitiative": "Sélectionnez une initiative",
     "lastUsed": "Dernier utilisé",
     "back": "Retour",
-    "noInitiatives": "Aucune initiative trouvée dans ce groupe."
+    "noInitiatives": "Aucune initiative ici à laquelle vous pouvez ajouter des documents."
   },
   "viewer": {
     "loadError": "Impossible de charger le document",

--- a/frontend/src/components/CommandCenter.tsx
+++ b/frontend/src/components/CommandCenter.tsx
@@ -29,6 +29,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useGlobalCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useRecents } from "@/hooks/useRecents";
 import { useTaskAutocomplete, useTasks } from "@/hooks/useTasks";
 import { commandFilter } from "@/lib/fuzzyMatch";
@@ -52,6 +53,7 @@ export function CommandCenter() {
   const router = useRouter();
   const { user } = useAuth();
   const { activeGuild, activeGuildId } = useGuilds();
+  const globalCreate = useGlobalCreateAccess();
   const getGuildPath = useGuildPath();
 
   // Switch into "guild-wide title search" mode once the debounced query is at
@@ -230,28 +232,33 @@ export function CommandCenter() {
       <CommandList>
         <CommandEmpty>{t("noResults")}</CommandEmpty>
 
-        {/* Actions */}
+        {/* Actions — each shown only when the user can land its wizard
+            somewhere (cmdk hides the group if it ends up empty). */}
         <CommandGroup heading={t("groups.actions")}>
-          <CommandItem
-            value="action-add-task"
-            onSelect={() => {
-              setOpen(false);
-              getOpenCreateTaskWizard()?.();
-            }}
-          >
-            <Plus className="text-muted-foreground" />
-            <span>{t("actions.addTask")}</span>
-          </CommandItem>
-          <CommandItem
-            value="action-add-document"
-            onSelect={() => {
-              setOpen(false);
-              getOpenCreateDocumentWizard()?.();
-            }}
-          >
-            <FilePlus className="text-muted-foreground" />
-            <span>{t("actions.addDocument")}</span>
-          </CommandItem>
+          {globalCreate.task && (
+            <CommandItem
+              value="action-add-task"
+              onSelect={() => {
+                setOpen(false);
+                getOpenCreateTaskWizard()?.();
+              }}
+            >
+              <Plus className="text-muted-foreground" />
+              <span>{t("actions.addTask")}</span>
+            </CommandItem>
+          )}
+          {globalCreate.document && (
+            <CommandItem
+              value="action-add-document"
+              onSelect={() => {
+                setOpen(false);
+                getOpenCreateDocumentWizard()?.();
+              }}
+            >
+              <FilePlus className="text-muted-foreground" />
+              <span>{t("actions.addDocument")}</span>
+            </CommandItem>
+          )}
         </CommandGroup>
 
         {/* Suggested — mixed recents across projects/documents/queues/counter

--- a/frontend/src/components/documents/CreateDocumentWizard.tsx
+++ b/frontend/src/components/documents/CreateDocumentWizard.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, FileText, Loader2, Zap } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { GuildAvatar } from "@/components/guilds/GuildSidebar";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,8 +13,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
-import { useInitiativesForGuild } from "@/hooks/useInitiatives";
+import { guildMayAuthorTools, useCreatableInitiatives } from "@/hooks/useInitiativeAccess";
 import { guildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
 import { getItem, removeItem, setItem } from "@/lib/storage";
@@ -71,7 +73,15 @@ type Step = "select-guild" | "select-initiative";
 export const CreateDocumentWizard = () => {
   const { t } = useTranslation("documents");
   const router = useRouter();
-  const { guilds } = useGuilds();
+  const { user } = useAuth();
+  const { guilds: allGuilds } = useGuilds();
+  // Only guilds the user could author a document in — drops frozen guilds and
+  // scoped PAM grants (which edit existing content but never author). The
+  // precise per-initiative call is made on the next step.
+  const guilds = useMemo(
+    () => allGuilds.filter((guild) => guildMayAuthorTools(guild, user)),
+    [allGuilds, user]
+  );
 
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<Step>("select-guild");
@@ -104,10 +114,12 @@ export const CreateDocumentWizard = () => {
 
   // ── Data fetching ───────────────────────────────────────────────────────
 
-  const initiativesQuery = useInitiativesForGuild(
+  // Initiatives the user can actually create documents in for the selected
+  // guild — fetched lazily only once the initiative step is reached.
+  const { initiatives, isLoading: initiativesLoading } = useCreatableInitiatives(
+    Tool.document,
     step === "select-initiative" ? selectedGuildId : null
   );
-  const initiatives = useMemo(() => initiativesQuery.data ?? [], [initiativesQuery.data]);
 
   // ── Handlers ────────────────────────────────────────────────────────────
 
@@ -176,14 +188,14 @@ export const CreateDocumentWizard = () => {
     if (
       open &&
       step === "select-initiative" &&
-      !initiativesQuery.isLoading &&
+      !initiativesLoading &&
       initiatives.length === 1 &&
       autoAdvancedRef.current !== "initiative"
     ) {
       autoAdvancedRef.current = "initiative";
       handleInitiativeSelect(initiatives[0].id, initiatives[0].name);
     }
-  }, [open, step, initiatives, initiativesQuery.isLoading, handleInitiativeSelect]);
+  }, [open, step, initiatives, initiativesLoading, handleInitiativeSelect]);
 
   const handleBack = useCallback(() => {
     autoAdvancedRef.current = null;
@@ -258,7 +270,7 @@ export const CreateDocumentWizard = () => {
         {/* Step 2: Select Initiative */}
         {step === "select-initiative" && (
           <div className="space-y-2">
-            {initiativesQuery.isLoading ? (
+            {initiativesLoading ? (
               <div className="flex items-center justify-center py-8">
                 <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
               </div>

--- a/frontend/src/components/navigation/BottomNav.tsx
+++ b/frontend/src/components/navigation/BottomNav.tsx
@@ -17,6 +17,7 @@ import {
 import { useSidebar } from "@/components/ui/sidebar";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAuth } from "@/hooks/useAuth";
+import { useGlobalCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useNotifications } from "@/hooks/useNotifications";
 
 const pillClass =
@@ -34,6 +35,7 @@ export function BottomNav() {
   const { setOpenMobile } = useSidebar();
   const { user } = useAuth();
   const { isCreateContext, action } = usePrimaryCreateAction();
+  const globalCreate = useGlobalCreateAccess();
 
   const notificationsQuery = useNotifications({
     refetchInterval: 30_000,
@@ -42,8 +44,11 @@ export function BottomNav() {
   const unreadCount = notificationsQuery.data?.unread_count ?? 0;
 
   // Hide the add button entirely on a create-context route where the user lacks
-  // permission. Non-create routes (no registration) fall back to the global menu.
-  const hideAdd = isCreateContext && action === null;
+  // permission. Non-create routes (no registration) fall back to the global menu,
+  // which itself hides when the user can create neither tasks nor documents in
+  // any of their guilds.
+  const canCreateGlobal = globalCreate.document || globalCreate.task;
+  const hideAdd = isCreateContext ? action === null : !canCreateGlobal;
 
   return (
     <div
@@ -112,14 +117,18 @@ export function BottomNav() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" side="top" className="mb-2">
-                <DropdownMenuItem onSelect={() => getOpenCreateTaskWizard()?.()}>
-                  <SquareCheckBig className="mr-2 h-4 w-4" />
-                  {t("bottomNav.addTask")}
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => getOpenCreateDocumentWizard()?.()}>
-                  <FilePlus className="mr-2 h-4 w-4" />
-                  {t("bottomNav.addDocument")}
-                </DropdownMenuItem>
+                {globalCreate.task && (
+                  <DropdownMenuItem onSelect={() => getOpenCreateTaskWizard()?.()}>
+                    <SquareCheckBig className="mr-2 h-4 w-4" />
+                    {t("bottomNav.addTask")}
+                  </DropdownMenuItem>
+                )}
+                {globalCreate.document && (
+                  <DropdownMenuItem onSelect={() => getOpenCreateDocumentWizard()?.()}>
+                    <FilePlus className="mr-2 h-4 w-4" />
+                    {t("bottomNav.addDocument")}
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           ))}

--- a/frontend/src/components/tasks/CreateTaskWizard.tsx
+++ b/frontend/src/components/tasks/CreateTaskWizard.tsx
@@ -13,7 +13,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
+import { guildMayWriteContent } from "@/hooks/useInitiativeAccess";
 import { useInitiativesForGuild } from "@/hooks/useInitiatives";
 import { useGlobalProjects } from "@/hooks/useProjects";
 import { guildPath } from "@/lib/guildUrl";
@@ -76,7 +78,17 @@ type Step = "select-guild" | "select-initiative" | "select-project";
 export const CreateTaskWizard = () => {
   const { t } = useTranslation("tasks");
   const router = useRouter();
-  const { guilds } = useGuilds();
+  const { user } = useAuth();
+  const { guilds: allGuilds } = useGuilds();
+  // A task is child content of a project, so it needs content-write access
+  // somewhere in the guild. Drop guilds where writes are impossible (frozen, or
+  // a read-only PAM grant); the project step then applies the precise per-project
+  // DAC check. A scoped read_write grant is kept — it can create tasks in
+  // projects it can write.
+  const guilds = useMemo(
+    () => allGuilds.filter((guild) => guildMayWriteContent(guild, user)),
+    [allGuilds, user]
+  );
 
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<Step>("select-guild");

--- a/frontend/src/hooks/useInitiativeAccess.test.ts
+++ b/frontend/src/hooks/useInitiativeAccess.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { buildInitiative, buildUser } from "@/__tests__/factories";
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
-import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import type { GuildEntry } from "@/hooks/useGuilds";
+import {
+  guildMayAuthorTools,
+  guildMayWriteContent,
+  useGlobalCreateAccess,
+  useInitiativeAccess,
+} from "@/hooks/useInitiativeAccess";
 
 const mockUseAuth = vi.fn();
 const mockUseGuilds = vi.fn();
@@ -70,5 +76,79 @@ describe("useInitiativeAccess grant classification", () => {
     const access = result.current.permissionsFor(buildInitiative());
 
     expect(access[Tool.project]).toEqual({ view: true, create: false });
+  });
+});
+
+// Minimal switcher entries for the cheap, entry-point create gates.
+const memberGuild = (over: Partial<GuildEntry> = {}) =>
+  ({ id: 1, role: "member", ...over }) as GuildEntry;
+const adminGuild = (over: Partial<GuildEntry> = {}) =>
+  ({ id: 1, role: "admin", ...over }) as GuildEntry;
+const grantEntry = (level: "read" | "read_write") =>
+  ({ id: 1, role: "member", accessType: "grant", grantAccessLevel: level }) as GuildEntry;
+
+describe("guild create gates (cheap, switcher-only)", () => {
+  const member = buildUser({ role: "member" });
+  const operator = buildUser({ role: "operator" }); // holds data.bypass
+
+  it("keeps a plain member for both authoring and writing", () => {
+    expect(guildMayAuthorTools(memberGuild(), member)).toBe(true);
+    expect(guildMayWriteContent(memberGuild(), member)).toBe(true);
+  });
+
+  it("drops a frozen guild for both gates", () => {
+    const frozen = memberGuild({ content_read_only: true });
+    expect(guildMayAuthorTools(frozen, member)).toBe(false);
+    expect(guildMayWriteContent(frozen, member)).toBe(false);
+  });
+
+  it("keeps an admin for both gates", () => {
+    expect(guildMayAuthorTools(adminGuild(), member)).toBe(true);
+    expect(guildMayWriteContent(adminGuild(), member)).toBe(true);
+  });
+
+  it("lets a scoped read_write grant write but not author", () => {
+    // The #881 rule: a scoped grant edits existing content (tasks in existing
+    // projects) but never authors a new tool. data.bypass makes it break-glass.
+    const scoped = grantEntry("read_write");
+    expect(guildMayAuthorTools(scoped, member)).toBe(false);
+    expect(guildMayWriteContent(scoped, member)).toBe(true);
+    expect(guildMayAuthorTools(scoped, operator)).toBe(true); // break-glass authors
+  });
+
+  it("denies a read grant both gates", () => {
+    const read = grantEntry("read");
+    expect(guildMayAuthorTools(read, operator)).toBe(false);
+    expect(guildMayWriteContent(read, operator)).toBe(false);
+  });
+});
+
+describe("useGlobalCreateAccess", () => {
+  it("is false for both when every guild is frozen or read-only-granted", () => {
+    mockUseAuth.mockReturnValue({ user: buildUser({ role: "member" }) });
+    mockUseGuilds.mockReturnValue({
+      guilds: [memberGuild({ id: 1, content_read_only: true }), grantEntry("read")],
+    });
+
+    const { result } = renderHook(() => useGlobalCreateAccess());
+    expect(result.current).toEqual({ document: false, task: false });
+  });
+
+  it("separates authoring from writing for a scoped read_write grant", () => {
+    // Only guild is a scoped read_write grant: can create tasks (write) but not
+    // author documents.
+    mockUseAuth.mockReturnValue({ user: buildUser({ role: "member" }) });
+    mockUseGuilds.mockReturnValue({ guilds: [grantEntry("read_write")] });
+
+    const { result } = renderHook(() => useGlobalCreateAccess());
+    expect(result.current).toEqual({ document: false, task: true });
+  });
+
+  it("is true for both when a member guild is present", () => {
+    mockUseAuth.mockReturnValue({ user: buildUser({ role: "member" }) });
+    mockUseGuilds.mockReturnValue({ guilds: [memberGuild()] });
+
+    const { result } = renderHook(() => useGlobalCreateAccess());
+    expect(result.current).toEqual({ document: true, task: true });
   });
 });

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -1,9 +1,9 @@
 import { useCallback, useMemo } from "react";
 
-import type { InitiativeRead, Tool } from "@/api/generated/initiativeAPI.schemas";
+import type { InitiativeRead, Tool, UserRead } from "@/api/generated/initiativeAPI.schemas";
 import { useAuth } from "@/hooks/useAuth";
-import { useGuilds } from "@/hooks/useGuilds";
-import { useInitiatives } from "@/hooks/useInitiatives";
+import { type GuildEntry, useGuilds } from "@/hooks/useGuilds";
+import { useInitiatives, useInitiativesForGuild } from "@/hooks/useInitiatives";
 import { Capability, hasCapability } from "@/lib/permissions";
 import {
   isToolEnabled,
@@ -24,6 +24,41 @@ export type InitiativeToolAccess = Record<Tool, ToolAccess>;
 
 const byName = (a: InitiativeRead, b: InitiativeRead) => a.name.localeCompare(b.name);
 
+/** The current user's standing in ONE guild — the admin / grant / break-glass /
+ * frozen legs the create logic branches on, resolved from that guild's switcher
+ * entry rather than assumed to be the active guild. Deriving these in one place
+ * lets both the active-guild hook and the cross-guild wizards share the exact
+ * same rule. */
+export interface GuildAccessContext {
+  isGuildAdmin: boolean;
+  isGrantGuild: boolean;
+  /** A read_write PAM grant (scoped or break-glass) — clears content-write DAC. */
+  grantReadWrite: boolean;
+  /** A read_write grant held by a `data.bypass` user: the backend routes it as a
+   * synthetic guild admin, so it may author new tools. A scoped read_write grant
+   * (no `data.bypass`) may edit existing content but not author — see #881. */
+  isBreakGlass: boolean;
+  contentReadOnly: boolean;
+}
+
+/**
+ * Resolve a guild's access context from its switcher entry + the current user.
+ * Works for ANY guild, so the active-guild hook and the cross-guild create
+ * wizards derive create permission the same way instead of re-implementing the
+ * admin / grant / frozen branches.
+ */
+export function deriveGuildAccess(
+  guild: GuildEntry | null | undefined,
+  user: Pick<UserRead, "capabilities"> | null | undefined
+): GuildAccessContext {
+  const isGuildAdmin = guild?.role === "admin";
+  const isGrantGuild = guild?.accessType === "grant";
+  const grantReadWrite = isGrantGuild && guild?.grantAccessLevel === "read_write";
+  const isBreakGlass = grantReadWrite && hasCapability(user, Capability.dataBypass);
+  const contentReadOnly = Boolean(guild?.content_read_only);
+  return { isGuildAdmin, isGrantGuild, grantReadWrite, isBreakGlass, contentReadOnly };
+}
+
 // Full visibility into every tool (gated by the initiative's master
 // switches); `canCreate` toggles the create affordances.
 const fullAccess = (initiative: InitiativeRead, canCreate: boolean): InitiativeToolAccess =>
@@ -39,6 +74,73 @@ const fullAccess = (initiative: InitiativeRead, canCreate: boolean): InitiativeT
 const readOnlyDefault: InitiativeToolAccess = Object.fromEntries(
   TOOLS.map((tool) => [tool, { view: TOOL_REGISTRY[tool].core, create: false }])
 ) as InitiativeToolAccess;
+
+/**
+ * Effective per-tool access for one initiative given a resolved guild context —
+ * the shared body behind `useInitiativeAccess().permissionsFor` (active guild)
+ * and the cross-guild create wizards. Reads server-computed values only: the
+ * guild-admin / grant legs, then the membership's `member_tool_flags`.
+ */
+export function toolAccessForInitiative(
+  access: GuildAccessContext,
+  initiative: InitiativeRead,
+  userId: number
+): InitiativeToolAccess {
+  const { isGuildAdmin, isGrantGuild, isBreakGlass, contentReadOnly } = access;
+  if (isGuildAdmin) return fullAccess(initiative, !contentReadOnly);
+  if (isGrantGuild) return fullAccess(initiative, isBreakGlass);
+  const membership = initiative.members.find((m) => m.user.id === userId);
+  if (!membership) return readOnlyDefault;
+  return Object.fromEntries(
+    TOOLS.map((tool) => [
+      tool,
+      {
+        view: Boolean(membership[toolMemberViewFlag(tool)] ?? TOOL_REGISTRY[tool].core),
+        create: !contentReadOnly && Boolean(membership[toolMemberCreateFlag(tool)] ?? false),
+      },
+    ])
+  ) as InitiativeToolAccess;
+}
+
+/**
+ * Cheap, switcher-entry-only test for whether the user could **author a new
+ * top-level tool** (gate 3) somewhere in this guild — used to gate always-mounted
+ * surfaces (the global create wizards' entry points and guild pickers) without
+ * fetching every guild's initiatives. It never yields a false "cannot": a real
+ * member is kept even though the definite answer needs their initiative role, so
+ * the wizard's own initiative picker makes the precise call. It excludes only the
+ * provably-dead guilds — frozen guilds and scoped PAM grants (which edit existing
+ * content but never author, per #881).
+ */
+export function guildMayAuthorTools(
+  guild: GuildEntry,
+  user: Pick<UserRead, "capabilities"> | null | undefined
+): boolean {
+  const a = deriveGuildAccess(guild, user);
+  if (a.contentReadOnly) return false;
+  if (a.isGuildAdmin) return true;
+  if (a.isGrantGuild) return a.isBreakGlass;
+  return true; // real member — the precise per-initiative answer is left to the picker
+}
+
+/**
+ * Cheap, switcher-entry-only test for whether the user could **write existing
+ * content** (gate 4 — e.g. create a task inside a project they can write) somewhere
+ * in this guild. Unlike authoring, a scoped read_write PAM grant qualifies (its
+ * `pam_write` clears content-write DAC). Excludes frozen guilds and read-only
+ * grants; a real member is kept (the precise per-project answer is left to the
+ * wizard's project step).
+ */
+export function guildMayWriteContent(
+  guild: GuildEntry,
+  user: Pick<UserRead, "capabilities"> | null | undefined
+): boolean {
+  const a = deriveGuildAccess(guild, user);
+  if (a.contentReadOnly) return false;
+  if (a.isGuildAdmin) return true;
+  if (a.isGrantGuild) return a.grantReadWrite;
+  return true; // real member — the precise per-project answer is left to the picker
+}
 
 /**
  * Centralizes "what initiatives can the current user see, and what can they do
@@ -61,21 +163,8 @@ export function useInitiativeAccess() {
   const { user } = useAuth();
   const { activeGuild } = useGuilds();
 
-  const isGuildAdmin = activeGuild?.role === "admin";
-  const isGrantGuild = activeGuild?.accessType === "grant";
-  const grantReadWrite = isGrantGuild && activeGuild?.grantAccessLevel === "read_write";
-  // A read_write grant is *break-glass* — the holder acts as a full guild
-  // admin for its window — only when held by a `data.bypass` user; the
-  // backend routes it as a synthetic guild admin. Any other grant (the
-  // request→approve flow) is scoped: it edits existing content only, so
-  // authoring new tools stays off. Both inputs are server-computed (the
-  // grant's access level and UserRead.capabilities), mirroring the backend's
-  // own break-glass rule.
-  const isBreakGlass = grantReadWrite && hasCapability(user, Capability.dataBypass);
-  // Content writes are frozen server-side (read_only lifecycle status) for
-  // real members — admins included. Grant entries never carry the flag (PAM /
-  // break-glass override the status), so no accessType check is needed.
-  const contentReadOnly = Boolean(activeGuild?.content_read_only);
+  const access = useMemo(() => deriveGuildAccess(activeGuild, user), [activeGuild, user]);
+  const { isGuildAdmin, isGrantGuild, grantReadWrite } = access;
   // Admins and PAM grantees see every initiative in the guild.
   const seesAllInitiatives = isGuildAdmin || isGrantGuild;
 
@@ -101,21 +190,9 @@ export function useInitiativeAccess() {
   const permissionsFor = useCallback(
     (initiative: InitiativeRead): InitiativeToolAccess => {
       if (!user) return readOnlyDefault;
-      if (isGuildAdmin) return fullAccess(initiative, !contentReadOnly);
-      if (isGrantGuild) return fullAccess(initiative, isBreakGlass);
-      const membership = initiative.members.find((m) => m.user.id === user.id);
-      if (!membership) return readOnlyDefault;
-      return Object.fromEntries(
-        TOOLS.map((tool) => [
-          tool,
-          {
-            view: Boolean(membership[toolMemberViewFlag(tool)] ?? TOOL_REGISTRY[tool].core),
-            create: !contentReadOnly && Boolean(membership[toolMemberCreateFlag(tool)] ?? false),
-          },
-        ])
-      ) as InitiativeToolAccess;
+      return toolAccessForInitiative(access, initiative, user.id);
     },
-    [user, isGuildAdmin, isGrantGuild, isBreakGlass, contentReadOnly]
+    [user, access]
   );
 
   /** Whether the user can manage (PM/admin) a specific initiative. A grant
@@ -170,4 +247,51 @@ export function useToolCreateAccess(
   }, [initiativeId, initiativesQuery.data, permissionsFor, tool, creatableInitiatives]);
 
   return { canCreate, creatableInitiatives };
+}
+
+/**
+ * Cross-guild variant of the create-access derivation, for the global create
+ * wizards (which pick a guild first, so `useInitiativeAccess`'s active-guild
+ * assumption doesn't hold). Given a specific guild, returns the non-archived
+ * initiatives the user can create `tool` in — resolved through the same
+ * server-computed rule as the active-guild path. The initiatives are fetched
+ * lazily (only when `guildId` is set), sharing the wizard's own query cache.
+ */
+export function useCreatableInitiatives(tool: Tool, guildId: number | null) {
+  const { user } = useAuth();
+  const { guilds } = useGuilds();
+  const query = useInitiativesForGuild(guildId);
+
+  const initiatives = useMemo(() => {
+    if (!user || !guildId) return [];
+    const guild = guilds.find((g) => g.id === guildId);
+    const access = deriveGuildAccess(guild, user);
+    return (query.data ?? [])
+      .filter((initiative) => !initiative.is_archived)
+      .filter((initiative) => toolAccessForInitiative(access, initiative, user.id)[tool].create)
+      .sort(byName);
+  }, [user, guildId, guilds, query.data, tool]);
+
+  return { initiatives, isLoading: query.isLoading };
+}
+
+/**
+ * Whether the user has anywhere to land the two global create wizards, from the
+ * guild switcher alone (no per-guild initiative fetch — this backs always-mounted
+ * entry points). `document` follows the authoring gate (gate 3); `task` follows
+ * the content-write gate (gate 4). Both err toward showing the entry: they hide
+ * only when every guild is provably dead (frozen or, for authoring, a scoped PAM
+ * grant), and the wizards' own pickers make the precise per-initiative call.
+ */
+export function useGlobalCreateAccess() {
+  const { user } = useAuth();
+  const { guilds } = useGuilds();
+
+  return useMemo(
+    () => ({
+      document: guilds.some((guild) => guildMayAuthorTools(guild, user)),
+      task: guilds.some((guild) => guildMayWriteContent(guild, user)),
+    }),
+    [guilds, user]
+  );
 }


### PR DESCRIPTION
## Problem

#880: the global "+" quick-create entry points weren't permission-gated at all. `CreateDocumentWizard` (bottom-bar menu + command palette) and `CreateTaskWizard` (bottom-bar menu) opened with no check, so a user could walk the whole guild → initiative (→ project) flow and only hit a failure toast on submit — in `read_only` guilds, scoped PAM grants, and for members whose initiative role can't create in any initiative. The in-guild tool pages were fixed in #1030/#881; the global wizards were the remaining gap.

## Approach

The wizards are **cross-guild** (they pick a guild first), so `useInitiativeAccess`/`useToolCreateAccess` — hardwired to the *active* guild — didn't apply. Rather than re-derive access inline (the drift #1030 removed), I **generalized the existing seam** to be guild-parameterized and Tool-keyed:

- [`deriveGuildAccess(guild, user)`](frontend/src/hooks/useInitiativeAccess.ts) + [`toolAccessForInitiative(access, initiative, userId)`](frontend/src/hooks/useInitiativeAccess.ts) — the admin/grant/break-glass/frozen legs and the per-tool membership derivation, extracted as **pure** functions. `useInitiativeAccess().permissionsFor` now calls them for the active guild (no behavior change; the existing 4 grant-classification tests still pass).
- [`useCreatableInitiatives(tool, guildId)`](frontend/src/hooks/useInitiativeAccess.ts) — per-guild, **lazy** (fetches only when a guild is picked; shares the wizard's own query cache). Backs the wizards' initiative pickers.
- [`useGlobalCreateAccess()`](frontend/src/hooks/useInitiativeAccess.ts) — cheap, switcher-entry-only `{ document, task }` for the always-mounted entry points.

## Two gates, honored honestly

- **Documents** = gate 3 (authoring a tool → initiative `create_documents`). Excludes scoped PAM grants.
- **Tasks** = gate 4 (child content → DAC write on a project). A scoped `read_write` grant **can** create tasks in existing projects (per #881), so it's kept; the wizard's project step already applies the precise per-project write check.

## Changes

- [CreateDocumentWizard](frontend/src/components/documents/CreateDocumentWizard.tsx): initiative step lists only creatable initiatives; guild step drops provably-dead guilds; empty-state copy updated (+ de/es/fr).
- [CreateTaskWizard](frontend/src/components/tasks/CreateTaskWizard.tsx): guild step drops guilds where writes are impossible; project step's write-access filter unchanged.
- [BottomNav](frontend/src/components/navigation/BottomNav.tsx) + [CommandCenter](frontend/src/components/CommandCenter.tsx): the Add Task / Add Document items hide per `useGlobalCreateAccess`; the bottom-bar "+" hides entirely when neither is creatable anywhere.

## Efficiency note

There's no cross-guild initiatives endpoint, and the nav is always mounted, so the **entry-point** gates use switcher-only signals (role/grant/frozen) — zero extra queries. They only ever hide when creation is *provably* impossible (frozen guilds, scoped grants); the residual "member whose role can't create in any initiative" still sees the item, but the wizard's filtered picker shows an empty state instead of a submit-time 403. Precise per-initiative entry hiding would require N cross-guild fetches on every page — rejected for scale.

## Testing

- `pnpm typecheck` — clean
- `pnpm biome check <changed>` — clean
- `./scripts/test-changed.sh` — 71 files, 948 tests pass (incl. 8 new cases for the guild gates + `useGlobalCreateAccess`, on top of the 4 existing grant-classification tests)

Fixes #880