### PR TITLE
Type the five untyped endpoint responses

### DIFF
--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -29,12 +29,15 @@ from app.schemas.platform.settings import (
     EmailSettingsResponse,
     EmailSettingsUpdate,
     EmailTestRequest,
+    EmailTestResponse,
     InterfaceSettingsResponse,
     InterfaceSettingsUpdate,
     OIDCClaimMappingCreate,
     OIDCClaimMappingRead,
     OIDCClaimMappingUpdate,
+    OIDCClaimPathResponse,
     OIDCClaimPathUpdate,
+    OIDCMappingOptionsResponse,
     OIDCMappingsResponse,
     OIDCSettingsResponse,
     OIDCSettingsUpdate,
@@ -210,7 +213,7 @@ async def send_test_email(
     payload: EmailTestRequest,
     session: UserSessionDep,
     _admin: ConfigManageDep,
-) -> dict:
+) -> EmailTestResponse:
     settings_obj = await app_settings_service.get_app_settings(session)
     recipient = payload.recipient or settings_obj.smtp_test_recipient
     if not recipient:
@@ -234,7 +237,7 @@ async def send_test_email(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=SettingsMessages.EMAIL_SEND_FAILED,
         ) from exc
-    return {"status": "sent"}
+    return EmailTestResponse(status="sent")
 
 
 # --- Object storage ---
@@ -620,13 +623,13 @@ async def update_oidc_claim_path(
     payload: OIDCClaimPathUpdate,
     session: AdminSessionDep,
     _admin: ConfigManageDep,
-) -> dict:
+) -> OIDCClaimPathResponse:
     # The role-claim path lives on the platform provider row; setting it
     # before the provider is configured creates a dormant skeleton row.
     claim_path = await platform_provider_service.set_platform_claim_path(
         session, payload.claim_path
     )
-    return {"claim_path": claim_path}
+    return OIDCClaimPathResponse(claim_path=claim_path)
 
 
 @router.post(
@@ -817,7 +820,7 @@ async def delete_oidc_mapping(
 async def get_oidc_mapping_options(
     session: AdminSessionDep,
     _admin: ConfigManageDep,
-) -> dict:
+) -> OIDCMappingOptionsResponse:
     """Return all guilds, initiatives, and initiative roles for the mapping form."""
     # Guilds live in shared public; materialize them before routing into any guild
     # schema (routing expunges the ORM objects).
@@ -860,8 +863,8 @@ async def get_oidc_mapping_options(
         # reset to the neutral admin baseline like every write path in this file.
         await _reset_admin_session(session)
 
-    return {
-        "guilds": guild_payload,
-        "initiatives": initiatives_payload,
-        "initiative_roles": roles_payload,
-    }
+    return OIDCMappingOptionsResponse(
+        guilds=guild_payload,
+        initiatives=initiatives_payload,
+        initiative_roles=roles_payload,
+    )

--- a/backend/app/api/v1/platform_endpoints/version.py
+++ b/backend/app/api/v1/platform_endpoints/version.py
@@ -8,6 +8,7 @@ import httpx
 from fastapi import APIRouter
 
 from app.core.version import __version__
+from app.schemas.platform.version import ChangelogEntry, ChangelogResponse
 
 router = APIRouter()
 
@@ -68,9 +69,7 @@ async def get_latest_dockerhub_version() -> dict[str, Optional[str]]:
 
 
 @router.get("/changelog")
-def get_changelog(
-    version: Optional[str] = None, limit: int = 1
-) -> dict[str, list[dict]]:
+def get_changelog(version: Optional[str] = None, limit: int = 1) -> ChangelogResponse:
     """
     Get changelog entries.
 
@@ -91,7 +90,7 @@ def get_changelog(
             )
 
         if not changelog_path.exists():
-            return {"entries": []}
+            return ChangelogResponse(entries=[])
 
         content = changelog_path.read_text()
 
@@ -101,7 +100,7 @@ def get_changelog(
         pattern = r"## \[([^\]]+)\] - ([^\n]+)\n(.*?)(?=\n## |\Z)"
         matches = re.findall(pattern, content, re.DOTALL)
 
-        entries = []
+        entries: list[ChangelogEntry] = []
         max_entries = limit if not version else len(matches)
 
         for version_num, date, changes in matches:
@@ -109,15 +108,16 @@ def get_changelog(
             if version and version_num != version:
                 continue
 
-            entry = {"version": version_num, "date": date, "changes": changes.strip()}
-            entries.append(entry)
+            entries.append(
+                ChangelogEntry(version=version_num, date=date, changes=changes.strip())
+            )
 
             # If we've collected enough entries, stop
             if len(entries) >= max_entries:
                 break
 
-        return {"entries": entries}
+        return ChangelogResponse(entries=entries)
 
     except Exception as e:
         print(f"Failed to read changelog: {e}")
-        return {"entries": []}
+        return ChangelogResponse(entries=[])

--- a/backend/app/api/v1/platform_endpoints/version_test.py
+++ b/backend/app/api/v1/platform_endpoints/version_test.py
@@ -1,0 +1,36 @@
+"""Tests for the version/changelog endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.schemas.base import MAX_PLAIN_TEXT_LENGTH
+
+
+@pytest.mark.integration
+async def test_changelog_returns_typed_entries(client: AsyncClient):
+    """The changelog is served as ``{entries: [{version, date, changes}]}`` —
+    the typed shape Orval generates from ChangelogResponse."""
+    resp = await client.get("/api/v1/changelog?limit=1")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "entries" in body
+    for entry in body["entries"]:
+        assert set(entry.keys()) == {"version", "date", "changes"}
+
+
+@pytest.mark.integration
+async def test_changelog_returns_large_sections_verbatim(client: AsyncClient):
+    """A single version's ``changes`` routinely exceeds the plain-text
+    sanitizer's length cap. ``changes`` is RawTextStr, so the section is
+    returned verbatim rather than rejected — pinning that a plain ``str`` field
+    (which raises past the cap) is never reintroduced."""
+    resp = await client.get("/api/v1/changelog?limit=1000")
+    assert resp.status_code == 200, resp.text
+    entries = resp.json()["entries"]
+    assert entries, "the repo CHANGELOG.md should yield released entries"
+    assert any(len(entry["changes"]) > MAX_PLAIN_TEXT_LENGTH for entry in entries), (
+        "expected at least one released section to exceed the plain-text cap; "
+        "the endpoint must return it intact, not 500 on sanitization"
+    )

--- a/backend/app/api/v1/tenant_endpoints/trash.py
+++ b/backend/app/api/v1/tenant_endpoints/trash.py
@@ -47,6 +47,7 @@ from app.schemas.tenant.trash import (
     EntityType,
     RestoreNeedsReassignmentResponse,
     RestoreRequest,
+    RestoreResponse,
     TrashItem,
     TrashListResponse,
 )
@@ -289,6 +290,7 @@ async def _load_trash_entity(
 @router.post(
     "/{entity_type}/{entity_id}/restore",
     status_code=status.HTTP_200_OK,
+    response_model=RestoreResponse,
     responses={
         status.HTTP_409_CONFLICT: {
             "model": RestoreNeedsReassignmentResponse,
@@ -353,7 +355,7 @@ async def restore_trash_entity(
         )
 
     await session.commit()
-    return {"restored": True}
+    return RestoreResponse(restored=True)
 
 
 @router.delete(

--- a/backend/app/schemas/platform/settings.py
+++ b/backend/app/schemas/platform/settings.py
@@ -168,6 +168,15 @@ class EmailTestRequest(SanitizedBaseModel):
     recipient: Optional[EmailStr] = None
 
 
+class EmailTestResponse(SanitizedBaseModel):
+    """Result of a test-email send. ``status`` is ``"sent"`` on success;
+    failures surface as HTTP errors, not a status value here."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    status: str
+
+
 # --- Object storage schemas ---
 
 
@@ -263,3 +272,46 @@ class OIDCMappingsResponse(SanitizedBaseModel):
 
     claim_path: Optional[str] = None
     mappings: List[OIDCClaimMappingRead] = Field(default_factory=list)
+
+
+class OIDCClaimPathResponse(SanitizedBaseModel):
+    """The role-claim path after an update (``None`` clears it)."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    claim_path: Optional[str] = None
+
+
+# The mapping form needs every guild, initiative, and initiative role to
+# populate its target selectors. Ids collide across guild schemas, so
+# initiatives and roles carry their ``guild_id`` for the client to disambiguate.
+class OIDCMappingOptionGuild(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    id: int
+    name: str
+
+
+class OIDCMappingOptionInitiative(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    id: int
+    name: str
+    guild_id: int
+
+
+class OIDCMappingOptionRole(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    id: int
+    name: str
+    initiative_id: int
+    guild_id: int
+
+
+class OIDCMappingOptionsResponse(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    guilds: List[OIDCMappingOptionGuild] = Field(default_factory=list)
+    initiatives: List[OIDCMappingOptionInitiative] = Field(default_factory=list)
+    initiative_roles: List[OIDCMappingOptionRole] = Field(default_factory=list)

--- a/backend/app/schemas/platform/version.py
+++ b/backend/app/schemas/platform/version.py
@@ -1,0 +1,28 @@
+from typing import List
+
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import RawTextStr, SanitizedBaseModel
+
+
+class ChangelogEntry(SanitizedBaseModel):
+    """One parsed ``## [version] - date`` section of CHANGELOG.md."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    version: str
+    date: str
+    # Server-controlled markdown read from CHANGELOG.md and rendered as markdown
+    # client-side — not user input. RawTextStr keeps it verbatim and, crucially,
+    # skips the plain-text length cap: a single version's section routinely
+    # exceeds it (some are >12k chars), and the default sanitizer would reject it.
+    changes: RawTextStr
+
+
+class ChangelogResponse(SanitizedBaseModel):
+    """The `/changelog` payload: the most recent N entries (or a single
+    requested version)."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    entries: List[ChangelogEntry] = Field(default_factory=list)

--- a/backend/app/schemas/tenant/trash.py
+++ b/backend/app/schemas/tenant/trash.py
@@ -54,6 +54,15 @@ class RestoreRequest(SanitizedBaseModel):
     new_owner_id: Optional[int] = None
 
 
+class RestoreResponse(SanitizedBaseModel):
+    """200 payload for a successful restore. The needs-reassignment case is a
+    409 with :class:`RestoreNeedsReassignmentResponse` instead."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    restored: bool
+
+
 class RestoreOwnerCandidate(SanitizedBaseModel):
     """A user eligible to become the restored entity's owner. Carries the
     display name so the picker needn't fetch the whole guild roster."""

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1114,6 +1114,23 @@ export interface CalendarEventUpdate {
   recurrence?: EventRecurrence | null;
 }
 
+/**
+ * One parsed ``## [version] - date`` section of CHANGELOG.md.
+ */
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  changes: string;
+}
+
+/**
+ * The `/changelog` payload: the most recent N entries (or a single
+ * requested version).
+ */
+export interface ChangelogResponse {
+  entries: ChangelogEntry[];
+}
+
 export interface CommentAuthor {
   id: number;
   email: string;
@@ -1599,6 +1616,14 @@ export interface EmailSettingsUpdate {
 
 export interface EmailTestRequest {
   recipient?: string | null;
+}
+
+/**
+ * Result of a test-email send. ``status`` is ``"sent"`` on success;
+ * failures surface as HTTP errors, not a status value here.
+ */
+export interface EmailTestResponse {
+  status: string;
 }
 
 export type EnvelopeImportRequestEnvelope = { [key: string]: unknown };
@@ -2338,8 +2363,39 @@ export interface OIDCClaimMappingUpdate {
   initiative_role_id?: number | null;
 }
 
+/**
+ * The role-claim path after an update (``None`` clears it).
+ */
+export interface OIDCClaimPathResponse {
+  claim_path: string | null;
+}
+
 export interface OIDCClaimPathUpdate {
   claim_path?: string | null;
+}
+
+export interface OIDCMappingOptionGuild {
+  id: number;
+  name: string;
+}
+
+export interface OIDCMappingOptionInitiative {
+  id: number;
+  name: string;
+  guild_id: number;
+}
+
+export interface OIDCMappingOptionRole {
+  id: number;
+  name: string;
+  initiative_id: number;
+  guild_id: number;
+}
+
+export interface OIDCMappingOptionsResponse {
+  guilds: OIDCMappingOptionGuild[];
+  initiatives: OIDCMappingOptionInitiative[];
+  initiative_roles: OIDCMappingOptionRole[];
 }
 
 export interface OIDCMappingsResponse {
@@ -2973,6 +3029,14 @@ export interface RestoreNeedsReassignmentResponse {
 
 export interface RestoreRequest {
   new_owner_id?: number | null;
+}
+
+/**
+ * 200 payload for a successful restore. The needs-reassignment case is a
+ * 409 with :class:`RestoreNeedsReassignmentResponse` instead.
+ */
+export interface RestoreResponse {
+  restored: boolean;
 }
 
 export type StorageBackfillStatusResponseStatus =
@@ -4038,12 +4102,6 @@ export type GetChangelogApiV1ChangelogGetParams = {
   limit?: number;
 };
 
-export type GetChangelogApiV1ChangelogGet200Item = { [key: string]: unknown };
-
-export type GetChangelogApiV1ChangelogGet200 = {
-  [key: string]: GetChangelogApiV1ChangelogGet200Item[];
-};
-
 export type GetBundleManifestApiV1NativeBundleManifestGet200 = { [key: string]: unknown };
 
 export type RegisterUserApiV1AuthRegisterPostParams = {
@@ -4119,16 +4177,6 @@ export type ListAccessGrantsApiV1AccessGrantsGetParams = {
    * @minimum 0
    */
   offset?: number;
-};
-
-export type SendTestEmailApiV1SettingsEmailTestPost200 = { [key: string]: unknown };
-
-export type UpdateOidcClaimPathApiV1SettingsOidcMappingsClaimPathPut200 = {
-  [key: string]: unknown;
-};
-
-export type GetOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet200 = {
-  [key: string]: unknown;
 };
 
 export type ListNotificationsApiV1NotificationsGetParams = {

--- a/frontend/src/api/generated/settings/settings.ts
+++ b/frontend/src/api/generated/settings/settings.ts
@@ -24,26 +24,26 @@ import type {
   EmailSettingsResponse,
   EmailSettingsUpdate,
   EmailTestRequest,
+  EmailTestResponse,
   FCMConfigResponse,
-  GetOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet200,
   HTTPValidationError,
   InterfaceSettingsResponse,
   InterfaceSettingsUpdate,
   OIDCClaimMappingCreate,
   OIDCClaimMappingRead,
   OIDCClaimMappingUpdate,
+  OIDCClaimPathResponse,
   OIDCClaimPathUpdate,
+  OIDCMappingOptionsResponse,
   OIDCMappingsResponse,
   OIDCSettingsResponse,
   OIDCSettingsUpdate,
   PlatformGuildStorageRead,
   PlatformGuildStorageUpdate,
-  SendTestEmailApiV1SettingsEmailTestPost200,
   StorageBackfillStatusResponse,
   StorageSettingsResponse,
   StorageSettingsUpdate,
   StorageTestResponse,
-  UpdateOidcClaimPathApiV1SettingsOidcMappingsClaimPathPut200,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -778,7 +778,7 @@ export const sendTestEmailApiV1SettingsEmailTestPost = (
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<SendTestEmailApiV1SettingsEmailTestPost200>(
+  return apiMutator<EmailTestResponse>(
     {
       url: `/api/v1/settings/email/test`,
       method: "POST",
@@ -2064,7 +2064,7 @@ export const updateOidcClaimPathApiV1SettingsOidcMappingsClaimPathPut = (
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<UpdateOidcClaimPathApiV1SettingsOidcMappingsClaimPathPut200>(
+  return apiMutator<OIDCClaimPathResponse>(
     {
       url: `/api/v1/settings/oidc-mappings/claim-path`,
       method: "PUT",
@@ -2334,7 +2334,7 @@ export const getOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet = (
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<GetOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet200>(
+  return apiMutator<OIDCMappingOptionsResponse>(
     { url: `/api/v1/settings/oidc-mappings/options`, method: "GET", signal },
     options
   );

--- a/frontend/src/api/generated/trash/trash.ts
+++ b/frontend/src/api/generated/trash/trash.ts
@@ -24,6 +24,7 @@ import type {
   HTTPValidationError,
   RestoreNeedsReassignmentResponse,
   RestoreRequest,
+  RestoreResponse,
   TrashListResponse,
 } from "../initiativeAPI.schemas";
 
@@ -234,7 +235,7 @@ export const restoreTrashEntityApiV1GGuildIdTrashEntityTypeEntityIdRestorePost =
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<unknown>(
+  return apiMutator<RestoreResponse>(
     {
       url: `/api/v1/g/${guildId}/trash/${entityType}/${entityId}/restore`,
       method: "POST",

--- a/frontend/src/api/generated/version/version.ts
+++ b/frontend/src/api/generated/version/version.ts
@@ -18,7 +18,7 @@ import type {
 } from "@tanstack/react-query";
 
 import type {
-  GetChangelogApiV1ChangelogGet200,
+  ChangelogResponse,
   GetChangelogApiV1ChangelogGetParams,
   GetLatestDockerhubVersionApiV1VersionLatestGet200,
   GetVersionApiV1VersionGet200,
@@ -328,7 +328,7 @@ export const getChangelogApiV1ChangelogGet = (
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<GetChangelogApiV1ChangelogGet200>(
+  return apiMutator<ChangelogResponse>(
     { url: `/api/v1/changelog`, method: "GET", params, signal },
     options
   );

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -11,6 +11,7 @@ import type {
   AuthProviderAdminRead,
   AuthProviderCreate,
   AuthProviderUpdate,
+  ChangelogResponse,
   EmailSettingsResponse,
   EmailSettingsUpdate,
   FCMConfigResponse,
@@ -21,6 +22,7 @@ import type {
   OIDCClaimMappingRead,
   OIDCClaimMappingUpdate,
   OIDCClaimPathUpdate,
+  OIDCMappingOptionsResponse,
   OIDCMappingsResponse,
   OIDCSettingsResponse,
   OIDCSettingsUpdate,
@@ -80,36 +82,6 @@ import { useApiMutation } from "@/hooks/useApiMutation";
 import type { MutationOpts } from "@/types/mutation";
 import type { QueryOpts } from "@/types/query";
 
-// ── Local types for untyped or loosely-typed generated responses ─────────
-
-/** Strongly-typed version of the mapping options response. */
-export interface MappingOptionItem {
-  id: number;
-  name: string;
-}
-
-export interface MappingInitiativeOption extends MappingOptionItem {
-  guild_id: number;
-}
-
-export interface MappingRoleOption extends MappingOptionItem {
-  initiative_id: number;
-  guild_id: number;
-}
-
-export interface MappingOptions {
-  guilds: MappingOptionItem[];
-  initiatives: MappingInitiativeOption[];
-  initiative_roles: MappingRoleOption[];
-}
-
-/** Changelog entry shape returned by the backend. */
-export interface ChangelogEntry {
-  version: string;
-  date: string;
-  changes: string;
-}
-
 // ── Queries ─────────────────────────────────────────────────────────────────
 
 export const useOidcSettings = (options?: QueryOpts<OIDCSettingsResponse>) => {
@@ -136,13 +108,9 @@ export const useOidcMappings = () => {
 };
 
 export const useOidcMappingOptions = () => {
-  return useQuery<MappingOptions>({
+  return useQuery<OIDCMappingOptionsResponse>({
     queryKey: getGetOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGetQueryKey(),
-    // The backend endpoint has no typed response model (plain dict), so the
-    // generated type is an index signature; the local MappingOptions interface
-    // narrows it. Remove the cast once the backend declares a response schema.
-    queryFn: () =>
-      getOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet() as unknown as Promise<MappingOptions>,
+    queryFn: () => getOidcMappingOptionsApiV1SettingsOidcMappingsOptionsGet(),
   });
 };
 
@@ -201,15 +169,11 @@ export const usePlatformGuilds = (options?: QueryOpts<PlatformGuildStorageRead[]
 
 export const useChangelog = (
   params: GetChangelogApiV1ChangelogGetParams,
-  options?: QueryOpts<{ entries: ChangelogEntry[] }>
+  options?: QueryOpts<ChangelogResponse>
 ) => {
-  return useQuery<{ entries: ChangelogEntry[] }>({
+  return useQuery<ChangelogResponse>({
     queryKey: getGetChangelogApiV1ChangelogGetQueryKey(params),
-    // The backend endpoint has no typed response model (plain dict); the local
-    // ChangelogEntry shape narrows it. Remove the cast once the backend
-    // declares a response schema.
-    queryFn: () =>
-      getChangelogApiV1ChangelogGet(params) as unknown as Promise<{ entries: ChangelogEntry[] }>,
+    queryFn: () => getChangelogApiV1ChangelogGet(params),
     ...options,
   });
 };

--- a/frontend/src/hooks/useTrash.ts
+++ b/frontend/src/hooks/useTrash.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   RestoreNeedsReassignmentResponse,
   RestoreRequest,
+  RestoreResponse,
   TrashItemEntityType,
   TrashListResponse,
 } from "@/api/generated/initiativeAPI.schemas";
@@ -91,7 +92,7 @@ export type RestoreTrashVars = {
 
 // 200 {restored: true} or — recovered from a 409 in mutationFn —
 // {needs_reassignment: true, ...}. The dialog branches on shape.
-export type RestoreTrashResponse = { restored: true } | RestoreNeedsReassignmentResponse;
+export type RestoreTrashResponse = RestoreResponse | RestoreNeedsReassignmentResponse;
 
 export const useRestoreTrashEntity = (
   options?: MutationOpts<RestoreTrashResponse, RestoreTrashVars>
@@ -101,16 +102,21 @@ export const useRestoreTrashEntity = (
 
   return useMutation({
     ...rest,
-    mutationFn: async ({ guildId, entityType, entityId, body }: RestoreTrashVars) => {
+    mutationFn: async ({
+      guildId,
+      entityType,
+      entityId,
+      body,
+    }: RestoreTrashVars): Promise<RestoreTrashResponse> => {
       try {
-        // The restore endpoint's OpenAPI response is untyped (plain dict), so
-        // narrow the payload to the local union here.
-        return (await restoreTrashEntityApiV1GGuildIdTrashEntityTypeEntityIdRestorePost(
+        // 200 → RestoreResponse. The 409 needs-reassignment branch is caught
+        // below and its body recovered into the same union.
+        return await restoreTrashEntityApiV1GGuildIdTrashEntityTypeEntityIdRestorePost(
           guildId,
           entityType,
           entityId,
           body ?? {}
-        )) as RestoreTrashResponse;
+        );
       } catch (err) {
         // The needs-reassignment branch is a successful interaction shape
         // (the user just needs to pick an owner) but the API correctly
@@ -125,7 +131,7 @@ export const useRestoreTrashEntity = (
           typeof data === "object" &&
           "needs_reassignment" in (data as object)
         ) {
-          return data as RestoreTrashResponse;
+          return data as RestoreNeedsReassignmentResponse;
         }
         throw err;
       }


### PR DESCRIPTION
## Problem

#1021: five endpoints declared their response as a bare `dict` (or had no return annotation), so the OpenAPI export produced a free-form object and Orval generated `{ [key: string]: unknown }`. The frontend compensated with local interfaces + `as unknown as Promise<…>` casts — the last response casts left after #866.

## Changes

**Backend — declare Pydantic response models and return them:**
- `get_changelog` → `ChangelogResponse { entries: ChangelogEntry[] }` ([schemas/platform/version.py](backend/app/schemas/platform/version.py), new)
- `send_test_email` → `EmailTestResponse { status }`
- `update_oidc_claim_path` → `OIDCClaimPathResponse { claim_path }`
- `get_oidc_mapping_options` → `OIDCMappingOptionsResponse { guilds, initiatives, initiative_roles }`
- `restore_trash_entity` → `response_model=RestoreResponse { restored }` (the 409 needs-reassignment mapping is unchanged)

**Frontend — delete the locals, import the generated types:**
- Removed `MappingOptions`/`MappingOptionItem`/`MappingInitiativeOption`/`MappingRoleOption` and `ChangelogEntry` from [useSettings.ts](frontend/src/hooks/useSettings.ts); the two hooks now use `OIDCMappingOptionsResponse` / `ChangelogResponse` with no cast.
- [useTrash.ts](frontend/src/hooks/useTrash.ts) `RestoreTrashResponse` is now `RestoreResponse | RestoreNeedsReassignmentResponse`; the mutationFn is typed and the two casts are gone (the 409-recovery branch narrows to `RestoreNeedsReassignmentResponse` after its runtime `"needs_reassignment" in data` check).
- Regenerated Orval output committed.

## One bug caught along the way

`ChangelogEntry.changes` is `RawTextStr`, not `str`. It's server-controlled markdown read from CHANGELOG.md and rendered client-side via `<Markdown>`, and a single version's section routinely exceeds `SanitizedBaseModel`'s 8192-char plain-text cap (0.58.0 is ~12.8k, 0.43.0 ~12.6k). A plain `str` field would have made the sanitizer **raise**, 500-ing `/changelog` for any request spanning those versions. `RawTextStr` opts out of both sanitization and the cap. New `version_test.py` pins that large sections come back intact.

## Testing

- `cd backend && pytest app/api/v1/platform_endpoints/settings_test.py app/api/v1/platform_endpoints/version_test.py app/services/tenant/soft_delete_test.py` — 57 passed (2 new)
- `ruff check app` clean; `ruff format app` applied
- `python scripts/export_openapi.py` + `pnpm orval` — all 6 schemas generate; fetchers now return the typed models
- `cd frontend && pnpm typecheck` clean; `pnpm biome check` clean; `./scripts/test-changed.sh` — 948 tests pass

No changelog entry: pure internal typing; the endpoints' JSON output is byte-identical.

Fixes #1021