### PR TITLE
Fix failing tests left by AI + egress refactors

### DIFF
--- a/backend/app/api/guild_support_role_test.py
+++ b/backend/app/api/guild_support_role_test.py
@@ -29,7 +29,7 @@ from app.testing import (
 
 pytestmark = pytest.mark.integration
 
-AI_SETTINGS = "/ai/guild"
+AI_SETTINGS = "/ai/connections"
 
 
 async def _live_grant(
@@ -55,15 +55,6 @@ async def _live_grant(
 
 def _ai_url(guild_id: int) -> str:
     return f"/api/v1/g/{guild_id}/settings{AI_SETTINGS}"
-
-
-async def _materialize_ai_settings(client: AsyncClient, guild_id: int, admin) -> None:
-    """The AI-settings row is lazily created on first read. Production seeds it
-    at guild creation; the test factory doesn't, so a read grant (routed into
-    the SELECT-only role) can't create it. Materialize it via an admin read
-    first so the support-read path is a pure SELECT."""
-    resp = await client.get(_ai_url(guild_id), headers=get_auth_headers(admin))
-    assert resp.status_code == 200, resp.text
 
 
 # ---------------------------------------------------------------------------
@@ -106,9 +97,9 @@ async def test_break_glass_stays_admin_not_support(session: AsyncSession):
 async def test_support_read_grant_reads_guild_settings(
     client: AsyncClient, session: AsyncSession, acting_user
 ):
-    """A support (read) grantee can READ the guild settings surface."""
+    """A support (read) grantee can READ the guild AI settings surface (the
+    connection list)."""
     admin = await acting_user(guild_role=GuildRole.admin)
-    await _materialize_ai_settings(client, admin.guild.id, admin.user)
 
     support = await create_user(session, role=UserRole.support)
     await _live_grant(session, user=support, guild=admin.guild, level="read")
@@ -121,17 +112,17 @@ async def test_support_read_grant_cannot_write_guild_settings(
     client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A support (read) grantee is routed into the SELECT-only role, so a
-    settings WRITE is denied at the database layer → generic 403."""
+    settings WRITE (creating a connection) is denied at the database layer →
+    generic 403."""
     admin = await acting_user(guild_role=GuildRole.admin)
-    await _materialize_ai_settings(client, admin.guild.id, admin.user)
 
     support = await create_user(session, role=UserRole.support)
     await _live_grant(session, user=support, guild=admin.guild, level="read")
 
-    resp = await client.put(
+    resp = await client.post(
         _ai_url(admin.guild.id),
         headers=get_auth_headers(support),
-        json={"enabled": True},
+        json={"label": "x", "provider": "openai"},
     )
     assert resp.status_code == 403, resp.text
     assert resp.json()["detail"] == GuildMessages.GUILD_ACCESS_DENIED
@@ -141,21 +132,21 @@ async def test_support_read_write_grant_writes_guild_settings(
     client: AsyncClient, session: AsyncSession, acting_user
 ):
     """A support (read_write) grantee — held by a non-bypass user, so NOT
-    break-glass — can WRITE the guild settings surface (the guild_<id>_support
-    role has UPDATE on guild_settings; a read grant on _ro does not)."""
+    break-glass — can WRITE the guild AI settings surface (the
+    guild_<id>_support role has DML on guild_ai_connections; a read grant on
+    _ro does not)."""
     admin = await acting_user(guild_role=GuildRole.admin)
-    await _materialize_ai_settings(client, admin.guild.id, admin.user)
 
     support = await create_user(session, role=UserRole.support)
     await _live_grant(session, user=support, guild=admin.guild, level="read_write")
 
-    resp = await client.put(
+    resp = await client.post(
         _ai_url(admin.guild.id),
         headers=get_auth_headers(support),
-        json={"enabled": True},
+        json={"label": "Team", "provider": "openai"},
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["enabled"] is True
+    assert resp.json()["label"] == "Team"
 
 
 async def test_plain_member_still_denied_guild_settings(

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
@@ -8,6 +8,8 @@ tests (which create rows via the same service layer).
 
 from __future__ import annotations
 
+import socket
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -15,6 +17,34 @@ from httpx import AsyncClient
 
 from app.models.platform.guild import GuildRole
 from app.testing import Actor
+
+_WEBHOOK_HOST = "hooks.example.com"
+# A public unicast IPv4 (example.com) with a real stream socket type/proto, so
+# constructing a socket from the tuple is valid.
+_FAKE_INFOS = [
+    (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("93.184.216.34", 0))
+]
+
+
+@contextmanager
+def _mock_public_dns():
+    """Resolve the webhook host to a fixed public IP without hitting the network.
+
+    The patch target is the shared ``socket`` module, so a blanket
+    ``return_value`` would also answer asyncpg's own ``getaddrinfo`` for the DB
+    host mid-request — feeding it a bogus address (and a ``type=0`` tuple that
+    ``socket.socket`` rejects). Scope the fake to the webhook host and pass every
+    other lookup through to the real resolver.
+    """
+    real_getaddrinfo = socket.getaddrinfo
+
+    def fake(host, *args, **kwargs):
+        if host == _WEBHOOK_HOST:
+            return _FAKE_INFOS
+        return real_getaddrinfo(host, *args, **kwargs)
+
+    with patch("app.services.webhook_target_url.socket.getaddrinfo", side_effect=fake):
+        yield
 
 
 async def _authed_post(client: AsyncClient, actor: Actor, body: dict):
@@ -84,11 +114,7 @@ async def test_create_accepts_public_target_when_dns_resolves_public(
     what we're asserting on."""
     a = await acting_user(guild_role=GuildRole.admin)
 
-    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]  # example.com IPv4
-    with patch(
-        "app.services.webhook_target_url.socket.getaddrinfo",
-        return_value=fake_infos,
-    ):
+    with _mock_public_dns():
         response = await _authed_post(
             client,
             a,
@@ -112,11 +138,7 @@ async def test_non_owner_member_cannot_delete(client: AsyncClient, acting_user):
     creator = await acting_user(guild_role=GuildRole.admin)
     other = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
 
-    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
-    with patch(
-        "app.services.webhook_target_url.socket.getaddrinfo",
-        return_value=fake_infos,
-    ):
+    with _mock_public_dns():
         created = await _authed_post(
             client,
             creator,
@@ -143,11 +165,7 @@ async def test_non_owner_member_cannot_update(client: AsyncClient, acting_user):
     creator = await acting_user(guild_role=GuildRole.admin)
     other = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
 
-    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
-    with patch(
-        "app.services.webhook_target_url.socket.getaddrinfo",
-        return_value=fake_infos,
-    ):
+    with _mock_public_dns():
         created = await _authed_post(
             client,
             creator,
@@ -178,11 +196,7 @@ async def test_guild_admin_can_delete_others_subscription(
     creator = await acting_user(guild_role=GuildRole.member)
     admin = await acting_user(guild_role=GuildRole.admin, guild=creator.guild)
 
-    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
-    with patch(
-        "app.services.webhook_target_url.socket.getaddrinfo",
-        return_value=fake_infos,
-    ):
+    with _mock_public_dns():
         created = await _authed_post(
             client,
             creator,
@@ -206,11 +220,7 @@ async def test_creator_can_update_own_subscription(client: AsyncClient, acting_u
     """The happy path: the creator can mutate their own subscription."""
     a = await acting_user(guild_role=GuildRole.member)
 
-    fake_infos = [(2, 0, 0, "", ("93.184.216.34", 0))]
-    with patch(
-        "app.services.webhook_target_url.socket.getaddrinfo",
-        return_value=fake_infos,
-    ):
+    with _mock_public_dns():
         created = await _authed_post(
             client,
             a,

--- a/backend/app/services/ai_settings.py
+++ b/backend/app/services/ai_settings.py
@@ -30,8 +30,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.encryption import SALT_AI_API_KEY, decrypt_field, encrypt_field
 from app.core.messages import AIMessages
 from app.db import session as db_session
-from app.db.schema_provisioning import guild_role_name, guild_schema_name
 from app.models.platform.ai_connection import PlatformAIConnection
+from app.models.platform.guild import Guild
 from app.models.platform.user import User
 from app.models.tenant.ai_connection import GuildAIConnection
 from app.models.tenant.ai_member_key import GuildAIMemberKey
@@ -181,51 +181,41 @@ async def _bump_ai_config_version(session: AsyncSession) -> None:
     session.add(settings)
 
 
-_MEMBER_TABLES = ("guild_ai_member_keys", "guild_ai_member_prefs")
-
-
 async def _purge_platform_connection_member_data(connection_id: int) -> None:
     """Delete every member key/pref that referenced a now-deleted platform
-    connection, across all guild schemas. Runs on the system engine, assuming
-    each guild's role with the admin GUC so the own-row RLS admits the sweep
-    (mirrors the secret-key rotation loop). Best-effort per guild — a failing
-    schema is logged and skipped; the rows are inert once the connection is gone.
+    connection, across all guild schemas. Runs on the system engine, routing
+    into each guild's schema with the admin GUC so the own-row RLS admits the
+    sweep (mirrors ``soft_delete_user``'s cross-guild member cleanup). Best-effort
+    per guild — a failing schema is rolled back and logged; the rows are inert
+    once the connection is gone.
     """
-    engine = db_session.admin_engine
-    async with engine.connect() as conn:
-        await conn.execute(text("SELECT set_config('role', 'none', false)"))
-        guild_ids = (
-            (await conn.execute(text("SELECT id FROM public.guilds ORDER BY id")))
-            .scalars()
-            .all()
-        )
-    for gid in guild_ids:
-        schema = guild_schema_name(gid)
-        try:
-            async with engine.begin() as wconn:
-                await wconn.execute(
-                    text("SELECT set_config('role', :r, true)"),
-                    {"r": guild_role_name(gid)},
+    async with db_session.AdminSessionLocal() as session:
+        guild_ids = (await session.exec(select(Guild.id).order_by(Guild.id))).all()
+        for gid in guild_ids:
+            try:
+                await db_session.set_rls_context(
+                    session, guild_id=gid, guild_role="admin"
                 )
-                await wconn.execute(
-                    text("SELECT set_config('app.current_guild_role', 'admin', true)")
-                )
-                for table in _MEMBER_TABLES:
-                    await wconn.execute(
-                        # schema comes from guild_schema_name(int) — never user input.
-                        text(
-                            f'DELETE FROM "{schema}".{table} '  # noqa: S608
-                            "WHERE connection_scope = 'platform' "
-                            "AND connection_id = :cid"
-                        ),
-                        {"cid": connection_id},
+                await session.exec(
+                    delete(GuildAIMemberKey).where(
+                        GuildAIMemberKey.connection_scope == "platform",
+                        GuildAIMemberKey.connection_id == connection_id,
                     )
-        except Exception:
-            logger.exception(
-                "failed to purge platform connection %s member data in %s",
-                connection_id,
-                schema,
-            )
+                )
+                await session.exec(
+                    delete(GuildAIMemberPref).where(
+                        GuildAIMemberPref.connection_scope == "platform",
+                        GuildAIMemberPref.connection_id == connection_id,
+                    )
+                )
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                logger.exception(
+                    "failed to purge platform connection %s member data in guild %s",
+                    connection_id,
+                    gid,
+                )
 
 
 def _conn_from_guild(row: GuildAIConnection) -> _ConnRow:


### PR DESCRIPTION
## Problem

Three test groups were red on `dev` (and shipped in the last release): the AI-config refactor and the SSRF-egress hardening landed without updating some callers/tests. All three files were byte-identical to `dev`, so this fixes dev directly.

## Changes

- **`sql_injection_guard` (2 tests)** — [`_purge_platform_connection_member_data`](backend/app/services/ai_settings.py) built `DELETE FROM "{schema}".{table}` with an f-string, a dynamic-SQL site on the service path that the guard forbids. Rewrote it to the standard cross-guild ORM pattern (`set_rls_context(guild_role="admin")` + `delete(GuildAIMemberKey/Pref)`), mirroring `soft_delete_user`. Behaviour is unchanged (best-effort per guild); no raw SQL.
- **`auto_subscriptions` (5 tests)** — [the test](backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py) patched `socket.getaddrinfo` **globally** with a blanket `return_value` whose tuple had `type=0`; asyncpg then picked that up when resolving the DB host mid-request → `socket.socket(type=0)` → `ESOCKTNOSUPPORT`. Replaced with a `_mock_public_dns()` helper that fakes only the webhook host (valid `SOCK_STREAM` tuple) and delegates every other lookup to the real resolver.
- **`guild_support_role` (4 tests)** — [the test](backend/app/api/guild_support_role_test.py) hit `/settings/ai/guild`, the singleton endpoint the AI refactor deleted (404). Repointed to the current `/settings/ai/connections` surface, which carries the same `require_guild_roles(admin, support)` gate and the read/write DB carve-out (read grant → GET 200 / write 403; read_write → write 200; plain member → 403).

## Testing

`cd backend && source .venv/bin/activate`
- `pytest app/db/sql_injection_guard_test.py app/api/v1/tenant_endpoints/auto_subscriptions_test.py app/api/guild_support_role_test.py` → **20 passed** (the 11 previously-failing + 9 already-green in those files)
- `ruff check` clean on all three files.