### PR TITLE
Move calendar panel into filter-bar dropdown

### DIFF
--- a/frontend/public/locales/de/calendars.json
+++ b/frontend/public/locales/de/calendars.json
@@ -127,6 +127,7 @@
   "deleteCalendar": "Kalender löschen",
   "deleteCalendarConfirm": "Diesen Kalender löschen? Alle seine Termine werden mit entfernt.",
   "panel": {
+    "calendars": "Kalender",
     "myCalendars": "Meine Kalender",
     "noCalendars": "Noch keine Kalender",
     "projectTasks": "Projektaufgaben",

--- a/frontend/public/locales/en/calendars.json
+++ b/frontend/public/locales/en/calendars.json
@@ -127,6 +127,7 @@
   "deleteCalendar": "Delete Calendar",
   "deleteCalendarConfirm": "Delete this calendar? All of its events go with it.",
   "panel": {
+    "calendars": "Calendars",
     "myCalendars": "My calendars",
     "noCalendars": "No calendars yet",
     "projectTasks": "Project tasks",

--- a/frontend/public/locales/es/calendars.json
+++ b/frontend/public/locales/es/calendars.json
@@ -127,6 +127,7 @@
   "deleteCalendar": "Eliminar calendario",
   "deleteCalendarConfirm": "¿Eliminar este calendario? Todos sus eventos se eliminarán con él.",
   "panel": {
+    "calendars": "Calendarios",
     "myCalendars": "Mis calendarios",
     "noCalendars": "Aún no hay calendarios",
     "projectTasks": "Tareas de proyectos",

--- a/frontend/public/locales/fr/calendars.json
+++ b/frontend/public/locales/fr/calendars.json
@@ -127,6 +127,7 @@
   "deleteCalendar": "Supprimer le calendrier",
   "deleteCalendarConfirm": "Supprimer ce calendrier ? Tous ses événements seront supprimés avec lui.",
   "panel": {
+    "calendars": "Calendriers",
     "myCalendars": "Mes calendriers",
     "noCalendars": "Aucun calendrier pour l'instant",
     "projectTasks": "Tâches des projets",

--- a/frontend/src/components/initiativeTools/events/CalendarListPanel.tsx
+++ b/frontend/src/components/initiativeTools/events/CalendarListPanel.tsx
@@ -1,11 +1,13 @@
 import { Link } from "@tanstack/react-router";
-import { Plus, Settings2 } from "lucide-react";
+import { CalendarDays, ChevronDown, Plus, Settings2 } from "lucide-react";
+import type { ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { CalendarSummary } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
 /** A derived, read-only "calendar" for one project's tasks — rendered from the
  * calendar-entries tasks payload, never stored server-side. */
@@ -33,6 +35,27 @@ interface CalendarListPanelProps {
   canCreate: boolean;
   onCreate: () => void;
 }
+
+/** The calendar list panel behind a filter-bar dropdown: a "Calendars"
+ * trigger opening the visibility panel, so the calendar grid keeps the full
+ * page width. */
+export const CalendarPanelDropdown = (props: ComponentProps<typeof CalendarListPanel>) => {
+  const { t } = useTranslation("calendars");
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm">
+          <CalendarDays className="h-4 w-4" />
+          {t("panel.calendars")}
+          <ChevronDown className="h-4 w-4 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="max-h-96 w-80 overflow-y-auto">
+        <CalendarListPanel {...props} />
+      </PopoverContent>
+    </Popover>
+  );
+};
 
 /** The calendar page's list panel — real calendars (color, visibility,
  * settings link) and one read-only task calendar per project, Google-Calendar

--- a/frontend/src/pages/initiativeTools/events/CalendarsPage.test.tsx
+++ b/frontend/src/pages/initiativeTools/events/CalendarsPage.test.tsx
@@ -147,9 +147,12 @@ describe("CalendarsView calendar-entries query", () => {
     renderCalendars();
 
     expect(await screen.findByText("Apollo task")).toBeInTheDocument();
+
+    // The visibility panel lives behind the filter bar's Calendars dropdown.
+    await user.click(screen.getByRole("button", { name: /calendars/i }));
     // Only Apollo has a task in the window, so only it gets a panel row.
-    expect(screen.getByText("Apollo")).toBeInTheDocument();
-    expect(screen.queryByText("Zeus")).toBeNull();
+    expect(await screen.findByRole("checkbox", { name: "Apollo" })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "Zeus" })).toBeNull();
 
     // Unchecking the project's calendar hides its tasks from the view.
     await user.click(screen.getByRole("checkbox", { name: "Apollo" }));

--- a/frontend/src/pages/initiativeTools/events/CalendarsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/CalendarsPage.tsx
@@ -25,7 +25,7 @@ import { ExportButton } from "@/components/exports/ExportButton";
 import { TOOL_EXPORT_FORMATS } from "@/components/exports/formats";
 import { ToolImportAction } from "@/components/imports/ToolImportAction";
 import {
-  CalendarListPanel,
+  CalendarPanelDropdown,
   type ProjectTaskCalendar,
 } from "@/components/initiativeTools/events/CalendarListPanel";
 import { CreateCalendarDialog } from "@/components/initiativeTools/events/CreateCalendarDialog";
@@ -512,6 +512,26 @@ export const CalendarsView = ({
         </div>
         <CollapsibleContent forceMount className="data-[state=closed]:hidden">
           <div className="mt-2 flex flex-wrap items-end gap-4 rounded-md border border-muted bg-background/40 p-3 sm:mt-0">
+            {/* Calendar visibility — real calendars + per-project task
+                calendars behind one dropdown, so the grid keeps full width. */}
+            <div className="flex items-end">
+              <CalendarPanelDropdown
+                calendars={calendars}
+                projectCalendars={projectCalendars}
+                isCalendarHidden={(calendar) => hiddenCalendarIds.has(calendar.id)}
+                isProjectHidden={(project) => hiddenProjectIds.has(project.projectId)}
+                onToggleCalendar={(calendar) =>
+                  setHiddenCalendarIds((prev) => toggleInSet(prev, calendar.id))
+                }
+                onToggleProject={(project) =>
+                  setHiddenProjectIds((prev) => toggleInSet(prev, project.projectId))
+                }
+                settingsPathFor={(calendar) => gp(`/calendars/${calendar.id}/settings`)}
+                canCreate={canCreateCalendars}
+                onCreate={() => setCreateCalendarOpen(true)}
+              />
+            </div>
+
             {/* Status filter (for tasks) */}
             <div className="w-full sm:w-48 lg:flex-1">
               <Label className="mb-2 block font-medium text-muted-foreground text-xs">
@@ -565,39 +585,17 @@ export const CalendarsView = ({
           {t("loading")}
         </div>
       ) : (
-        <div className="flex flex-col gap-4 lg:flex-row">
-          {/* Calendar list panel — real calendars + per-project task calendars. */}
-          <aside className="shrink-0 lg:w-60">
-            <CalendarListPanel
-              calendars={calendars}
-              projectCalendars={projectCalendars}
-              isCalendarHidden={(calendar) => hiddenCalendarIds.has(calendar.id)}
-              isProjectHidden={(project) => hiddenProjectIds.has(project.projectId)}
-              onToggleCalendar={(calendar) =>
-                setHiddenCalendarIds((prev) => toggleInSet(prev, calendar.id))
-              }
-              onToggleProject={(project) =>
-                setHiddenProjectIds((prev) => toggleInSet(prev, project.projectId))
-              }
-              settingsPathFor={(calendar) => gp(`/calendars/${calendar.id}/settings`)}
-              canCreate={canCreateCalendars}
-              onCreate={() => setCreateCalendarOpen(true)}
-            />
-          </aside>
-          <div className="min-w-0 flex-1">
-            <CalendarView
-              entries={calendarEntries}
-              viewMode={viewMode}
-              onViewModeChange={setViewMode}
-              focusDate={focusDate}
-              onFocusDateChange={setFocusDate}
-              onEntryClick={handleEntryClick}
-              onSlotClick={canCreateEvents ? handleSlotClick : undefined}
-              onEntryReschedule={handleEntryReschedule}
-              weekStartsOn={weekStartsOn}
-            />
-          </div>
-        </div>
+        <CalendarView
+          entries={calendarEntries}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+          focusDate={focusDate}
+          onFocusDateChange={setFocusDate}
+          onEntryClick={handleEntryClick}
+          onSlotClick={canCreateEvents ? handleSlotClick : undefined}
+          onEntryReschedule={handleEntryReschedule}
+          weekStartsOn={weekStartsOn}
+        />
       )}
 
       <CreateEventDialog

--- a/frontend/src/pages/user/MyCalendarPage.tsx
+++ b/frontend/src/pages/user/MyCalendarPage.tsx
@@ -20,7 +20,7 @@ import {
   calendarVisibleRange,
 } from "@/components/calendar";
 import {
-  CalendarListPanel,
+  CalendarPanelDropdown,
   type ProjectTaskCalendar,
 } from "@/components/initiativeTools/events/CalendarListPanel";
 import { PullToRefresh } from "@/components/PullToRefresh";
@@ -97,6 +97,9 @@ const readStoredVisibility = (): StoredVisibility => {
     return { hiddenCalendarKeys: [], hiddenProjectKeys: [] };
   }
 };
+
+const taskProjectKey = (guildId: number | null | undefined, projectId: number): string =>
+  `${guildId ?? 0}:${projectId}`;
 
 const toggleInSet = (prev: ReadonlySet<string>, key: string): Set<string> => {
   const next = new Set(prev);
@@ -238,14 +241,15 @@ export const MyCalendarPage = () => {
   const projectCalendars = useMemo<ProjectTaskCalendar[]>(() => {
     const seen = new Map<string, ProjectTaskCalendar>();
     for (const task of entriesQuery.data?.tasks ?? []) {
-      if (task.project_id == null || task.guild_id == null) continue;
-      const key = `${task.guild_id}:${task.project_id}`;
+      if (task.project_id == null) continue;
+      const key = taskProjectKey(task.guild_id, task.project_id);
       if (seen.has(key)) continue;
-      const guildName = multiGuild ? guildNamesById.get(task.guild_id) : undefined;
+      const guildName =
+        multiGuild && task.guild_id != null ? guildNamesById.get(task.guild_id) : undefined;
       const baseName = task.project_name ?? `#${task.project_id}`;
       seen.set(key, {
         projectId: task.project_id,
-        guildId: task.guild_id,
+        guildId: task.guild_id ?? 0,
         name: guildName ? `${baseName} · ${guildName}` : baseName,
         color: getProjectColor(task.project_id),
       });
@@ -262,7 +266,10 @@ export const MyCalendarPage = () => {
     // meta for cross-guild navigation. Not draggable here (My Calendar has no
     // reschedule handler).
     for (const task of entriesQuery.data?.tasks ?? []) {
-      if (task.project_id != null && hiddenProjectKeys.has(`${task.guild_id}:${task.project_id}`)) {
+      if (
+        task.project_id != null &&
+        hiddenProjectKeys.has(taskProjectKey(task.guild_id, task.project_id))
+      ) {
         continue;
       }
       for (const entry of buildTaskCalendarEntries(task, getProjectColor(task.project_id), false)) {
@@ -377,6 +384,41 @@ export const MyCalendarPage = () => {
           </div>
           <CollapsibleContent forceMount className="data-[state=closed]:hidden">
             <div className="mt-2 flex flex-wrap items-end gap-4 rounded-md border border-muted bg-background/40 p-3 sm:mt-0">
+              {/* Calendar visibility — the user's calendars across guilds +
+                  per-project task calendars behind one dropdown. */}
+              <div className="flex items-end">
+                <CalendarPanelDropdown
+                  calendars={calendars}
+                  projectCalendars={projectCalendars}
+                  isCalendarHidden={(calendar) =>
+                    hiddenCalendarKeys.has(`${calendar.guild_id}:${calendar.id}`)
+                  }
+                  isProjectHidden={(project) =>
+                    hiddenProjectKeys.has(taskProjectKey(project.guildId, project.projectId))
+                  }
+                  onToggleCalendar={(calendar) =>
+                    setHiddenCalendarKeys((prev) =>
+                      toggleInSet(prev, `${calendar.guild_id}:${calendar.id}`)
+                    )
+                  }
+                  onToggleProject={(project) =>
+                    setHiddenProjectKeys((prev) =>
+                      toggleInSet(prev, taskProjectKey(project.guildId, project.projectId))
+                    )
+                  }
+                  calendarLabel={(calendar) => {
+                    const guildName = multiGuild
+                      ? guildNamesById.get(calendar.guild_id)
+                      : undefined;
+                    return guildName ? `${calendar.name} · ${guildName}` : calendar.name;
+                  }}
+                  settingsPathFor={(calendar) =>
+                    guildPath(calendar.guild_id, `/calendars/${calendar.id}/settings`)
+                  }
+                  canCreate={false}
+                  onCreate={() => {}}
+                />
+              </div>
               <div className="w-full sm:w-48 lg:flex-1">
                 <Label className="mb-2 block font-medium text-muted-foreground text-xs">
                   {t("tasks:filters.filterByStatusCategory")}
@@ -431,52 +473,15 @@ export const MyCalendarPage = () => {
             <Loader2 className="h-8 w-8 animate-spin" />
           </div>
         ) : (
-          <div className="flex flex-col gap-4 lg:flex-row">
-            {/* Grouping panel — the user's calendars across guilds plus one
-                task calendar per project with tasks in the window. */}
-            <aside className="shrink-0 lg:w-60">
-              <CalendarListPanel
-                calendars={calendars}
-                projectCalendars={projectCalendars}
-                isCalendarHidden={(calendar) =>
-                  hiddenCalendarKeys.has(`${calendar.guild_id}:${calendar.id}`)
-                }
-                isProjectHidden={(project) =>
-                  hiddenProjectKeys.has(`${project.guildId}:${project.projectId}`)
-                }
-                onToggleCalendar={(calendar) =>
-                  setHiddenCalendarKeys((prev) =>
-                    toggleInSet(prev, `${calendar.guild_id}:${calendar.id}`)
-                  )
-                }
-                onToggleProject={(project) =>
-                  setHiddenProjectKeys((prev) =>
-                    toggleInSet(prev, `${project.guildId}:${project.projectId}`)
-                  )
-                }
-                calendarLabel={(calendar) => {
-                  const guildName = multiGuild ? guildNamesById.get(calendar.guild_id) : undefined;
-                  return guildName ? `${calendar.name} · ${guildName}` : calendar.name;
-                }}
-                settingsPathFor={(calendar) =>
-                  guildPath(calendar.guild_id, `/calendars/${calendar.id}/settings`)
-                }
-                canCreate={false}
-                onCreate={() => {}}
-              />
-            </aside>
-            <div className="min-w-0 flex-1">
-              <CalendarView
-                entries={calendarEntries}
-                viewMode={calendarViewMode}
-                onViewModeChange={setCalendarViewMode}
-                focusDate={focusDate}
-                onFocusDateChange={setFocusDate}
-                onEntryClick={handleEntryClick}
-                weekStartsOn={weekStartsOn}
-              />
-            </div>
-          </div>
+          <CalendarView
+            entries={calendarEntries}
+            viewMode={calendarViewMode}
+            onViewModeChange={setCalendarViewMode}
+            focusDate={focusDate}
+            onFocusDateChange={setFocusDate}
+            onEntryClick={handleEntryClick}
+            weekStartsOn={weekStartsOn}
+          />
         )}
       </div>
     </PullToRefresh>


### PR DESCRIPTION
## Problem

The calendar page's visibility panel rendered as a left sidebar, squeezing the calendar grid — especially cramped on smaller windows. Follow-up feedback on #1037.

## Changes

- The panel (your calendars + one read-only task calendar per project with tasks in view) now sits behind a **Calendars** dropdown as the first control in the filter bar ([CalendarListPanel.tsx](frontend/src/components/initiativeTools/events/CalendarListPanel.tsx) gains a `CalendarPanelDropdown` wrapper); the calendar grid gets the full page width back on both the guild calendar page and My Calendar
- My Calendar keying fix: the panel skipped tasks with a null `guild_id` while the grid keyed them as `"null:<id>"` — a task could render with no matching panel row. Both sides now share one `taskProjectKey` helper with a `?? 0` fallback, so every visible project's tasks always get a panel row
- New `panel.calendars` label in all four locales

## Testing

- `frontend: ./scripts/test-changed.sh` — 71 files, 948 tests passed (the page test now opens the dropdown before asserting panel rows/toggles)
- `pnpm tsc --noEmit`, `pnpm biome check src` — clean