### PR TITLE
Render only the calendar's stored color

### DIFF
--- a/backend/alembic/versions/20260806_0159_require_calendar_color.py
+++ b/backend/alembic/versions/20260806_0159_require_calendar_color.py
@@ -1,0 +1,57 @@
+"""require calendar color
+
+A calendar always has a color: existing colorless rows get the app default,
+then the column goes NOT NULL with a server default. Rendering reads the
+stored value everywhere, so grid and picker can never disagree again.
+
+The backfill UPDATE runs as the table owner with FORCE RLS toggled off around
+it (FORCE would leave the owner policy-bound and silently skip rows) and
+asserts no colorless rows remain per schema.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.guild_migrations import run_for_each_guild_schema
+from app.models.tenant.calendar import DEFAULT_CALENDAR_COLOR
+
+revision = "20260806_0159"
+down_revision = "20260806_0158"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_upgrade)
+
+
+def _apply_upgrade() -> None:
+    op.execute("ALTER TABLE calendars NO FORCE ROW LEVEL SECURITY")
+    try:
+        op.execute(
+            sa.text(
+                "UPDATE calendars SET color = :color WHERE color IS NULL"
+            ).bindparams(color=DEFAULT_CALENDAR_COLOR)
+        )
+        remaining = (
+            op.get_bind()
+            .execute(sa.text("SELECT count(*) FROM calendars WHERE color IS NULL"))
+            .scalar()
+        )
+        if remaining:
+            raise RuntimeError(f"{remaining} calendars still have no color")
+    finally:
+        op.execute("ALTER TABLE calendars FORCE ROW LEVEL SECURITY")
+    op.execute(
+        f"ALTER TABLE calendars ALTER COLUMN color SET DEFAULT '{DEFAULT_CALENDAR_COLOR}'"
+    )
+    op.execute("ALTER TABLE calendars ALTER COLUMN color SET NOT NULL")
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_downgrade)
+
+
+def _apply_downgrade() -> None:
+    op.execute("ALTER TABLE calendars ALTER COLUMN color DROP NOT NULL")
+    op.execute("ALTER TABLE calendars ALTER COLUMN color DROP DEFAULT")

--- a/frontend/src/components/initiativeTools/events/CalendarListPanel.tsx
+++ b/frontend/src/components/initiativeTools/events/CalendarListPanel.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { getCalendarColor } from "@/lib/projectColor";
 
 /** A derived, read-only "calendar" for one project's tasks — rendered from the
  * calendar-entries tasks payload, never stored server-side. */
@@ -117,7 +116,7 @@ export const CalendarListPanel = ({
                   />
                   <span
                     className="h-2.5 w-2.5 shrink-0 rounded-full"
-                    style={{ backgroundColor: getCalendarColor(calendar.id, calendar.color) }}
+                    style={{ backgroundColor: calendar.color ?? "#6366f1" }}
                   />
                   <Label
                     htmlFor={`calendar-toggle-${calendar.guild_id}-${calendar.id}`}

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -34,7 +34,6 @@ import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useAuth } from "@/hooks/useAuth";
 import { useCreateCalendarEvent } from "@/hooks/useCalendarEvents";
 import { useCalendarsList } from "@/hooks/useCalendars";
-import { getCalendarColor } from "@/lib/projectColor";
 import { getItem, setItem } from "@/lib/storage";
 import type { DialogProps } from "@/types/dialog";
 
@@ -316,7 +315,7 @@ export const CreateEventDialog = ({
                       <span className="inline-flex items-center gap-2">
                         <span
                           className="inline-block h-2.5 w-2.5 rounded-full"
-                          style={{ backgroundColor: getCalendarColor(calendar.id, calendar.color) }}
+                          style={{ backgroundColor: calendar.color ?? "#6366f1" }}
                         />
                         {calendar.name}
                       </span>

--- a/frontend/src/lib/projectColor.ts
+++ b/frontend/src/lib/projectColor.ts
@@ -15,9 +15,3 @@ const PROJECT_COLORS = [
 
 export const getProjectColor = (projectId: number): string =>
   PROJECT_COLORS[projectId % PROJECT_COLORS.length];
-
-/** A calendar's display color: its stored color, else a stable palette color
- *  by id. Events carry no color of their own — they always render in their
- *  calendar's color, so this is the single place an event color comes from. */
-export const getCalendarColor = (calendarId: number, storedColor?: string | null): string =>
-  storedColor ?? PROJECT_COLORS[calendarId % PROJECT_COLORS.length];

--- a/frontend/src/pages/initiativeTools/events/CalendarSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/CalendarSettingsPage.tsx
@@ -164,7 +164,7 @@ export function CalendarSettingsPage() {
             <Label htmlFor="calendar-color">{t("calendarColor")}</Label>
             <ColorPickerPopover
               id="calendar-color"
-              value={color || "#6366F1"}
+              value={color || "#6366f1"}
               onChange={setColor}
               triggerLabel={t("calendarColor")}
             />

--- a/frontend/src/pages/initiativeTools/events/CalendarsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/CalendarsPage.tsx
@@ -57,7 +57,7 @@ import { useUpdateTask } from "@/hooks/useTasks";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { exportFilenameStem } from "@/lib/exportDownload";
 import { useGuildPath } from "@/lib/guildUrl";
-import { getCalendarColor, getProjectColor } from "@/lib/projectColor";
+import { getProjectColor } from "@/lib/projectColor";
 import { PRIORITY_ORDER } from "@/lib/sorting";
 import { getItem, setItem } from "@/lib/storage";
 import { toolExportEndpoint } from "@/lib/tools";
@@ -66,6 +66,8 @@ const STORAGE_KEY = "initiative-calendars-prefs";
 const VISIBILITY_KEY = "initiative-calendar-visibility";
 
 const STATUS_CATEGORIES: TaskStatusCategory[] = ["backlog", "todo", "in_progress", "done"];
+
+const DEFAULT_EVENT_COLOR = "#6366f1";
 
 interface StoredPrefs {
   statusFilters: TaskStatusCategory[];
@@ -343,8 +345,8 @@ export const CalendarsView = ({
         startAt: event.start_at,
         endAt: event.end_at,
         allDay: event.all_day,
-        // Events render in their calendar's color (stored or palette-derived).
-        color: getCalendarColor(event.calendar_id, calendar?.color),
+        // Events render in their calendar's stored color.
+        color: calendar?.color ?? DEFAULT_EVENT_COLOR,
         attendees: (event.attendee_previews ?? []).map((att) => ({
           name: att.name,
           avatarUrl: att.avatar_url,

--- a/frontend/src/pages/user/MyCalendarPage.tsx
+++ b/frontend/src/pages/user/MyCalendarPage.tsx
@@ -36,7 +36,7 @@ import { useGuilds } from "@/hooks/useGuilds";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { toast } from "@/lib/chesterToast";
 import { guildPath, useGuildPath } from "@/lib/guildUrl";
-import { getCalendarColor, getProjectColor } from "@/lib/projectColor";
+import { getProjectColor } from "@/lib/projectColor";
 import { PRIORITY_ORDER } from "@/lib/sorting";
 import { getItem, setItem } from "@/lib/storage";
 
@@ -291,8 +291,8 @@ export const MyCalendarPage = () => {
         startAt: event.start_at,
         endAt: event.end_at,
         allDay: event.all_day,
-        // Events render in their calendar's color (stored or palette-derived).
-        color: getCalendarColor(event.calendar_id, calendar?.color),
+        // Events render in their calendar's stored color.
+        color: calendar?.color ?? "#6366f1",
         attendees: (event.attendee_previews ?? []).map((att) => ({
           name: att.name,
           avatarUrl: att.avatar_url,

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -1355,10 +1355,15 @@ async def _create_calendar_events(
         creator = all_users[ed["created_by"]]
         calendar = calendars_by_initiative.get(ed["initiative_id"])
         if calendar is None:
+            # Store the initiative's color explicitly so the seeded calendar
+            # renders intentionally (a colorless calendar falls back to a
+            # palette color derived from its id).
+            initiative = await session.get(Initiative, ed["initiative_id"])
             calendar = Calendar(
                 guild_id=guild.id,
                 initiative_id=ed["initiative_id"],
                 name="Default Calendar",
+                color=initiative.color if initiative else None,
                 created_by_id=creator.id,
             )
             session.add(calendar)

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -133,17 +133,18 @@ NOW = datetime.now(timezone.utc)
 # Lexical document content helper
 # ---------------------------------------------------------------------------
 
+
 def _doc(paragraphs: list[str]) -> dict:
     """Build a minimal Lexical editor JSON structure from plain text paragraphs."""
     children = []
     for text in paragraphs:
-        children.append({
-            "children": [{"text": text, "type": "text"}],
-            "type": "paragraph",
-        })
+        children.append(
+            {
+                "children": [{"text": text, "type": "text"}],
+                "type": "paragraph",
+            }
+        )
     return {"root": {"children": children, "type": "root"}}
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -151,38 +152,82 @@ def _doc(paragraphs: list[str]) -> dict:
 # ---------------------------------------------------------------------------
 
 _DUNGEON_AREAS = [
-    "Entrance Hall", "Crypt of Whispers", "The Bone Gallery", "Flooded Caverns",
-    "Shadow Forge", "Hall of Mirrors", "Spider Nest", "Collapsed Library",
-    "Throne of Ashes", "Ritual Chamber", "Fungal Grotto", "Iron Cage Arena",
-    "Ember Vaults", "Wailing Cells", "Clockwork Passage", "Dread Pantry",
-    "Ossuary", "Sunken Chapel", "Alchemist Lab", "Guard Barracks",
+    "Entrance Hall",
+    "Crypt of Whispers",
+    "The Bone Gallery",
+    "Flooded Caverns",
+    "Shadow Forge",
+    "Hall of Mirrors",
+    "Spider Nest",
+    "Collapsed Library",
+    "Throne of Ashes",
+    "Ritual Chamber",
+    "Fungal Grotto",
+    "Iron Cage Arena",
+    "Ember Vaults",
+    "Wailing Cells",
+    "Clockwork Passage",
+    "Dread Pantry",
+    "Ossuary",
+    "Sunken Chapel",
+    "Alchemist Lab",
+    "Guard Barracks",
 ]
 
 _DUNGEON_VERBS = [
-    "Clear", "Explore", "Map", "Loot", "Secure", "Investigate",
-    "Disarm traps in", "Search for secrets in", "Barricade", "Purify",
+    "Clear",
+    "Explore",
+    "Map",
+    "Loot",
+    "Secure",
+    "Investigate",
+    "Disarm traps in",
+    "Search for secrets in",
+    "Barricade",
+    "Purify",
 ]
 
 _DUNGEON_USERS = [
-    "Dungeon Master", "Thorn Ironforge", "Elara Moonwhisper",
-    "Vex Shadowstep", "Admin User",
+    "Dungeon Master",
+    "Thorn Ironforge",
+    "Elara Moonwhisper",
+    "Vex Shadowstep",
+    "Admin User",
 ]
 
 
 def _generate_mega_dungeon_tasks(project_id: int) -> list[dict]:
     """Generate 1 000 TTRPG-themed task defs for the mega dungeon project."""
     import random as _rng
+
     _rng.seed(42)  # deterministic for reproducible seeds
 
-    priorities = [TaskPriority.low, TaskPriority.medium, TaskPriority.high, TaskPriority.urgent]
+    priorities = [
+        TaskPriority.low,
+        TaskPriority.medium,
+        TaskPriority.high,
+        TaskPriority.urgent,
+    ]
     categories = [
-        TaskStatusCategory.backlog, TaskStatusCategory.todo,
-        TaskStatusCategory.in_progress, TaskStatusCategory.done,
+        TaskStatusCategory.backlog,
+        TaskStatusCategory.todo,
+        TaskStatusCategory.in_progress,
+        TaskStatusCategory.done,
     ]
 
     _adjectives = [
-        "Cursed", "Hidden", "Burning", "Frozen", "Ancient", "Ruined",
-        "Enchanted", "Haunted", "Gilded", "Shattered", "Verdant", "Infernal",
+        "Cursed",
+        "Hidden",
+        "Burning",
+        "Frozen",
+        "Ancient",
+        "Ruined",
+        "Enchanted",
+        "Haunted",
+        "Gilded",
+        "Shattered",
+        "Verdant",
+        "Infernal",
     ]
 
     tasks: list[dict] = []
@@ -197,7 +242,7 @@ def _generate_mega_dungeon_tasks(project_id: int) -> list[dict]:
             "project_id": project_id,
             "title": f"Floor {floor}, Room {room}: {verb} the {adj} {area}",
             "description": f"Level {floor} exploration — {verb.lower()} the {adj.lower()} {area} "
-                           f"and report findings to the party.",
+            f"and report findings to the party.",
             "priority": _rng.choice(priorities),
             "category": _rng.choice(categories),
         }
@@ -231,6 +276,7 @@ def _generate_mega_dungeon_tasks(project_id: int) -> list[dict]:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _save_state(state: dict) -> None:
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
     STATE_FILE.write_text(json.dumps(state, indent=2))
@@ -249,7 +295,9 @@ async def _find_superuser(session: AsyncSession) -> User:
     if not email:
         print("ERROR: FIRST_OWNER_EMAIL is not set in .env or environment.")
         sys.exit(1)
-    result = await session.exec(select(User).where(User.email_hash == hash_email(email)))
+    result = await session.exec(
+        select(User).where(User.email_hash == hash_email(email))
+    )
     user = result.one_or_none()
     if user is None:
         print(f"ERROR: Superuser {email} not found.")
@@ -261,6 +309,7 @@ async def _find_superuser(session: AsyncSession) -> User:
 # ---------------------------------------------------------------------------
 # ID tracker — collects all created IDs for cleanup
 # ---------------------------------------------------------------------------
+
 
 class IDTracker:
     def __init__(self) -> None:
@@ -318,6 +367,7 @@ class IDTracker:
 # ---------------------------------------------------------------------------
 # Guild seeder helpers
 # ---------------------------------------------------------------------------
+
 
 async def _create_users(
     session: AsyncSession,
@@ -473,7 +523,9 @@ async def _create_initiative(
     await session.flush()
     ids.add("initiatives", initiative.id)
 
-    pm_role, member_role = await create_builtin_roles(session, initiative_id=initiative.id)
+    pm_role, member_role = await create_builtin_roles(
+        session, initiative_id=initiative.id
+    )
     ids.add("initiative_roles", pm_role.id)
     ids.add("initiative_roles", member_role.id)
 
@@ -485,10 +537,13 @@ async def _create_initiative(
             )
         )
         for perm in result.all():
-            ids.add("initiative_role_permissions", {
-                "initiative_role_id": perm.initiative_role_id,
-                "permission_key": perm.permission_key,
-            })
+            ids.add(
+                "initiative_role_permissions",
+                {
+                    "initiative_role_id": perm.initiative_role_id,
+                    "permission_key": perm.permission_key,
+                },
+            )
 
     # Add PM
     pm_member = InitiativeMember(
@@ -498,10 +553,12 @@ async def _create_initiative(
         role_id=pm_role.id,
     )
     session.add(pm_member)
-    ids.add("initiative_members", {"initiative_id": initiative.id, "user_id": pm_user.id})
+    ids.add(
+        "initiative_members", {"initiative_id": initiative.id, "user_id": pm_user.id}
+    )
 
     # Add members
-    for user in (member_users or []):
+    for user in member_users or []:
         m = InitiativeMember(
             initiative_id=initiative.id,
             user_id=user.id,
@@ -509,7 +566,9 @@ async def _create_initiative(
             role_id=member_role.id,
         )
         session.add(m)
-        ids.add("initiative_members", {"initiative_id": initiative.id, "user_id": user.id})
+        ids.add(
+            "initiative_members", {"initiative_id": initiative.id, "user_id": user.id}
+        )
 
     await session.flush()
     return initiative, pm_role, member_role
@@ -560,7 +619,7 @@ async def _create_project(
     session.add(perm)
     ids.add("project_permissions", {"project_id": project.id, "user_id": owner.id})
 
-    for user in (write_users or []):
+    for user in write_users or []:
         p = ResourceGrant(
             resource_type="project",
             resource_id=project.id,
@@ -572,7 +631,7 @@ async def _create_project(
         session.add(p)
         ids.add("project_permissions", {"project_id": project.id, "user_id": user.id})
 
-    for user in (read_users or []):
+    for user in read_users or []:
         p = ResourceGrant(
             resource_type="project",
             resource_id=project.id,
@@ -584,7 +643,7 @@ async def _create_project(
         session.add(p)
         ids.add("project_permissions", {"project_id": project.id, "user_id": user.id})
 
-    for role, level in (role_grants or []):
+    for role, level in role_grants or []:
         p = ResourceGrant(
             resource_type="project",
             resource_id=project.id,
@@ -779,7 +838,9 @@ async def _create_documents(
                     level=ResourceAccessLevel.write,
                 )
                 session.add(dp)
-                ids.add("document_permissions", {"document_id": doc.id, "user_id": w.id})
+                ids.add(
+                    "document_permissions", {"document_id": doc.id, "user_id": w.id}
+                )
 
         for reader_name in dd.get("readers", []):
             r = all_users.get(reader_name)
@@ -793,7 +854,9 @@ async def _create_documents(
                     level=ResourceAccessLevel.read,
                 )
                 session.add(dp)
-                ids.add("document_permissions", {"document_id": doc.id, "user_id": r.id})
+                ids.add(
+                    "document_permissions", {"document_id": doc.id, "user_id": r.id}
+                )
 
         for role, level in dd.get("role_grants", []):
             dp = ResourceGrant(
@@ -950,10 +1013,13 @@ async def _create_document_links(
             guild_id=guild.id,
         )
         session.add(dl)
-        ids.add("document_links", {
-            "source_document_id": source.id,
-            "target_document_id": target.id,
-        })
+        ids.add(
+            "document_links",
+            {
+                "source_document_id": source.id,
+                "target_document_id": target.id,
+            },
+        )
     await session.flush()
 
 
@@ -995,6 +1061,7 @@ async def _apply_user_settings(
 # Queue permission helper
 # ---------------------------------------------------------------------------
 
+
 async def _enable_queue_permissions(
     session: AsyncSession,
     member_roles: list[InitiativeRoleModel],
@@ -1017,6 +1084,7 @@ async def _enable_queue_permissions(
 # ---------------------------------------------------------------------------
 # Queue seeder helpers
 # ---------------------------------------------------------------------------
+
 
 async def _create_queues(
     session: AsyncSession,
@@ -1065,9 +1133,13 @@ async def _create_queues(
             level=ResourceAccessLevel.owner,
         )
         session.add(owner_perm)
-        ids.add("queue_permissions", {
-            "queue_id": queue.id, "user_id": creator.id,
-        })
+        ids.add(
+            "queue_permissions",
+            {
+                "queue_id": queue.id,
+                "user_id": creator.id,
+            },
+        )
 
         # Write permissions
         for uname in qd.get("write_users", []):
@@ -1082,9 +1154,13 @@ async def _create_queues(
                     level=ResourceAccessLevel.write,
                 )
                 session.add(wp)
-                ids.add("queue_permissions", {
-                    "queue_id": queue.id, "user_id": user.id,
-                })
+                ids.add(
+                    "queue_permissions",
+                    {
+                        "queue_id": queue.id,
+                        "user_id": user.id,
+                    },
+                )
 
         # Read permissions
         for uname in qd.get("read_users", []):
@@ -1099,9 +1175,13 @@ async def _create_queues(
                     level=ResourceAccessLevel.read,
                 )
                 session.add(rp)
-                ids.add("queue_permissions", {
-                    "queue_id": queue.id, "user_id": user.id,
-                })
+                ids.add(
+                    "queue_permissions",
+                    {
+                        "queue_id": queue.id,
+                        "user_id": user.id,
+                    },
+                )
 
         # Role grants
         for role, level in qd.get("role_grants", []):
@@ -1114,9 +1194,13 @@ async def _create_queues(
                 level=level,
             )
             session.add(rg)
-            ids.add("queue_permissions", {
-                "queue_id": queue.id, "role_id": role.id,
-            })
+            ids.add(
+                "queue_permissions",
+                {
+                    "queue_id": queue.id,
+                    "role_id": role.id,
+                },
+            )
 
         # General access (all initiative members)
         if qd.get("general_access") is not None:
@@ -1165,9 +1249,13 @@ async def _create_queues(
                         tag_id=tag.id,
                     )
                     session.add(qit)
-                    ids.add("queue_item_tags", {
-                        "queue_item_id": qi.id, "tag_id": tag.id,
-                    })
+                    ids.add(
+                        "queue_item_tags",
+                        {
+                            "queue_item_id": qi.id,
+                            "tag_id": tag.id,
+                        },
+                    )
             await session.flush()
 
         # Set active item
@@ -1184,6 +1272,7 @@ async def _create_queues(
 # ---------------------------------------------------------------------------
 # Counter / calendar event / property seeder helpers
 # ---------------------------------------------------------------------------
+
 
 async def _enable_role_feature(
     session: AsyncSession,
@@ -1252,9 +1341,13 @@ async def _create_counter_groups(
             level=ResourceAccessLevel.owner,
         )
         session.add(owner_perm)
-        ids.add("counter_group_permissions", {
-            "counter_group_id": group.id, "user_id": creator.id,
-        })
+        ids.add(
+            "counter_group_permissions",
+            {
+                "counter_group_id": group.id,
+                "user_id": creator.id,
+            },
+        )
 
         # Extra user grants
         for grant in gd.get("user_grants", []):
@@ -1269,9 +1362,13 @@ async def _create_counter_groups(
                     level=grant.get("level", ResourceAccessLevel.write),
                 )
                 session.add(up)
-                ids.add("counter_group_permissions", {
-                    "counter_group_id": group.id, "user_id": user.id,
-                })
+                ids.add(
+                    "counter_group_permissions",
+                    {
+                        "counter_group_id": group.id,
+                        "user_id": user.id,
+                    },
+                )
 
         # Role grants
         for grant in gd.get("role_grants", []):
@@ -1284,10 +1381,13 @@ async def _create_counter_groups(
                 level=grant.get("level", ResourceAccessLevel.read),
             )
             session.add(rp)
-            ids.add("counter_group_role_permissions", {
-                "counter_group_id": group.id,
-                "initiative_role_id": grant["role_id"],
-            })
+            ids.add(
+                "counter_group_role_permissions",
+                {
+                    "counter_group_id": group.id,
+                    "initiative_role_id": grant["role_id"],
+                },
+            )
 
         # General access (all initiative members)
         if gd.get("general_access") is not None:
@@ -1300,9 +1400,13 @@ async def _create_counter_groups(
                 all_initiative_members=True,
             )
             session.add(ga)
-            ids.add("counter_group_permissions", {
-                "counter_group_id": group.id, "general": True,
-            })
+            ids.add(
+                "counter_group_permissions",
+                {
+                    "counter_group_id": group.id,
+                    "general": True,
+                },
+            )
         await session.flush()
 
         # Counters
@@ -1366,29 +1470,34 @@ async def _create_calendar_events(
                 guild_id=guild.id,
                 initiative_id=ed["initiative_id"],
                 name="Default Calendar",
-                color=initiative.color if initiative else None,
+                color=(initiative.color if initiative else None)
+                or DEFAULT_CALENDAR_COLOR,
                 created_by_id=creator.id,
             )
             session.add(calendar)
             await session.flush()
             calendars_by_initiative[ed["initiative_id"]] = calendar
             ids.add("calendars", calendar.id)
-            session.add(ResourceGrant(
-                resource_type="calendar",
-                resource_id=calendar.id,
-                user_id=creator.id,
-                guild_id=guild.id,
-                initiative_id=calendar.initiative_id,
-                level=ResourceAccessLevel.owner,
-            ))
-            session.add(ResourceGrant(
-                resource_type="calendar",
-                resource_id=calendar.id,
-                guild_id=guild.id,
-                initiative_id=calendar.initiative_id,
-                level=ResourceAccessLevel.read,
-                all_initiative_members=True,
-            ))
+            session.add(
+                ResourceGrant(
+                    resource_type="calendar",
+                    resource_id=calendar.id,
+                    user_id=creator.id,
+                    guild_id=guild.id,
+                    initiative_id=calendar.initiative_id,
+                    level=ResourceAccessLevel.owner,
+                )
+            )
+            session.add(
+                ResourceGrant(
+                    resource_type="calendar",
+                    resource_id=calendar.id,
+                    guild_id=guild.id,
+                    initiative_id=calendar.initiative_id,
+                    level=ResourceAccessLevel.read,
+                    all_initiative_members=True,
+                )
+            )
         recurrence_raw = ed.get("recurrence")
         event = CalendarEvent(
             guild_id=guild.id,
@@ -1418,9 +1527,13 @@ async def _create_calendar_events(
                 rsvp_status=att.get("rsvp_status", RSVPStatus.pending),
             )
             session.add(attendee)
-            ids.add("calendar_event_attendees", {
-                "calendar_event_id": event.id, "user_id": user.id,
-            })
+            ids.add(
+                "calendar_event_attendees",
+                {
+                    "calendar_event_id": event.id,
+                    "user_id": user.id,
+                },
+            )
 
         # Tag links
         for tag_name in ed.get("tags", []):
@@ -1432,9 +1545,13 @@ async def _create_calendar_events(
                 tag_id=tag.id,
             )
             session.add(link)
-            ids.add("calendar_event_tags", {
-                "calendar_event_id": event.id, "tag_id": tag.id,
-            })
+            ids.add(
+                "calendar_event_tags",
+                {
+                    "calendar_event_id": event.id,
+                    "tag_id": tag.id,
+                },
+            )
 
         # Document links
         for doc_title in ed.get("documents", []):
@@ -1448,9 +1565,13 @@ async def _create_calendar_events(
                 attached_by_id=creator.id,
             )
             session.add(link)
-            ids.add("calendar_event_documents", {
-                "calendar_event_id": event.id, "document_id": doc.id,
-            })
+            ids.add(
+                "calendar_event_documents",
+                {
+                    "calendar_event_id": event.id,
+                    "document_id": doc.id,
+                },
+            )
 
         await session.flush()
         events[ed["title"]] = event
@@ -1552,6 +1673,7 @@ async def _attach_property_values(
 # PAM access-grant seeder (platform-role testing paths)
 # ---------------------------------------------------------------------------
 
+
 async def _create_access_grants(
     session: AsyncSession,
     ids: IDTracker,
@@ -1585,10 +1707,14 @@ async def _create_access_grants(
             approved_by_id=gd["approved_by"].id if gd.get("approved_by") else None,
             requested_at=NOW + gd.get("requested_delta", timedelta(0)),
             decided_at=(
-                NOW + gd["decided_delta"] if gd.get("decided_delta") is not None else None
+                NOW + gd["decided_delta"]
+                if gd.get("decided_delta") is not None
+                else None
             ),
             expires_at=(
-                NOW + gd["expires_delta"] if gd.get("expires_delta") is not None else None
+                NOW + gd["expires_delta"]
+                if gd.get("expires_delta") is not None
+                else None
             ),
         )
         session.add(grant)
@@ -1599,6 +1725,7 @@ async def _create_access_grants(
 # ---------------------------------------------------------------------------
 # Seed
 # ---------------------------------------------------------------------------
+
 
 async def seed() -> None:
     if _load_state() is not None:
@@ -1618,55 +1745,136 @@ async def seed() -> None:
         # Users (all password: "changeme")
         # ==============================================================
         print("  Creating users...")
-        new_users = await _create_users(session, ids, [
-            {"email": "user1@example.com", "full_name": "Dungeon Master",
-             "timezone": "America/New_York", "color_theme": "strahd", "week_starts_on": 1},
-            {"email": "user2@example.com", "full_name": "Thorn Ironforge",
-             "timezone": "America/Chicago", "color_theme": "kobold"},
-            {"email": "user3@example.com", "full_name": "Elara Moonwhisper",
-             "timezone": "Europe/London", "color_theme": "displacer", "week_starts_on": 1,
-             "email_overdue_tasks": False, "push_overdue_tasks": False},
-            {"email": "user4@example.com", "full_name": "Vex Shadowstep",
-             "timezone": "America/Los_Angeles", "color_theme": "strahd",
-             "email_task_assignment": False},
-            {"email": "user5@example.com", "full_name": "Seraphina Dawnlight",
-             "timezone": "Europe/Berlin", "color_theme": "kobold", "week_starts_on": 1},
-            {"email": "user6@example.com", "full_name": "Finley Goldtongue",
-             "timezone": "Asia/Tokyo", "color_theme": "displacer"},
-            {"email": "user7@example.com", "full_name": "Kael Windrunner",
-             "timezone": "Australia/Sydney", "color_theme": "kobold",
-             "push_task_assignment": False, "push_overdue_tasks": False},
-            {"email": "user8@example.com", "full_name": "Aurelia Brightshield",
-             "timezone": "America/Denver", "color_theme": "strahd", "week_starts_on": 1},
-            # Dedicated guild admins — user1..8 above are ALWAYS regular guild
-            # members (several are initiative PMs), so these four carry every
-            # guild-admin membership instead. Platform tier stays `member`:
-            # guild admin is a guild role, orthogonal to the platform ladder.
-            {"email": "admin1@example.com", "full_name": "Guildmaster Aldric",
-             "timezone": "America/New_York", "color_theme": "kobold"},
-            {"email": "admin2@example.com", "full_name": "Overseer Nova",
-             "timezone": "America/Los_Angeles", "color_theme": "displacer"},
-            {"email": "admin3@example.com", "full_name": "Harbormaster Marisol",
-             "timezone": "Europe/Lisbon", "color_theme": "strahd", "week_starts_on": 1},
-            {"email": "admin4@example.com", "full_name": "Archivist Okoro",
-             "timezone": "Africa/Lagos", "color_theme": "kobold"},
-            # Platform-role users — one per tier for exercising the privilege ladder.
-            # (member@ rounds out the set; user1..8 above are also members.)
-            {"email": "owner@example.com", "full_name": "Platform Owner",
-             "role": UserRole.owner, "color_theme": "kobold"},
-            {"email": "operator@example.com", "full_name": "Platform Operator",
-             "role": UserRole.operator, "color_theme": "strahd"},
-            {"email": "moderator@example.com", "full_name": "Platform Moderator",
-             "role": UserRole.moderator, "color_theme": "displacer"},
-            {"email": "support@example.com", "full_name": "Platform Support",
-             "role": UserRole.support, "color_theme": "kobold"},
-            {"email": "member@example.com", "full_name": "Platform Member",
-             "role": UserRole.member, "color_theme": "strahd"},
-        ])
+        new_users = await _create_users(
+            session,
+            ids,
+            [
+                {
+                    "email": "user1@example.com",
+                    "full_name": "Dungeon Master",
+                    "timezone": "America/New_York",
+                    "color_theme": "strahd",
+                    "week_starts_on": 1,
+                },
+                {
+                    "email": "user2@example.com",
+                    "full_name": "Thorn Ironforge",
+                    "timezone": "America/Chicago",
+                    "color_theme": "kobold",
+                },
+                {
+                    "email": "user3@example.com",
+                    "full_name": "Elara Moonwhisper",
+                    "timezone": "Europe/London",
+                    "color_theme": "displacer",
+                    "week_starts_on": 1,
+                    "email_overdue_tasks": False,
+                    "push_overdue_tasks": False,
+                },
+                {
+                    "email": "user4@example.com",
+                    "full_name": "Vex Shadowstep",
+                    "timezone": "America/Los_Angeles",
+                    "color_theme": "strahd",
+                    "email_task_assignment": False,
+                },
+                {
+                    "email": "user5@example.com",
+                    "full_name": "Seraphina Dawnlight",
+                    "timezone": "Europe/Berlin",
+                    "color_theme": "kobold",
+                    "week_starts_on": 1,
+                },
+                {
+                    "email": "user6@example.com",
+                    "full_name": "Finley Goldtongue",
+                    "timezone": "Asia/Tokyo",
+                    "color_theme": "displacer",
+                },
+                {
+                    "email": "user7@example.com",
+                    "full_name": "Kael Windrunner",
+                    "timezone": "Australia/Sydney",
+                    "color_theme": "kobold",
+                    "push_task_assignment": False,
+                    "push_overdue_tasks": False,
+                },
+                {
+                    "email": "user8@example.com",
+                    "full_name": "Aurelia Brightshield",
+                    "timezone": "America/Denver",
+                    "color_theme": "strahd",
+                    "week_starts_on": 1,
+                },
+                # Dedicated guild admins — user1..8 above are ALWAYS regular guild
+                # members (several are initiative PMs), so these four carry every
+                # guild-admin membership instead. Platform tier stays `member`:
+                # guild admin is a guild role, orthogonal to the platform ladder.
+                {
+                    "email": "admin1@example.com",
+                    "full_name": "Guildmaster Aldric",
+                    "timezone": "America/New_York",
+                    "color_theme": "kobold",
+                },
+                {
+                    "email": "admin2@example.com",
+                    "full_name": "Overseer Nova",
+                    "timezone": "America/Los_Angeles",
+                    "color_theme": "displacer",
+                },
+                {
+                    "email": "admin3@example.com",
+                    "full_name": "Harbormaster Marisol",
+                    "timezone": "Europe/Lisbon",
+                    "color_theme": "strahd",
+                    "week_starts_on": 1,
+                },
+                {
+                    "email": "admin4@example.com",
+                    "full_name": "Archivist Okoro",
+                    "timezone": "Africa/Lagos",
+                    "color_theme": "kobold",
+                },
+                # Platform-role users — one per tier for exercising the privilege ladder.
+                # (member@ rounds out the set; user1..8 above are also members.)
+                {
+                    "email": "owner@example.com",
+                    "full_name": "Platform Owner",
+                    "role": UserRole.owner,
+                    "color_theme": "kobold",
+                },
+                {
+                    "email": "operator@example.com",
+                    "full_name": "Platform Operator",
+                    "role": UserRole.operator,
+                    "color_theme": "strahd",
+                },
+                {
+                    "email": "moderator@example.com",
+                    "full_name": "Platform Moderator",
+                    "role": UserRole.moderator,
+                    "color_theme": "displacer",
+                },
+                {
+                    "email": "support@example.com",
+                    "full_name": "Platform Support",
+                    "role": UserRole.support,
+                    "color_theme": "kobold",
+                },
+                {
+                    "email": "member@example.com",
+                    "full_name": "Platform Member",
+                    "role": UserRole.member,
+                    "color_theme": "strahd",
+                },
+            ],
+        )
 
         # Apply settings to the superuser too
         await _apply_user_settings(
-            session, ids, admin_user,
+            session,
+            ids,
+            admin_user,
             timezone="America/Los_Angeles",
             color_theme="kobold",
             week_starts_on=0,
@@ -1721,7 +1929,9 @@ async def seed() -> None:
         # of guild 1 must be empty (initiative RLS hides everything; content
         # 404s, not 403s).
         await _add_guild_members(
-            session, ids, g1,
+            session,
+            ids,
+            g1,
             [admin1, admin4, dm, thorn, elara, vex, sera, kael, p_operator, p_support],
             admin_users=[admin1, admin4],
         )
@@ -1769,14 +1979,19 @@ async def seed() -> None:
                 role_id=pm_role.id,
             )
             session.add(m)
-            ids.add("initiative_members", {
-                "initiative_id": g1_default_init.id, "user_id": user.id,
-            })
+            ids.add(
+                "initiative_members",
+                {
+                    "initiative_id": g1_default_init.id,
+                    "user_id": user.id,
+                },
+            )
         await session.flush()
 
         # --- Initiative: Curse of Strahd ---
         g1_strahd, g1_strahd_pm, g1_strahd_mem = await _create_initiative(
-            session, ids,
+            session,
+            ids,
             guild=g1,
             name="Campaign: Curse of Strahd",
             description="A gothic horror adventure in the demiplane of Barovia",
@@ -1790,7 +2005,8 @@ async def seed() -> None:
 
         # --- Initiative: Lost Mine of Phandelver ---
         g1_lmop, g1_lmop_pm, g1_lmop_mem = await _create_initiative(
-            session, ids,
+            session,
+            ids,
             guild=g1,
             name="Campaign: Lost Mine of Phandelver",
             description="A classic introductory adventure in the Sword Coast",
@@ -1811,10 +2027,12 @@ async def seed() -> None:
         #   Homebrew Rules   — general access (Editor)
         #   DM's Secret Vault — private: owner-only, no other grants
         g1_barovia = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_strahd,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_strahd,
             name="Barovia Arc",
-            icon="\U0001F9DB",
+            icon="\U0001f9db",
             description="The main horror campaign storyline through Castle Ravenloft",
             owner=dm,
             write_users=[thorn, elara],
@@ -1823,10 +2041,12 @@ async def seed() -> None:
         )
 
         g1_ravenloft = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_strahd,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_strahd,
             name="Castle Ravenloft",
-            icon="\U0001F3F0",
+            icon="\U0001f3f0",
             description="The final dungeon — Strahd's fortress atop the Pillarstone",
             owner=dm,
             write_users=[thorn],
@@ -1834,20 +2054,24 @@ async def seed() -> None:
         )
 
         g1_phandalin = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_lmop,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_lmop,
             name="Phandalin Adventures",
-            icon="\u2694\uFE0F",
+            icon="\u2694\ufe0f",
             description="Classic starter campaign in the Sword Coast region",
             owner=admin_user,
             write_users=[dm, thorn, elara],
         )
 
         g1_wave_echo = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_lmop,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_lmop,
             name="Wave Echo Cave",
-            icon="\U0001F48E",
+            icon="\U0001f48e",
             description="The lost mine of Phandelver and the Forge of Spells",
             owner=admin_user,
             write_users=[dm],
@@ -1855,20 +2079,24 @@ async def seed() -> None:
         )
 
         g1_session_zero = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_default_init,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_default_init,
             name="Session Zero & Planning",
-            icon="\U0001F4CB",
+            icon="\U0001f4cb",
             description="Meta-campaign logistics and session planning",
             owner=dm,
             write_users=[admin_user],
         )
 
         g1_homebrew = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_default_init,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_default_init,
             name="Homebrew Rules",
-            icon="\U0001F4DC",
+            icon="\U0001f4dc",
             description="Custom house rules, variant options, and homebrew content",
             owner=dm,
             write_users=[admin_user, thorn],
@@ -1876,22 +2104,26 @@ async def seed() -> None:
         )
 
         g1_secret = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_strahd,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_strahd,
             name="DM's Secret Vault",
-            icon="\U0001F512",
+            icon="\U0001f512",
             description="Unshared DM prep — plot twists the players must not see. "
-                        "Tests the private (owner-only) share status.",
+            "Tests the private (owner-only) share status.",
             owner=dm,
         )
 
         g1_mega_dungeon = await _create_project(
-            session, ids,
-            guild=g1, initiative=g1_strahd,
+            session,
+            ids,
+            guild=g1,
+            initiative=g1_strahd,
             name="Mega Dungeon: Halls of the Dread Lord",
-            icon="\U0001F3F0",
+            icon="\U0001f3f0",
             description="A sprawling 200-room dungeon crawl beneath Castle Ravenloft. "
-                        "Used to stress-test large task lists.",
+            "Used to stress-test large task lists.",
             owner=dm,
             write_users=[admin_user, thorn, elara],
             read_users=[vex, sera],
@@ -1899,7 +2131,16 @@ async def seed() -> None:
 
         # Task statuses
         print("  Creating Guild 1 task statuses...")
-        g1_projects = [g1_barovia, g1_ravenloft, g1_phandalin, g1_wave_echo, g1_session_zero, g1_homebrew, g1_secret, g1_mega_dungeon]
+        g1_projects = [
+            g1_barovia,
+            g1_ravenloft,
+            g1_phandalin,
+            g1_wave_echo,
+            g1_session_zero,
+            g1_homebrew,
+            g1_secret,
+            g1_mega_dungeon,
+        ]
         g1_status_maps: dict[int, dict[str, TaskStatus]] = {}
         for proj in g1_projects:
             statuses = await ensure_default_statuses(session, proj.id)
@@ -1914,137 +2155,293 @@ async def seed() -> None:
         print("  Creating Guild 1 tasks...")
         g1_task_defs = [
             # Barovia Arc
-            {"project_id": g1_barovia.id, "title": "Defeat Strahd von Zarovich",
-             "description": "The vampire lord must be destroyed to free Barovia from his curse.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.backlog,
-             "assignees": ["Thorn Ironforge", "Elara Moonwhisper"], "due_days": 30},
-            {"project_id": g1_barovia.id, "title": "Survive the Death House",
-             "description": "Navigate the haunted mansion on the outskirts of the Village of Barovia.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Dungeon Master"],
-             "subtasks": ["Explore the basement", "Find the hidden altar", "Escape before the house collapses"]},
-            {"project_id": g1_barovia.id, "title": "Find the Sunsword in the Amber Temple",
-             "description": "The legendary weapon is key to defeating the Dark Lord.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.todo, "due_days": 14,
-             "assignees": ["Thorn Ironforge"]},
-            {"project_id": g1_barovia.id, "title": "Negotiate with the Vistani caravan",
-             "description": "The Vistani hold secrets about Strahd and safe passage through the mists.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done,
-             "assignees": ["Vex Shadowstep"]},
-            {"project_id": g1_barovia.id, "title": "Retrieve the Tome of Strahd",
-             "description": "The tome reveals Strahd's history and weaknesses.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.todo,
-             "assignees": ["Elara Moonwhisper"], "due_days": 7},
-            {"project_id": g1_barovia.id, "title": "Ally with the werewolf pack",
-             "description": "The werewolves of Barovia could be powerful allies against Strahd if convinced.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.backlog},
-            {"project_id": g1_barovia.id, "title": "Escort Ireena to Vallaki",
-             "description": "Protect Ireena Kolyana from Strahd's minions on the road to Vallaki.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.done,
-             "assignees": ["Seraphina Dawnlight", "Thorn Ironforge"],
-             "subtasks": ["Pack supplies for the journey", "Guard Ireena through the Svalich Woods",
-                          "Arrive at Vallaki gates"]},
+            {
+                "project_id": g1_barovia.id,
+                "title": "Defeat Strahd von Zarovich",
+                "description": "The vampire lord must be destroyed to free Barovia from his curse.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.backlog,
+                "assignees": ["Thorn Ironforge", "Elara Moonwhisper"],
+                "due_days": 30,
+            },
+            {
+                "project_id": g1_barovia.id,
+                "title": "Survive the Death House",
+                "description": "Navigate the haunted mansion on the outskirts of the Village of Barovia.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Dungeon Master"],
+                "subtasks": [
+                    "Explore the basement",
+                    "Find the hidden altar",
+                    "Escape before the house collapses",
+                ],
+            },
+            {
+                "project_id": g1_barovia.id,
+                "title": "Find the Sunsword in the Amber Temple",
+                "description": "The legendary weapon is key to defeating the Dark Lord.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.todo,
+                "due_days": 14,
+                "assignees": ["Thorn Ironforge"],
+            },
+            {
+                "project_id": g1_barovia.id,
+                "title": "Negotiate with the Vistani caravan",
+                "description": "The Vistani hold secrets about Strahd and safe passage through the mists.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Vex Shadowstep"],
+            },
+            {
+                "project_id": g1_barovia.id,
+                "title": "Retrieve the Tome of Strahd",
+                "description": "The tome reveals Strahd's history and weaknesses.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Elara Moonwhisper"],
+                "due_days": 7,
+            },
+            {
+                "project_id": g1_barovia.id,
+                "title": "Ally with the werewolf pack",
+                "description": "The werewolves of Barovia could be powerful allies against Strahd if convinced.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.backlog,
+            },
+            {
+                "project_id": g1_barovia.id,
+                "title": "Escort Ireena to Vallaki",
+                "description": "Protect Ireena Kolyana from Strahd's minions on the road to Vallaki.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Seraphina Dawnlight", "Thorn Ironforge"],
+                "subtasks": [
+                    "Pack supplies for the journey",
+                    "Guard Ireena through the Svalich Woods",
+                    "Arrive at Vallaki gates",
+                ],
+            },
             # Castle Ravenloft
-            {"project_id": g1_ravenloft.id, "title": "Map Castle Ravenloft's layout",
-             "description": "Sketch out known rooms and passages for the final assault.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Dungeon Master"],
-             "subtasks": ["Map the main floor", "Map the crypts", "Map the towers", "Map Strahd's tomb"]},
-            {"project_id": g1_ravenloft.id, "title": "Disable the castle traps",
-             "description": "Ravenloft is full of deadly traps protecting the vampire lord.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo,
-             "assignees": ["Vex Shadowstep"]},
-            {"project_id": g1_ravenloft.id, "title": "Find the Heart of Sorrow",
-             "description": "The crystal heart protects Strahd and must be destroyed first.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.backlog,
-             "due_days": 21},
+            {
+                "project_id": g1_ravenloft.id,
+                "title": "Map Castle Ravenloft's layout",
+                "description": "Sketch out known rooms and passages for the final assault.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Dungeon Master"],
+                "subtasks": [
+                    "Map the main floor",
+                    "Map the crypts",
+                    "Map the towers",
+                    "Map Strahd's tomb",
+                ],
+            },
+            {
+                "project_id": g1_ravenloft.id,
+                "title": "Disable the castle traps",
+                "description": "Ravenloft is full of deadly traps protecting the vampire lord.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Vex Shadowstep"],
+            },
+            {
+                "project_id": g1_ravenloft.id,
+                "title": "Find the Heart of Sorrow",
+                "description": "The crystal heart protects Strahd and must be destroyed first.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.backlog,
+                "due_days": 21,
+            },
             # Phandalin Adventures
-            {"project_id": g1_phandalin.id, "title": "Rescue Gundren Rockseeker",
-             "description": "The dwarf was kidnapped on the road to Phandalin. Find him!",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Admin User", "Thorn Ironforge"], "due_days": 3},
-            {"project_id": g1_phandalin.id, "title": "Clear the Redbrand Hideout",
-             "description": "The Redbrand ruffians terrorize Phandalin from their base under Tresendar Manor.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.done,
-             "assignees": ["Thorn Ironforge", "Elara Moonwhisper"]},
-            {"project_id": g1_phandalin.id, "title": "Escort merchant supplies to Phandalin",
-             "description": "Deliver the wagon of supplies safely along the Triboar Trail.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done},
-            {"project_id": g1_phandalin.id, "title": "Investigate the Cragmaw goblins",
-             "description": "A tribe of goblins ambushed the party. Their hideout must be cleared.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done,
-             "subtasks": ["Find the Cragmaw Hideout", "Defeat Klarg the bugbear", "Free Sildar Hallwinter"],
-             "subtasks_done": True},
-            {"project_id": g1_phandalin.id, "title": "Talk to Halia Thornton at the Miner's Exchange",
-             "description": "She may have intel about the Redbrands and the Black Spider.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.todo,
-             "assignees": ["Elara Moonwhisper"]},
-            {"project_id": g1_phandalin.id, "title": "Visit Old Owl Well",
-             "description": "Reports of undead activity near the old watchtower ruins.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.backlog},
+            {
+                "project_id": g1_phandalin.id,
+                "title": "Rescue Gundren Rockseeker",
+                "description": "The dwarf was kidnapped on the road to Phandalin. Find him!",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Admin User", "Thorn Ironforge"],
+                "due_days": 3,
+            },
+            {
+                "project_id": g1_phandalin.id,
+                "title": "Clear the Redbrand Hideout",
+                "description": "The Redbrand ruffians terrorize Phandalin from their base under Tresendar Manor.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Thorn Ironforge", "Elara Moonwhisper"],
+            },
+            {
+                "project_id": g1_phandalin.id,
+                "title": "Escort merchant supplies to Phandalin",
+                "description": "Deliver the wagon of supplies safely along the Triboar Trail.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+            },
+            {
+                "project_id": g1_phandalin.id,
+                "title": "Investigate the Cragmaw goblins",
+                "description": "A tribe of goblins ambushed the party. Their hideout must be cleared.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+                "subtasks": [
+                    "Find the Cragmaw Hideout",
+                    "Defeat Klarg the bugbear",
+                    "Free Sildar Hallwinter",
+                ],
+                "subtasks_done": True,
+            },
+            {
+                "project_id": g1_phandalin.id,
+                "title": "Talk to Halia Thornton at the Miner's Exchange",
+                "description": "She may have intel about the Redbrands and the Black Spider.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Elara Moonwhisper"],
+            },
+            {
+                "project_id": g1_phandalin.id,
+                "title": "Visit Old Owl Well",
+                "description": "Reports of undead activity near the old watchtower ruins.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.backlog,
+            },
             # Wave Echo Cave
-            {"project_id": g1_wave_echo.id, "title": "Defeat the Black Spider in Wave Echo Cave",
-             "description": "Nezznar the Black Spider seeks the Forge of Spells.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.backlog,
-             "subtasks": ["Find the entrance to Wave Echo Cave", "Navigate the mine tunnels", "Confront Nezznar"],
-             "due_days": 10},
-            {"project_id": g1_wave_echo.id, "title": "Activate the Forge of Spells",
-             "description": "The ancient dwarven forge could create powerful magic items.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.backlog,
-             "assignees": ["Elara Moonwhisper"]},
-            {"project_id": g1_wave_echo.id, "title": "Clear the undead miners",
-             "description": "Ghosts and skeletons of the original miners still haunt the tunnels.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo,
-             "assignees": ["Seraphina Dawnlight"]},
+            {
+                "project_id": g1_wave_echo.id,
+                "title": "Defeat the Black Spider in Wave Echo Cave",
+                "description": "Nezznar the Black Spider seeks the Forge of Spells.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.backlog,
+                "subtasks": [
+                    "Find the entrance to Wave Echo Cave",
+                    "Navigate the mine tunnels",
+                    "Confront Nezznar",
+                ],
+                "due_days": 10,
+            },
+            {
+                "project_id": g1_wave_echo.id,
+                "title": "Activate the Forge of Spells",
+                "description": "The ancient dwarven forge could create powerful magic items.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.backlog,
+                "assignees": ["Elara Moonwhisper"],
+            },
+            {
+                "project_id": g1_wave_echo.id,
+                "title": "Clear the undead miners",
+                "description": "Ghosts and skeletons of the original miners still haunt the tunnels.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Seraphina Dawnlight"],
+            },
             # Session Zero & Planning
-            {"project_id": g1_session_zero.id, "title": "Finalize character backstories",
-             "description": "All players need to submit their character backstories before Session 1.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done},
-            {"project_id": g1_session_zero.id, "title": "Schedule Session 4",
-             "description": "Find a date that works for all five players.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.todo, "due_days": 5,
-             "assignees": ["Dungeon Master"]},
-            {"project_id": g1_session_zero.id, "title": "Review leveling rules for Tier 2",
-             "description": "Characters approaching level 5 — review multiclassing and feat rules.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.backlog},
-            {"project_id": g1_session_zero.id, "title": "Prepare battle maps for next session",
-             "description": "Print or prepare VTT maps for the upcoming dungeon crawl.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Dungeon Master"], "due_days": 2},
-            {"project_id": g1_session_zero.id, "title": "Order new dice set for the table",
-             "description": "The group agreed to get matching dice for the campaign.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.done},
+            {
+                "project_id": g1_session_zero.id,
+                "title": "Finalize character backstories",
+                "description": "All players need to submit their character backstories before Session 1.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+            },
+            {
+                "project_id": g1_session_zero.id,
+                "title": "Schedule Session 4",
+                "description": "Find a date that works for all five players.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.todo,
+                "due_days": 5,
+                "assignees": ["Dungeon Master"],
+            },
+            {
+                "project_id": g1_session_zero.id,
+                "title": "Review leveling rules for Tier 2",
+                "description": "Characters approaching level 5 — review multiclassing and feat rules.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.backlog,
+            },
+            {
+                "project_id": g1_session_zero.id,
+                "title": "Prepare battle maps for next session",
+                "description": "Print or prepare VTT maps for the upcoming dungeon crawl.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Dungeon Master"],
+                "due_days": 2,
+            },
+            {
+                "project_id": g1_session_zero.id,
+                "title": "Order new dice set for the table",
+                "description": "The group agreed to get matching dice for the campaign.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.done,
+            },
             # Homebrew Rules
-            {"project_id": g1_homebrew.id, "title": "Write critical hit tables",
-             "description": "Custom critical hit effects for each damage type.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Dungeon Master"],
-             "subtasks": ["Slashing crits", "Piercing crits", "Bludgeoning crits",
-                          "Fire crits", "Cold crits", "Lightning crits"]},
-            {"project_id": g1_homebrew.id, "title": "Balance the Gunslinger subclass",
-             "description": "Homebrew fighter subclass needs playtesting feedback.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.todo,
-             "assignees": ["Thorn Ironforge"]},
-            {"project_id": g1_homebrew.id, "title": "Revise potion crafting rules",
-             "description": "Current rules are too restrictive — allow crafting during short rests.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done,
-             "assignees": ["Admin User"]},
-            {"project_id": g1_homebrew.id, "title": "Retire the old initiative-tracker house rule",
-             "description": "Superseded by the queues feature. Kept for the archive view.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.done,
-             "archived": True},
+            {
+                "project_id": g1_homebrew.id,
+                "title": "Write critical hit tables",
+                "description": "Custom critical hit effects for each damage type.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Dungeon Master"],
+                "subtasks": [
+                    "Slashing crits",
+                    "Piercing crits",
+                    "Bludgeoning crits",
+                    "Fire crits",
+                    "Cold crits",
+                    "Lightning crits",
+                ],
+            },
+            {
+                "project_id": g1_homebrew.id,
+                "title": "Balance the Gunslinger subclass",
+                "description": "Homebrew fighter subclass needs playtesting feedback.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Thorn Ironforge"],
+            },
+            {
+                "project_id": g1_homebrew.id,
+                "title": "Revise potion crafting rules",
+                "description": "Current rules are too restrictive — allow crafting during short rests.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Admin User"],
+            },
+            {
+                "project_id": g1_homebrew.id,
+                "title": "Retire the old initiative-tracker house rule",
+                "description": "Superseded by the queues feature. Kept for the archive view.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.done,
+                "archived": True,
+            },
             # DM's Secret Vault (private project — owner-only)
-            {"project_id": g1_secret.id, "title": "Plan the Ireena/Tatyana reveal",
-             "description": "Session 15 twist. Absolutely no player visibility.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Dungeon Master"]},
-            {"project_id": g1_secret.id, "title": "Stat the secret final boss variant",
-             "description": "Strahd's heart-linked form if the party destroys the Heart of Sorrow first.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo},
-            {"project_id": g1_secret.id, "title": "Scrapped subplot: the mongrelfolk uprising",
-             "description": "Cut for pacing. Archived so it stops cluttering the board.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.backlog,
-             "archived": True},
+            {
+                "project_id": g1_secret.id,
+                "title": "Plan the Ireena/Tatyana reveal",
+                "description": "Session 15 twist. Absolutely no player visibility.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Dungeon Master"],
+            },
+            {
+                "project_id": g1_secret.id,
+                "title": "Stat the secret final boss variant",
+                "description": "Strahd's heart-linked form if the party destroys the Heart of Sorrow first.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+            },
+            {
+                "project_id": g1_secret.id,
+                "title": "Scrapped subplot: the mongrelfolk uprising",
+                "description": "Cut for pacing. Archived so it stops cluttering the board.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.backlog,
+                "archived": True,
+            },
             # Mega Dungeon — 200 rooms generated programmatically
             *_generate_mega_dungeon_tasks(g1_mega_dungeon.id),
         ]
@@ -2053,7 +2450,8 @@ async def seed() -> None:
         for proj in g1_projects:
             proj_tasks = [td for td in g1_task_defs if td["project_id"] == proj.id]
             tasks = await _create_tasks(
-                session, ids,
+                session,
+                ids,
                 guild=g1,
                 status_map=g1_status_maps[proj.id],
                 task_defs=proj_tasks,
@@ -2063,511 +2461,898 @@ async def seed() -> None:
 
         # -- Tags --
         print("  Creating Guild 1 tags...")
-        g1_tags = await _create_tags(session, ids, g1, [
-            ("quest", "#EF4444"),
-            ("NPC", "#8B5CF6"),
-            ("lore", "#F59E0B"),
-            ("combat", "#DC2626"),
-            ("roleplay", "#3B82F6"),
-            ("exploration", "#10B981"),
-            ("puzzle", "#F97316"),
-            ("boss fight", "#991B1B"),
-            ("side quest", "#6366F1"),
-            ("items/loot", "#D97706"),
-        ])
+        g1_tags = await _create_tags(
+            session,
+            ids,
+            g1,
+            [
+                ("quest", "#EF4444"),
+                ("NPC", "#8B5CF6"),
+                ("lore", "#F59E0B"),
+                ("combat", "#DC2626"),
+                ("roleplay", "#3B82F6"),
+                ("exploration", "#10B981"),
+                ("puzzle", "#F97316"),
+                ("boss fight", "#991B1B"),
+                ("side quest", "#6366F1"),
+                ("items/loot", "#D97706"),
+            ],
+        )
 
-        await _link_task_tags(session, ids, g1_tasks, g1_tags, [
-            ("Defeat Strahd von Zarovich", ["quest", "combat", "boss fight"]),
-            ("Survive the Death House", ["quest", "combat", "exploration"]),
-            ("Find the Sunsword in the Amber Temple", ["quest", "lore", "items/loot"]),
-            ("Negotiate with the Vistani caravan", ["NPC", "roleplay"]),
-            ("Retrieve the Tome of Strahd", ["quest", "lore", "items/loot"]),
-            ("Escort Ireena to Vallaki", ["quest", "NPC", "roleplay"]),
-            ("Map Castle Ravenloft's layout", ["exploration", "puzzle"]),
-            ("Find the Heart of Sorrow", ["quest", "boss fight"]),
-            ("Rescue Gundren Rockseeker", ["quest", "NPC"]),
-            ("Clear the Redbrand Hideout", ["quest", "combat"]),
-            ("Investigate the Cragmaw goblins", ["quest", "combat", "exploration"]),
-            ("Defeat the Black Spider in Wave Echo Cave", ["quest", "combat", "boss fight"]),
-            ("Activate the Forge of Spells", ["lore", "items/loot", "puzzle"]),
-            ("Write critical hit tables", ["combat"]),
-            ("Balance the Gunslinger subclass", ["combat"]),
-        ])
+        await _link_task_tags(
+            session,
+            ids,
+            g1_tasks,
+            g1_tags,
+            [
+                ("Defeat Strahd von Zarovich", ["quest", "combat", "boss fight"]),
+                ("Survive the Death House", ["quest", "combat", "exploration"]),
+                (
+                    "Find the Sunsword in the Amber Temple",
+                    ["quest", "lore", "items/loot"],
+                ),
+                ("Negotiate with the Vistani caravan", ["NPC", "roleplay"]),
+                ("Retrieve the Tome of Strahd", ["quest", "lore", "items/loot"]),
+                ("Escort Ireena to Vallaki", ["quest", "NPC", "roleplay"]),
+                ("Map Castle Ravenloft's layout", ["exploration", "puzzle"]),
+                ("Find the Heart of Sorrow", ["quest", "boss fight"]),
+                ("Rescue Gundren Rockseeker", ["quest", "NPC"]),
+                ("Clear the Redbrand Hideout", ["quest", "combat"]),
+                ("Investigate the Cragmaw goblins", ["quest", "combat", "exploration"]),
+                (
+                    "Defeat the Black Spider in Wave Echo Cave",
+                    ["quest", "combat", "boss fight"],
+                ),
+                ("Activate the Forge of Spells", ["lore", "items/loot", "puzzle"]),
+                ("Write critical hit tables", ["combat"]),
+                ("Balance the Gunslinger subclass", ["combat"]),
+            ],
+        )
 
-        await _link_project_tags(session, ids, g1_tags, [
-            (g1_barovia.id, ["combat", "lore", "quest"]),
-            (g1_ravenloft.id, ["combat", "exploration", "boss fight"]),
-            (g1_phandalin.id, ["quest", "NPC"]),
-            (g1_wave_echo.id, ["quest", "exploration", "items/loot"]),
-            (g1_session_zero.id, ["roleplay"]),
-            (g1_homebrew.id, ["combat", "items/loot"]),
-        ])
+        await _link_project_tags(
+            session,
+            ids,
+            g1_tags,
+            [
+                (g1_barovia.id, ["combat", "lore", "quest"]),
+                (g1_ravenloft.id, ["combat", "exploration", "boss fight"]),
+                (g1_phandalin.id, ["quest", "NPC"]),
+                (g1_wave_echo.id, ["quest", "exploration", "items/loot"]),
+                (g1_session_zero.id, ["roleplay"]),
+                (g1_homebrew.id, ["combat", "items/loot"]),
+            ],
+        )
 
         # -- Documents --
         print("  Creating Guild 1 documents...")
-        g1_docs = await _create_documents(session, ids, guild=g1, all_users=all_users, doc_defs=[
-            {
-                "initiative_id": g1_strahd.id,
-                "title": "Campaign Setting: The Land of Barovia",
-                "creator": "Dungeon Master",
-                "writers": ["Admin User"],
-                "readers": ["Thorn Ironforge", "Elara Moonwhisper"],
-                "general_access": ResourceAccessLevel.read,
-                "paragraphs": [
-                    "Barovia is a demiplane of dread, shrouded in perpetual mist. "
-                    "The land is ruled by Count Strahd von Zarovich, a vampire lord "
-                    "who has cursed this realm for centuries.",
-                    "No one enters or leaves without Strahd's permission. The sun never "
-                    "truly shines here, and the people live in constant fear of the "
-                    "creatures that stalk the night.",
-                    "Key locations: Village of Barovia, Vallaki, Krezk, the Amber Temple, "
-                    "Castle Ravenloft, Old Bonegrinder, Argynvostholt, and Yester Hill.",
-                ],
-            },
-            {
-                "initiative_id": g1_strahd.id,
-                "title": "NPC Roster: Curse of Strahd",
-                "creator": "Dungeon Master",
-                "role_grants": [(g1_strahd_mem, ResourceAccessLevel.read)],
-                "paragraphs": [
-                    "Strahd von Zarovich — The vampire lord of Barovia. Ancient, cunning, and tragically cursed.",
-                    "Ireena Kolyana — Adopted daughter of the burgomaster. Strahd believes she is Tatyana reborn.",
-                    "Ismark the Lesser — Ireena's brother, desperate to protect her.",
-                    "Madam Eva — Vistani seer who reads the party's fortune with the Tarokka deck.",
-                    "Kasimir Velikov — Dusk elf mage who seeks to resurrect his sister from the Amber Temple.",
-                    "Ezmerelda d'Avenir — Monster hunter and Van Richten's former protege.",
-                ],
-            },
-            {
-                "initiative_id": g1_lmop.id,
-                "title": "NPC Compendium: Phandelver",
-                "creator": "Admin User",
-                "writers": ["Dungeon Master"],
-                "paragraphs": [
-                    "Key NPCs: Gundren Rockseeker (quest giver), Sildar Hallwinter (Lords' Alliance agent), "
-                    "Sister Garaele (Harper contact in Phandalin), Nezznar the Black Spider (main antagonist), "
-                    "Glasstaff/Iarno Albrek (Redbrand leader).",
-                    "Phandalin Townfolk: Toblen Stonehill (innkeeper), Elmar Barthen (merchant), "
-                    "Linene Graywind (Lionshield Coster), Harbin Wester (cowardly townmaster).",
-                ],
-            },
-            {
-                "initiative_id": g1_default_init.id,
-                "title": "Session 1 Recap: Into the Mists",
-                "creator": "Dungeon Master",
-                "readers": ["Thorn Ironforge", "Elara Moonwhisper", "Vex Shadowstep", "Seraphina Dawnlight"],
-                "paragraphs": [
-                    "The party received a mysterious letter and traveled to the village of Barovia. "
-                    "After surviving the Death House, they met Ismark and Ireena.",
-                    "The session ended with the party heading toward the church in the village center. "
-                    "Next session: travel to Vallaki.",
-                ],
-            },
-            {
-                "initiative_id": g1_default_init.id,
-                "title": "Session 2 Recap: The Road to Vallaki",
-                "creator": "Dungeon Master",
-                "paragraphs": [
-                    "The party escorted Ireena through the Svalich Woods, fighting off dire wolves. "
-                    "They discovered the windmill at Old Bonegrinder was inhabited by night hags.",
-                    "Arrived at Vallaki and met Baron Vargas Vallakovich, who insists that 'All Will Be Well.'",
-                ],
-            },
-            {
-                "initiative_id": g1_default_init.id,
-                "title": "Session 3 Recap: Festival of the Blazing Sun",
-                "creator": "Dungeon Master",
-                "paragraphs": [
-                    "The Baron's festival went horribly wrong. The wicker sun failed to light, and the "
-                    "crowd nearly rioted. The party intervened to prevent bloodshed.",
-                    "Vex discovered a secret stash of bones beneath St. Andral's church. "
-                    "A vampire spawn attacked during the night.",
-                ],
-            },
-            {
-                "initiative_id": g1_strahd.id,
-                "title": "Tarokka Card Reading Results",
-                "creator": "Dungeon Master",
-                "paragraphs": [
-                    "The Tome of Strahd: Look for a wizard's tower on a lake (Van Richten's Tower).",
-                    "The Holy Symbol of Ravenkind: In a castle of bones (Argynvostholt).",
-                    "The Sunsword: A fallen temple of amber (Amber Temple).",
-                    "Strahd's Enemy: A young woman who has lost her family (Ezmerelda).",
-                    "Strahd's Location: The heart of his castle — the throne room.",
-                ],
-            },
-            {
-                # Private document — owner-only, no shares at all.
-                "initiative_id": g1_strahd.id,
-                "title": "DM Notes: Strahd's True Motives",
-                "creator": "Dungeon Master",
-                "paragraphs": [
-                    "Strahd is not hunting the party — he is auditioning them. He wants a "
-                    "successor who can break the curse he no longer believes he deserves "
-                    "to escape.",
-                    "If the players read this document, the seed data's private share "
-                    "status is broken.",
-                ],
-            },
-            {
-                "initiative_id": g1_default_init.id,
-                "title": "House Rules v2",
-                "creator": "Dungeon Master",
-                "writers": ["Admin User"],
-                "general_access": ResourceAccessLevel.write,
-                "paragraphs": [
-                    "1. Critical hits: Roll damage dice twice plus modifiers (no doubling modifiers).",
-                    "2. Potions: Drinking a potion is a bonus action. Feeding one to another is an action.",
-                    "3. Inspiration: Can be given to other players. Max 1 at a time.",
-                    "4. Death saves: Hidden from other players unless Medicine check DC 10.",
-                    "5. Flanking: +2 bonus instead of advantage.",
-                ],
-            },
-        ])
+        g1_docs = await _create_documents(
+            session,
+            ids,
+            guild=g1,
+            all_users=all_users,
+            doc_defs=[
+                {
+                    "initiative_id": g1_strahd.id,
+                    "title": "Campaign Setting: The Land of Barovia",
+                    "creator": "Dungeon Master",
+                    "writers": ["Admin User"],
+                    "readers": ["Thorn Ironforge", "Elara Moonwhisper"],
+                    "general_access": ResourceAccessLevel.read,
+                    "paragraphs": [
+                        "Barovia is a demiplane of dread, shrouded in perpetual mist. "
+                        "The land is ruled by Count Strahd von Zarovich, a vampire lord "
+                        "who has cursed this realm for centuries.",
+                        "No one enters or leaves without Strahd's permission. The sun never "
+                        "truly shines here, and the people live in constant fear of the "
+                        "creatures that stalk the night.",
+                        "Key locations: Village of Barovia, Vallaki, Krezk, the Amber Temple, "
+                        "Castle Ravenloft, Old Bonegrinder, Argynvostholt, and Yester Hill.",
+                    ],
+                },
+                {
+                    "initiative_id": g1_strahd.id,
+                    "title": "NPC Roster: Curse of Strahd",
+                    "creator": "Dungeon Master",
+                    "role_grants": [(g1_strahd_mem, ResourceAccessLevel.read)],
+                    "paragraphs": [
+                        "Strahd von Zarovich — The vampire lord of Barovia. Ancient, cunning, and tragically cursed.",
+                        "Ireena Kolyana — Adopted daughter of the burgomaster. Strahd believes she is Tatyana reborn.",
+                        "Ismark the Lesser — Ireena's brother, desperate to protect her.",
+                        "Madam Eva — Vistani seer who reads the party's fortune with the Tarokka deck.",
+                        "Kasimir Velikov — Dusk elf mage who seeks to resurrect his sister from the Amber Temple.",
+                        "Ezmerelda d'Avenir — Monster hunter and Van Richten's former protege.",
+                    ],
+                },
+                {
+                    "initiative_id": g1_lmop.id,
+                    "title": "NPC Compendium: Phandelver",
+                    "creator": "Admin User",
+                    "writers": ["Dungeon Master"],
+                    "paragraphs": [
+                        "Key NPCs: Gundren Rockseeker (quest giver), Sildar Hallwinter (Lords' Alliance agent), "
+                        "Sister Garaele (Harper contact in Phandalin), Nezznar the Black Spider (main antagonist), "
+                        "Glasstaff/Iarno Albrek (Redbrand leader).",
+                        "Phandalin Townfolk: Toblen Stonehill (innkeeper), Elmar Barthen (merchant), "
+                        "Linene Graywind (Lionshield Coster), Harbin Wester (cowardly townmaster).",
+                    ],
+                },
+                {
+                    "initiative_id": g1_default_init.id,
+                    "title": "Session 1 Recap: Into the Mists",
+                    "creator": "Dungeon Master",
+                    "readers": [
+                        "Thorn Ironforge",
+                        "Elara Moonwhisper",
+                        "Vex Shadowstep",
+                        "Seraphina Dawnlight",
+                    ],
+                    "paragraphs": [
+                        "The party received a mysterious letter and traveled to the village of Barovia. "
+                        "After surviving the Death House, they met Ismark and Ireena.",
+                        "The session ended with the party heading toward the church in the village center. "
+                        "Next session: travel to Vallaki.",
+                    ],
+                },
+                {
+                    "initiative_id": g1_default_init.id,
+                    "title": "Session 2 Recap: The Road to Vallaki",
+                    "creator": "Dungeon Master",
+                    "paragraphs": [
+                        "The party escorted Ireena through the Svalich Woods, fighting off dire wolves. "
+                        "They discovered the windmill at Old Bonegrinder was inhabited by night hags.",
+                        "Arrived at Vallaki and met Baron Vargas Vallakovich, who insists that 'All Will Be Well.'",
+                    ],
+                },
+                {
+                    "initiative_id": g1_default_init.id,
+                    "title": "Session 3 Recap: Festival of the Blazing Sun",
+                    "creator": "Dungeon Master",
+                    "paragraphs": [
+                        "The Baron's festival went horribly wrong. The wicker sun failed to light, and the "
+                        "crowd nearly rioted. The party intervened to prevent bloodshed.",
+                        "Vex discovered a secret stash of bones beneath St. Andral's church. "
+                        "A vampire spawn attacked during the night.",
+                    ],
+                },
+                {
+                    "initiative_id": g1_strahd.id,
+                    "title": "Tarokka Card Reading Results",
+                    "creator": "Dungeon Master",
+                    "paragraphs": [
+                        "The Tome of Strahd: Look for a wizard's tower on a lake (Van Richten's Tower).",
+                        "The Holy Symbol of Ravenkind: In a castle of bones (Argynvostholt).",
+                        "The Sunsword: A fallen temple of amber (Amber Temple).",
+                        "Strahd's Enemy: A young woman who has lost her family (Ezmerelda).",
+                        "Strahd's Location: The heart of his castle — the throne room.",
+                    ],
+                },
+                {
+                    # Private document — owner-only, no shares at all.
+                    "initiative_id": g1_strahd.id,
+                    "title": "DM Notes: Strahd's True Motives",
+                    "creator": "Dungeon Master",
+                    "paragraphs": [
+                        "Strahd is not hunting the party — he is auditioning them. He wants a "
+                        "successor who can break the curse he no longer believes he deserves "
+                        "to escape.",
+                        "If the players read this document, the seed data's private share "
+                        "status is broken.",
+                    ],
+                },
+                {
+                    "initiative_id": g1_default_init.id,
+                    "title": "House Rules v2",
+                    "creator": "Dungeon Master",
+                    "writers": ["Admin User"],
+                    "general_access": ResourceAccessLevel.write,
+                    "paragraphs": [
+                        "1. Critical hits: Roll damage dice twice plus modifiers (no doubling modifiers).",
+                        "2. Potions: Drinking a potion is a bonus action. Feeding one to another is an action.",
+                        "3. Inspiration: Can be given to other players. Max 1 at a time.",
+                        "4. Death saves: Hidden from other players unless Medicine check DC 10.",
+                        "5. Flanking: +2 bonus instead of advantage.",
+                    ],
+                },
+            ],
+        )
 
-        await _link_doc_projects(session, ids, g1, [
-            (g1_barovia.id, g1_docs["Campaign Setting: The Land of Barovia"].id, dm),
-            (g1_barovia.id, g1_docs["NPC Roster: Curse of Strahd"].id, dm),
-            (g1_barovia.id, g1_docs["Tarokka Card Reading Results"].id, dm),
-            (g1_phandalin.id, g1_docs["NPC Compendium: Phandelver"].id, admin_user),
-            (g1_session_zero.id, g1_docs["Session 1 Recap: Into the Mists"].id, dm),
-            (g1_session_zero.id, g1_docs["Session 2 Recap: The Road to Vallaki"].id, dm),
-            (g1_session_zero.id, g1_docs["Session 3 Recap: Festival of the Blazing Sun"].id, dm),
-            (g1_homebrew.id, g1_docs["House Rules v2"].id, dm),
-        ])
+        await _link_doc_projects(
+            session,
+            ids,
+            g1,
+            [
+                (
+                    g1_barovia.id,
+                    g1_docs["Campaign Setting: The Land of Barovia"].id,
+                    dm,
+                ),
+                (g1_barovia.id, g1_docs["NPC Roster: Curse of Strahd"].id, dm),
+                (g1_barovia.id, g1_docs["Tarokka Card Reading Results"].id, dm),
+                (g1_phandalin.id, g1_docs["NPC Compendium: Phandelver"].id, admin_user),
+                (g1_session_zero.id, g1_docs["Session 1 Recap: Into the Mists"].id, dm),
+                (
+                    g1_session_zero.id,
+                    g1_docs["Session 2 Recap: The Road to Vallaki"].id,
+                    dm,
+                ),
+                (
+                    g1_session_zero.id,
+                    g1_docs["Session 3 Recap: Festival of the Blazing Sun"].id,
+                    dm,
+                ),
+                (g1_homebrew.id, g1_docs["House Rules v2"].id, dm),
+            ],
+        )
 
-        await _link_doc_tags(session, ids, g1_docs, g1_tags, [
-            ("Campaign Setting: The Land of Barovia", ["lore"]),
-            ("NPC Roster: Curse of Strahd", ["NPC", "lore"]),
-            ("NPC Compendium: Phandelver", ["NPC"]),
-            ("Tarokka Card Reading Results", ["lore", "items/loot"]),
-            ("House Rules v2", ["combat"]),
-        ])
+        await _link_doc_tags(
+            session,
+            ids,
+            g1_docs,
+            g1_tags,
+            [
+                ("Campaign Setting: The Land of Barovia", ["lore"]),
+                ("NPC Roster: Curse of Strahd", ["NPC", "lore"]),
+                ("NPC Compendium: Phandelver", ["NPC"]),
+                ("Tarokka Card Reading Results", ["lore", "items/loot"]),
+                ("House Rules v2", ["combat"]),
+            ],
+        )
 
         # -- Comments --
         print("  Creating Guild 1 comments...")
-        await _create_comments(session, ids, g1, [
-            {"author": "Thorn Ironforge", "task_title": "Defeat Strahd von Zarovich",
-             "content": "We need the Sunsword AND the Holy Symbol before attempting this."},
-            {"author": "Elara Moonwhisper", "task_title": "Defeat Strahd von Zarovich",
-             "content": "I can prepare Daylight and Greater Restoration. We should also stock up on holy water."},
-            {"author": "Dungeon Master", "task_title": "Defeat Strahd von Zarovich",
-             "content": "Remember: Strahd can retreat to his coffin. You need to find it first."},
-            {"author": "Admin User", "task_title": "Rescue Gundren Rockseeker",
-             "content": "Last seen heading to Cragmaw Castle with the map."},
-            {"author": "Thorn Ironforge", "task_title": "Clear the Redbrand Hideout",
-             "content": "Completed! The party found Glasstaff's letters from the Black Spider."},
-            {"author": "Vex Shadowstep", "task_title": "Disable the castle traps",
-             "content": "I'll need thieves' tools and a lot of patience. DC 15+ on most of these."},
-            {"author": "Seraphina Dawnlight", "task_title": "Find the Heart of Sorrow",
-             "content": "The crystal heart is somewhere high in the castle towers. I can sense its dark energy."},
-            {"author": "Dungeon Master", "task_title": "Write critical hit tables",
-             "content": "Playtest feedback from session 2: slashing crits feel too strong at low levels."},
-            {"author": "Dungeon Master", "doc_title": "Campaign Setting: The Land of Barovia",
-             "content": "Don't forget \u2014 Barovia is a demiplane, no escape without defeating Strahd."},
-            {"author": "Elara Moonwhisper", "doc_title": "Tarokka Card Reading Results",
-             "content": "We should head to the Amber Temple first. The Sunsword is our highest priority."},
-        ], g1_tasks, g1_docs, all_users)
+        await _create_comments(
+            session,
+            ids,
+            g1,
+            [
+                {
+                    "author": "Thorn Ironforge",
+                    "task_title": "Defeat Strahd von Zarovich",
+                    "content": "We need the Sunsword AND the Holy Symbol before attempting this.",
+                },
+                {
+                    "author": "Elara Moonwhisper",
+                    "task_title": "Defeat Strahd von Zarovich",
+                    "content": "I can prepare Daylight and Greater Restoration. We should also stock up on holy water.",
+                },
+                {
+                    "author": "Dungeon Master",
+                    "task_title": "Defeat Strahd von Zarovich",
+                    "content": "Remember: Strahd can retreat to his coffin. You need to find it first.",
+                },
+                {
+                    "author": "Admin User",
+                    "task_title": "Rescue Gundren Rockseeker",
+                    "content": "Last seen heading to Cragmaw Castle with the map.",
+                },
+                {
+                    "author": "Thorn Ironforge",
+                    "task_title": "Clear the Redbrand Hideout",
+                    "content": "Completed! The party found Glasstaff's letters from the Black Spider.",
+                },
+                {
+                    "author": "Vex Shadowstep",
+                    "task_title": "Disable the castle traps",
+                    "content": "I'll need thieves' tools and a lot of patience. DC 15+ on most of these.",
+                },
+                {
+                    "author": "Seraphina Dawnlight",
+                    "task_title": "Find the Heart of Sorrow",
+                    "content": "The crystal heart is somewhere high in the castle towers. I can sense its dark energy.",
+                },
+                {
+                    "author": "Dungeon Master",
+                    "task_title": "Write critical hit tables",
+                    "content": "Playtest feedback from session 2: slashing crits feel too strong at low levels.",
+                },
+                {
+                    "author": "Dungeon Master",
+                    "doc_title": "Campaign Setting: The Land of Barovia",
+                    "content": "Don't forget \u2014 Barovia is a demiplane, no escape without defeating Strahd.",
+                },
+                {
+                    "author": "Elara Moonwhisper",
+                    "doc_title": "Tarokka Card Reading Results",
+                    "content": "We should head to the Amber Temple first. The Sunsword is our highest priority.",
+                },
+            ],
+            g1_tasks,
+            g1_docs,
+            all_users,
+        )
 
         # -- Favorites & Recent Views --
         print("  Creating Guild 1 favorites & views...")
-        await _create_favorites(session, ids, g1, [
-            (dm, g1_barovia), (dm, g1_ravenloft), (dm, g1_session_zero),
-            (thorn, g1_barovia), (thorn, g1_phandalin),
-            (elara, g1_barovia), (elara, g1_wave_echo),
-            (vex, g1_ravenloft),
-            (sera, g1_barovia),
-            (admin_user, g1_phandalin), (admin_user, g1_wave_echo),
-            # Guild admin favoriting a project they access purely via the
-            # guild-admin override (admin1 is in no G1 initiative).
-            (admin1, g1_barovia),
-        ])
-        await _create_recent_views(session, ids, g1, [
-            (dm, g1_barovia), (dm, g1_ravenloft), (dm, g1_session_zero),
-            (dm, g1_homebrew),
-            (thorn, g1_barovia), (thorn, g1_phandalin),
-            (elara, g1_barovia), (elara, g1_wave_echo),
-            (admin_user, g1_phandalin), (admin_user, g1_session_zero),
-        ])
+        await _create_favorites(
+            session,
+            ids,
+            g1,
+            [
+                (dm, g1_barovia),
+                (dm, g1_ravenloft),
+                (dm, g1_session_zero),
+                (thorn, g1_barovia),
+                (thorn, g1_phandalin),
+                (elara, g1_barovia),
+                (elara, g1_wave_echo),
+                (vex, g1_ravenloft),
+                (sera, g1_barovia),
+                (admin_user, g1_phandalin),
+                (admin_user, g1_wave_echo),
+                # Guild admin favoriting a project they access purely via the
+                # guild-admin override (admin1 is in no G1 initiative).
+                (admin1, g1_barovia),
+            ],
+        )
+        await _create_recent_views(
+            session,
+            ids,
+            g1,
+            [
+                (dm, g1_barovia),
+                (dm, g1_ravenloft),
+                (dm, g1_session_zero),
+                (dm, g1_homebrew),
+                (thorn, g1_barovia),
+                (thorn, g1_phandalin),
+                (elara, g1_barovia),
+                (elara, g1_wave_echo),
+                (admin_user, g1_phandalin),
+                (admin_user, g1_session_zero),
+            ],
+        )
 
         # -- Document Links (wikilinks) --
         print("  Creating Guild 1 document links...")
-        await _create_document_links(session, ids, g1, g1_docs, [
-            ("Session 1 Recap: Into the Mists", "Campaign Setting: The Land of Barovia"),
-            ("Session 1 Recap: Into the Mists", "NPC Roster: Curse of Strahd"),
-            ("Session 2 Recap: The Road to Vallaki", "Campaign Setting: The Land of Barovia"),
-            ("Session 2 Recap: The Road to Vallaki", "NPC Roster: Curse of Strahd"),
-            ("Session 3 Recap: Festival of the Blazing Sun", "NPC Roster: Curse of Strahd"),
-            ("Tarokka Card Reading Results", "Campaign Setting: The Land of Barovia"),
-            ("NPC Roster: Curse of Strahd", "Campaign Setting: The Land of Barovia"),
-            ("House Rules v2", "Session 1 Recap: Into the Mists"),
-        ])
+        await _create_document_links(
+            session,
+            ids,
+            g1,
+            g1_docs,
+            [
+                (
+                    "Session 1 Recap: Into the Mists",
+                    "Campaign Setting: The Land of Barovia",
+                ),
+                ("Session 1 Recap: Into the Mists", "NPC Roster: Curse of Strahd"),
+                (
+                    "Session 2 Recap: The Road to Vallaki",
+                    "Campaign Setting: The Land of Barovia",
+                ),
+                ("Session 2 Recap: The Road to Vallaki", "NPC Roster: Curse of Strahd"),
+                (
+                    "Session 3 Recap: Festival of the Blazing Sun",
+                    "NPC Roster: Curse of Strahd",
+                ),
+                (
+                    "Tarokka Card Reading Results",
+                    "Campaign Setting: The Land of Barovia",
+                ),
+                (
+                    "NPC Roster: Curse of Strahd",
+                    "Campaign Setting: The Land of Barovia",
+                ),
+                ("House Rules v2", "Session 1 Recap: Into the Mists"),
+            ],
+        )
 
         # -- Queues --
         print("  Creating Guild 1 queues...")
-        await _create_queues(session, ids, g1, all_users, g1_tags, [
-            {
-                "initiative_id": g1_strahd.id,
-                "name": "Death House Encounter",
-                "description": "Combat encounter in the haunted Death House basement",
-                "created_by": "Dungeon Master",
-                "is_active": True,
-                "current_round": 3,
-                "write_users": ["Thorn Ironforge", "Elara Moonwhisper"],
-                "read_users": ["Vex Shadowstep", "Seraphina Dawnlight"],
-                "active_item_label": "Thorn Ironforge",
-                "items": [
-                    {"label": "Thorn Ironforge", "position": 22, "user": "Thorn Ironforge",
-                     "color": "#DC2626", "notes": "Raging — advantage on Str checks",
-                     "tags": ["combat"]},
-                    {"label": "Elara Moonwhisper", "position": 19, "user": "Elara Moonwhisper",
-                     "color": "#3B82F6", "notes": "Concentration: Spirit Guardians",
-                     "tags": ["combat"]},
-                    {"label": "Shambling Mound", "position": 17,
-                     "color": "#10B981", "notes": "HP: 136/136",
-                     "tags": ["combat", "boss fight"]},
-                    {"label": "Vex Shadowstep", "position": 16, "user": "Vex Shadowstep",
-                     "color": "#8B5CF6", "notes": "Hidden — bonus action stealth",
-                     "tags": ["combat"]},
-                    {"label": "Seraphina Dawnlight", "position": 12, "user": "Seraphina Dawnlight",
-                     "color": "#F59E0B", "tags": ["combat"]},
-                    {"label": "Shadow #1", "position": 9, "color": "#374151",
-                     "notes": "HP: 16/16"},
-                    {"label": "Shadow #2", "position": 5, "color": "#374151",
-                     "notes": "HP: 16/16"},
-                    {"label": "Shadow #3", "position": 3, "color": "#374151",
-                     "is_visible": False, "notes": "Surprise round — not yet revealed"},
-                ],
-            },
-            {
-                "initiative_id": g1_strahd.id,
-                "name": "Vallaki Town Square Ambush",
-                "description": "Strahd's wolves attack during the Festival of the Blazing Sun",
-                "created_by": "Dungeon Master",
-                "is_active": False,
-                "current_round": 1,
-                "write_users": ["Thorn Ironforge"],
-                "role_grants": [(g1_strahd_mem, ResourceAccessLevel.read)],
-                "items": [
-                    {"label": "Dire Wolf Alpha", "position": 20,
-                     "color": "#6B7280", "notes": "Pack leader — AC 14, HP: 37",
-                     "tags": ["combat"]},
-                    {"label": "Thorn Ironforge", "position": 18, "user": "Thorn Ironforge",
-                     "color": "#DC2626"},
-                    {"label": "Elara Moonwhisper", "position": 15, "user": "Elara Moonwhisper",
-                     "color": "#3B82F6"},
-                    {"label": "Wolf Pack (x4)", "position": 13,
-                     "color": "#9CA3AF", "notes": "HP: 11 each"},
-                    {"label": "Vex Shadowstep", "position": 11, "user": "Vex Shadowstep",
-                     "color": "#8B5CF6"},
-                    {"label": "Seraphina Dawnlight", "position": 8, "user": "Seraphina Dawnlight",
-                     "color": "#F59E0B"},
-                ],
-            },
-            {
-                "initiative_id": g1_lmop.id,
-                "name": "Cragmaw Hideout Assault",
-                "description": "The party storms the goblin cave to rescue Sildar Hallwinter",
-                "created_by": "Admin User",
-                "is_active": False,
-                "current_round": 5,
-                "write_users": ["Dungeon Master", "Thorn Ironforge", "Elara Moonwhisper"],
-                "general_access": ResourceAccessLevel.read,
-                "items": [
-                    {"label": "Admin User (Ranger)", "position": 21, "user": "Admin User",
-                     "color": "#059669", "notes": "Hunter's Mark on Klarg"},
-                    {"label": "Thorn Ironforge", "position": 18, "user": "Thorn Ironforge",
-                     "color": "#DC2626"},
-                    {"label": "Klarg the Bugbear", "position": 15,
-                     "color": "#B91C1C", "notes": "HP: 27/27 — boss",
-                     "tags": ["combat", "boss fight"]},
-                    {"label": "Elara Moonwhisper", "position": 14, "user": "Elara Moonwhisper",
-                     "color": "#3B82F6"},
-                    {"label": "Goblin Archer #1", "position": 10,
-                     "color": "#65A30D", "notes": "HP: 7/7"},
-                    {"label": "Goblin Archer #2", "position": 7,
-                     "color": "#65A30D", "notes": "HP: 7/7"},
-                    {"label": "Ripper (Wolf)", "position": 4,
-                     "color": "#78716C", "notes": "HP: 11/11 — Klarg's pet"},
-                ],
-            },
-        ])
+        await _create_queues(
+            session,
+            ids,
+            g1,
+            all_users,
+            g1_tags,
+            [
+                {
+                    "initiative_id": g1_strahd.id,
+                    "name": "Death House Encounter",
+                    "description": "Combat encounter in the haunted Death House basement",
+                    "created_by": "Dungeon Master",
+                    "is_active": True,
+                    "current_round": 3,
+                    "write_users": ["Thorn Ironforge", "Elara Moonwhisper"],
+                    "read_users": ["Vex Shadowstep", "Seraphina Dawnlight"],
+                    "active_item_label": "Thorn Ironforge",
+                    "items": [
+                        {
+                            "label": "Thorn Ironforge",
+                            "position": 22,
+                            "user": "Thorn Ironforge",
+                            "color": "#DC2626",
+                            "notes": "Raging — advantage on Str checks",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Elara Moonwhisper",
+                            "position": 19,
+                            "user": "Elara Moonwhisper",
+                            "color": "#3B82F6",
+                            "notes": "Concentration: Spirit Guardians",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Shambling Mound",
+                            "position": 17,
+                            "color": "#10B981",
+                            "notes": "HP: 136/136",
+                            "tags": ["combat", "boss fight"],
+                        },
+                        {
+                            "label": "Vex Shadowstep",
+                            "position": 16,
+                            "user": "Vex Shadowstep",
+                            "color": "#8B5CF6",
+                            "notes": "Hidden — bonus action stealth",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Seraphina Dawnlight",
+                            "position": 12,
+                            "user": "Seraphina Dawnlight",
+                            "color": "#F59E0B",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Shadow #1",
+                            "position": 9,
+                            "color": "#374151",
+                            "notes": "HP: 16/16",
+                        },
+                        {
+                            "label": "Shadow #2",
+                            "position": 5,
+                            "color": "#374151",
+                            "notes": "HP: 16/16",
+                        },
+                        {
+                            "label": "Shadow #3",
+                            "position": 3,
+                            "color": "#374151",
+                            "is_visible": False,
+                            "notes": "Surprise round — not yet revealed",
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g1_strahd.id,
+                    "name": "Vallaki Town Square Ambush",
+                    "description": "Strahd's wolves attack during the Festival of the Blazing Sun",
+                    "created_by": "Dungeon Master",
+                    "is_active": False,
+                    "current_round": 1,
+                    "write_users": ["Thorn Ironforge"],
+                    "role_grants": [(g1_strahd_mem, ResourceAccessLevel.read)],
+                    "items": [
+                        {
+                            "label": "Dire Wolf Alpha",
+                            "position": 20,
+                            "color": "#6B7280",
+                            "notes": "Pack leader — AC 14, HP: 37",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Thorn Ironforge",
+                            "position": 18,
+                            "user": "Thorn Ironforge",
+                            "color": "#DC2626",
+                        },
+                        {
+                            "label": "Elara Moonwhisper",
+                            "position": 15,
+                            "user": "Elara Moonwhisper",
+                            "color": "#3B82F6",
+                        },
+                        {
+                            "label": "Wolf Pack (x4)",
+                            "position": 13,
+                            "color": "#9CA3AF",
+                            "notes": "HP: 11 each",
+                        },
+                        {
+                            "label": "Vex Shadowstep",
+                            "position": 11,
+                            "user": "Vex Shadowstep",
+                            "color": "#8B5CF6",
+                        },
+                        {
+                            "label": "Seraphina Dawnlight",
+                            "position": 8,
+                            "user": "Seraphina Dawnlight",
+                            "color": "#F59E0B",
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g1_lmop.id,
+                    "name": "Cragmaw Hideout Assault",
+                    "description": "The party storms the goblin cave to rescue Sildar Hallwinter",
+                    "created_by": "Admin User",
+                    "is_active": False,
+                    "current_round": 5,
+                    "write_users": [
+                        "Dungeon Master",
+                        "Thorn Ironforge",
+                        "Elara Moonwhisper",
+                    ],
+                    "general_access": ResourceAccessLevel.read,
+                    "items": [
+                        {
+                            "label": "Admin User (Ranger)",
+                            "position": 21,
+                            "user": "Admin User",
+                            "color": "#059669",
+                            "notes": "Hunter's Mark on Klarg",
+                        },
+                        {
+                            "label": "Thorn Ironforge",
+                            "position": 18,
+                            "user": "Thorn Ironforge",
+                            "color": "#DC2626",
+                        },
+                        {
+                            "label": "Klarg the Bugbear",
+                            "position": 15,
+                            "color": "#B91C1C",
+                            "notes": "HP: 27/27 — boss",
+                            "tags": ["combat", "boss fight"],
+                        },
+                        {
+                            "label": "Elara Moonwhisper",
+                            "position": 14,
+                            "user": "Elara Moonwhisper",
+                            "color": "#3B82F6",
+                        },
+                        {
+                            "label": "Goblin Archer #1",
+                            "position": 10,
+                            "color": "#65A30D",
+                            "notes": "HP: 7/7",
+                        },
+                        {
+                            "label": "Goblin Archer #2",
+                            "position": 7,
+                            "color": "#65A30D",
+                            "notes": "HP: 7/7",
+                        },
+                        {
+                            "label": "Ripper (Wolf)",
+                            "position": 4,
+                            "color": "#78716C",
+                            "notes": "HP: 11/11 — Klarg's pet",
+                        },
+                    ],
+                },
+            ],
+        )
 
         # Enable queue visibility for members in initiatives that have queues
         await _enable_queue_permissions(
-            session, [g1_strahd_mem, g1_lmop_mem],
+            session,
+            [g1_strahd_mem, g1_lmop_mem],
         )
 
         # -- Counters --
         print("  Creating Guild 1 counter groups...")
-        await _create_counter_groups(session, ids, g1, all_users, [
-            {
-                "initiative_id": g1_strahd.id,
-                "name": "Party Vitals (Strahd)",
-                "description": "Combat-relevant counters for the Curse of Strahd party.",
-                "created_by": "Dungeon Master",
-                "role_grants": [{"role_id": g1_strahd_mem.id, "level": ResourceAccessLevel.write}],
-                "counters": [
-                    {"name": "Thorn HP", "color": "#DC2626", "count": 38, "min": 0, "max": 42,
-                     "step": 1, "initial_count": 42, "view_mode": CounterViewMode.progress_bar, "position": 1},
-                    {"name": "Elara HP", "color": "#3B82F6", "count": 24, "min": 0, "max": 28,
-                     "step": 1, "initial_count": 28, "view_mode": CounterViewMode.progress_bar, "position": 2},
-                    {"name": "Inspiration Pool", "color": "#F59E0B", "count": 2, "min": 0, "max": 5,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 3},
-                    {"name": "Long Rest Clock", "color": "#7C3AED", "count": 3, "min": 0, "max": 8,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.segmented_clock, "position": 4},
-                ],
-            },
-            {
-                # Deliberately private: DM-only, no user/role/general grants.
-                "initiative_id": g1_strahd.id,
-                "name": "Castle Ravenloft Doom Clock",
-                "description": "Strahd's awareness of the party. At 8 he comes for them.",
-                "created_by": "Dungeon Master",
-                "counters": [
-                    {"name": "Strahd's Awareness", "color": "#991B1B", "count": 4, "min": 0, "max": 8,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.segmented_clock, "position": 1},
-                    {"name": "Holy Symbols Found", "color": "#FBBF24", "count": 2, "min": 0, "max": 3,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 2},
-                    {"name": "Tarokka Cards Drawn", "color": "#A855F7", "count": 3, "min": 0, "max": 5,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 3},
-                ],
-            },
-            {
-                "initiative_id": g1_lmop.id,
-                "name": "Phandelver Reputation",
-                "description": "Faction standing for the Lost Mine of Phandelver party.",
-                "created_by": "Admin User",
-                "general_access": ResourceAccessLevel.read,
-                "counters": [
-                    {"name": "Phandalin Reputation", "color": "#10B981", "count": 3, "min": -5, "max": 10,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 1},
-                    {"name": "Redbrand Hideout Cleared", "color": "#DC2626", "count": 4, "min": 0, "max": 6,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.progress_bar, "position": 2},
-                ],
-            },
-        ])
-        await _enable_role_feature(session, [g1_strahd_mem, g1_lmop_mem], "counter_groups_enabled")
+        await _create_counter_groups(
+            session,
+            ids,
+            g1,
+            all_users,
+            [
+                {
+                    "initiative_id": g1_strahd.id,
+                    "name": "Party Vitals (Strahd)",
+                    "description": "Combat-relevant counters for the Curse of Strahd party.",
+                    "created_by": "Dungeon Master",
+                    "role_grants": [
+                        {
+                            "role_id": g1_strahd_mem.id,
+                            "level": ResourceAccessLevel.write,
+                        }
+                    ],
+                    "counters": [
+                        {
+                            "name": "Thorn HP",
+                            "color": "#DC2626",
+                            "count": 38,
+                            "min": 0,
+                            "max": 42,
+                            "step": 1,
+                            "initial_count": 42,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Elara HP",
+                            "color": "#3B82F6",
+                            "count": 24,
+                            "min": 0,
+                            "max": 28,
+                            "step": 1,
+                            "initial_count": 28,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 2,
+                        },
+                        {
+                            "name": "Inspiration Pool",
+                            "color": "#F59E0B",
+                            "count": 2,
+                            "min": 0,
+                            "max": 5,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 3,
+                        },
+                        {
+                            "name": "Long Rest Clock",
+                            "color": "#7C3AED",
+                            "count": 3,
+                            "min": 0,
+                            "max": 8,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.segmented_clock,
+                            "position": 4,
+                        },
+                    ],
+                },
+                {
+                    # Deliberately private: DM-only, no user/role/general grants.
+                    "initiative_id": g1_strahd.id,
+                    "name": "Castle Ravenloft Doom Clock",
+                    "description": "Strahd's awareness of the party. At 8 he comes for them.",
+                    "created_by": "Dungeon Master",
+                    "counters": [
+                        {
+                            "name": "Strahd's Awareness",
+                            "color": "#991B1B",
+                            "count": 4,
+                            "min": 0,
+                            "max": 8,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.segmented_clock,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Holy Symbols Found",
+                            "color": "#FBBF24",
+                            "count": 2,
+                            "min": 0,
+                            "max": 3,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 2,
+                        },
+                        {
+                            "name": "Tarokka Cards Drawn",
+                            "color": "#A855F7",
+                            "count": 3,
+                            "min": 0,
+                            "max": 5,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 3,
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g1_lmop.id,
+                    "name": "Phandelver Reputation",
+                    "description": "Faction standing for the Lost Mine of Phandelver party.",
+                    "created_by": "Admin User",
+                    "general_access": ResourceAccessLevel.read,
+                    "counters": [
+                        {
+                            "name": "Phandalin Reputation",
+                            "color": "#10B981",
+                            "count": 3,
+                            "min": -5,
+                            "max": 10,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Redbrand Hideout Cleared",
+                            "color": "#DC2626",
+                            "count": 4,
+                            "min": 0,
+                            "max": 6,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 2,
+                        },
+                    ],
+                },
+            ],
+        )
+        await _enable_role_feature(
+            session, [g1_strahd_mem, g1_lmop_mem], "counter_groups_enabled"
+        )
 
         # -- Calendar events --
         print("  Creating Guild 1 calendar events...")
-        g1_events = await _create_calendar_events(session, ids, g1, all_users, g1_tags, g1_docs, [
-            {
-                "initiative_id": g1_strahd.id,
-                "title": "Session 12: Into the Amber Temple",
-                "description": "The party finally reaches the Amber Temple to bargain with the Dark Powers.",
-                "location": "Tabletop @ DM's house",
-                "start_at": NOW + timedelta(days=2, hours=2),
-                "end_at": NOW + timedelta(days=2, hours=6),
-                "color": "#7C3AED",
-                "created_by": "Dungeon Master",
-                "attendees": [
-                    {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Elara Moonwhisper", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Vex Shadowstep", "rsvp_status": RSVPStatus.tentative},
-                    {"user": "Seraphina Dawnlight", "rsvp_status": RSVPStatus.declined},
-                    {"user": "Platform Operator", "rsvp_status": RSVPStatus.pending},
-                ],
-                "tags": ["quest", "lore"],
-                "documents": ["NPC Roster: Curse of Strahd"],
-            },
-            {
-                "initiative_id": g1_strahd.id,
-                "title": "Weekly Strahd Session",
-                "description": "Standing campaign night.",
-                "location": "Roll20",
-                "start_at": NOW + timedelta(days=7, hours=1),
-                "end_at": NOW + timedelta(days=7, hours=5),
-                "color": "#7C3AED",
-                "created_by": "Dungeon Master",
-                "recurrence": {
-                    "frequency": "weekly", "interval": 1,
-                    "weekdays": ["fr"], "ends": "after_occurrences",
-                    "end_after_occurrences": 12,
+        g1_events = await _create_calendar_events(
+            session,
+            ids,
+            g1,
+            all_users,
+            g1_tags,
+            g1_docs,
+            [
+                {
+                    "initiative_id": g1_strahd.id,
+                    "title": "Session 12: Into the Amber Temple",
+                    "description": "The party finally reaches the Amber Temple to bargain with the Dark Powers.",
+                    "location": "Tabletop @ DM's house",
+                    "start_at": NOW + timedelta(days=2, hours=2),
+                    "end_at": NOW + timedelta(days=2, hours=6),
+                    "color": "#7C3AED",
+                    "created_by": "Dungeon Master",
+                    "attendees": [
+                        {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
+                        {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
+                        {
+                            "user": "Elara Moonwhisper",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {"user": "Vex Shadowstep", "rsvp_status": RSVPStatus.tentative},
+                        {
+                            "user": "Seraphina Dawnlight",
+                            "rsvp_status": RSVPStatus.declined,
+                        },
+                        {
+                            "user": "Platform Operator",
+                            "rsvp_status": RSVPStatus.pending,
+                        },
+                    ],
+                    "tags": ["quest", "lore"],
+                    "documents": ["NPC Roster: Curse of Strahd"],
                 },
-                "attendees": [
-                    {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Elara Moonwhisper", "rsvp_status": RSVPStatus.accepted},
-                ],
-            },
-            {
-                "initiative_id": g1_strahd.id,
-                "title": "Player Off-Site Retrospective",
-                "description": "All-day session: replay session 8-11 with snacks.",
-                "location": "Cabin in the woods",
-                "start_at": NOW + timedelta(days=14),
-                "end_at": NOW + timedelta(days=14),
-                "all_day": True,
-                "color": "#059669",
-                "created_by": "Dungeon Master",
-                "tags": ["roleplay"],
-            },
-            {
-                "initiative_id": g1_strahd.id,
-                "title": "Session 11: Vallaki Festival",
-                "description": "Wrapped up: the Festival of the Blazing Sun.",
-                "location": "Tabletop @ DM's house",
-                "start_at": NOW - timedelta(days=5, hours=22),
-                "end_at": NOW - timedelta(days=5, hours=18),
-                "color": "#7C3AED",
-                "created_by": "Dungeon Master",
-                "attendees": [
-                    {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
-                ],
-            },
-            {
-                "initiative_id": g1_lmop.id,
-                "title": "Session: Cragmaw Hideout",
-                "description": "Rescue Gundren Rockseeker from the goblins.",
-                "location": "Roll20",
-                "start_at": NOW + timedelta(days=4, hours=3),
-                "end_at": NOW + timedelta(days=4, hours=7),
-                "color": "#059669",
-                "created_by": "Admin User",
-                "attendees": [
-                    {"user": "Admin User", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Dungeon Master", "rsvp_status": RSVPStatus.tentative},
-                ],
-                "tags": ["combat", "quest"],
-            },
-            {
-                "initiative_id": g1_lmop.id,
-                "title": "Prep: Wave Echo Cave maps",
-                "description": "DM-only prep slot for the finale dungeon.",
-                "start_at": NOW + timedelta(days=10, hours=20),
-                "end_at": NOW + timedelta(days=10, hours=22),
-                "color": "#6B7280",
-                "created_by": "Admin User",
-            },
-        ])
-        await _enable_role_feature(session, [g1_strahd_mem, g1_lmop_mem], "calendars_enabled")
+                {
+                    "initiative_id": g1_strahd.id,
+                    "title": "Weekly Strahd Session",
+                    "description": "Standing campaign night.",
+                    "location": "Roll20",
+                    "start_at": NOW + timedelta(days=7, hours=1),
+                    "end_at": NOW + timedelta(days=7, hours=5),
+                    "color": "#7C3AED",
+                    "created_by": "Dungeon Master",
+                    "recurrence": {
+                        "frequency": "weekly",
+                        "interval": 1,
+                        "weekdays": ["fr"],
+                        "ends": "after_occurrences",
+                        "end_after_occurrences": 12,
+                    },
+                    "attendees": [
+                        {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
+                        {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
+                        {
+                            "user": "Elara Moonwhisper",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g1_strahd.id,
+                    "title": "Player Off-Site Retrospective",
+                    "description": "All-day session: replay session 8-11 with snacks.",
+                    "location": "Cabin in the woods",
+                    "start_at": NOW + timedelta(days=14),
+                    "end_at": NOW + timedelta(days=14),
+                    "all_day": True,
+                    "color": "#059669",
+                    "created_by": "Dungeon Master",
+                    "tags": ["roleplay"],
+                },
+                {
+                    "initiative_id": g1_strahd.id,
+                    "title": "Session 11: Vallaki Festival",
+                    "description": "Wrapped up: the Festival of the Blazing Sun.",
+                    "location": "Tabletop @ DM's house",
+                    "start_at": NOW - timedelta(days=5, hours=22),
+                    "end_at": NOW - timedelta(days=5, hours=18),
+                    "color": "#7C3AED",
+                    "created_by": "Dungeon Master",
+                    "attendees": [
+                        {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
+                        {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
+                    ],
+                },
+                {
+                    "initiative_id": g1_lmop.id,
+                    "title": "Session: Cragmaw Hideout",
+                    "description": "Rescue Gundren Rockseeker from the goblins.",
+                    "location": "Roll20",
+                    "start_at": NOW + timedelta(days=4, hours=3),
+                    "end_at": NOW + timedelta(days=4, hours=7),
+                    "color": "#059669",
+                    "created_by": "Admin User",
+                    "attendees": [
+                        {"user": "Admin User", "rsvp_status": RSVPStatus.accepted},
+                        {"user": "Dungeon Master", "rsvp_status": RSVPStatus.tentative},
+                    ],
+                    "tags": ["combat", "quest"],
+                },
+                {
+                    "initiative_id": g1_lmop.id,
+                    "title": "Prep: Wave Echo Cave maps",
+                    "description": "DM-only prep slot for the finale dungeon.",
+                    "start_at": NOW + timedelta(days=10, hours=20),
+                    "end_at": NOW + timedelta(days=10, hours=22),
+                    "color": "#6B7280",
+                    "created_by": "Admin User",
+                },
+            ],
+        )
+        await _enable_role_feature(
+            session, [g1_strahd_mem, g1_lmop_mem], "calendars_enabled"
+        )
 
         # -- Custom properties --
         print("  Creating Guild 1 property definitions + values...")
-        g1_strahd_props = await _create_property_definitions(session, ids, g1_strahd, [
-            {"name": "Difficulty", "type": PropertyType.select, "position": 1.0, "color": "#DC2626",
-             "options": [
-                 {"value": "trivial", "label": "Trivial", "color": "#10B981"},
-                 {"value": "moderate", "label": "Moderate", "color": "#F59E0B"},
-                 {"value": "hard", "label": "Hard", "color": "#DC2626"},
-                 {"value": "deadly", "label": "Deadly", "color": "#7F1D1D"},
-             ]},
-            {"name": "XP Reward", "type": PropertyType.number, "position": 2.0, "color": "#F59E0B"},
-            {"name": "Prep Notes", "type": PropertyType.text, "position": 3.0},
-            {"name": "Themes", "type": PropertyType.multi_select, "position": 4.0,
-             "options": [
-                 {"value": "horror", "label": "Horror", "color": "#7F1D1D"},
-                 {"value": "investigation", "label": "Investigation", "color": "#3B82F6"},
-                 {"value": "social", "label": "Social", "color": "#10B981"},
-                 {"value": "combat", "label": "Combat", "color": "#DC2626"},
-             ]},
-            {"name": "Deadline", "type": PropertyType.date, "position": 5.0},
-            {"name": "Owner", "type": PropertyType.user_reference, "position": 6.0, "color": "#8B5CF6"},
-            {"name": "Public Knowledge", "type": PropertyType.checkbox, "position": 7.0},
-        ])
+        g1_strahd_props = await _create_property_definitions(
+            session,
+            ids,
+            g1_strahd,
+            [
+                {
+                    "name": "Difficulty",
+                    "type": PropertyType.select,
+                    "position": 1.0,
+                    "color": "#DC2626",
+                    "options": [
+                        {"value": "trivial", "label": "Trivial", "color": "#10B981"},
+                        {"value": "moderate", "label": "Moderate", "color": "#F59E0B"},
+                        {"value": "hard", "label": "Hard", "color": "#DC2626"},
+                        {"value": "deadly", "label": "Deadly", "color": "#7F1D1D"},
+                    ],
+                },
+                {
+                    "name": "XP Reward",
+                    "type": PropertyType.number,
+                    "position": 2.0,
+                    "color": "#F59E0B",
+                },
+                {"name": "Prep Notes", "type": PropertyType.text, "position": 3.0},
+                {
+                    "name": "Themes",
+                    "type": PropertyType.multi_select,
+                    "position": 4.0,
+                    "options": [
+                        {"value": "horror", "label": "Horror", "color": "#7F1D1D"},
+                        {
+                            "value": "investigation",
+                            "label": "Investigation",
+                            "color": "#3B82F6",
+                        },
+                        {"value": "social", "label": "Social", "color": "#10B981"},
+                        {"value": "combat", "label": "Combat", "color": "#DC2626"},
+                    ],
+                },
+                {"name": "Deadline", "type": PropertyType.date, "position": 5.0},
+                {
+                    "name": "Owner",
+                    "type": PropertyType.user_reference,
+                    "position": 6.0,
+                    "color": "#8B5CF6",
+                },
+                {
+                    "name": "Public Knowledge",
+                    "type": PropertyType.checkbox,
+                    "position": 7.0,
+                },
+            ],
+        )
 
         # Property values on a handful of known-titled tasks / docs.
         t_defeat_id = g1_tasks["Defeat Strahd von Zarovich"].id
@@ -2575,50 +3360,120 @@ async def seed() -> None:
         doc_setting_id = g1_docs["Campaign Setting: The Land of Barovia"].id
         doc_npcs_id = g1_docs["NPC Roster: Curse of Strahd"].id
 
-        await _attach_property_values(session, ids, g1_strahd_props["Difficulty"], [
-            ("task", t_defeat_id, "deadly"),
-            ("task", t_death_id, "hard"),
-        ])
-        await _attach_property_values(session, ids, g1_strahd_props["XP Reward"], [
-            ("task", t_defeat_id, Decimal("50000")),
-            ("task", t_death_id, Decimal("4500")),
-        ])
-        await _attach_property_values(session, ids, g1_strahd_props["Themes"], [
-            ("task", t_defeat_id, ["horror", "combat"]),
-            ("task", t_death_id, ["horror", "investigation"]),
-        ])
-        await _attach_property_values(session, ids, g1_strahd_props["Public Knowledge"], [
-            ("document", doc_setting_id, True),
-            ("document", doc_npcs_id, False),
-        ])
-        await _attach_property_values(session, ids, g1_strahd_props["Owner"], [
-            ("task", t_defeat_id, dm.id),
-        ])
-        await _attach_property_values(session, ids, g1_strahd_props["Deadline"], [
-            ("task", t_defeat_id, (NOW + timedelta(days=30)).date()),
-        ])
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Difficulty"],
+            [
+                ("task", t_defeat_id, "deadly"),
+                ("task", t_death_id, "hard"),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["XP Reward"],
+            [
+                ("task", t_defeat_id, Decimal("50000")),
+                ("task", t_death_id, Decimal("4500")),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Themes"],
+            [
+                ("task", t_defeat_id, ["horror", "combat"]),
+                ("task", t_death_id, ["horror", "investigation"]),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Public Knowledge"],
+            [
+                ("document", doc_setting_id, True),
+                ("document", doc_npcs_id, False),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Owner"],
+            [
+                ("task", t_defeat_id, dm.id),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Deadline"],
+            [
+                ("task", t_defeat_id, (NOW + timedelta(days=30)).date()),
+            ],
+        )
         # Calendar event values — exercise the third value table.
-        await _attach_property_values(session, ids, g1_strahd_props["Difficulty"], [
-            ("event", g1_events["Session 12: Into the Amber Temple"].id, "deadly"),
-            ("event", g1_events["Session 11: Vallaki Festival"].id, "moderate"),
-        ])
-        await _attach_property_values(session, ids, g1_strahd_props["Themes"], [
-            ("event", g1_events["Session 12: Into the Amber Temple"].id,
-             ["horror", "investigation"]),
-        ])
-        await _attach_property_values(session, ids, g1_strahd_props["Owner"], [
-            ("event", g1_events["Weekly Strahd Session"].id, dm.id),
-        ])
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Difficulty"],
+            [
+                ("event", g1_events["Session 12: Into the Amber Temple"].id, "deadly"),
+                ("event", g1_events["Session 11: Vallaki Festival"].id, "moderate"),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Themes"],
+            [
+                (
+                    "event",
+                    g1_events["Session 12: Into the Amber Temple"].id,
+                    ["horror", "investigation"],
+                ),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_strahd_props["Owner"],
+            [
+                ("event", g1_events["Weekly Strahd Session"].id, dm.id),
+            ],
+        )
 
-        g1_lmop_props = await _create_property_definitions(session, ids, g1_lmop, [
-            {"name": "Hook", "type": PropertyType.text, "position": 1.0},
-            {"name": "Quest Giver", "type": PropertyType.user_reference, "position": 2.0},
-            {"name": "Map Link", "type": PropertyType.url, "position": 3.0, "color": "#3B82F6"},
-        ])
-        await _attach_property_values(session, ids, g1_lmop_props["Map Link"], [
-            ("document", g1_docs["NPC Compendium: Phandelver"].id,
-             "https://example.com/maps/lmop-overview"),
-        ])
+        g1_lmop_props = await _create_property_definitions(
+            session,
+            ids,
+            g1_lmop,
+            [
+                {"name": "Hook", "type": PropertyType.text, "position": 1.0},
+                {
+                    "name": "Quest Giver",
+                    "type": PropertyType.user_reference,
+                    "position": 2.0,
+                },
+                {
+                    "name": "Map Link",
+                    "type": PropertyType.url,
+                    "position": 3.0,
+                    "color": "#3B82F6",
+                },
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g1_lmop_props["Map Link"],
+            [
+                (
+                    "document",
+                    g1_docs["NPC Compendium: Phandelver"].id,
+                    "https://example.com/maps/lmop-overview",
+                ),
+            ],
+        )
 
         # ==============================================================
         # GUILD 2: "Starforge Collective" — Sci-Fi Campaign
@@ -2626,7 +3481,8 @@ async def seed() -> None:
         print("\n  --- Guild 2: Starforge Collective (Sci-Fi) ---")
 
         g2 = await _create_guild(
-            session, ids,
+            session,
+            ids,
             name="Starforge Collective",
             description="A science fiction tabletop campaign set in the far reaches of the galaxy",
             creator=admin_user,
@@ -2636,7 +3492,9 @@ async def seed() -> None:
         # Commit the new guild's shared rows (also flushes guild 1's data), then
         # provision its schema.
         await session.commit()
-        _expunge_guild_scoped(session)  # clear guild 1's per-schema ids from the identity map
+        _expunge_guild_scoped(
+            session
+        )  # clear guild 1's per-schema ids from the identity map
         await provision_guild(g2_id)
 
         # Memberships are a shared-table system-engine write — add them before
@@ -2644,7 +3502,9 @@ async def seed() -> None:
         # admin; finley is a regular member who is PM of the Side Missions
         # initiative below.
         await _add_guild_members(
-            session, ids, g2,
+            session,
+            ids,
+            g2,
             [admin2, finley, kael, aurelia, vex, elara, p_moderator, p_member],
             admin_users=[admin2],
         )
@@ -2655,7 +3515,9 @@ async def seed() -> None:
         )
 
         # Default initiative for g2
-        g2_default_init = await ensure_default_initiative(session, admin_user, guild_id=g2_id)
+        g2_default_init = await ensure_default_initiative(
+            session, admin_user, guild_id=g2_id
+        )
         # Track the roles and members that ensure_default_initiative created
         result = await session.exec(
             select(InitiativeRoleModel).where(
@@ -2670,10 +3532,13 @@ async def seed() -> None:
                 )
             )
             for perm in perms_result.all():
-                ids.add("initiative_role_permissions", {
-                    "initiative_role_id": perm.initiative_role_id,
-                    "permission_key": perm.permission_key,
-                })
+                ids.add(
+                    "initiative_role_permissions",
+                    {
+                        "initiative_role_id": perm.initiative_role_id,
+                        "permission_key": perm.permission_key,
+                    },
+                )
 
         ids.add("initiatives", g2_default_init.id)
 
@@ -2693,13 +3558,18 @@ async def seed() -> None:
                 role_id=g2_def_member_role.id,
             )
             session.add(m)
-            ids.add("initiative_members", {
-                "initiative_id": g2_default_init.id, "user_id": user.id,
-            })
+            ids.add(
+                "initiative_members",
+                {
+                    "initiative_id": g2_default_init.id,
+                    "user_id": user.id,
+                },
+            )
         await session.flush()
 
         g2_main, g2_main_pm, g2_main_mem = await _create_initiative(
-            session, ids,
+            session,
+            ids,
             guild=g2,
             name="Starfall: The Exodus Protocol",
             description="Humanity's last fleet searches for a new homeworld after Earth's collapse",
@@ -2712,7 +3582,8 @@ async def seed() -> None:
         )
 
         g2_side, g2_side_pm, g2_side_mem = await _create_initiative(
-            session, ids,
+            session,
+            ids,
             guild=g2,
             name="Side Missions: Fringe Space",
             description="One-shots and side adventures in the frontier sectors",
@@ -2727,10 +3598,12 @@ async def seed() -> None:
         # Projects
         print("  Creating Guild 2 projects...")
         g2_exodus = await _create_project(
-            session, ids,
-            guild=g2, initiative=g2_main,
+            session,
+            ids,
+            guild=g2,
+            initiative=g2_main,
             name="The Exodus Fleet",
-            icon="\U0001F680",
+            icon="\U0001f680",
             description="Managing the fleet's journey across the void between stars",
             owner=admin_user,
             write_users=[finley, kael],
@@ -2738,10 +3611,12 @@ async def seed() -> None:
         )
 
         g2_colony = await _create_project(
-            session, ids,
-            guild=g2, initiative=g2_main,
+            session,
+            ids,
+            guild=g2,
+            initiative=g2_main,
             name="Colony Alpha",
-            icon="\U0001F30D",
+            icon="\U0001f30d",
             description="Establishing the first settlement on the candidate planet",
             owner=admin_user,
             write_users=[finley, aurelia],
@@ -2749,10 +3624,12 @@ async def seed() -> None:
         )
 
         g2_fringe = await _create_project(
-            session, ids,
-            guild=g2, initiative=g2_side,
+            session,
+            ids,
+            guild=g2,
+            initiative=g2_side,
             name="Smuggler's Run",
-            icon="\U0001F4B0",
+            icon="\U0001f4b0",
             description="A one-shot heist adventure on a derelict space station",
             owner=finley,
             write_users=[kael, vex],
@@ -2760,10 +3637,12 @@ async def seed() -> None:
         )
 
         g2_engineering = await _create_project(
-            session, ids,
-            guild=g2, initiative=g2_main,
+            session,
+            ids,
+            guild=g2,
+            initiative=g2_main,
             name="Engineering Bay",
-            icon="\U0001F527",
+            icon="\U0001f527",
             description="Ship upgrades, tech research, and equipment management",
             owner=kael,
             write_users=[admin_user, elara],
@@ -2771,10 +3650,12 @@ async def seed() -> None:
         )
 
         g2_planning = await _create_project(
-            session, ids,
-            guild=g2, initiative=g2_default_init,
+            session,
+            ids,
+            guild=g2,
+            initiative=g2_default_init,
             name="Campaign Planning",
-            icon="\U0001F4C5",
+            icon="\U0001f4c5",
             description="Session scheduling and campaign logistics",
             owner=admin_user,
             write_users=[finley],
@@ -2796,96 +3677,187 @@ async def seed() -> None:
         print("  Creating Guild 2 tasks...")
         g2_task_defs = [
             # Exodus Fleet
-            {"project_id": g2_exodus.id, "title": "Repair the FTL drive core",
-             "description": "The main drive is failing. Without repairs, the fleet is stranded.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Kael Windrunner"],
-             "subtasks": ["Diagnose the plasma leak", "Source replacement crystals", "Recalibrate the nav array"],
-             "due_days": 2},
-            {"project_id": g2_exodus.id, "title": "Investigate the distress signal from Sector 7G",
-             "description": "An automated distress beacon is broadcasting from an uncharted system.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.todo,
-             "assignees": ["Aurelia Brightshield", "Vex Shadowstep"], "due_days": 7},
-            {"project_id": g2_exodus.id, "title": "Negotiate passage through Krellix space",
-             "description": "The Krellix Dominion controls the only safe corridor to the target system.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.backlog,
-             "assignees": ["Finley Goldtongue"]},
-            {"project_id": g2_exodus.id, "title": "Quell the mutiny on Deck 7",
-             "description": "A group of colonists is threatening to take a shuttle and break from the fleet.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.done,
-             "assignees": ["Admin User", "Aurelia Brightshield"]},
-            {"project_id": g2_exodus.id, "title": "Map the nebula passage",
-             "description": "Chart a safe course through the Verdant Nebula to save 3 months of travel.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo,
-             "assignees": ["Elara Moonwhisper"]},
-            {"project_id": g2_exodus.id, "title": "Decommission the Icarus VII",
-             "description": "The oldest ship in the fleet is no longer spaceworthy. Salvage what we can.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.backlog},
+            {
+                "project_id": g2_exodus.id,
+                "title": "Repair the FTL drive core",
+                "description": "The main drive is failing. Without repairs, the fleet is stranded.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Kael Windrunner"],
+                "subtasks": [
+                    "Diagnose the plasma leak",
+                    "Source replacement crystals",
+                    "Recalibrate the nav array",
+                ],
+                "due_days": 2,
+            },
+            {
+                "project_id": g2_exodus.id,
+                "title": "Investigate the distress signal from Sector 7G",
+                "description": "An automated distress beacon is broadcasting from an uncharted system.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Aurelia Brightshield", "Vex Shadowstep"],
+                "due_days": 7,
+            },
+            {
+                "project_id": g2_exodus.id,
+                "title": "Negotiate passage through Krellix space",
+                "description": "The Krellix Dominion controls the only safe corridor to the target system.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.backlog,
+                "assignees": ["Finley Goldtongue"],
+            },
+            {
+                "project_id": g2_exodus.id,
+                "title": "Quell the mutiny on Deck 7",
+                "description": "A group of colonists is threatening to take a shuttle and break from the fleet.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Admin User", "Aurelia Brightshield"],
+            },
+            {
+                "project_id": g2_exodus.id,
+                "title": "Map the nebula passage",
+                "description": "Chart a safe course through the Verdant Nebula to save 3 months of travel.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Elara Moonwhisper"],
+            },
+            {
+                "project_id": g2_exodus.id,
+                "title": "Decommission the Icarus VII",
+                "description": "The oldest ship in the fleet is no longer spaceworthy. Salvage what we can.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.backlog,
+            },
             # Colony Alpha
-            {"project_id": g2_colony.id, "title": "Survey landing sites on Kepler-442b",
-             "description": "Send probes to evaluate three candidate sites for the colony.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Admin User"],
-             "subtasks": ["Deploy orbital probes", "Analyze atmospheric data", "Check for hostile fauna"],
-             "due_days": 14},
-            {"project_id": g2_colony.id, "title": "Design the colony habitat modules",
-             "description": "Prefab habitats need to support 500 colonists in the first wave.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo,
-             "assignees": ["Kael Windrunner"]},
-            {"project_id": g2_colony.id, "title": "Establish a perimeter defense grid",
-             "description": "Unknown life forms detected. We need automated defenses.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.backlog,
-             "assignees": ["Aurelia Brightshield"]},
-            {"project_id": g2_colony.id, "title": "Set up the hydroponics bay",
-             "description": "Food production must begin within 48 hours of landing.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.todo,
-             "due_days": 3},
+            {
+                "project_id": g2_colony.id,
+                "title": "Survey landing sites on Kepler-442b",
+                "description": "Send probes to evaluate three candidate sites for the colony.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Admin User"],
+                "subtasks": [
+                    "Deploy orbital probes",
+                    "Analyze atmospheric data",
+                    "Check for hostile fauna",
+                ],
+                "due_days": 14,
+            },
+            {
+                "project_id": g2_colony.id,
+                "title": "Design the colony habitat modules",
+                "description": "Prefab habitats need to support 500 colonists in the first wave.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Kael Windrunner"],
+            },
+            {
+                "project_id": g2_colony.id,
+                "title": "Establish a perimeter defense grid",
+                "description": "Unknown life forms detected. We need automated defenses.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.backlog,
+                "assignees": ["Aurelia Brightshield"],
+            },
+            {
+                "project_id": g2_colony.id,
+                "title": "Set up the hydroponics bay",
+                "description": "Food production must begin within 48 hours of landing.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.todo,
+                "due_days": 3,
+            },
             # Smuggler's Run
-            {"project_id": g2_fringe.id, "title": "Infiltrate Station Omega",
-             "description": "The heist begins: get past security and reach the vault level.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Vex Shadowstep", "Finley Goldtongue"],
-             "subtasks": ["Forge ID badges", "Disable security cameras on Level 3", "Create a distraction"]},
-            {"project_id": g2_fringe.id, "title": "Crack the vault encryption",
-             "description": "The vault uses quantum encryption. We need a specialist AI.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.todo,
-             "assignees": ["Kael Windrunner"]},
-            {"project_id": g2_fringe.id, "title": "Escape before station self-destructs",
-             "description": "Once the vault opens, the station's failsafe triggers. 10 minutes to escape.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.backlog},
+            {
+                "project_id": g2_fringe.id,
+                "title": "Infiltrate Station Omega",
+                "description": "The heist begins: get past security and reach the vault level.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Vex Shadowstep", "Finley Goldtongue"],
+                "subtasks": [
+                    "Forge ID badges",
+                    "Disable security cameras on Level 3",
+                    "Create a distraction",
+                ],
+            },
+            {
+                "project_id": g2_fringe.id,
+                "title": "Crack the vault encryption",
+                "description": "The vault uses quantum encryption. We need a specialist AI.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Kael Windrunner"],
+            },
+            {
+                "project_id": g2_fringe.id,
+                "title": "Escape before station self-destructs",
+                "description": "Once the vault opens, the station's failsafe triggers. 10 minutes to escape.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.backlog,
+            },
             # Engineering Bay
-            {"project_id": g2_engineering.id, "title": "Upgrade shield generators to Mark IV",
-             "description": "Current shields can't handle Krellix plasma weapons.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Kael Windrunner", "Elara Moonwhisper"]},
-            {"project_id": g2_engineering.id, "title": "Research cloaking technology",
-             "description": "Salvaged alien tech might allow partial cloaking of smaller vessels.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.backlog,
-             "assignees": ["Elara Moonwhisper"]},
-            {"project_id": g2_engineering.id, "title": "Fabricate replacement hull plating",
-             "description": "Asteroid impacts have weakened the port side. Fabricate and install repairs.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done,
-             "assignees": ["Kael Windrunner"]},
+            {
+                "project_id": g2_engineering.id,
+                "title": "Upgrade shield generators to Mark IV",
+                "description": "Current shields can't handle Krellix plasma weapons.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Kael Windrunner", "Elara Moonwhisper"],
+            },
+            {
+                "project_id": g2_engineering.id,
+                "title": "Research cloaking technology",
+                "description": "Salvaged alien tech might allow partial cloaking of smaller vessels.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.backlog,
+                "assignees": ["Elara Moonwhisper"],
+            },
+            {
+                "project_id": g2_engineering.id,
+                "title": "Fabricate replacement hull plating",
+                "description": "Asteroid impacts have weakened the port side. Fabricate and install repairs.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Kael Windrunner"],
+            },
             # Planning
-            {"project_id": g2_planning.id, "title": "Schedule Session 5: Colony Landfall",
-             "description": "The big session where the fleet arrives at Kepler-442b.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo,
-             "assignees": ["Admin User"], "due_days": 10},
-            {"project_id": g2_planning.id, "title": "Prep NPC stat blocks for Krellix diplomats",
-             "description": "Need stats for 3 Krellix NPCs with unique abilities.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Admin User"]},
-            {"project_id": g2_planning.id, "title": "Session 3 scheduling poll",
-             "description": "Closed poll — session happened. Archived.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.done,
-             "archived": True},
+            {
+                "project_id": g2_planning.id,
+                "title": "Schedule Session 5: Colony Landfall",
+                "description": "The big session where the fleet arrives at Kepler-442b.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Admin User"],
+                "due_days": 10,
+            },
+            {
+                "project_id": g2_planning.id,
+                "title": "Prep NPC stat blocks for Krellix diplomats",
+                "description": "Need stats for 3 Krellix NPCs with unique abilities.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Admin User"],
+            },
+            {
+                "project_id": g2_planning.id,
+                "title": "Session 3 scheduling poll",
+                "description": "Closed poll — session happened. Archived.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.done,
+                "archived": True,
+            },
         ]
 
         g2_tasks: dict[str, Task] = {}
         for proj in g2_projects:
             proj_tasks = [td for td in g2_task_defs if td["project_id"] == proj.id]
             tasks = await _create_tasks(
-                session, ids,
+                session,
+                ids,
                 guild=g2,
                 status_map=g2_status_maps[proj.id],
                 task_defs=proj_tasks,
@@ -2895,128 +3867,208 @@ async def seed() -> None:
 
         # Tags
         print("  Creating Guild 2 tags...")
-        g2_tags = await _create_tags(session, ids, g2, [
-            ("main quest", "#EF4444"),
-            ("side quest", "#6366F1"),
-            ("engineering", "#0EA5E9"),
-            ("diplomacy", "#10B981"),
-            ("combat", "#DC2626"),
-            ("exploration", "#8B5CF6"),
-            ("NPC", "#F59E0B"),
-            ("loot", "#D97706"),
-            ("survival", "#059669"),
-            ("stealth", "#475569"),
-        ])
+        g2_tags = await _create_tags(
+            session,
+            ids,
+            g2,
+            [
+                ("main quest", "#EF4444"),
+                ("side quest", "#6366F1"),
+                ("engineering", "#0EA5E9"),
+                ("diplomacy", "#10B981"),
+                ("combat", "#DC2626"),
+                ("exploration", "#8B5CF6"),
+                ("NPC", "#F59E0B"),
+                ("loot", "#D97706"),
+                ("survival", "#059669"),
+                ("stealth", "#475569"),
+            ],
+        )
 
-        await _link_task_tags(session, ids, g2_tasks, g2_tags, [
-            ("Repair the FTL drive core", ["main quest", "engineering"]),
-            ("Investigate the distress signal from Sector 7G", ["exploration", "side quest"]),
-            ("Negotiate passage through Krellix space", ["diplomacy", "main quest"]),
-            ("Quell the mutiny on Deck 7", ["main quest", "NPC"]),
-            ("Infiltrate Station Omega", ["stealth", "side quest"]),
-            ("Crack the vault encryption", ["stealth", "engineering"]),
-            ("Upgrade shield generators to Mark IV", ["engineering"]),
-            ("Survey landing sites on Kepler-442b", ["exploration", "main quest"]),
-            ("Establish a perimeter defense grid", ["combat", "survival"]),
-            ("Set up the hydroponics bay", ["survival"]),
-        ])
+        await _link_task_tags(
+            session,
+            ids,
+            g2_tasks,
+            g2_tags,
+            [
+                ("Repair the FTL drive core", ["main quest", "engineering"]),
+                (
+                    "Investigate the distress signal from Sector 7G",
+                    ["exploration", "side quest"],
+                ),
+                (
+                    "Negotiate passage through Krellix space",
+                    ["diplomacy", "main quest"],
+                ),
+                ("Quell the mutiny on Deck 7", ["main quest", "NPC"]),
+                ("Infiltrate Station Omega", ["stealth", "side quest"]),
+                ("Crack the vault encryption", ["stealth", "engineering"]),
+                ("Upgrade shield generators to Mark IV", ["engineering"]),
+                ("Survey landing sites on Kepler-442b", ["exploration", "main quest"]),
+                ("Establish a perimeter defense grid", ["combat", "survival"]),
+                ("Set up the hydroponics bay", ["survival"]),
+            ],
+        )
 
-        await _link_project_tags(session, ids, g2_tags, [
-            (g2_exodus.id, ["main quest", "exploration"]),
-            (g2_colony.id, ["main quest", "survival"]),
-            (g2_fringe.id, ["side quest", "stealth", "loot"]),
-            (g2_engineering.id, ["engineering"]),
-        ])
+        await _link_project_tags(
+            session,
+            ids,
+            g2_tags,
+            [
+                (g2_exodus.id, ["main quest", "exploration"]),
+                (g2_colony.id, ["main quest", "survival"]),
+                (g2_fringe.id, ["side quest", "stealth", "loot"]),
+                (g2_engineering.id, ["engineering"]),
+            ],
+        )
 
         # Documents
         print("  Creating Guild 2 documents...")
-        g2_docs = await _create_documents(session, ids, guild=g2, all_users=all_users, doc_defs=[
-            {
-                "initiative_id": g2_main.id,
-                "title": "Setting Bible: The Exodus Protocol",
-                "creator": "Admin User",
-                "writers": ["Finley Goldtongue"],
-                "readers": ["Kael Windrunner", "Aurelia Brightshield"],
-                "paragraphs": [
-                    "The year is 2487. Earth was rendered uninhabitable by the Cascade Event — a catastrophic "
-                    "chain reaction in the planet's magnetic field. The last 50,000 humans fled aboard "
-                    "the Exodus Fleet: 12 ships of varying size and capability.",
-                    "The fleet has been traveling for 73 years. Most colonists are in cryosleep, rotated "
-                    "in shifts. The active crew numbers about 2,000 at any given time.",
-                    "FTL travel exists but is expensive and unreliable. The fleet's main FTL drive "
-                    "can make one jump per month. Smaller scout ships have limited-range jump drives.",
-                ],
-            },
-            {
-                "initiative_id": g2_main.id,
-                "title": "Faction Guide: Krellix Dominion",
-                "creator": "Admin User",
-                "general_access": ResourceAccessLevel.read,
-                "paragraphs": [
-                    "The Krellix are a territorial insectoid species that controls a swathe of space "
-                    "between the fleet and the target system. They are technologically advanced but "
-                    "not inherently hostile — diplomacy is possible.",
-                    "Krellix society is caste-based: Workers, Warriors, Diplomats, and the Overmind. "
-                    "Trade agreements require approval from a local Diplomat caste leader.",
-                ],
-            },
-            {
-                "initiative_id": g2_side.id,
-                "title": "One-Shot: Smuggler's Run Briefing",
-                "creator": "Finley Goldtongue",
-                "role_grants": [(g2_side_mem, ResourceAccessLevel.write)],
-                "paragraphs": [
-                    "Station Omega is a decommissioned military research station now operated by "
-                    "the Crimson Syndicate. Inside the vault: a prototype cloaking device worth "
-                    "enough credits to fund the fleet for a decade.",
-                    "The station has 5 levels. Security increases with each level. The vault is "
-                    "on Level 5. Self-destruct activates 10 minutes after the vault is breached.",
-                ],
-            },
-            {
-                "initiative_id": g2_default_init.id,
-                "title": "Session 1 Recap: Into the Void",
-                "creator": "Admin User",
-                "paragraphs": [
-                    "The crew awoke from cryosleep to find the fleet's AI, ORACLE, had gone silent. "
-                    "Emergency protocols activated. The FTL drive was offline.",
-                    "The team discovered sabotage — someone had manually overridden ORACLE's core "
-                    "directives. Suspicion fell on the Deck 7 separatists.",
-                ],
-            },
-        ])
+        g2_docs = await _create_documents(
+            session,
+            ids,
+            guild=g2,
+            all_users=all_users,
+            doc_defs=[
+                {
+                    "initiative_id": g2_main.id,
+                    "title": "Setting Bible: The Exodus Protocol",
+                    "creator": "Admin User",
+                    "writers": ["Finley Goldtongue"],
+                    "readers": ["Kael Windrunner", "Aurelia Brightshield"],
+                    "paragraphs": [
+                        "The year is 2487. Earth was rendered uninhabitable by the Cascade Event — a catastrophic "
+                        "chain reaction in the planet's magnetic field. The last 50,000 humans fled aboard "
+                        "the Exodus Fleet: 12 ships of varying size and capability.",
+                        "The fleet has been traveling for 73 years. Most colonists are in cryosleep, rotated "
+                        "in shifts. The active crew numbers about 2,000 at any given time.",
+                        "FTL travel exists but is expensive and unreliable. The fleet's main FTL drive "
+                        "can make one jump per month. Smaller scout ships have limited-range jump drives.",
+                    ],
+                },
+                {
+                    "initiative_id": g2_main.id,
+                    "title": "Faction Guide: Krellix Dominion",
+                    "creator": "Admin User",
+                    "general_access": ResourceAccessLevel.read,
+                    "paragraphs": [
+                        "The Krellix are a territorial insectoid species that controls a swathe of space "
+                        "between the fleet and the target system. They are technologically advanced but "
+                        "not inherently hostile — diplomacy is possible.",
+                        "Krellix society is caste-based: Workers, Warriors, Diplomats, and the Overmind. "
+                        "Trade agreements require approval from a local Diplomat caste leader.",
+                    ],
+                },
+                {
+                    "initiative_id": g2_side.id,
+                    "title": "One-Shot: Smuggler's Run Briefing",
+                    "creator": "Finley Goldtongue",
+                    "role_grants": [(g2_side_mem, ResourceAccessLevel.write)],
+                    "paragraphs": [
+                        "Station Omega is a decommissioned military research station now operated by "
+                        "the Crimson Syndicate. Inside the vault: a prototype cloaking device worth "
+                        "enough credits to fund the fleet for a decade.",
+                        "The station has 5 levels. Security increases with each level. The vault is "
+                        "on Level 5. Self-destruct activates 10 minutes after the vault is breached.",
+                    ],
+                },
+                {
+                    "initiative_id": g2_default_init.id,
+                    "title": "Session 1 Recap: Into the Void",
+                    "creator": "Admin User",
+                    "paragraphs": [
+                        "The crew awoke from cryosleep to find the fleet's AI, ORACLE, had gone silent. "
+                        "Emergency protocols activated. The FTL drive was offline.",
+                        "The team discovered sabotage — someone had manually overridden ORACLE's core "
+                        "directives. Suspicion fell on the Deck 7 separatists.",
+                    ],
+                },
+            ],
+        )
 
-        await _link_doc_projects(session, ids, g2, [
-            (g2_exodus.id, g2_docs["Setting Bible: The Exodus Protocol"].id, admin_user),
-            (g2_exodus.id, g2_docs["Faction Guide: Krellix Dominion"].id, admin_user),
-            (g2_fringe.id, g2_docs["One-Shot: Smuggler's Run Briefing"].id, finley),
-            (g2_planning.id, g2_docs["Session 1 Recap: Into the Void"].id, admin_user),
-        ])
+        await _link_doc_projects(
+            session,
+            ids,
+            g2,
+            [
+                (
+                    g2_exodus.id,
+                    g2_docs["Setting Bible: The Exodus Protocol"].id,
+                    admin_user,
+                ),
+                (
+                    g2_exodus.id,
+                    g2_docs["Faction Guide: Krellix Dominion"].id,
+                    admin_user,
+                ),
+                (g2_fringe.id, g2_docs["One-Shot: Smuggler's Run Briefing"].id, finley),
+                (
+                    g2_planning.id,
+                    g2_docs["Session 1 Recap: Into the Void"].id,
+                    admin_user,
+                ),
+            ],
+        )
 
-        await _link_doc_tags(session, ids, g2_docs, g2_tags, [
-            ("Setting Bible: The Exodus Protocol", ["main quest"]),
-            ("Faction Guide: Krellix Dominion", ["NPC", "diplomacy"]),
-            ("One-Shot: Smuggler's Run Briefing", ["stealth", "loot"]),
-        ])
+        await _link_doc_tags(
+            session,
+            ids,
+            g2_docs,
+            g2_tags,
+            [
+                ("Setting Bible: The Exodus Protocol", ["main quest"]),
+                ("Faction Guide: Krellix Dominion", ["NPC", "diplomacy"]),
+                ("One-Shot: Smuggler's Run Briefing", ["stealth", "loot"]),
+            ],
+        )
 
         # Comments
         print("  Creating Guild 2 comments...")
-        await _create_comments(session, ids, g2, [
-            {"author": "Kael Windrunner", "task_title": "Repair the FTL drive core",
-             "content": "The plasma leak is worse than expected. We might need to cannibalize the Icarus VII."},
-            {"author": "Admin User", "task_title": "Repair the FTL drive core",
-             "content": "Do it. The Icarus was going to be decommissioned anyway."},
-            {"author": "Finley Goldtongue", "task_title": "Negotiate passage through Krellix space",
-             "content": "I have a contact in the Diplomat caste. We'll need a gift — something they don't have."},
-            {"author": "Aurelia Brightshield", "task_title": "Investigate the distress signal from Sector 7G",
-             "content": "Could be a trap. The Crimson Syndicate uses fake distress beacons."},
-            {"author": "Vex Shadowstep", "task_title": "Infiltrate Station Omega",
-             "content": "I can forge the ID badges. Kael, can you loop the security feeds?"},
-            {"author": "Kael Windrunner", "task_title": "Infiltrate Station Omega",
-             "content": "Already on it. I'll need 30 minutes once we're inside."},
-            {"author": "Elara Moonwhisper", "doc_title": "Setting Bible: The Exodus Protocol",
-             "content": "We should add a section on the cryosleep rotation schedule — it came up last session."},
-        ], g2_tasks, g2_docs, all_users)
+        await _create_comments(
+            session,
+            ids,
+            g2,
+            [
+                {
+                    "author": "Kael Windrunner",
+                    "task_title": "Repair the FTL drive core",
+                    "content": "The plasma leak is worse than expected. We might need to cannibalize the Icarus VII.",
+                },
+                {
+                    "author": "Admin User",
+                    "task_title": "Repair the FTL drive core",
+                    "content": "Do it. The Icarus was going to be decommissioned anyway.",
+                },
+                {
+                    "author": "Finley Goldtongue",
+                    "task_title": "Negotiate passage through Krellix space",
+                    "content": "I have a contact in the Diplomat caste. We'll need a gift — something they don't have.",
+                },
+                {
+                    "author": "Aurelia Brightshield",
+                    "task_title": "Investigate the distress signal from Sector 7G",
+                    "content": "Could be a trap. The Crimson Syndicate uses fake distress beacons.",
+                },
+                {
+                    "author": "Vex Shadowstep",
+                    "task_title": "Infiltrate Station Omega",
+                    "content": "I can forge the ID badges. Kael, can you loop the security feeds?",
+                },
+                {
+                    "author": "Kael Windrunner",
+                    "task_title": "Infiltrate Station Omega",
+                    "content": "Already on it. I'll need 30 minutes once we're inside.",
+                },
+                {
+                    "author": "Elara Moonwhisper",
+                    "doc_title": "Setting Bible: The Exodus Protocol",
+                    "content": "We should add a section on the cryosleep rotation schedule — it came up last session.",
+                },
+            ],
+            g2_tasks,
+            g2_docs,
+            all_users,
+        )
 
         # -- Guild 2 Settings --
         print("  Creating Guild 2 settings...")
@@ -3024,258 +4076,520 @@ async def seed() -> None:
 
         # -- Favorites & Recent Views --
         print("  Creating Guild 2 favorites & views...")
-        await _create_favorites(session, ids, g2, [
-            (admin_user, g2_exodus), (admin_user, g2_colony),
-            (finley, g2_fringe), (finley, g2_exodus),
-            (kael, g2_engineering), (kael, g2_exodus),
-            (aurelia, g2_colony),
-            (vex, g2_fringe),
-        ])
-        await _create_recent_views(session, ids, g2, [
-            (admin_user, g2_exodus), (admin_user, g2_colony), (admin_user, g2_planning),
-            (finley, g2_fringe), (finley, g2_exodus),
-            (kael, g2_engineering), (kael, g2_exodus),
-        ])
+        await _create_favorites(
+            session,
+            ids,
+            g2,
+            [
+                (admin_user, g2_exodus),
+                (admin_user, g2_colony),
+                (finley, g2_fringe),
+                (finley, g2_exodus),
+                (kael, g2_engineering),
+                (kael, g2_exodus),
+                (aurelia, g2_colony),
+                (vex, g2_fringe),
+            ],
+        )
+        await _create_recent_views(
+            session,
+            ids,
+            g2,
+            [
+                (admin_user, g2_exodus),
+                (admin_user, g2_colony),
+                (admin_user, g2_planning),
+                (finley, g2_fringe),
+                (finley, g2_exodus),
+                (kael, g2_engineering),
+                (kael, g2_exodus),
+            ],
+        )
 
         # -- Document Links --
         print("  Creating Guild 2 document links...")
-        await _create_document_links(session, ids, g2, g2_docs, [
-            ("Faction Guide: Krellix Dominion", "Setting Bible: The Exodus Protocol"),
-            ("Session 1 Recap: Into the Void", "Setting Bible: The Exodus Protocol"),
-            ("One-Shot: Smuggler's Run Briefing", "Setting Bible: The Exodus Protocol"),
-        ])
+        await _create_document_links(
+            session,
+            ids,
+            g2,
+            g2_docs,
+            [
+                (
+                    "Faction Guide: Krellix Dominion",
+                    "Setting Bible: The Exodus Protocol",
+                ),
+                (
+                    "Session 1 Recap: Into the Void",
+                    "Setting Bible: The Exodus Protocol",
+                ),
+                (
+                    "One-Shot: Smuggler's Run Briefing",
+                    "Setting Bible: The Exodus Protocol",
+                ),
+            ],
+        )
 
         # -- Queues --
         print("  Creating Guild 2 queues...")
-        await _create_queues(session, ids, g2, all_users, g2_tags, [
-            {
-                "initiative_id": g2_main.id,
-                "name": "Bridge Standoff: Krellix Boarding Party",
-                "description": "The Krellix shock troopers have breached the main airlock",
-                "created_by": "Admin User",
-                "is_active": True,
-                "current_round": 2,
-                "write_users": ["Finley Goldtongue", "Kael Windrunner"],
-                "read_users": ["Vex Shadowstep"],
-                "general_access": ResourceAccessLevel.read,
-                "active_item_label": "Krellix Shock Trooper #1",
-                "items": [
-                    {"label": "Kael Windrunner", "position": 24, "user": "Kael Windrunner",
-                     "color": "#0EA5E9", "notes": "Shield generator overcharged — +2 AC"},
-                    {"label": "Krellix Shock Trooper #1", "position": 21,
-                     "color": "#EF4444", "notes": "HP: 45/45 — plasma rifle",
-                     "tags": ["combat"]},
-                    {"label": "Aurelia Brightshield", "position": 19, "user": "Aurelia Brightshield",
-                     "color": "#F59E0B"},
-                    {"label": "Krellix Shock Trooper #2", "position": 17,
-                     "color": "#EF4444", "notes": "HP: 45/45"},
-                    {"label": "Finley Goldtongue", "position": 15, "user": "Finley Goldtongue",
-                     "color": "#8B5CF6", "notes": "Attempting to hack the airlock controls"},
-                    {"label": "Vex Shadowstep", "position": 12, "user": "Vex Shadowstep",
-                     "color": "#6366F1"},
-                    {"label": "Krellix Commander", "position": 10,
-                     "color": "#B91C1C", "notes": "HP: 80/80 — energy blade",
-                     "tags": ["combat", "boss fight"]},
-                ],
-            },
-        ])
+        await _create_queues(
+            session,
+            ids,
+            g2,
+            all_users,
+            g2_tags,
+            [
+                {
+                    "initiative_id": g2_main.id,
+                    "name": "Bridge Standoff: Krellix Boarding Party",
+                    "description": "The Krellix shock troopers have breached the main airlock",
+                    "created_by": "Admin User",
+                    "is_active": True,
+                    "current_round": 2,
+                    "write_users": ["Finley Goldtongue", "Kael Windrunner"],
+                    "read_users": ["Vex Shadowstep"],
+                    "general_access": ResourceAccessLevel.read,
+                    "active_item_label": "Krellix Shock Trooper #1",
+                    "items": [
+                        {
+                            "label": "Kael Windrunner",
+                            "position": 24,
+                            "user": "Kael Windrunner",
+                            "color": "#0EA5E9",
+                            "notes": "Shield generator overcharged — +2 AC",
+                        },
+                        {
+                            "label": "Krellix Shock Trooper #1",
+                            "position": 21,
+                            "color": "#EF4444",
+                            "notes": "HP: 45/45 — plasma rifle",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Aurelia Brightshield",
+                            "position": 19,
+                            "user": "Aurelia Brightshield",
+                            "color": "#F59E0B",
+                        },
+                        {
+                            "label": "Krellix Shock Trooper #2",
+                            "position": 17,
+                            "color": "#EF4444",
+                            "notes": "HP: 45/45",
+                        },
+                        {
+                            "label": "Finley Goldtongue",
+                            "position": 15,
+                            "user": "Finley Goldtongue",
+                            "color": "#8B5CF6",
+                            "notes": "Attempting to hack the airlock controls",
+                        },
+                        {
+                            "label": "Vex Shadowstep",
+                            "position": 12,
+                            "user": "Vex Shadowstep",
+                            "color": "#6366F1",
+                        },
+                        {
+                            "label": "Krellix Commander",
+                            "position": 10,
+                            "color": "#B91C1C",
+                            "notes": "HP: 80/80 — energy blade",
+                            "tags": ["combat", "boss fight"],
+                        },
+                    ],
+                },
+            ],
+        )
 
         await _enable_queue_permissions(session, [g2_main_mem])
 
         # -- Counters --
         print("  Creating Guild 2 counter groups...")
-        await _create_counter_groups(session, ids, g2, all_users, [
-            {
-                "initiative_id": g2_main.id,
-                "name": "Fleet Status",
-                "description": "Ship integrity and resource levels for The Exodus Protocol.",
-                "created_by": "Admin User",
-                "role_grants": [{"role_id": g2_main_mem.id, "level": ResourceAccessLevel.write}],
-                "counters": [
-                    {"name": "Hull Integrity", "color": "#3B82F6", "count": 78, "min": 0, "max": 100,
-                     "step": 5, "initial_count": 100, "view_mode": CounterViewMode.progress_bar, "position": 1},
-                    {"name": "Plasma Reserves", "color": "#F59E0B", "count": 42, "min": 0, "max": 80,
-                     "step": 1, "initial_count": 80, "view_mode": CounterViewMode.progress_bar, "position": 2},
-                    {"name": "Colonists in Cryo", "color": "#10B981", "count": 4870, "min": 0,
-                     "step": 1, "initial_count": 5000, "view_mode": CounterViewMode.number, "position": 3},
-                    {"name": "Days to Kepler-442b", "color": "#7C3AED", "count": 6, "min": 0, "max": 8,
-                     "step": 1, "initial_count": 8, "view_mode": CounterViewMode.segmented_clock, "position": 4},
-                ],
-            },
-            {
-                "initiative_id": g2_main.id,
-                "name": "Krellix Diplomatic Tracker",
-                "description": "Relations with the Krellix Dominion.",
-                "created_by": "Admin User",
-                "general_access": ResourceAccessLevel.read,
-                "counters": [
-                    {"name": "Treaty Progress", "color": "#0EA5E9", "count": 2, "min": 0, "max": 5,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.segmented_clock, "position": 1},
-                    {"name": "Hostility Score", "color": "#DC2626", "count": 3, "min": 0, "max": 10,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 2},
-                ],
-            },
-            {
-                "initiative_id": g2_side.id,
-                "name": "Heist Crew Funds",
-                "description": "Loot stash and expenses for the Smuggler's Run crew.",
-                "created_by": "Finley Goldtongue",
-                "counters": [
-                    {"name": "Credits", "color": "#F59E0B", "count": 12500, "min": 0,
-                     "step": 100, "initial_count": 8000, "view_mode": CounterViewMode.number, "position": 1},
-                    {"name": "Bribes Spent", "color": "#7F1D1D", "count": 1800, "min": 0,
-                     "step": 50, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 2},
-                ],
-            },
-        ])
-        await _enable_role_feature(session, [g2_main_mem, g2_side_mem], "counter_groups_enabled")
+        await _create_counter_groups(
+            session,
+            ids,
+            g2,
+            all_users,
+            [
+                {
+                    "initiative_id": g2_main.id,
+                    "name": "Fleet Status",
+                    "description": "Ship integrity and resource levels for The Exodus Protocol.",
+                    "created_by": "Admin User",
+                    "role_grants": [
+                        {"role_id": g2_main_mem.id, "level": ResourceAccessLevel.write}
+                    ],
+                    "counters": [
+                        {
+                            "name": "Hull Integrity",
+                            "color": "#3B82F6",
+                            "count": 78,
+                            "min": 0,
+                            "max": 100,
+                            "step": 5,
+                            "initial_count": 100,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Plasma Reserves",
+                            "color": "#F59E0B",
+                            "count": 42,
+                            "min": 0,
+                            "max": 80,
+                            "step": 1,
+                            "initial_count": 80,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 2,
+                        },
+                        {
+                            "name": "Colonists in Cryo",
+                            "color": "#10B981",
+                            "count": 4870,
+                            "min": 0,
+                            "step": 1,
+                            "initial_count": 5000,
+                            "view_mode": CounterViewMode.number,
+                            "position": 3,
+                        },
+                        {
+                            "name": "Days to Kepler-442b",
+                            "color": "#7C3AED",
+                            "count": 6,
+                            "min": 0,
+                            "max": 8,
+                            "step": 1,
+                            "initial_count": 8,
+                            "view_mode": CounterViewMode.segmented_clock,
+                            "position": 4,
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g2_main.id,
+                    "name": "Krellix Diplomatic Tracker",
+                    "description": "Relations with the Krellix Dominion.",
+                    "created_by": "Admin User",
+                    "general_access": ResourceAccessLevel.read,
+                    "counters": [
+                        {
+                            "name": "Treaty Progress",
+                            "color": "#0EA5E9",
+                            "count": 2,
+                            "min": 0,
+                            "max": 5,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.segmented_clock,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Hostility Score",
+                            "color": "#DC2626",
+                            "count": 3,
+                            "min": 0,
+                            "max": 10,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 2,
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g2_side.id,
+                    "name": "Heist Crew Funds",
+                    "description": "Loot stash and expenses for the Smuggler's Run crew.",
+                    "created_by": "Finley Goldtongue",
+                    "counters": [
+                        {
+                            "name": "Credits",
+                            "color": "#F59E0B",
+                            "count": 12500,
+                            "min": 0,
+                            "step": 100,
+                            "initial_count": 8000,
+                            "view_mode": CounterViewMode.number,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Bribes Spent",
+                            "color": "#7F1D1D",
+                            "count": 1800,
+                            "min": 0,
+                            "step": 50,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 2,
+                        },
+                    ],
+                },
+            ],
+        )
+        await _enable_role_feature(
+            session, [g2_main_mem, g2_side_mem], "counter_groups_enabled"
+        )
 
         # -- Calendar events --
         print("  Creating Guild 2 calendar events...")
-        await _create_calendar_events(session, ids, g2, all_users, g2_tags, g2_docs, [
-            {
-                "initiative_id": g2_main.id,
-                "title": "Session 5: Colony Landfall",
-                "description": "The fleet arrives at Kepler-442b.",
-                "location": "Discord voice",
-                "start_at": NOW + timedelta(days=3, hours=1),
-                "end_at": NOW + timedelta(days=3, hours=4),
-                "color": "#0EA5E9",
-                "created_by": "Admin User",
-                "attendees": [
-                    {"user": "Admin User", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Finley Goldtongue", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Aurelia Brightshield", "rsvp_status": RSVPStatus.tentative},
-                    {"user": "Vex Shadowstep", "rsvp_status": RSVPStatus.declined},
-                    {"user": "Elara Moonwhisper", "rsvp_status": RSVPStatus.pending},
-                ],
-                "tags": ["combat"] if "combat" in g2_tags else [],
-                "documents": ["Setting Bible: The Exodus Protocol"],
-            },
-            {
-                "initiative_id": g2_main.id,
-                "title": "Bi-weekly Starfall Session",
-                "description": "Standing campaign night.",
-                "start_at": NOW + timedelta(days=10, hours=2),
-                "end_at": NOW + timedelta(days=10, hours=5),
-                "color": "#0EA5E9",
-                "created_by": "Admin User",
-                "recurrence": {
-                    "frequency": "weekly", "interval": 2,
-                    "weekdays": ["sa"], "ends": "after_occurrences",
-                    "end_after_occurrences": 8,
+        await _create_calendar_events(
+            session,
+            ids,
+            g2,
+            all_users,
+            g2_tags,
+            g2_docs,
+            [
+                {
+                    "initiative_id": g2_main.id,
+                    "title": "Session 5: Colony Landfall",
+                    "description": "The fleet arrives at Kepler-442b.",
+                    "location": "Discord voice",
+                    "start_at": NOW + timedelta(days=3, hours=1),
+                    "end_at": NOW + timedelta(days=3, hours=4),
+                    "color": "#0EA5E9",
+                    "created_by": "Admin User",
+                    "attendees": [
+                        {"user": "Admin User", "rsvp_status": RSVPStatus.accepted},
+                        {
+                            "user": "Finley Goldtongue",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
+                        {
+                            "user": "Aurelia Brightshield",
+                            "rsvp_status": RSVPStatus.tentative,
+                        },
+                        {"user": "Vex Shadowstep", "rsvp_status": RSVPStatus.declined},
+                        {
+                            "user": "Elara Moonwhisper",
+                            "rsvp_status": RSVPStatus.pending,
+                        },
+                    ],
+                    "tags": ["combat"] if "combat" in g2_tags else [],
+                    "documents": ["Setting Bible: The Exodus Protocol"],
                 },
-                "attendees": [
-                    {"user": "Admin User", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
-                ],
-            },
-            {
-                "initiative_id": g2_main.id,
-                "title": "Session 4: Distress Signal",
-                "description": "Past session — investigated Sector 7G.",
-                "start_at": NOW - timedelta(days=10, hours=23),
-                "end_at": NOW - timedelta(days=10, hours=20),
-                "color": "#0EA5E9",
-                "created_by": "Admin User",
-            },
-            {
-                "initiative_id": g2_main.id,
-                "title": "Worldbuilding Day",
-                "description": "All-day workshop with the players for the post-landfall arc.",
-                "start_at": NOW + timedelta(days=21),
-                "end_at": NOW + timedelta(days=21),
-                "all_day": True,
-                "color": "#10B981",
-                "created_by": "Admin User",
-                "tags": ["roleplay"] if "roleplay" in g2_tags else [],
-            },
-            {
-                "initiative_id": g2_side.id,
-                "title": "One-shot: Smuggler's Run",
-                "description": "Heist night.",
-                "location": "Discord voice",
-                "start_at": NOW + timedelta(days=5, hours=3),
-                "end_at": NOW + timedelta(days=5, hours=7),
-                "color": "#F59E0B",
-                "created_by": "Finley Goldtongue",
-                "attendees": [
-                    {"user": "Finley Goldtongue", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Vex Shadowstep", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.pending},
-                ],
-                "documents": ["One-Shot: Smuggler's Run Briefing"],
-            },
-        ])
-        await _enable_role_feature(session, [g2_main_mem, g2_side_mem], "calendars_enabled")
+                {
+                    "initiative_id": g2_main.id,
+                    "title": "Bi-weekly Starfall Session",
+                    "description": "Standing campaign night.",
+                    "start_at": NOW + timedelta(days=10, hours=2),
+                    "end_at": NOW + timedelta(days=10, hours=5),
+                    "color": "#0EA5E9",
+                    "created_by": "Admin User",
+                    "recurrence": {
+                        "frequency": "weekly",
+                        "interval": 2,
+                        "weekdays": ["sa"],
+                        "ends": "after_occurrences",
+                        "end_after_occurrences": 8,
+                    },
+                    "attendees": [
+                        {"user": "Admin User", "rsvp_status": RSVPStatus.accepted},
+                        {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
+                    ],
+                },
+                {
+                    "initiative_id": g2_main.id,
+                    "title": "Session 4: Distress Signal",
+                    "description": "Past session — investigated Sector 7G.",
+                    "start_at": NOW - timedelta(days=10, hours=23),
+                    "end_at": NOW - timedelta(days=10, hours=20),
+                    "color": "#0EA5E9",
+                    "created_by": "Admin User",
+                },
+                {
+                    "initiative_id": g2_main.id,
+                    "title": "Worldbuilding Day",
+                    "description": "All-day workshop with the players for the post-landfall arc.",
+                    "start_at": NOW + timedelta(days=21),
+                    "end_at": NOW + timedelta(days=21),
+                    "all_day": True,
+                    "color": "#10B981",
+                    "created_by": "Admin User",
+                    "tags": ["roleplay"] if "roleplay" in g2_tags else [],
+                },
+                {
+                    "initiative_id": g2_side.id,
+                    "title": "One-shot: Smuggler's Run",
+                    "description": "Heist night.",
+                    "location": "Discord voice",
+                    "start_at": NOW + timedelta(days=5, hours=3),
+                    "end_at": NOW + timedelta(days=5, hours=7),
+                    "color": "#F59E0B",
+                    "created_by": "Finley Goldtongue",
+                    "attendees": [
+                        {
+                            "user": "Finley Goldtongue",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {"user": "Vex Shadowstep", "rsvp_status": RSVPStatus.accepted},
+                        {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.pending},
+                    ],
+                    "documents": ["One-Shot: Smuggler's Run Briefing"],
+                },
+            ],
+        )
+        await _enable_role_feature(
+            session, [g2_main_mem, g2_side_mem], "calendars_enabled"
+        )
 
         # -- Custom properties --
         print("  Creating Guild 2 property definitions + values...")
-        g2_main_props = await _create_property_definitions(session, ids, g2_main, [
-            {"name": "System", "type": PropertyType.select, "position": 1.0,
-             "options": [
-                 {"value": "starfinder", "label": "Starfinder", "color": "#3B82F6"},
-                 {"value": "stars_without_number", "label": "Stars Without Number", "color": "#10B981"},
-                 {"value": "homebrew", "label": "Homebrew", "color": "#F59E0B"},
-             ]},
-            {"name": "Tech Level", "type": PropertyType.number, "position": 2.0, "color": "#0EA5E9"},
-            {"name": "Faction Tags", "type": PropertyType.multi_select, "position": 3.0,
-             "options": [
-                 {"value": "exodus_fleet", "label": "Exodus Fleet", "color": "#3B82F6"},
-                 {"value": "krellix", "label": "Krellix Dominion", "color": "#DC2626"},
-                 {"value": "merchant_guild", "label": "Merchant Guild", "color": "#F59E0B"},
-             ]},
-            {"name": "Briefing Required", "type": PropertyType.checkbox, "position": 4.0},
-            {"name": "Owner", "type": PropertyType.user_reference, "position": 5.0},
-        ])
+        g2_main_props = await _create_property_definitions(
+            session,
+            ids,
+            g2_main,
+            [
+                {
+                    "name": "System",
+                    "type": PropertyType.select,
+                    "position": 1.0,
+                    "options": [
+                        {
+                            "value": "starfinder",
+                            "label": "Starfinder",
+                            "color": "#3B82F6",
+                        },
+                        {
+                            "value": "stars_without_number",
+                            "label": "Stars Without Number",
+                            "color": "#10B981",
+                        },
+                        {"value": "homebrew", "label": "Homebrew", "color": "#F59E0B"},
+                    ],
+                },
+                {
+                    "name": "Tech Level",
+                    "type": PropertyType.number,
+                    "position": 2.0,
+                    "color": "#0EA5E9",
+                },
+                {
+                    "name": "Faction Tags",
+                    "type": PropertyType.multi_select,
+                    "position": 3.0,
+                    "options": [
+                        {
+                            "value": "exodus_fleet",
+                            "label": "Exodus Fleet",
+                            "color": "#3B82F6",
+                        },
+                        {
+                            "value": "krellix",
+                            "label": "Krellix Dominion",
+                            "color": "#DC2626",
+                        },
+                        {
+                            "value": "merchant_guild",
+                            "label": "Merchant Guild",
+                            "color": "#F59E0B",
+                        },
+                    ],
+                },
+                {
+                    "name": "Briefing Required",
+                    "type": PropertyType.checkbox,
+                    "position": 4.0,
+                },
+                {"name": "Owner", "type": PropertyType.user_reference, "position": 5.0},
+            ],
+        )
         t_repair_id = g2_tasks["Repair the FTL drive core"].id
         t_negotiate_id = g2_tasks["Negotiate passage through Krellix space"].id
         t_mutiny_id = g2_tasks["Quell the mutiny on Deck 7"].id
         doc_setting_g2_id = g2_docs["Setting Bible: The Exodus Protocol"].id
         doc_krellix_id = g2_docs["Faction Guide: Krellix Dominion"].id
 
-        await _attach_property_values(session, ids, g2_main_props["System"], [
-            ("task", t_repair_id, "starfinder"),
-            ("task", t_negotiate_id, "homebrew"),
-        ])
-        await _attach_property_values(session, ids, g2_main_props["Tech Level"], [
-            ("task", t_repair_id, Decimal("9")),
-            ("task", t_negotiate_id, Decimal("7")),
-        ])
-        await _attach_property_values(session, ids, g2_main_props["Faction Tags"], [
-            ("task", t_negotiate_id, ["exodus_fleet", "krellix"]),
-            ("document", doc_krellix_id, ["krellix"]),
-        ])
-        await _attach_property_values(session, ids, g2_main_props["Briefing Required"], [
-            ("task", t_repair_id, True),
-            ("task", t_mutiny_id, False),
-        ])
-        await _attach_property_values(session, ids, g2_main_props["Owner"], [
-            ("task", t_repair_id, kael.id),
-            ("task", t_negotiate_id, finley.id),
-            ("document", doc_setting_g2_id, admin_user.id),
-        ])
+        await _attach_property_values(
+            session,
+            ids,
+            g2_main_props["System"],
+            [
+                ("task", t_repair_id, "starfinder"),
+                ("task", t_negotiate_id, "homebrew"),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g2_main_props["Tech Level"],
+            [
+                ("task", t_repair_id, Decimal("9")),
+                ("task", t_negotiate_id, Decimal("7")),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g2_main_props["Faction Tags"],
+            [
+                ("task", t_negotiate_id, ["exodus_fleet", "krellix"]),
+                ("document", doc_krellix_id, ["krellix"]),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g2_main_props["Briefing Required"],
+            [
+                ("task", t_repair_id, True),
+                ("task", t_mutiny_id, False),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g2_main_props["Owner"],
+            [
+                ("task", t_repair_id, kael.id),
+                ("task", t_negotiate_id, finley.id),
+                ("document", doc_setting_g2_id, admin_user.id),
+            ],
+        )
 
-        g2_side_props = await _create_property_definitions(session, ids, g2_side, [
-            {"name": "Mission Status", "type": PropertyType.select, "position": 1.0,
-             "options": [
-                 {"value": "scoping", "label": "Scoping"},
-                 {"value": "active", "label": "Active", "color": "#10B981"},
-                 {"value": "complete", "label": "Complete", "color": "#6B7280"},
-             ]},
-            {"name": "Payout (credits)", "type": PropertyType.number, "position": 2.0},
-            {"name": "Map Link", "type": PropertyType.url, "position": 3.0},
-        ])
+        g2_side_props = await _create_property_definitions(
+            session,
+            ids,
+            g2_side,
+            [
+                {
+                    "name": "Mission Status",
+                    "type": PropertyType.select,
+                    "position": 1.0,
+                    "options": [
+                        {"value": "scoping", "label": "Scoping"},
+                        {"value": "active", "label": "Active", "color": "#10B981"},
+                        {"value": "complete", "label": "Complete", "color": "#6B7280"},
+                    ],
+                },
+                {
+                    "name": "Payout (credits)",
+                    "type": PropertyType.number,
+                    "position": 2.0,
+                },
+                {"name": "Map Link", "type": PropertyType.url, "position": 3.0},
+            ],
+        )
         t_infiltrate_id = g2_tasks["Infiltrate Station Omega"].id
         t_crack_id = g2_tasks["Crack the vault encryption"].id
-        await _attach_property_values(session, ids, g2_side_props["Mission Status"], [
-            ("task", t_infiltrate_id, "active"),
-            ("task", t_crack_id, "scoping"),
-        ])
-        await _attach_property_values(session, ids, g2_side_props["Payout (credits)"], [
-            ("task", t_infiltrate_id, Decimal("75000")),
-        ])
+        await _attach_property_values(
+            session,
+            ids,
+            g2_side_props["Mission Status"],
+            [
+                ("task", t_infiltrate_id, "active"),
+                ("task", t_crack_id, "scoping"),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g2_side_props["Payout (credits)"],
+            [
+                ("task", t_infiltrate_id, Decimal("75000")),
+            ],
+        )
 
         # ==============================================================
         # GUILD 3: "Realm of Tides" — Pirate/Nautical Campaign
@@ -3286,7 +4600,8 @@ async def seed() -> None:
         # member who is PM of the main initiative below. The platform owner
         # superuser is deliberately a plain member here.
         g3 = await _create_guild(
-            session, ids,
+            session,
+            ids,
             name="Realm of Tides",
             description="A nautical fantasy campaign across the Shattered Seas",
             creator=admin3,
@@ -3295,13 +4610,28 @@ async def seed() -> None:
 
         # Commit guild 2's data + guild 3's shared rows, then provision.
         await session.commit()
-        _expunge_guild_scoped(session)  # clear guild 2's per-schema ids from the identity map
+        _expunge_guild_scoped(
+            session
+        )  # clear guild 2's per-schema ids from the identity map
         await provision_guild(g3_id)
 
         # Shared-table membership writes before routing into the guild.
         await _add_guild_members(
-            session, ids, g3,
-            [admin4, admin_user, finley, dm, thorn, kael, aurelia, sera, p_owner, p_operator],
+            session,
+            ids,
+            g3,
+            [
+                admin4,
+                admin_user,
+                finley,
+                dm,
+                thorn,
+                kael,
+                aurelia,
+                sera,
+                p_owner,
+                p_operator,
+            ],
             admin_users=[admin4],
         )
 
@@ -3310,7 +4640,9 @@ async def seed() -> None:
         )
 
         # Default initiative (admin3, the guild creator, becomes its PM)
-        g3_default_init = await ensure_default_initiative(session, admin3, guild_id=g3_id)
+        g3_default_init = await ensure_default_initiative(
+            session, admin3, guild_id=g3_id
+        )
         result = await session.exec(
             select(InitiativeRoleModel).where(
                 InitiativeRoleModel.initiative_id == g3_default_init.id,
@@ -3324,10 +4656,13 @@ async def seed() -> None:
                 )
             )
             for perm in perms_result.all():
-                ids.add("initiative_role_permissions", {
-                    "initiative_role_id": perm.initiative_role_id,
-                    "permission_key": perm.permission_key,
-                })
+                ids.add(
+                    "initiative_role_permissions",
+                    {
+                        "initiative_role_id": perm.initiative_role_id,
+                        "permission_key": perm.permission_key,
+                    },
+                )
         ids.add("initiatives", g3_default_init.id)
 
         # Add some members to default initiative
@@ -3349,13 +4684,18 @@ async def seed() -> None:
                 role_id=g3_def_member_role.id,
             )
             session.add(m)
-            ids.add("initiative_members", {
-                "initiative_id": g3_default_init.id, "user_id": user.id,
-            })
+            ids.add(
+                "initiative_members",
+                {
+                    "initiative_id": g3_default_init.id,
+                    "user_id": user.id,
+                },
+            )
         await session.flush()
 
         g3_main, g3_main_pm, g3_main_mem = await _create_initiative(
-            session, ids,
+            session,
+            ids,
             guild=g3,
             name="The Crimson Tide Campaign",
             description="A pirate crew sails the Shattered Seas in search of the Leviathan's Heart",
@@ -3368,7 +4708,8 @@ async def seed() -> None:
         )
 
         g3_navy, g3_navy_pm, g3_navy_mem = await _create_initiative(
-            session, ids,
+            session,
+            ids,
             guild=g3,
             name="Royal Navy Conflicts",
             description="Encounters and battles with the Imperial Navy",
@@ -3383,8 +4724,10 @@ async def seed() -> None:
         # Projects
         print("  Creating Guild 3 projects...")
         g3_ship = await _create_project(
-            session, ids,
-            guild=g3, initiative=g3_main,
+            session,
+            ids,
+            guild=g3,
+            initiative=g3_main,
             name="The Crimson Maiden",
             icon="\u2693",
             description="Managing the party's ship, crew, and upgrades",
@@ -3394,10 +4737,12 @@ async def seed() -> None:
         )
 
         g3_treasure = await _create_project(
-            session, ids,
-            guild=g3, initiative=g3_main,
+            session,
+            ids,
+            guild=g3,
+            initiative=g3_main,
             name="Treasure of the Leviathan",
-            icon="\U0001F4B0",
+            icon="\U0001f4b0",
             description="The legendary hoard guarded by the sea beast",
             owner=finley,
             write_users=[admin_user, dm],
@@ -3405,10 +4750,12 @@ async def seed() -> None:
         )
 
         g3_islands = await _create_project(
-            session, ids,
-            guild=g3, initiative=g3_main,
+            session,
+            ids,
+            guild=g3,
+            initiative=g3_main,
             name="Island Exploration",
-            icon="\U0001F3DD\uFE0F",
+            icon="\U0001f3dd\ufe0f",
             description="Uncharted islands and their mysteries",
             owner=dm,
             write_users=[finley, kael],
@@ -3416,10 +4763,12 @@ async def seed() -> None:
         )
 
         g3_navy_proj = await _create_project(
-            session, ids,
-            guild=g3, initiative=g3_navy,
+            session,
+            ids,
+            guild=g3,
+            initiative=g3_navy,
             name="Admiral Blackwood's Fleet",
-            icon="\u2694\uFE0F",
+            icon="\u2694\ufe0f",
             description="Tracking the movements and strength of the Imperial Navy",
             owner=dm,
             write_users=[finley, thorn],
@@ -3427,10 +4776,12 @@ async def seed() -> None:
         )
 
         g3_planning = await _create_project(
-            session, ids,
-            guild=g3, initiative=g3_default_init,
+            session,
+            ids,
+            guild=g3,
+            initiative=g3_default_init,
             name="Campaign Notes",
-            icon="\U0001F4DD",
+            icon="\U0001f4dd",
             description="Session recaps and campaign logistics",
             owner=finley,
             write_users=[admin_user, dm],
@@ -3452,97 +4803,190 @@ async def seed() -> None:
         print("  Creating Guild 3 tasks...")
         g3_task_defs = [
             # The Crimson Maiden
-            {"project_id": g3_ship.id, "title": "Recruit a new helmsman",
-             "description": "Old Barnaby fell overboard. We need someone who can navigate the Shattered Reefs.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.todo,
-             "assignees": ["Finley Goldtongue"], "due_days": 5},
-            {"project_id": g3_ship.id, "title": "Repair the hull after the kraken attack",
-             "description": "Three breaches below the waterline. She's taking on water.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Thorn Ironforge", "Kael Windrunner"],
-             "subtasks": ["Patch the port breach", "Reinforce the keel", "Replace the damaged mast"]},
-            {"project_id": g3_ship.id, "title": "Upgrade cannons to dragon-fire shot",
-             "description": "Alchemical ammunition from the black market in Port Havoc.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.backlog,
-             "assignees": ["Thorn Ironforge"]},
-            {"project_id": g3_ship.id, "title": "Restock provisions at Port Havoc",
-             "description": "Fresh water, hardtack, rum, and gunpowder. The essentials.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done},
-            {"project_id": g3_ship.id, "title": "Install the enchanted compass",
-             "description": "The compass from the Sea Witch should point to the Leviathan's lair.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.todo,
-             "assignees": ["Aurelia Brightshield"]},
+            {
+                "project_id": g3_ship.id,
+                "title": "Recruit a new helmsman",
+                "description": "Old Barnaby fell overboard. We need someone who can navigate the Shattered Reefs.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Finley Goldtongue"],
+                "due_days": 5,
+            },
+            {
+                "project_id": g3_ship.id,
+                "title": "Repair the hull after the kraken attack",
+                "description": "Three breaches below the waterline. She's taking on water.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Thorn Ironforge", "Kael Windrunner"],
+                "subtasks": [
+                    "Patch the port breach",
+                    "Reinforce the keel",
+                    "Replace the damaged mast",
+                ],
+            },
+            {
+                "project_id": g3_ship.id,
+                "title": "Upgrade cannons to dragon-fire shot",
+                "description": "Alchemical ammunition from the black market in Port Havoc.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.backlog,
+                "assignees": ["Thorn Ironforge"],
+            },
+            {
+                "project_id": g3_ship.id,
+                "title": "Restock provisions at Port Havoc",
+                "description": "Fresh water, hardtack, rum, and gunpowder. The essentials.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+            },
+            {
+                "project_id": g3_ship.id,
+                "title": "Install the enchanted compass",
+                "description": "The compass from the Sea Witch should point to the Leviathan's lair.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Aurelia Brightshield"],
+            },
             # Treasure of the Leviathan
-            {"project_id": g3_treasure.id, "title": "Decipher the Leviathan Map",
-             "description": "The map is written in Old Merfolk. Find someone who can read it.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Finley Goldtongue", "Admin User"],
-             "subtasks": ["Find a translator in Port Havoc", "Cross-reference with known charts",
-                          "Identify the three key landmarks"]},
-            {"project_id": g3_treasure.id, "title": "Collect the three Tidestones",
-             "description": "Legend says three enchanted stones unlock the Leviathan's vault.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.backlog,
-             "subtasks": ["Tidestone of Storms (Tempest Isle)", "Tidestone of Depths (Abyssal Trench)",
-                          "Tidestone of Calm (Sanctuary Reef)"]},
-            {"project_id": g3_treasure.id, "title": "Defeat the Leviathan guardian",
-             "description": "An ancient sea serpent guards the entrance to the vault. This won't be easy.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.backlog,
-             "due_days": 45},
-            {"project_id": g3_treasure.id, "title": "Research the Leviathan's weakness",
-             "description": "The old legends mention a weakness. Check the library at Coral Keep.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo,
-             "assignees": ["Admin User"]},
+            {
+                "project_id": g3_treasure.id,
+                "title": "Decipher the Leviathan Map",
+                "description": "The map is written in Old Merfolk. Find someone who can read it.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Finley Goldtongue", "Admin User"],
+                "subtasks": [
+                    "Find a translator in Port Havoc",
+                    "Cross-reference with known charts",
+                    "Identify the three key landmarks",
+                ],
+            },
+            {
+                "project_id": g3_treasure.id,
+                "title": "Collect the three Tidestones",
+                "description": "Legend says three enchanted stones unlock the Leviathan's vault.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.backlog,
+                "subtasks": [
+                    "Tidestone of Storms (Tempest Isle)",
+                    "Tidestone of Depths (Abyssal Trench)",
+                    "Tidestone of Calm (Sanctuary Reef)",
+                ],
+            },
+            {
+                "project_id": g3_treasure.id,
+                "title": "Defeat the Leviathan guardian",
+                "description": "An ancient sea serpent guards the entrance to the vault. This won't be easy.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.backlog,
+                "due_days": 45,
+            },
+            {
+                "project_id": g3_treasure.id,
+                "title": "Research the Leviathan's weakness",
+                "description": "The old legends mention a weakness. Check the library at Coral Keep.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Admin User"],
+            },
             # Island Exploration
-            {"project_id": g3_islands.id, "title": "Explore Skull Cove",
-             "description": "A hidden cove on the south side of Dagger Isle. Rumored to hold pirate treasure.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.done,
-             "assignees": ["Kael Windrunner", "Finley Goldtongue"]},
-            {"project_id": g3_islands.id, "title": "Map the Whispering Jungle",
-             "description": "The interior of Tempest Isle is unmapped. Strange sounds at night.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Kael Windrunner"],
-             "subtasks": ["Chart the coastline", "Find the source of the whispers",
-                          "Locate the ruined temple"]},
-            {"project_id": g3_islands.id, "title": "Negotiate with the Coral Elves",
-             "description": "The Coral Elves of Sanctuary Reef may know where a Tidestone is hidden.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.todo,
-             "assignees": ["Finley Goldtongue", "Aurelia Brightshield"]},
-            {"project_id": g3_islands.id, "title": "Investigate the ghost ship sightings",
-             "description": "Multiple ships report a phantom vessel near the Abyssal Trench.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.backlog},
+            {
+                "project_id": g3_islands.id,
+                "title": "Explore Skull Cove",
+                "description": "A hidden cove on the south side of Dagger Isle. Rumored to hold pirate treasure.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Kael Windrunner", "Finley Goldtongue"],
+            },
+            {
+                "project_id": g3_islands.id,
+                "title": "Map the Whispering Jungle",
+                "description": "The interior of Tempest Isle is unmapped. Strange sounds at night.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Kael Windrunner"],
+                "subtasks": [
+                    "Chart the coastline",
+                    "Find the source of the whispers",
+                    "Locate the ruined temple",
+                ],
+            },
+            {
+                "project_id": g3_islands.id,
+                "title": "Negotiate with the Coral Elves",
+                "description": "The Coral Elves of Sanctuary Reef may know where a Tidestone is hidden.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Finley Goldtongue", "Aurelia Brightshield"],
+            },
+            {
+                "project_id": g3_islands.id,
+                "title": "Investigate the ghost ship sightings",
+                "description": "Multiple ships report a phantom vessel near the Abyssal Trench.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.backlog,
+            },
             # Admiral Blackwood
-            {"project_id": g3_navy_proj.id, "title": "Evade the HMS Vengeance",
-             "description": "Blackwood's flagship is patrolling the straits. We need an alternate route.",
-             "priority": TaskPriority.urgent, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Dungeon Master", "Finley Goldtongue"]},
-            {"project_id": g3_navy_proj.id, "title": "Raid the supply convoy near Coral Keep",
-             "description": "Three merchant ships carrying weapons and gold, lightly guarded.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.todo,
-             "assignees": ["Thorn Ironforge"], "due_days": 7},
-            {"project_id": g3_navy_proj.id, "title": "Forge letters of marque",
-             "description": "If we can forge royal papers, we can pass as privateers instead of pirates.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.todo,
-             "assignees": ["Finley Goldtongue"]},
-            {"project_id": g3_navy_proj.id, "title": "Sink the HMS Ironclad",
-             "description": "Blackwood's second-in-command's ship. Remove it and weaken the fleet.",
-             "priority": TaskPriority.high, "category": TaskStatusCategory.done,
-             "assignees": ["Thorn Ironforge", "Kael Windrunner"]},
+            {
+                "project_id": g3_navy_proj.id,
+                "title": "Evade the HMS Vengeance",
+                "description": "Blackwood's flagship is patrolling the straits. We need an alternate route.",
+                "priority": TaskPriority.urgent,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Dungeon Master", "Finley Goldtongue"],
+            },
+            {
+                "project_id": g3_navy_proj.id,
+                "title": "Raid the supply convoy near Coral Keep",
+                "description": "Three merchant ships carrying weapons and gold, lightly guarded.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Thorn Ironforge"],
+                "due_days": 7,
+            },
+            {
+                "project_id": g3_navy_proj.id,
+                "title": "Forge letters of marque",
+                "description": "If we can forge royal papers, we can pass as privateers instead of pirates.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Finley Goldtongue"],
+            },
+            {
+                "project_id": g3_navy_proj.id,
+                "title": "Sink the HMS Ironclad",
+                "description": "Blackwood's second-in-command's ship. Remove it and weaken the fleet.",
+                "priority": TaskPriority.high,
+                "category": TaskStatusCategory.done,
+                "assignees": ["Thorn Ironforge", "Kael Windrunner"],
+            },
             # Campaign Notes
-            {"project_id": g3_planning.id, "title": "Write session 6 recap",
-             "description": "The kraken fight and arrival at Port Havoc.",
-             "priority": TaskPriority.low, "category": TaskStatusCategory.todo,
-             "assignees": ["Admin User"]},
-            {"project_id": g3_planning.id, "title": "Schedule next session",
-             "description": "Probably the weekend after next. Check with everyone.",
-             "priority": TaskPriority.medium, "category": TaskStatusCategory.in_progress,
-             "assignees": ["Finley Goldtongue"], "due_days": 4},
+            {
+                "project_id": g3_planning.id,
+                "title": "Write session 6 recap",
+                "description": "The kraken fight and arrival at Port Havoc.",
+                "priority": TaskPriority.low,
+                "category": TaskStatusCategory.todo,
+                "assignees": ["Admin User"],
+            },
+            {
+                "project_id": g3_planning.id,
+                "title": "Schedule next session",
+                "description": "Probably the weekend after next. Check with everyone.",
+                "priority": TaskPriority.medium,
+                "category": TaskStatusCategory.in_progress,
+                "assignees": ["Finley Goldtongue"],
+                "due_days": 4,
+            },
         ]
 
         g3_tasks: dict[str, Task] = {}
         for proj in g3_projects:
             proj_tasks = [td for td in g3_task_defs if td["project_id"] == proj.id]
             tasks = await _create_tasks(
-                session, ids,
+                session,
+                ids,
                 guild=g3,
                 status_map=g3_status_maps[proj.id],
                 task_defs=proj_tasks,
@@ -3552,156 +4996,239 @@ async def seed() -> None:
 
         # Tags
         print("  Creating Guild 3 tags...")
-        g3_tags = await _create_tags(session, ids, g3, [
-            ("main quest", "#EF4444"),
-            ("side quest", "#6366F1"),
-            ("naval combat", "#0EA5E9"),
-            ("NPC", "#F59E0B"),
-            ("exploration", "#10B981"),
-            ("loot", "#D97706"),
-            ("ship upgrades", "#8B5CF6"),
-            ("stealth", "#475569"),
-            ("boss fight", "#991B1B"),
-            ("diplomacy", "#059669"),
-        ])
+        g3_tags = await _create_tags(
+            session,
+            ids,
+            g3,
+            [
+                ("main quest", "#EF4444"),
+                ("side quest", "#6366F1"),
+                ("naval combat", "#0EA5E9"),
+                ("NPC", "#F59E0B"),
+                ("exploration", "#10B981"),
+                ("loot", "#D97706"),
+                ("ship upgrades", "#8B5CF6"),
+                ("stealth", "#475569"),
+                ("boss fight", "#991B1B"),
+                ("diplomacy", "#059669"),
+            ],
+        )
 
-        await _link_task_tags(session, ids, g3_tasks, g3_tags, [
-            ("Repair the hull after the kraken attack", ["ship upgrades"]),
-            ("Upgrade cannons to dragon-fire shot", ["ship upgrades", "loot"]),
-            ("Install the enchanted compass", ["ship upgrades", "loot"]),
-            ("Decipher the Leviathan Map", ["main quest", "exploration"]),
-            ("Collect the three Tidestones", ["main quest", "exploration"]),
-            ("Defeat the Leviathan guardian", ["main quest", "boss fight"]),
-            ("Explore Skull Cove", ["exploration", "loot"]),
-            ("Map the Whispering Jungle", ["exploration"]),
-            ("Negotiate with the Coral Elves", ["diplomacy", "NPC"]),
-            ("Investigate the ghost ship sightings", ["exploration", "side quest"]),
-            ("Evade the HMS Vengeance", ["naval combat", "stealth"]),
-            ("Raid the supply convoy near Coral Keep", ["naval combat", "loot"]),
-            ("Forge letters of marque", ["stealth", "diplomacy"]),
-            ("Sink the HMS Ironclad", ["naval combat", "boss fight"]),
-            ("Recruit a new helmsman", ["NPC"]),
-        ])
+        await _link_task_tags(
+            session,
+            ids,
+            g3_tasks,
+            g3_tags,
+            [
+                ("Repair the hull after the kraken attack", ["ship upgrades"]),
+                ("Upgrade cannons to dragon-fire shot", ["ship upgrades", "loot"]),
+                ("Install the enchanted compass", ["ship upgrades", "loot"]),
+                ("Decipher the Leviathan Map", ["main quest", "exploration"]),
+                ("Collect the three Tidestones", ["main quest", "exploration"]),
+                ("Defeat the Leviathan guardian", ["main quest", "boss fight"]),
+                ("Explore Skull Cove", ["exploration", "loot"]),
+                ("Map the Whispering Jungle", ["exploration"]),
+                ("Negotiate with the Coral Elves", ["diplomacy", "NPC"]),
+                ("Investigate the ghost ship sightings", ["exploration", "side quest"]),
+                ("Evade the HMS Vengeance", ["naval combat", "stealth"]),
+                ("Raid the supply convoy near Coral Keep", ["naval combat", "loot"]),
+                ("Forge letters of marque", ["stealth", "diplomacy"]),
+                ("Sink the HMS Ironclad", ["naval combat", "boss fight"]),
+                ("Recruit a new helmsman", ["NPC"]),
+            ],
+        )
 
-        await _link_project_tags(session, ids, g3_tags, [
-            (g3_ship.id, ["ship upgrades"]),
-            (g3_treasure.id, ["main quest", "exploration", "boss fight"]),
-            (g3_islands.id, ["exploration", "side quest"]),
-            (g3_navy_proj.id, ["naval combat", "stealth"]),
-        ])
+        await _link_project_tags(
+            session,
+            ids,
+            g3_tags,
+            [
+                (g3_ship.id, ["ship upgrades"]),
+                (g3_treasure.id, ["main quest", "exploration", "boss fight"]),
+                (g3_islands.id, ["exploration", "side quest"]),
+                (g3_navy_proj.id, ["naval combat", "stealth"]),
+            ],
+        )
 
         # Documents
         print("  Creating Guild 3 documents...")
-        g3_docs = await _create_documents(session, ids, guild=g3, all_users=all_users, doc_defs=[
-            {
-                "initiative_id": g3_main.id,
-                "title": "The Shattered Seas: World Guide",
-                "creator": "Finley Goldtongue",
-                "writers": ["Dungeon Master"],
-                "readers": ["Admin User", "Thorn Ironforge"],
-                "general_access": ResourceAccessLevel.read,
-                "paragraphs": [
-                    "The Shattered Seas are a vast archipelago formed when the old continent sank "
-                    "a thousand years ago. Hundreds of islands dot the warm waters, from volcanic "
-                    "peaks to coral atolls.",
-                    "Major factions: The Imperial Navy (law and order), the Pirate Lords (freedom and chaos), "
-                    "the Coral Elves (ancient guardians), and the Deep Ones (mysterious undersea dwellers).",
-                    "Currency: Gold doubloons, silver pieces, and trade goods. A good ship is worth "
-                    "more than gold — it's your life.",
-                ],
-            },
-            {
-                "initiative_id": g3_main.id,
-                "title": "Crew Manifest: The Crimson Maiden",
-                "creator": "Finley Goldtongue",
-                "paragraphs": [
-                    "Captain: Finley 'Goldtongue' Ashford — Bard/Swashbuckler. Charisma is the real weapon.",
-                    "First Mate: Thorn Ironforge — Fighter/Battlemaster. Handles boarding actions.",
-                    "Navigator: Kael Windrunner — Ranger/Horizon Walker. Reads the stars and tides.",
-                    "Quartermaster: Aurelia Brightshield — Paladin of the Sea. Keeps the crew honest.",
-                    "Ship's Chaplain: Seraphina Dawnlight — Cleric of the Tide Mother.",
-                    "Crew complement: 47 sailors, 12 marines, 3 officers.",
-                ],
-            },
-            {
-                "initiative_id": g3_navy.id,
-                "title": "Intelligence Report: Admiral Blackwood",
-                "creator": "Dungeon Master",
-                "readers": ["Finley Goldtongue", "Thorn Ironforge"],
-                "role_grants": [(g3_navy_mem, ResourceAccessLevel.read)],
-                "paragraphs": [
-                    "Admiral Helena Blackwood commands the 3rd Imperial Fleet from her flagship, "
-                    "the HMS Vengeance (a 74-gun ship of the line). She is ruthless, brilliant, "
-                    "and has a personal vendetta against Captain Ashford.",
-                    "Known ships: HMS Vengeance (flagship), HMS Ironclad (sunk by party), "
-                    "HMS Stormbreak, HMS Resolute, plus 8 frigates and 12 sloops.",
-                    "Weakness: Blackwood's supply lines are stretched thin. Hit the convoys.",
-                ],
-            },
-            {
-                "initiative_id": g3_default_init.id,
-                "title": "Session 5 Recap: The Kraken's Fury",
-                "creator": "Finley Goldtongue",
-                "paragraphs": [
-                    "The Crimson Maiden was ambushed by a kraken near the Abyssal Trench. "
-                    "The battle was fierce — we lost 6 crew and the mainmast before driving "
-                    "the beast off with alchemist's fire.",
-                    "Limped into Port Havoc for repairs. Made contact with a fence who claims "
-                    "to know a translator for the Leviathan Map.",
-                ],
-            },
-            {
-                "initiative_id": g3_default_init.id,
-                "title": "Session 4 Recap: The Ironclad Falls",
-                "creator": "Finley Goldtongue",
-                "paragraphs": [
-                    "Ambushed the HMS Ironclad in a fog bank near Dagger Isle. Thorn led the "
-                    "boarding party while Kael maneuvered us alongside. The Ironclad's captain "
-                    "surrendered after we took the helm.",
-                    "Salvaged: 200 gold doubloons, 50 barrels of gunpowder, a chest of maps, "
-                    "and the enchanted compass (which turned out to be a Tidestone detector).",
-                ],
-            },
-        ])
+        g3_docs = await _create_documents(
+            session,
+            ids,
+            guild=g3,
+            all_users=all_users,
+            doc_defs=[
+                {
+                    "initiative_id": g3_main.id,
+                    "title": "The Shattered Seas: World Guide",
+                    "creator": "Finley Goldtongue",
+                    "writers": ["Dungeon Master"],
+                    "readers": ["Admin User", "Thorn Ironforge"],
+                    "general_access": ResourceAccessLevel.read,
+                    "paragraphs": [
+                        "The Shattered Seas are a vast archipelago formed when the old continent sank "
+                        "a thousand years ago. Hundreds of islands dot the warm waters, from volcanic "
+                        "peaks to coral atolls.",
+                        "Major factions: The Imperial Navy (law and order), the Pirate Lords (freedom and chaos), "
+                        "the Coral Elves (ancient guardians), and the Deep Ones (mysterious undersea dwellers).",
+                        "Currency: Gold doubloons, silver pieces, and trade goods. A good ship is worth "
+                        "more than gold — it's your life.",
+                    ],
+                },
+                {
+                    "initiative_id": g3_main.id,
+                    "title": "Crew Manifest: The Crimson Maiden",
+                    "creator": "Finley Goldtongue",
+                    "paragraphs": [
+                        "Captain: Finley 'Goldtongue' Ashford — Bard/Swashbuckler. Charisma is the real weapon.",
+                        "First Mate: Thorn Ironforge — Fighter/Battlemaster. Handles boarding actions.",
+                        "Navigator: Kael Windrunner — Ranger/Horizon Walker. Reads the stars and tides.",
+                        "Quartermaster: Aurelia Brightshield — Paladin of the Sea. Keeps the crew honest.",
+                        "Ship's Chaplain: Seraphina Dawnlight — Cleric of the Tide Mother.",
+                        "Crew complement: 47 sailors, 12 marines, 3 officers.",
+                    ],
+                },
+                {
+                    "initiative_id": g3_navy.id,
+                    "title": "Intelligence Report: Admiral Blackwood",
+                    "creator": "Dungeon Master",
+                    "readers": ["Finley Goldtongue", "Thorn Ironforge"],
+                    "role_grants": [(g3_navy_mem, ResourceAccessLevel.read)],
+                    "paragraphs": [
+                        "Admiral Helena Blackwood commands the 3rd Imperial Fleet from her flagship, "
+                        "the HMS Vengeance (a 74-gun ship of the line). She is ruthless, brilliant, "
+                        "and has a personal vendetta against Captain Ashford.",
+                        "Known ships: HMS Vengeance (flagship), HMS Ironclad (sunk by party), "
+                        "HMS Stormbreak, HMS Resolute, plus 8 frigates and 12 sloops.",
+                        "Weakness: Blackwood's supply lines are stretched thin. Hit the convoys.",
+                    ],
+                },
+                {
+                    "initiative_id": g3_default_init.id,
+                    "title": "Session 5 Recap: The Kraken's Fury",
+                    "creator": "Finley Goldtongue",
+                    "paragraphs": [
+                        "The Crimson Maiden was ambushed by a kraken near the Abyssal Trench. "
+                        "The battle was fierce — we lost 6 crew and the mainmast before driving "
+                        "the beast off with alchemist's fire.",
+                        "Limped into Port Havoc for repairs. Made contact with a fence who claims "
+                        "to know a translator for the Leviathan Map.",
+                    ],
+                },
+                {
+                    "initiative_id": g3_default_init.id,
+                    "title": "Session 4 Recap: The Ironclad Falls",
+                    "creator": "Finley Goldtongue",
+                    "paragraphs": [
+                        "Ambushed the HMS Ironclad in a fog bank near Dagger Isle. Thorn led the "
+                        "boarding party while Kael maneuvered us alongside. The Ironclad's captain "
+                        "surrendered after we took the helm.",
+                        "Salvaged: 200 gold doubloons, 50 barrels of gunpowder, a chest of maps, "
+                        "and the enchanted compass (which turned out to be a Tidestone detector).",
+                    ],
+                },
+            ],
+        )
 
-        await _link_doc_projects(session, ids, g3, [
-            (g3_ship.id, g3_docs["Crew Manifest: The Crimson Maiden"].id, finley),
-            (g3_treasure.id, g3_docs["The Shattered Seas: World Guide"].id, finley),
-            (g3_navy_proj.id, g3_docs["Intelligence Report: Admiral Blackwood"].id, dm),
-            (g3_planning.id, g3_docs["Session 5 Recap: The Kraken's Fury"].id, finley),
-            (g3_planning.id, g3_docs["Session 4 Recap: The Ironclad Falls"].id, finley),
-        ])
+        await _link_doc_projects(
+            session,
+            ids,
+            g3,
+            [
+                (g3_ship.id, g3_docs["Crew Manifest: The Crimson Maiden"].id, finley),
+                (g3_treasure.id, g3_docs["The Shattered Seas: World Guide"].id, finley),
+                (
+                    g3_navy_proj.id,
+                    g3_docs["Intelligence Report: Admiral Blackwood"].id,
+                    dm,
+                ),
+                (
+                    g3_planning.id,
+                    g3_docs["Session 5 Recap: The Kraken's Fury"].id,
+                    finley,
+                ),
+                (
+                    g3_planning.id,
+                    g3_docs["Session 4 Recap: The Ironclad Falls"].id,
+                    finley,
+                ),
+            ],
+        )
 
-        await _link_doc_tags(session, ids, g3_docs, g3_tags, [
-            ("The Shattered Seas: World Guide", ["exploration"]),
-            ("Crew Manifest: The Crimson Maiden", ["NPC"]),
-            ("Intelligence Report: Admiral Blackwood", ["NPC", "naval combat"]),
-        ])
+        await _link_doc_tags(
+            session,
+            ids,
+            g3_docs,
+            g3_tags,
+            [
+                ("The Shattered Seas: World Guide", ["exploration"]),
+                ("Crew Manifest: The Crimson Maiden", ["NPC"]),
+                ("Intelligence Report: Admiral Blackwood", ["NPC", "naval combat"]),
+            ],
+        )
 
         # Comments
         print("  Creating Guild 3 comments...")
-        await _create_comments(session, ids, g3, [
-            {"author": "Thorn Ironforge", "task_title": "Repair the hull after the kraken attack",
-             "content": "The port breach is the worst. We'll need to beach her to fix the keel properly."},
-            {"author": "Kael Windrunner", "task_title": "Repair the hull after the kraken attack",
-             "content": "I know a cove on the west side of Port Havoc. Sheltered and private."},
-            {"author": "Finley Goldtongue", "task_title": "Decipher the Leviathan Map",
-             "content": "The fence wants 50 doubloons for the translator. Steep but worth it."},
-            {"author": "Admin User", "task_title": "Decipher the Leviathan Map",
-             "content": "I can cover the cost. Let's not haggle when we're this close."},
-            {"author": "Dungeon Master", "task_title": "Evade the HMS Vengeance",
-             "content": "Blackwood knows you're in Port Havoc. You have maybe 3 days before she arrives."},
-            {"author": "Aurelia Brightshield", "task_title": "Negotiate with the Coral Elves",
-             "content": "The Coral Elves respect strength but value honor. We should approach openly, not sneak."},
-            {"author": "Finley Goldtongue", "task_title": "Forge letters of marque",
-             "content": "I've got the royal seal impression from when we raided the Ironclad. Just need the right paper."},
-            {"author": "Seraphina Dawnlight", "task_title": "Defeat the Leviathan guardian",
-             "content": "The Tide Mother has granted me a vision. The guardian is bound, not willing. Perhaps we can free it instead of fighting."},
-            {"author": "Dungeon Master", "doc_title": "Intelligence Report: Admiral Blackwood",
-             "content": "Updated: Ironclad confirmed sunk. Blackwood is furious. Expect retaliation."},
-            {"author": "Thorn Ironforge", "doc_title": "Crew Manifest: The Crimson Maiden",
-             "content": "We lost 6 crew in the kraken fight. Need to update the manifest and recruit in Port Havoc."},
-        ], g3_tasks, g3_docs, all_users)
+        await _create_comments(
+            session,
+            ids,
+            g3,
+            [
+                {
+                    "author": "Thorn Ironforge",
+                    "task_title": "Repair the hull after the kraken attack",
+                    "content": "The port breach is the worst. We'll need to beach her to fix the keel properly.",
+                },
+                {
+                    "author": "Kael Windrunner",
+                    "task_title": "Repair the hull after the kraken attack",
+                    "content": "I know a cove on the west side of Port Havoc. Sheltered and private.",
+                },
+                {
+                    "author": "Finley Goldtongue",
+                    "task_title": "Decipher the Leviathan Map",
+                    "content": "The fence wants 50 doubloons for the translator. Steep but worth it.",
+                },
+                {
+                    "author": "Admin User",
+                    "task_title": "Decipher the Leviathan Map",
+                    "content": "I can cover the cost. Let's not haggle when we're this close.",
+                },
+                {
+                    "author": "Dungeon Master",
+                    "task_title": "Evade the HMS Vengeance",
+                    "content": "Blackwood knows you're in Port Havoc. You have maybe 3 days before she arrives.",
+                },
+                {
+                    "author": "Aurelia Brightshield",
+                    "task_title": "Negotiate with the Coral Elves",
+                    "content": "The Coral Elves respect strength but value honor. We should approach openly, not sneak.",
+                },
+                {
+                    "author": "Finley Goldtongue",
+                    "task_title": "Forge letters of marque",
+                    "content": "I've got the royal seal impression from when we raided the Ironclad. Just need the right paper.",
+                },
+                {
+                    "author": "Seraphina Dawnlight",
+                    "task_title": "Defeat the Leviathan guardian",
+                    "content": "The Tide Mother has granted me a vision. The guardian is bound, not willing. Perhaps we can free it instead of fighting.",
+                },
+                {
+                    "author": "Dungeon Master",
+                    "doc_title": "Intelligence Report: Admiral Blackwood",
+                    "content": "Updated: Ironclad confirmed sunk. Blackwood is furious. Expect retaliation.",
+                },
+                {
+                    "author": "Thorn Ironforge",
+                    "doc_title": "Crew Manifest: The Crimson Maiden",
+                    "content": "We lost 6 crew in the kraken fight. Need to update the manifest and recruit in Port Havoc.",
+                },
+            ],
+            g3_tasks,
+            g3_docs,
+            all_users,
+        )
 
         # -- Guild 3 Settings --
         print("  Creating Guild 3 settings...")
@@ -3709,308 +5236,641 @@ async def seed() -> None:
 
         # -- Favorites & Recent Views --
         print("  Creating Guild 3 favorites & views...")
-        await _create_favorites(session, ids, g3, [
-            (finley, g3_ship), (finley, g3_treasure),
-            (admin_user, g3_treasure), (admin_user, g3_navy_proj),
-            (dm, g3_navy_proj), (dm, g3_islands),
-            (thorn, g3_ship), (thorn, g3_navy_proj),
-            (kael, g3_islands), (kael, g3_ship),
-            (aurelia, g3_ship),
-        ])
-        await _create_recent_views(session, ids, g3, [
-            (finley, g3_ship), (finley, g3_treasure), (finley, g3_planning),
-            (admin_user, g3_treasure), (admin_user, g3_navy_proj),
-            (dm, g3_navy_proj), (dm, g3_islands),
-            (thorn, g3_ship), (thorn, g3_navy_proj),
-            (kael, g3_islands),
-        ])
+        await _create_favorites(
+            session,
+            ids,
+            g3,
+            [
+                (finley, g3_ship),
+                (finley, g3_treasure),
+                (admin_user, g3_treasure),
+                (admin_user, g3_navy_proj),
+                (dm, g3_navy_proj),
+                (dm, g3_islands),
+                (thorn, g3_ship),
+                (thorn, g3_navy_proj),
+                (kael, g3_islands),
+                (kael, g3_ship),
+                (aurelia, g3_ship),
+            ],
+        )
+        await _create_recent_views(
+            session,
+            ids,
+            g3,
+            [
+                (finley, g3_ship),
+                (finley, g3_treasure),
+                (finley, g3_planning),
+                (admin_user, g3_treasure),
+                (admin_user, g3_navy_proj),
+                (dm, g3_navy_proj),
+                (dm, g3_islands),
+                (thorn, g3_ship),
+                (thorn, g3_navy_proj),
+                (kael, g3_islands),
+            ],
+        )
 
         # -- Document Links --
         print("  Creating Guild 3 document links...")
-        await _create_document_links(session, ids, g3, g3_docs, [
-            ("Crew Manifest: The Crimson Maiden", "The Shattered Seas: World Guide"),
-            ("Intelligence Report: Admiral Blackwood", "The Shattered Seas: World Guide"),
-            ("Session 5 Recap: The Kraken's Fury", "Crew Manifest: The Crimson Maiden"),
-            ("Session 5 Recap: The Kraken's Fury", "The Shattered Seas: World Guide"),
-            ("Session 4 Recap: The Ironclad Falls", "Intelligence Report: Admiral Blackwood"),
-            ("Session 4 Recap: The Ironclad Falls", "Crew Manifest: The Crimson Maiden"),
-        ])
+        await _create_document_links(
+            session,
+            ids,
+            g3,
+            g3_docs,
+            [
+                (
+                    "Crew Manifest: The Crimson Maiden",
+                    "The Shattered Seas: World Guide",
+                ),
+                (
+                    "Intelligence Report: Admiral Blackwood",
+                    "The Shattered Seas: World Guide",
+                ),
+                (
+                    "Session 5 Recap: The Kraken's Fury",
+                    "Crew Manifest: The Crimson Maiden",
+                ),
+                (
+                    "Session 5 Recap: The Kraken's Fury",
+                    "The Shattered Seas: World Guide",
+                ),
+                (
+                    "Session 4 Recap: The Ironclad Falls",
+                    "Intelligence Report: Admiral Blackwood",
+                ),
+                (
+                    "Session 4 Recap: The Ironclad Falls",
+                    "Crew Manifest: The Crimson Maiden",
+                ),
+            ],
+        )
 
         # -- Queues --
         print("  Creating Guild 3 queues...")
-        await _create_queues(session, ids, g3, all_users, g3_tags, [
-            {
-                "initiative_id": g3_main.id,
-                "name": "Kraken Attack on the Crimson Maiden",
-                "description": "A massive kraken surfaces and wraps its tentacles around the ship",
-                "created_by": "Finley Goldtongue",
-                "is_active": True,
-                "current_round": 4,
-                "write_users": ["Admin User", "Dungeon Master", "Thorn Ironforge"],
-                "active_item_label": "Finley Goldtongue",
-                "items": [
-                    {"label": "Finley Goldtongue", "position": 23, "user": "Finley Goldtongue",
-                     "color": "#F59E0B", "notes": "At the helm — trying to steer free"},
-                    {"label": "Kraken Tentacle (Port)", "position": 20,
-                     "color": "#7C3AED", "notes": "HP: 30/30 — grappling the mast",
-                     "tags": ["combat"]},
-                    {"label": "Thorn Ironforge", "position": 19, "user": "Thorn Ironforge",
-                     "color": "#DC2626", "notes": "Hacking at the starboard tentacle",
-                     "tags": ["combat"]},
-                    {"label": "Kraken Tentacle (Starboard)", "position": 18,
-                     "color": "#7C3AED", "notes": "HP: 30/30",
-                     "tags": ["combat"]},
-                    {"label": "Kael Windrunner", "position": 16, "user": "Kael Windrunner",
-                     "color": "#0EA5E9", "notes": "In the crow's nest — firing arrows"},
-                    {"label": "Admin User (First Mate)", "position": 14, "user": "Admin User",
-                     "color": "#059669"},
-                    {"label": "Aurelia Brightshield", "position": 11, "user": "Aurelia Brightshield",
-                     "color": "#EAB308", "notes": "Channeling Tide Mother's blessing"},
-                    {"label": "Seraphina Dawnlight", "position": 8, "user": "Seraphina Dawnlight",
-                     "color": "#EC4899"},
-                    {"label": "Kraken (Body)", "position": 5,
-                     "color": "#581C87", "notes": "HP: 200/200 — submerged, surfaces round 6",
-                     "is_visible": False, "tags": ["combat", "boss fight"]},
-                ],
-            },
-            {
-                "initiative_id": g3_main.id,
-                "name": "Port Havoc Bar Brawl",
-                "description": "A tavern argument escalates into a full-blown melee",
-                "created_by": "Dungeon Master",
-                "is_active": False,
-                "current_round": 1,
-                "write_users": ["Finley Goldtongue"],
-                "general_access": ResourceAccessLevel.read,
-                "items": [
-                    {"label": "Finley Goldtongue", "position": 19, "user": "Finley Goldtongue",
-                     "color": "#F59E0B"},
-                    {"label": "Thorn Ironforge", "position": 17, "user": "Thorn Ironforge",
-                     "color": "#DC2626"},
-                    {"label": "Rival Pirate Captain", "position": 15,
-                     "color": "#B91C1C", "notes": "Dual-wielding cutlasses"},
-                    {"label": "Rival Crew (x3)", "position": 12,
-                     "color": "#9CA3AF", "notes": "HP: 9 each"},
-                    {"label": "Kael Windrunner", "position": 10, "user": "Kael Windrunner",
-                     "color": "#0EA5E9"},
-                    {"label": "Barkeep (Non-combatant)", "position": 1,
-                     "color": "#78716C", "notes": "Hiding behind the bar"},
-                ],
-            },
-        ])
+        await _create_queues(
+            session,
+            ids,
+            g3,
+            all_users,
+            g3_tags,
+            [
+                {
+                    "initiative_id": g3_main.id,
+                    "name": "Kraken Attack on the Crimson Maiden",
+                    "description": "A massive kraken surfaces and wraps its tentacles around the ship",
+                    "created_by": "Finley Goldtongue",
+                    "is_active": True,
+                    "current_round": 4,
+                    "write_users": ["Admin User", "Dungeon Master", "Thorn Ironforge"],
+                    "active_item_label": "Finley Goldtongue",
+                    "items": [
+                        {
+                            "label": "Finley Goldtongue",
+                            "position": 23,
+                            "user": "Finley Goldtongue",
+                            "color": "#F59E0B",
+                            "notes": "At the helm — trying to steer free",
+                        },
+                        {
+                            "label": "Kraken Tentacle (Port)",
+                            "position": 20,
+                            "color": "#7C3AED",
+                            "notes": "HP: 30/30 — grappling the mast",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Thorn Ironforge",
+                            "position": 19,
+                            "user": "Thorn Ironforge",
+                            "color": "#DC2626",
+                            "notes": "Hacking at the starboard tentacle",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Kraken Tentacle (Starboard)",
+                            "position": 18,
+                            "color": "#7C3AED",
+                            "notes": "HP: 30/30",
+                            "tags": ["combat"],
+                        },
+                        {
+                            "label": "Kael Windrunner",
+                            "position": 16,
+                            "user": "Kael Windrunner",
+                            "color": "#0EA5E9",
+                            "notes": "In the crow's nest — firing arrows",
+                        },
+                        {
+                            "label": "Admin User (First Mate)",
+                            "position": 14,
+                            "user": "Admin User",
+                            "color": "#059669",
+                        },
+                        {
+                            "label": "Aurelia Brightshield",
+                            "position": 11,
+                            "user": "Aurelia Brightshield",
+                            "color": "#EAB308",
+                            "notes": "Channeling Tide Mother's blessing",
+                        },
+                        {
+                            "label": "Seraphina Dawnlight",
+                            "position": 8,
+                            "user": "Seraphina Dawnlight",
+                            "color": "#EC4899",
+                        },
+                        {
+                            "label": "Kraken (Body)",
+                            "position": 5,
+                            "color": "#581C87",
+                            "notes": "HP: 200/200 — submerged, surfaces round 6",
+                            "is_visible": False,
+                            "tags": ["combat", "boss fight"],
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g3_main.id,
+                    "name": "Port Havoc Bar Brawl",
+                    "description": "A tavern argument escalates into a full-blown melee",
+                    "created_by": "Dungeon Master",
+                    "is_active": False,
+                    "current_round": 1,
+                    "write_users": ["Finley Goldtongue"],
+                    "general_access": ResourceAccessLevel.read,
+                    "items": [
+                        {
+                            "label": "Finley Goldtongue",
+                            "position": 19,
+                            "user": "Finley Goldtongue",
+                            "color": "#F59E0B",
+                        },
+                        {
+                            "label": "Thorn Ironforge",
+                            "position": 17,
+                            "user": "Thorn Ironforge",
+                            "color": "#DC2626",
+                        },
+                        {
+                            "label": "Rival Pirate Captain",
+                            "position": 15,
+                            "color": "#B91C1C",
+                            "notes": "Dual-wielding cutlasses",
+                        },
+                        {
+                            "label": "Rival Crew (x3)",
+                            "position": 12,
+                            "color": "#9CA3AF",
+                            "notes": "HP: 9 each",
+                        },
+                        {
+                            "label": "Kael Windrunner",
+                            "position": 10,
+                            "user": "Kael Windrunner",
+                            "color": "#0EA5E9",
+                        },
+                        {
+                            "label": "Barkeep (Non-combatant)",
+                            "position": 1,
+                            "color": "#78716C",
+                            "notes": "Hiding behind the bar",
+                        },
+                    ],
+                },
+            ],
+        )
 
         await _enable_queue_permissions(session, [g3_main_mem])
 
         # -- Counters --
         print("  Creating Guild 3 counter groups...")
-        await _create_counter_groups(session, ids, g3, all_users, [
-            {
-                "initiative_id": g3_main.id,
-                "name": "The Crimson Maiden",
-                "description": "Ship state for the pirate vessel.",
-                "created_by": "Finley Goldtongue",
-                "role_grants": [{"role_id": g3_main_mem.id, "level": ResourceAccessLevel.write}],
-                "counters": [
-                    {"name": "Hull HP", "color": "#92400E", "count": 87, "min": 0, "max": 120,
-                     "step": 1, "initial_count": 120, "view_mode": CounterViewMode.progress_bar, "position": 1},
-                    {"name": "Sails", "color": "#FBBF24", "count": 4, "min": 0, "max": 4,
-                     "step": 1, "initial_count": 4, "view_mode": CounterViewMode.number, "position": 2},
-                    {"name": "Crew Morale", "color": "#10B981", "count": 6, "min": 0, "max": 10,
-                     "step": 1, "initial_count": 7, "view_mode": CounterViewMode.progress_bar, "position": 3},
-                    {"name": "Rations (days)", "color": "#65A30D", "count": 18, "min": 0,
-                     "step": 1, "initial_count": 30, "view_mode": CounterViewMode.number, "position": 4},
-                    {"name": "Storm Brewing", "color": "#1E40AF", "count": 2, "min": 0, "max": 6,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.segmented_clock, "position": 5},
-                ],
-            },
-            {
-                "initiative_id": g3_main.id,
-                "name": "Plunder Vault",
-                "description": "Treasure recovered toward the Leviathan's Heart.",
-                "created_by": "Finley Goldtongue",
-                "general_access": ResourceAccessLevel.write,
-                "counters": [
-                    {"name": "Tidestones Recovered", "color": "#0EA5E9", "count": 1, "min": 0, "max": 3,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.progress_bar, "position": 1},
-                    {"name": "Gold (doubloons)", "color": "#F59E0B", "count": 4200, "min": 0,
-                     "step": 100, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 2},
-                ],
-            },
-            {
-                "initiative_id": g3_navy.id,
-                "name": "Navy Threat Tracker",
-                "description": "How close the Imperial Navy is to catching us.",
-                "created_by": "Dungeon Master",
-                "counters": [
-                    {"name": "Bounty Level", "color": "#DC2626", "count": 3, "min": 0, "max": 5,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.segmented_clock, "position": 1},
-                    {"name": "Ships of the Line Sunk", "color": "#1E40AF", "count": 2, "min": 0,
-                     "step": 1, "initial_count": 0, "view_mode": CounterViewMode.number, "position": 2},
-                ],
-            },
-        ])
-        await _enable_role_feature(session, [g3_main_mem, g3_navy_mem], "counter_groups_enabled")
+        await _create_counter_groups(
+            session,
+            ids,
+            g3,
+            all_users,
+            [
+                {
+                    "initiative_id": g3_main.id,
+                    "name": "The Crimson Maiden",
+                    "description": "Ship state for the pirate vessel.",
+                    "created_by": "Finley Goldtongue",
+                    "role_grants": [
+                        {"role_id": g3_main_mem.id, "level": ResourceAccessLevel.write}
+                    ],
+                    "counters": [
+                        {
+                            "name": "Hull HP",
+                            "color": "#92400E",
+                            "count": 87,
+                            "min": 0,
+                            "max": 120,
+                            "step": 1,
+                            "initial_count": 120,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Sails",
+                            "color": "#FBBF24",
+                            "count": 4,
+                            "min": 0,
+                            "max": 4,
+                            "step": 1,
+                            "initial_count": 4,
+                            "view_mode": CounterViewMode.number,
+                            "position": 2,
+                        },
+                        {
+                            "name": "Crew Morale",
+                            "color": "#10B981",
+                            "count": 6,
+                            "min": 0,
+                            "max": 10,
+                            "step": 1,
+                            "initial_count": 7,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 3,
+                        },
+                        {
+                            "name": "Rations (days)",
+                            "color": "#65A30D",
+                            "count": 18,
+                            "min": 0,
+                            "step": 1,
+                            "initial_count": 30,
+                            "view_mode": CounterViewMode.number,
+                            "position": 4,
+                        },
+                        {
+                            "name": "Storm Brewing",
+                            "color": "#1E40AF",
+                            "count": 2,
+                            "min": 0,
+                            "max": 6,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.segmented_clock,
+                            "position": 5,
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g3_main.id,
+                    "name": "Plunder Vault",
+                    "description": "Treasure recovered toward the Leviathan's Heart.",
+                    "created_by": "Finley Goldtongue",
+                    "general_access": ResourceAccessLevel.write,
+                    "counters": [
+                        {
+                            "name": "Tidestones Recovered",
+                            "color": "#0EA5E9",
+                            "count": 1,
+                            "min": 0,
+                            "max": 3,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.progress_bar,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Gold (doubloons)",
+                            "color": "#F59E0B",
+                            "count": 4200,
+                            "min": 0,
+                            "step": 100,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 2,
+                        },
+                    ],
+                },
+                {
+                    "initiative_id": g3_navy.id,
+                    "name": "Navy Threat Tracker",
+                    "description": "How close the Imperial Navy is to catching us.",
+                    "created_by": "Dungeon Master",
+                    "counters": [
+                        {
+                            "name": "Bounty Level",
+                            "color": "#DC2626",
+                            "count": 3,
+                            "min": 0,
+                            "max": 5,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.segmented_clock,
+                            "position": 1,
+                        },
+                        {
+                            "name": "Ships of the Line Sunk",
+                            "color": "#1E40AF",
+                            "count": 2,
+                            "min": 0,
+                            "step": 1,
+                            "initial_count": 0,
+                            "view_mode": CounterViewMode.number,
+                            "position": 2,
+                        },
+                    ],
+                },
+            ],
+        )
+        await _enable_role_feature(
+            session, [g3_main_mem, g3_navy_mem], "counter_groups_enabled"
+        )
 
         # -- Calendar events --
         print("  Creating Guild 3 calendar events...")
-        await _create_calendar_events(session, ids, g3, all_users, g3_tags, g3_docs, [
-            {
-                "initiative_id": g3_main.id,
-                "title": "Session 7: The Leviathan's Maw",
-                "description": "Descent into the underwater grotto.",
-                "location": "Captain's quarters (Roll20)",
-                "start_at": NOW + timedelta(days=1, hours=2),
-                "end_at": NOW + timedelta(days=1, hours=6),
-                "color": "#DC2626",
-                "created_by": "Finley Goldtongue",
-                "attendees": [
-                    {"user": "Finley Goldtongue", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Aurelia Brightshield", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Seraphina Dawnlight", "rsvp_status": RSVPStatus.tentative},
-                    {"user": "Platform Owner", "rsvp_status": RSVPStatus.declined},
-                ],
-                "documents": ["The Shattered Seas: World Guide"],
-            },
-            {
-                # Multi-day event — spans three calendar days.
-                "initiative_id": g3_main.id,
-                "title": "Voyage to the Abyssal Trench",
-                "description": "Three in-game days of open-sea travel, storms, and random encounters.",
-                "location": "The Crimson Maiden",
-                "start_at": NOW + timedelta(days=8),
-                "end_at": NOW + timedelta(days=10, hours=6),
-                "color": "#0EA5E9",
-                "created_by": "Finley Goldtongue",
-                "attendees": [
-                    {"user": "Finley Goldtongue", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Aurelia Brightshield", "rsvp_status": RSVPStatus.pending},
-                ],
-                "tags": ["exploration"],
-            },
-            {
-                "initiative_id": g3_main.id,
-                "title": "Sunday Pirate Night",
-                "description": "Weekly campaign session.",
-                "start_at": NOW + timedelta(days=6, hours=2),
-                "end_at": NOW + timedelta(days=6, hours=5),
-                "color": "#DC2626",
-                "created_by": "Finley Goldtongue",
-                "recurrence": {
-                    "frequency": "weekly", "interval": 1,
-                    "weekdays": ["su"], "ends": "never",
+        await _create_calendar_events(
+            session,
+            ids,
+            g3,
+            all_users,
+            g3_tags,
+            g3_docs,
+            [
+                {
+                    "initiative_id": g3_main.id,
+                    "title": "Session 7: The Leviathan's Maw",
+                    "description": "Descent into the underwater grotto.",
+                    "location": "Captain's quarters (Roll20)",
+                    "start_at": NOW + timedelta(days=1, hours=2),
+                    "end_at": NOW + timedelta(days=1, hours=6),
+                    "color": "#DC2626",
+                    "created_by": "Finley Goldtongue",
+                    "attendees": [
+                        {
+                            "user": "Finley Goldtongue",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.accepted},
+                        {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
+                        {
+                            "user": "Aurelia Brightshield",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {
+                            "user": "Seraphina Dawnlight",
+                            "rsvp_status": RSVPStatus.tentative,
+                        },
+                        {"user": "Platform Owner", "rsvp_status": RSVPStatus.declined},
+                    ],
+                    "documents": ["The Shattered Seas: World Guide"],
                 },
-                "attendees": [
-                    {"user": "Finley Goldtongue", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
-                ],
-            },
-            {
-                "initiative_id": g3_main.id,
-                "title": "Session 6: The Ironclad Falls",
-                "description": "Past session — sank the HMS Ironclad.",
-                "start_at": NOW - timedelta(days=7, hours=22),
-                "end_at": NOW - timedelta(days=7, hours=19),
-                "color": "#DC2626",
-                "created_by": "Finley Goldtongue",
-            },
-            {
-                "initiative_id": g3_navy.id,
-                "title": "Naval Engagement: HMS Vengeance Pursuit",
-                "description": "Cat-and-mouse with Admiral Blackwood's flagship.",
-                "start_at": NOW + timedelta(days=4, hours=3),
-                "end_at": NOW + timedelta(days=4, hours=6),
-                "color": "#1E40AF",
-                "created_by": "Dungeon Master",
-                "attendees": [
-                    {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Finley Goldtongue", "rsvp_status": RSVPStatus.accepted},
-                    {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.pending},
-                ],
-                "documents": ["Intelligence Report: Admiral Blackwood"],
-            },
-            {
-                "initiative_id": g3_navy.id,
-                "title": "Shore Leave (all-day)",
-                "description": "Crew gets a day in Port Havoc.",
-                "start_at": NOW + timedelta(days=12),
-                "end_at": NOW + timedelta(days=12),
-                "all_day": True,
-                "color": "#FBBF24",
-                "created_by": "Dungeon Master",
-            },
-        ])
-        await _enable_role_feature(session, [g3_main_mem, g3_navy_mem], "calendars_enabled")
+                {
+                    # Multi-day event — spans three calendar days.
+                    "initiative_id": g3_main.id,
+                    "title": "Voyage to the Abyssal Trench",
+                    "description": "Three in-game days of open-sea travel, storms, and random encounters.",
+                    "location": "The Crimson Maiden",
+                    "start_at": NOW + timedelta(days=8),
+                    "end_at": NOW + timedelta(days=10, hours=6),
+                    "color": "#0EA5E9",
+                    "created_by": "Finley Goldtongue",
+                    "attendees": [
+                        {
+                            "user": "Finley Goldtongue",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
+                        {
+                            "user": "Aurelia Brightshield",
+                            "rsvp_status": RSVPStatus.pending,
+                        },
+                    ],
+                    "tags": ["exploration"],
+                },
+                {
+                    "initiative_id": g3_main.id,
+                    "title": "Sunday Pirate Night",
+                    "description": "Weekly campaign session.",
+                    "start_at": NOW + timedelta(days=6, hours=2),
+                    "end_at": NOW + timedelta(days=6, hours=5),
+                    "color": "#DC2626",
+                    "created_by": "Finley Goldtongue",
+                    "recurrence": {
+                        "frequency": "weekly",
+                        "interval": 1,
+                        "weekdays": ["su"],
+                        "ends": "never",
+                    },
+                    "attendees": [
+                        {
+                            "user": "Finley Goldtongue",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {"user": "Kael Windrunner", "rsvp_status": RSVPStatus.accepted},
+                    ],
+                },
+                {
+                    "initiative_id": g3_main.id,
+                    "title": "Session 6: The Ironclad Falls",
+                    "description": "Past session — sank the HMS Ironclad.",
+                    "start_at": NOW - timedelta(days=7, hours=22),
+                    "end_at": NOW - timedelta(days=7, hours=19),
+                    "color": "#DC2626",
+                    "created_by": "Finley Goldtongue",
+                },
+                {
+                    "initiative_id": g3_navy.id,
+                    "title": "Naval Engagement: HMS Vengeance Pursuit",
+                    "description": "Cat-and-mouse with Admiral Blackwood's flagship.",
+                    "start_at": NOW + timedelta(days=4, hours=3),
+                    "end_at": NOW + timedelta(days=4, hours=6),
+                    "color": "#1E40AF",
+                    "created_by": "Dungeon Master",
+                    "attendees": [
+                        {"user": "Dungeon Master", "rsvp_status": RSVPStatus.accepted},
+                        {
+                            "user": "Finley Goldtongue",
+                            "rsvp_status": RSVPStatus.accepted,
+                        },
+                        {"user": "Thorn Ironforge", "rsvp_status": RSVPStatus.pending},
+                    ],
+                    "documents": ["Intelligence Report: Admiral Blackwood"],
+                },
+                {
+                    "initiative_id": g3_navy.id,
+                    "title": "Shore Leave (all-day)",
+                    "description": "Crew gets a day in Port Havoc.",
+                    "start_at": NOW + timedelta(days=12),
+                    "end_at": NOW + timedelta(days=12),
+                    "all_day": True,
+                    "color": "#FBBF24",
+                    "created_by": "Dungeon Master",
+                },
+            ],
+        )
+        await _enable_role_feature(
+            session, [g3_main_mem, g3_navy_mem], "calendars_enabled"
+        )
 
         # -- Custom properties --
         print("  Creating Guild 3 property definitions + values...")
-        g3_main_props = await _create_property_definitions(session, ids, g3_main, [
-            {"name": "Arc", "type": PropertyType.select, "position": 1.0, "color": "#DC2626",
-             "options": [
-                 {"value": "shattered_seas", "label": "Shattered Seas"},
-                 {"value": "tidestone_hunt", "label": "Tidestone Hunt", "color": "#0EA5E9"},
-                 {"value": "leviathan_finale", "label": "Leviathan Finale", "color": "#7F1D1D"},
-             ]},
-            {"name": "Crew Reward (gold)", "type": PropertyType.number, "position": 2.0, "color": "#F59E0B"},
-            {"name": "Quest Hooks", "type": PropertyType.multi_select, "position": 3.0,
-             "options": [
-                 {"value": "treasure", "label": "Treasure", "color": "#F59E0B"},
-                 {"value": "rescue", "label": "Rescue", "color": "#10B981"},
-                 {"value": "revenge", "label": "Revenge", "color": "#DC2626"},
-                 {"value": "exploration", "label": "Exploration", "color": "#0EA5E9"},
-             ]},
-            {"name": "Spoilers Allowed", "type": PropertyType.checkbox, "position": 4.0},
-            {"name": "Quest Giver", "type": PropertyType.user_reference, "position": 5.0},
-            {"name": "Map Link", "type": PropertyType.url, "position": 6.0},
-        ])
+        g3_main_props = await _create_property_definitions(
+            session,
+            ids,
+            g3_main,
+            [
+                {
+                    "name": "Arc",
+                    "type": PropertyType.select,
+                    "position": 1.0,
+                    "color": "#DC2626",
+                    "options": [
+                        {"value": "shattered_seas", "label": "Shattered Seas"},
+                        {
+                            "value": "tidestone_hunt",
+                            "label": "Tidestone Hunt",
+                            "color": "#0EA5E9",
+                        },
+                        {
+                            "value": "leviathan_finale",
+                            "label": "Leviathan Finale",
+                            "color": "#7F1D1D",
+                        },
+                    ],
+                },
+                {
+                    "name": "Crew Reward (gold)",
+                    "type": PropertyType.number,
+                    "position": 2.0,
+                    "color": "#F59E0B",
+                },
+                {
+                    "name": "Quest Hooks",
+                    "type": PropertyType.multi_select,
+                    "position": 3.0,
+                    "options": [
+                        {"value": "treasure", "label": "Treasure", "color": "#F59E0B"},
+                        {"value": "rescue", "label": "Rescue", "color": "#10B981"},
+                        {"value": "revenge", "label": "Revenge", "color": "#DC2626"},
+                        {
+                            "value": "exploration",
+                            "label": "Exploration",
+                            "color": "#0EA5E9",
+                        },
+                    ],
+                },
+                {
+                    "name": "Spoilers Allowed",
+                    "type": PropertyType.checkbox,
+                    "position": 4.0,
+                },
+                {
+                    "name": "Quest Giver",
+                    "type": PropertyType.user_reference,
+                    "position": 5.0,
+                },
+                {"name": "Map Link", "type": PropertyType.url, "position": 6.0},
+            ],
+        )
         t_leviathan_id = g3_tasks["Defeat the Leviathan guardian"].id
         t_decipher_id = g3_tasks["Decipher the Leviathan Map"].id
         t_collect_id = g3_tasks["Collect the three Tidestones"].id
         doc_world_g3_id = g3_docs["The Shattered Seas: World Guide"].id
         doc_crew_g3_id = g3_docs["Crew Manifest: The Crimson Maiden"].id
 
-        await _attach_property_values(session, ids, g3_main_props["Arc"], [
-            ("task", t_leviathan_id, "leviathan_finale"),
-            ("task", t_decipher_id, "tidestone_hunt"),
-            ("task", t_collect_id, "tidestone_hunt"),
-        ])
-        await _attach_property_values(session, ids, g3_main_props["Crew Reward (gold)"], [
-            ("task", t_leviathan_id, Decimal("25000")),
-            ("task", t_collect_id, Decimal("9000")),
-        ])
-        await _attach_property_values(session, ids, g3_main_props["Quest Hooks"], [
-            ("task", t_leviathan_id, ["treasure", "revenge"]),
-            ("task", t_decipher_id, ["treasure", "exploration"]),
-        ])
-        await _attach_property_values(session, ids, g3_main_props["Spoilers Allowed"], [
-            ("document", doc_world_g3_id, True),
-            ("document", doc_crew_g3_id, False),
-        ])
-        await _attach_property_values(session, ids, g3_main_props["Quest Giver"], [
-            ("task", t_decipher_id, finley.id),
-        ])
-        await _attach_property_values(session, ids, g3_main_props["Map Link"], [
-            ("document", doc_world_g3_id, "https://example.com/maps/shattered-seas"),
-        ])
+        await _attach_property_values(
+            session,
+            ids,
+            g3_main_props["Arc"],
+            [
+                ("task", t_leviathan_id, "leviathan_finale"),
+                ("task", t_decipher_id, "tidestone_hunt"),
+                ("task", t_collect_id, "tidestone_hunt"),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g3_main_props["Crew Reward (gold)"],
+            [
+                ("task", t_leviathan_id, Decimal("25000")),
+                ("task", t_collect_id, Decimal("9000")),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g3_main_props["Quest Hooks"],
+            [
+                ("task", t_leviathan_id, ["treasure", "revenge"]),
+                ("task", t_decipher_id, ["treasure", "exploration"]),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g3_main_props["Spoilers Allowed"],
+            [
+                ("document", doc_world_g3_id, True),
+                ("document", doc_crew_g3_id, False),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g3_main_props["Quest Giver"],
+            [
+                ("task", t_decipher_id, finley.id),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g3_main_props["Map Link"],
+            [
+                (
+                    "document",
+                    doc_world_g3_id,
+                    "https://example.com/maps/shattered-seas",
+                ),
+            ],
+        )
 
-        g3_navy_props = await _create_property_definitions(session, ids, g3_navy, [
-            {"name": "Threat Level", "type": PropertyType.select, "position": 1.0,
-             "options": [
-                 {"value": "frigate", "label": "Frigate", "color": "#10B981"},
-                 {"value": "ship_of_the_line", "label": "Ship of the Line", "color": "#F59E0B"},
-                 {"value": "flagship", "label": "Flagship", "color": "#DC2626"},
-             ]},
-            {"name": "Engagement Date", "type": PropertyType.date, "position": 2.0},
-        ])
+        g3_navy_props = await _create_property_definitions(
+            session,
+            ids,
+            g3_navy,
+            [
+                {
+                    "name": "Threat Level",
+                    "type": PropertyType.select,
+                    "position": 1.0,
+                    "options": [
+                        {"value": "frigate", "label": "Frigate", "color": "#10B981"},
+                        {
+                            "value": "ship_of_the_line",
+                            "label": "Ship of the Line",
+                            "color": "#F59E0B",
+                        },
+                        {"value": "flagship", "label": "Flagship", "color": "#DC2626"},
+                    ],
+                },
+                {"name": "Engagement Date", "type": PropertyType.date, "position": 2.0},
+            ],
+        )
         t_evade_id = g3_tasks["Evade the HMS Vengeance"].id
-        await _attach_property_values(session, ids, g3_navy_props["Threat Level"], [
-            ("task", t_evade_id, "flagship"),
-        ])
-        await _attach_property_values(session, ids, g3_navy_props["Engagement Date"], [
-            ("task", t_evade_id, (NOW + timedelta(days=4)).date()),
-            ])
+        await _attach_property_values(
+            session,
+            ids,
+            g3_navy_props["Threat Level"],
+            [
+                ("task", t_evade_id, "flagship"),
+            ],
+        )
+        await _attach_property_values(
+            session,
+            ids,
+            g3_navy_props["Engagement Date"],
+            [
+                ("task", t_evade_id, (NOW + timedelta(days=4)).date()),
+            ],
+        )
 
         # Commit guild 3's data — each guild section is committed as it completes
         # (its writes are routed into that guild's schema).
@@ -4025,66 +5885,75 @@ async def seed() -> None:
         # denied, and expired.
         print("\n  Creating PAM access grants...")
         await set_rls_context(session)  # shared/public table — leave guild routing
-        await _create_access_grants(session, ids, [
-            {
-                # Pending request awaiting an approver (shows in the admin queue).
-                "user": p_support, "guild_id": g2_id,
-                "access_level": AccessLevel.read,
-                "status": AccessGrantStatus.pending,
-                "reason": "Investigating a reported sync issue in Starforge Collective "
-                          "(ticket #4821).",
-                "requested_duration_minutes": 120,
-                "requested_delta": -timedelta(hours=2),
-            },
-            {
-                # Live read grant — moderator currently inside Realm of Tides.
-                "user": p_moderator, "guild_id": g3_id,
-                "access_level": AccessLevel.read,
-                "status": AccessGrantStatus.approved,
-                "reason": "Reviewing a content report against a queue in Realm of Tides.",
-                "requested_duration_minutes": 480,
-                "approved_by": admin_user,
-                "requested_delta": -timedelta(hours=2),
-                "decided_delta": -timedelta(hours=1),
-                "expires_delta": timedelta(hours=7),
-            },
-            {
-                # Live break-glass — operator self-issued and self-approved,
-                # read_write (acts as a full guild admin for the window).
-                "user": p_operator, "guild_id": g2_id,
-                "access_level": AccessLevel.read_write,
-                "status": AccessGrantStatus.approved,
-                "reason": "Break-glass: restoring a corrupted queue after a failed import.",
-                "requested_duration_minutes": 90,
-                "approved_by": p_operator,
-                "requested_delta": -timedelta(minutes=30),
-                "decided_delta": -timedelta(minutes=30),
-                "expires_delta": timedelta(hours=1),
-            },
-            {
-                # Denied request (audit-trail / history view).
-                "user": p_support, "guild_id": g3_id,
-                "access_level": AccessLevel.read_write,
-                "status": AccessGrantStatus.denied,
-                "reason": "Wanted to fix a typo in a user's document directly.",
-                "requested_duration_minutes": 60,
-                "approved_by": p_owner,
-                "requested_delta": -timedelta(days=2),
-                "decided_delta": -timedelta(days=2) + timedelta(hours=1),
-            },
-            {
-                # Expired grant (window long past).
-                "user": p_moderator, "guild_id": g1_id,
-                "access_level": AccessLevel.read,
-                "status": AccessGrantStatus.expired,
-                "reason": "Audited invite spam originating from the primary guild.",
-                "requested_duration_minutes": 240,
-                "approved_by": admin_user,
-                "requested_delta": -timedelta(days=3),
-                "decided_delta": -timedelta(days=3) + timedelta(minutes=10),
-                "expires_delta": -timedelta(days=3) + timedelta(hours=4),
-            },
-        ])
+        await _create_access_grants(
+            session,
+            ids,
+            [
+                {
+                    # Pending request awaiting an approver (shows in the admin queue).
+                    "user": p_support,
+                    "guild_id": g2_id,
+                    "access_level": AccessLevel.read,
+                    "status": AccessGrantStatus.pending,
+                    "reason": "Investigating a reported sync issue in Starforge Collective "
+                    "(ticket #4821).",
+                    "requested_duration_minutes": 120,
+                    "requested_delta": -timedelta(hours=2),
+                },
+                {
+                    # Live read grant — moderator currently inside Realm of Tides.
+                    "user": p_moderator,
+                    "guild_id": g3_id,
+                    "access_level": AccessLevel.read,
+                    "status": AccessGrantStatus.approved,
+                    "reason": "Reviewing a content report against a queue in Realm of Tides.",
+                    "requested_duration_minutes": 480,
+                    "approved_by": admin_user,
+                    "requested_delta": -timedelta(hours=2),
+                    "decided_delta": -timedelta(hours=1),
+                    "expires_delta": timedelta(hours=7),
+                },
+                {
+                    # Live break-glass — operator self-issued and self-approved,
+                    # read_write (acts as a full guild admin for the window).
+                    "user": p_operator,
+                    "guild_id": g2_id,
+                    "access_level": AccessLevel.read_write,
+                    "status": AccessGrantStatus.approved,
+                    "reason": "Break-glass: restoring a corrupted queue after a failed import.",
+                    "requested_duration_minutes": 90,
+                    "approved_by": p_operator,
+                    "requested_delta": -timedelta(minutes=30),
+                    "decided_delta": -timedelta(minutes=30),
+                    "expires_delta": timedelta(hours=1),
+                },
+                {
+                    # Denied request (audit-trail / history view).
+                    "user": p_support,
+                    "guild_id": g3_id,
+                    "access_level": AccessLevel.read_write,
+                    "status": AccessGrantStatus.denied,
+                    "reason": "Wanted to fix a typo in a user's document directly.",
+                    "requested_duration_minutes": 60,
+                    "approved_by": p_owner,
+                    "requested_delta": -timedelta(days=2),
+                    "decided_delta": -timedelta(days=2) + timedelta(hours=1),
+                },
+                {
+                    # Expired grant (window long past).
+                    "user": p_moderator,
+                    "guild_id": g1_id,
+                    "access_level": AccessLevel.read,
+                    "status": AccessGrantStatus.expired,
+                    "reason": "Audited invite spam originating from the primary guild.",
+                    "requested_duration_minutes": 240,
+                    "approved_by": admin_user,
+                    "requested_delta": -timedelta(days=3),
+                    "decided_delta": -timedelta(days=3) + timedelta(minutes=10),
+                    "expires_delta": -timedelta(days=3) + timedelta(hours=4),
+                },
+            ],
+        )
         await session.commit()
 
     _save_state(ids.data)
@@ -4099,7 +5968,9 @@ async def seed() -> None:
     print(f"  3 guilds, {len(ids.data['initiatives'])} initiatives")
     print(f"  {total_projects} projects, {total_tasks} tasks")
     print(f"  {total_docs} documents, {len(ids.data['tags'])} tags")
-    print(f"  {len(ids.data['queues'])} queues, {len(ids.data['queue_items'])} queue items")
+    print(
+        f"  {len(ids.data['queues'])} queues, {len(ids.data['queue_items'])} queue items"
+    )
     print(
         f"  {len(ids.data['counter_groups'])} counter groups, "
         f"{len(ids.data['counters'])} counters"
@@ -4118,9 +5989,15 @@ async def seed() -> None:
         f"{total_property_values} property values"
     )
     print(f"  {len(ids.data['comments'])} comments")
-    print(f"  {len(ids.data['project_favorites'])} favorites, {len(ids.data['document_links'])} doc links")
-    print(f"  {len(ids.data['access_grants'])} PAM access grants (pending/live/break-glass/denied/expired)")
-    print(f"\n  Owner login: {settings.FIRST_OWNER_EMAIL} / {settings.FIRST_OWNER_PASSWORD}")
+    print(
+        f"  {len(ids.data['project_favorites'])} favorites, {len(ids.data['document_links'])} doc links"
+    )
+    print(
+        f"  {len(ids.data['access_grants'])} PAM access grants (pending/live/break-glass/denied/expired)"
+    )
+    print(
+        f"\n  Owner login: {settings.FIRST_OWNER_EMAIL} / {settings.FIRST_OWNER_PASSWORD}"
+    )
     print("  Guild admins (password: changeme):")
     print("    admin1@example.com (guild 1), admin2@example.com (guild 2),")
     print("    admin3@example.com (guild 3), admin4@example.com (guilds 1+3)")
@@ -4135,6 +6012,7 @@ async def seed() -> None:
 # ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
+
 
 async def clean() -> None:
     """Remove all seeded dev data.
@@ -4153,7 +6031,8 @@ async def clean() -> None:
     async with db_session.provisioning_engine.begin() as conn:
         await conn.exec_driver_sql("SET lock_timeout = '10s'")
         schemas = [
-            s for (s,) in (
+            s
+            for (s,) in (
                 await conn.exec_driver_sql(
                     "SELECT nspname FROM pg_namespace WHERE nspname ~ '^guild_[0-9]+$'"
                 )
@@ -4162,13 +6041,16 @@ async def clean() -> None:
         for schema in schemas:
             await conn.exec_driver_sql(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         roles = [
-            r for (r,) in (
+            r
+            for (r,) in (
                 await conn.exec_driver_sql(
                     "SELECT rolname FROM pg_roles WHERE rolname ~ '^guild_[0-9]+(_ro)?$'"
                 )
             ).all()
         ]
-        await conn.exec_driver_sql("TRUNCATE TABLE users, guilds RESTART IDENTITY CASCADE")
+        await conn.exec_driver_sql(
+            "TRUNCATE TABLE users, guilds RESTART IDENTITY CASCADE"
+        )
 
     # Drop guild roles best-effort, each in its own transaction: guild roles are
     # cluster-global, so one a co-located test DB also uses owns objects in *that*
@@ -4181,10 +6063,14 @@ async def clean() -> None:
                 await rconn.exec_driver_sql(f'DROP OWNED BY "{role}"')
                 await rconn.exec_driver_sql(f'DROP ROLE IF EXISTS "{role}"')
             dropped += 1
-    print(f"  Dropped {len(schemas)} guild schema(s) + {dropped}/{len(roles)} role(s); wiped users + guilds")
+    print(
+        f"  Dropped {len(schemas)} guild schema(s) + {dropped}/{len(roles)} role(s); wiped users + guilds"
+    )
 
     STATE_FILE.unlink(missing_ok=True)
-    print("Done! All dev data removed. Run dev-migrate to recreate the primary guild + superuser.")
+    print(
+        "Done! All dev data removed. Run dev-migrate to recreate the primary guild + superuser."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A calendar with no stored color rendered differently in different places: the grid derived a palette color from the calendar's id while the settings picker displayed indigo — so a seeded calendar could show amber events while its picker claimed blue (the Fringe Space case; its initiative color being amber made it look like the initiative's color was bleeding through).

## Changes

- **No color derivation or auto-assignment anywhere.** Every calendar surface (grid events, panel dots, create-dialog picker dots, settings picker) reads `calendars.color` exactly as saved, with one static default (`#6366f1`) when a calendar has none — consistent everywhere. The `getCalendarColor` palette-by-id helper is removed; `getProjectColor` for task chips is untouched.
- **Seeder** stores the initiative's color on each Default Calendar it creates, so seeded data carries real saved colors (reseed to pick this up).

## Testing

- `frontend: ./scripts/test-changed.sh` — 71 files, 948 tests passed; `tsc --noEmit` + biome clean
- Verified against the live seeded dev DB via API that the mismatch case (calendar id 2, "Fringe Space", stored color `None`) now renders the same color in every surface