### PR TITLE
Fix 0157 downgrade blocked by recents policies

### DIFF
--- a/backend/alembic/versions/20260804_0157_calendar_container.py
+++ b/backend/alembic/versions/20260804_0157_calendar_container.py
@@ -432,8 +432,10 @@ def _apply_downgrade() -> None:
         )
 
     # The current policies read calendar_id (and join calendars, blocking its
-    # DROP TABLE below) and must go first.
-    _drop_initiative_member_policies(_EVENT_POLICY_TABLES)
+    # DROP TABLE below) and must go first. recent_views' policy resolves a
+    # recent's initiative through the recentable entity tables — calendars
+    # among them — so it blocks the table drop too.
+    _drop_initiative_member_policies(_EVENT_POLICY_TABLES + ("recent_views",))
     op.alter_column("calendar_events", "initiative_id", nullable=False)
     with op.batch_alter_table("calendar_events", schema=None) as batch_op:
         batch_op.create_index(


### PR DESCRIPTION
## Problem

The migrations round-trip test fails on dev (seen on #1040's last CI run, merged before the fix landed): downgrading the calendar container migration hits `cannot drop table calendars` — the registry-rendered `recent_views` policy resolves a recent's initiative through the recentable entity tables, `calendars` among them, so it blocks the `DROP TABLE`.

## Changes

- `20260804_0157` downgrade also drops `recent_views`' four `initiative_member_*` policies before the table drops (they re-render from the registry at the next boot backfill, same as the event tables' policies). **Downgrade-only edit** — the upgrade path and its stamp are untouched, so already-migrated deployments are unaffected.

## Testing

- Full `0159 → 0156` downgrade and re-upgrade against a migrated database — previously failed at `DROP TABLE calendars`, now clean. (The round-trip test itself needs the CI superuser's CREATE DATABASE privilege, so it was exercised directly.)