### PR TITLE
Drop recent_views policies in calendar migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The 0.60.0 calendar migration failed on upgraded installs ("cannot drop column initiative_id of table calendar_events") because the pre-0.60 `recent_views` row-security policies still referenced that column. The migration now drops and re-renders those policies alongside the event-table ones; deployments stuck on the failed migration start cleanly on this release with no manual intervention.
+
 ## [0.60.0] - 2026-08-05
 
 ### Changed

--- a/backend/alembic/versions/20260804_0157_calendar_container.py
+++ b/backend/alembic/versions/20260804_0157_calendar_container.py
@@ -347,8 +347,10 @@ def _apply_upgrade(rls_statements: list[str]) -> None:
 
     # 5. Swap the anchor column: calendar_id becomes the identity, the direct
     #    initiative_id goes away (initiative derives via the calendar). The old
-    #    policies read initiative_id and must go first.
-    _drop_initiative_member_policies(_EVENT_POLICY_TABLES)
+    #    policies read initiative_id and must go first — including recent_views',
+    #    whose pre-0.60 polymorphic path has a calendar_events.initiative_id leg
+    #    (calendar_event was recentable then), so it blocks the column drop too.
+    _drop_initiative_member_policies(_EVENT_POLICY_TABLES + ("recent_views",))
     op.alter_column("calendar_events", "calendar_id", nullable=False)
     with op.batch_alter_table("calendar_events", schema=None) as batch_op:
         batch_op.create_index(


### PR DESCRIPTION
## Problem

Deploying 0.60.0 on an install upgraded from 0.59 fails at boot: migration `20260804_0157_calendar_container` cannot drop `calendar_events.initiative_id` because the `recent_views` RLS policies still reference it.

```
asyncpg.exceptions.DependentObjectsStillExistError: cannot drop column initiative_id of table calendar_events because other objects depend on it
DETAIL:  policy initiative_member_select on table recent_views depends on column initiative_id of table calendar_events
```

In 0.59, `calendar_event` was a recentable entity, so the polymorphic `recent_views` policy rendered by that release's boot backfill carries an `EXISTS (... calendar_events.initiative_id ...)` leg. The migration drops the event tables' own policies before the column swap ([`_EVENT_POLICY_TABLES`](backend/alembic/versions/20260804_0157_calendar_container.py)) but missed `recent_views` — the downgrade path already handles this exact dependency, the upgrade just didn't mirror it. It escaped CI because freshly provisioned/migrated schemas get the new-shape policy with no `calendar_events` leg; only a database carrying 0.59-era policies trips it.

## Changes

- [20260804_0157_calendar_container.py](backend/alembic/versions/20260804_0157_calendar_container.py): include `recent_views` in the upgrade's pre-drop policy sweep, mirroring the downgrade. Safe because step 8 re-renders the full registry RLS (drop-if-exists + create for every table, `recent_views` included) in the same transaction, so the policies come back in their new calendar-based shape.
- [CHANGELOG.md](CHANGELOG.md): `[Unreleased]` Fixed entry.

Editing the shipped migration in place is correct here: installs that already ran it successfully (fresh installs) won't re-run it, and every failed upgrade rolled back completely (transactional DDL), so affected installs execute the fixed version from an untouched 0.59 state — no manual intervention needed.

## Testing

- Reproduced production against a scratch database in the local Postgres container: migrated to the 0.59 head (`20260803_0156`), installed 0.59-shape `recent_views` policies (with the `calendar_event` leg), ran `alembic upgrade head`:
  - unfixed migration → identical `DependentObjectsStillExistError`
  - fixed migration → upgrades cleanly through head; all four `recent_views` policies re-created referencing `calendars`, none referencing `calendar_events`
- `cd backend && uv run ruff check app alembic/versions/20260804_0157_calendar_container.py` → passes