### PR TITLE
Fix drops into long Kanban columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A Focus list at the top of My Tasks.** What actually needs doing now — work due soon plus anything urgent — with whatever you pin held at the top regardless of its dates. Ticking something off does not make it vanish: completions stay on the list, struck through, until the day turns over, alongside a running "3 of 6 done" count. Pin or unpin from either the list or the task table below it, set the date window and the urgent-work rule from the settings menu, and collapse the whole section if you would rather not have it. Every task matching your settings is shown, so a shorter list comes from a tighter date window rather than a hidden cutoff. The list spans all your guilds and is independent of the table's filters, so narrowing the table never empties it.
 - **Group a project's task table by tag.** "Group by" on a project's task list now offers Tag alongside Date window. A task sits under every tag it carries — one tagged both "bug" and "urgent" shows up in both groups rather than being filed under whichever tag came first — and tasks with no tags gather under Untagged. Each group is headed by the tag itself, in its colour. As with grouping by date window, manual drag-to-reorder pauses while a grouping is on; filtering, sorting, and bulk selection keep working, and a task selected in one of its groups counts once.
 
+### Fixed
+
+- Dragging a card into a long Kanban column now changes its status. Once a column held more than about twenty cards the board drew only the ones on screen, and a drop into it could be credited to the last card the pointer crossed on the way in — so the card sprang back to where it started instead of moving. Columns that accumulate cards, Done most of all, were the ones affected.
+
 ## [0.60.1] - 2026-08-06
 
 ### Fixed

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -39,6 +39,7 @@ import {
   computeMidpoint,
   isDraggingDown,
   reorderTaskList,
+  resolveKanbanDropTarget,
   shouldInsertAfter,
 } from "@/components/projects/taskOrdering";
 import type { PropertyFilterCondition } from "@/components/properties/PropertyFilter";
@@ -783,24 +784,19 @@ export const ProjectTasksSection = ({
       lastKanbanOverRef.current = null;
       return;
     }
-    const { active, over } = event;
-    const finalOver = over ?? lastKanbanOverRef.current;
-    if (!finalOver) {
+    const { active } = event;
+    const finalOver = resolveKanbanDropTarget(event, lastKanbanOverRef.current);
+    const activeId = Number(active.id);
+    const currentTask = Number.isFinite(activeId)
+      ? tasks.find((task) => task.id === activeId)
+      : undefined;
+    if (!finalOver || !currentTask) {
       setActiveTaskId(null);
       lastKanbanOverRef.current = null;
       return;
     }
-    const activeId = Number(active.id);
-    if (!Number.isFinite(activeId)) {
-      return;
-    }
 
-    const currentTask = tasks.find((task) => task.id === activeId);
-    if (!currentTask) {
-      return;
-    }
-
-    const overData = finalOver.data.current as { type?: string; statusId?: number } | undefined;
+    const overData = finalOver.data;
     let targetStatusId = currentTask.task_status_id;
     let overTaskId: number | null = null;
     let insertAfter = false;
@@ -826,11 +822,10 @@ export const ProjectTasksSection = ({
       targetStatusId = overData.statusId ?? targetStatusId;
     }
 
-    if (targetStatusId === currentTask.task_status_id && overTaskId === currentTask.id) {
-      return;
+    // Released on itself: nothing to persist, but the overlay still has to go.
+    if (targetStatusId !== currentTask.task_status_id || overTaskId !== currentTask.id) {
+      moveTaskInOrder(activeId, targetStatusId, overTaskId, insertAfter);
     }
-
-    moveTaskInOrder(activeId, targetStatusId, overTaskId, insertAfter);
     setActiveTaskId(null);
     lastKanbanOverRef.current = null;
   };

--- a/frontend/src/components/projects/taskOrdering.test.ts
+++ b/frontend/src/components/projects/taskOrdering.test.ts
@@ -1,9 +1,11 @@
+import type { DragEndEvent, DragOverEvent } from "@dnd-kit/core";
 import { describe, expect, it } from "vitest";
 
 import {
   computeMidpoint,
   isDraggingDown,
   reorderTaskList,
+  resolveKanbanDropTarget,
   shouldInsertAfter,
 } from "./taskOrdering";
 
@@ -38,6 +40,63 @@ describe("computeMidpoint", () => {
     const result = computeMidpoint(tasks, 1);
     // (1 + 1.0000000001) / 2 = 1.00000000005, rounded to 10 dp.
     expect(result).toBe(Number((1.00000000005).toFixed(10)));
+  });
+});
+
+describe("resolveKanbanDropTarget", () => {
+  const rect = { top: 0, height: 40 };
+  // A collision entry as dnd-kit builds it: the winning droppable's container,
+  // whose data/rect are live refs.
+  const collision = (id: string, data: { type: string; statusId: number }) => ({
+    id,
+    data: {
+      droppableContainer: { id, data: { current: data }, rect: { current: rect } },
+      value: 0,
+    },
+  });
+  // dnd-kit's `over`, which only refreshes when the winning id changes.
+  const over = (id: string, data: { type: string; statusId: number }) =>
+    ({ id, rect, disabled: false, data: { current: data } }) as unknown as DragOverEvent["over"];
+  const event = (partial: Partial<DragEndEvent>) => partial as DragEndEvent;
+
+  it("uses the collision under the pointer when over went stale", () => {
+    // The card the pointer crossed on its way into the Done column, kept by the
+    // caller as the last non-null `over`.
+    const stale = over("7", { type: "task", statusId: 1 });
+    const result = resolveKanbanDropTarget(
+      event({ over: null, collisions: [collision("42", { type: "task", statusId: 2 })] }),
+      stale
+    );
+    expect(result?.data?.statusId).toBe(2);
+    expect(result?.id).toBe("42");
+  });
+
+  it("resolves to the column when the pointer is on empty column body", () => {
+    const result = resolveKanbanDropTarget(
+      event({ over: null, collisions: [collision("column-2", { type: "column", statusId: 2 })] }),
+      null
+    );
+    expect(result?.data).toEqual({ type: "column", statusId: 2 });
+  });
+
+  it("falls back to over when collision detection came up empty", () => {
+    const result = resolveKanbanDropTarget(
+      event({ over: over("9", { type: "task", statusId: 3 }), collisions: [] }),
+      null
+    );
+    expect(result?.data?.statusId).toBe(3);
+  });
+
+  it("falls back to the last over when the drop has neither", () => {
+    const result = resolveKanbanDropTarget(
+      event({ over: null, collisions: null }),
+      over("9", { type: "task", statusId: 3 })
+    );
+    expect(result?.data?.statusId).toBe(3);
+  });
+
+  it("returns null when there is nothing to drop onto", () => {
+    expect(resolveKanbanDropTarget(event({ over: null, collisions: null }), null)).toBeNull();
   });
 });
 

--- a/frontend/src/components/projects/taskOrdering.ts
+++ b/frontend/src/components/projects/taskOrdering.ts
@@ -1,3 +1,48 @@
+import type { DragEndEvent, DragOverEvent, UniqueIdentifier } from "@dnd-kit/core";
+
+/** The droppable a kanban drop landed on, reduced to what the move needs. */
+export type KanbanDropTarget = {
+  id: UniqueIdentifier;
+  data: { type?: string; statusId?: number } | undefined;
+  rect: { top: number; height: number } | null;
+};
+
+/**
+ * The droppable a kanban card was released over, preferring the collision list
+ * over dnd-kit's ``over``.
+ *
+ * ``over`` is only recomputed when the winning droppable's *id* changes, and it
+ * resolves to null whenever that droppable is no longer registered by the time
+ * the update runs. A virtualized column unmounts its cards as its window moves,
+ * so a drop into one frequently arrives with ``over === null`` while the pointer
+ * is squarely inside the column — and the previous ``over`` (the last card the
+ * pointer crossed on its way there, usually back in the source column) is the
+ * wrong answer: the card gets reordered in place instead of changing status.
+ *
+ * ``collisions`` is recomputed on every render, so it still names the droppable
+ * under the pointer, and each entry carries the container itself — whose data
+ * ref holds the right ``statusId`` even if the card has since unmounted. Falls
+ * back to ``over``, then to ``lastOver``, for drops where collision detection
+ * came up empty.
+ */
+export const resolveKanbanDropTarget = (
+  event: DragEndEvent,
+  lastOver: DragOverEvent["over"] | null
+): KanbanDropTarget | null => {
+  const container = event.collisions?.[0]?.data?.droppableContainer as
+    | {
+        id: UniqueIdentifier;
+        data: { current?: { type?: string; statusId?: number } };
+        rect: { current: { top: number; height: number } | null };
+      }
+    | undefined;
+  if (container) {
+    return { id: container.id, data: container.data.current, rect: container.rect.current };
+  }
+  const over = event.over ?? lastOver;
+  return over ? { id: over.id, data: over.data?.current, rect: over.rect } : null;
+};
+
 /**
  * Fractional midpoint position for a task being inserted at ``targetIndex`` of
  * ``tasks`` (the project's tasks in global order, WITHOUT the moved task).


### PR DESCRIPTION
## Problem

Dragging a card into a Kanban column that holds more than ~20 cards does not change its status. The card is reordered in place and springs back on the next refetch. Smaller columns work fine, and the Done checkbox works fine.

It is not the Done column as such — it is column *size*. [KanbanColumn.tsx](frontend/src/components/projects/KanbanColumn.tsx#L32) virtualizes any column past 20 cards, so Done is usually the only one over the line.

The failure is a race between virtualization and dnd-kit:

1. Virtualized cards unmount/remount as the window moves, so their droppables register and deregister mid-drag.
2. dnd-kit (`@dnd-kit/core` 6.3.1) refreshes `over` only when the winning droppable's **id** changes (`useEffect(…, [overId])`), and resolves it to `null` when that droppable is no longer registered. A drop into a virtualized column therefore often arrives with `over === null` — and stays null, because the id has not changed.
3. `handleKanbanDragEnd` fell back to `lastKanbanOverRef`, which holds the last *non-null* over: the last card the pointer crossed on the way in, usually still in the source column.

So the drop was credited to the source column. The reorder request was sent and succeeded — with the old `task_status_id`.

## Changes

- [taskOrdering.ts](frontend/src/components/projects/taskOrdering.ts): new pure `resolveKanbanDropTarget`, which resolves the drop target from `event.collisions` (recomputed every render, and each entry carries the droppable container whose `data` ref still holds the right `statusId` even after the card unmounts), falling back to `over` and then the last-over ref.
- [ProjectTasksSection.tsx](frontend/src/components/projects/ProjectTasksSection.tsx): `handleKanbanDragEnd` uses it, and now clears the drag overlay on the early returns that previously left it stuck.
- [taskOrdering.test.ts](frontend/src/components/projects/taskOrdering.test.ts): 5 tests covering the stale-`over` case, the empty-column-body case, and each fallback.
- `CHANGELOG.md` entry under `[Unreleased] / Fixed`.

## Testing

- `pnpm typecheck` — clean.
- `pnpm lint` — clean; 4 warnings, all pre-existing (`CreateDocumentDialog.tsx`, `styles.css`).
- `./scripts/test-changed.sh` — 979 tests across 73 files pass.

Note: this was traced through the dnd-kit source rather than reproduced in a test — a virtualized drag needs real layout, and jsdom's `ResizeObserver` is a no-op stub in this suite. Worth a manual check on a 100+ card column.

## Related, not fixed here

- `useReorderTasks` uses raw `useMutation` rather than `useGuildMutation`, so a *failed* reorder is silent. Not the cause, but it is why nothing surfaced.
- The table view is virtualized via `data-table.tsx` and `handleListDragEnd` has no fallback at all. Same race there drops the reorder silently — wrong position, never wrong status, so a milder and separate bug.