### PR TITLE
Resolve names for picker selections given as ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A Focus list at the top of My Tasks.** What actually needs doing now — work due soon plus anything urgent — with whatever you pin held at the top regardless of its dates. Ticking something off does not make it vanish: completions stay on the list, struck through, until the day turns over, alongside a running "3 of 6 done" count. Pin or unpin from either the list or the task table below it, set the date window and the urgent-work rule from the settings menu, and collapse the whole section if you would rather not have it. Every task matching your settings is shown, so a shorter list comes from a tighter date window rather than a hidden cutoff. The list spans all your guilds and is independent of the table's filters, so narrowing the table never empties it.
 - **Group a project's task table by tag.** "Group by" on a project's task list now offers Tag alongside Date window. A task sits under every tag it carries — one tagged both "bug" and "urgent" shows up in both groups rather than being filed under whichever tag came first — and tasks with no tags gather under Untagged. Each group is headed by the tag itself, in its colour. As with grouping by date window, manual drag-to-reorder pauses while a grouping is on; filtering, sorting, and bulk selection keep working, and a task selected in one of its groups counts once.
 
+### Changed
+
+- The linked-user picker on queue items is now a search, like every other person picker, instead of loading the initiative's whole roster up front.
+
 ### Fixed
 
 - Dragging a card into a long Kanban column now changes its status. Once a column held more than about twenty cards the board drew only the ones on screen, and a drop into it could be credited to the last card the pointer crossed on the way in — so the card sprang back to where it started instead of moving. Columns that accumulate cards, Done most of all, were the ones affected.
+- Person pickers no longer show "User #12" where a name belongs. A selection the picker was handed rather than one you just made — the assignee filter you get back when you return to a project, a saved user property, the linked user on a queue item — is now resolved to a name and avatar against the same roster the dropdown searches. An id nobody in that roster matches still shows as an id, since there is no one to name.
 
 ## [0.60.1] - 2026-08-06
 

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -76,7 +76,7 @@ from app.services.platform import csv_export
 from app.services.tenant import stats_service
 from app.services.platform import user_tokens as user_tokens_service
 from app.services.tenant import recent_views as recent_views_service
-from app.db.query import page_has_next, paginated_query
+from app.db.query import MAX_ID_FILTER_VALUES, page_has_next, paginated_query
 
 # Allowed values for the optional "task completion visual feedback" effect.
 # Mirrored on the frontend in src/lib/taskCompletionVisualFeedback.ts; keep
@@ -180,16 +180,20 @@ async def search_users(
         default=None,
         description="Case-insensitive substring match on the member's name.",
     ),
+    user_id: Annotated[list[int] | None, Query(max_length=MAX_ID_FILTER_VALUES)] = None,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=0, le=100),
 ) -> UserSummaryListResponse:
     """Slim, searchable, paginated roster for typeahead/pickers.
 
     Same authorization as the full member list (``RLSSessionDep`` +
-    ``GuildContextDep``, membership re-validated per request): the new params
+    ``GuildContextDep``, membership re-validated per request): the params
     are additive filters on an already-RLS-gated query, so they only ever
     narrow the row set. Returns :class:`UserSummary` (no email, roles, or
     ``initiative_roles`` enrichment) instead of the heavy ``UserGuildMember``.
+
+    Pass ``user_id`` one or more times to resolve a known selection (a picker
+    rehydrating stored ids into names/avatars) rather than searching.
     """
     base = (
         select(User)
@@ -198,6 +202,8 @@ async def search_users(
     )
     if search and (term := search.strip()):
         base = base.where(User.full_name.ilike(f"%{term}%"))
+    if user_id:
+        base = base.where(User.id.in_(user_id))
 
     count_stmt = select(func.count()).select_from(base.subquery())
     data_stmt = base.order_by(User.full_name.asc(), User.id.asc())

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -14,6 +14,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
+from app.db.query import MAX_ID_FILTER_VALUES
 from app.models.platform.guild import GuildRole
 from app.models.platform.user import User, UserRole, UserStatus
 
@@ -182,6 +183,68 @@ async def test_search_users_filters_by_name(client: AsyncClient, session: AsyncS
     body = response.json()
     assert body["total_count"] == 1
     assert [item["full_name"] for item in body["items"]] == ["Alice Smith"]
+
+
+@pytest.mark.integration
+async def test_search_users_filters_by_user_id(
+    client: AsyncClient, session: AsyncSession
+):
+    """`user_id` resolves a known selection, and only ever narrows the roster
+    the caller can already see — an id from another guild returns nothing."""
+    guild = await create_guild(session)
+    caller = await create_user(
+        session, email="caller@example.com", full_name="Alice Smith"
+    )
+    bob = await create_user(session, email="bob@example.com", full_name="Bob Jones")
+    for user in (caller, bob):
+        await create_guild_membership(session, user=user, guild=guild)
+
+    other_guild = await create_guild(session)
+    stranger = await create_user(
+        session, email="stranger@example.com", full_name="Stranger Danger"
+    )
+    await create_guild_membership(session, user=stranger, guild=other_guild)
+
+    headers = get_auth_headers(caller)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/search",
+        headers=headers,
+        params={"user_id": [bob.id]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["full_name"] for item in body["items"]] == ["Bob Jones"]
+
+    # An id outside the guild is filtered out, not resolved.
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/search",
+        headers=headers,
+        params={"user_id": [bob.id, stranger.id]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [bob.id]
+
+
+@pytest.mark.integration
+async def test_search_users_rejects_oversized_user_id_list(
+    client: AsyncClient, session: AsyncSession
+):
+    """The id filter is bounded so one request can't submit an unbounded list."""
+    guild = await create_guild(session)
+    caller = await create_user(session, email="caller@example.com")
+    await create_guild_membership(session, user=caller, guild=guild)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/search",
+        headers=get_auth_headers(caller),
+        params={"user_id": list(range(MAX_ID_FILTER_VALUES + 1))},
+    )
+
+    assert response.status_code == 422
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -56,7 +56,7 @@ from app.schemas.platform.user import (
     UserSummary,
     UserSummaryListResponse,
 )
-from app.db.query import page_has_next, paginated_query
+from app.db.query import MAX_ID_FILTER_VALUES, page_has_next, paginated_query
 from app.services import notifications as notifications_service
 from app.services.tenant import initiatives as initiatives_service
 from app.services.platform import guilds as guilds_service
@@ -905,16 +905,20 @@ async def search_initiative_members(
         default=None,
         description="Case-insensitive substring match on the member's name.",
     ),
+    user_id: Annotated[list[int] | None, Query(max_length=MAX_ID_FILTER_VALUES)] = None,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=0, le=100),
 ) -> UserSummaryListResponse:
     """Slim, searchable, paginated roster of an initiative's members.
 
     Same authorization as :func:`get_initiative_members` (member, guild
-    admin, or PAM/break-glass grantee); the search/pagination params are
+    admin, or PAM/break-glass grantee); the search/id/pagination params are
     additive filters on the already-RLS-gated query. Returns
     :class:`UserSummary` for typeahead/picker surfaces instead of the full
     ``UserPublic`` roster.
+
+    Pass ``user_id`` one or more times to resolve a known selection (a picker
+    rehydrating stored ids into names/avatars) rather than searching.
     """
     await _get_initiative_or_404(initiative_id, session, guild_context.guild_id)
 
@@ -940,6 +944,8 @@ async def search_initiative_members(
     )
     if search and (term := search.strip()):
         base = base.where(User.full_name.ilike(f"%{term}%"))
+    if user_id:
+        base = base.where(User.id.in_(user_id))
 
     count_stmt = select(func.count()).select_from(base.subquery())
     data_stmt = base.order_by(User.full_name.asc(), User.id.asc())

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -467,6 +467,43 @@ async def test_search_initiative_members_slim_and_filtered(
 
 
 @pytest.mark.integration
+async def test_search_initiative_members_filters_by_user_id(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """`user_id` resolves a known selection, narrowing the same member set —
+    a guild member outside the initiative is never resolved through it."""
+    admin = await acting_user(guild_role=GuildRole.admin, full_name="Zed Admin")
+    initiative = await create_initiative(
+        session, admin.guild, admin.user, name="Id Filter Initiative"
+    )
+    alice = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=initiative,
+        initiative_role="member",
+        email="alice-ids@example.com",
+        full_name="Alice Wonderland",
+    )
+    outsider = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        email="outsider-ids@example.com",
+        full_name="Olive Outsider",
+    )
+
+    response = await client.get(
+        admin.g(f"/initiatives/{initiative.id}/members/search"),
+        headers=admin.headers,
+        params={"user_id": [alice.user.id, outsider.user.id]},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["full_name"] for item in body["items"]] == ["Alice Wonderland"]
+
+
+@pytest.mark.integration
 async def test_search_initiative_members_as_nonmember_forbidden(
     client: AsyncClient, session: AsyncSession, acting_user
 ):

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -56,6 +56,7 @@ from app.services.tenant import task_completion
 from app.core.messages import ProjectMessages
 from app.core.config import settings as app_settings
 from app.db.query import (
+    MAX_ID_FILTER_VALUES,
     apply_pagination,
     clamp_page,
     page_has_next,
@@ -1696,6 +1697,7 @@ async def search_project_members(
         default=None,
         description="Case-insensitive substring match on the member's name.",
     ),
+    user_id: Annotated[list[int] | None, Query(max_length=MAX_ID_FILTER_VALUES)] = None,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=0, le=100),
 ) -> UserSummaryListResponse:
@@ -1707,6 +1709,10 @@ async def search_project_members(
     via the shared permission engine. This replaces the client-side
     ``project.grants`` derivation the pickers used to run over the full guild
     roster. Requester needs read access to the project.
+
+    Pass ``user_id`` one or more times to resolve a known selection (a picker
+    rehydrating stored ids into names/avatars) rather than searching; it
+    narrows the same assignable set, so an id outside it returns nothing.
     """
     project = await _get_project_or_404(project_id, session, guild_context.guild_id)
     await _require_project_membership(project, current_user, session, access="read")
@@ -1728,6 +1734,9 @@ async def search_project_members(
     term = (search or "").strip().lower()
     if term:
         assignable = [u for u in assignable if term in (u.full_name or "").lower()]
+    if user_id:
+        wanted = set(user_id)
+        assignable = [u for u in assignable if u.id in wanted]
 
     assignable.sort(key=lambda u: ((u.full_name or "").lower(), u.id))
 

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -179,6 +179,17 @@ async def test_search_project_members_returns_write_access_set(
     body = response.json()
     assert [item["full_name"] for item in body["items"]] == ["Wanda Writer"]
 
+    # Id filter (a picker resolving stored ids into names) narrows the same
+    # assignable set — the read-only member is not resolvable through it.
+    response = await client.get(
+        admin.g(f"/projects/{project.id}/members/search"),
+        headers=admin.headers,
+        params={"user_id": [writer.user.id, reader.user.id]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["full_name"] for item in body["items"]] == ["Wanda Writer"]
+
 
 @pytest.mark.integration
 async def test_search_project_members_requires_read_access(

--- a/backend/app/db/query.py
+++ b/backend/app/db/query.py
@@ -430,6 +430,11 @@ def _resolve_sort_fields(
 # tune — it only keeps any single response's row count finite (SEC-14).
 FETCH_ALL_WINDOW = 1000
 
+# How many ids one request may pass to an ``id``-filtered list endpoint. Matches
+# the ``page_size`` ceiling those endpoints declare, since a longer id list can
+# never yield more rows than a single page returns anyway.
+MAX_ID_FILTER_VALUES = 100
+
 
 def effective_page_size(page_size: int) -> int:
     """The row window a request actually gets for its requested ``page_size``.

--- a/frontend/src/__tests__/factories/index.ts
+++ b/frontend/src/__tests__/factories/index.ts
@@ -52,6 +52,7 @@ export {
   buildUser,
   buildUserGuildMember,
   buildUserPublic,
+  buildUserSummary,
   resetCounter as resetUserCounter,
 } from "./user.factory";
 

--- a/frontend/src/__tests__/factories/user.factory.ts
+++ b/frontend/src/__tests__/factories/user.factory.ts
@@ -3,6 +3,7 @@ import type {
   UserPublic,
   UserRead,
   UserRole,
+  UserSummary,
 } from "@/api/generated/initiativeAPI.schemas";
 
 let counter = 0;
@@ -68,6 +69,21 @@ export function buildUserPublic(overrides: Partial<UserPublic> = {}): UserPublic
     full_name: `User ${counter}`,
     avatar_base64: null,
     avatar_url: null,
+    ...overrides,
+  };
+}
+
+/** The slim projection the member search/typeahead endpoints return — no
+ *  email, role, or timestamps. Use this for picker fixtures so a test can't
+ *  pass on a field the real payload never carries. */
+export function buildUserSummary(overrides: Partial<UserSummary> = {}): UserSummary {
+  counter++;
+  return {
+    id: counter,
+    full_name: `User ${counter}`,
+    avatar_base64: null,
+    avatar_url: null,
+    status: "active",
     ...overrides,
   };
 }

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4294,6 +4294,7 @@ export type SearchProjectMembersApiV1GGuildIdProjectsProjectIdMembersSearchGetPa
    * Case-insensitive substring match on the member's name.
    */
   search?: string | null;
+  user_id?: number[] | null;
   /**
    * @minimum 1
    */
@@ -4396,6 +4397,7 @@ export type SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSe
    * Case-insensitive substring match on the member's name.
    */
   search?: string | null;
+  user_id?: number[] | null;
   /**
    * @minimum 1
    */
@@ -4805,6 +4807,7 @@ export type SearchUsersApiV1GGuildIdUsersSearchGetParams = {
    * Case-insensitive substring match on the member's name.
    */
   search?: string | null;
+  user_id?: number[] | null;
   /**
    * @minimum 1
    */

--- a/frontend/src/api/generated/initiatives/initiatives.ts
+++ b/frontend/src/api/generated/initiatives/initiatives.ts
@@ -1956,10 +1956,13 @@ export const useAddInitiativeMemberApiV1GGuildIdInitiativesInitiativeIdMembersPo
  * Slim, searchable, paginated roster of an initiative's members.
  *
  * Same authorization as :func:`get_initiative_members` (member, guild
- * admin, or PAM/break-glass grantee); the search/pagination params are
+ * admin, or PAM/break-glass grantee); the search/id/pagination params are
  * additive filters on the already-RLS-gated query. Returns
  * :class:`UserSummary` for typeahead/picker surfaces instead of the full
  * ``UserPublic`` roster.
+ *
+ * Pass ``user_id`` one or more times to resolve a known selection (a picker
+ * rehydrating stored ids into names/avatars) rather than searching.
  * @summary Search Initiative Members
  */
 export const searchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet = (

--- a/frontend/src/api/generated/projects/projects.ts
+++ b/frontend/src/api/generated/projects/projects.ts
@@ -2073,6 +2073,10 @@ export const useDeleteProjectApiV1GGuildIdProjectsProjectIdDelete = <
  * via the shared permission engine. This replaces the client-side
  * ``project.grants`` derivation the pickers used to run over the full guild
  * roster. Requester needs read access to the project.
+ *
+ * Pass ``user_id`` one or more times to resolve a known selection (a picker
+ * rehydrating stored ids into names/avatars) rather than searching; it
+ * narrows the same assignable set, so an id outside it returns nothing.
  * @summary Search Project Members
  */
 export const searchProjectMembersApiV1GGuildIdProjectsProjectIdMembersSearchGet = (

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -1277,10 +1277,13 @@ export const useCreateUserApiV1GGuildIdUsersPost = <
  * Slim, searchable, paginated roster for typeahead/pickers.
  *
  * Same authorization as the full member list (``RLSSessionDep`` +
- * ``GuildContextDep``, membership re-validated per request): the new params
+ * ``GuildContextDep``, membership re-validated per request): the params
  * are additive filters on an already-RLS-gated query, so they only ever
  * narrow the row set. Returns :class:`UserSummary` (no email, roles, or
  * ``initiative_roles`` enrichment) instead of the heavy ``UserGuildMember``.
+ *
+ * Pass ``user_id`` one or more times to resolve a known selection (a picker
+ * rehydrating stored ids into names/avatars) rather than searching.
  * @summary Search Users
  */
 export const searchUsersApiV1GGuildIdUsersSearchGet = (

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -156,20 +156,20 @@ export const CreateDocumentDialog = ({
       setCreateDialogTab("new");
       setGrants([...DEFAULT_GRANTS]);
     }
-  }, [open, defaultInitiativeId]);
+  }, [open, defaultInitiativeId, clearTemplate]);
 
   // Clear template when "save as template" is toggled on
   useEffect(() => {
     if (isTemplateDocument && selectedTemplateId) {
       clearTemplate();
     }
-  }, [isTemplateDocument, selectedTemplateId]);
+  }, [isTemplateDocument, selectedTemplateId, clearTemplate]);
 
   // Clear template when the document type changes so we don't accidentally
   // copy a native template into a whiteboard (or vice versa).
   useEffect(() => {
     clearTemplate();
-  }, [newDocumentType]);
+  }, [newDocumentType, clearTemplate]);
 
   const createDocument = useCreateDocument({
     onSuccess: (document) => {

--- a/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { LinkedEntityPicker } from "@/components/initiativeTools/queues/LinkedEntityPicker";
 import { useQueueItemForm } from "@/components/initiativeTools/queues/useQueueItemForm";
+import { MemberSelect } from "@/components/members/MemberSearchSelect";
 import { TagPicker } from "@/components/tags/TagPicker";
 import { Button } from "@/components/ui/button";
 import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
@@ -16,7 +17,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateQueueItem } from "@/hooks/useQueues";
@@ -63,7 +63,6 @@ export const AddQueueItemDialog = ({
     setDocPickerOpen,
     setTaskSearch,
     setTaskPickerOpen,
-    memberItems,
     docResults,
     docsLoading,
     taskResults,
@@ -185,10 +184,10 @@ export const AddQueueItemDialog = ({
           <div className="space-y-2">
             <Label>{t("linkedUser")}</Label>
             <div className="flex items-center gap-2">
-              <SearchableCombobox
-                items={memberItems}
-                value={userId !== null ? String(userId) : null}
-                onValueChange={(val) => setUserId(val ? Number(val) : null)}
+              <MemberSelect
+                scope={{ type: "initiative", initiativeId }}
+                value={userId}
+                onChange={setUserId}
                 placeholder={t("selectUser")}
                 emptyMessage={t("noUser")}
               />

--- a/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import type { QueueItemRead } from "@/api/generated/initiativeAPI.schemas";
 import { LinkedEntityPicker } from "@/components/initiativeTools/queues/LinkedEntityPicker";
 import { useQueueItemForm } from "@/components/initiativeTools/queues/useQueueItemForm";
+import { MemberSelect } from "@/components/members/MemberSearchSelect";
 import { TagPicker } from "@/components/tags/TagPicker";
 import { Button } from "@/components/ui/button";
 import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
@@ -19,7 +20,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -76,7 +76,7 @@ export const EditQueueItemDialog = ({
     setDocPickerOpen,
     setTaskSearch,
     setTaskPickerOpen,
-    memberItems,
+    selectedUser,
     docResults,
     docsLoading,
     taskResults,
@@ -261,10 +261,11 @@ export const EditQueueItemDialog = ({
             <div className="space-y-2">
               <Label>{t("linkedUser")}</Label>
               <div className="flex items-center gap-2">
-                <SearchableCombobox
-                  items={memberItems}
-                  value={userId !== null ? String(userId) : null}
-                  onValueChange={(val) => setUserId(val ? Number(val) : null)}
+                <MemberSelect
+                  scope={{ type: "initiative", initiativeId }}
+                  value={userId}
+                  onChange={setUserId}
+                  selectedUser={selectedUser}
                   placeholder={t("selectUser")}
                   emptyMessage={t("noUser")}
                   disabled={readOnly}

--- a/frontend/src/components/initiativeTools/queues/useQueueItemForm.ts
+++ b/frontend/src/components/initiativeTools/queues/useQueueItemForm.ts
@@ -6,9 +6,7 @@ import {
   type LinkedEntity,
 } from "@/components/initiativeTools/queues/LinkedEntityPicker";
 import { useDocumentAutocomplete } from "@/hooks/useDocuments";
-import { useInitiativeMembers } from "@/hooks/useInitiatives";
 import { useTaskAutocomplete } from "@/hooks/useTasks";
-import { getUserDisplayName } from "@/lib/userDisplay";
 
 const DEFAULT_COLOR = "#6366F1";
 
@@ -86,16 +84,10 @@ export const useQueueItemForm = ({ open, initiativeId, item }: UseQueueItemFormA
     }
   }, [open, item]);
 
-  // Fetch initiative members for user picker
-  const membersQuery = useInitiativeMembers(initiativeId);
-  const memberItems = useMemo(
-    () =>
-      (membersQuery.data ?? []).map((member) => ({
-        value: String(member.id),
-        label: getUserDisplayName(member),
-      })),
-    [membersQuery.data]
-  );
+  // The user picker is a server typeahead over the initiative's members
+  // (`MemberSelect`), so the form no longer pulls the full roster. An edited
+  // item ships its own linked user, which saves the picker a lookup.
+  const selectedUser = item?.user ?? null;
 
   // Document picker — server typeahead, only while the picker is open.
   const docsQuery = useDocumentAutocomplete(initiativeId, docSearch, {
@@ -144,7 +136,7 @@ export const useQueueItemForm = ({ open, initiativeId, item }: UseQueueItemFormA
     setTaskSearch,
     setTaskPickerOpen,
     // Picker option lists
-    memberItems,
+    selectedUser,
     docResults,
     docsLoading: docsQuery.isFetching,
     taskResults,

--- a/frontend/src/components/members/MemberSearchSelect.test.tsx
+++ b/frontend/src/components/members/MemberSearchSelect.test.tsx
@@ -2,28 +2,18 @@ import { screen, waitFor } from "@testing-library/react";
 import { HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
+import { buildUserSummary } from "@/__tests__/factories";
 import { guildHttp } from "@/__tests__/helpers/guildHttp";
 import { server } from "@/__tests__/helpers/msw-server";
 import { renderWithProviders } from "@/__tests__/helpers/render";
 
 import { MemberMultiSelect, MemberSelect } from "./MemberSearchSelect";
 
-const ADA = {
-  id: 42,
-  full_name: "Ada Lovelace",
-  avatar_url: null,
-  avatar_base64: null,
-  status: "active",
-};
-const GRACE = {
-  id: 43,
-  full_name: "Grace Hopper",
-  avatar_url: null,
-  avatar_base64: null,
-  status: "active",
-};
+const ADA = buildUserSummary({ id: 42, full_name: "Ada Lovelace" });
+const GRACE = buildUserSummary({ id: 43, full_name: "Grace Hopper" });
 
 const ROSTER = [ADA, GRACE];
+const MISSING_ID = 999;
 
 /** The project member typeahead, honouring the `user_id` lookup filter the
  *  pickers use to resolve a selection they were handed as bare ids. */
@@ -88,12 +78,12 @@ describe("MemberMultiSelect", () => {
       <MemberMultiSelect
         variant="filter"
         scope={{ type: "project", projectId: 7 }}
-        selectedIds={[999]}
+        selectedIds={[MISSING_ID]}
         onChange={() => {}}
       />
     );
 
-    expect(await screen.findByText("User #999")).toBeInTheDocument();
+    expect(await screen.findByText(`User #${MISSING_ID}`)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/members/MemberSearchSelect.test.tsx
+++ b/frontend/src/components/members/MemberSearchSelect.test.tsx
@@ -1,0 +1,115 @@
+import { screen, waitFor } from "@testing-library/react";
+import { HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { renderWithProviders } from "@/__tests__/helpers/render";
+
+import { MemberMultiSelect, MemberSelect } from "./MemberSearchSelect";
+
+const ADA = {
+  id: 42,
+  full_name: "Ada Lovelace",
+  avatar_url: null,
+  avatar_base64: null,
+  status: "active",
+};
+const GRACE = {
+  id: 43,
+  full_name: "Grace Hopper",
+  avatar_url: null,
+  avatar_base64: null,
+  status: "active",
+};
+
+const ROSTER = [ADA, GRACE];
+
+/** The project member typeahead, honouring the `user_id` lookup filter the
+ *  pickers use to resolve a selection they were handed as bare ids. */
+const memberSearchHandler = (onRequest?: (ids: string[]) => void) =>
+  guildHttp.get("/projects/:projectId/members/search", ({ request }) => {
+    const ids = new URL(request.url).searchParams.getAll("user_id");
+    onRequest?.(ids);
+    const items = ids.length ? ROSTER.filter((user) => ids.includes(String(user.id))) : ROSTER;
+    return HttpResponse.json({
+      items,
+      total_count: items.length,
+      page: 1,
+      page_size: 25,
+      has_next: false,
+      has_prev: false,
+    });
+  });
+
+describe("MemberMultiSelect", () => {
+  it("names a selection it was given as bare ids", async () => {
+    server.use(memberSearchHandler());
+
+    renderWithProviders(
+      <MemberMultiSelect
+        variant="filter"
+        scope={{ type: "project", projectId: 7 }}
+        selectedIds={[ADA.id]}
+        onChange={() => {}}
+        placeholder="All assignees"
+      />
+    );
+
+    // The trigger starts on the id fallback, then resolves to the real name.
+    expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.queryByText(`User #${ADA.id}`)).not.toBeInTheDocument();
+  });
+
+  it("only looks up the ids it cannot already name", async () => {
+    const lookups: string[][] = [];
+    server.use(memberSearchHandler((ids) => ids.length && lookups.push(ids)));
+
+    renderWithProviders(
+      <MemberMultiSelect
+        variant="filter"
+        scope={{ type: "project", projectId: 7 }}
+        selectedIds={[ADA.id, GRACE.id]}
+        selectedUsers={[GRACE]}
+        onChange={() => {}}
+      />
+    );
+
+    await screen.findByText("2 selected");
+    await waitFor(() => expect(lookups.length).toBeGreaterThan(0));
+    // Grace came in via `selectedUsers`; only Ada needs resolving.
+    expect(lookups[0]).toEqual([String(ADA.id)]);
+  });
+
+  it("falls back to the id when the selection is not in the scoped roster", async () => {
+    server.use(memberSearchHandler());
+
+    renderWithProviders(
+      <MemberMultiSelect
+        variant="filter"
+        scope={{ type: "project", projectId: 7 }}
+        selectedIds={[999]}
+        onChange={() => {}}
+      />
+    );
+
+    expect(await screen.findByText("User #999")).toBeInTheDocument();
+  });
+});
+
+describe("MemberSelect", () => {
+  it("names a value it was given as a bare id", async () => {
+    server.use(memberSearchHandler());
+
+    renderWithProviders(
+      <MemberSelect
+        scope={{ type: "project", projectId: 7 }}
+        value={GRACE.id}
+        onChange={() => {}}
+      />
+    );
+
+    expect(await screen.findByText("Grace Hopper")).toBeInTheDocument();
+    expect(screen.queryByText(`User #${GRACE.id}`)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/members/MemberSearchSelect.tsx
+++ b/frontend/src/components/members/MemberSearchSelect.tsx
@@ -15,8 +15,13 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import { type MemberSearchScope, useMemberSearch } from "@/hooks/useUsers";
-import { getAvatarSrc, getInitialsForUser, getUserDisplayName } from "@/lib/userDisplay";
+import { type MemberSearchScope, USER_ID_LOOKUP_MAX, useMemberSearch } from "@/hooks/useUsers";
+import {
+  getAvatarSrc,
+  getInitialsForUser,
+  getUserDisplayName,
+  hasDisplayName,
+} from "@/lib/userDisplay";
 import { cn } from "@/lib/utils";
 
 /** The slim user shape these pickers render (the search endpoints' `UserSummary`). */
@@ -31,26 +36,55 @@ export type MemberSummary = Pick<
 export type MemberLike = { id: number } & Partial<MemberSummary>;
 
 /** Accumulate display info for users we've seen — from the caller-provided
- *  already-selected set plus every search page — so a selected chip keeps its
- *  name/avatar even after the query changes and the row leaves the results. */
-const useSeenMembers = (selectedUsers: MemberLike[] | undefined, results: MemberSummary[]) => {
+ *  already-selected set, every search page, and the id lookup below — so a
+ *  selected chip keeps its name/avatar even after the query changes and the
+ *  row leaves the results.
+ *
+ *  A selection can also arrive as bare ids with no display info at all: a
+ *  filter restored from storage, a stored user-reference property, a page
+ *  opened straight onto an existing selection. Those ids are resolved against
+ *  the same scoped roster the dropdown searches, so the trigger names them
+ *  instead of falling back to "User #<id>". */
+const useSeenMembers = (
+  scope: MemberSearchScope,
+  selectedIds: number[],
+  selectedUsers: MemberLike[] | undefined,
+  results: MemberSummary[]
+) => {
   const [seen, setSeen] = useState<Map<number, MemberLike>>(() => new Map());
+
+  const unresolvedIds = useMemo(() => {
+    const known = new Map<number, MemberLike>(seen);
+    for (const user of [...(selectedUsers ?? []), ...results]) known.set(user.id, user);
+    // Sorted so the lookup's query key doesn't churn with selection order.
+    return selectedIds.filter((id) => !hasDisplayName(known.get(id))).sort((a, b) => a - b);
+  }, [seen, selectedIds, selectedUsers, results]);
+
+  const lookup = useMemberSearch(scope, {
+    userIds: unresolvedIds,
+    pageSize: USER_ID_LOOKUP_MAX,
+    enabled: unresolvedIds.length > 0,
+  });
+  const resolved = useMemo<MemberSummary[]>(() => lookup.data?.items ?? [], [lookup.data]);
+
   useEffect(() => {
     setSeen((prev) => {
       const next = new Map(prev);
       let changed = false;
-      // Only add ids we haven't seen — the update must be idempotent, or a
-      // fresh `selectedUsers`/`results` array identity on every render would
-      // loop (setState → render → effect → setState).
-      for (const user of [...(selectedUsers ?? []), ...results]) {
-        if (!next.has(user.id)) {
-          next.set(user.id, user);
-          changed = true;
-        }
+      // Add an id we haven't seen, and upgrade a placeholder we couldn't name
+      // once a named record arrives. Every other case must be a no-op — the
+      // update has to be idempotent, or a fresh array identity on each render
+      // would loop (setState → render → effect → setState).
+      for (const user of [...(selectedUsers ?? []), ...results, ...resolved]) {
+        const current = next.get(user.id);
+        if (current && (hasDisplayName(current) || !hasDisplayName(user))) continue;
+        next.set(user.id, user);
+        changed = true;
       }
       return changed ? next : prev;
     });
-  }, [selectedUsers, results]);
+  }, [selectedUsers, results, resolved]);
+
   return seen;
 };
 
@@ -112,7 +146,7 @@ export const MemberMultiSelect = ({
     () => searchResult.data?.items ?? [],
     [searchResult.data]
   );
-  const seen = useSeenMembers(selectedUsers, results);
+  const seen = useSeenMembers(scope, selectedIds, selectedUsers, results);
 
   const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
   const resolvedPlaceholder = placeholder ?? t("projects:assignee.searchPlaceholder");
@@ -336,7 +370,8 @@ export const MemberSelect = ({
     [searchResult.data]
   );
   const selectedUsers = useMemo(() => (selectedUser ? [selectedUser] : undefined), [selectedUser]);
-  const seen = useSeenMembers(selectedUsers, results);
+  const selectedIds = useMemo(() => (value != null ? [value] : []), [value]);
+  const seen = useSeenMembers(scope, selectedIds, selectedUsers, results);
 
   const handleOpenChange = (next: boolean) => {
     if (disabled) return;

--- a/frontend/src/hooks/useInitiatives.ts
+++ b/frontend/src/hooks/useInitiatives.ts
@@ -1,19 +1,13 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
-import type {
-  InitiativeCreate,
-  InitiativeRead,
-  UserPublic,
-} from "@/api/generated/initiativeAPI.schemas";
+import type { InitiativeCreate, InitiativeRead } from "@/api/generated/initiativeAPI.schemas";
 import {
   addInitiativeMemberApiV1GGuildIdInitiativesInitiativeIdMembersPost,
   createInitiativeApiV1GGuildIdInitiativesPost,
   deleteInitiativeApiV1GGuildIdInitiativesInitiativeIdDelete,
   getGetInitiativeApiV1GGuildIdInitiativesInitiativeIdGetQueryKey,
-  getGetInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersGetQueryKey,
   getInitiativeApiV1GGuildIdInitiativesInitiativeIdGet,
-  getInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersGet,
   getListInitiativesApiV1GGuildIdInitiativesGetQueryKey,
   listInitiativesApiV1GGuildIdInitiativesGet,
   removeInitiativeMemberApiV1GGuildIdInitiativesInitiativeIdMembersUserIdDelete,
@@ -71,24 +65,6 @@ export const useInitiative = (initiativeId: number | null, options?: QueryOpts<I
       initiativeId!
     ),
     queryFn: () => getInitiativeApiV1GGuildIdInitiativesInitiativeIdGet(guildId, initiativeId!),
-    enabled: initiativeId !== null && Number.isFinite(initiativeId) && userEnabled,
-    ...rest,
-  });
-};
-
-export const useInitiativeMembers = (
-  initiativeId: number | null,
-  options?: QueryOpts<UserPublic[]>
-) => {
-  const guildId = useActiveGuildId();
-  const { enabled: userEnabled = true, ...rest } = options ?? {};
-  return useQuery<UserPublic[]>({
-    queryKey: getGetInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersGetQueryKey(
-      guildId,
-      initiativeId!
-    ),
-    queryFn: () =>
-      getInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersGet(guildId, initiativeId!),
     enabled: initiativeId !== null && Number.isFinite(initiativeId) && userEnabled,
     ...rest,
   });

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -49,9 +49,17 @@ export const useUsers = (options?: QueryOpts<UserGuildMember[]>, guildIdOverride
  *  task search (a bounded dropdown-sized window, not the whole roster). */
 export const USER_SEARCH_PAGE_SIZE = 25;
 
+/** Server-side ceiling on one request's `userIds` list — mirrors
+ *  `MAX_ID_FILTER_VALUES` in `backend/app/db/query.py`. */
+export const USER_ID_LOOKUP_MAX = 100;
+
 export interface UserSearchOptions {
   /** Case-insensitive substring match on the member's name. */
   search?: string;
+  /** Resolve these specific members instead of browsing the roster — how a
+   *  picker turns stored ids back into names/avatars. Narrows the same scoped
+   *  set, so an id outside it simply doesn't come back. */
+  userIds?: number[];
   /** Bounded page size (server caps at 100). */
   pageSize?: number;
   /** Gate the request — pass the picker's `open` state so we don't fetch until
@@ -61,6 +69,12 @@ export interface UserSearchOptions {
   guildIdOverride?: number;
 }
 
+/** Shared query params for the three slim member-search endpoints. */
+const memberSearchParams = (search: string | undefined, userIds: number[] | undefined) => ({
+  search: search?.trim() || undefined,
+  user_id: userIds?.length ? userIds.slice(0, USER_ID_LOOKUP_MAX) : undefined,
+});
+
 /**
  * Slim, server-side member typeahead for the active guild. Returns
  * {@link UserSummary} rows (id, name, avatar, status) for a bounded page —
@@ -69,16 +83,16 @@ export interface UserSearchOptions {
  */
 export const useUserSearch = ({
   search,
+  userIds,
   pageSize = USER_SEARCH_PAGE_SIZE,
   enabled = true,
   guildIdOverride,
 }: UserSearchOptions = {}) => {
   const activeGuildId = useActiveGuildId();
   const guildId = guildIdOverride ?? activeGuildId;
-  const trimmed = search?.trim();
   return useSearchUsersApiV1GGuildIdUsersSearchGet(
     guildId,
-    { search: trimmed || undefined, page_size: pageSize },
+    { ...memberSearchParams(search, userIds), page_size: pageSize },
     {
       query: {
         enabled: enabled && guildId != null,
@@ -100,6 +114,7 @@ export const useInitiativeMemberSearch = (
   initiativeId: number | null | undefined,
   {
     search,
+    userIds,
     pageSize = USER_SEARCH_PAGE_SIZE,
     enabled = true,
     guildIdOverride,
@@ -107,11 +122,10 @@ export const useInitiativeMemberSearch = (
 ) => {
   const activeGuildId = useActiveGuildId();
   const guildId = guildIdOverride ?? activeGuildId;
-  const trimmed = search?.trim();
   return useSearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSearchGet(
     guildId,
     initiativeId as number,
-    { search: trimmed || undefined, page_size: pageSize },
+    { ...memberSearchParams(search, userIds), page_size: pageSize },
     {
       query: {
         enabled: enabled && guildId != null && initiativeId != null,
@@ -132,6 +146,7 @@ export const useProjectMemberSearch = (
   projectId: number | null | undefined,
   {
     search,
+    userIds,
     pageSize = USER_SEARCH_PAGE_SIZE,
     enabled = true,
     guildIdOverride,
@@ -139,11 +154,10 @@ export const useProjectMemberSearch = (
 ) => {
   const activeGuildId = useActiveGuildId();
   const guildId = guildIdOverride ?? activeGuildId;
-  const trimmed = search?.trim();
   return useSearchProjectMembersApiV1GGuildIdProjectsProjectIdMembersSearchGet(
     guildId,
     projectId as number,
-    { search: trimmed || undefined, page_size: pageSize },
+    { ...memberSearchParams(search, userIds), page_size: pageSize },
     {
       query: {
         enabled: enabled && guildId != null && projectId != null,
@@ -175,23 +189,25 @@ export const useMemberSearch = (
   scope: MemberSearchScope,
   {
     search,
+    userIds,
     pageSize = USER_SEARCH_PAGE_SIZE,
     enabled = true,
   }: Omit<UserSearchOptions, "guildIdOverride"> = {}
 ) => {
   const guildQuery = useUserSearch({
     search,
+    userIds,
     pageSize,
     enabled: enabled && scope.type === "guild",
     guildIdOverride: scope.type === "guild" ? scope.guildIdOverride : undefined,
   });
   const initiativeQuery = useInitiativeMemberSearch(
     scope.type === "initiative" ? scope.initiativeId : undefined,
-    { search, pageSize, enabled: enabled && scope.type === "initiative" }
+    { search, userIds, pageSize, enabled: enabled && scope.type === "initiative" }
   );
   const projectQuery = useProjectMemberSearch(
     scope.type === "project" ? scope.projectId : undefined,
-    { search, pageSize, enabled: enabled && scope.type === "project" }
+    { search, userIds, pageSize, enabled: enabled && scope.type === "project" }
   );
 
   if (scope.type === "guild") return guildQuery;

--- a/frontend/src/lib/userDisplay.ts
+++ b/frontend/src/lib/userDisplay.ts
@@ -54,6 +54,18 @@ export const isAnonymizedUser = (user: DisplayableUser | null | undefined): bool
   user?.status === "anonymized";
 
 /**
+ * Whether we hold enough of a user to name them — i.e. whether
+ * {@link getUserDisplayName} would return something real rather than the
+ * caller's fallback. Pickers use this to decide which selected ids they still
+ * need to resolve from the server instead of rendering "User #<id>".
+ */
+export const hasDisplayName = (user: DisplayableUser | null | undefined): boolean => {
+  if (!user) return false;
+  if (isAnonymizedUser(user)) return true;
+  return Boolean(user.full_name?.trim() || user.email?.trim());
+};
+
+/**
  * Initials to render in an avatar fallback for the given user. Returns
  * the muted ``–`` sentinel for anonymized accounts; otherwise delegates
  * to ``getInitials`` with the user's name (or email fallback).

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -539,5 +539,9 @@ html.pride [data-slot="button"].bg-primary:hover {
 .robot-toast-bottom-center,
 .robot-toast-bottom-left,
 .robot-toast-bottom-right {
+  /* biome-ignore lint/complexity/noImportantStyles: robot-toast injects its own
+     rules for this container at runtime under the higher-specificity
+     `.robot-toast-wrapper.robot-toast-bottom-*`, so the override has to outrank
+     a stylesheet we don't control. */
   margin-bottom: calc(4.5rem + var(--safe-area-inset-bottom, 0px)) !important;
 }


### PR DESCRIPTION
## Problem

User typeaheads rendered `User #12` in place of a name whenever the selection arrived as bare ids rather than from a search.

The pickers only learned a user's name by seeing them come back from a search request. Anything that hands the picker a pre-existing selection had no name to render, so `MemberSearchSelect` fell through to its `User #<id>` fallback:

- the assignee filter on a project's task list, restored from storage on page load
- a stored user-reference property value
- a queue item's linked user

It looked correct immediately after picking someone (they were still in the results) and broke on the next visit — which is why it read as "when 1 user is selected".

## Changes

**Backend** — a repeatable `user_id` query param on the three member-search endpoints, so a picker can resolve a known selection instead of browsing the roster:

- `GET /g/{guild_id}/users/search`
- `GET /g/{guild_id}/initiatives/{id}/members/search`
- `GET /g/{guild_id}/projects/{id}/members/search`

It only ever **narrows** the already-scoped, RLS-gated set the endpoint would return anyway — an id outside the guild / initiative / project-assignable set resolves to nothing rather than leaking a name. Each endpoint has a test asserting exactly that. Bounded at 100 ids (`MAX_ID_FILTER_VALUES` in `app/db/query.py`), matching the `page_size` ceiling those endpoints already declare.

**Frontend** — `useSeenMembers` now takes the picker's scope and selected ids, looks up only the ids it cannot already name, and merges the result into the same map the chips and trigger read. The merge upgrades a placeholder once a named record arrives and is otherwise a no-op, so it stays idempotent (a non-idempotent update here loops: setState → render → effect → setState).

`hasDisplayName` in `lib/userDisplay.ts` is the single rule for "would this fall back to the placeholder", so the picker and the display helper cannot drift.

**Also** — the queue-item linked-user picker was fetching every initiative member as `UserPublic` (emails and all) to build a `{value, label}` list, then rendering only the name. It now uses `MemberSelect` like every other person picker: server typeahead, avatars, no roster fetch. An edited item already ships its own `user`, so that case needs no lookup at all.

`useInitiativeMembers` (`hooks/useInitiatives.ts`) has no callers left after this. Left in place rather than deleted, since several branches are in flight — happy to drop it if you'd rather.

## Schema / env

No migration, no env changes. OpenAPI spec and orval output regenerated and verified in sync against the branch's backend.

## Testing

```
# backend
cd backend && pytest app/api/v1/platform_endpoints/users_test.py \
  app/api/v1/tenant_endpoints/initiatives_test.py app/db/query_test.py
#   214 passed
cd backend && pytest app/api/v1/tenant_endpoints/projects_test.py -k search_project_members
#   2 passed
cd backend && ruff check app && ruff format app

# frontend
cd frontend && pnpm vitest run src/components/members src/components/initiativeTools/queues \
  src/components/projects src/components/ui/data-table.test.tsx
#   60 passed
cd frontend && pnpm exec tsc --noEmit    # clean
cd frontend && pnpm lint                 # 4 warnings, all pre-existing, none in changed files

# openapi in sync
cd backend && python scripts/export_openapi.py /tmp/check.json && diff /tmp/check.json ../frontend/openapi.json
```

New tests in `frontend/src/components/members/MemberSearchSelect.test.tsx` cover the bug directly: a selection given as bare ids resolves to a name; only unnamed ids are looked up (one already supplied via `selectedUsers` is not re-fetched); and an id outside the scoped roster still falls back to `User #<id>`, since there is no one to name. With the lookup disabled, 3 of the 4 fail — verified, so they would have caught this.

## Screenshots

No visual redesign — the assignee filter trigger now reads the member's name where it previously read `User #12`.
