### PR TITLE
Drop "My" from the calendar panel heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Dragging a card into a long Kanban column now changes its status. Once a column held more than about twenty cards the board drew only the ones on screen, and a drop into it could be credited to the last card the pointer crossed on the way in — so the card sprang back to where it started instead of moving. Columns that accumulate cards, Done most of all, were the ones affected.
+- The calendar visibility dropdown no longer heads its list "My calendars". A calendar belongs to its initiative and is shared with the people in it, so the section is now simply "Calendars".
 - Person pickers no longer show "User #12" where a name belongs. A selection the picker was handed rather than one you just made — the assignee filter you get back when you return to a project, a saved user property, the linked user on a queue item — is now resolved to a name and avatar against the same roster the dropdown searches. An id nobody in that roster matches still shows as an id, since there is no one to name.
 
 ## [0.60.1] - 2026-08-06

--- a/frontend/public/locales/de/calendars.json
+++ b/frontend/public/locales/de/calendars.json
@@ -128,7 +128,6 @@
   "deleteCalendarConfirm": "Diesen Kalender löschen? Alle seine Termine werden mit entfernt.",
   "panel": {
     "calendars": "Kalender",
-    "myCalendars": "Meine Kalender",
     "noCalendars": "Noch keine Kalender",
     "projectTasks": "Projektaufgaben",
     "calendarSettings": "Einstellungen für {{name}}"

--- a/frontend/public/locales/en/calendars.json
+++ b/frontend/public/locales/en/calendars.json
@@ -128,7 +128,6 @@
   "deleteCalendarConfirm": "Delete this calendar? All of its events go with it.",
   "panel": {
     "calendars": "Calendars",
-    "myCalendars": "My calendars",
     "noCalendars": "No calendars yet",
     "projectTasks": "Project tasks",
     "calendarSettings": "Settings for {{name}}"

--- a/frontend/public/locales/es/calendars.json
+++ b/frontend/public/locales/es/calendars.json
@@ -128,7 +128,6 @@
   "deleteCalendarConfirm": "¿Eliminar este calendario? Todos sus eventos se eliminarán con él.",
   "panel": {
     "calendars": "Calendarios",
-    "myCalendars": "Mis calendarios",
     "noCalendars": "Aún no hay calendarios",
     "projectTasks": "Tareas de proyectos",
     "calendarSettings": "Configuración de {{name}}"

--- a/frontend/public/locales/fr/calendars.json
+++ b/frontend/public/locales/fr/calendars.json
@@ -128,7 +128,6 @@
   "deleteCalendarConfirm": "Supprimer ce calendrier ? Tous ses événements seront supprimés avec lui.",
   "panel": {
     "calendars": "Calendriers",
-    "myCalendars": "Mes calendriers",
     "noCalendars": "Aucun calendrier pour l'instant",
     "projectTasks": "Tâches des projets",
     "calendarSettings": "Paramètres de {{name}}"

--- a/frontend/src/components/initiativeTools/events/CalendarListPanel.tsx
+++ b/frontend/src/components/initiativeTools/events/CalendarListPanel.tsx
@@ -82,7 +82,7 @@ export const CalendarListPanel = ({
       <section className="space-y-1">
         <div className="flex items-center justify-between">
           <h2 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-            {t("panel.myCalendars")}
+            {t("panel.calendars")}
           </h2>
           {canCreate && (
             <Button


### PR DESCRIPTION
## Problem

The calendar visibility panel headed its first section "My calendars". Nothing
in that list is personal: a calendar belongs to its initiative and is shared
with the people in it — whoever can see the calendar sees the same one. The
label read as ownership where there is none, and it was wrong on both surfaces
that render the panel (the initiative Calendars page and the cross-guild My
Calendar page).

## Changes

- [CalendarListPanel.tsx](frontend/src/components/initiativeTools/events/CalendarListPanel.tsx) now heads the section with the existing `panel.calendars` key — the same one the dropdown trigger uses — instead of `panel.myCalendars`.
- Removed the now-unused `panel.myCalendars` from all four locales (en/de/es/fr).
- Changelog entry under `[Unreleased] → Fixed`.

No behavior change beyond the label; the sections inside the popover still read
"CALENDARS" then "PROJECT TASKS", and the create (+) button stays in that header
row.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — clean (860 files, no findings)
- `pnpm vitest run src/pages/initiativeTools/events/CalendarsPage.test.tsx` — 3 passed
- `pnpm vitest run src/__tests__/locale-keys.test.ts` — 354 passed (locale parity after the key removal)