### PR TITLE
Reschedule template tasks on project create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Building a project from a template now reschedules its tasks.** Task start and due dates in a template are treated as relative: give the new project a start date and each task lands the same distance from it as it sat from the template's start — a task due three weeks in stays three weeks in. A template without dates of its own anchors on its earliest scheduled task, and giving only an end date anchors the schedule on the end instead. Leave the new project undated and task dates copy across unchanged, as before. Template task start dates, previously dropped, now carry over too.
+
 ## [0.61.1] - 2026-08-10
 
 ### Fixed

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -348,6 +348,37 @@ def _ensure_not_archived(project: Project) -> None:
         )
 
 
+def _template_task_date_shift(
+    template: Project,
+    new_project: Project,
+    template_tasks: list[Task],
+) -> timedelta | None:
+    """Offset to move template task dates onto the new project's schedule.
+
+    Task dates in a template are relative: a task due three weeks after the
+    template's start should land three weeks after the new project's start.
+    Anchors on the projects' start dates when the new project has one,
+    otherwise on their end dates. A template without an explicit start/end
+    falls back to its earliest/latest task date. Returns None when there is
+    nothing to anchor on, in which case dates are copied as-is.
+    """
+    task_dates = [
+        value.date()
+        for task in template_tasks
+        for value in (task.start_date, task.due_date)
+        if value is not None
+    ]
+    if new_project.start_date is not None:
+        anchor = template.start_date or (min(task_dates) if task_dates else None)
+        if anchor is not None:
+            return new_project.start_date - anchor
+    if new_project.end_date is not None:
+        anchor = template.end_date or (max(task_dates) if task_dates else None)
+        if anchor is not None:
+            return new_project.end_date - anchor
+    return None
+
+
 async def _duplicate_template_tasks(
     session: SessionDep,
     template: Project,
@@ -374,6 +405,7 @@ async def _duplicate_template_tasks(
 
     now = datetime.now(timezone.utc)
     categories = await task_completion.status_categories(session, new_project.id)
+    date_shift = _template_task_date_shift(template, new_project, list(template_tasks))
     for template_task in template_tasks:
         template_status_id = getattr(template_task, "task_status_id", None)
         mapped_status_id = None
@@ -387,13 +419,21 @@ async def _duplicate_template_tasks(
                 mapped_status_id = fallback_status_ids.get(category)
         if mapped_status_id is None and fallback_status_ids:
             mapped_status_id = next(iter(fallback_status_ids.values()))
+        start_date = template_task.start_date
+        due_date = template_task.due_date
+        if date_shift is not None:
+            if start_date is not None:
+                start_date = start_date + date_shift
+            if due_date is not None:
+                due_date = due_date + date_shift
         new_task = Task(
             project_id=new_project.id,
             title=template_task.title,
             description=template_task.description,
             task_status_id=mapped_status_id,
             priority=template_task.priority,
-            due_date=template_task.due_date,
+            start_date=start_date,
+            due_date=due_date,
             position=template_task.position,
         )
         task_completion.sync_completed_at(

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -12,6 +12,9 @@ Tests the project API endpoints at /api/v1/projects including:
 - Project duplication
 """
 
+import json
+from datetime import date, datetime, timezone
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
@@ -26,6 +29,7 @@ from app.testing.factories import (
     create_guild_membership,
     create_initiative,
     create_project,
+    create_task,
     create_task_status,
 )
 
@@ -447,6 +451,208 @@ async def test_create_project_without_dates_leaves_them_unset(
     data = response.json()
     assert data["start_date"] is None
     assert data["end_date"] is None
+
+
+def _as_utc(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+async def _tasks_by_title(
+    client: AsyncClient, actor, project_id: int
+) -> dict[str, dict]:
+    conditions = json.dumps([{"field": "project_id", "op": "eq", "value": project_id}])
+    response = await client.get(
+        actor.g(f"/tasks/?conditions={conditions}"), headers=actor.headers
+    )
+    assert response.status_code == 200
+    return {item["title"]: item for item in response.json()["items"]}
+
+
+@pytest.mark.integration
+async def test_create_from_template_shifts_task_dates(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Template task dates are re-anchored to the new project's start date.
+
+    A task due three weeks after the template's start lands three weeks after
+    the new start, keeping its time of day.
+    """
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    template = await create_project(
+        session,
+        admin.initiative,
+        admin.user,
+        name="Launch Template",
+        is_template=True,
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 2, 2),
+    )
+    await create_task(
+        session,
+        template,
+        title="Kickoff",
+        start_date=datetime(2026, 1, 5, 9, 0, tzinfo=timezone.utc),
+        due_date=datetime(2026, 1, 7, 17, 0, tzinfo=timezone.utc),
+    )
+    await create_task(
+        session,
+        template,
+        title="Three weeks in",
+        due_date=datetime(2026, 1, 26, 12, 0, tzinfo=timezone.utc),
+    )
+
+    response = await client.post(
+        admin.g("/projects/"),
+        headers=admin.headers,
+        json={
+            "name": "Spring Launch",
+            "initiative_id": admin.initiative.id,
+            "template_id": template.id,
+            "start_date": "2026-04-06",
+            "end_date": "2026-05-04",
+        },
+    )
+    assert response.status_code == 201
+
+    tasks = await _tasks_by_title(client, admin, response.json()["id"])
+    kickoff = tasks["Kickoff"]
+    assert _as_utc(kickoff["start_date"]) == datetime(
+        2026, 4, 6, 9, 0, tzinfo=timezone.utc
+    )
+    assert _as_utc(kickoff["due_date"]) == datetime(
+        2026, 4, 8, 17, 0, tzinfo=timezone.utc
+    )
+    assert _as_utc(tasks["Three weeks in"]["due_date"]) == datetime(
+        2026, 4, 27, 12, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.integration
+async def test_create_from_undated_template_anchors_on_earliest_task(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A template without its own dates anchors on its earliest task date, so
+    the first scheduled task lands on the new start and spacing is kept."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    template = await create_project(
+        session, admin.initiative, admin.user, name="Undated Template", is_template=True
+    )
+    await create_task(
+        session,
+        template,
+        title="First",
+        due_date=datetime(2026, 1, 5, 10, 0, tzinfo=timezone.utc),
+    )
+    await create_task(
+        session,
+        template,
+        title="Two weeks later",
+        due_date=datetime(2026, 1, 19, 10, 0, tzinfo=timezone.utc),
+    )
+
+    response = await client.post(
+        admin.g("/projects/"),
+        headers=admin.headers,
+        json={
+            "name": "Summer Run",
+            "initiative_id": admin.initiative.id,
+            "template_id": template.id,
+            "start_date": "2026-06-01",
+        },
+    )
+    assert response.status_code == 201
+
+    tasks = await _tasks_by_title(client, admin, response.json()["id"])
+    assert _as_utc(tasks["First"]["due_date"]) == datetime(
+        2026, 6, 1, 10, 0, tzinfo=timezone.utc
+    )
+    assert _as_utc(tasks["Two weeks later"]["due_date"]) == datetime(
+        2026, 6, 15, 10, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.integration
+async def test_create_from_template_end_date_only_anchors_on_end(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """With only an end date given, tasks shift so the template's end maps to
+    the new end (a task due a week before the end stays a week before it)."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    template = await create_project(
+        session,
+        admin.initiative,
+        admin.user,
+        name="Deadline Template",
+        is_template=True,
+        end_date=date(2026, 2, 2),
+    )
+    await create_task(
+        session,
+        template,
+        title="Final review",
+        due_date=datetime(2026, 1, 26, 15, 0, tzinfo=timezone.utc),
+    )
+
+    response = await client.post(
+        admin.g("/projects/"),
+        headers=admin.headers,
+        json={
+            "name": "Autumn Deadline",
+            "initiative_id": admin.initiative.id,
+            "template_id": template.id,
+            "end_date": "2026-08-31",
+        },
+    )
+    assert response.status_code == 201
+
+    tasks = await _tasks_by_title(client, admin, response.json()["id"])
+    assert _as_utc(tasks["Final review"]["due_date"]) == datetime(
+        2026, 8, 24, 15, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.integration
+async def test_create_from_template_without_dates_copies_task_dates_verbatim(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """No start or end on the new project means no re-anchoring — task dates
+    (including start dates) come across unchanged."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    template = await create_project(
+        session,
+        admin.initiative,
+        admin.user,
+        name="Plain Template",
+        is_template=True,
+        start_date=date(2026, 1, 5),
+    )
+    await create_task(
+        session,
+        template,
+        title="Kickoff",
+        start_date=datetime(2026, 1, 5, 9, 0, tzinfo=timezone.utc),
+        due_date=datetime(2026, 1, 26, 12, 0, tzinfo=timezone.utc),
+    )
+
+    response = await client.post(
+        admin.g("/projects/"),
+        headers=admin.headers,
+        json={
+            "name": "Undated Run",
+            "initiative_id": admin.initiative.id,
+            "template_id": template.id,
+        },
+    )
+    assert response.status_code == 201
+
+    tasks = await _tasks_by_title(client, admin, response.json()["id"])
+    kickoff = tasks["Kickoff"]
+    assert _as_utc(kickoff["start_date"]) == datetime(
+        2026, 1, 5, 9, 0, tzinfo=timezone.utc
+    )
+    assert _as_utc(kickoff["due_date"]) == datetime(
+        2026, 1, 26, 12, 0, tzinfo=timezone.utc
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Problem
Creating a project from a template copied task due dates verbatim, so a template authored in January produced a project full of stale January deadlines — and template task start dates were dropped entirely. Dates in a template are really relative ("due three weeks in"), not absolute.

## Changes
- [projects.py](backend/app/api/v1/tenant_endpoints/projects.py): `_duplicate_template_tasks` now shifts each task's start/due date by the gap between the template's schedule and the new project's, via the new `_template_task_date_shift` helper:
  - New project has a **start date** → anchor on the template's start date (falling back to its earliest task date if the template is undated).
  - Only an **end date** → anchor on the template's end date (falling back to its latest task date).
  - **No dates** given → task dates copy across unchanged, as before.
- Task `start_date` is now carried over from templates (it was previously dropped).
- Duplicate-project is unaffected: it copies the source's dates onto the copy, so the computed shift is zero.
- [CHANGELOG.md](CHANGELOG.md): entry under Unreleased.

## Testing
- `cd backend && uv run pytest app/api/v1/tenant_endpoints/projects_test.py -k template -q` — 4 new integration tests pass (start-anchored shift preserving time of day, earliest-task fallback for undated templates, end-date-only anchoring, verbatim copy when no dates given).
- `cd backend && uv run ruff check app && uv run ruff format app` — clean.