### PR TITLE
Fix 500 when completing a tagged recurring task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Completing a recurring task that carries tags failed with a server error.** Dragging such a task to a Done column (or otherwise marking it complete) returned a 500 and the next occurrence was not created. Only recurring tasks with at least one tag were affected, which made it look like a single project was broken.
+
 ## [0.61.2] - 2026-08-11
 
 ### Changed

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -867,7 +867,20 @@ async def _advance_recurrence_if_needed(
         target_id=new_task.id,
     )
     await session.flush()
-    await session.refresh(new_task, attribute_names=["assignees", "tag_links"])
+    # Reload through a select rather than ``session.refresh``: refresh takes no
+    # loader options, so it would populate ``tag_links`` while leaving each
+    # link's ``tag`` unloaded — and the annotation below reads ``link.tag``,
+    # which then has to emit IO from sync context. ``populate_existing`` applies
+    # the freshly loaded rows to the identity-mapped instance.
+    await session.exec(
+        select(Task)
+        .where(Task.id == new_task.id)
+        .options(
+            selectinload(Task.assignees),
+            tags_service.TAG_LINKS["task"].load_options(),
+        )
+        .execution_options(populate_existing=True)
+    )
     tags_service.annotate_tags([new_task])
     await _broadcast_task(
         session, new_task.guild_id, new_task.project_id, "created", task_id=new_task.id

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -1288,30 +1288,32 @@ async def test_completing_a_tagged_recurring_task_copies_tags_to_next_occurrence
     from app.api.v1.tenant_endpoints.tasks import _advance_recurrence_if_needed
     from app.models.tenant.tag import TaskTag
     from app.models.tenant.task import Task, TaskStatusCategory
-    from app.services.tenant import task_statuses as task_statuses_service
-    from app.testing.factories import create_tag
+    from app.services.tenant import tags as tags_service
+    from app.testing.factories import create_tag, create_task, create_task_status
 
     a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
     project = a.project
 
-    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
-    todo_status = next(s for s in statuses if s.is_default)
-    done_status = next(s for s in statuses if s.name == "Done")
     tag = await create_tag(session, a.guild, name="Chores", color="#112233")
-    await session.commit()
-
-    task = Task(
+    task = await create_task(
+        session,
+        project,
         title="Tagged recurring task",
-        project_id=project.id,
-        task_status_id=todo_status.id,
-        guild_id=a.guild.id,
+        status_category=TaskStatusCategory.todo,
         due_date=datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc),
         recurrence={"frequency": "daily", "interval": 1, "ends": "never"},
         recurrence_strategy="fixed",
     )
-    session.add(task)
-    await session.commit()
-    session.add(TaskTag(task_id=task.id, tag_id=tag.id))
+    done_status = await create_task_status(
+        session, project, name="Done", category=TaskStatusCategory.done, position=1
+    )
+    await tags_service.set_entity_tags(
+        session,
+        tags_service.TAG_LINKS["task"],
+        guild_id=a.guild.id,
+        entity_id=task.id,
+        tag_ids=[tag.id],
+    )
     await session.commit()
     await session.refresh(
         task, attribute_names=["task_status", "assignees", "tag_links"]

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -1271,6 +1271,91 @@ async def test_rolling_recurrence_spring_forward_preserves_wall_clock_time(
 
 
 @pytest.mark.integration
+async def test_completing_a_tagged_recurring_task_copies_tags_to_next_occurrence(
+    session: AsyncSession,
+    acting_user,
+):
+    """Advancing recurrence on a *tagged* task serializes the new
+    occurrence's tags without emitting IO from sync context.
+
+    Repro: the next occurrence's tag links were reloaded without their
+    ``tag`` relationship, so annotating them lazy-loaded each tag and the
+    request died with ``MissingGreenlet``. Only tagged recurring tasks hit
+    it, which is why it looked project-specific.
+    """
+    from datetime import datetime, timezone
+
+    from app.api.v1.tenant_endpoints.tasks import _advance_recurrence_if_needed
+    from app.models.tenant.tag import TaskTag
+    from app.models.tenant.task import Task, TaskStatusCategory
+    from app.services.tenant import task_statuses as task_statuses_service
+    from app.testing.factories import create_tag
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    project = a.project
+
+    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    todo_status = next(s for s in statuses if s.is_default)
+    done_status = next(s for s in statuses if s.name == "Done")
+    tag = await create_tag(session, a.guild, name="Chores", color="#112233")
+    await session.commit()
+
+    task = Task(
+        title="Tagged recurring task",
+        project_id=project.id,
+        task_status_id=todo_status.id,
+        guild_id=a.guild.id,
+        due_date=datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc),
+        recurrence={"frequency": "daily", "interval": 1, "ends": "never"},
+        recurrence_strategy="fixed",
+    )
+    session.add(task)
+    await session.commit()
+    session.add(TaskTag(task_id=task.id, tag_id=tag.id))
+    await session.commit()
+    await session.refresh(
+        task, attribute_names=["task_status", "assignees", "tag_links"]
+    )
+
+    task.task_status_id = done_status.id  # ty: ignore[invalid-assignment] — persisted row, id is set
+    task.task_status = done_status
+
+    # Drop the tag from the identity map so reading a link's ``tag`` has to
+    # go to the database — as it does on a real request, where the tag was
+    # never loaded into this session. Keeping it resident lets SQLAlchemy
+    # satisfy the many-to-one from memory and the bug stays hidden.
+    tag_id = tag.id
+    session.expunge(tag)
+
+    advanced = await _advance_recurrence_if_needed(
+        session,
+        task,
+        previous_status_category=TaskStatusCategory.todo,
+        now=datetime(2026, 5, 4, 13, 0, 0, tzinfo=timezone.utc),
+        user_timezone="UTC",
+    )
+    # Getting here at all is the regression: serializing the new occurrence's
+    # tags used to raise before this line.
+    assert advanced is True
+    await session.commit()
+
+    from sqlmodel import select as _select
+
+    new_task = (
+        await session.exec(
+            _select(Task).where(Task.project_id == project.id, Task.id != task.id)
+        )
+    ).first()
+    assert new_task is not None
+    copied = (
+        await session.exec(
+            _select(TaskTag.tag_id).where(TaskTag.task_id == new_task.id)
+        )
+    ).all()
+    assert list(copied) == [tag_id]
+
+
+@pytest.mark.integration
 async def test_filter_tasks_by_date_window_group(
     client: AsyncClient, session: AsyncSession, acting_user
 ):


### PR DESCRIPTION
## Problem

Dragging a task into a Done column returned `500 Internal Server Error` from `POST /api/v1/g/{guild}/tasks/reorder`, and the next occurrence was never created:

```
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called;
can't call await_only() here. Was IO attempted in an unexpected place?
  tasks.py:871 in _advance_recurrence_if_needed
    tags_service.annotate_tags([new_task])
  tag.py:58 in tag_summaries
    tag = getattr(link, "tag", None)
```

`_advance_recurrence_if_needed` reloaded the newly created occurrence with `session.refresh(new_task, attribute_names=["assignees", "tag_links"])`. `refresh()` accepts no loader options, so it populated the junction rows while leaving each link's `tag` relationship unloaded. The next line, `annotate_tags`, reads `link.tag` — a lazy load firing from sync serialization context, which under asyncpg is exactly `MissingGreenlet`.

The path only runs for a **recurring** task, and only faults if that task carries **at least one tag** — hence it presenting as one specific project being broken. Every other tag load in the file uses the `selectinload(Task.tag_links).selectinload(TaskTag.tag)` chain; this one call site did not.

This is longstanding rather than a recent regression: the pre-registry `_annotate_task_tags` read `link.tag` the same way.

## Changes

- [tasks.py](backend/app/api/v1/tenant_endpoints/tasks.py) — replace the `session.refresh` with a `populate_existing` select carrying the eager-load chain, sourced from the tag registry's own `TAG_LINKS["task"].load_options()` so it can't drift from the rest of the tagging path. `assignees` stays eager-loaded as before.
- [tasks_test.py](backend/app/api/v1/tenant_endpoints/tasks_test.py) — regression test covering completion of a tagged recurring task.

Note on the test: it expunges the tag from the session before advancing. Without that, SQLAlchemy satisfies the many-to-one from the identity map without emitting SQL and the bug stays invisible — which is why the existing recurrence coverage passed straight through it.

## Testing

- `cd backend && uv run pytest app/api/v1/tenant_endpoints/tasks_test.py` → 47 passed
- `cd backend && ./scripts/test-changed.sh` → 52 passed
- `cd backend && uv run ruff check app` → All checks passed
- Reverting only the `tasks.py` hunk makes the new test fail with the identical `MissingGreenlet` from the production traceback; restoring it passes.

No schema, migration, or env changes. Backend only — no generated-type regeneration needed (no schema changes).