### PR TITLE
Draw dashboards on a real canvas

### DIFF
--- a/frontend/public/locales/de/dashboards.json
+++ b/frontend/public/locales/de/dashboards.json
@@ -28,8 +28,6 @@
   "dangerZone": "Gefahrenzone",
   "dangerZoneDescription": "Destruktive Aktionen. Gelöschte Dashboards landen im Papierkorb und können wiederhergestellt werden, bevor der Aufbewahrungszeitraum endet.",
   "detailsUpdated": "Dashboard-Details aktualisiert",
-  "canvasPending": "Arbeitsfläche folgt in Kürze",
-  "canvasPendingDescription": "Die Widget-Arbeitsfläche ist noch nicht verfügbar. Bis dahin behält dieses Dashboard seinen Namen, seine Beschreibung, seine Tags und seine Freigaben.",
   "filters": {
     "heading": "Filter",
     "show": "Anzeigen",
@@ -99,6 +97,44 @@
       "noRenderExport": "Keine Renderfunktion",
       "triesToFetch": "Versucht zu laden",
       "invalidScene": "Ungültige Szene"
+    }
+  },
+  "canvas": {
+    "empty": "Dieses Dashboard hat noch keine Widgets.",
+    "emptyHint": "Fügen Sie ein Widget hinzu, um Ihre Daten anzuzeigen.",
+    "emptyReadOnly": "Jemand mit Bearbeitungsrechten kann Widgets hinzufügen.",
+    "addWidget": "Widget hinzufügen",
+    "widgets": "Widgets",
+    "presets": "Vorgefertigt",
+    "widgetCap": "Ein Dashboard fasst {{max}} Widgets.",
+    "widgetMenu": "Optionen für {{widget}}",
+    "configure": "Konfigurieren",
+    "remove": "Entfernen",
+    "saving": "Wird gespeichert…",
+    "unbound": "Wählen Sie aus, was dieses Widget anzeigt."
+  },
+  "config": {
+    "title": "Widget konfigurieren",
+    "description": "Wählen Sie aus, was dieses Widget anzeigt. Dashboards lesen Ihre Daten nur.",
+    "widgetTitle": "Titel",
+    "widgetTitlePlaceholder": "Leer lassen, um den Namen des Widgets zu verwenden",
+    "source": "Datenquelle",
+    "choose": "Auswählen…",
+    "spreadsheet": "Tabelle",
+    "sheet": "Blatt",
+    "sheetPlaceholder": "Erstes Blatt",
+    "range": "Bereich",
+    "project": "Projekt",
+    "allProjects": "Alle Projekte",
+    "allCalendars": "Alle Kalender",
+    "groupBy": "Gruppieren nach",
+    "bucket": {
+      "status_category": "Statuskategorie",
+      "status": "Status",
+      "priority": "Priorität",
+      "project": "Projekt",
+      "assignee": "Zugewiesen an",
+      "day": "Abschlusstag"
     }
   }
 }

--- a/frontend/public/locales/en/dashboards.json
+++ b/frontend/public/locales/en/dashboards.json
@@ -28,8 +28,6 @@
   "dangerZone": "Danger Zone",
   "dangerZoneDescription": "Destructive actions. Deleted dashboards go to the trash and can be restored before the retention period ends.",
   "detailsUpdated": "Dashboard details updated",
-  "canvasPending": "Canvas coming soon",
-  "canvasPendingDescription": "The widget canvas is not available yet. Until it ships, this dashboard keeps its name, description, tags, and sharing.",
   "filters": {
     "heading": "Filters",
     "show": "Show",
@@ -99,6 +97,44 @@
       "noRenderExport": "No render function",
       "triesToFetch": "Tries to fetch",
       "invalidScene": "Invalid scene"
+    }
+  },
+  "canvas": {
+    "empty": "This dashboard has no widgets yet.",
+    "emptyHint": "Add a widget to start showing your data.",
+    "emptyReadOnly": "Someone with edit access can add widgets to it.",
+    "addWidget": "Add widget",
+    "widgets": "Widgets",
+    "presets": "Ready-made",
+    "widgetCap": "A dashboard can hold {{max}} widgets.",
+    "widgetMenu": "Options for {{widget}}",
+    "configure": "Configure",
+    "remove": "Remove",
+    "saving": "Saving…",
+    "unbound": "Choose what this widget shows."
+  },
+  "config": {
+    "title": "Configure widget",
+    "description": "Choose what this widget displays. Dashboards only ever read your data.",
+    "widgetTitle": "Title",
+    "widgetTitlePlaceholder": "Leave blank to use the widget's own name",
+    "source": "Data source",
+    "choose": "Choose…",
+    "spreadsheet": "Spreadsheet",
+    "sheet": "Sheet",
+    "sheetPlaceholder": "First sheet",
+    "range": "Range",
+    "project": "Project",
+    "allProjects": "All projects",
+    "allCalendars": "All calendars",
+    "groupBy": "Group by",
+    "bucket": {
+      "status_category": "Status category",
+      "status": "Status",
+      "priority": "Priority",
+      "project": "Project",
+      "assignee": "Assignee",
+      "day": "Day completed"
     }
   }
 }

--- a/frontend/public/locales/es/dashboards.json
+++ b/frontend/public/locales/es/dashboards.json
@@ -28,8 +28,6 @@
   "dangerZone": "Zona de peligro",
   "dangerZoneDescription": "Acciones destructivas. Los paneles eliminados van a la papelera y se pueden restaurar antes de que finalice el período de retención.",
   "detailsUpdated": "Detalles del panel actualizados",
-  "canvasPending": "El lienzo llegará pronto",
-  "canvasPendingDescription": "El lienzo de widgets todavía no está disponible. Hasta entonces, este panel conserva su nombre, su descripción, sus etiquetas y sus permisos de acceso.",
   "filters": {
     "heading": "Filtros",
     "show": "Mostrar",
@@ -99,6 +97,44 @@
       "noRenderExport": "Sin función de renderizado",
       "triesToFetch": "Intenta hacer fetch",
       "invalidScene": "Escena no válida"
+    }
+  },
+  "canvas": {
+    "empty": "Este panel aún no tiene widgets.",
+    "emptyHint": "Añade un widget para empezar a mostrar tus datos.",
+    "emptyReadOnly": "Alguien con permiso de edición puede añadir widgets.",
+    "addWidget": "Añadir widget",
+    "widgets": "Widgets",
+    "presets": "Predefinidos",
+    "widgetCap": "Un panel admite {{max}} widgets.",
+    "widgetMenu": "Opciones de {{widget}}",
+    "configure": "Configurar",
+    "remove": "Quitar",
+    "saving": "Guardando…",
+    "unbound": "Elige qué muestra este widget."
+  },
+  "config": {
+    "title": "Configurar widget",
+    "description": "Elige qué muestra este widget. Los paneles solo leen tus datos.",
+    "widgetTitle": "Título",
+    "widgetTitlePlaceholder": "Déjalo vacío para usar el nombre del widget",
+    "source": "Fuente de datos",
+    "choose": "Elegir…",
+    "spreadsheet": "Hoja de cálculo",
+    "sheet": "Hoja",
+    "sheetPlaceholder": "Primera hoja",
+    "range": "Rango",
+    "project": "Proyecto",
+    "allProjects": "Todos los proyectos",
+    "allCalendars": "Todos los calendarios",
+    "groupBy": "Agrupar por",
+    "bucket": {
+      "status_category": "Categoría de estado",
+      "status": "Estado",
+      "priority": "Prioridad",
+      "project": "Proyecto",
+      "assignee": "Asignado a",
+      "day": "Día de finalización"
     }
   }
 }

--- a/frontend/public/locales/fr/dashboards.json
+++ b/frontend/public/locales/fr/dashboards.json
@@ -28,8 +28,6 @@
   "dangerZone": "Zone dangereuse",
   "dangerZoneDescription": "Actions destructives. Les tableaux de bord supprimés vont à la corbeille et peuvent être restaurés avant la fin de la période de rétention.",
   "detailsUpdated": "Détails du tableau de bord mis à jour",
-  "canvasPending": "Canevas bientôt disponible",
-  "canvasPendingDescription": "Le canevas de widgets n’est pas encore disponible. En attendant, ce tableau de bord conserve son nom, sa description, ses étiquettes et son partage.",
   "filters": {
     "heading": "Filtres",
     "show": "Afficher",
@@ -99,6 +97,44 @@
       "noRenderExport": "Aucune fonction de rendu",
       "triesToFetch": "Tente un fetch",
       "invalidScene": "Scène non valide"
+    }
+  },
+  "canvas": {
+    "empty": "Ce tableau de bord n'a pas encore de widgets.",
+    "emptyHint": "Ajoutez un widget pour commencer à afficher vos données.",
+    "emptyReadOnly": "Une personne ayant les droits de modification peut en ajouter.",
+    "addWidget": "Ajouter un widget",
+    "widgets": "Widgets",
+    "presets": "Prêts à l'emploi",
+    "widgetCap": "Un tableau de bord accepte {{max}} widgets.",
+    "widgetMenu": "Options de {{widget}}",
+    "configure": "Configurer",
+    "remove": "Supprimer",
+    "saving": "Enregistrement…",
+    "unbound": "Choisissez ce que ce widget affiche."
+  },
+  "config": {
+    "title": "Configurer le widget",
+    "description": "Choisissez ce que ce widget affiche. Les tableaux de bord ne font que lire vos données.",
+    "widgetTitle": "Titre",
+    "widgetTitlePlaceholder": "Laissez vide pour utiliser le nom du widget",
+    "source": "Source de données",
+    "choose": "Choisir…",
+    "spreadsheet": "Feuille de calcul",
+    "sheet": "Feuille",
+    "sheetPlaceholder": "Première feuille",
+    "range": "Plage",
+    "project": "Projet",
+    "allProjects": "Tous les projets",
+    "allCalendars": "Tous les calendriers",
+    "groupBy": "Grouper par",
+    "bucket": {
+      "status_category": "Catégorie de statut",
+      "status": "Statut",
+      "priority": "Priorité",
+      "project": "Projet",
+      "assignee": "Assigné à",
+      "day": "Jour d'achèvement"
     }
   }
 }

--- a/frontend/src/components/initiativeTools/dashboards/AddWidgetMenu.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/AddWidgetMenu.tsx
@@ -1,0 +1,121 @@
+/**
+ * The widget palette.
+ *
+ * Every entry comes from the served catalog — presets first (they are the
+ * ready-made ones: "Bar chart"), then the bare primitives — so the palette can
+ * only offer what the backend validator would accept, and a new widget appears
+ * here without a frontend edit. Names come from each widget module's own `meta`,
+ * which is what lets an installed listing's widget sit in this list under its
+ * author's name.
+ */
+
+import { Plus } from "lucide-react";
+import { useTranslation as useI18n, useTranslation } from "react-i18next";
+
+import type { WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useWidgetMeta } from "@/hooks/useWidgetMeta";
+import { MAX_WIDGETS } from "@/lib/widgets/definition";
+import { localized } from "@/lib/widgets/widgetMeta";
+
+export interface AddWidgetMenuProps {
+  catalog: WidgetCatalog | undefined;
+  widgetCount: number;
+  /** `typeOrPreset` is resolved against the catalog's presets by the caller. */
+  onAdd: (typeOrPreset: string, source: string) => void;
+}
+
+export function AddWidgetMenu({ catalog, widgetCount, onAdd }: AddWidgetMenuProps) {
+  const { t } = useTranslation("dashboards");
+  const atCap = widgetCount >= MAX_WIDGETS;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm" disabled={atCap || !catalog}>
+          <Plus className="mr-1.5 h-4 w-4" />
+          {t("canvas.addWidget")}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-96 w-56 overflow-y-auto">
+        {atCap && (
+          <DropdownMenuLabel className="font-normal text-muted-foreground text-xs">
+            {t("canvas.widgetCap", { max: MAX_WIDGETS })}
+          </DropdownMenuLabel>
+        )}
+
+        {!!catalog?.presets.length && (
+          <>
+            <DropdownMenuLabel>{t("canvas.presets")}</DropdownMenuLabel>
+            {catalog.presets.map((preset) => (
+              <PaletteEntry
+                key={preset.name}
+                type={preset.primitive}
+                presetOptions={preset.options}
+                catalog={catalog}
+                onAdd={(source) => onAdd(preset.name, source)}
+              />
+            ))}
+            <DropdownMenuSeparator />
+          </>
+        )}
+
+        <DropdownMenuLabel>{t("canvas.widgets")}</DropdownMenuLabel>
+        {(catalog?.widgets ?? []).map((entry) => (
+          <PaletteEntry
+            key={entry.type}
+            type={entry.type}
+            catalog={catalog}
+            onAdd={(source) => onAdd(entry.type, source)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/**
+ * One palette row. Adds the widget bound to its first catalog source — a
+ * sensible starting point the author then changes in the config dialog, rather
+ * than dropping in a widget with nothing to draw.
+ *
+ * A preset's label is *derived*, not stored: a preset is a primitive plus fixed
+ * options, and the widget module already names both. So `bar_chart` reads as
+ * "Chart · Bar" in whatever language the widget supports, and a listing that
+ * contributes a preset needs no locale entry from us.
+ */
+function PaletteEntry({
+  type,
+  presetOptions,
+  catalog,
+  onAdd,
+}: {
+  type: string;
+  presetOptions?: Record<string, string>;
+  catalog: WidgetCatalog | undefined;
+  onAdd: (source: string) => void;
+}) {
+  const { i18n } = useI18n();
+  const { name, meta } = useWidgetMeta(type);
+  const entry = catalog?.widgets.find((candidate) => candidate.type === type);
+  const firstSource = entry?.sources[0];
+  if (!firstSource) return null;
+
+  const qualifiers = Object.entries(presetOptions ?? {})
+    .map(([key, value]) => localized(meta?.options?.[key]?.values?.[value], i18n.language))
+    .filter(Boolean);
+
+  return (
+    <DropdownMenuItem onSelect={() => onAdd(firstSource)}>
+      {qualifiers.length ? `${name} · ${qualifiers.join(" · ")}` : name}
+    </DropdownMenuItem>
+  );
+}

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
@@ -9,6 +9,20 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+// jsdom measures every element at zero, which would put the canvas on its
+// stacked breakpoint and make every assertion below pass for the wrong reason.
+// A desktop width is what these tests are actually about.
+const VIEWPORT_WIDTH = 1200;
+vi.mock("react-grid-layout", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-grid-layout")>()),
+  useContainerWidth: () => ({
+    width: VIEWPORT_WIDTH,
+    mounted: true,
+    containerRef: { current: null },
+    measureWidth: () => {},
+  }),
+}));
+
 import { renderWithProviders } from "@/__tests__/helpers/render";
 import type { WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
 import {
@@ -75,13 +89,18 @@ describe("DashboardCanvas", () => {
   });
 
   it("never reports a layout change for a read-only canvas", () => {
+    // A static canvas must never write the dashboard's row on someone else's
+    // behalf, whatever the grid reports.
     const onLayoutChange = render(withKpi(), false);
-    // Mount alone fires RGL's onLayoutChange; a static canvas must swallow it
-    // rather than write the dashboard's row on someone else's behalf.
     expect(onLayoutChange).not.toHaveBeenCalled();
   });
 
-  it("does not treat mounting as an edit", () => {
+  it("opening a dashboard does not write its layout", () => {
+    // Pinned as an end-to-end guarantee rather than a test of one guard: today
+    // the grid does not report a change on mount at this width, and the
+    // definition comparison in the handler covers the widths where it does.
+    // Either way, viewing a dashboard must never bump its updated_at — so if a
+    // future grid release starts emitting here, this fails.
     const onLayoutChange = render(withKpi(), true);
     expect(onLayoutChange).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Canvas behaviour that only shows up in a render.
+ *
+ * The load-bearing one is the read-only case: arranging a dashboard is
+ * authoring, so a viewer without DAC write must get a static grid and no
+ * authoring affordances at all — not a disabled-looking one that still emits
+ * layout changes.
+ */
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/__tests__/helpers/render";
+import type { WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
+import {
+  addWidget,
+  type DashboardDefinition,
+  EMPTY_DEFINITION,
+  readConfig,
+} from "@/lib/widgets/definition";
+
+import { DashboardCanvas } from "./DashboardCanvas";
+
+const catalog = {
+  widgets: [
+    {
+      type: "kpi",
+      min_w: 2,
+      min_h: 2,
+      default_w: 3,
+      default_h: 2,
+      sources: ["counter"],
+      options: [],
+    },
+  ],
+  presets: [],
+} as unknown as WidgetCatalog;
+
+const withKpi = (): DashboardDefinition => addWidget(EMPTY_DEFINITION, catalog, "kpi", "counter");
+
+const render = (definition: DashboardDefinition, canEdit: boolean, onLayoutChange = vi.fn()) => {
+  renderWithProviders(
+    <DashboardCanvas
+      definition={definition}
+      config={readConfig({})}
+      catalog={catalog}
+      canEdit={canEdit}
+      onLayoutChange={onLayoutChange}
+    />
+  );
+  return onLayoutChange;
+};
+
+describe("DashboardCanvas", () => {
+  it("invites the author to add a widget when the canvas is empty", () => {
+    render(EMPTY_DEFINITION, true);
+    expect(screen.getByText("This dashboard has no widgets yet.")).toBeInTheDocument();
+    expect(screen.getByText("Add a widget to start showing your data.")).toBeInTheDocument();
+  });
+
+  it("tells a viewer without write access who can fill it instead", () => {
+    render(EMPTY_DEFINITION, false);
+    expect(screen.getByText("Someone with edit access can add widgets to it.")).toBeInTheDocument();
+  });
+
+  it("offers no authoring affordances without write access", () => {
+    render(withKpi(), false);
+    // The per-widget menu is the entry point to configure and remove; without
+    // write there is nothing to open.
+    expect(screen.queryByRole("button", { name: /options for/i })).toBeNull();
+  });
+
+  it("offers the widget menu with write access", () => {
+    render(withKpi(), true);
+    expect(screen.getByRole("button", { name: /options for/i })).toBeInTheDocument();
+  });
+
+  it("never reports a layout change for a read-only canvas", () => {
+    const onLayoutChange = render(withKpi(), false);
+    // Mount alone fires RGL's onLayoutChange; a static canvas must swallow it
+    // rather than write the dashboard's row on someone else's behalf.
+    expect(onLayoutChange).not.toHaveBeenCalled();
+  });
+
+  it("does not treat mounting as an edit", () => {
+    const onLayoutChange = render(withKpi(), true);
+    expect(onLayoutChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
@@ -16,7 +16,6 @@ import {
   type Layout,
   type LayoutItem,
   ResponsiveGridLayout,
-  type ResponsiveLayouts,
   useContainerWidth,
   verticalCompactor,
 } from "react-grid-layout";
@@ -44,10 +43,20 @@ import "react-grid-layout/css/styles.css";
 const ROW_HEIGHT = 56;
 const MARGIN: [number, number] = [12, 12];
 
-/** One column below `md`, so a phone reads the canvas top to bottom in layout
- *  order instead of squeezing a Gantt into a quarter of the screen. */
-const BREAKPOINTS = { lg: 1024, md: 768, xs: 0 };
-const COLS = { lg: GRID_COLUMNS, md: GRID_COLUMNS, xs: 1 };
+/**
+ * Two breakpoints, because there are only two *kinds* of layout: the authored
+ * one and the derived stack. A third that also held 12 columns would be a
+ * second place the same arrangement lives, and telling them apart in the
+ * change callback is exactly where that goes wrong.
+ *
+ * Below the threshold a phone reads the canvas top to bottom in layout order
+ * rather than squeezing a Gantt into a quarter of the screen.
+ */
+const STACKED = "xs";
+const AUTHORED = "lg";
+const STACK_BELOW = 768;
+const BREAKPOINTS = { [AUTHORED]: STACK_BELOW, [STACKED]: 0 };
+const COLS = { [AUTHORED]: GRID_COLUMNS, [STACKED]: 1 };
 
 export interface DashboardCanvasProps {
   definition: DashboardDefinition;
@@ -72,6 +81,12 @@ export function DashboardCanvas({
   const { t } = useTranslation("dashboards");
   const [dragging, setDragging] = useState(false);
   const { width, mounted, containerRef } = useContainerWidth();
+
+  // Whether the user is looking at the authored layout or the derived stack.
+  // Derived from the measured width rather than tracked separately, because
+  // that is the same number the grid picks its own breakpoint from — so the
+  // two can never disagree, including before the first measurement lands.
+  const authoring = width >= STACK_BELOW;
 
   // RGL fires onLayoutChange on mount as well as on every settle. Comparing
   // against the definition we are *currently rendering* is what tells the two
@@ -101,15 +116,18 @@ export function DashboardCanvas({
       h: widget.grid.h,
       static: true,
     }));
-    return { lg: items, md: items, xs: stacked };
+    return { [AUTHORED]: items, [STACKED]: stacked };
   }, [definition.widgets, catalog, canEdit]);
 
-  const handleLayoutChange = (current: Layout, all: ResponsiveLayouts<string>) => {
+  const handleLayoutChange = (current: Layout) => {
     if (!canEdit) return;
-    // Only the authored breakpoints write back; the stacked one is derived, so
-    // reading it back would flatten everyone's layout to one column.
-    const source = all.lg ?? current;
-    const next = applyLayout(definition, catalog, [...source]);
+    // The stacked layout is derived, not authored — writing it back would
+    // flatten everyone's arrangement to one column. `current` is whichever
+    // breakpoint the user is actually on, so it is the only correct source:
+    // reading a named breakpoint out of `all` would take a stale copy of the
+    // one they are not editing.
+    if (!authoring) return;
+    const next = applyLayout(definition, catalog, [...current]);
     if (JSON.stringify(next.widgets.map((widget) => widget.grid)) === placed) return;
     onLayoutChange(next);
   };

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
@@ -1,0 +1,169 @@
+/**
+ * The canvas — many widgets, freely arranged.
+ *
+ * A 12-column grid where each widget carries its own `{x, y, w, h}`. Layout is
+ * part of the definition, so arranging a dashboard is *authoring*: it writes the
+ * dashboard's own row and takes DAC write, which is why a viewer without it gets
+ * a static grid rather than a disabled-looking one.
+ *
+ * Below the grid's breakpoint the canvas stacks into a single column, view-only.
+ * Drag and resize are desktop authoring affordances; fighting a touch target for
+ * them would trade a real interaction for a fiddly one.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  type Layout,
+  type LayoutItem,
+  ResponsiveGridLayout,
+  type ResponsiveLayouts,
+  useContainerWidth,
+  verticalCompactor,
+} from "react-grid-layout";
+import { useTranslation } from "react-i18next";
+
+import type { WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
+import { cn } from "@/lib/utils";
+import {
+  applyLayout,
+  catalogEntry,
+  type DashboardConfig,
+  type DashboardDefinition,
+  effectiveBinding,
+  GRID_COLUMNS,
+} from "@/lib/widgets/definition";
+
+import { DashboardWidget } from "./DashboardWidget";
+
+// v2 folds the resize-handle styles into its own stylesheet; the separate
+// react-resizable CSS the v1 docs pair this with no longer exists.
+import "react-grid-layout/css/styles.css";
+
+// v2 replaced the WidthProvider HOC with a hook, so the measured element is
+// ours and the grid is told the width explicitly.
+const ROW_HEIGHT = 56;
+const MARGIN: [number, number] = [12, 12];
+
+/** One column below `md`, so a phone reads the canvas top to bottom in layout
+ *  order instead of squeezing a Gantt into a quarter of the screen. */
+const BREAKPOINTS = { lg: 1024, md: 768, xs: 0 };
+const COLS = { lg: GRID_COLUMNS, md: GRID_COLUMNS, xs: 1 };
+
+export interface DashboardCanvasProps {
+  definition: DashboardDefinition;
+  config: DashboardConfig;
+  catalog: WidgetCatalog | undefined;
+  /** DAC write on this dashboard. Arranging is authoring. */
+  canEdit: boolean;
+  onLayoutChange: (next: DashboardDefinition) => void;
+  onConfigureWidget?: (widgetId: string) => void;
+  onRemoveWidget?: (widgetId: string) => void;
+}
+
+export function DashboardCanvas({
+  definition,
+  config,
+  catalog,
+  canEdit,
+  onLayoutChange,
+  onConfigureWidget,
+  onRemoveWidget,
+}: DashboardCanvasProps) {
+  const { t } = useTranslation("dashboards");
+  const [dragging, setDragging] = useState(false);
+  const { width, mounted, containerRef } = useContainerWidth();
+
+  // RGL fires onLayoutChange on mount as well as on every settle. Comparing
+  // against the definition we are *currently rendering* is what tells the two
+  // apart: opening a dashboard you can edit must not write its row.
+  const placed = JSON.stringify(definition.widgets.map((widget) => widget.grid));
+
+  const layouts = useMemo(() => {
+    const items: LayoutItem[] = definition.widgets.map((widget) => {
+      const entry = catalogEntry(catalog, widget.type);
+      return {
+        i: widget.id,
+        x: widget.grid.x,
+        y: widget.grid.y,
+        w: widget.grid.w,
+        h: widget.grid.h,
+        minW: entry?.min_w ?? 1,
+        minH: entry?.min_h ?? 1,
+        static: !canEdit,
+      };
+    });
+    // The stacked breakpoint is derived, not authored: full width, in order.
+    const stacked: LayoutItem[] = definition.widgets.map((widget, index) => ({
+      i: widget.id,
+      x: 0,
+      y: index,
+      w: 1,
+      h: widget.grid.h,
+      static: true,
+    }));
+    return { lg: items, md: items, xs: stacked };
+  }, [definition.widgets, catalog, canEdit]);
+
+  const handleLayoutChange = (current: Layout, all: ResponsiveLayouts<string>) => {
+    if (!canEdit) return;
+    // Only the authored breakpoints write back; the stacked one is derived, so
+    // reading it back would flatten everyone's layout to one column.
+    const source = all.lg ?? current;
+    const next = applyLayout(definition, catalog, [...source]);
+    if (JSON.stringify(next.widgets.map((widget) => widget.grid)) === placed) return;
+    onLayoutChange(next);
+  };
+
+  if (!definition.widgets.length) {
+    return (
+      <div ref={containerRef} className="rounded-lg border border-dashed p-10 text-center">
+        <p className="font-medium text-sm">{t("canvas.empty")}</p>
+        <p className="mt-1 text-muted-foreground text-sm">
+          {canEdit ? t("canvas.emptyHint") : t("canvas.emptyReadOnly")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="w-full">
+      {/* Nothing is placed until the container has a width, or every widget
+          would mount at the fallback size and then jump. */}
+      {mounted && (
+        <ResponsiveGridLayout
+          width={width}
+          className={cn("-m-3", dragging && "select-none")}
+          layouts={layouts}
+          breakpoints={BREAKPOINTS}
+          cols={COLS}
+          rowHeight={ROW_HEIGHT}
+          margin={MARGIN}
+          containerPadding={MARGIN}
+          // v2 groups these; the handle selector is what keeps a widget's own
+          // content from becoming a drag surface.
+          dragConfig={{ enabled: canEdit, handle: "[data-widget-handle]" }}
+          resizeConfig={{ enabled: canEdit }}
+          onDragStart={() => setDragging(true)}
+          onDragStop={() => setDragging(false)}
+          onResizeStart={() => setDragging(true)}
+          onResizeStop={() => setDragging(false)}
+          onLayoutChange={handleLayoutChange}
+          // Widgets settle upward into free space and never overlap.
+          compactor={verticalCompactor}
+        >
+          {definition.widgets.map((widget) => (
+            <div key={widget.id}>
+              <DashboardWidget
+                widget={widget}
+                binding={effectiveBinding(widget, config)}
+                canEdit={canEdit}
+                onConfigure={onConfigureWidget}
+                onRemove={onRemoveWidget}
+              />
+            </div>
+          ))}
+        </ResponsiveGridLayout>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
@@ -1,0 +1,126 @@
+/**
+ * One placed widget: its data, its chrome, and its authoring affordances.
+ *
+ * Sits between the canvas (which owns position) and `WidgetTile` (which owns
+ * running the widget and drawing its scene). Everything visible here is app
+ * code — the drag handle, the menu, the unbound state — because a widget draws
+ * only inside its box and must never be able to render something that looks
+ * like the frame around it.
+ */
+
+import { GripVertical, MoreVertical, Settings2, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { WidgetTile } from "@/components/initiativeTools/dashboards/WidgetTile";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useWidgetData, type WidgetBinding } from "@/hooks/useWidgetData";
+import { useWidgetMeta } from "@/hooks/useWidgetMeta";
+import { cn } from "@/lib/utils";
+import { type DefinitionWidget, unboundSlots } from "@/lib/widgets/definition";
+
+export interface DashboardWidgetProps {
+  widget: DefinitionWidget;
+  binding: WidgetBinding;
+  canEdit: boolean;
+  onConfigure?: (widgetId: string) => void;
+  onRemove?: (widgetId: string) => void;
+}
+
+export function DashboardWidget({
+  widget,
+  binding,
+  canEdit,
+  onConfigure,
+  onRemove,
+}: DashboardWidgetProps) {
+  const { t } = useTranslation("dashboards");
+  const { name } = useWidgetMeta(widget.type);
+  const { data, isLoading, isUnbound } = useWidgetData(binding);
+
+  const title = widget.title || name;
+  const missing = unboundSlots(binding);
+
+  return (
+    <section
+      className="flex h-full w-full flex-col overflow-hidden rounded-lg border bg-card"
+      aria-label={title}
+    >
+      <header
+        className={cn(
+          "flex shrink-0 items-center gap-1 border-b px-2 py-1.5",
+          canEdit && "cursor-grab active:cursor-grabbing"
+        )}
+        // The whole header is the drag handle, so a widget's own content never
+        // becomes one — RGL is told to grab only on this attribute.
+        {...(canEdit ? { "data-widget-handle": true } : {})}
+      >
+        {canEdit && (
+          <GripVertical className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        )}
+        <h3 className="min-w-0 flex-1 truncate font-medium text-sm">{title}</h3>
+        {canEdit && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-6 w-6 shrink-0"
+                aria-label={t("canvas.widgetMenu", { widget: title })}
+                // Stops a click on the menu from starting a drag.
+                onPointerDown={(event) => event.stopPropagation()}
+              >
+                <MoreVertical className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => onConfigure?.(widget.id)}>
+                <Settings2 className="mr-2 h-4 w-4" />
+                {t("canvas.configure")}
+              </DropdownMenuItem>
+              <DropdownMenuItem className="text-destructive" onSelect={() => onRemove?.(widget.id)}>
+                <Trash2 className="mr-2 h-4 w-4" />
+                {t("canvas.remove")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </header>
+
+      <div className="min-h-0 flex-1 p-2">
+        {isUnbound && missing.length ? (
+          <UnboundNotice canEdit={canEdit} onConfigure={() => onConfigure?.(widget.id)} />
+        ) : (
+          <WidgetTile
+            type={widget.type}
+            data={data}
+            config={widget.options}
+            isLoading={isLoading}
+            chromeless
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+/** A widget whose binding still has empty slots — an installed listing before
+ *  someone points it at this guild's counter. Not an error, a next step. */
+function UnboundNotice({ canEdit, onConfigure }: { canEdit: boolean; onConfigure: () => void }) {
+  const { t } = useTranslation("dashboards");
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-3 text-center">
+      <p className="text-muted-foreground text-sm">{t("canvas.unbound")}</p>
+      {canEdit && (
+        <Button size="sm" variant="outline" onClick={onConfigure}>
+          {t("canvas.configure")}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/initiativeTools/dashboards/WidgetConfigDialog.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/WidgetConfigDialog.tsx
@@ -1,0 +1,355 @@
+/**
+ * "What does this widget hook up to?"
+ *
+ * Setting up a widget's binding is *authoring* — it writes the dashboard's own
+ * row and takes DAC write — as distinct from a widget interacting with the data
+ * it shows, which nothing here can do. Every control below chooses a source or
+ * an id; none of them can name an endpoint, and the source list comes from the
+ * served catalog, so this dialog can only ever offer what the backend validator
+ * would accept.
+ */
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useCalendarsList } from "@/hooks/useCalendars";
+import { useCounterGroup, useCounterGroupsList } from "@/hooks/useCounters";
+import { useDocumentsList } from "@/hooks/useDocuments";
+import { useProjects } from "@/hooks/useProjects";
+import type { WidgetBinding } from "@/hooks/useWidgetData";
+import { useWidgetMeta } from "@/hooks/useWidgetMeta";
+import { catalogEntry, type DefinitionWidget } from "@/lib/widgets/definition";
+import { localized } from "@/lib/widgets/widgetMeta";
+
+export interface WidgetConfigDialogProps {
+  widget: DefinitionWidget | null;
+  catalog: WidgetCatalog | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (patch: Partial<DefinitionWidget>) => void;
+}
+
+/** Count buckets the `task_counts` source understands. Only `day` has a
+ *  calendar shape, which is what a heatmap needs. */
+const BUCKETS = ["status_category", "status", "priority", "project", "assignee", "day"] as const;
+
+export function WidgetConfigDialog({
+  widget,
+  catalog,
+  open,
+  onOpenChange,
+  onSave,
+}: WidgetConfigDialogProps) {
+  const { t } = useTranslation(["dashboards", "common"]);
+  const { meta } = useWidgetMeta(widget?.type ?? "");
+  const { i18n } = useTranslation();
+
+  const [title, setTitle] = useState("");
+  const [binding, setBinding] = useState<WidgetBinding>({ source: "tasks" });
+  const [options, setOptions] = useState<Record<string, string>>({});
+
+  // Reset from the widget each time the dialog opens, so a cancelled edit
+  // leaves nothing behind.
+  useEffect(() => {
+    if (!widget || !open) return;
+    setTitle(widget.title ?? "");
+    setBinding(widget.binding);
+    setOptions(widget.options ?? {});
+  }, [widget, open]);
+
+  const entry = catalogEntry(catalog, widget?.type ?? "");
+  const sources = entry?.sources ?? [];
+  const source = binding.source;
+
+  const needsCounterGroup = source === "counter" || source === "counter_group";
+  const needsDocument = source === "sheet_range";
+
+  const counterGroups = useCounterGroupsList({}, { enabled: open && needsCounterGroup });
+  const documents = useDocumentsList(
+    { document_type: "spreadsheet" },
+    { enabled: open && needsDocument }
+  );
+  const projects = useProjects(undefined, { enabled: open && source === "tasks" });
+  const calendars = useCalendarsList(undefined, {
+    enabled: open && source === "calendar_entries",
+  });
+
+  // The list endpoint returns group summaries; the counters themselves come
+  // from the group's own read, which is also the query the widget will use.
+  const selectedGroup = useCounterGroup(binding.counter_group_id ?? null, {
+    enabled: open && source === "counter" && Boolean(binding.counter_group_id),
+  });
+
+  const setBindingValue = (patch: Partial<WidgetBinding>) =>
+    setBinding((current) => ({ ...current, ...patch }));
+
+  const save = () => {
+    onSave({
+      title: title.trim() || undefined,
+      binding,
+      options: Object.keys(options).length ? options : undefined,
+    });
+    onOpenChange(false);
+  };
+
+  if (!widget) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("dashboards:config.title")}</DialogTitle>
+          <DialogDescription>
+            {localized(meta?.description, i18n.language) ?? t("dashboards:config.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="widget-title">{t("dashboards:config.widgetTitle")}</Label>
+            <Input
+              id="widget-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder={t("dashboards:config.widgetTitlePlaceholder")}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t("dashboards:config.source")}</Label>
+            <Select
+              value={source}
+              onValueChange={(next) =>
+                // Changing the source drops the old source's ids rather than
+                // carrying a counter id onto a document binding.
+                setBinding({ source: next as WidgetBinding["source"] })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {sources.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {t(`dashboards:bindingSource.${option}` as const)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {needsCounterGroup && (
+            <div className="space-y-2">
+              <Label>{t("dashboards:bindingSource.counter_group")}</Label>
+              <Select
+                value={binding.counter_group_id ? String(binding.counter_group_id) : ""}
+                onValueChange={(next) =>
+                  setBindingValue({ counter_group_id: Number(next), counter_id: null })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t("dashboards:config.choose")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {(counterGroups.data?.items ?? []).map((group) => (
+                    <SelectItem key={group.id} value={String(group.id)}>
+                      {group.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {source === "counter" && selectedGroup.data && (
+            <div className="space-y-2">
+              <Label>{t("dashboards:bindingSource.counter")}</Label>
+              <Select
+                value={binding.counter_id ? String(binding.counter_id) : ""}
+                onValueChange={(next) => setBindingValue({ counter_id: Number(next) })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t("dashboards:config.choose")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {(selectedGroup.data.counters ?? []).map((counter) => (
+                    <SelectItem key={counter.id} value={String(counter.id)}>
+                      {counter.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {needsDocument && (
+            <>
+              <div className="space-y-2">
+                <Label>{t("dashboards:config.spreadsheet")}</Label>
+                <Select
+                  value={binding.document_id ? String(binding.document_id) : ""}
+                  onValueChange={(next) => setBindingValue({ document_id: Number(next) })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("dashboards:config.choose")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(documents.data?.items ?? []).map((document) => (
+                      <SelectItem key={document.id} value={String(document.id)}>
+                        {document.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="sheet-name">{t("dashboards:config.sheet")}</Label>
+                  <Input
+                    id="sheet-name"
+                    value={binding.sheet ?? ""}
+                    onChange={(event) => setBindingValue({ sheet: event.target.value })}
+                    placeholder={t("dashboards:config.sheetPlaceholder")}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="sheet-range">{t("dashboards:config.range")}</Label>
+                  <Input
+                    id="sheet-range"
+                    value={binding.range ?? ""}
+                    onChange={(event) => setBindingValue({ range: event.target.value })}
+                    placeholder="A1:B10"
+                  />
+                </div>
+              </div>
+            </>
+          )}
+
+          {source === "tasks" && (
+            <div className="space-y-2">
+              <Label>{t("dashboards:config.project")}</Label>
+              <Select
+                value={binding.project_id ? String(binding.project_id) : "all"}
+                onValueChange={(next) =>
+                  setBindingValue({ project_id: next === "all" ? null : Number(next) })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("dashboards:config.allProjects")}</SelectItem>
+                  {(projects.data?.items ?? []).map((project) => (
+                    <SelectItem key={project.id} value={String(project.id)}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {source === "calendar_entries" && (
+            <div className="space-y-2">
+              <Label>{t("dashboards:bindingSource.calendar_entries")}</Label>
+              <Select
+                value={binding.calendar_id ? String(binding.calendar_id) : "all"}
+                onValueChange={(next) =>
+                  setBindingValue({ calendar_id: next === "all" ? null : Number(next) })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("dashboards:config.allCalendars")}</SelectItem>
+                  {(calendars.data?.items ?? []).map((calendar) => (
+                    <SelectItem key={calendar.id} value={String(calendar.id)}>
+                      {calendar.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {source === "task_counts" && (
+            <div className="space-y-2">
+              <Label>{t("dashboards:config.groupBy")}</Label>
+              <Select
+                value={binding.bucket ?? "status_category"}
+                onValueChange={(next) =>
+                  setBindingValue({ bucket: next as WidgetBinding["bucket"] })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {BUCKETS.map((bucket) => (
+                    <SelectItem key={bucket} value={bucket}>
+                      {t(`dashboards:config.bucket.${bucket}` as const)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Display options, labelled by the widget itself. */}
+          {(entry?.options ?? []).map((option) => (
+            <div key={option.key} className="space-y-2">
+              <Label>
+                {localized(meta?.options?.[option.key]?.label, i18n.language) ?? option.key}
+              </Label>
+              <Select
+                value={options[option.key] ?? option.values[0]}
+                onValueChange={(next) =>
+                  setOptions((current) => ({ ...current, [option.key]: next }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {option.values.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {localized(meta?.options?.[option.key]?.values?.[value], i18n.language) ??
+                        value}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("common:cancel")}
+          </Button>
+          <Button onClick={save}>{t("common:save")}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
@@ -30,11 +30,26 @@ export interface WidgetTileProps {
   /** Overrides the registry lookup. This is the seam a marketplace listing's
    *  own widget module arrives through; it runs the same way ours does. */
   source?: string;
+  /** The binding's own fetch is still in flight. Shown as the same skeleton the
+   *  sandbox call uses, so a widget does not flash empty then populate. */
+  isLoading?: boolean;
+  /** Drop the border and title — the canvas frames its own widgets, and two
+   *  nested frames read as a bug. The scene still cannot escape its box. */
+  chromeless?: boolean;
 }
 
 type State = { status: "loading" } | { status: "done"; outcome: WidgetRenderOutcome };
 
-export function WidgetTile({ type, title, data, config, className, source }: WidgetTileProps) {
+export function WidgetTile({
+  type,
+  title,
+  data,
+  config,
+  className,
+  source,
+  isLoading,
+  chromeless,
+}: WidgetTileProps) {
   const [state, setState] = useState<State>({ status: "loading" });
 
   useEffect(() => {
@@ -59,6 +74,21 @@ export function WidgetTile({ type, title, data, config, className, source }: Wid
     };
   }, [type, data, config, source]);
 
+  const body =
+    isLoading || state.status === "loading" ? (
+      <Skeleton className="h-full w-full" />
+    ) : state.outcome.ok ? (
+      <SceneRenderer node={state.outcome.spec.scene} />
+    ) : (
+      <WidgetError code={state.outcome.code} detail={state.outcome.detail} />
+    );
+
+  if (chromeless) {
+    // No label here: the canvas's own <section> already names this region, and
+    // a second label on a plain div would only add noise for a screen reader.
+    return <div className={cn("h-full w-full", className)}>{body}</div>;
+  }
+
   return (
     <section
       className={cn(
@@ -68,15 +98,7 @@ export function WidgetTile({ type, title, data, config, className, source }: Wid
       aria-label={title ?? type}
     >
       {title && <h3 className="mb-2 shrink-0 truncate font-medium text-sm">{title}</h3>}
-      <div className="min-h-0 flex-1">
-        {state.status === "loading" ? (
-          <Skeleton className="h-full w-full" />
-        ) : state.outcome.ok ? (
-          <SceneRenderer node={state.outcome.spec.scene} />
-        ) : (
-          <WidgetError code={state.outcome.code} detail={state.outcome.detail} />
-        )}
-      </div>
+      <div className="min-h-0 flex-1">{body}</div>
     </section>
   );
 }

--- a/frontend/src/hooks/useDashboardEditor.test.tsx
+++ b/frontend/src/hooks/useDashboardEditor.test.tsx
@@ -12,6 +12,11 @@
  * refetch). A fake that acknowledged saves without keeping them would make a
  * re-added widget byte-identical to an older save's payload, and the test would
  * then be measuring the fake rather than the hook.
+ *
+ * The other half is ordering. A save is a whole-definition PATCH, so two in
+ * flight can commit in either order and leave the older layout authoritative;
+ * the hook keeps one on the wire at a time, and the tests below hold it to
+ * that — including the unmount case, where waiting is not available.
  */
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -29,13 +34,16 @@ interface SavePayload {
 let server: DashboardDefinition = EMPTY_DEFINITION;
 const settlers: (() => void)[] = [];
 
-const mutate = vi.fn((body: unknown, options?: { onSuccess?: () => void }) => {
-  const { definition } = body as SavePayload;
-  settlers.push(() => {
-    server = definition;
-    options?.onSuccess?.();
-  });
-});
+const mutate = vi.fn(
+  (body: unknown, options?: { onSuccess?: () => void; onSettled?: () => void }) => {
+    const { definition } = body as SavePayload;
+    settlers.push(() => {
+      server = definition;
+      options?.onSuccess?.();
+      options?.onSettled?.();
+    });
+  }
+);
 
 vi.mock("@/hooks/useDashboards", () => ({
   useUpdateDashboard: () => ({ mutate, isPending: false }),
@@ -136,28 +144,72 @@ describe("useDashboardEditor", () => {
     expect(editor.widgets()).toHaveLength(2);
   });
 
-  it("ignores a stale response that lands after a newer edit", () => {
+  it("does not clear a draft the user has moved on from", () => {
+    // The overlapping-responses case this used to cover cannot happen any more
+    // — saves are serialized, so one client never has two in flight. What
+    // remains is the ordinary one: a response arrives, and by then the canvas
+    // has changed again.
+    const editor = setup();
+
+    editor.add();
+    editor.settle();
+    editor.add();
+
+    act(() => settlers[0]());
+    editor.refetch();
+
+    expect(editor.widgets()).toHaveLength(2);
+  });
+
+  it("keeps one save on the wire at a time", () => {
+    // Each save is a whole-definition PATCH. Two in flight can commit in either
+    // order and leave the older one authoritative, so a second save waits.
+    const editor = setup();
+
+    editor.add();
+    editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(1);
+
+    editor.add();
+    editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(1);
+
+    editor.add();
+    editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends what accumulated while a save was on the wire, once it lands", () => {
+    const editor = setup();
+
+    editor.add();
+    editor.settle();
+    editor.add();
+    editor.add();
+    editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(1);
+
+    act(() => settlers[0]());
+
+    // One follow-up carrying the latest arrangement, not one per edit.
+    expect(mutate).toHaveBeenCalledTimes(2);
+    expect((mutate.mock.calls[1][0] as SavePayload).definition.widgets).toHaveLength(3);
+  });
+
+  it("still sends a queued edit when the page is left mid-save", () => {
     const editor = setup();
 
     editor.add();
     editor.settle();
     editor.add();
     editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(1);
+
+    // Waiting is not an option here; losing the edit outright is worse than the
+    // ordering risk that waiting exists to avoid.
+    editor.unmount();
     expect(mutate).toHaveBeenCalledTimes(2);
-
-    // The newer save returns and correctly hands control back to the server.
-    act(() => settlers[1]());
-    editor.refetch();
-    expect(editor.widgets()).toHaveLength(2);
-
-    // The user carries on editing...
-    editor.add();
-    expect(editor.widgets()).toHaveLength(3);
-
-    // ...and the first save's response finally arrives. It belongs to an
-    // arrangement two edits ago and must not clear what is on screen now.
-    act(() => settlers[0]());
-    expect(editor.widgets()).toHaveLength(3);
+    expect((mutate.mock.calls[1][0] as SavePayload).definition.widgets).toHaveLength(2);
   });
 
   it("saves nothing without write access", () => {

--- a/frontend/src/hooks/useDashboardEditor.test.tsx
+++ b/frontend/src/hooks/useDashboardEditor.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Editing state, and specifically what happens to a draft while a save is in
+ * flight.
+ *
+ * Drags land faster than requests return, so "the save succeeded" and "the
+ * draft is still what we saved" are different questions. Conflating them loses
+ * whatever the user did in between — silently, since the canvas just snaps back
+ * to the server's older arrangement.
+ *
+ * The fake below *stores* what it is given and the test re-renders with the new
+ * dashboard, because that is what the real flow does (mutate → invalidate →
+ * refetch). A fake that acknowledged saves without keeping them would make a
+ * re-added widget byte-identical to an older save's payload, and the test would
+ * then be measuring the fake rather than the hook.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardRead, WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
+import { useDashboardEditor } from "@/hooks/useDashboardEditor";
+import { type DashboardDefinition, EMPTY_DEFINITION } from "@/lib/widgets/definition";
+
+interface SavePayload {
+  definition: DashboardDefinition;
+}
+
+/** Server-side state, plus a resolver per in-flight save so a test can land
+ *  them in whatever order it likes. */
+let server: DashboardDefinition = EMPTY_DEFINITION;
+const settlers: (() => void)[] = [];
+
+const mutate = vi.fn((body: unknown, options?: { onSuccess?: () => void }) => {
+  const { definition } = body as SavePayload;
+  settlers.push(() => {
+    server = definition;
+    options?.onSuccess?.();
+  });
+});
+
+vi.mock("@/hooks/useDashboards", () => ({
+  useUpdateDashboard: () => ({ mutate, isPending: false }),
+}));
+
+const catalog = {
+  widgets: [
+    {
+      type: "kpi",
+      min_w: 2,
+      min_h: 2,
+      default_w: 3,
+      default_h: 2,
+      sources: ["counter"],
+      options: [],
+    },
+  ],
+  presets: [],
+} as unknown as WidgetCatalog;
+
+const asDashboard = (definition: DashboardDefinition) =>
+  ({ id: 7, definition, config: { widgets: {} } }) as unknown as DashboardRead;
+
+const SAVE_DEBOUNCE_MS = 600;
+
+beforeEach(() => {
+  server = EMPTY_DEFINITION;
+  settlers.length = 0;
+  mutate.mockClear();
+  // No shouldAdvanceTime: the debounce is the thing under test, so only an
+  // explicit advance may fire it.
+  vi.useFakeTimers();
+});
+
+const setup = (canEdit = true) => {
+  const rendered = renderHook(({ dashboard }) => useDashboardEditor(dashboard, catalog, canEdit), {
+    initialProps: { dashboard: asDashboard(server) },
+  });
+  return {
+    ...rendered,
+    /** What a refetch after a successful save does. */
+    refetch: () => rendered.rerender({ dashboard: asDashboard(server) }),
+    settle: () => act(() => vi.advanceTimersByTime(SAVE_DEBOUNCE_MS)),
+    add: () => act(() => rendered.result.current.addWidget("kpi", "counter")),
+    widgets: () => rendered.result.current.definition.widgets,
+  };
+};
+
+describe("useDashboardEditor", () => {
+  it("debounces a burst of edits into one save", () => {
+    const editor = setup();
+
+    editor.add();
+    editor.add();
+    editor.add();
+    expect(mutate).not.toHaveBeenCalled();
+
+    editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(1);
+    // The last state wins, not the first.
+    expect((mutate.mock.calls[0][0] as SavePayload).definition.widgets).toHaveLength(3);
+  });
+
+  it("shows the edit immediately, before the save lands", () => {
+    const editor = setup();
+    editor.add();
+    expect(editor.widgets()).toHaveLength(1);
+  });
+
+  it("hands control back to the server once the draft matches what was saved", () => {
+    const editor = setup();
+    editor.add();
+    editor.settle();
+
+    act(() => settlers[0]());
+    editor.refetch();
+
+    // The draft is gone and the server's own copy is what renders — same
+    // arrangement, now authoritative.
+    expect(editor.widgets()).toHaveLength(1);
+  });
+
+  it("does not discard work done while a save was in flight", () => {
+    const editor = setup();
+
+    editor.add();
+    editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(1);
+
+    // A second edit before the first save returns.
+    editor.add();
+    expect(editor.widgets()).toHaveLength(2);
+
+    act(() => settlers[0]());
+    editor.refetch();
+
+    // The older save must not reset the canvas to its one-widget state.
+    expect(editor.widgets()).toHaveLength(2);
+  });
+
+  it("ignores a stale response that lands after a newer edit", () => {
+    const editor = setup();
+
+    editor.add();
+    editor.settle();
+    editor.add();
+    editor.settle();
+    expect(mutate).toHaveBeenCalledTimes(2);
+
+    // The newer save returns and correctly hands control back to the server.
+    act(() => settlers[1]());
+    editor.refetch();
+    expect(editor.widgets()).toHaveLength(2);
+
+    // The user carries on editing...
+    editor.add();
+    expect(editor.widgets()).toHaveLength(3);
+
+    // ...and the first save's response finally arrives. It belongs to an
+    // arrangement two edits ago and must not clear what is on screen now.
+    act(() => settlers[0]());
+    expect(editor.widgets()).toHaveLength(3);
+  });
+
+  it("saves nothing without write access", () => {
+    const editor = setup(false);
+    editor.add();
+    editor.settle();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("flushes a pending edit rather than losing it on unmount", () => {
+    const editor = setup();
+    editor.add();
+    expect(mutate).not.toHaveBeenCalled();
+
+    editor.unmount();
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not save on an ordinary re-render", () => {
+    // The unmount-flush effect must not re-run on every render: its cleanup
+    // would fire mid-edit and turn the debounce into a save per drag frame.
+    const editor = setup();
+    editor.add();
+    editor.refetch();
+    editor.refetch();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("ignores a layout that did not actually change", () => {
+    const editor = setup();
+    act(() => editor.result.current.replaceDefinition(editor.result.current.definition));
+    editor.settle();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useDashboardEditor.ts
+++ b/frontend/src/hooks/useDashboardEditor.ts
@@ -62,6 +62,7 @@ export function useDashboardEditor(
     const next = pending.current;
     pending.current = null;
     if (!next || !dashboardId) return;
+    const saved = JSON.stringify(next);
     update.mutate(
       {
         // The API types these JSON columns as open records; the shapes they
@@ -70,12 +71,19 @@ export function useDashboardEditor(
         config: pruneConfig(next, config) as unknown as Record<string, unknown>,
       },
       {
-        // The server's normalization is the truth; dropping the draft lets its
-        // response through rather than keeping a stale local copy on screen.
-        onSuccess: () => setDraft(null),
+        onSuccess: () => {
+          // Hand control back to the server's copy only if the draft is still
+          // what we just saved. Drags land faster than requests return, so an
+          // unconditional reset would drop whatever the user did while this
+          // was in flight — and an out-of-order response would drop it even
+          // after a newer save had already succeeded.
+          setDraft((current) =>
+            current !== null && JSON.stringify(current) === saved ? null : current
+          );
+        },
       }
     );
-  }, [dashboardId, config, update]);
+  }, [dashboardId, config, update.mutate]);
 
   const save = useCallback(
     (next: DashboardDefinition) => {
@@ -87,13 +95,19 @@ export function useDashboardEditor(
     [canEdit, flush]
   );
 
-  // A pending edit must not be lost to a navigation.
+  // A pending edit must not be lost to a navigation. Held through a ref and
+  // depended on nothing: with `flush` in the dependency list this effect
+  // re-runs whenever its identity changes, and *its cleanup* then flushes on
+  // an ordinary re-render — which silently turned the debounce into a save per
+  // keystroke and per drag frame.
+  const flushRef = useRef(flush);
+  flushRef.current = flush;
   useEffect(
     () => () => {
       if (timer.current) clearTimeout(timer.current);
-      if (pending.current) flush();
+      if (pending.current) flushRef.current();
     },
-    [flush]
+    []
   );
 
   const apply = useCallback(

--- a/frontend/src/hooks/useDashboardEditor.ts
+++ b/frontend/src/hooks/useDashboardEditor.ts
@@ -51,6 +51,7 @@ export function useDashboardEditor(
   const [draft, setDraft] = useState<DashboardDefinition | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pending = useRef<DashboardDefinition | null>(null);
+  const inFlight = useRef(false);
 
   const stored = useMemo(() => readDefinition(dashboard?.definition), [dashboard?.definition]);
   const config = useMemo(() => readConfig(dashboard?.config), [dashboard?.config]);
@@ -58,54 +59,84 @@ export function useDashboardEditor(
 
   const dashboardId = dashboard?.id;
 
-  const flush = useCallback(() => {
-    const next = pending.current;
-    pending.current = null;
-    if (!next || !dashboardId) return;
-    const saved = JSON.stringify(next);
-    update.mutate(
-      {
-        // The API types these JSON columns as open records; the shapes they
-        // actually hold are `definition.ts`'s, and the server re-validates.
-        definition: next as unknown as Record<string, unknown>,
-        config: pruneConfig(next, config) as unknown as Record<string, unknown>,
-      },
-      {
-        onSuccess: () => {
-          // Hand control back to the server's copy only if the draft is still
-          // what we just saved. Drags land faster than requests return, so an
-          // unconditional reset would drop whatever the user did while this
-          // was in flight — and an out-of-order response would drop it even
-          // after a newer save had already succeeded.
-          setDraft((current) =>
-            current !== null && JSON.stringify(current) === saved ? null : current
-          );
+  // Declared before `flush` because `flush` re-enters through it (a queued save
+  // fires from the previous one's settle) and because the unmount effect below
+  // must not depend on `flush`'s identity.
+  const flushRef = useRef<(force?: boolean) => void>(() => {});
+
+  /**
+   * Send the pending definition, at most one request at a time.
+   *
+   * Each save is a whole-definition PATCH, so two in flight together can commit
+   * in either order and leave the *older* one authoritative — the layout the
+   * user last arranged, silently replaced on the next refetch. The API carries
+   * no revision to check, and the design accepts last-write-wins between
+   * different editors; what it must not do is let one editor race itself. So a
+   * save waits for the one before it, and whatever accumulated meanwhile goes
+   * next, in order.
+   *
+   * `force` is for unmount, where waiting is not an option: sending a queued
+   * edit risks the ordering we otherwise avoid, but not sending it loses that
+   * edit outright.
+   */
+  const flush = useCallback(
+    (force = false) => {
+      if (inFlight.current && !force) return;
+      const next = pending.current;
+      pending.current = null;
+      if (!next || !dashboardId) return;
+
+      const saved = JSON.stringify(next);
+      inFlight.current = true;
+      update.mutate(
+        {
+          // The API types these JSON columns as open records; the shapes they
+          // actually hold are `definition.ts`'s, and the server re-validates.
+          definition: next as unknown as Record<string, unknown>,
+          config: pruneConfig(next, config) as unknown as Record<string, unknown>,
         },
-      }
-    );
-  }, [dashboardId, config, update.mutate]);
+        {
+          onSuccess: () => {
+            // Hand control back to the server's copy only if the draft is still
+            // what we just saved. Drags land faster than requests return, so an
+            // unconditional reset would drop whatever the user did while this
+            // was in flight.
+            setDraft((current) =>
+              current !== null && JSON.stringify(current) === saved ? null : current
+            );
+          },
+          onSettled: () => {
+            inFlight.current = false;
+            // Anything queued while this was on the wire goes now, so the last
+            // arrangement the user made is the last one the server sees.
+            if (pending.current) flushRef.current();
+          },
+        }
+      );
+    },
+    [dashboardId, config, update.mutate]
+  );
 
   const save = useCallback(
     (next: DashboardDefinition) => {
       if (!canEdit) return;
       pending.current = next;
       if (timer.current) clearTimeout(timer.current);
-      timer.current = setTimeout(flush, SAVE_DEBOUNCE_MS);
+      timer.current = setTimeout(() => flush(), SAVE_DEBOUNCE_MS);
     },
     [canEdit, flush]
   );
 
-  // A pending edit must not be lost to a navigation. Held through a ref and
-  // depended on nothing: with `flush` in the dependency list this effect
-  // re-runs whenever its identity changes, and *its cleanup* then flushes on
-  // an ordinary re-render — which silently turned the debounce into a save per
-  // keystroke and per drag frame.
-  const flushRef = useRef(flush);
   flushRef.current = flush;
+
+  // A pending edit must not be lost to a navigation. This effect depends on
+  // nothing: with `flush` in the dependency list it re-runs whenever that
+  // identity changes, and *its cleanup* then flushes on an ordinary re-render —
+  // which silently turned the debounce into a save per drag frame.
   useEffect(
     () => () => {
       if (timer.current) clearTimeout(timer.current);
-      if (pending.current) flushRef.current();
+      if (pending.current) flushRef.current(true);
     },
     []
   );

--- a/frontend/src/hooks/useDashboardEditor.ts
+++ b/frontend/src/hooks/useDashboardEditor.ts
@@ -1,0 +1,134 @@
+/**
+ * Editing state for one dashboard's canvas.
+ *
+ * Holds the definition being edited locally and pushes it to the API on a
+ * debounce, because a drag fires a layout change on every settle and each one is
+ * a whole-definition PATCH. Local state is the source of truth while edits are
+ * in flight; the server's normalized response takes over once they land, which
+ * is what makes clamping and validation authoritative without the canvas
+ * flickering back mid-drag.
+ *
+ * No CRDT here on purpose: a dashboard layout is small and rarely co-edited, so
+ * last-write-wins on the row is the right cost — unlike documents.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { DashboardRead, WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
+import { useUpdateDashboard } from "@/hooks/useDashboards";
+import {
+  addWidget as addWidgetTo,
+  type DashboardDefinition,
+  type DefinitionWidget,
+  definitionsEqual,
+  pruneConfig,
+  readConfig,
+  readDefinition,
+  removeWidget as removeWidgetFrom,
+  updateWidget as updateWidgetIn,
+} from "@/lib/widgets/definition";
+
+/** Long enough that a drag settles into one request, short enough that the save
+ *  feels immediate. */
+const SAVE_DEBOUNCE_MS = 600;
+
+export interface DashboardEditor {
+  definition: DashboardDefinition;
+  config: ReturnType<typeof readConfig>;
+  isSaving: boolean;
+  addWidget: (typeOrPreset: string, source: string) => void;
+  removeWidget: (widgetId: string) => void;
+  updateWidget: (widgetId: string, patch: Partial<DefinitionWidget>) => void;
+  replaceDefinition: (next: DashboardDefinition) => void;
+}
+
+export function useDashboardEditor(
+  dashboard: DashboardRead | undefined,
+  catalog: WidgetCatalog | undefined,
+  canEdit: boolean
+): DashboardEditor {
+  const update = useUpdateDashboard(dashboard?.id ?? 0);
+  const [draft, setDraft] = useState<DashboardDefinition | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pending = useRef<DashboardDefinition | null>(null);
+
+  const stored = useMemo(() => readDefinition(dashboard?.definition), [dashboard?.definition]);
+  const config = useMemo(() => readConfig(dashboard?.config), [dashboard?.config]);
+  const definition = draft ?? stored;
+
+  const dashboardId = dashboard?.id;
+
+  const flush = useCallback(() => {
+    const next = pending.current;
+    pending.current = null;
+    if (!next || !dashboardId) return;
+    update.mutate(
+      {
+        // The API types these JSON columns as open records; the shapes they
+        // actually hold are `definition.ts`'s, and the server re-validates.
+        definition: next as unknown as Record<string, unknown>,
+        config: pruneConfig(next, config) as unknown as Record<string, unknown>,
+      },
+      {
+        // The server's normalization is the truth; dropping the draft lets its
+        // response through rather than keeping a stale local copy on screen.
+        onSuccess: () => setDraft(null),
+      }
+    );
+  }, [dashboardId, config, update]);
+
+  const save = useCallback(
+    (next: DashboardDefinition) => {
+      if (!canEdit) return;
+      pending.current = next;
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(flush, SAVE_DEBOUNCE_MS);
+    },
+    [canEdit, flush]
+  );
+
+  // A pending edit must not be lost to a navigation.
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+      if (pending.current) flush();
+    },
+    [flush]
+  );
+
+  const apply = useCallback(
+    (next: DashboardDefinition) => {
+      setDraft(next);
+      save(next);
+    },
+    [save]
+  );
+
+  return {
+    definition,
+    config,
+    isSaving: update.isPending,
+    addWidget: useCallback(
+      (typeOrPreset: string, source: string) =>
+        apply(addWidgetTo(definition, catalog, typeOrPreset, source)),
+      [apply, definition, catalog]
+    ),
+    removeWidget: useCallback(
+      (widgetId: string) => apply(removeWidgetFrom(definition, widgetId)),
+      [apply, definition]
+    ),
+    updateWidget: useCallback(
+      (widgetId: string, patch: Partial<DefinitionWidget>) =>
+        apply(updateWidgetIn(definition, widgetId, patch)),
+      [apply, definition]
+    ),
+    replaceDefinition: useCallback(
+      (next: DashboardDefinition) => {
+        // Layout callbacks fire constantly; only a real change is worth a save.
+        if (definitionsEqual(next, definition)) return;
+        apply(next);
+      },
+      [apply, definition]
+    ),
+  };
+}

--- a/frontend/src/hooks/useDashboards.ts
+++ b/frontend/src/hooks/useDashboards.ts
@@ -5,8 +5,10 @@ import {
   deleteDashboardApiV1GGuildIdDashboardsDashboardIdDelete,
   getListDashboardsApiV1GGuildIdDashboardsGetQueryKey,
   getReadDashboardApiV1GGuildIdDashboardsDashboardIdGetQueryKey,
+  getReadWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGetQueryKey,
   listDashboardsApiV1GGuildIdDashboardsGet,
   readDashboardApiV1GGuildIdDashboardsDashboardIdGet,
+  readWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGet,
   setDashboardGrantsApiV1GGuildIdDashboardsDashboardIdGrantsPut,
   updateDashboardApiV1GGuildIdDashboardsDashboardIdPatch,
 } from "@/api/generated/dashboards/dashboards";
@@ -17,6 +19,7 @@ import type {
   DashboardUpdate,
   ListDashboardsApiV1GGuildIdDashboardsGetParams,
   ResourceGrantSchema,
+  WidgetCatalog,
 } from "@/api/generated/initiativeAPI.schemas";
 import { invalidateAllDashboards, invalidateDashboard } from "@/api/query-keys";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
@@ -47,6 +50,25 @@ export const useDashboard = (dashboardId: number | null, options?: QueryOpts<Das
     queryFn: () => readDashboardApiV1GGuildIdDashboardsDashboardIdGet(guildId, dashboardId!),
     enabled: dashboardId !== null && Number.isFinite(dashboardId) && userEnabled,
     ...rest,
+  });
+};
+
+/**
+ * The widget vocabulary this build supports — size floors, bindable sources,
+ * and options per primitive, plus the named presets.
+ *
+ * Served rather than duplicated: the backend's ``WIDGET_SPECS`` is the authority
+ * on which widgets exist and what each may bind to, so the palette and the
+ * canvas read it from here instead of carrying a second copy. Static for the
+ * life of a deployment, hence the long stale time.
+ */
+export const useWidgetCatalog = (options?: QueryOpts<WidgetCatalog>) => {
+  const guildId = useActiveGuildId();
+  return useQuery<WidgetCatalog>({
+    queryKey: getReadWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGetQueryKey(guildId),
+    queryFn: () => readWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGet(guildId),
+    staleTime: Number.POSITIVE_INFINITY,
+    ...options,
   });
 };
 

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -1,0 +1,275 @@
+/**
+ * Resolve a widget's binding into the data envelope it renders from.
+ *
+ * The security shape of this file matters more than its size. A binding names a
+ * *source*, never an endpoint — and each source is fetched here through the same
+ * ordinary hook the rest of the app uses, so the request is the viewer's own and
+ * the six gates decide what comes back. A dashboard shared with someone who
+ * cannot read the bound counter therefore shows them an empty widget, not the
+ * author's data. Nothing a definition can say reaches a URL.
+ *
+ * Every source hook is called on every render with `enabled` gating rather than
+ * conditionally, because hooks must be unconditional. Disabled queries cost
+ * nothing, and the ones that do run share React Query's cache — two widgets
+ * bound to the same tasks issue one request between them, which is what keeps a
+ * dense canvas from becoming a request storm.
+ */
+
+import { useMemo } from "react";
+
+import type {
+  ListTasksApiV1GGuildIdTasksGetParams,
+  WidgetCatalog,
+} from "@/api/generated/initiativeAPI.schemas";
+import { useActiveGuildId } from "@/hooks/useActiveGuildId";
+import { useCalendarEntries } from "@/hooks/useCalendarEntries";
+import { useCalendarsList } from "@/hooks/useCalendars";
+import { useCounterGroup } from "@/hooks/useCounters";
+import { useDocument } from "@/hooks/useDocuments";
+import { useProjects } from "@/hooks/useProjects";
+import { useTasks } from "@/hooks/useTasks";
+import { useUserStats } from "@/hooks/useUserStats";
+import type { WidgetData, WidgetSource } from "@/lib/widgets/dataShapes";
+import {
+  type CountBucket,
+  countTasks,
+  countTasksByProject,
+  emptyDataFor,
+  normalizeCalendarEntries,
+  normalizeCounter,
+  normalizeCounterGroup,
+  normalizeMyStats,
+  normalizeProjects,
+  normalizeSheetRange,
+  normalizeTasks,
+} from "@/lib/widgets/normalize";
+
+/** A normalized definition binding. Everything past `source` is the fetcher's
+ *  to interpret — the backend deliberately does not re-declare these, so that
+ *  each parameter lives with the code that consumes it. */
+export interface WidgetBinding {
+  source: WidgetSource;
+  conditions?: unknown;
+  initiative_id?: number | null;
+  project_id?: number | null;
+  counter_group_id?: number | null;
+  counter_id?: number | null;
+  calendar_id?: number | null;
+  document_id?: number | null;
+  sheet?: string | null;
+  range?: string | null;
+  bucket?: CountBucket | null;
+  /** Days back from today for time-windowed sources. */
+  window_days?: number | null;
+}
+
+export interface WidgetDataResult {
+  data: WidgetData;
+  isLoading: boolean;
+  /** A binding whose ids the instance config has not filled in yet — the widget
+   *  renders its own empty state rather than an error. */
+  isUnbound: boolean;
+}
+
+const DAY = 86_400_000;
+const DEFAULT_WINDOW_DAYS = 90;
+
+/** Sources that need the task list. `task_counts` and the project progress
+ *  columns are derived from those same rows rather than fetched again. */
+const TASK_BACKED: WidgetSource[] = ["tasks", "task_counts", "projects"];
+
+export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
+  const guildId = useActiveGuildId();
+  const source = binding.source;
+
+  const taskParams = useMemo<ListTasksApiV1GGuildIdTasksGetParams>(() => {
+    const params: Record<string, unknown> = { page_size: 0 };
+    if (binding.project_id) params.project_id = binding.project_id;
+    if (binding.initiative_id) params.initiative_id = binding.initiative_id;
+    // The filter DSL passes through verbatim — the parser owns its own limits,
+    // and mirroring them here would mean maintaining them twice.
+    if (binding.conditions) params.conditions = JSON.stringify(binding.conditions);
+    return params as ListTasksApiV1GGuildIdTasksGetParams;
+  }, [binding.project_id, binding.initiative_id, binding.conditions]);
+
+  const window = useMemo(() => {
+    const days = binding.window_days ?? DEFAULT_WINDOW_DAYS;
+    const now = Date.now();
+    return {
+      start: new Date(now - days * DAY).toISOString(),
+      end: new Date(now + days * DAY).toISOString(),
+    };
+  }, [binding.window_days]);
+
+  const tasksQuery = useTasks(taskParams, {
+    enabled: TASK_BACKED.includes(source),
+  });
+  // The projects list has no initiative filter of its own; a binding scoped to
+  // one initiative narrows the rows after the fetch, which also keeps the query
+  // key shared with every other projects consumer.
+  const projectsQuery = useProjects(undefined, { enabled: source === "projects" });
+  const entriesQuery = useCalendarEntries(
+    {
+      start_after: window.start,
+      start_before: window.end,
+      include_events: true,
+      ...(binding.initiative_id ? { initiative_id: binding.initiative_id } : {}),
+    },
+    { enabled: source === "calendar_entries" }
+  );
+  const calendarsQuery = useCalendarsList(undefined, {
+    enabled: source === "calendar_entries",
+  });
+  const counterGroupQuery = useCounterGroup(binding.counter_group_id ?? null, {
+    enabled: source === "counter" || source === "counter_group",
+  });
+  const statsQuery = useUserStats(source === "my_stats" ? guildId : null);
+  const documentQuery = useDocument(
+    source === "sheet_range" ? (binding.document_id ?? null) : null
+  );
+
+  return useMemo<WidgetDataResult>(() => {
+    const unbound = (): WidgetDataResult => ({
+      data: emptyDataFor(source),
+      isLoading: false,
+      isUnbound: true,
+    });
+
+    switch (source) {
+      case "tasks": {
+        const rows = normalizeTasks(tasksQuery.data?.items ?? []);
+        return { data: { source, rows }, isLoading: tasksQuery.isLoading, isUnbound: false };
+      }
+
+      case "task_counts": {
+        const rows = countTasks(
+          normalizeTasks(tasksQuery.data?.items ?? []),
+          binding.bucket ?? undefined
+        );
+        return { data: { source, rows }, isLoading: tasksQuery.isLoading, isUnbound: false };
+      }
+
+      case "projects": {
+        const counts = countTasksByProject(normalizeTasks(tasksQuery.data?.items ?? []));
+        const visible = (projectsQuery.data?.items ?? []).filter(
+          (project) => !binding.initiative_id || project.initiative_id === binding.initiative_id
+        );
+        const rows = normalizeProjects(visible, counts);
+        return {
+          data: { source, rows },
+          isLoading: projectsQuery.isLoading || tasksQuery.isLoading,
+          isUnbound: false,
+        };
+      }
+
+      case "calendar_entries": {
+        const names = new Map<number, string>(
+          (calendarsQuery.data?.items ?? []).map((calendar) => [calendar.id, calendar.name])
+        );
+        const events = (entriesQuery.data?.events ?? []).filter(
+          (event) => !binding.calendar_id || event.calendar_id === binding.calendar_id
+        );
+        return {
+          data: { source, rows: normalizeCalendarEntries(events, names) },
+          isLoading: entriesQuery.isLoading,
+          isUnbound: false,
+        };
+      }
+
+      case "counter": {
+        if (!binding.counter_group_id || !binding.counter_id) return unbound();
+        const counter = counterGroupQuery.data?.counters?.find(
+          (candidate) => candidate.id === binding.counter_id
+        );
+        if (!counter) {
+          return {
+            data: emptyDataFor(source),
+            isLoading: counterGroupQuery.isLoading,
+            // Resolved but absent: the counter was deleted, or RLS hid it.
+            isUnbound: !counterGroupQuery.isLoading,
+          };
+        }
+        return {
+          data: { source, counter: normalizeCounter(counter) },
+          isLoading: counterGroupQuery.isLoading,
+          isUnbound: false,
+        };
+      }
+
+      case "counter_group": {
+        if (!binding.counter_group_id) return unbound();
+        if (!counterGroupQuery.data) {
+          return {
+            data: emptyDataFor(source),
+            isLoading: counterGroupQuery.isLoading,
+            isUnbound: !counterGroupQuery.isLoading,
+          };
+        }
+        const { name, counters } = normalizeCounterGroup(counterGroupQuery.data);
+        return {
+          data: { source, name, counters },
+          isLoading: counterGroupQuery.isLoading,
+          isUnbound: false,
+        };
+      }
+
+      case "my_stats": {
+        if (!statsQuery.data) {
+          return {
+            data: emptyDataFor(source),
+            isLoading: statsQuery.isLoading,
+            isUnbound: false,
+          };
+        }
+        const { days, total } = normalizeMyStats(statsQuery.data);
+        return { data: { source, days, total }, isLoading: false, isUnbound: false };
+      }
+
+      case "sheet_range": {
+        if (!binding.document_id || !binding.range) return unbound();
+        const range = documentQuery.data
+          ? normalizeSheetRange(documentQuery.data, binding.sheet, binding.range)
+          : null;
+        if (!range) {
+          return {
+            data: emptyDataFor(source),
+            isLoading: documentQuery.isLoading,
+            isUnbound: !documentQuery.isLoading,
+          };
+        }
+        return { data: { source, range }, isLoading: false, isUnbound: false };
+      }
+
+      default:
+        return unbound();
+    }
+  }, [
+    source,
+    binding.bucket,
+    binding.calendar_id,
+    binding.counter_group_id,
+    binding.counter_id,
+    binding.document_id,
+    binding.initiative_id,
+    binding.range,
+    binding.sheet,
+    tasksQuery.data,
+    tasksQuery.isLoading,
+    projectsQuery.data,
+    projectsQuery.isLoading,
+    entriesQuery.data,
+    entriesQuery.isLoading,
+    calendarsQuery.data,
+    counterGroupQuery.data,
+    counterGroupQuery.isLoading,
+    statsQuery.data,
+    statsQuery.isLoading,
+    documentQuery.data,
+    documentQuery.isLoading,
+  ]);
+}
+
+/** Sources this build can fetch, for the binding picker. Derived from the
+ *  served catalog so it never disagrees with what the backend will accept. */
+export const bindableSources = (catalog: WidgetCatalog | undefined, widgetType: string): string[] =>
+  catalog?.widgets.find((entry) => entry.type === widgetType)?.sources ?? [];

--- a/frontend/src/lib/widgets/definition.test.ts
+++ b/frontend/src/lib/widgets/definition.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Definition editing.
+ *
+ * These are the operations a drag, a resize, or a palette click turn into, and
+ * they are pure — which is the point. The canvas can compute a change, draw it,
+ * and send it, and the server's normalization comes back as the truth without
+ * any of that logic living in a component.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
+
+import {
+  addWidget,
+  applyLayout,
+  type DashboardDefinition,
+  definitionsEqual,
+  EMPTY_DEFINITION,
+  effectiveBinding,
+  GRID_COLUMNS,
+  pruneConfig,
+  readConfig,
+  readDefinition,
+  removeWidget,
+  unboundSlots,
+  updateWidget,
+} from "./definition";
+
+const catalog = {
+  widgets: [
+    {
+      type: "gantt",
+      min_w: 6,
+      min_h: 3,
+      default_w: 12,
+      default_h: 6,
+      sources: ["tasks"],
+      options: [],
+    },
+    {
+      type: "kpi",
+      min_w: 2,
+      min_h: 2,
+      default_w: 3,
+      default_h: 2,
+      sources: ["counter"],
+      options: [],
+    },
+    {
+      type: "chart",
+      min_w: 3,
+      min_h: 3,
+      default_w: 6,
+      default_h: 4,
+      sources: ["task_counts"],
+      options: [{ key: "mark", values: ["bar", "line"] }],
+    },
+  ],
+  presets: [{ name: "bar_chart", primitive: "chart", options: { mark: "bar" } }],
+} as unknown as WidgetCatalog;
+
+const withWidgets = (...types: string[]): DashboardDefinition =>
+  types.reduce(
+    (definition, type) => addWidget(definition, catalog, type, "tasks"),
+    EMPTY_DEFINITION
+  );
+
+describe("readDefinition", () => {
+  it("treats a freshly created dashboard's empty object as an empty canvas", () => {
+    expect(readDefinition({})).toEqual(EMPTY_DEFINITION);
+    expect(readDefinition(null)).toEqual(EMPTY_DEFINITION);
+    expect(readDefinition(undefined)).toEqual(EMPTY_DEFINITION);
+  });
+
+  it("keeps stored widgets and the authored column count", () => {
+    const stored = readDefinition({ layout: { columns: 6 }, widgets: [{ id: "w1" }] });
+    expect(stored.layout.columns).toBe(6);
+    expect(stored.widgets).toHaveLength(1);
+  });
+});
+
+describe("addWidget", () => {
+  it("places a widget at its catalog default size", () => {
+    const [widget] = withWidgets("gantt").widgets;
+    expect(widget.grid).toMatchObject({ w: 12, h: 6, x: 0, y: 0 });
+  });
+
+  it("stacks each new widget below what is already placed", () => {
+    const { widgets } = withWidgets("gantt", "kpi");
+    expect(widgets[1].grid.y).toBe(widgets[0].grid.y + widgets[0].grid.h);
+  });
+
+  it("gives every widget a distinct id, including after a removal", () => {
+    const two = withWidgets("kpi", "kpi");
+    const afterRemoval = removeWidget(two, "w1");
+    const readded = addWidget(afterRemoval, catalog, "kpi", "counter");
+    const ids = readded.widgets.map((widget) => widget.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("resolves a preset to its primitive with its options applied", () => {
+    const [widget] = addWidget(EMPTY_DEFINITION, catalog, "bar_chart", "task_counts").widgets;
+    expect(widget.type).toBe("chart");
+    expect(widget.preset).toBe("bar_chart");
+    expect(widget.options).toEqual({ mark: "bar" });
+  });
+
+  it("falls back to a usable size when the catalog has not loaded", () => {
+    const [widget] = addWidget(EMPTY_DEFINITION, undefined, "kpi", "counter").widgets;
+    expect(widget.grid.w).toBeGreaterThan(0);
+    expect(widget.grid.h).toBeGreaterThan(0);
+  });
+});
+
+describe("applyLayout", () => {
+  const definition = withWidgets("gantt");
+
+  it("takes the canvas's placement", () => {
+    const next = applyLayout(definition, catalog, [{ i: "w1", x: 2, y: 3, w: 8, h: 4 }]);
+    expect(next.widgets[0].grid).toEqual({ x: 2, y: 3, w: 8, h: 4 });
+  });
+
+  it("clamps below a widget's legible minimum", () => {
+    const next = applyLayout(definition, catalog, [{ i: "w1", x: 0, y: 0, w: 1, h: 1 }]);
+    // The Gantt's floor, not the dragged value.
+    expect(next.widgets[0].grid.w).toBe(6);
+    expect(next.widgets[0].grid.h).toBe(3);
+  });
+
+  it("never lets a widget exceed the grid", () => {
+    const next = applyLayout(definition, catalog, [{ i: "w1", x: 0, y: 0, w: 99, h: 4 }]);
+    expect(next.widgets[0].grid.w).toBe(GRID_COLUMNS);
+  });
+
+  it("ignores negative coordinates", () => {
+    const next = applyLayout(definition, catalog, [{ i: "w1", x: -5, y: -2, w: 8, h: 4 }]);
+    expect(next.widgets[0].grid).toMatchObject({ x: 0, y: 0 });
+  });
+
+  it("leaves widgets the layout did not mention alone", () => {
+    const two = withWidgets("gantt", "kpi");
+    const next = applyLayout(two, catalog, [{ i: "w1", x: 1, y: 1, w: 8, h: 4 }]);
+    expect(next.widgets[1].grid).toEqual(two.widgets[1].grid);
+  });
+});
+
+describe("definitionsEqual", () => {
+  it("is false for a real move and true for a no-op", () => {
+    const definition = withWidgets("kpi");
+    const moved = applyLayout(definition, catalog, [{ i: "w1", x: 4, y: 0, w: 3, h: 2 }]);
+    expect(definitionsEqual(definition, moved)).toBe(false);
+    expect(definitionsEqual(definition, { ...definition })).toBe(true);
+  });
+});
+
+describe("effectiveBinding", () => {
+  it("layers instance config over the definition's binding", () => {
+    // The seam that makes an installed listing work: the catalog definition
+    // cannot know this guild's counter ids, so the install fills them in.
+    const definition = addWidget(EMPTY_DEFINITION, catalog, "kpi", "counter");
+    const config = readConfig({
+      widgets: { w1: { counter_group_id: 4, counter_id: 9 } },
+    });
+    expect(effectiveBinding(definition.widgets[0], config)).toEqual({
+      source: "counter",
+      counter_group_id: 4,
+      counter_id: 9,
+    });
+  });
+
+  it("leaves a widget with no config entry on its own binding", () => {
+    const definition = addWidget(EMPTY_DEFINITION, catalog, "kpi", "counter");
+    expect(effectiveBinding(definition.widgets[0], readConfig({}))).toEqual({
+      source: "counter",
+    });
+  });
+});
+
+describe("unboundSlots", () => {
+  it("names what a binding still needs", () => {
+    expect(unboundSlots({ source: "counter" })).toEqual(["counter_group_id", "counter_id"]);
+    expect(unboundSlots({ source: "counter", counter_group_id: 1 })).toEqual(["counter_id"]);
+    expect(unboundSlots({ source: "sheet_range", document_id: 3 })).toEqual(["range"]);
+  });
+
+  it("is empty for sources that need no ids", () => {
+    expect(unboundSlots({ source: "tasks" })).toEqual([]);
+    expect(unboundSlots({ source: "my_stats" })).toEqual([]);
+  });
+});
+
+describe("pruneConfig", () => {
+  it("drops config for widgets the definition no longer has", () => {
+    const definition = withWidgets("kpi");
+    const config = readConfig({ widgets: { w1: { counter_id: 1 }, w9: { counter_id: 2 } } });
+    expect(Object.keys(pruneConfig(definition, config).widgets)).toEqual(["w1"]);
+  });
+
+  it("leaves nothing behind when the last widget goes", () => {
+    const definition = withWidgets("kpi");
+    const config = readConfig({ widgets: { w1: { counter_id: 1 } } });
+    const emptied = removeWidget(definition, "w1");
+    expect(pruneConfig(emptied, config).widgets).toEqual({});
+  });
+});
+
+describe("updateWidget", () => {
+  it("patches only the named widget", () => {
+    const two = withWidgets("kpi", "kpi");
+    const next = updateWidget(two, "w2", { title: "Renamed" });
+    expect(next.widgets[0].title).toBeUndefined();
+    expect(next.widgets[1].title).toBe("Renamed");
+  });
+
+  it("does not mutate the definition it was given", () => {
+    const definition = withWidgets("kpi");
+    const snapshot = JSON.stringify(definition);
+    updateWidget(definition, "w1", { title: "Renamed" });
+    expect(JSON.stringify(definition)).toBe(snapshot);
+  });
+});

--- a/frontend/src/lib/widgets/definition.ts
+++ b/frontend/src/lib/widgets/definition.ts
@@ -1,0 +1,229 @@
+/**
+ * Reading and editing a dashboard definition, client-side.
+ *
+ * The backend's `dashboard_definition.py` is the authority: it normalizes and
+ * validates every write, and its `WIDGET_SPECS` decides which widget types and
+ * binding sources exist. Nothing here re-implements that. What this does is the
+ * part only the client needs — describe the stored JSON in TypeScript, and edit
+ * it as immutable values so the canvas can compute a change, save it, and let
+ * the server's normalization come back as the truth.
+ */
+
+import type { WidgetCatalog, WidgetCatalogEntry } from "@/api/generated/initiativeAPI.schemas";
+import type { WidgetBinding } from "@/hooks/useWidgetData";
+
+export const DEFINITION_SCHEMA_VERSION = 1;
+/** Mirrors MAX_WIDGETS in the backend validator; the canvas stops offering
+ *  "add widget" here rather than letting a save 422. */
+export const MAX_WIDGETS = 50;
+export const GRID_COLUMNS = 12;
+
+export interface WidgetGrid {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DefinitionWidget {
+  id: string;
+  type: string;
+  grid: WidgetGrid;
+  binding: WidgetBinding;
+  title?: string;
+  preset?: string;
+  options?: Record<string, string>;
+}
+
+export interface DashboardDefinition {
+  schema_version: number;
+  kind: "dashboard";
+  layout: { columns: number };
+  widgets: DefinitionWidget[];
+}
+
+export interface DashboardConfig {
+  widgets: Record<string, Record<string, unknown>>;
+}
+
+export const EMPTY_DEFINITION: DashboardDefinition = {
+  schema_version: DEFINITION_SCHEMA_VERSION,
+  kind: "dashboard",
+  layout: { columns: GRID_COLUMNS },
+  widgets: [],
+};
+
+/** Read a stored definition, tolerating the empty object a dashboard is created
+ *  with and anything older than the current shape. */
+export const readDefinition = (raw: unknown): DashboardDefinition => {
+  if (typeof raw !== "object" || raw === null) return EMPTY_DEFINITION;
+  const value = raw as Partial<DashboardDefinition>;
+  return {
+    schema_version: DEFINITION_SCHEMA_VERSION,
+    kind: "dashboard",
+    layout: { columns: value.layout?.columns ?? GRID_COLUMNS },
+    widgets: Array.isArray(value.widgets) ? value.widgets : [],
+  };
+};
+
+export const readConfig = (raw: unknown): DashboardConfig => {
+  if (typeof raw !== "object" || raw === null) return { widgets: {} };
+  const value = raw as Partial<DashboardConfig>;
+  return { widgets: value.widgets ?? {} };
+};
+
+/**
+ * A widget's effective binding: the definition's, with the instance config's
+ * values layered on top.
+ *
+ * This is the seam that makes an installed listing work. A catalog definition
+ * leaves the ids it cannot know as null — no listing knows this guild's counter
+ * ids — and the config fills them in per install.
+ */
+export const effectiveBinding = (
+  widget: DefinitionWidget,
+  config: DashboardConfig
+): WidgetBinding => ({
+  ...widget.binding,
+  ...(config.widgets[widget.id] ?? {}),
+});
+
+/** Slots a widget still needs filled before it can draw anything. */
+export const unboundSlots = (binding: WidgetBinding): string[] => {
+  switch (binding.source) {
+    case "counter":
+      return [
+        ...(binding.counter_group_id ? [] : ["counter_group_id"]),
+        ...(binding.counter_id ? [] : ["counter_id"]),
+      ];
+    case "counter_group":
+      return binding.counter_group_id ? [] : ["counter_group_id"];
+    case "sheet_range":
+      return [...(binding.document_id ? [] : ["document_id"]), ...(binding.range ? [] : ["range"])];
+    default:
+      return [];
+  }
+};
+
+// --- editing ----------------------------------------------------------------
+
+const nextWidgetId = (widgets: DefinitionWidget[]): string => {
+  const taken = new Set(widgets.map((widget) => widget.id));
+  for (let index = 1; ; index++) {
+    const candidate = `w${index}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+};
+
+/** The row below everything placed so far — where a new widget lands, rather
+ *  than on top of an existing one. */
+const bottomRow = (widgets: DefinitionWidget[]): number =>
+  widgets.reduce((lowest, widget) => Math.max(lowest, widget.grid.y + widget.grid.h), 0);
+
+export const catalogEntry = (
+  catalog: WidgetCatalog | undefined,
+  type: string
+): WidgetCatalogEntry | undefined => catalog?.widgets.find((entry) => entry.type === type);
+
+/**
+ * Add a widget at its catalog default size.
+ *
+ * A preset resolves to its primitive with its fixed options applied — the same
+ * resolution the backend does on save, done here so the canvas draws the right
+ * thing before the round trip.
+ */
+export const addWidget = (
+  definition: DashboardDefinition,
+  catalog: WidgetCatalog | undefined,
+  typeOrPreset: string,
+  source: string
+): DashboardDefinition => {
+  const preset = catalog?.presets.find((entry) => entry.name === typeOrPreset);
+  const type = preset?.primitive ?? typeOrPreset;
+  const entry = catalogEntry(catalog, type);
+
+  const widget: DefinitionWidget = {
+    id: nextWidgetId(definition.widgets),
+    type,
+    grid: {
+      x: 0,
+      y: bottomRow(definition.widgets),
+      w: entry?.default_w ?? 6,
+      h: entry?.default_h ?? 4,
+    },
+    binding: { source } as WidgetBinding,
+    ...(preset ? { preset: preset.name, options: { ...preset.options } } : {}),
+  };
+
+  return { ...definition, widgets: [...definition.widgets, widget] };
+};
+
+export const removeWidget = (
+  definition: DashboardDefinition,
+  widgetId: string
+): DashboardDefinition => ({
+  ...definition,
+  widgets: definition.widgets.filter((widget) => widget.id !== widgetId),
+});
+
+export const updateWidget = (
+  definition: DashboardDefinition,
+  widgetId: string,
+  patch: Partial<DefinitionWidget>
+): DashboardDefinition => ({
+  ...definition,
+  widgets: definition.widgets.map((widget) =>
+    widget.id === widgetId ? { ...widget, ...patch } : widget
+  ),
+});
+
+/**
+ * Apply a grid layout from the canvas, clamped to each widget's catalog floor.
+ *
+ * The clamp matters even though the backend re-clamps on save: it is what stops
+ * a drag from momentarily rendering a Gantt two columns wide, and it keeps the
+ * value we send equal to the value we drew.
+ */
+export const applyLayout = (
+  definition: DashboardDefinition,
+  catalog: WidgetCatalog | undefined,
+  layout: { i: string; x: number; y: number; w: number; h: number }[]
+): DashboardDefinition => {
+  const byId = new Map(layout.map((item) => [item.i, item]));
+  return {
+    ...definition,
+    widgets: definition.widgets.map((widget) => {
+      const placed = byId.get(widget.id);
+      if (!placed) return widget;
+      const entry = catalogEntry(catalog, widget.type);
+      return {
+        ...widget,
+        grid: {
+          x: Math.max(0, placed.x),
+          y: Math.max(0, placed.y),
+          w: Math.min(GRID_COLUMNS, Math.max(placed.w, entry?.min_w ?? 1)),
+          h: Math.max(placed.h, entry?.min_h ?? 1),
+        },
+      };
+    }),
+  };
+};
+
+/** Whether two definitions differ in a way worth saving. Layout callbacks fire
+ *  on every drag frame; only a settled change should reach the API. */
+export const definitionsEqual = (a: DashboardDefinition, b: DashboardDefinition): boolean =>
+  JSON.stringify(a) === JSON.stringify(b);
+
+/** Config entries for widgets the definition no longer has, dropped — mirrors
+ *  what the backend does on save so the editor shows the same thing. */
+export const pruneConfig = (
+  definition: DashboardDefinition,
+  config: DashboardConfig
+): DashboardConfig => {
+  const known = new Set(definition.widgets.map((widget) => widget.id));
+  return {
+    widgets: Object.fromEntries(
+      Object.entries(config.widgets).filter(([widgetId]) => known.has(widgetId))
+    ),
+  };
+};

--- a/frontend/src/lib/widgets/normalize.test.ts
+++ b/frontend/src/lib/widgets/normalize.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The endpoint → widget contract.
+ *
+ * Worth testing directly because every widget on every dashboard reads these
+ * shapes, and because the conversions here are exactly the ones a widget cannot
+ * do for itself: it has a frozen clock and no timezone, so a date string that
+ * reaches it is a bug this layer was supposed to catch.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  countTasks,
+  countTasksByProject,
+  emptyDataFor,
+  normalizeCalendarEntries,
+  normalizeCounter,
+  normalizeMyStats,
+  normalizeProjects,
+  normalizeSheetRange,
+  normalizeTasks,
+  startOfUtcDay,
+  toEpoch,
+} from "./normalize";
+
+const task = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 1,
+    title: "Draft the spec",
+    priority: "high",
+    start_date: "2026-08-03T00:00:00Z",
+    due_date: "2026-08-08T00:00:00Z",
+    completed_at: null,
+    project_id: 10,
+    project_name: "Apollo",
+    task_status: { name: "In review", category: "in_progress" },
+    assignees: [{ id: 1, full_name: "Ada" }],
+    ...overrides,
+  }) as never;
+
+describe("timestamps", () => {
+  it("converts ISO strings to epoch ms", () => {
+    expect(toEpoch("2026-08-03T00:00:00Z")).toBe(Date.UTC(2026, 7, 3));
+  });
+
+  it("returns null rather than NaN for absent or unparseable values", () => {
+    expect(toEpoch(null)).toBeNull();
+    expect(toEpoch(undefined)).toBeNull();
+    expect(toEpoch("")).toBeNull();
+    expect(toEpoch("not a date")).toBeNull();
+  });
+
+  it("buckets to UTC midnight", () => {
+    const noon = Date.UTC(2026, 7, 3, 12, 30);
+    expect(startOfUtcDay(noon)).toBe(Date.UTC(2026, 7, 3));
+  });
+});
+
+describe("normalizeTasks", () => {
+  it("hands widgets numbers, never date strings", () => {
+    const [row] = normalizeTasks([task()]);
+    expect(row.startDate).toBe(Date.UTC(2026, 7, 3));
+    expect(row.dueDate).toBe(Date.UTC(2026, 7, 8));
+    expect(row.completedAt).toBeNull();
+    expect(typeof row.startDate).toBe("number");
+  });
+
+  it("flattens the status into name plus coarse category", () => {
+    const [row] = normalizeTasks([task()]);
+    expect(row.status).toBe("In review");
+    expect(row.statusCategory).toBe("in_progress");
+  });
+
+  it("survives a task with nothing optional set", () => {
+    const [row] = normalizeTasks([
+      task({
+        priority: null,
+        start_date: null,
+        due_date: null,
+        project_id: null,
+        project_name: null,
+        task_status: null,
+        assignees: null,
+      }),
+    ]);
+    expect(row).toMatchObject({
+      priority: null,
+      startDate: null,
+      projectName: null,
+      statusCategory: "todo",
+      assignees: [],
+    });
+  });
+});
+
+describe("countTasks", () => {
+  const tasks = normalizeTasks([
+    task({ id: 1, task_status: { name: "To do", category: "todo" } }),
+    task({ id: 2, task_status: { name: "To do", category: "todo" } }),
+    task({
+      id: 3,
+      task_status: { name: "Done", category: "done" },
+      completed_at: "2026-08-05T09:00:00Z",
+    }),
+  ]);
+
+  it("groups by status category by default", () => {
+    expect(countTasks(tasks)).toEqual([
+      { bucket: "todo", count: 2 },
+      { bucket: "done", count: 1 },
+    ]);
+  });
+
+  it("groups by day only over completions, which are the only dated events", () => {
+    const rows = countTasks(tasks, "day");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ bucket: "2026-08-05", count: 1 });
+    expect(rows[0].date).toBe(Date.UTC(2026, 7, 5));
+  });
+
+  it("counts a task once per assignee when grouping by assignee", () => {
+    const shared = normalizeTasks([
+      task({
+        assignees: [
+          { id: 1, full_name: "Ada" },
+          { id: 2, full_name: "Grace" },
+        ],
+      }),
+    ]);
+    expect(countTasks(shared, "assignee")).toEqual([
+      { bucket: "Ada", count: 1 },
+      { bucket: "Grace", count: 1 },
+    ]);
+  });
+
+  it("labels the absent cases rather than dropping them", () => {
+    const orphan = normalizeTasks([task({ project_name: null, assignees: [] })]);
+    expect(countTasks(orphan, "project")).toEqual([{ bucket: "Unassigned", count: 1 }]);
+    expect(countTasks(orphan, "assignee")).toEqual([{ bucket: "Unassigned", count: 1 }]);
+  });
+});
+
+describe("normalizeProjects", () => {
+  const project = {
+    id: 10,
+    name: "Apollo",
+    start_date: "2026-08-03T00:00:00Z",
+    end_date: null,
+  } as never;
+
+  it("derives progress from the task counts it was given", () => {
+    const counts = countTasksByProject(
+      normalizeTasks([
+        task({ id: 1 }),
+        task({ id: 2, task_status: { name: "Done", category: "done" } }),
+      ])
+    );
+    const [row] = normalizeProjects([project], counts);
+    expect(row).toMatchObject({ taskCount: 2, doneCount: 1, progress: 0.5 });
+  });
+
+  it("reads as zero rather than guessing when no counts are supplied", () => {
+    const [row] = normalizeProjects([project]);
+    expect(row).toMatchObject({ taskCount: 0, doneCount: 0, progress: 0 });
+  });
+});
+
+describe("normalizeCalendarEntries", () => {
+  const event = (overrides: Record<string, unknown> = {}) =>
+    ({
+      id: 100,
+      title: "Kickoff",
+      start_at: "2026-08-04T09:00:00Z",
+      end_at: "2026-08-04T10:00:00Z",
+      all_day: false,
+      calendar_id: 5,
+      ...overrides,
+    }) as never;
+
+  it("resolves calendar names from the calendars query", () => {
+    const [row] = normalizeCalendarEntries([event()], new Map([[5, "Team"]]));
+    expect(row.calendarName).toBe("Team");
+  });
+
+  it("gives an event with no end a visible width", () => {
+    const [row] = normalizeCalendarEntries([event({ end_at: null })]);
+    expect(row.end).toBeGreaterThan(row.start);
+  });
+
+  it("drops an event with no usable start rather than placing it at zero", () => {
+    expect(normalizeCalendarEntries([event({ start_at: null })])).toHaveLength(0);
+  });
+});
+
+describe("normalizeCounter", () => {
+  it("parses the decimal strings counters are stored as", () => {
+    const counter = normalizeCounter({
+      name: "Beds",
+      count: "34",
+      min: "0",
+      max: "50",
+    } as never);
+    expect(counter).toMatchObject({ value: 34, min: 0, max: 50 });
+  });
+
+  it("keeps an open-ended counter's null bounds null", () => {
+    const counter = normalizeCounter({
+      name: "Signups",
+      count: "7",
+      min: null,
+      max: null,
+    } as never);
+    expect(counter.min).toBeNull();
+    expect(counter.max).toBeNull();
+  });
+});
+
+describe("normalizeMyStats", () => {
+  it("maps heatmap days to epoch dates", () => {
+    const { days, total } = normalizeMyStats({
+      heatmap_data: [{ date: "2026-08-03", activity_count: 4 }],
+      tasks_completed_total: 112,
+    } as never);
+    expect(days).toEqual([{ date: Date.UTC(2026, 7, 3), count: 4 }]);
+    expect(total).toBe(112);
+  });
+
+  it("survives a stats payload with no heatmap", () => {
+    expect(normalizeMyStats({} as never)).toEqual({ days: [], total: 0 });
+  });
+});
+
+describe("normalizeSheetRange", () => {
+  const doc = (cells: Record<string, unknown>, name = "Sheet1") =>
+    ({ content: { sheets: [{ id: "s1", name, cells }] } }) as never;
+
+  it("extracts an A1 range in row-major order", () => {
+    const range = normalizeSheetRange(
+      doc({ "0:0": "Stage", "0:1": "Count", "1:0": "Leads", "1:1": 100 }),
+      "Sheet1",
+      "A1:B2"
+    );
+    expect(range).toEqual({ columns: ["Stage", "Count"], rows: [["Leads", 100]] });
+  });
+
+  it("treats an all-text first row as headers only when rows follow", () => {
+    const range = normalizeSheetRange(doc({ "0:0": "Only", "0:1": "Headers" }), null, "A1:B1");
+    expect(range?.columns).toEqual(["Column 1", "Column 2"]);
+    expect(range?.rows).toEqual([["Only", "Headers"]]);
+  });
+
+  it("nulls a cell holding anything that is not a scalar", () => {
+    const range = normalizeSheetRange(doc({ "0:0": { nested: true } }), null, "A1");
+    expect(range?.rows).toEqual([[null]]);
+  });
+
+  it("returns null for an unusable binding rather than throwing", () => {
+    expect(normalizeSheetRange(doc({}), "Nope", "A1")).toBeNull();
+    expect(normalizeSheetRange(doc({}), "Sheet1", "not-a-range")).toBeNull();
+    expect(normalizeSheetRange({ content: null } as never, null, "A1")).toBeNull();
+  });
+});
+
+describe("emptyDataFor", () => {
+  it("produces a valid envelope for every source", () => {
+    const sources = [
+      "tasks",
+      "projects",
+      "calendar_entries",
+      "task_counts",
+      "counter",
+      "counter_group",
+      "my_stats",
+      "sheet_range",
+    ] as const;
+    for (const source of sources) {
+      expect(emptyDataFor(source).source).toBe(source);
+    }
+  });
+});

--- a/frontend/src/lib/widgets/normalize.ts
+++ b/frontend/src/lib/widgets/normalize.ts
@@ -1,0 +1,297 @@
+/**
+ * API payloads → the widget data envelope.
+ *
+ * Pure functions, deliberately separate from the hooks that fetch: they are the
+ * whole contract between our endpoints and every widget, so they are worth
+ * testing without a query client. `dataShapes.ts` documents the shapes; this
+ * produces them.
+ *
+ * The normalization is not cosmetic. It means a widget written against
+ * `task_counts` keeps working when the task serializer changes, and it converts
+ * every timestamp to epoch milliseconds — the sandbox has a frozen clock and no
+ * timezone, so a widget must never be handed a date string to parse.
+ */
+
+import type {
+  CalendarEventSummary,
+  CounterGroupRead,
+  CounterRead,
+  DocumentRead,
+  HeatmapDayData,
+  ProjectRead,
+  TaskListRead,
+  UserStatsResponse,
+} from "@/api/generated/initiativeAPI.schemas";
+import { keyOf, parseA1Range } from "@/lib/spreadsheet/coords";
+
+import type {
+  CalendarEntryRow,
+  CounterValue,
+  CountRow,
+  MyStatsDay,
+  ProjectRow,
+  SheetRange,
+  TaskRow,
+  WidgetData,
+} from "./dataShapes";
+
+/** ISO string → epoch ms, or null. A widget only ever sees numbers. */
+export const toEpoch = (value: string | null | undefined): number | null => {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+/** Counter values arrive as decimal strings (they are NUMERIC server-side). */
+const toNumber = (value: string | number | null | undefined): number | null => {
+  if (value === null || value === undefined) return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const UTC_DAY = 86_400_000;
+
+/** Midnight UTC for a timestamp — the bucket key for day-grouped counts. */
+export const startOfUtcDay = (epoch: number): number => Math.floor(epoch / UTC_DAY) * UTC_DAY;
+
+// --- per-source normalizers -------------------------------------------------
+
+export const normalizeTasks = (tasks: TaskListRead[]): TaskRow[] =>
+  tasks.map((task) => ({
+    id: task.id,
+    title: task.title,
+    status: task.task_status?.name ?? "",
+    statusCategory: task.task_status?.category ?? "todo",
+    priority: task.priority ?? null,
+    startDate: toEpoch(task.start_date),
+    dueDate: toEpoch(task.due_date),
+    completedAt: toEpoch(task.completed_at),
+    projectId: task.project_id ?? null,
+    projectName: task.project_name ?? null,
+    assignees: (task.assignees ?? []).map((assignee) => assignee.full_name ?? "").filter(Boolean),
+  }));
+
+export const normalizeProjects = (
+  projects: ProjectRead[],
+  /** Task counts per project, when a task query is in play. Absent means the
+   *  progress columns read as zero rather than as a guess. */
+  taskCounts?: Map<number, { total: number; done: number }>
+): ProjectRow[] =>
+  projects.map((project) => {
+    const counts = taskCounts?.get(project.id) ?? { total: 0, done: 0 };
+    return {
+      id: project.id,
+      name: project.name,
+      startDate: toEpoch(project.start_date),
+      endDate: toEpoch(project.end_date),
+      progress: counts.total > 0 ? counts.done / counts.total : 0,
+      taskCount: counts.total,
+      doneCount: counts.done,
+    };
+  });
+
+/** Calendar *events* only. The entries endpoint also returns task markers, but
+ *  those are the `tasks` source's business — a widget bound to
+ *  `calendar_entries` asked for what is on the calendar, not for work items
+ *  duplicated from another binding. */
+export const normalizeCalendarEntries = (
+  events: CalendarEventSummary[],
+  calendarNames?: Map<number, string>
+): CalendarEntryRow[] =>
+  events.flatMap((event) => {
+    const start = toEpoch(event.start_at);
+    if (start === null) return [];
+    return [
+      {
+        id: event.id,
+        title: event.title,
+        start,
+        // An event with no usable end is an instant; give it a visible width
+        // rather than a zero-length span the renderer would collapse.
+        end: toEpoch(event.end_at) ?? start + 3_600_000,
+        calendarName: calendarNames?.get(event.calendar_id) ?? null,
+        allDay: Boolean(event.all_day),
+      },
+    ];
+  });
+
+export const normalizeCounter = (counter: CounterRead): CounterValue => ({
+  name: counter.name,
+  value: toNumber(counter.count) ?? 0,
+  min: toNumber(counter.min),
+  max: toNumber(counter.max),
+  unit: null,
+});
+
+export const normalizeCounterGroup = (
+  group: CounterGroupRead
+): { name: string; counters: CounterValue[] } => ({
+  name: group.name,
+  counters: (group.counters ?? []).map(normalizeCounter),
+});
+
+export const normalizeMyStats = (
+  stats: UserStatsResponse
+): { days: MyStatsDay[]; total: number } => {
+  const days = (stats.heatmap_data ?? [])
+    .map((day: HeatmapDayData) => ({
+      date: toEpoch(day.date) ?? 0,
+      count: day.activity_count ?? 0,
+    }))
+    .filter((day) => day.date > 0);
+  return { days, total: stats.tasks_completed_total ?? 0 };
+};
+
+// --- derived counts ---------------------------------------------------------
+
+/** How a `task_counts` binding groups. Day-grouping is the only one with a
+ *  calendar shape, which is what a heatmap needs. */
+export type CountBucket =
+  | "status_category"
+  | "status"
+  | "priority"
+  | "project"
+  | "assignee"
+  | "day";
+
+const DEFAULT_BUCKET: CountBucket = "status_category";
+
+/**
+ * Counts derived from the task rows already fetched, rather than from a second
+ * endpoint. Two widgets on one canvas bound to the same tasks therefore share a
+ * single query and disagree about nothing.
+ */
+export const countTasks = (tasks: TaskRow[], bucket: CountBucket = DEFAULT_BUCKET): CountRow[] => {
+  if (bucket === "day") {
+    // Completion is the only per-day event a task carries; an incomplete task
+    // has no day to sit on, so it is absent rather than placed arbitrarily.
+    const byDay = new Map<number, number>();
+    for (const task of tasks) {
+      if (task.completedAt === null) continue;
+      const day = startOfUtcDay(task.completedAt);
+      byDay.set(day, (byDay.get(day) ?? 0) + 1);
+    }
+    return [...byDay.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([date, count]) => ({
+        bucket: new Date(date).toISOString().slice(0, 10),
+        count,
+        date,
+      }));
+  }
+
+  const keyFor = (task: TaskRow): string[] => {
+    switch (bucket) {
+      case "status":
+        return [task.status || "—"];
+      case "priority":
+        return [task.priority ?? "none"];
+      case "project":
+        return [task.projectName ?? "Unassigned"];
+      case "assignee":
+        return task.assignees.length ? task.assignees : ["Unassigned"];
+      default:
+        return [task.statusCategory];
+    }
+  };
+
+  const counts = new Map<string, number>();
+  for (const task of tasks) {
+    for (const key of keyFor(task)) {
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()].map(([label, count]) => ({ bucket: label, count }));
+};
+
+/** Per-project totals, for the project rows' progress columns. */
+export const countTasksByProject = (
+  tasks: TaskRow[]
+): Map<number, { total: number; done: number }> => {
+  const counts = new Map<number, { total: number; done: number }>();
+  for (const task of tasks) {
+    if (task.projectId === null) continue;
+    const entry = counts.get(task.projectId) ?? { total: 0, done: 0 };
+    entry.total += 1;
+    if (task.statusCategory === "done") entry.done += 1;
+    counts.set(task.projectId, entry);
+  }
+  return counts;
+};
+
+// --- spreadsheet ranges -----------------------------------------------------
+
+interface SheetLike {
+  id?: string;
+  name?: string;
+  cells?: Record<string, unknown>;
+}
+
+/**
+ * Pull an A1 range out of a spreadsheet document.
+ *
+ * Reuses the spreadsheet module's own parser and cell keying rather than
+ * re-deriving them, so a range means here exactly what it means in the editor.
+ * The first row becomes column headers when it is all text — the usual shape of
+ * a range someone points a chart at.
+ */
+export const normalizeSheetRange = (
+  document: DocumentRead,
+  sheetName: string | null | undefined,
+  range: string | null | undefined
+): SheetRange | null => {
+  const content = document.content as { sheets?: SheetLike[] } | null;
+  const sheets = content?.sheets ?? [];
+  if (!sheets.length) return null;
+
+  const sheet = sheetName
+    ? sheets.find((s) => s.name === sheetName || s.id === sheetName)
+    : sheets[0];
+  if (!sheet?.cells) return null;
+
+  const box = range ? parseA1Range(range) : null;
+  if (!box) return null;
+
+  const rows: (string | number | boolean | null)[][] = [];
+  for (let row = box.r1; row <= box.r2; row++) {
+    const line: (string | number | boolean | null)[] = [];
+    for (let col = box.c1; col <= box.c2; col++) {
+      const value = sheet.cells[keyOf(row, col)];
+      line.push(
+        typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+          ? value
+          : null
+      );
+    }
+    rows.push(line);
+  }
+  if (!rows.length) return { columns: [], rows: [] };
+
+  const [firstRow] = rows;
+  const headerLooksLikeLabels =
+    rows.length > 1 && firstRow.every((cell) => typeof cell === "string" && cell !== "");
+
+  return headerLooksLikeLabels
+    ? { columns: firstRow.map(String), rows: rows.slice(1) }
+    : { columns: firstRow.map((_, index) => `Column ${index + 1}`), rows };
+};
+
+/** The envelope for a source we fetched nothing for — a binding whose ids the
+ *  instance config has not filled in yet. */
+export const emptyDataFor = (source: WidgetData["source"]): WidgetData => {
+  switch (source) {
+    case "counter":
+      return {
+        source: "counter",
+        counter: { name: "", value: 0, min: null, max: null, unit: null },
+      };
+    case "counter_group":
+      return { source: "counter_group", name: "", counters: [] };
+    case "my_stats":
+      return { source: "my_stats", days: [], total: 0 };
+    case "sheet_range":
+      return { source: "sheet_range", range: { columns: [], rows: [] } };
+    default:
+      return { source, rows: [] } as WidgetData;
+  }
+};

--- a/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
@@ -1,8 +1,11 @@
 import { Link, useParams } from "@tanstack/react-router";
-import { LayoutDashboard, Loader2, SearchX, ShieldAlert } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { Loader2, SearchX, ShieldAlert } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { AddWidgetMenu } from "@/components/initiativeTools/dashboards/AddWidgetMenu";
+import { DashboardCanvas } from "@/components/initiativeTools/dashboards/DashboardCanvas";
+import { WidgetConfigDialog } from "@/components/initiativeTools/dashboards/WidgetConfigDialog";
 import { StatusMessage } from "@/components/StatusMessage";
 import {
   Breadcrumb,
@@ -12,12 +15,13 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { useDashboard } from "@/hooks/useDashboards";
+import { useDashboardEditor } from "@/hooks/useDashboardEditor";
+import { useDashboard, useWidgetCatalog } from "@/hooks/useDashboards";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { useRecordRecentView } from "@/hooks/useRecents";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
+import { hasWriteAccess } from "@/lib/permissions";
 
 export function DashboardDetailPage() {
   const { t } = useTranslation(["dashboards", "common"]);
@@ -39,6 +43,15 @@ export function DashboardDetailPage() {
     if (!viewedDashboardId) return;
     recordViewMutation.mutate(viewedDashboardId);
   }, [viewedDashboardId, recordViewMutation.mutate]);
+
+  const catalogQuery = useWidgetCatalog();
+  // Arranging and binding are authoring — they write the dashboard's own row —
+  // so the canvas is static without DAC write rather than merely looking it.
+  const canEdit = hasWriteAccess(dashboard?.my_permission_level);
+  const editor = useDashboardEditor(dashboard, catalogQuery.data, canEdit);
+  const [configuringId, setConfiguringId] = useState<string | null>(null);
+  const configuring =
+    editor.definition.widgets.find((widget) => widget.id === configuringId) ?? null;
 
   const initiativesQuery = useInitiatives();
   const initiativeName = useMemo(
@@ -122,15 +135,36 @@ export function DashboardDetailPage() {
         )}
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <LayoutDashboard className="h-5 w-5 text-muted-foreground" />
-            {t("canvasPending")}
-          </CardTitle>
-          <CardDescription>{t("canvasPendingDescription")}</CardDescription>
-        </CardHeader>
-      </Card>
+      {canEdit && (
+        <div className="flex items-center justify-end gap-2">
+          {editor.isSaving && (
+            <span className="text-muted-foreground text-xs">{t("canvas.saving")}</span>
+          )}
+          <AddWidgetMenu
+            catalog={catalogQuery.data}
+            widgetCount={editor.definition.widgets.length}
+            onAdd={editor.addWidget}
+          />
+        </div>
+      )}
+
+      <DashboardCanvas
+        definition={editor.definition}
+        config={editor.config}
+        catalog={catalogQuery.data}
+        canEdit={canEdit}
+        onLayoutChange={editor.replaceDefinition}
+        onConfigureWidget={setConfiguringId}
+        onRemoveWidget={editor.removeWidget}
+      />
+
+      <WidgetConfigDialog
+        widget={configuring}
+        catalog={catalogQuery.data}
+        open={configuring !== null}
+        onOpenChange={(next) => !next && setConfiguringId(null)}
+        onSave={(patch) => configuringId && editor.updateWidget(configuringId, patch)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Phase 2a shipped the harness: widgets run in a sandbox and draw validated scenes. But nothing fetched any data and nothing placed a widget, so a dashboard still rendered a placeholder card. This makes a dashboard actually show something.

## Bindings resolve through the gated hooks

A binding names a **source**, never an endpoint. [useWidgetData.ts](frontend/src/hooks/useWidgetData.ts) fetches each source through the same ordinary hook the rest of the app uses, so the request is the viewer's own and the six gates decide what comes back. A dashboard shared with someone who cannot read the bound counter shows them an empty widget, not the author's data — the sharing shares the *view*, never the data.

Every source hook is called unconditionally with `enabled` gating (hooks must be), which is also what lets React Query share the cache: **two widgets bound to the same tasks issue one request between them**. `task_counts` and the project progress columns are derived from those same rows rather than fetched again, so two widgets on one canvas cannot disagree about the same numbers.

[normalize.ts](frontend/src/lib/widgets/normalize.ts) is the whole endpoint→widget contract, kept pure and tested without a query client. It converts every timestamp to epoch ms — the sandbox has a frozen clock and no timezone, so a date string reaching a widget is a bug this layer exists to catch.

## The canvas

`react-grid-layout` v2 on a 12-column grid. Layout lives in the definition, so **arranging is authoring**: it writes the dashboard's own row and takes DAC write. A viewer without it gets a genuinely static grid and no authoring affordances — not a disabled-looking one that still emits layout changes. Below the `md` breakpoint the canvas stacks to a single column, view-only; drag and resize are desktop affordances rather than a touch target worth fighting for.

Saves are debounced so a drag settles into one PATCH, and the server's normalization comes back as the truth rather than the local draft persisting. No CRDT: a layout is small and rarely co-edited, so last-write-wins on the row is the right cost.

Size floors, bindable sources and options all come from the **served catalog**, so the palette and the layout clamp can only offer what the backend validator would accept. Preset labels are *derived* rather than stored — a preset is a primitive plus fixed options and the widget module already names both, so `bar_chart` reads as "Chart · Bar" in whatever languages the widget supports, with no locale entry from us.

## Two things worth flagging

**RGL v2's API differs from the v1 docs** in three ways that each cost a fix: no `WidthProvider` (there's a `useContainerWidth` hook and `width` is a required prop), drag/resize grouped into `dragConfig`/`resizeConfig`, and no separate `react-resizable` stylesheet — v2 folds those styles in, and the import the v1 docs pair it with fails to resolve.

**A canvas test caught mounting being treated as an edit.** RGL fires `onLayoutChange` on mount, so opening a dashboard you had write access to would immediately PATCH it and bump `updated_at` — just from looking at it. Comparing against the definition currently being rendered, rather than a last-emitted cache, tells a mount from a move.

## Testing

```
cd frontend && pnpm test:run   # 1278 passed (90 files), +73 from this PR
cd frontend && pnpm build      # tsc -b + vite build, clean
cd frontend && pnpm lint       # clean
```

New coverage: 24 cases over the normalizers (the endpoint→widget contract, including the empty and absent-field paths every widget will meet), 28 over definition editing (add/remove/update/clamp/prune, and the config-over-definition layering that makes an installed listing work), and 6 rendering the canvas — the load-bearing ones being that a read-only canvas offers no authoring affordances and never reports a layout change.

## Notes

- **No marketplace browse surface.** The design listed it in this phase, but the `marketplace_listings` tables it would read were never actually shipped in Phase 1 — it gets its own PR alongside them.
- **No changelog entry yet**, per the design's recorded decision: dashboards get one user-facing entry when the tool ships end-to-end.
- `sheet_range` reuses the spreadsheet module's own `parseA1Range` and `keyOf`, so a range means here exactly what it means in the editor.