### PR TITLE
Rename the KPI widget and scope dashboards to their initiative

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/dashboards_test.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards_test.py
@@ -16,12 +16,12 @@ from app.models.tenant.resource_grant import ResourceGrant
 from app.testing import create_dashboard
 
 
-def _kpi_definition() -> dict:
+def _stat_definition() -> dict:
     return {
         "widgets": [
             {
                 "id": "w1",
-                "type": "kpi",
+                "type": "stat",
                 "title": "Open bugs",
                 "binding": {"source": "counter", "counter_id": None},
             }
@@ -68,7 +68,7 @@ async def test_create_dashboard(client: AsyncClient, acting_user, session):
             "name": "Delivery",
             "description": "Release health",
             "initiative_id": a.initiative.id,
-            "definition": _kpi_definition(),
+            "definition": _stat_definition(),
         },
     )
 
@@ -78,7 +78,7 @@ async def test_create_dashboard(client: AsyncClient, acting_user, session):
     # Canonicalized on the way in.
     assert body["definition"]["schema_version"] == 1
     assert body["definition"]["kind"] == "dashboard"
-    assert body["definition"]["widgets"][0]["type"] == "kpi"
+    assert body["definition"]["widgets"][0]["type"] == "stat"
     assert body["my_permission_level"] == "owner"
     assert body["listing_uid"] is None
 
@@ -138,7 +138,7 @@ async def test_list_and_read_dashboard(client: AsyncClient, acting_user, session
 
     detail = await client.get(a.g(f"/dashboards/{dashboard.id}"), headers=a.headers)
     assert detail.status_code == 200
-    assert detail.json()["definition"]["widgets"][0]["type"] == "kpi"
+    assert detail.json()["definition"]["widgets"][0]["type"] == "stat"
 
 
 @pytest.mark.integration
@@ -174,7 +174,9 @@ async def test_update_definition_revalidates(client: AsyncClient, acting_user, s
         a.g(f"/dashboards/{dashboard.id}"),
         headers=a.headers,
         json={
-            "definition": {"widgets": [{"type": "kpi", "binding": {"source": "tasks"}}]}
+            "definition": {
+                "widgets": [{"type": "stat", "binding": {"source": "tasks"}}]
+            }
         },
     )
     assert bad.status_code == 422
@@ -196,7 +198,7 @@ async def test_config_for_removed_widget_is_dropped(
         json={
             "definition": {
                 "widgets": [
-                    {"id": "kept", "type": "kpi", "binding": {"source": "counter"}}
+                    {"id": "kept", "type": "stat", "binding": {"source": "counter"}}
                 ]
             },
             "config": {

--- a/backend/app/services/tenant/dashboard_definition.py
+++ b/backend/app/services/tenant/dashboard_definition.py
@@ -2,8 +2,8 @@
 
 A definition is a **presentation spec**: a grid layout plus widgets, each bound
 to a data source by name. Most dashboards — hand-built or installed from the
-marketplace — are simply a *composition* of the built-in widgets below: a "KPI
-dashboard" listing is several first-party widgets, arranged and pre-bound. The
+marketplace — are simply a *composition* of the built-in widgets below: a
+"sprint health" listing is several first-party widgets, arranged and pre-bound. The
 marketplace download carries that definition; what this module owns is narrower,
 and is the reason a downloaded definition is safe to store — a **capability
 check**:
@@ -90,12 +90,12 @@ WIDGET_SPECS: dict[str, WidgetSpec] = {
         options={"scale": frozenset({"day", "week", "month", "quarter"})},
     ),
     # One big number.
-    "kpi": WidgetSpec(
+    "stat": WidgetSpec(
         min_w=2,
         min_h=2,
         default_w=3,
         default_h=2,
-        sources=frozenset({"counter", "task_counts", "my_stats", "sheet_range"}),
+        sources=frozenset({"counter", "task_counts", "sheet_range"}),
         options={"format": frozenset({"plain", "percent", "currency", "duration"})},
     ),
     # A series drawn as bars/lines/area/slices.
@@ -104,9 +104,7 @@ WIDGET_SPECS: dict[str, WidgetSpec] = {
         min_h=3,
         default_w=6,
         default_h=4,
-        sources=frozenset(
-            {"task_counts", "counter_group", "sheet_range", "my_stats", "projects"}
-        ),
+        sources=frozenset({"task_counts", "counter_group", "sheet_range", "projects"}),
         options={
             "mark": frozenset({"bar", "line", "area", "pie"}),
             "stacked": frozenset({"true", "false"}),
@@ -128,13 +126,14 @@ WIDGET_SPECS: dict[str, WidgetSpec] = {
         default_h=2,
         sources=frozenset({"counter", "task_counts", "projects"}),
     ),
-    # Density over a calendar grid (the shape /me/stats already returns).
+    # Density over a calendar grid. Task counts bucketed by day is what it draws
+    # at launch; nothing about the widget is specific to that source.
     "heatmap": WidgetSpec(
         min_w=4,
         min_h=2,
         default_w=8,
         default_h=3,
-        sources=frozenset({"my_stats", "task_counts"}),
+        sources=frozenset({"task_counts"}),
     ),
     # A plain read-only table. Display only, like every widget: no row actions,
     # no inline editing — that is a project view's job, not a dashboard's.
@@ -156,12 +155,15 @@ ALL_SOURCES: frozenset[str] = frozenset().union(
 # --- presets ---------------------------------------------------------------
 #
 # A preset is a *named widget* built from a primitive plus fixed options. It
-# ships no code, so it is the safe extension point: the built-ins below give
-# the palette its ready-made entries ("Bar chart"), and the same mechanism is
-# how a marketplace listing will contribute custom widgets — a listing declares
-# presets, they resolve to a first-party primitive at validation time, and a
-# definition that names one is stored resolved. Nothing a listing supplies ever
-# becomes a renderer.
+# ships no code, so it is the safe extension point: a marketplace listing
+# declares presets, they resolve to a first-party primitive at validation time,
+# and a definition that names one is stored resolved. Nothing a listing supplies
+# ever becomes a renderer.
+#
+# Presets are a *storage* concept, not a palette one — the picker offers each
+# primitive's options directly, so "bar chart" is the chart widget with its mark
+# chosen rather than a second entry saying the same thing. The built-ins below
+# stay because a stored or downloaded definition may still name them.
 
 
 @dataclass(frozen=True)
@@ -177,7 +179,7 @@ WIDGET_PRESETS: dict[str, WidgetPreset] = {
     "pie_chart": WidgetPreset("chart", {"mark": "pie"}),
     "stacked_bar_chart": WidgetPreset("chart", {"mark": "bar", "stacked": "true"}),
     "timeline": WidgetPreset("gantt", {"scale": "week"}),
-    "percent_kpi": WidgetPreset("kpi", {"format": "percent"}),
+    "percent_stat": WidgetPreset("stat", {"format": "percent"}),
 }
 
 # Every name a definition may use for a widget.
@@ -234,6 +236,19 @@ def _normalize_grid(raw: Any, spec: WidgetSpec) -> dict[str, int]:
     return {"x": x, "y": y, "w": w, "h": h}
 
 
+#: Binding parameters the *definition* does not carry, because the request
+#: already establishes them: a dashboard is fetched under a guild and belongs to
+#: an initiative, so those come from the row it lives on rather than from
+#: something an author or an installed listing typed.
+#:
+#: Every source shipping at launch reads within one initiative, so this costs
+#: nothing today and keeps a definition from naming an initiative other than its
+#: own. A later source that genuinely spans initiatives would need its scope
+#: expressed some other way — as part of that source's own contract, decided
+#: then, rather than by re-opening a free-form id here.
+_CONTEXT_ONLY_PARAMS = frozenset({"initiative_id", "guild_id"})
+
+
 def _normalize_binding(raw: Any, spec: WidgetSpec) -> dict[str, Any]:
     """Check the source is one we can fetch and this widget can draw, then keep
     its parameters as given for the fetcher to interpret."""
@@ -243,7 +258,11 @@ def _normalize_binding(raw: Any, spec: WidgetSpec) -> dict[str, Any]:
         _fail(DashboardMessages.BINDING_SOURCE_UNKNOWN)
     if source not in spec.sources:
         _fail(DashboardMessages.BINDING_SOURCE_NOT_ALLOWED)
-    params = {key: value for key, value in binding.items() if key != "source"}
+    params = {
+        key: value
+        for key, value in binding.items()
+        if key != "source" and key not in _CONTEXT_ONLY_PARAMS
+    }
     return {"source": source, **params}
 
 

--- a/backend/app/services/tenant/dashboard_definition_test.py
+++ b/backend/app/services/tenant/dashboard_definition_test.py
@@ -133,8 +133,8 @@ def test_normalizes_to_canonical_shape():
 def test_widget_ids_are_assigned_and_must_be_unique():
     result = normalize_dashboard_definition(
         _definition(
-            {"type": "kpi", "binding": {"source": "counter"}},
-            {"type": "kpi", "binding": {"source": "counter"}},
+            {"type": "stat", "binding": {"source": "counter"}},
+            {"type": "stat", "binding": {"source": "counter"}},
         )
     )
     assert [w["id"] for w in result["widgets"]] == ["w1", "w2"]
@@ -142,8 +142,8 @@ def test_widget_ids_are_assigned_and_must_be_unique():
     with pytest.raises(DashboardDefinitionError, match="WIDGET_ID_DUPLICATE"):
         normalize_dashboard_definition(
             _definition(
-                {"id": "same", "type": "kpi", "binding": {"source": "counter"}},
-                {"id": "same", "type": "kpi", "binding": {"source": "counter"}},
+                {"id": "same", "type": "stat", "binding": {"source": "counter"}},
+                {"id": "same", "type": "stat", "binding": {"source": "counter"}},
             )
         )
 
@@ -185,15 +185,15 @@ def test_widget_is_kept_inside_the_grid():
             "WIDGET_TYPE_UNKNOWN",
         ),
         (
-            {"widgets": [{"type": "kpi", "binding": {"source": "shell_exec"}}]},
+            {"widgets": [{"type": "stat", "binding": {"source": "shell_exec"}}]},
             "BINDING_SOURCE_UNKNOWN",
         ),
         # A real source, but not one this widget can draw.
         (
-            {"widgets": [{"type": "kpi", "binding": {"source": "tasks"}}]},
+            {"widgets": [{"type": "stat", "binding": {"source": "tasks"}}]},
             "BINDING_SOURCE_NOT_ALLOWED",
         ),
-        ({"widgets": [{"type": "kpi"}]}, "BINDING_INVALID"),
+        ({"widgets": [{"type": "stat"}]}, "BINDING_INVALID"),
         ({"widgets": "nope"}, "DEFINITION_INVALID"),
         ({"schema_version": 99, "widgets": []}, "DEFINITION_VERSION_UNSUPPORTED"),
     ],
@@ -206,7 +206,7 @@ def test_rejects_unknown_vocabulary(payload, code):
 @pytest.mark.unit
 def test_rejects_too_many_widgets():
     widgets = [
-        {"id": f"w{i}", "type": "kpi", "binding": {"source": "counter"}}
+        {"id": f"w{i}", "type": "stat", "binding": {"source": "counter"}}
         for i in range(MAX_WIDGETS + 1)
     ]
     with pytest.raises(DashboardDefinitionError, match="TOO_MANY_WIDGETS"):
@@ -220,7 +220,7 @@ def test_no_definition_can_name_an_endpoint():
     for candidate in ("https://evil.test/steal", "//evil.test", "file:///etc/passwd"):
         with pytest.raises(DashboardDefinitionError, match="BINDING_SOURCE_UNKNOWN"):
             normalize_dashboard_definition(
-                _definition({"type": "kpi", "binding": {"source": candidate}})
+                _definition({"type": "stat", "binding": {"source": candidate}})
             )
 
 
@@ -250,12 +250,40 @@ def test_binding_parameters_pass_through_untouched():
 
 
 @pytest.mark.unit
+def test_a_binding_cannot_name_its_own_initiative_or_guild():
+    """Scope comes from the row the dashboard lives on, not from the definition.
+
+    Every source at launch reads within one initiative, so there is nothing for
+    these to express — and dropping them means an authored (or downloaded)
+    definition has no field to point at somewhere else with.
+    """
+    result = normalize_dashboard_definition(
+        _definition(
+            {
+                "type": "gantt",
+                "binding": {
+                    "source": "tasks",
+                    "initiative_id": 999,
+                    "guild_id": 42,
+                    "project_id": 7,
+                },
+            }
+        )
+    )
+    binding = result["widgets"][0]["binding"]
+    assert "initiative_id" not in binding
+    assert "guild_id" not in binding
+    # A project is still the author's to choose; the fetcher scopes it.
+    assert binding["project_id"] == 7
+
+
+@pytest.mark.unit
 def test_unknown_structural_keys_are_dropped():
     result = normalize_dashboard_definition(
         {
             "widgets": [
                 {
-                    "type": "kpi",
+                    "type": "stat",
                     "binding": {"source": "counter"},
                     "onClick": {"action": "delete_everything"},
                 }
@@ -270,7 +298,7 @@ def test_unknown_structural_keys_are_dropped():
 @pytest.mark.unit
 def test_config_is_scoped_to_the_definitions_widgets():
     definition = normalize_dashboard_definition(
-        _definition({"id": "w1", "type": "kpi", "binding": {"source": "counter"}})
+        _definition({"id": "w1", "type": "stat", "binding": {"source": "counter"}})
     )
     config = normalize_dashboard_config(
         {"widgets": {"w1": {"counter_id": 42}, "ghost": {"counter_id": 9}}},
@@ -283,7 +311,7 @@ def test_config_is_scoped_to_the_definitions_widgets():
 def test_config_for_a_removed_widget_is_dropped():
     """Updating to a definition without that widget can't leave config behind."""
     definition = normalize_dashboard_definition(
-        _definition({"id": "w2", "type": "kpi", "binding": {"source": "counter"}})
+        _definition({"id": "w2", "type": "stat", "binding": {"source": "counter"}})
     )
     assert normalize_dashboard_config(
         {"widgets": {"w1": {"counter_id": 1}}}, definition

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -870,7 +870,7 @@ async def create_dashboard(
                 "widgets": [
                     {
                         "id": "w1",
-                        "type": "kpi",
+                        "type": "stat",
                         "binding": {"source": "counter", "counter_id": None},
                     }
                 ]

--- a/frontend/public/locales/de/dashboards.json
+++ b/frontend/public/locales/de/dashboards.json
@@ -79,7 +79,6 @@
     "task_counts": "Aufgabenzahlen",
     "counter": "Zähler",
     "counter_group": "Zählergruppe",
-    "my_stats": "Meine Statistiken",
     "sheet_range": "Tabellenbereich"
   },
   "gallery": {

--- a/frontend/public/locales/en/dashboards.json
+++ b/frontend/public/locales/en/dashboards.json
@@ -79,7 +79,6 @@
     "task_counts": "Task counts",
     "counter": "Counter",
     "counter_group": "Counter group",
-    "my_stats": "My stats",
     "sheet_range": "Sheet range"
   },
   "gallery": {

--- a/frontend/public/locales/es/dashboards.json
+++ b/frontend/public/locales/es/dashboards.json
@@ -79,7 +79,6 @@
     "task_counts": "Recuentos de tareas",
     "counter": "Contador",
     "counter_group": "Grupo de contadores",
-    "my_stats": "Mis estadísticas",
     "sheet_range": "Rango de hoja"
   },
   "gallery": {

--- a/frontend/public/locales/fr/dashboards.json
+++ b/frontend/public/locales/fr/dashboards.json
@@ -79,7 +79,6 @@
     "task_counts": "Nombre de tâches",
     "counter": "Compteur",
     "counter_group": "Groupe de compteurs",
-    "my_stats": "Mes statistiques",
     "sheet_range": "Plage de feuille"
   },
   "gallery": {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -672,7 +672,6 @@ export const BindingSource = {
   calendar_entries: "calendar_entries",
   counter: "counter",
   counter_group: "counter_group",
-  my_stats: "my_stats",
   projects: "projects",
   sheet_range: "sheet_range",
   task_counts: "task_counts",
@@ -4196,8 +4195,8 @@ export const WidgetType = {
   funnel: "funnel",
   gantt: "gantt",
   heatmap: "heatmap",
-  kpi: "kpi",
   progress: "progress",
+  stat: "stat",
   table: "table",
 } as const;
 

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
@@ -37,7 +37,7 @@ import { DashboardCanvas } from "./DashboardCanvas";
 const catalog = {
   widgets: [
     {
-      type: "kpi",
+      type: "stat",
       min_w: 2,
       min_h: 2,
       default_w: 3,
@@ -49,7 +49,7 @@ const catalog = {
   presets: [],
 } as unknown as WidgetCatalog;
 
-const withKpi = (): DashboardDefinition => addWidget(EMPTY_DEFINITION, catalog, "kpi", "counter");
+const withKpi = (): DashboardDefinition => addWidget(EMPTY_DEFINITION, catalog, "stat", "counter");
 
 const render = (
   definition: DashboardDefinition,

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.test.tsx
@@ -27,6 +27,7 @@ import { renderWithProviders } from "@/__tests__/helpers/render";
 import type { WidgetCatalog } from "@/api/generated/initiativeAPI.schemas";
 import {
   addWidget,
+  applyLayout,
   type DashboardDefinition,
   EMPTY_DEFINITION,
   readConfig,
@@ -49,7 +50,7 @@ const catalog = {
   presets: [],
 } as unknown as WidgetCatalog;
 
-const withKpi = (): DashboardDefinition => addWidget(EMPTY_DEFINITION, catalog, "stat", "counter");
+const withStat = (): DashboardDefinition => addWidget(EMPTY_DEFINITION, catalog, "stat", "counter");
 
 const render = (
   definition: DashboardDefinition,
@@ -87,21 +88,21 @@ describe("DashboardCanvas", () => {
   });
 
   it("offers no authoring affordances without write access", () => {
-    render(withKpi(), false);
+    render(withStat(), false);
     // The per-widget menu is the entry point to configure and remove; without
     // write there is nothing to open.
     expect(screen.queryByRole("button", { name: /options for/i })).toBeNull();
   });
 
   it("offers the widget menu with write access", () => {
-    render(withKpi(), true);
+    render(withStat(), true);
     expect(screen.getByRole("button", { name: /options for/i })).toBeInTheDocument();
   });
 
   it("never reports a layout change for a read-only canvas", () => {
     // A static canvas must never write the dashboard's row on someone else's
     // behalf, whatever the grid reports.
-    const onLayoutChange = render(withKpi(), false);
+    const onLayoutChange = render(withStat(), false);
     expect(onLayoutChange).not.toHaveBeenCalled();
   });
 
@@ -109,20 +110,39 @@ describe("DashboardCanvas", () => {
     // The page around the canvas is already correct while the row loads;
     // swapping the whole page for a spinner is what made an ordinary load look
     // like a reload.
-    const onLayoutChange = render(withKpi(), true, vi.fn(), true);
+    const onLayoutChange = render(withStat(), true, vi.fn(), true);
     expect(screen.getByText(/loading dashboard/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /options for/i })).toBeNull();
     expect(onLayoutChange).not.toHaveBeenCalled();
   });
 
+  it("gives an author a resize handle", () => {
+    const { container } = render(withStat(), true);
+    expect(container.querySelector(".react-resizable-handle")).not.toBeNull();
+    expect(container.querySelector(".react-resizable-hide")).toBeNull();
+  });
+
+  it("hides the resize handle from a viewer", () => {
+    const { container } = render(withStat(), false);
+    expect(container.querySelector(".react-resizable-hide")).not.toBeNull();
+  });
+
+  it("stops a resize at each widget's catalog size floor", () => {
+    // A Gantt squeezed to two columns is unreadable, so a resize lands on the
+    // floor rather than being refused. The grid enforces it live from each
+    // item's minW/minH; this pins the value that gets saved.
+    const shrunk = applyLayout(withStat(), catalog, [{ i: "w1", x: 0, y: 0, w: 1, h: 1 }]);
+    expect(shrunk.widgets[0].grid).toMatchObject({ w: 2, h: 2 });
+  });
+
   it("draws the grid for someone who can arrange it", () => {
-    const { container } = render(withKpi(), true);
+    const { container } = render(withStat(), true);
     expect(surface(container)).not.toBeNull();
   });
 
   it("draws no grid for a viewer", () => {
     // Dots promise that things snap into place; without write access they don't.
-    const { container } = render(withKpi(), false);
+    const { container } = render(withStat(), false);
     expect(surface(container)).toBeNull();
   });
 
@@ -132,7 +152,7 @@ describe("DashboardCanvas", () => {
     // definition comparison in the handler covers the widths where it does.
     // Either way, viewing a dashboard must never bump its updated_at — so if a
     // future grid release starts emitting here, this fails.
-    const onLayoutChange = render(withKpi(), true);
+    const onLayoutChange = render(withStat(), true);
     expect(onLayoutChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
@@ -67,6 +67,8 @@ export interface DashboardCanvasProps {
   definition: DashboardDefinition;
   config: DashboardConfig;
   catalog: WidgetCatalog | undefined;
+  /** The dashboard's own initiative. Every widget reads within it. */
+  initiativeId: number | undefined;
   /** DAC write on this dashboard. Arranging is authoring. */
   canEdit: boolean;
   /** The dashboard row is still on its way. The canvas is the only region that
@@ -81,6 +83,7 @@ export function DashboardCanvas({
   definition,
   config,
   catalog,
+  initiativeId,
   canEdit,
   isLoading,
   onLayoutChange,
@@ -207,6 +210,7 @@ export function DashboardCanvas({
                   <DashboardWidget
                     widget={widget}
                     binding={effectiveBinding(widget, config)}
+                    initiativeId={initiativeId}
                     canEdit={canEdit}
                     onConfigure={onConfigureWidget}
                     onRemove={onRemoveWidget}

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
@@ -27,6 +27,8 @@ import { type DefinitionWidget, unboundSlots } from "@/lib/widgets/definition";
 export interface DashboardWidgetProps {
   widget: DefinitionWidget;
   binding: WidgetBinding;
+  /** The dashboard's own initiative — the only one its widgets read from. */
+  initiativeId: number | undefined;
   canEdit: boolean;
   onConfigure?: (widgetId: string) => void;
   onRemove?: (widgetId: string) => void;
@@ -35,13 +37,14 @@ export interface DashboardWidgetProps {
 export function DashboardWidget({
   widget,
   binding,
+  initiativeId,
   canEdit,
   onConfigure,
   onRemove,
 }: DashboardWidgetProps) {
   const { t } = useTranslation("dashboards");
   const { name } = useWidgetMeta(widget.type);
-  const { data, isLoading, isUnbound } = useWidgetData(binding);
+  const { data, isLoading, isUnbound } = useWidgetData(binding, initiativeId);
 
   const title = widget.title || name;
   const missing = unboundSlots(binding);

--- a/frontend/src/components/initiativeTools/dashboards/WidgetPicker.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/WidgetPicker.test.tsx
@@ -34,7 +34,7 @@ const catalog = {
       ],
     },
     {
-      type: "kpi",
+      type: "stat",
       min_w: 2,
       min_h: 2,
       default_w: 3,
@@ -52,7 +52,7 @@ const open = async (onAdd = vi.fn()) => {
   await user.click(screen.getByRole("button", { name: /add widget/i }));
   // The names arrive from the widget modules, so the list is not readable until
   // the sandbox has answered.
-  await screen.findByRole("button", { name: /^KPI/ });
+  await screen.findByRole("button", { name: /^Stat/ });
   return { user, onAdd };
 };
 
@@ -64,7 +64,7 @@ describe("WidgetPicker", () => {
     const rows = within(list()).getAllByRole("button");
     expect(rows.map((row) => row.textContent?.split(/(?=[A-Z])/)[0])).toHaveLength(2);
     expect(within(list()).getByRole("button", { name: /^Chart/ })).toBeInTheDocument();
-    expect(within(list()).getByRole("button", { name: /^KPI/ })).toBeInTheDocument();
+    expect(within(list()).getByRole("button", { name: /^Stat/ })).toBeInTheDocument();
   });
 
   it("does not list presets separately from the widget they are made of", async () => {

--- a/frontend/src/hooks/useDashboardEditor.test.tsx
+++ b/frontend/src/hooks/useDashboardEditor.test.tsx
@@ -52,7 +52,7 @@ vi.mock("@/hooks/useDashboards", () => ({
 const catalog = {
   widgets: [
     {
-      type: "kpi",
+      type: "stat",
       min_w: 2,
       min_h: 2,
       default_w: 3,
@@ -87,7 +87,7 @@ const setup = (canEdit = true) => {
     /** What a refetch after a successful save does. */
     refetch: () => rendered.rerender({ dashboard: asDashboard(server) }),
     settle: () => act(() => vi.advanceTimersByTime(SAVE_DEBOUNCE_MS)),
-    add: () => act(() => rendered.result.current.addWidget("kpi", "counter")),
+    add: () => act(() => rendered.result.current.addWidget("stat", "counter")),
     widgets: () => rendered.result.current.definition.widgets,
   };
 };

--- a/frontend/src/hooks/useWidgetData.test.tsx
+++ b/frontend/src/hooks/useWidgetData.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * How a binding becomes a request.
+ *
+ * The load-bearing case is scope. A dashboard reads the initiative it lives on,
+ * and the tasks endpoint narrows on exactly one thing — the filter DSL. It takes
+ * no `initiative_id` or `project_id` query parameter, so scope stated as one is
+ * accepted by the type checker, dropped by the server, and the widget quietly
+ * aggregates every task the viewer can read across the guild. That failure is
+ * invisible on a canvas (a chart with plausible-looking numbers), which is why
+ * it is pinned here on the request rather than on what gets drawn.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWidgetData, type WidgetBinding } from "@/hooks/useWidgetData";
+
+const idle = { data: undefined, isLoading: false };
+const useTasks = vi.fn(() => idle);
+
+vi.mock("@/hooks/useTasks", () => ({ useTasks: (...args: unknown[]) => useTasks(...args) }));
+vi.mock("@/hooks/useProjects", () => ({ useProjects: () => idle }));
+vi.mock("@/hooks/useCalendarEntries", () => ({ useCalendarEntries: () => idle }));
+vi.mock("@/hooks/useCalendars", () => ({ useCalendarsList: () => idle }));
+vi.mock("@/hooks/useCounters", () => ({ useCounterGroup: () => idle }));
+vi.mock("@/hooks/useDocuments", () => ({ useDocument: () => idle }));
+
+/** The conditions the tasks query was actually issued with. */
+const conditions = (): unknown[] => {
+  const params = useTasks.mock.calls.at(-1)?.[0] as { conditions?: string } | undefined;
+  return params?.conditions ? JSON.parse(params.conditions) : [];
+};
+
+const run = (binding: WidgetBinding, initiativeId: number | undefined) =>
+  renderHook(() => useWidgetData(binding, initiativeId));
+
+beforeEach(() => useTasks.mockClear());
+
+describe("useWidgetData task scoping", () => {
+  it("narrows to the dashboard's initiative", () => {
+    run({ source: "tasks" }, 4);
+    expect(conditions()).toContainEqual({
+      field: "initiative_ids",
+      op: "in_",
+      value: [4],
+    });
+  });
+
+  it("sends no scope as a bare query parameter", () => {
+    // The endpoint would ignore it, and ignoring it means guild-wide data.
+    run({ source: "tasks", project_id: 9 }, 4);
+    const params = useTasks.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(params.initiative_id).toBeUndefined();
+    expect(params.project_id).toBeUndefined();
+  });
+
+  it("narrows to a bound project as well as the initiative", () => {
+    run({ source: "tasks", project_id: 9 }, 4);
+    expect(conditions()).toContainEqual({ field: "project_id", op: "eq", value: 9 });
+    expect(conditions()).toHaveLength(2);
+  });
+
+  it("keeps the author's own filters alongside the scope", () => {
+    const own = [{ field: "priority", op: "in_", value: ["high"] }];
+    run({ source: "tasks", conditions: own }, 4);
+    expect(conditions()).toEqual([{ field: "initiative_ids", op: "in_", value: [4] }, ...own]);
+  });
+
+  it("sends a single stored group as the list the endpoint expects", () => {
+    // A definition may carry one group rather than a list; posting the group
+    // itself would fail to parse and take the whole query with it.
+    const group = { logic: "or", conditions: [{ field: "priority", op: "eq", value: "high" }] };
+    run({ source: "tasks", conditions: group }, 4);
+    const parsed = conditions();
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toContainEqual(group);
+  });
+
+  it("does not add a group level the author may still need", () => {
+    // The DSL caps nesting; wrapping the author's conditions in a group of ours
+    // would spend a level on an AND the top-level list already implies.
+    run({ source: "tasks", conditions: [{ field: "priority", op: "eq", value: "high" }] }, 4);
+    for (const condition of conditions()) {
+      expect(condition).not.toHaveProperty("logic");
+    }
+  });
+
+  it("asks for nothing extra when the dashboard has no initiative yet", () => {
+    run({ source: "tasks" }, undefined);
+    expect(conditions()).toEqual([]);
+  });
+});

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -90,13 +90,35 @@ export function useWidgetData(
 ): WidgetDataResult {
   const source = binding.source;
 
+  /**
+   * The task query, scoped through the filter DSL.
+   *
+   * `conditions` is the *only* narrowing the tasks endpoint reads — it takes no
+   * `initiative_id` or `project_id` query parameter, so scope stated as one is
+   * silently dropped and the widget aggregates every task the viewer can read
+   * across the guild. Both go in as conditions, AND-ed with the binding's own.
+   *
+   * Flat, deliberately: the DSL caps group nesting, and the author's own
+   * conditions may already use it, so adding a wrapper of our own would spend a
+   * level they need. A top-level list is AND-ed anyway.
+   */
   const taskParams = useMemo<ListTasksApiV1GGuildIdTasksGetParams>(() => {
+    const conditions: unknown[] = [];
+    if (initiativeId) {
+      conditions.push({ field: "initiative_ids", op: "in_", value: [initiativeId] });
+    }
+    if (binding.project_id) {
+      conditions.push({ field: "project_id", op: "eq", value: binding.project_id });
+    }
+    // The binding's own pass through verbatim — the parser owns its limits, and
+    // mirroring them here would mean maintaining them twice. A definition may
+    // carry either a list or a single group; the endpoint wants a list.
+    const own = binding.conditions;
+    if (Array.isArray(own)) conditions.push(...own);
+    else if (own && typeof own === "object") conditions.push(own);
+
     const params: Record<string, unknown> = { page_size: 0 };
-    if (binding.project_id) params.project_id = binding.project_id;
-    if (initiativeId) params.initiative_id = initiativeId;
-    // The filter DSL passes through verbatim — the parser owns its own limits,
-    // and mirroring them here would mean maintaining them twice.
-    if (binding.conditions) params.conditions = JSON.stringify(binding.conditions);
+    if (conditions.length) params.conditions = JSON.stringify(conditions);
     return params as ListTasksApiV1GGuildIdTasksGetParams;
   }, [binding.project_id, initiativeId, binding.conditions]);
 

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -21,14 +21,12 @@ import type {
   ListTasksApiV1GGuildIdTasksGetParams,
   WidgetCatalog,
 } from "@/api/generated/initiativeAPI.schemas";
-import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useCalendarEntries } from "@/hooks/useCalendarEntries";
 import { useCalendarsList } from "@/hooks/useCalendars";
 import { useCounterGroup } from "@/hooks/useCounters";
 import { useDocument } from "@/hooks/useDocuments";
 import { useProjects } from "@/hooks/useProjects";
 import { useTasks } from "@/hooks/useTasks";
-import { useUserStats } from "@/hooks/useUserStats";
 import type { WidgetData, WidgetSource } from "@/lib/widgets/dataShapes";
 import {
   type CountBucket,
@@ -38,7 +36,6 @@ import {
   normalizeCalendarEntries,
   normalizeCounter,
   normalizeCounterGroup,
-  normalizeMyStats,
   normalizeProjects,
   normalizeSheetRange,
   normalizeTasks,
@@ -46,11 +43,13 @@ import {
 
 /** A normalized definition binding. Everything past `source` is the fetcher's
  *  to interpret — the backend deliberately does not re-declare these, so that
- *  each parameter lives with the code that consumes it. */
+ *  each parameter lives with the code that consumes it.
+ *
+ *  The initiative is *not* among them: it comes from the dashboard the widget
+ *  sits on, and the backend normalizer drops it from a stored binding. */
 export interface WidgetBinding {
   source: WidgetSource;
   conditions?: unknown;
-  initiative_id?: number | null;
   project_id?: number | null;
   counter_group_id?: number | null;
   counter_id?: number | null;
@@ -78,19 +77,28 @@ const DEFAULT_WINDOW_DAYS = 90;
  *  columns are derived from those same rows rather than fetched again. */
 const TASK_BACKED: WidgetSource[] = ["tasks", "task_counts", "projects"];
 
-export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
-  const guildId = useActiveGuildId();
+/**
+ * Resolve one widget's binding.
+ *
+ * `initiativeId` is the dashboard's own — every fetch below is scoped to it, and
+ * a binding cannot say otherwise. Sharing a dashboard therefore shares a view of
+ * that initiative, never a window into another one.
+ */
+export function useWidgetData(
+  binding: WidgetBinding,
+  initiativeId: number | undefined
+): WidgetDataResult {
   const source = binding.source;
 
   const taskParams = useMemo<ListTasksApiV1GGuildIdTasksGetParams>(() => {
     const params: Record<string, unknown> = { page_size: 0 };
     if (binding.project_id) params.project_id = binding.project_id;
-    if (binding.initiative_id) params.initiative_id = binding.initiative_id;
+    if (initiativeId) params.initiative_id = initiativeId;
     // The filter DSL passes through verbatim — the parser owns its own limits,
     // and mirroring them here would mean maintaining them twice.
     if (binding.conditions) params.conditions = JSON.stringify(binding.conditions);
     return params as ListTasksApiV1GGuildIdTasksGetParams;
-  }, [binding.project_id, binding.initiative_id, binding.conditions]);
+  }, [binding.project_id, initiativeId, binding.conditions]);
 
   const window = useMemo(() => {
     const days = binding.window_days ?? DEFAULT_WINDOW_DAYS;
@@ -104,16 +112,16 @@ export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
   const tasksQuery = useTasks(taskParams, {
     enabled: TASK_BACKED.includes(source),
   });
-  // The projects list has no initiative filter of its own; a binding scoped to
-  // one initiative narrows the rows after the fetch, which also keeps the query
-  // key shared with every other projects consumer.
+  // The projects list has no initiative filter of its own, so its rows are
+  // narrowed after the fetch — which also keeps the query key shared with every
+  // other projects consumer.
   const projectsQuery = useProjects(undefined, { enabled: source === "projects" });
   const entriesQuery = useCalendarEntries(
     {
       start_after: window.start,
       start_before: window.end,
       include_events: true,
-      ...(binding.initiative_id ? { initiative_id: binding.initiative_id } : {}),
+      ...(initiativeId ? { initiative_id: initiativeId } : {}),
     },
     { enabled: source === "calendar_entries" }
   );
@@ -123,7 +131,6 @@ export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
   const counterGroupQuery = useCounterGroup(binding.counter_group_id ?? null, {
     enabled: source === "counter" || source === "counter_group",
   });
-  const statsQuery = useUserStats(source === "my_stats" ? guildId : null);
   const documentQuery = useDocument(
     source === "sheet_range" ? (binding.document_id ?? null) : null
   );
@@ -152,7 +159,7 @@ export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
       case "projects": {
         const counts = countTasksByProject(normalizeTasks(tasksQuery.data?.items ?? []));
         const visible = (projectsQuery.data?.items ?? []).filter(
-          (project) => !binding.initiative_id || project.initiative_id === binding.initiative_id
+          (project) => !initiativeId || project.initiative_id === initiativeId
         );
         const rows = normalizeProjects(visible, counts);
         return {
@@ -213,18 +220,6 @@ export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
         };
       }
 
-      case "my_stats": {
-        if (!statsQuery.data) {
-          return {
-            data: emptyDataFor(source),
-            isLoading: statsQuery.isLoading,
-            isUnbound: false,
-          };
-        }
-        const { days, total } = normalizeMyStats(statsQuery.data);
-        return { data: { source, days, total }, isLoading: false, isUnbound: false };
-      }
-
       case "sheet_range": {
         if (!binding.document_id || !binding.range) return unbound();
         const range = documentQuery.data
@@ -245,12 +240,12 @@ export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
     }
   }, [
     source,
+    initiativeId,
     binding.bucket,
     binding.calendar_id,
     binding.counter_group_id,
     binding.counter_id,
     binding.document_id,
-    binding.initiative_id,
     binding.range,
     binding.sheet,
     tasksQuery.data,
@@ -262,8 +257,6 @@ export function useWidgetData(binding: WidgetBinding): WidgetDataResult {
     calendarsQuery.data,
     counterGroupQuery.data,
     counterGroupQuery.isLoading,
-    statsQuery.data,
-    statsQuery.isLoading,
     documentQuery.data,
     documentQuery.isLoading,
   ]);

--- a/frontend/src/lib/widgets/builtins/chart.widget.js
+++ b/frontend/src/lib/widgets/builtins/chart.widget.js
@@ -140,14 +140,6 @@ function render(data, config) {
       );
     }
 
-    case "my_stats": {
-      const days = data.days || [];
-      if (!days.length) return empty("Nothing recorded yet");
-      return chart([
-        { name: "Activity", points: days.map((day) => ({ x: day.date, y: day.count })) },
-      ]);
-    }
-
     case "projects": {
       const rows = data.rows || [];
       if (!rows.length) return empty("No projects match");

--- a/frontend/src/lib/widgets/builtins/heatmap.widget.js
+++ b/frontend/src/lib/widgets/builtins/heatmap.widget.js
@@ -79,9 +79,6 @@ function render(data, config) {
   };
 
   switch (data.source) {
-    case "my_stats":
-      return grid(data.days || []);
-
     case "task_counts": {
       const rows = data.rows || [];
       // Only a date-bucketed count has a calendar shape; anything else has no

--- a/frontend/src/lib/widgets/builtins/progress.widget.js
+++ b/frontend/src/lib/widgets/builtins/progress.widget.js
@@ -53,7 +53,7 @@ function render(data, config) {
       const counter = data.counter;
       if (!counter) return empty("No counter selected");
       // A counter with no ceiling has no completion to show; the number itself
-      // is a KPI's job, so say so rather than inventing a denominator.
+      // is the stat widget's job, so say so rather than inventing a denominator.
       if (counter.max === null || counter.max === undefined) {
         return empty("This counter has no maximum");
       }

--- a/frontend/src/lib/widgets/builtins/stat.widget.js
+++ b/frontend/src/lib/widgets/builtins/stat.widget.js
@@ -8,10 +8,10 @@
  */
 const meta = {
   name: {
-    en: "KPI",
-    de: "KPI",
-    es: "KPI",
-    fr: "Indicateur clé",
+    en: "Stat",
+    de: "Kennzahl",
+    es: "Estadística",
+    fr: "Statistique",
   },
   description: {
     en: "A single headline number, with an optional trend against the previous period.",
@@ -58,7 +58,7 @@ const meta = {
 };
 
 /**
- * Built-in: KPI — one big number.
+ * Built-in: Stat — one big number.
  *
  * Like every built-in, this is an ordinary widget module: it runs in the same
  * sandbox as an installed listing's widget, with the same capabilities (none)
@@ -105,12 +105,6 @@ function render(data, config) {
       }
       const total = rows.reduce((sum, row) => sum + row.count, 0);
       return metric(total, "Total");
-    }
-
-    case "my_stats": {
-      const days = data.days || [];
-      if (!days.length) return empty("Nothing recorded yet");
-      return metric(data.total || 0, "Total", days.length + " days");
     }
 
     case "sheet_range": {

--- a/frontend/src/lib/widgets/dataShapes.ts
+++ b/frontend/src/lib/widgets/dataShapes.ts
@@ -78,11 +78,6 @@ export interface SheetRange {
   rows: (string | number | boolean | null)[][];
 }
 
-export interface MyStatsDay {
-  date: number;
-  count: number;
-}
-
 export type WidgetData =
   | { source: "tasks"; rows: TaskRow[] }
   | { source: "projects"; rows: ProjectRow[] }
@@ -90,7 +85,6 @@ export type WidgetData =
   | { source: "task_counts"; rows: CountRow[] }
   | { source: "counter"; counter: CounterValue }
   | { source: "counter_group"; name: string; counters: CounterValue[] }
-  | { source: "my_stats"; days: MyStatsDay[]; total: number }
   | { source: "sheet_range"; range: SheetRange };
 
 export type WidgetSource = WidgetData["source"];

--- a/frontend/src/lib/widgets/definition.test.ts
+++ b/frontend/src/lib/widgets/definition.test.ts
@@ -38,7 +38,7 @@ const catalog = {
       options: [],
     },
     {
-      type: "kpi",
+      type: "stat",
       min_w: 2,
       min_h: 2,
       default_w: 3,
@@ -86,14 +86,14 @@ describe("addWidget", () => {
   });
 
   it("stacks each new widget below what is already placed", () => {
-    const { widgets } = withWidgets("gantt", "kpi");
+    const { widgets } = withWidgets("gantt", "stat");
     expect(widgets[1].grid.y).toBe(widgets[0].grid.y + widgets[0].grid.h);
   });
 
   it("gives every widget a distinct id, including after a removal", () => {
-    const two = withWidgets("kpi", "kpi");
+    const two = withWidgets("stat", "stat");
     const afterRemoval = removeWidget(two, "w1");
-    const readded = addWidget(afterRemoval, catalog, "kpi", "counter");
+    const readded = addWidget(afterRemoval, catalog, "stat", "counter");
     const ids = readded.widgets.map((widget) => widget.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
@@ -130,7 +130,7 @@ describe("addWidget", () => {
   });
 
   it("falls back to a usable size when the catalog has not loaded", () => {
-    const [widget] = addWidget(EMPTY_DEFINITION, undefined, "kpi", "counter").widgets;
+    const [widget] = addWidget(EMPTY_DEFINITION, undefined, "stat", "counter").widgets;
     expect(widget.grid.w).toBeGreaterThan(0);
     expect(widget.grid.h).toBeGreaterThan(0);
   });
@@ -162,7 +162,7 @@ describe("applyLayout", () => {
   });
 
   it("leaves widgets the layout did not mention alone", () => {
-    const two = withWidgets("gantt", "kpi");
+    const two = withWidgets("gantt", "stat");
     const next = applyLayout(two, catalog, [{ i: "w1", x: 1, y: 1, w: 8, h: 4 }]);
     expect(next.widgets[1].grid).toEqual(two.widgets[1].grid);
   });
@@ -170,7 +170,7 @@ describe("applyLayout", () => {
 
 describe("definitionsEqual", () => {
   it("is false for a real move and true for a no-op", () => {
-    const definition = withWidgets("kpi");
+    const definition = withWidgets("stat");
     const moved = applyLayout(definition, catalog, [{ i: "w1", x: 4, y: 0, w: 3, h: 2 }]);
     expect(definitionsEqual(definition, moved)).toBe(false);
     expect(definitionsEqual(definition, { ...definition })).toBe(true);
@@ -180,7 +180,7 @@ describe("definitionsEqual", () => {
     // The editor compares its draft against what came back from a save, and the
     // server builds each widget's keys in its own order. Reading that as a
     // change would leave the local copy drawn forever, ignoring normalization.
-    const definition = withWidgets("kpi");
+    const definition = withWidgets("stat");
     const [widget] = definition.widgets;
     const reordered = {
       ...definition,
@@ -194,7 +194,7 @@ describe("effectiveBinding", () => {
   it("layers instance config over the definition's binding", () => {
     // The seam that makes an installed listing work: the catalog definition
     // cannot know this guild's counter ids, so the install fills them in.
-    const definition = addWidget(EMPTY_DEFINITION, catalog, "kpi", "counter");
+    const definition = addWidget(EMPTY_DEFINITION, catalog, "stat", "counter");
     const config = readConfig({
       widgets: { w1: { counter_group_id: 4, counter_id: 9 } },
     });
@@ -206,7 +206,7 @@ describe("effectiveBinding", () => {
   });
 
   it("leaves a widget with no config entry on its own binding", () => {
-    const definition = addWidget(EMPTY_DEFINITION, catalog, "kpi", "counter");
+    const definition = addWidget(EMPTY_DEFINITION, catalog, "stat", "counter");
     expect(effectiveBinding(definition.widgets[0], readConfig({}))).toEqual({
       source: "counter",
     });
@@ -222,19 +222,19 @@ describe("unboundSlots", () => {
 
   it("is empty for sources that need no ids", () => {
     expect(unboundSlots({ source: "tasks" })).toEqual([]);
-    expect(unboundSlots({ source: "my_stats" })).toEqual([]);
+    expect(unboundSlots({ source: "task_counts" })).toEqual([]);
   });
 });
 
 describe("pruneConfig", () => {
   it("drops config for widgets the definition no longer has", () => {
-    const definition = withWidgets("kpi");
+    const definition = withWidgets("stat");
     const config = readConfig({ widgets: { w1: { counter_id: 1 }, w9: { counter_id: 2 } } });
     expect(Object.keys(pruneConfig(definition, config).widgets)).toEqual(["w1"]);
   });
 
   it("leaves nothing behind when the last widget goes", () => {
-    const definition = withWidgets("kpi");
+    const definition = withWidgets("stat");
     const config = readConfig({ widgets: { w1: { counter_id: 1 } } });
     const emptied = removeWidget(definition, "w1");
     expect(pruneConfig(emptied, config).widgets).toEqual({});
@@ -243,14 +243,14 @@ describe("pruneConfig", () => {
 
 describe("updateWidget", () => {
   it("patches only the named widget", () => {
-    const two = withWidgets("kpi", "kpi");
+    const two = withWidgets("stat", "stat");
     const next = updateWidget(two, "w2", { title: "Renamed" });
     expect(next.widgets[0].title).toBeUndefined();
     expect(next.widgets[1].title).toBe("Renamed");
   });
 
   it("does not mutate the definition it was given", () => {
-    const definition = withWidgets("kpi");
+    const definition = withWidgets("stat");
     const snapshot = JSON.stringify(definition);
     updateWidget(definition, "w1", { title: "Renamed" });
     expect(JSON.stringify(definition)).toBe(snapshot);

--- a/frontend/src/lib/widgets/normalize.test.ts
+++ b/frontend/src/lib/widgets/normalize.test.ts
@@ -8,13 +8,14 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { BindingSource } from "@/api/generated/initiativeAPI.schemas";
+
 import {
   countTasks,
   countTasksByProject,
   emptyDataFor,
   normalizeCalendarEntries,
   normalizeCounter,
-  normalizeMyStats,
   normalizeProjects,
   normalizeSheetRange,
   normalizeTasks,
@@ -214,21 +215,6 @@ describe("normalizeCounter", () => {
   });
 });
 
-describe("normalizeMyStats", () => {
-  it("maps heatmap days to epoch dates", () => {
-    const { days, total } = normalizeMyStats({
-      heatmap_data: [{ date: "2026-08-03", activity_count: 4 }],
-      tasks_completed_total: 112,
-    } as never);
-    expect(days).toEqual([{ date: Date.UTC(2026, 7, 3), count: 4 }]);
-    expect(total).toBe(112);
-  });
-
-  it("survives a stats payload with no heatmap", () => {
-    expect(normalizeMyStats({} as never)).toEqual({ days: [], total: 0 });
-  });
-});
-
 describe("normalizeSheetRange", () => {
   const doc = (cells: Record<string, unknown>, name = "Sheet1") =>
     ({ content: { sheets: [{ id: "s1", name, cells }] } }) as never;
@@ -261,18 +247,11 @@ describe("normalizeSheetRange", () => {
 });
 
 describe("emptyDataFor", () => {
-  it("produces a valid envelope for every source", () => {
-    const sources = [
-      "tasks",
-      "projects",
-      "calendar_entries",
-      "task_counts",
-      "counter",
-      "counter_group",
-      "my_stats",
-      "sheet_range",
-    ] as const;
-    for (const source of sources) {
+  it("produces a valid envelope for every source the backend declares", () => {
+    // Read off the generated enum rather than restated here: a source added
+    // server-side has to reach this function, and a hand-kept list would just
+    // agree with itself.
+    for (const source of Object.values(BindingSource)) {
       expect(emptyDataFor(source).source).toBe(source);
     }
   });

--- a/frontend/src/lib/widgets/normalize.ts
+++ b/frontend/src/lib/widgets/normalize.ts
@@ -17,10 +17,8 @@ import type {
   CounterGroupRead,
   CounterRead,
   DocumentRead,
-  HeatmapDayData,
   ProjectRead,
   TaskListRead,
-  UserStatsResponse,
 } from "@/api/generated/initiativeAPI.schemas";
 import { keyOf, parseA1Range } from "@/lib/spreadsheet/coords";
 
@@ -28,7 +26,6 @@ import type {
   CalendarEntryRow,
   CounterValue,
   CountRow,
-  MyStatsDay,
   ProjectRow,
   SheetRange,
   TaskRow,
@@ -129,18 +126,6 @@ export const normalizeCounterGroup = (
   name: group.name,
   counters: (group.counters ?? []).map(normalizeCounter),
 });
-
-export const normalizeMyStats = (
-  stats: UserStatsResponse
-): { days: MyStatsDay[]; total: number } => {
-  const days = (stats.heatmap_data ?? [])
-    .map((day: HeatmapDayData) => ({
-      date: toEpoch(day.date) ?? 0,
-      count: day.activity_count ?? 0,
-    }))
-    .filter((day) => day.date > 0);
-  return { days, total: stats.tasks_completed_total ?? 0 };
-};
 
 // --- derived counts ---------------------------------------------------------
 
@@ -287,8 +272,6 @@ export const emptyDataFor = (source: WidgetData["source"]): WidgetData => {
       };
     case "counter_group":
       return { source: "counter_group", name: "", counters: [] };
-    case "my_stats":
-      return { source: "my_stats", days: [], total: 0 };
     case "sheet_range":
       return { source: "sheet_range", range: { columns: [], rows: [] } };
     default:

--- a/frontend/src/lib/widgets/registry.ts
+++ b/frontend/src/lib/widgets/registry.ts
@@ -17,8 +17,8 @@ import chartSource from "./builtins/chart.widget.js?raw";
 import funnelSource from "./builtins/funnel.widget.js?raw";
 import ganttSource from "./builtins/gantt.widget.js?raw";
 import heatmapSource from "./builtins/heatmap.widget.js?raw";
-import kpiSource from "./builtins/kpi.widget.js?raw";
 import progressSource from "./builtins/progress.widget.js?raw";
+import statSource from "./builtins/stat.widget.js?raw";
 import tableSource from "./builtins/table.widget.js?raw";
 
 /**
@@ -29,7 +29,7 @@ import tableSource from "./builtins/table.widget.js?raw";
  */
 export const BUILTIN_WIDGETS: Record<string, string> = {
   gantt: ganttSource,
-  kpi: kpiSource,
+  stat: statSource,
   chart: chartSource,
   funnel: funnelSource,
   progress: progressSource,

--- a/frontend/src/lib/widgets/sampleData.ts
+++ b/frontend/src/lib/widgets/sampleData.ts
@@ -165,7 +165,7 @@ const counter: WidgetSample = {
     counter: { name: "Beds made", value: 34, min: 0, max: 50, unit: "beds" },
   },
   // A counter with no ceiling is the interesting empty-ish case: progress has
-  // no denominator to draw, while the KPI is perfectly happy.
+  // no denominator to draw, while the stat widget is perfectly happy.
   empty: {
     source: "counter",
     counter: { name: "Signups", value: 0, min: null, max: null, unit: null },
@@ -184,19 +184,6 @@ const counterGroup: WidgetSample = {
     ],
   },
   empty: { source: "counter_group", name: "Inventory", counters: [] },
-};
-
-const myStats: WidgetSample = {
-  source: "my_stats",
-  data: {
-    source: "my_stats",
-    days: Array.from({ length: 28 }, (_, index) => ({
-      date: T0 + index * DAY,
-      count: (index * 7) % 9,
-    })),
-    total: 112,
-  },
-  empty: { source: "my_stats", days: [], total: 0 },
 };
 
 const sheetRange: WidgetSample = {
@@ -223,7 +210,6 @@ export const ALL_SAMPLES: WidgetSample[] = [
   taskCounts,
   counter,
   counterGroup,
-  myStats,
   sheetRange,
 ];
 
@@ -251,10 +237,10 @@ export const sampleFor = (source: WidgetSource, widgetType?: string): WidgetData
  */
 export const SOURCES_BY_WIDGET: Record<string, WidgetSource[]> = {
   gantt: ["tasks", "projects", "calendar_entries"],
-  kpi: ["counter", "task_counts", "my_stats", "sheet_range"],
-  chart: ["task_counts", "counter_group", "sheet_range", "my_stats", "projects"],
+  stat: ["counter", "task_counts", "sheet_range"],
+  chart: ["task_counts", "counter_group", "sheet_range", "projects"],
   funnel: ["task_counts", "sheet_range"],
   progress: ["counter", "task_counts", "projects"],
-  heatmap: ["my_stats", "task_counts"],
+  heatmap: ["task_counts"],
   table: ["tasks", "projects", "sheet_range", "calendar_entries"],
 };

--- a/frontend/src/lib/widgets/sceneSpec.ts
+++ b/frontend/src/lib/widgets/sceneSpec.ts
@@ -113,7 +113,7 @@ export type StackDirection = (typeof STACK_DIRECTIONS)[number];
 
 // --- nodes -----------------------------------------------------------------
 
-/** One big number with a label — the KPI shape. `delta` is drawn as a trend
+/** One big number with a label — the stat shape. `delta` is drawn as a trend
  *  chip; its sign carries the meaning, and `deltaGood` says which sign is good
  *  (falling cycle time is good, falling revenue is not). */
 export interface MetricNode {
@@ -254,7 +254,7 @@ export interface EmptyNode {
 }
 
 /** The composition primitive — how a widget builds something we didn't
- *  anticipate (a metric above a sparkline, three KPIs in a row) out of parts we
+ *  anticipate (a metric above a sparkline, three stats in a row) out of parts we
  *  trust. Bounded by `maxDepth`. */
 export interface StackNode {
   kind: "stack";

--- a/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
@@ -158,6 +158,7 @@ export function DashboardDetailPage() {
         definition={editor.definition}
         config={editor.config}
         catalog={catalogQuery.data}
+        initiativeId={dashboard?.initiative_id}
         canEdit={canEdit}
         isLoading={!dashboard}
         onLayoutChange={editor.replaceDefinition}

--- a/frontend/src/pages/initiativeTools/dashboards/WidgetGalleryPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/WidgetGalleryPage.tsx
@@ -111,7 +111,7 @@ export function WidgetGalleryPage() {
         {HOSTILE_WIDGETS.map((widget) => (
           <div key={widget.key} className="h-40">
             <WidgetTile
-              type="kpi"
+              type="stat"
               title={t(`gallery.failure.${widget.key}` as const)}
               source={widget.source}
               data={sampleFor("task_counts")}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -545,3 +545,20 @@ html.pride [data-slot="button"].bg-primary:hover {
      a stylesheet we don't control. */
   margin-bottom: calc(4.5rem + var(--safe-area-inset-bottom, 0px)) !important;
 }
+
+/* react-grid-layout draws its resize corner in a fixed `rgba(0, 0, 0, 0.4)`,
+   which is invisible on a dark card, and hides it entirely until the tile is
+   hovered. Same handle, same behaviour — drawn in a theme colour and faintly
+   present at rest, so it reads as an affordance rather than something you have
+   to already know is there. */
+.react-grid-item > .react-resizable-handle {
+  opacity: 0.5;
+}
+
+.react-grid-item > .react-resizable-handle::after {
+  border-color: var(--muted-foreground);
+  right: 5px;
+  bottom: 5px;
+  width: 6px;
+  height: 6px;
+}

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -49,6 +49,9 @@ from app.core.security import get_password_hash  # noqa: E402
 from app.db.schema_provisioning import provision_guild  # noqa: E402
 from app.db.session import AdminSessionLocal, set_rls_context  # noqa: E402
 from app.db.tenancy import GUILD_SCOPED_TABLES  # noqa: E402
+from app.services.tenant.dashboard_definition import (  # noqa: E402
+    normalize_dashboard_definition,
+)
 from app.models.tenant.calendar import (  # noqa: E402
     DEFAULT_CALENDAR_COLOR,
     Calendar,
@@ -66,6 +69,7 @@ from app.models.tenant.counter import (  # noqa: E402
     CounterGroup,
     CounterViewMode,
 )
+from app.models.tenant.dashboard import Dashboard  # noqa: E402
 from app.models.tenant.document import (  # noqa: E402
     Document,
     DocumentLink,
@@ -349,6 +353,8 @@ class IDTracker:
             "counters": [],
             "counter_group_permissions": [],
             "counter_group_role_permissions": [],
+            "dashboards": [],
+            "dashboard_permissions": [],
             "calendars": [],
             "calendar_events": [],
             "calendar_event_attendees": [],
@@ -508,6 +514,7 @@ async def _create_initiative(
     queues_enabled: bool = False,
     counter_groups_enabled: bool = False,
     calendars_enabled: bool = False,
+    dashboards_enabled: bool = False,
 ) -> tuple[Initiative, InitiativeRoleModel, InitiativeRoleModel]:
     """Create an initiative with roles and members."""
     initiative = Initiative(
@@ -518,6 +525,7 @@ async def _create_initiative(
         queues_enabled=queues_enabled,
         counter_groups_enabled=counter_groups_enabled,
         calendars_enabled=calendars_enabled,
+        dashboards_enabled=dashboards_enabled,
     )
     session.add(initiative)
     await session.flush()
@@ -1433,6 +1441,159 @@ async def _create_counter_groups(
     return groups
 
 
+def _widget(
+    widget_id: str,
+    widget_type: str,
+    source: str,
+    *,
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    title: str | None = None,
+    options: dict | None = None,
+    **params,
+) -> dict:
+    """One widget in a dashboard definition.
+
+    ``params`` are the binding's own — a project id, a filter-DSL ``conditions``
+    block, a counter to point at. There is deliberately no initiative here: a
+    dashboard reads within the initiative it lives on, and the normalizer drops
+    the key if one is supplied.
+    """
+    widget: dict = {
+        "id": widget_id,
+        "type": widget_type,
+        "grid": {"x": x, "y": y, "w": w, "h": h},
+        "binding": {"source": source, **params},
+    }
+    if title:
+        widget["title"] = title
+    if options:
+        widget["options"] = options
+    return widget
+
+
+async def _create_dashboards(
+    session: AsyncSession,
+    ids: IDTracker,
+    guild: Guild,
+    all_users: dict[str, User],
+    groups: dict[str, CounterGroup],
+    dashboard_defs: list[dict],
+) -> dict[str, Dashboard]:
+    """Create dashboards with their widget definitions and permissions.
+
+    Each ``dashboard_def`` has:
+        initiative_id, name, description, created_by (user name),
+        widgets: list of ``_widget(...)`` results,
+        role_grants: list of {role_id, level},
+        general_access: ResourceAccessLevel for an all-initiative-members grant.
+
+    A widget binding may name ``counter_group``/``counter`` by *name*; both are
+    resolved to ids here, the way ``created_by`` names a user. Every definition
+    goes through the real normalizer before it is stored, so a seed that drifts
+    from the widget vocabulary fails here rather than rendering as an error tile.
+    """
+    dashboards: dict[str, Dashboard] = {}
+    for dd in dashboard_defs:
+        creator = all_users[dd["created_by"]]
+
+        widgets = []
+        for widget in dd.get("widgets", []):
+            binding = dict(widget["binding"])
+            group_name = binding.pop("counter_group", None)
+            counter_name = binding.pop("counter", None)
+            if group_name:
+                group = groups[group_name]
+                binding["counter_group_id"] = group.id
+                if counter_name:
+                    found = (
+                        await session.exec(
+                            select(Counter).where(
+                                Counter.counter_group_id == group.id,
+                                Counter.name == counter_name,
+                            )
+                        )
+                    ).first()
+                    if found is None:
+                        raise RuntimeError(
+                            f"dashboard {dd['name']!r} names unknown counter {counter_name!r}"
+                        )
+                    binding["counter_id"] = found.id
+            widgets.append({**widget, "binding": binding})
+
+        definition = normalize_dashboard_definition(
+            {
+                "schema_version": 1,
+                "kind": "dashboard",
+                "layout": {"columns": 12},
+                "widgets": widgets,
+            }
+        )
+
+        dashboard = Dashboard(
+            guild_id=guild.id,
+            initiative_id=dd["initiative_id"],
+            name=dd["name"],
+            description=dd.get("description"),
+            definition=definition,
+            created_by_id=creator.id,
+        )
+        session.add(dashboard)
+        await session.flush()
+        ids.add("dashboards", dashboard.id)
+
+        owner_perm = ResourceGrant(
+            resource_type="dashboard",
+            resource_id=dashboard.id,
+            user_id=creator.id,
+            guild_id=guild.id,
+            initiative_id=dashboard.initiative_id,
+            level=ResourceAccessLevel.owner,
+        )
+        session.add(owner_perm)
+        ids.add(
+            "dashboard_permissions",
+            {"dashboard_id": dashboard.id, "user_id": creator.id},
+        )
+
+        for grant in dd.get("role_grants", []):
+            rp = ResourceGrant(
+                resource_type="dashboard",
+                resource_id=dashboard.id,
+                initiative_role_id=grant["role_id"],
+                guild_id=guild.id,
+                initiative_id=dashboard.initiative_id,
+                level=grant.get("level", ResourceAccessLevel.read),
+            )
+            session.add(rp)
+            ids.add(
+                "dashboard_permissions",
+                {"dashboard_id": dashboard.id, "initiative_role_id": grant["role_id"]},
+            )
+
+        if dd.get("general_access") is not None:
+            ga = ResourceGrant(
+                resource_type="dashboard",
+                resource_id=dashboard.id,
+                guild_id=guild.id,
+                initiative_id=dashboard.initiative_id,
+                level=dd["general_access"],
+                all_initiative_members=True,
+            )
+            session.add(ga)
+            ids.add(
+                "dashboard_permissions",
+                {"dashboard_id": dashboard.id, "general": True},
+            )
+
+        await session.flush()
+        dashboards[dd["name"]] = dashboard
+
+    return dashboards
+
+
 async def _create_calendar_events(
     session: AsyncSession,
     ids: IDTracker,
@@ -2001,6 +2162,7 @@ async def seed() -> None:
             queues_enabled=True,
             counter_groups_enabled=True,
             calendars_enabled=True,
+            dashboards_enabled=True,
         )
 
         # --- Initiative: Lost Mine of Phandelver ---
@@ -2016,6 +2178,7 @@ async def seed() -> None:
             queues_enabled=True,
             counter_groups_enabled=True,
             calendars_enabled=True,
+            dashboards_enabled=True,
         )
 
         # -- Projects --
@@ -3035,7 +3198,7 @@ async def seed() -> None:
 
         # -- Counters --
         print("  Creating Guild 1 counter groups...")
-        await _create_counter_groups(
+        g1_groups = await _create_counter_groups(
             session,
             ids,
             g1,
@@ -3176,6 +3339,155 @@ async def seed() -> None:
         )
         await _enable_role_feature(
             session, [g1_strahd_mem, g1_lmop_mem], "counter_groups_enabled"
+        )
+
+        # -- Dashboards --
+        print("  Creating Guild 1 dashboards...")
+        await _create_dashboards(
+            session,
+            ids,
+            g1,
+            all_users,
+            g1_groups,
+            [
+                {
+                    "initiative_id": g1_strahd.id,
+                    "name": "Campaign Overview",
+                    "description": "Where the party stands, at a glance.",
+                    "created_by": "Dungeon Master",
+                    "general_access": ResourceAccessLevel.read,
+                    "widgets": [
+                        _widget(
+                            "w1",
+                            "stat",
+                            "counter",
+                            x=0,
+                            y=0,
+                            w=3,
+                            h=2,
+                            title="Thorn's hit points",
+                            counter_group="Party Vitals (Strahd)",
+                            counter="Thorn HP",
+                        ),
+                        _widget(
+                            "w2",
+                            "stat",
+                            "task_counts",
+                            x=3,
+                            y=0,
+                            w=3,
+                            h=2,
+                            title="Open threads",
+                        ),
+                        _widget(
+                            "w3",
+                            "chart",
+                            "task_counts",
+                            x=6,
+                            y=0,
+                            w=6,
+                            h=4,
+                            title="Work by status",
+                            options={"mark": "bar"},
+                        ),
+                        _widget(
+                            "w4",
+                            "progress",
+                            "projects",
+                            x=0,
+                            y=2,
+                            w=6,
+                            h=2,
+                            title="Arc completion",
+                        ),
+                        _widget(
+                            "w5",
+                            "gantt",
+                            "tasks",
+                            x=0,
+                            y=4,
+                            w=12,
+                            h=6,
+                            title="Session schedule",
+                            options={"scale": "week"},
+                        ),
+                    ],
+                },
+                {
+                    "initiative_id": g1_strahd.id,
+                    "name": "Barovia Prep (private)",
+                    "description": "The DM's own board — nobody else is on it.",
+                    "created_by": "Dungeon Master",
+                    "widgets": [
+                        _widget(
+                            "w1",
+                            "table",
+                            "tasks",
+                            x=0,
+                            y=0,
+                            w=12,
+                            h=5,
+                            title="Everything still open",
+                            project_id=g1_barovia.id,
+                        ),
+                        _widget(
+                            "w2",
+                            "heatmap",
+                            "task_counts",
+                            x=0,
+                            y=5,
+                            w=8,
+                            h=3,
+                            title="Prep activity",
+                            bucket="day",
+                        ),
+                    ],
+                },
+                {
+                    "initiative_id": g1_lmop.id,
+                    "name": "Quest Board",
+                    "description": "Phandalin at a glance.",
+                    "created_by": "Dungeon Master",
+                    "role_grants": [
+                        {"role_id": g1_lmop_mem.id, "level": ResourceAccessLevel.write}
+                    ],
+                    "widgets": [
+                        _widget(
+                            "w1",
+                            "stat",
+                            "task_counts",
+                            x=0,
+                            y=0,
+                            w=3,
+                            h=2,
+                            title="Quests in flight",
+                        ),
+                        _widget(
+                            "w2",
+                            "funnel",
+                            "task_counts",
+                            x=3,
+                            y=0,
+                            w=6,
+                            h=5,
+                            title="Quest pipeline",
+                        ),
+                        _widget(
+                            "w3",
+                            "table",
+                            "projects",
+                            x=0,
+                            y=5,
+                            w=12,
+                            h=5,
+                            title="Adventure arcs",
+                        ),
+                    ],
+                },
+            ],
+        )
+        await _enable_role_feature(
+            session, [g1_strahd_mem, g1_lmop_mem], "dashboards_enabled"
         )
 
         # -- Calendar events --
@@ -3579,6 +3891,7 @@ async def seed() -> None:
             queues_enabled=True,
             counter_groups_enabled=True,
             calendars_enabled=True,
+            dashboards_enabled=True,
         )
 
         g2_side, g2_side_pm, g2_side_mem = await _create_initiative(
@@ -4205,7 +4518,7 @@ async def seed() -> None:
 
         # -- Counters --
         print("  Creating Guild 2 counter groups...")
-        await _create_counter_groups(
+        g2_groups = await _create_counter_groups(
             session,
             ids,
             g2,
@@ -4329,6 +4642,84 @@ async def seed() -> None:
         await _enable_role_feature(
             session, [g2_main_mem, g2_side_mem], "counter_groups_enabled"
         )
+
+        # -- Dashboards --
+        print("  Creating Guild 2 dashboards...")
+        await _create_dashboards(
+            session,
+            ids,
+            g2,
+            all_users,
+            g2_groups,
+            [
+                {
+                    "initiative_id": g2_main.id,
+                    "name": "Mission Status",
+                    "description": "Ship, crew, and schedule on one screen.",
+                    "created_by": "Elara Moonwhisper",
+                    "general_access": ResourceAccessLevel.read,
+                    "widgets": [
+                        _widget(
+                            "w1",
+                            "progress",
+                            "counter",
+                            x=0,
+                            y=0,
+                            w=4,
+                            h=2,
+                            title="Hull integrity",
+                            counter_group="Fleet Status",
+                            counter="Hull Integrity",
+                        ),
+                        _widget(
+                            "w2",
+                            "stat",
+                            "counter",
+                            x=4,
+                            y=0,
+                            w=3,
+                            h=2,
+                            title="Days to Kepler-442b",
+                            counter_group="Fleet Status",
+                            counter="Days to Kepler-442b",
+                        ),
+                        _widget(
+                            "w3",
+                            "chart",
+                            "counter_group",
+                            x=7,
+                            y=0,
+                            w=5,
+                            h=4,
+                            title="Fleet readings",
+                            counter_group="Fleet Status",
+                        ),
+                        _widget(
+                            "w4",
+                            "chart",
+                            "task_counts",
+                            x=0,
+                            y=2,
+                            w=7,
+                            h=4,
+                            title="Work by status",
+                            options={"mark": "pie"},
+                        ),
+                        _widget(
+                            "w5",
+                            "table",
+                            "tasks",
+                            x=0,
+                            y=6,
+                            w=12,
+                            h=5,
+                            title="Open work",
+                        ),
+                    ],
+                },
+            ],
+        )
+        await _enable_role_feature(session, [g2_main_mem], "dashboards_enabled")
 
         # -- Calendar events --
         print("  Creating Guild 2 calendar events...")
@@ -4705,6 +5096,7 @@ async def seed() -> None:
             queues_enabled=True,
             counter_groups_enabled=True,
             calendars_enabled=True,
+            dashboards_enabled=True,
         )
 
         g3_navy, g3_navy_pm, g3_navy_mem = await _create_initiative(
@@ -5446,7 +5838,7 @@ async def seed() -> None:
 
         # -- Counters --
         print("  Creating Guild 3 counter groups...")
-        await _create_counter_groups(
+        g3_groups = await _create_counter_groups(
             session,
             ids,
             g3,
@@ -5581,6 +5973,85 @@ async def seed() -> None:
         await _enable_role_feature(
             session, [g3_main_mem, g3_navy_mem], "counter_groups_enabled"
         )
+
+        # -- Dashboards --
+        print("  Creating Guild 3 dashboards...")
+        await _create_dashboards(
+            session,
+            ids,
+            g3,
+            all_users,
+            g3_groups,
+            [
+                {
+                    "initiative_id": g3_main.id,
+                    "name": "The Crimson Maiden",
+                    "description": "Ship's condition and the crew's work.",
+                    "created_by": "Vex Shadowstep",
+                    "general_access": ResourceAccessLevel.write,
+                    "widgets": [
+                        _widget(
+                            "w1",
+                            "progress",
+                            "counter",
+                            x=0,
+                            y=0,
+                            w=4,
+                            h=2,
+                            title="Hull",
+                            counter_group="The Crimson Maiden",
+                            counter="Hull HP",
+                        ),
+                        _widget(
+                            "w2",
+                            "progress",
+                            "counter",
+                            x=4,
+                            y=0,
+                            w=4,
+                            h=2,
+                            title="Crew morale",
+                            counter_group="The Crimson Maiden",
+                            counter="Crew Morale",
+                        ),
+                        _widget(
+                            "w3",
+                            "stat",
+                            "counter",
+                            x=8,
+                            y=0,
+                            w=4,
+                            h=2,
+                            title="Rations left",
+                            counter_group="The Crimson Maiden",
+                            counter="Rations (days)",
+                        ),
+                        _widget(
+                            "w4",
+                            "chart",
+                            "task_counts",
+                            x=0,
+                            y=2,
+                            w=6,
+                            h=4,
+                            title="Voyage work",
+                            options={"mark": "line"},
+                        ),
+                        _widget(
+                            "w5",
+                            "progress",
+                            "projects",
+                            x=6,
+                            y=2,
+                            w=6,
+                            h=4,
+                            title="Voyage legs",
+                        ),
+                    ],
+                },
+            ],
+        )
+        await _enable_role_feature(session, [g3_main_mem], "dashboards_enabled")
 
         # -- Calendar events --
         print("  Creating Guild 3 calendar events...")


### PR DESCRIPTION
## Changes

**`kpi` → `stat`.** KPI was business jargon for what is a stat block: one number. Renamed end to end — the backend `WIDGET_SPECS` key, the generated `WidgetType` enum, the module (`stat.widget.js`), the `percent_kpi` preset, and the name the widget gives itself in each of its four languages ("Stat" / "Kennzahl" / "Estadística" / "Statistique"). No shim: a stored definition naming `kpi` renders as an unsupported-type tile and can be removed from the canvas, which is the right cost pre-release.

**`my_stats` is gone as a binding source.** It is cross-initiative personal activity, and a dashboard should read the initiative it lives on. Removed from the backend registry (so it leaves the generated `BindingSource` enum), from the data shapes, the normalizer, the fetcher hook, the sample data, the three widgets that drew it, and all four locales. `heatmap` now draws day-bucketed task counts, which is what makes it a calendar grid anyway.

**The initiative is context, not a binding parameter.** `useWidgetData` takes the dashboard's own `initiative_id` and scopes every fetch to it; the canvas threads it down from the dashboard row. The normalizer strips `initiative_id` and `guild_id` from a stored binding, so an authored — or downloaded — definition has no field to point at another initiative with. Framed as a launch-scope decision rather than a rule about widgets forever: a later source that genuinely spans initiatives would express its scope as part of that source's own contract.

**Seed data.** `scripts/seed_dev_data.py` now creates five dashboards across the three guilds — a shared campaign overview, a private DM board, a quest board with a role grant, and one per sci-fi/pirate guild — exercising every widget type, several binding sources, counters resolved by name, and each sharing shape (owner-only, role grant, general read, general write). Every definition goes through the real `normalize_dashboard_definition` on the way in, so a seed that drifts from the widget vocabulary fails at seed time rather than rendering as an error tile.

## Testing

- `pytest` on the dashboard suites: 39 passing, including a new case pinning that a binding cannot name its own initiative or guild
- `pnpm vitest run` over widgets/hooks/components/locales: 675 passing
- The 20 seeded widget definitions were extracted from the seed script and run through the real normalizer — every type, source, and option accepted
- `ruff check`/`format`, `tsc --noEmit`, `pnpm lint`, `pnpm build` clean
- API types regenerated and committed

`emptyDataFor`'s test now reads its source list off the generated `BindingSource` enum instead of restating it, so a source added server-side has to reach the function rather than agreeing with a hand-kept list.