### PR TITLE
Fix the dashboard role grant in the dev seed

### DIFF
--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -1495,6 +1495,28 @@ async def _create_dashboards(
     goes through the real normalizer before it is stored, so a seed that drifts
     from the widget vocabulary fails here rather than rendering as an error tile.
     """
+
+    def _grant(**fields) -> ResourceGrant:
+        """One grant row, checked before it reaches Postgres.
+
+        ``resource_grants`` requires exactly one grantee (a user, a role, or the
+        whole initiative). SQLModel accepts an unknown kwarg silently — a
+        misspelled column name leaves the real one NULL and the row arrives with
+        no grantee at all, which surfaces as a check-constraint traceback a long
+        way from the typo.
+        """
+        grant = ResourceGrant(**fields)
+        grantees = (
+            int(grant.user_id is not None)
+            + int(grant.role_id is not None)
+            + int(bool(grant.all_initiative_members))
+        )
+        if grantees != 1:
+            raise RuntimeError(
+                f"grant needs exactly one grantee, got {grantees}: {fields}"
+            )
+        return grant
+
     dashboards: dict[str, Dashboard] = {}
     for dd in dashboard_defs:
         creator = all_users[dd["created_by"]]
@@ -1544,7 +1566,7 @@ async def _create_dashboards(
         await session.flush()
         ids.add("dashboards", dashboard.id)
 
-        owner_perm = ResourceGrant(
+        owner_perm = _grant(
             resource_type="dashboard",
             resource_id=dashboard.id,
             user_id=creator.id,
@@ -1559,10 +1581,10 @@ async def _create_dashboards(
         )
 
         for grant in dd.get("role_grants", []):
-            rp = ResourceGrant(
+            rp = _grant(
                 resource_type="dashboard",
                 resource_id=dashboard.id,
-                initiative_role_id=grant["role_id"],
+                role_id=grant["role_id"],
                 guild_id=guild.id,
                 initiative_id=dashboard.initiative_id,
                 level=grant.get("level", ResourceAccessLevel.read),
@@ -1570,11 +1592,11 @@ async def _create_dashboards(
             session.add(rp)
             ids.add(
                 "dashboard_permissions",
-                {"dashboard_id": dashboard.id, "initiative_role_id": grant["role_id"]},
+                {"dashboard_id": dashboard.id, "role_id": grant["role_id"]},
             )
 
         if dd.get("general_access") is not None:
-            ga = ResourceGrant(
+            ga = _grant(
                 resource_type="dashboard",
                 resource_id=dashboard.id,
                 guild_id=guild.id,


### PR DESCRIPTION
## Problem

`./scripts/dev-seed.sh` fails partway through guild 1:

```
asyncpg.exceptions.CheckViolationError: new row for relation "resource_grants"
violates check constraint "resource_grants_one_grantee"
```

`_create_dashboards` built the Quest Board's role grant with `initiative_role_id=`, but the column is `role_id`. SQLModel accepts an unknown kwarg on a `table=True` model without complaint — it sets a plain attribute the mapper ignores — so `role_id` stayed NULL and the row arrived with zero grantees. Guild 1's transaction rolls back; the users/guilds commit before it does not, so the database is left half-seeded with no state file.

## Changes

- `role_id`, which is what the model calls it.
- Grants in this helper go through a small `_grant(...)` builder that counts grantees (user / role / whole-initiative) and raises with the offending fields if it isn't exactly one. The constraint already catches this — the point is to catch it next to the typo rather than sixty frames away, given the kwarg itself is silently accepted.

## Testing

Verified the three grant shapes the helper builds against the constraint's own expression, with the mappers registered:

```
owner    user_id=2 role_id=None all=False -> 1
role     user_id=None role_id=9 all=False -> 1
general  user_id=None role_id=None all=True -> 1
typo     role_id=None -> 0   <- what the seed hit
```

`ruff check` / `ruff format` clean.

**To recover a half-seeded database:** `./scripts/dev-seed.sh --clean`, then `dev-migrate`, then seed again.