### PR TITLE
Add the marketplace browse surface

### DIFF
--- a/backend/app/api/v1/platform_endpoints/marketplace.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace.py
@@ -100,19 +100,7 @@ async def list_marketplace_listings(
     return MarketplaceListingPage(items=items, total=total)
 
 
-@router.get("/listings/{public_id}", response_model=MarketplaceListingDetail)
-async def read_marketplace_listing(
-    public_id: str,
-    session: UserSessionDep,
-    current_user: CurrentUser,
-) -> MarketplaceListingDetail:
-    """One listing, with what it would install and every version it has."""
-    listing = await catalog_service.get_listing(session, public_id)
-    if listing is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=MarketplaceMessages.LISTING_NOT_FOUND,
-        )
+async def _detail(session, listing: MarketplaceListing) -> MarketplaceListingDetail:
     latest = await catalog_service.get_listing_version(
         session, listing.latest_version_id
     )
@@ -126,3 +114,42 @@ async def read_marketplace_listing(
         definition=dict(latest.definition) if latest else None,
         versions=[read for v in versions if (read := _version_read(v))],
     )
+
+
+# Declared before ``/listings/{public_id}`` so the literal segment wins: uids and
+# public ids are different identifier spaces and a path has to pick one.
+@router.get("/listings/by-uid/{uid}", response_model=MarketplaceListingDetail)
+async def resolve_marketplace_listing(
+    uid: str,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> MarketplaceListingDetail:
+    """The listing a code names.
+
+    This is what an installed instance uses to find where it came from: the
+    instance stores the uid, and the catalog answers with the listing and the
+    version it currently publishes.
+    """
+    listing = await catalog_service.get_listing_by_uid(session, uid)
+    if listing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=MarketplaceMessages.LISTING_NOT_FOUND,
+        )
+    return await _detail(session, listing)
+
+
+@router.get("/listings/{public_id}", response_model=MarketplaceListingDetail)
+async def read_marketplace_listing(
+    public_id: str,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> MarketplaceListingDetail:
+    """One listing, with what it would install and every version it has."""
+    listing = await catalog_service.get_listing(session, public_id)
+    if listing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=MarketplaceMessages.LISTING_NOT_FOUND,
+        )
+    return await _detail(session, listing)

--- a/backend/app/api/v1/platform_endpoints/marketplace_test.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace_test.py
@@ -110,6 +110,36 @@ class TestDetail:
         assert [v["version"] for v in body["versions"]] == ["1.0.0"]
         assert body["installable"] is True
 
+    async def test_a_uid_resolves_to_its_listing(self, client, acting_user, listing):
+        """An installed dashboard stores the uid, not the public id, so this is
+        how it finds the listing it came from."""
+        actor = await acting_user("member")
+        response = await client.get(
+            "/api/v1/marketplace/listings/by-uid/BRWSE000000001", headers=actor.headers
+        )
+        assert response.status_code == 200
+        assert response.json()["public_id"] == "tests.browse"
+        assert response.json()["latest_version"]["version"] == "1.0.0"
+
+    async def test_an_unknown_uid_is_a_404(self, client, acting_user, listing):
+        actor = await acting_user("member")
+        response = await client.get(
+            "/api/v1/marketplace/listings/by-uid/NTHERE00000001",
+            headers=actor.headers,
+        )
+        assert response.status_code == 404
+
+    async def test_the_uid_route_is_not_read_as_a_public_id(
+        self, client, acting_user, listing
+    ):
+        """`by-uid` is a literal segment, not a listing called 'by-uid'."""
+        actor = await acting_user("member")
+        response = await client.get(
+            "/api/v1/marketplace/listings/by-uid", headers=actor.headers
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == MarketplaceMessages.LISTING_NOT_FOUND
+
     async def test_an_unknown_listing_is_a_404(self, client, acting_user):
         actor = await acting_user("member")
         response = await client.get(

--- a/backend/app/api/v1/tenant_endpoints/dashboards.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards.py
@@ -44,6 +44,7 @@ from app.models.tenant.dashboard import Dashboard
 from app.models.tenant.initiative import Initiative, PermissionKey
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.schemas.tenant.dashboard import (
+    DashboardInstalledListings,
     DashboardCreate,
     DashboardListResponse,
     DashboardRead,
@@ -276,6 +277,34 @@ async def list_dashboards(
         page=page,
         page_size=page_size,
         has_next=has_next,
+    )
+
+
+# Declared before /{dashboard_id} so the literal path wins the match.
+@router.get("/installed-listings", response_model=DashboardInstalledListings)
+async def read_installed_listings(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> DashboardInstalledListings:
+    """Which marketplace listings this guild has installed, and how many of each.
+
+    One row per distinct listing rather than per dashboard, so the answer is
+    complete in one response — the dashboard list is paginated, and a partial
+    page would mark some installs and miss others.
+
+    RLS-scoped like every other read here: it counts the dashboards the caller
+    can see.
+    """
+    rows = (
+        await session.exec(
+            select(Dashboard.listing_uid, func.count())
+            .where(Dashboard.listing_uid.is_not(None))
+            .group_by(Dashboard.listing_uid)
+        )
+    ).all()
+    return DashboardInstalledListings(
+        counts={uid: int(count) for uid, count in rows if uid}
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
@@ -379,6 +379,64 @@ class TestUpgrade:
         assert response.json()["config"]["widgets"] == {}
 
 
+class TestInstalledListings:
+    async def test_counts_every_install_regardless_of_list_paging(
+        self, client: AsyncClient, acting_user, session, listing
+    ):
+        """The dashboard list is paginated; this answer is not. A browse surface
+        deriving 'already installed' from a page would mark some installs and
+        miss others."""
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+        await _enable(session, a.initiative)
+        for name in ("One", "Two", "Three"):
+            response = await client.post(
+                a.g("/dashboards/"),
+                headers=a.headers,
+                json={
+                    "name": name,
+                    "initiative_id": a.initiative.id,
+                    "listing_uid": INSTALL_UID,
+                },
+            )
+            assert response.status_code == 201, response.text
+
+        response = await client.get(
+            a.g("/dashboards/installed-listings"), headers=a.headers
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["counts"] == {INSTALL_UID: 3}
+
+    async def test_a_dashboard_authored_here_is_not_counted(
+        self, client: AsyncClient, acting_user, session
+    ):
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+        await _enable(session, a.initiative)
+        await client.post(
+            a.g("/dashboards/"),
+            headers=a.headers,
+            json={
+                "name": "Mine",
+                "initiative_id": a.initiative.id,
+                "definition": _definition(),
+            },
+        )
+        response = await client.get(
+            a.g("/dashboards/installed-listings"), headers=a.headers
+        )
+        assert response.json()["counts"] == {}
+
+    async def test_the_literal_path_is_not_read_as_a_dashboard_id(
+        self, client: AsyncClient, acting_user, session
+    ):
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+        await _enable(session, a.initiative)
+        response = await client.get(
+            a.g("/dashboards/installed-listings"), headers=a.headers
+        )
+        assert response.status_code == 200
+        assert "counts" in response.json()
+
+
 class TestCatalogIsolation:
     async def test_a_routed_session_can_read_the_catalog_but_not_write_it(
         self, role_session, acting_user, session, listing

--- a/backend/app/schemas/tenant/dashboard.py
+++ b/backend/app/schemas/tenant/dashboard.py
@@ -60,6 +60,21 @@ class DashboardCreate(DashboardBase):
     )
 
 
+class DashboardInstalledListings(SanitizedBaseModel):
+    """How many dashboards in this guild came from each marketplace listing.
+
+    Keyed by listing uid, because that is what an install pins. Answered here
+    rather than by the catalog: which listings a guild has is guild data, and the
+    catalog holds none of it. Small and unpaginated by construction — one entry
+    per distinct listing, not per dashboard — so a browse surface can mark what
+    is already installed without walking the dashboard list.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    counts: Dict[str, int] = Field(default_factory=dict)
+
+
 class DashboardUpdate(SanitizedBaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     description: Optional[str] = Field(default=None, max_length=2000)

--- a/frontend/public/locales/de/dashboards.json
+++ b/frontend/public/locales/de/dashboards.json
@@ -143,5 +143,6 @@
     "data": "Daten",
     "needsBinding": "Was genau angezeigt wird, legst du nach dem Hinzufügen fest.",
     "add": "{{widget}} hinzufügen"
-  }
+  },
+  "browseMarketplace": "Marktplatz durchsuchen"
 }

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -1,0 +1,47 @@
+{
+  "title": "Marktplatz",
+  "subtitle": "Fertige Dashboards, die du einer Initiative hinzufügen kannst.",
+  "searchPlaceholder": "Marktplatz durchsuchen…",
+  "backToMarketplace": "Zurück zum Marktplatz",
+  "card": {
+    "installed": "Installiert",
+    "version": "v{{version}}",
+    "needsUpdate": "Benötigt neuere App"
+  },
+  "empty": {
+    "title": "Noch nichts hier",
+    "description": "Diese Installation bietet keine Einträge an."
+  },
+  "noResults": {
+    "title": "Keine Treffer",
+    "description": "Nichts im Marktplatz passt zu „{{query}}“."
+  },
+  "detail": {
+    "by": "von {{publisher}}",
+    "installs_one": "{{count}} Installation",
+    "installs_other": "{{count}} Installationen",
+    "install": "Zu einer Initiative hinzufügen",
+    "preview": "Vorschau",
+    "versions": "Versionen",
+    "needsUpdate": "Benötigt eine neuere Version der App.",
+    "withdrawn": "Wird nicht mehr angeboten.",
+    "notFound": "Eintrag nicht gefunden",
+    "notFoundDescription": "Er wurde vielleicht zurückgezogen, oder der Link stimmt nicht."
+  },
+  "install": {
+    "title": "{{name}} hinzufügen",
+    "description": "Wähle, wohin es kommt. Umbenennen kannst du es jetzt oder später.",
+    "initiative": "Initiative",
+    "name": "Name",
+    "action": "Hinzufügen",
+    "done": "{{name}} hinzugefügt.",
+    "failed": "Dieser Eintrag konnte nicht hinzugefügt werden.",
+    "noInitiatives": "Du kannst noch in keiner Initiative Dashboards erstellen. Frage eine Initiativleitung nach Zugriff."
+  },
+  "update": {
+    "available": "Version {{version}} verfügbar",
+    "action": "Aktualisieren",
+    "done": "Auf {{version}} aktualisiert.",
+    "failed": "Dieses Dashboard konnte nicht aktualisiert werden."
+  }
+}

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -47,5 +47,6 @@
   "unavailable": {
     "title": "Marktplatz nicht erreichbar",
     "description": "Der Katalog konnte nicht geladen werden. Versuche es gleich noch einmal."
-  }
+  },
+  "installedUnknown": "Es konnte nicht geprüft werden, welche davon du bereits hast – deshalb ist unten nichts als installiert markiert."
 }

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -43,5 +43,9 @@
     "action": "Aktualisieren",
     "done": "Auf {{version}} aktualisiert.",
     "failed": "Dieses Dashboard konnte nicht aktualisiert werden."
+  },
+  "unavailable": {
+    "title": "Marktplatz nicht erreichbar",
+    "description": "Der Katalog konnte nicht geladen werden. Versuche es gleich noch einmal."
   }
 }

--- a/frontend/public/locales/de/nav.json
+++ b/frontend/public/locales/de/nav.json
@@ -78,5 +78,6 @@
     "finalizing": "Weiterleitung wird abgeschlossen…",
     "goHome": "Zurück zur Startseite"
   },
-  "adminDashboard": "Administrator-Dashboard"
+  "adminDashboard": "Administrator-Dashboard",
+  "marketplace": "Marktplatz"
 }

--- a/frontend/public/locales/en/dashboards.json
+++ b/frontend/public/locales/en/dashboards.json
@@ -143,5 +143,6 @@
     "data": "Data",
     "needsBinding": "You'll choose exactly what this shows after adding it.",
     "add": "Add {{widget}}"
-  }
+  },
+  "browseMarketplace": "Browse the marketplace"
 }

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -43,5 +43,9 @@
     "action": "Update",
     "done": "Updated to {{version}}.",
     "failed": "Could not update this dashboard."
+  },
+  "unavailable": {
+    "title": "Marketplace unavailable",
+    "description": "The catalog could not be reached. Try again in a moment."
   }
 }

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -1,0 +1,47 @@
+{
+  "title": "Marketplace",
+  "subtitle": "Ready-made dashboards you can add to an initiative.",
+  "searchPlaceholder": "Search the marketplace…",
+  "backToMarketplace": "Back to the marketplace",
+  "card": {
+    "installed": "Installed",
+    "version": "v{{version}}",
+    "needsUpdate": "Needs a newer app"
+  },
+  "empty": {
+    "title": "Nothing here yet",
+    "description": "This deployment has no listings to offer."
+  },
+  "noResults": {
+    "title": "No matches",
+    "description": "Nothing in the marketplace matches “{{query}}”."
+  },
+  "detail": {
+    "by": "by {{publisher}}",
+    "installs_one": "{{count}} install",
+    "installs_other": "{{count}} installs",
+    "install": "Add to an initiative",
+    "preview": "Preview",
+    "versions": "Versions",
+    "needsUpdate": "Needs a newer version of the app.",
+    "withdrawn": "No longer offered.",
+    "notFound": "Listing not found",
+    "notFoundDescription": "It may have been withdrawn, or the link may be wrong."
+  },
+  "install": {
+    "title": "Add {{name}}",
+    "description": "Choose where it goes. You can rename it now or later.",
+    "initiative": "Initiative",
+    "name": "Name",
+    "action": "Add",
+    "done": "{{name}} added.",
+    "failed": "Could not add that listing.",
+    "noInitiatives": "You cannot create dashboards in any initiative yet. Ask an initiative manager for access."
+  },
+  "update": {
+    "available": "Version {{version}} available",
+    "action": "Update",
+    "done": "Updated to {{version}}.",
+    "failed": "Could not update this dashboard."
+  }
+}

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -47,5 +47,6 @@
   "unavailable": {
     "title": "Marketplace unavailable",
     "description": "The catalog could not be reached. Try again in a moment."
-  }
+  },
+  "installedUnknown": "Couldn't check which of these you already have, so nothing below is marked as installed."
 }

--- a/frontend/public/locales/en/nav.json
+++ b/frontend/public/locales/en/nav.json
@@ -78,5 +78,6 @@
     "finalizing": "Finalizing redirect…",
     "goHome": "Go back home"
   },
-  "adminDashboard": "Admin dashboard"
+  "adminDashboard": "Admin dashboard",
+  "marketplace": "Marketplace"
 }

--- a/frontend/public/locales/es/dashboards.json
+++ b/frontend/public/locales/es/dashboards.json
@@ -143,5 +143,6 @@
     "data": "Datos",
     "needsBinding": "Elegirás exactamente qué muestra después de añadirlo.",
     "add": "Añadir {{widget}}"
-  }
+  },
+  "browseMarketplace": "Explorar el mercado"
 }

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -43,5 +43,9 @@
     "action": "Actualizar",
     "done": "Actualizado a {{version}}.",
     "failed": "No se pudo actualizar este panel."
+  },
+  "unavailable": {
+    "title": "Mercado no disponible",
+    "description": "No se pudo acceder al catálogo. Inténtalo de nuevo en un momento."
   }
 }

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -1,0 +1,47 @@
+{
+  "title": "Mercado",
+  "subtitle": "Paneles listos para usar que puedes añadir a una iniciativa.",
+  "searchPlaceholder": "Buscar en el mercado…",
+  "backToMarketplace": "Volver al mercado",
+  "card": {
+    "installed": "Instalado",
+    "version": "v{{version}}",
+    "needsUpdate": "Necesita una app más reciente"
+  },
+  "empty": {
+    "title": "Aquí no hay nada todavía",
+    "description": "Esta instalación no ofrece ningún elemento."
+  },
+  "noResults": {
+    "title": "Sin coincidencias",
+    "description": "Nada en el mercado coincide con «{{query}}»."
+  },
+  "detail": {
+    "by": "de {{publisher}}",
+    "installs_one": "{{count}} instalación",
+    "installs_other": "{{count}} instalaciones",
+    "install": "Añadir a una iniciativa",
+    "preview": "Vista previa",
+    "versions": "Versiones",
+    "needsUpdate": "Necesita una versión más reciente de la aplicación.",
+    "withdrawn": "Ya no está disponible.",
+    "notFound": "Elemento no encontrado",
+    "notFoundDescription": "Puede que se haya retirado o que el enlace sea incorrecto."
+  },
+  "install": {
+    "title": "Añadir {{name}}",
+    "description": "Elige dónde va. Puedes renombrarlo ahora o más tarde.",
+    "initiative": "Iniciativa",
+    "name": "Nombre",
+    "action": "Añadir",
+    "done": "{{name}} añadido.",
+    "failed": "No se pudo añadir ese elemento.",
+    "noInitiatives": "Todavía no puedes crear paneles en ninguna iniciativa. Pide acceso a una persona responsable de la iniciativa."
+  },
+  "update": {
+    "available": "Versión {{version}} disponible",
+    "action": "Actualizar",
+    "done": "Actualizado a {{version}}.",
+    "failed": "No se pudo actualizar este panel."
+  }
+}

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -47,5 +47,6 @@
   "unavailable": {
     "title": "Mercado no disponible",
     "description": "No se pudo acceder al catálogo. Inténtalo de nuevo en un momento."
-  }
+  },
+  "installedUnknown": "No se pudo comprobar cuáles de estos ya tienes, así que nada de lo siguiente aparece como instalado."
 }

--- a/frontend/public/locales/es/nav.json
+++ b/frontend/public/locales/es/nav.json
@@ -78,5 +78,6 @@
   "advancedTools": "Herramientas avanzadas",
   "createAdvancedTool": "Nueva herramienta avanzada",
   "createExternally": "Se crea en {{name}}",
-  "adminDashboard": "Panel de administración"
+  "adminDashboard": "Panel de administración",
+  "marketplace": "Mercado"
 }

--- a/frontend/public/locales/fr/dashboards.json
+++ b/frontend/public/locales/fr/dashboards.json
@@ -143,5 +143,6 @@
     "data": "Données",
     "needsBinding": "Vous choisirez précisément ce qu'il affiche après l'avoir ajouté.",
     "add": "Ajouter {{widget}}"
-  }
+  },
+  "browseMarketplace": "Parcourir le catalogue"
 }

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -43,5 +43,9 @@
     "action": "Mettre à jour",
     "done": "Mis à jour vers {{version}}.",
     "failed": "Impossible de mettre à jour ce tableau de bord."
+  },
+  "unavailable": {
+    "title": "Catalogue indisponible",
+    "description": "Le catalogue n'a pas pu être joint. Réessayez dans un instant."
   }
 }

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -47,5 +47,6 @@
   "unavailable": {
     "title": "Catalogue indisponible",
     "description": "Le catalogue n'a pas pu être joint. Réessayez dans un instant."
-  }
+  },
+  "installedUnknown": "Impossible de vérifier lesquels vous possédez déjà : rien ci-dessous n'est donc marqué comme installé."
 }

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -1,0 +1,47 @@
+{
+  "title": "Catalogue",
+  "subtitle": "Des tableaux de bord prêts à l'emploi, à ajouter à une initiative.",
+  "searchPlaceholder": "Rechercher dans le catalogue…",
+  "backToMarketplace": "Retour au catalogue",
+  "card": {
+    "installed": "Installé",
+    "version": "v{{version}}",
+    "needsUpdate": "Nécessite une app plus récente"
+  },
+  "empty": {
+    "title": "Rien ici pour l'instant",
+    "description": "Cette instance ne propose aucune fiche."
+  },
+  "noResults": {
+    "title": "Aucun résultat",
+    "description": "Rien dans le catalogue ne correspond à « {{query}} »."
+  },
+  "detail": {
+    "by": "par {{publisher}}",
+    "installs_one": "{{count}} installation",
+    "installs_other": "{{count}} installations",
+    "install": "Ajouter à une initiative",
+    "preview": "Aperçu",
+    "versions": "Versions",
+    "needsUpdate": "Nécessite une version plus récente de l'application.",
+    "withdrawn": "N'est plus proposé.",
+    "notFound": "Fiche introuvable",
+    "notFoundDescription": "Elle a peut-être été retirée, ou le lien est incorrect."
+  },
+  "install": {
+    "title": "Ajouter {{name}}",
+    "description": "Choisissez sa destination. Vous pourrez le renommer maintenant ou plus tard.",
+    "initiative": "Initiative",
+    "name": "Nom",
+    "action": "Ajouter",
+    "done": "{{name}} ajouté.",
+    "failed": "Impossible d'ajouter cette fiche.",
+    "noInitiatives": "Vous ne pouvez encore créer de tableaux de bord dans aucune initiative. Demandez l'accès à une personne responsable de l'initiative."
+  },
+  "update": {
+    "available": "Version {{version}} disponible",
+    "action": "Mettre à jour",
+    "done": "Mis à jour vers {{version}}.",
+    "failed": "Impossible de mettre à jour ce tableau de bord."
+  }
+}

--- a/frontend/public/locales/fr/nav.json
+++ b/frontend/public/locales/fr/nav.json
@@ -78,5 +78,6 @@
   "advancedTools": "Outils avancés",
   "createAdvancedTool": "Nouvel outil avancé",
   "createExternally": "Créé dans {{name}}",
-  "adminDashboard": "Tableau de bord admin"
+  "adminDashboard": "Tableau de bord admin",
+  "marketplace": "Catalogue"
 }

--- a/frontend/public/marketplace/core-delivery-timeline.svg
+++ b/frontend/public/marketplace/core-delivery-timeline.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f766e"/>
+      <stop offset="1" stop-color="#22c55e"/>
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="20" fill="url(#g)"/>
+  <g fill="#fff" fill-opacity=".92">
+    <rect x="22" y="28" width="40" height="9" rx="4.5"/>
+    <rect x="34" y="43" width="40" height="9" rx="4.5"/>
+    <rect x="28" y="58" width="28" height="9" rx="4.5"/>
+  </g>
+  <rect x="22" y="74" width="52" height="3" rx="1.5" fill="#fff" fill-opacity=".45"/>
+</svg>

--- a/frontend/public/marketplace/core-project-health.svg
+++ b/frontend/public/marketplace/core-project-health.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4f46e5"/>
+      <stop offset="1" stop-color="#0ea5e9"/>
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="20" fill="url(#g)"/>
+  <g fill="#fff" fill-opacity=".92">
+    <rect x="24" y="52" width="10" height="20" rx="3"/>
+    <rect x="40" y="42" width="10" height="30" rx="3"/>
+    <rect x="56" y="30" width="10" height="42" rx="3"/>
+  </g>
+  <rect x="22" y="74" width="52" height="3" rx="1.5" fill="#fff" fill-opacity=".45"/>
+</svg>

--- a/frontend/public/marketplace/core-task-flow.svg
+++ b/frontend/public/marketplace/core-task-flow.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#b45309"/>
+      <stop offset="1" stop-color="#f59e0b"/>
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="20" fill="url(#g)"/>
+  <g fill="#fff" fill-opacity=".92">
+    <rect x="22" y="28" width="52" height="10" rx="5"/>
+    <rect x="30" y="43" width="36" height="10" rx="5"/>
+    <rect x="38" y="58" width="20" height="10" rx="5"/>
+  </g>
+</svg>

--- a/frontend/src/api/generated/dashboards/dashboards.ts
+++ b/frontend/src/api/generated/dashboards/dashboards.ts
@@ -22,6 +22,7 @@ import type {
 
 import type {
   DashboardCreate,
+  DashboardInstalledListings,
   DashboardListResponse,
   DashboardRead,
   DashboardUpdate,
@@ -318,6 +319,213 @@ export const useCreateDashboardApiV1GGuildIdDashboardsPost = <
     queryClient
   );
 };
+/**
+ * Which marketplace listings this guild has installed, and how many of each.
+ *
+ * One row per distinct listing rather than per dashboard, so the answer is
+ * complete in one response — the dashboard list is paginated, and a partial
+ * page would mark some installs and miss others.
+ *
+ * RLS-scoped like every other read here: it counts the dashboards the caller
+ * can see.
+ * @summary Read Installed Listings
+ */
+export const readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet = (
+  guildId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DashboardInstalledListings>(
+    { url: `/api/v1/g/${guildId}/dashboards/installed-listings`, method: "GET", signal },
+    options
+  );
+};
+
+export const getReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryKey = (
+  guildId: number
+) => {
+  return [`/api/v1/g/${guildId}/dashboards/installed-listings`] as const;
+};
+
+export const getReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryOptions = <
+  TData = Awaited<
+    ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryKey(guildId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>>
+  > = ({ signal }) =>
+    readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet(
+      guildId,
+      requestOptions,
+      signal
+    );
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: guildId !== null && guildId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryResult =
+  NonNullable<
+    Awaited<ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>>
+  >;
+export type ReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet<
+  TData = Awaited<
+    ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<
+            ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+          >,
+          TError,
+          Awaited<
+            ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet<
+  TData = Awaited<
+    ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<
+            ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+          >,
+          TError,
+          Awaited<
+            ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+          >
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet<
+  TData = Awaited<
+    ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Read Installed Listings
+ */
+
+export function useReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet<
+  TData = Awaited<
+    ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+  >,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet>
+        >,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions =
+    getReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryOptions(
+      guildId,
+      options
+    );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
 /**
  * The widget vocabulary this build supports — size floors, bindable
  * sources, and display options per primitive, plus the named presets.

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1413,6 +1413,21 @@ export interface DashboardCreate {
   grants?: ResourceGrantSchema[];
 }
 
+export type DashboardInstalledListingsCounts = { [key: string]: number };
+
+/**
+ * How many dashboards in this guild came from each marketplace listing.
+ *
+ * Keyed by listing uid, because that is what an install pins. Answered here
+ * rather than by the catalog: which listings a guild has is guild data, and the
+ * catalog holds none of it. Small and unpaginated by construction — one entry
+ * per distinct listing, not per dashboard — so a browse surface can mark what
+ * is already installed without walking the dashboard list.
+ */
+export interface DashboardInstalledListings {
+  counts: DashboardInstalledListingsCounts;
+}
+
 export interface DashboardSummary {
   /**
    * @minLength 1

--- a/frontend/src/api/generated/marketplace/marketplace.ts
+++ b/frontend/src/api/generated/marketplace/marketplace.ts
@@ -205,6 +205,176 @@ export function useListMarketplaceListingsApiV1MarketplaceListingsGet<
 }
 
 /**
+ * The listing a code names.
+ *
+ * This is what an installed instance uses to find where it came from: the
+ * instance stores the uid, and the catalog answers with the listing and the
+ * version it currently publishes.
+ * @summary Resolve Marketplace Listing
+ */
+export const resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet = (
+  uid: string,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<MarketplaceListingDetail>(
+    { url: `/api/v1/marketplace/listings/by-uid/${uid}`, method: "GET", signal },
+    options
+  );
+};
+
+export const getResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryKey = (
+  uid: string
+) => {
+  return [`/api/v1/marketplace/listings/by-uid/${uid}`] as const;
+};
+
+export const getResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  uid: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryKey(uid);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>
+  > = ({ signal }) =>
+    resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet(uid, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: uid !== null && uid !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>
+>;
+export type ResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet<
+  TData = Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  uid: string,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+          TError,
+          Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet<
+  TData = Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  uid: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+          TError,
+          Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet<
+  TData = Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  uid: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Resolve Marketplace Listing
+ */
+
+export function useResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet<
+  TData = Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  uid: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryOptions(
+    uid,
+    options
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
  * One listing, with what it would install and every version it has.
  * @summary Read Marketplace Listing
  */

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -9,6 +9,7 @@ import {
   ScrollText,
   Settings,
   Star,
+  Store,
   Tag,
   Users,
 } from "lucide-react";
@@ -466,6 +467,23 @@ export const AppSidebar = () => {
                                 </SidebarMenuItem>
                               </SidebarMenu>
                             )}
+                          </SidebarGroupContent>
+                        </SidebarGroup>
+
+                        {/* Guild-level, below the initiatives: browsing is open
+                            to every member — installing is where the gates are. */}
+                        <SidebarGroup>
+                          <SidebarGroupContent>
+                            <SidebarMenu>
+                              <SidebarMenuItem>
+                                <SidebarMenuButton asChild size="sm">
+                                  <Link to={gp("/marketplace")}>
+                                    <Store className="h-4 w-4" />
+                                    <span>{t("marketplace")}</span>
+                                  </Link>
+                                </SidebarMenuButton>
+                              </SidebarMenuItem>
+                            </SidebarMenu>
                           </SidebarGroupContent>
                         </SidebarGroup>
                       </SidebarContent>

--- a/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The "there's a newer version" affordance.
+ *
+ * It is only ever an offer. Applying a version replaces the dashboard's canvas,
+ * so it takes the same write access editing does — and it must not appear at all
+ * for a dashboard nobody installed, a listing that is gone, a version this build
+ * cannot run, or a version already pinned. Each of those is a separate reason to
+ * show nothing, and getting any of them wrong puts a button in front of someone
+ * that either does nothing or changes their dashboard when they didn't ask.
+ */
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/__tests__/helpers/render";
+import type {
+  DashboardRead,
+  MarketplaceListingDetail,
+} from "@/api/generated/initiativeAPI.schemas";
+
+import { DashboardUpdateBadge } from "./DashboardUpdateBadge";
+
+const upgrade = vi.fn();
+let listing: Partial<MarketplaceListingDetail> | undefined;
+
+vi.mock("@/hooks/useMarketplace", () => ({
+  useMarketplaceListingByUid: (uid: string | null | undefined) => ({
+    data: uid ? listing : undefined,
+  }),
+}));
+
+vi.mock("@/hooks/useDashboards", () => ({
+  useUpgradeDashboard: () => ({ mutate: upgrade, isPending: false }),
+}));
+
+const dashboard = (overrides: Partial<DashboardRead> = {}) =>
+  ({
+    id: 3,
+    name: "Sprint health",
+    listing_uid: "NSTA0000000001",
+    listing_version: "1.0.0",
+    ...overrides,
+  }) as DashboardRead;
+
+const publishing = (version: string, compatible = true) => ({
+  latest_version: { version, compatible },
+});
+
+beforeEach(() => {
+  upgrade.mockClear();
+  listing = publishing("2.0.0") as Partial<MarketplaceListingDetail>;
+});
+
+describe("DashboardUpdateBadge", () => {
+  it("offers the newer version to someone who can apply it", () => {
+    renderWithProviders(<DashboardUpdateBadge dashboard={dashboard()} canEdit />);
+    expect(screen.getByRole("button", { name: /2\.0\.0/ })).toBeInTheDocument();
+  });
+
+  it("applies it only when asked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DashboardUpdateBadge dashboard={dashboard()} canEdit />);
+    expect(upgrade).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /2\.0\.0/ }));
+    expect(upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("tells a viewer without write access rather than offering a button", () => {
+    renderWithProviders(<DashboardUpdateBadge dashboard={dashboard()} canEdit={false} />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText(/2\.0\.0/)).toBeInTheDocument();
+  });
+
+  it("shows nothing for a dashboard that was authored here", () => {
+    const { container } = renderWithProviders(
+      <DashboardUpdateBadge dashboard={dashboard({ listing_uid: null })} canEdit />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows nothing when the pinned version is the current one", () => {
+    listing = publishing("1.0.0") as Partial<MarketplaceListingDetail>;
+    const { container } = renderWithProviders(
+      <DashboardUpdateBadge dashboard={dashboard()} canEdit />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows nothing when this build cannot run the newer version", () => {
+    // Offering it would produce a 409; the listing page is where "upgrade the
+    // app first" belongs, not a button here that cannot work.
+    listing = publishing("3.0.0", false) as Partial<MarketplaceListingDetail>;
+    const { container } = renderWithProviders(
+      <DashboardUpdateBadge dashboard={dashboard()} canEdit />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows nothing when the listing is no longer in the catalog", () => {
+    listing = undefined;
+    const { container } = renderWithProviders(
+      <DashboardUpdateBadge dashboard={dashboard()} canEdit />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.test.tsx
@@ -42,8 +42,9 @@ const dashboard = (overrides: Partial<DashboardRead> = {}) =>
     ...overrides,
   }) as DashboardRead;
 
-const publishing = (version: string, compatible = true) => ({
-  latest_version: { version, compatible },
+const publishing = (version: string, installable = true) => ({
+  installable,
+  latest_version: { version, compatible: installable },
 });
 
 beforeEach(() => {
@@ -91,6 +92,20 @@ describe("DashboardUpdateBadge", () => {
     // Offering it would produce a 409; the listing page is where "upgrade the
     // app first" belongs, not a button here that cannot work.
     listing = publishing("3.0.0", false) as Partial<MarketplaceListingDetail>;
+    const { container } = renderWithProviders(
+      <DashboardUpdateBadge dashboard={dashboard()} canEdit />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows nothing when the listing has been withdrawn", () => {
+    // A withdrawn listing can still have a newer version on record. Installing
+    // or upgrading it is refused, so offering the button would only fail.
+    listing = {
+      installable: false,
+      available: false,
+      latest_version: { version: "2.0.0", compatible: true },
+    } as Partial<MarketplaceListingDetail>;
     const { container } = renderWithProviders(
       <DashboardUpdateBadge dashboard={dashboard()} canEdit />
     );

--- a/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.tsx
@@ -32,10 +32,13 @@ export function DashboardUpdateBadge({ dashboard, canEdit }: DashboardUpdateBadg
   const listingQuery = useMarketplaceListingByUid(dashboard.listing_uid);
   const upgrade = useUpgradeDashboard(dashboard.id);
 
-  const latest = listingQuery.data?.latest_version;
-  // Nothing to offer: not installed, the listing is gone, this build cannot run
-  // the new version, or it is already the pinned one.
-  if (!latest?.compatible || latest.version === dashboard.listing_version) {
+  const listing = listingQuery.data;
+  const latest = listing?.latest_version;
+  // `installable` is the server's own verdict — still offered, has a version,
+  // and that version runs on this build — so the button appears only when the
+  // upgrade would actually be accepted. Re-deriving it here is how a withdrawn
+  // listing ends up offering an update that 409s.
+  if (!listing?.installable || !latest || latest.version === dashboard.listing_version) {
     return null;
   }
 

--- a/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardUpdateBadge.tsx
@@ -1,0 +1,70 @@
+/**
+ * "There's a newer version of this."
+ *
+ * Shown only for a dashboard that was installed from a listing, and only when
+ * the version it is pinned to is not the one the listing currently publishes.
+ * Taking it is always a click: applying a new version replaces this dashboard's
+ * canvas, so it is the author's call and nobody else's — and it re-pins this
+ * dashboard alone, leaving any other install of the same listing where it is.
+ *
+ * A dashboard authored here has no listing and renders nothing at all.
+ */
+
+import { ArrowUpCircle, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import type { DashboardRead } from "@/api/generated/initiativeAPI.schemas";
+import { Button } from "@/components/ui/button";
+import { useUpgradeDashboard } from "@/hooks/useDashboards";
+import { useMarketplaceListingByUid } from "@/hooks/useMarketplace";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+
+export interface DashboardUpdateBadgeProps {
+  dashboard: DashboardRead;
+  /** Applying a version rewrites the canvas, so it takes the same write access
+   *  that editing does. Without it the badge is informational. */
+  canEdit: boolean;
+}
+
+export function DashboardUpdateBadge({ dashboard, canEdit }: DashboardUpdateBadgeProps) {
+  const { t } = useTranslation("marketplace");
+  const listingQuery = useMarketplaceListingByUid(dashboard.listing_uid);
+  const upgrade = useUpgradeDashboard(dashboard.id);
+
+  const latest = listingQuery.data?.latest_version;
+  // Nothing to offer: not installed, the listing is gone, this build cannot run
+  // the new version, or it is already the pinned one.
+  if (!latest?.compatible || latest.version === dashboard.listing_version) {
+    return null;
+  }
+
+  const apply = () =>
+    upgrade.mutate(undefined, {
+      onSuccess: (updated) => {
+        toast.success(t("update.done", { version: updated.listing_version }));
+      },
+      onError: (error) => {
+        toast.error(getErrorMessage(error, "marketplace:update.failed"));
+      },
+    });
+
+  if (!canEdit) {
+    return (
+      <span className="text-muted-foreground text-xs">
+        {t("update.available", { version: latest.version })}
+      </span>
+    );
+  }
+
+  return (
+    <Button size="sm" variant="outline" onClick={apply} disabled={upgrade.isPending}>
+      {upgrade.isPending ? (
+        <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+      ) : (
+        <ArrowUpCircle className="mr-1.5 h-4 w-4" />
+      )}
+      {t("update.available", { version: latest.version })}
+    </Button>
+  );
+}

--- a/frontend/src/components/marketplace/InstallListingDialog.tsx
+++ b/frontend/src/components/marketplace/InstallListingDialog.tsx
@@ -1,0 +1,156 @@
+/**
+ * "Where should this go?"
+ *
+ * A dashboard belongs to an initiative, so installing one is a choice of which.
+ * The picker offers only the initiatives where the viewer may create dashboards
+ * — the same permission the create flow uses, and the same one the server checks
+ * — so the list is what the install will actually accept.
+ *
+ * The definition is never sent. The request names the listing; the server reads
+ * what that listing publishes.
+ */
+
+import { useNavigate } from "@tanstack/react-router";
+import { Download, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { MarketplaceListingDetail, Tool } from "@/api/generated/initiativeAPI.schemas";
+import { Tool as ToolEnum } from "@/api/generated/initiativeAPI.schemas";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useCreateDashboard } from "@/hooks/useDashboards";
+import { useToolCreateAccess } from "@/hooks/useInitiativeAccess";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { useGuildPath } from "@/lib/guildUrl";
+import type { DialogProps } from "@/types/dialog";
+
+export interface InstallListingDialogProps extends DialogProps {
+  listing: MarketplaceListingDetail;
+  /** Pre-selected when the viewer arrived from an initiative. */
+  defaultInitiativeId?: number;
+}
+
+export function InstallListingDialog({
+  listing,
+  defaultInitiativeId,
+  open,
+  onOpenChange,
+}: InstallListingDialogProps) {
+  const { t } = useTranslation(["marketplace", "common"]);
+  const navigate = useNavigate();
+  const gp = useGuildPath();
+
+  const { creatableInitiatives } = useToolCreateAccess(ToolEnum.dashboard as Tool);
+  const [initiativeId, setInitiativeId] = useState<string>("");
+  const [name, setName] = useState(listing.name);
+  const install = useCreateDashboard();
+
+  // Seeded once the options are known: the initiative the viewer came from when
+  // they may create there, otherwise the only one they can.
+  useEffect(() => {
+    if (initiativeId || !creatableInitiatives.length) return;
+    const fromContext = creatableInitiatives.find((i) => i.id === defaultInitiativeId);
+    setInitiativeId(String((fromContext ?? creatableInitiatives[0]).id));
+  }, [creatableInitiatives, defaultInitiativeId, initiativeId]);
+
+  const submit = () => {
+    if (!initiativeId) return;
+    install.mutate(
+      {
+        name: name.trim() || listing.name,
+        initiative_id: Number(initiativeId),
+        listing_uid: listing.uid,
+      },
+      {
+        onSuccess: (dashboard) => {
+          toast.success(t("marketplace:install.done", { name: dashboard.name }));
+          onOpenChange(false);
+          navigate({ to: gp(`/dashboards/${dashboard.id}`) });
+        },
+        onError: (error) => {
+          toast.error(getErrorMessage(error, "marketplace:install.failed"));
+        },
+      }
+    );
+  };
+
+  const nowhereToInstall = creatableInitiatives.length === 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("marketplace:install.title", { name: listing.name })}</DialogTitle>
+          <DialogDescription>{t("marketplace:install.description")}</DialogDescription>
+        </DialogHeader>
+
+        {nowhereToInstall ? (
+          <p className="text-muted-foreground text-sm">{t("marketplace:install.noInitiatives")}</p>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="install-initiative">{t("marketplace:install.initiative")}</Label>
+              <Select value={initiativeId} onValueChange={setInitiativeId}>
+                <SelectTrigger id="install-initiative">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {creatableInitiatives.map((initiative) => (
+                    <SelectItem key={initiative.id} value={String(initiative.id)}>
+                      {initiative.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="install-name">{t("marketplace:install.name")}</Label>
+              <Input
+                id="install-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder={listing.name}
+              />
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("common:cancel")}
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={nowhereToInstall || !initiativeId || install.isPending}
+          >
+            {install.isPending ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="mr-1.5 h-4 w-4" />
+            )}
+            {t("marketplace:install.action")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/marketplace/MarketplaceCard.tsx
+++ b/frontend/src/components/marketplace/MarketplaceCard.tsx
@@ -1,0 +1,72 @@
+/**
+ * One listing on the browse grid.
+ *
+ * The artwork is the listing's own — every listing ships custom art, so this
+ * never falls back to a product icon and one listing never looks like another.
+ * It renders as a plain `<img>`; a listing supplies a URL, never markup.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+
+import type { MarketplaceListingSummary } from "@/api/generated/initiativeAPI.schemas";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { useGuildPath } from "@/lib/guildUrl";
+import { cn } from "@/lib/utils";
+
+export interface MarketplaceCardProps {
+  listing: MarketplaceListingSummary;
+  /** Set when this guild already has an install of this listing. */
+  installedCount?: number;
+}
+
+export function MarketplaceCard({ listing, installedCount = 0 }: MarketplaceCardProps) {
+  const { t } = useTranslation("marketplace");
+  const gp = useGuildPath();
+
+  return (
+    <Card className="h-full transition-colors hover:border-primary/50">
+      <Link
+        to={gp(`/marketplace/${listing.public_id}`)}
+        className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <CardContent className="flex h-full gap-3 p-4">
+          <img
+            src={listing.avatar_url}
+            alt=""
+            aria-hidden
+            className="h-12 w-12 shrink-0 rounded-lg object-cover"
+            loading="lazy"
+          />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="truncate font-medium text-sm">{listing.name}</h3>
+              {installedCount > 0 && (
+                <Badge variant="secondary" className="shrink-0">
+                  {t("card.installed")}
+                </Badge>
+              )}
+            </div>
+            <p className="truncate text-muted-foreground text-xs">{listing.publisher}</p>
+            <p className="mt-1.5 line-clamp-2 text-muted-foreground text-sm">
+              {listing.description}
+            </p>
+            <div className={cn("mt-auto flex items-center gap-2 pt-2")}>
+              {listing.latest_version && (
+                <span className="text-muted-foreground text-xs">
+                  {t("card.version", { version: listing.latest_version.version })}
+                </span>
+              )}
+              {!listing.installable && (
+                <Badge variant="outline" className="text-xs">
+                  {t("card.needsUpdate")}
+                </Badge>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Link>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useDashboards.ts
+++ b/frontend/src/hooks/useDashboards.ts
@@ -11,6 +11,7 @@ import {
   readWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGet,
   setDashboardGrantsApiV1GGuildIdDashboardsDashboardIdGrantsPut,
   updateDashboardApiV1GGuildIdDashboardsDashboardIdPatch,
+  upgradeDashboardApiV1GGuildIdDashboardsDashboardIdUpgradePost,
 } from "@/api/generated/dashboards/dashboards";
 import type {
   DashboardCreate,
@@ -104,6 +105,35 @@ export const useUpdateDashboard = (
         // save succeeds and renders the *old* server layout for a beat — a
         // dragged widget visibly snaps back to where it came from, then jumps
         // forward again when the refetch arrives.
+        queryClient.setQueryData(
+          getReadDashboardApiV1GGuildIdDashboardsDashboardIdGetQueryKey(guildId, dashboardId),
+          updated
+        );
+        return invalidateDashboardAndList(dashboardId);
+      },
+      errorKey: "dashboards:error",
+    },
+    options
+  );
+};
+
+/**
+ * Take the version a listing currently publishes.
+ *
+ * Only ever explicit: a new version sits in the catalog until someone with
+ * write access on this dashboard asks for it, and applying it re-pins this
+ * instance alone.
+ */
+export const useUpgradeDashboard = (
+  dashboardId: number,
+  options?: MutationOpts<DashboardRead, void>
+) => {
+  const guildId = useActiveGuildId();
+  return useGuildMutation<DashboardRead, void>(
+    {
+      mutationFn: (guildId) =>
+        upgradeDashboardApiV1GGuildIdDashboardsDashboardIdUpgradePost(guildId, dashboardId),
+      invalidate: (updated) => {
         queryClient.setQueryData(
           getReadDashboardApiV1GGuildIdDashboardsDashboardIdGetQueryKey(guildId, dashboardId),
           updated

--- a/frontend/src/hooks/useDashboards.ts
+++ b/frontend/src/hooks/useDashboards.ts
@@ -5,9 +5,11 @@ import {
   deleteDashboardApiV1GGuildIdDashboardsDashboardIdDelete,
   getListDashboardsApiV1GGuildIdDashboardsGetQueryKey,
   getReadDashboardApiV1GGuildIdDashboardsDashboardIdGetQueryKey,
+  getReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryKey,
   getReadWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGetQueryKey,
   listDashboardsApiV1GGuildIdDashboardsGet,
   readDashboardApiV1GGuildIdDashboardsDashboardIdGet,
+  readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet,
   readWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGet,
   setDashboardGrantsApiV1GGuildIdDashboardsDashboardIdGrantsPut,
   updateDashboardApiV1GGuildIdDashboardsDashboardIdPatch,
@@ -15,6 +17,7 @@ import {
 } from "@/api/generated/dashboards/dashboards";
 import type {
   DashboardCreate,
+  DashboardInstalledListings,
   DashboardListResponse,
   DashboardRead,
   DashboardUpdate,
@@ -70,6 +73,22 @@ export const useWidgetCatalog = (options?: QueryOpts<WidgetCatalog>) => {
     queryKey: getReadWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGetQueryKey(guildId),
     queryFn: () => readWidgetCatalogApiV1GGuildIdDashboardsWidgetCatalogGet(guildId),
     staleTime: Number.POSITIVE_INFINITY,
+    ...options,
+  });
+};
+
+/**
+ * Which marketplace listings this guild has installed, and how many of each.
+ *
+ * Keyed by the listing uid an install pins. Separate from the dashboards list on
+ * purpose: that list is paginated, and deriving "already installed" from one
+ * page would mark some installs and miss the rest.
+ */
+export const useInstalledListings = (options?: QueryOpts<DashboardInstalledListings>) => {
+  const guildId = useActiveGuildId();
+  return useQuery<DashboardInstalledListings>({
+    queryKey: getReadInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGetQueryKey(guildId),
+    queryFn: () => readInstalledListingsApiV1GGuildIdDashboardsInstalledListingsGet(guildId),
     ...options,
   });
 };

--- a/frontend/src/hooks/useMarketplace.ts
+++ b/frontend/src/hooks/useMarketplace.ts
@@ -1,0 +1,85 @@
+/**
+ * Reading the marketplace catalog.
+ *
+ * The catalog is platform-level: one shared surface, addressed by globally
+ * unique ids, with no guild in the request or the response. So these queries are
+ * keyed on what was asked for and nothing else, and two guilds browsing the same
+ * deployment share one cache entry.
+ *
+ * Whether a listing is *installed here* is a per-guild question the dashboards
+ * endpoints answer; the surface merges the two client-side rather than asking
+ * the catalog something it does not know.
+ */
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import type {
+  ListMarketplaceListingsApiV1MarketplaceListingsGetParams,
+  MarketplaceListingDetail,
+  MarketplaceListingPage,
+} from "@/api/generated/initiativeAPI.schemas";
+import {
+  getListMarketplaceListingsApiV1MarketplaceListingsGetQueryKey,
+  getReadMarketplaceListingApiV1MarketplaceListingsPublicIdGetQueryKey,
+  getResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryKey,
+  listMarketplaceListingsApiV1MarketplaceListingsGet,
+  readMarketplaceListingApiV1MarketplaceListingsPublicIdGet,
+  resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet,
+} from "@/api/generated/marketplace/marketplace";
+import type { QueryOpts } from "@/types/query";
+
+/** The catalog changes when a deployment is upgraded or a registry refresh
+ *  runs, not while someone is browsing. */
+const CATALOG_STALE_MS = 5 * 60 * 1000;
+
+export const useMarketplaceListings = (
+  params?: ListMarketplaceListingsApiV1MarketplaceListingsGetParams,
+  options?: QueryOpts<MarketplaceListingPage>
+) =>
+  useQuery<MarketplaceListingPage>({
+    queryKey: getListMarketplaceListingsApiV1MarketplaceListingsGetQueryKey(params),
+    queryFn: () => listMarketplaceListingsApiV1MarketplaceListingsGet(params),
+    // Typing keeps the previous page on screen while the next one loads, so the
+    // grid does not blank out on every keystroke.
+    placeholderData: keepPreviousData,
+    staleTime: CATALOG_STALE_MS,
+    ...options,
+  });
+
+export const useMarketplaceListing = (
+  publicId: string | null,
+  options?: QueryOpts<MarketplaceListingDetail>
+) => {
+  const { enabled: userEnabled = true, ...rest } = options ?? {};
+  return useQuery<MarketplaceListingDetail>({
+    queryKey: getReadMarketplaceListingApiV1MarketplaceListingsPublicIdGetQueryKey(publicId ?? ""),
+    queryFn: () => readMarketplaceListingApiV1MarketplaceListingsPublicIdGet(publicId as string),
+    enabled: Boolean(publicId) && userEnabled,
+    staleTime: CATALOG_STALE_MS,
+    ...rest,
+  });
+};
+
+/**
+ * The listing behind an installed instance.
+ *
+ * An install stores its listing's uid, not its public id — the uid is the stable
+ * identity across deployments — so finding "where did this come from, and is
+ * there a newer version?" goes through the uid.
+ */
+export const useMarketplaceListingByUid = (
+  uid: string | null | undefined,
+  options?: QueryOpts<MarketplaceListingDetail>
+) => {
+  const { enabled: userEnabled = true, ...rest } = options ?? {};
+  return useQuery<MarketplaceListingDetail>({
+    queryKey: getResolveMarketplaceListingApiV1MarketplaceListingsByUidUidGetQueryKey(uid ?? ""),
+    queryFn: () => resolveMarketplaceListingApiV1MarketplaceListingsByUidUidGet(uid as string),
+    enabled: Boolean(uid) && userEnabled,
+    staleTime: CATALOG_STALE_MS,
+    // A listing can be withdrawn; that is a real answer for an installed
+    // dashboard, not something to retry.
+    retry: false,
+    ...rest,
+  });
+};

--- a/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { DashboardCanvas } from "@/components/initiativeTools/dashboards/DashboardCanvas";
+import { DashboardUpdateBadge } from "@/components/initiativeTools/dashboards/DashboardUpdateBadge";
 import { WidgetConfigDialog } from "@/components/initiativeTools/dashboards/WidgetConfigDialog";
 import { WidgetPicker } from "@/components/initiativeTools/dashboards/WidgetPicker";
 import { StatusMessage } from "@/components/StatusMessage";
@@ -140,18 +141,21 @@ export function DashboardDetailPage() {
           )}
         </div>
 
-        {canEdit && (
-          <div className="flex shrink-0 items-center gap-2">
-            {editor.isSaving && (
-              <span className="text-muted-foreground text-xs">{t("canvas.saving")}</span>
-            )}
-            <WidgetPicker
-              catalog={catalogQuery.data}
-              widgetCount={editor.definition.widgets.length}
-              onAdd={editor.addWidget}
-            />
-          </div>
-        )}
+        <div className="flex shrink-0 items-center gap-2">
+          {dashboard && <DashboardUpdateBadge dashboard={dashboard} canEdit={canEdit} />}
+          {canEdit && (
+            <>
+              {editor.isSaving && (
+                <span className="text-muted-foreground text-xs">{t("canvas.saving")}</span>
+              )}
+              <WidgetPicker
+                catalog={catalogQuery.data}
+                widgetCount={editor.definition.widgets.length}
+                onAdd={editor.addWidget}
+              />
+            </>
+          )}
+        </div>
       </div>
 
       <DashboardCanvas

--- a/frontend/src/pages/initiativeTools/dashboards/DashboardsPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/DashboardsPage.tsx
@@ -1,5 +1,5 @@
-import { useRouter } from "@tanstack/react-router";
-import { Loader2, Plus } from "lucide-react";
+import { Link, useRouter } from "@tanstack/react-router";
+import { Loader2, Plus, Store } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -108,6 +108,14 @@ export const DashboardsView = ({ fixedInitiativeId, canCreate }: DashboardsViewP
                   {t("createDashboard")}
                 </Button>
               )}
+              {canCreateDashboards && (
+                <Button size="sm" variant="ghost" asChild>
+                  <Link to={gp("/marketplace")}>
+                    <Store className="h-4 w-4" />
+                    {t("browseMarketplace")}
+                  </Link>
+                </Button>
+              )}
             </div>
             <p className="text-muted-foreground text-sm">{t("noDashboardsDescription")}</p>
           </div>
@@ -119,6 +127,12 @@ export const DashboardsView = ({ fixedInitiativeId, canCreate }: DashboardsViewP
           <Button variant="outline" onClick={() => setCreateOpen(true)}>
             <Plus className="h-4 w-4" />
             {t("createDashboard")}
+          </Button>
+          <Button variant="ghost" asChild>
+            <Link to={gp("/marketplace")}>
+              <Store className="h-4 w-4" />
+              {t("browseMarketplace")}
+            </Link>
           </Button>
         </div>
       )}

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
@@ -22,8 +22,13 @@ vi.mock("@/hooks/useMarketplace", () => ({
   useMarketplaceListings: (params: unknown) => listingsFor(params),
 }));
 
+let installedFailed = false;
+
 vi.mock("@/hooks/useDashboards", () => ({
-  useInstalledListings: () => ({ data: { counts: installed } }),
+  useInstalledListings: () => ({
+    data: installedFailed ? undefined : { counts: installed },
+    isError: installedFailed,
+  }),
 }));
 
 const listing = (overrides: Partial<MarketplaceListingSummary> = {}) =>
@@ -47,6 +52,7 @@ const listing = (overrides: Partial<MarketplaceListingSummary> = {}) =>
 
 beforeEach(() => {
   installed = {};
+  installedFailed = false;
   listingsFor.mockReturnValue({
     data: { items: [listing()], total: 1 },
     isLoading: false,
@@ -92,6 +98,23 @@ describe("MarketplaceBrowsePage", () => {
     await waitFor(() =>
       expect(listingsFor).toHaveBeenCalledWith(expect.objectContaining({ q: "burndown" }))
     );
+  });
+
+  it("says so rather than marking everything uninstalled when the check fails", async () => {
+    // "We do not know" and "you have none of these" look identical on a card,
+    // and only one of them is true — so the page says which.
+    installedFailed = true;
+    renderPage(MarketplaceBrowsePage);
+    await screen.findByText("Sprint health");
+    expect(screen.queryByText("Installed")).toBeNull();
+    expect(screen.getByText(/couldn't check which of these/i)).toBeInTheDocument();
+  });
+
+  it("says nothing extra when the check succeeds", async () => {
+    installed = { SPRNT000000001: 1 };
+    renderPage(MarketplaceBrowsePage);
+    await screen.findByText("Installed");
+    expect(screen.queryByText(/couldn't check which of these/i)).toBeNull();
   });
 
   it("does not present a failed catalog as an empty one", async () => {

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Browsing the catalog.
+ *
+ * The load-bearing detail is where "already installed" comes from. The catalog
+ * is platform-level and holds nothing about this guild, so the badge has to be
+ * derived from the guild's own dashboards — matched on the listing uid an
+ * install pins, not on the name or the public id.
+ */
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+import type {
+  DashboardSummary,
+  MarketplaceListingSummary,
+} from "@/api/generated/initiativeAPI.schemas";
+
+import { MarketplaceBrowsePage } from "./MarketplaceBrowsePage";
+
+const listingsFor = vi.fn();
+let dashboards: Partial<DashboardSummary>[] = [];
+
+vi.mock("@/hooks/useMarketplace", () => ({
+  useMarketplaceListings: (params: unknown) => listingsFor(params),
+}));
+
+vi.mock("@/hooks/useDashboards", () => ({
+  useDashboardsList: () => ({ data: { items: dashboards } }),
+}));
+
+const listing = (overrides: Partial<MarketplaceListingSummary> = {}) =>
+  ({
+    uid: "SPRNT000000001",
+    public_id: "core.sprint",
+    kind: "dashboard",
+    source: "builtin",
+    name: "Sprint health",
+    publisher: "Initiative",
+    description: "How the sprint is going.",
+    avatar_url: "/marketplace/sprint.svg",
+    images: [],
+    installs_count: 0,
+    available: true,
+    installable: true,
+    latest_version: { version: "1.0.0", compatible: true, published_at: "" },
+    updated_at: "",
+    ...overrides,
+  }) as MarketplaceListingSummary;
+
+beforeEach(() => {
+  dashboards = [];
+  listingsFor.mockReturnValue({
+    data: { items: [listing()], total: 1 },
+    isLoading: false,
+  });
+});
+
+describe("MarketplaceBrowsePage", () => {
+  it("shows a card per listing", async () => {
+    renderPage(MarketplaceBrowsePage);
+    expect(await screen.findByText("Sprint health")).toBeInTheDocument();
+    expect(screen.getByText("Initiative")).toBeInTheDocument();
+  });
+
+  it("asks the catalog only for dashboards", async () => {
+    renderPage(MarketplaceBrowsePage);
+    await screen.findByText("Sprint health");
+    expect(listingsFor).toHaveBeenCalledWith(expect.objectContaining({ kind: "dashboard" }));
+  });
+
+  it("marks a listing this guild already installed", async () => {
+    // Matched on the uid an install pins — the catalog says nothing about who
+    // installed what, so this can only come from the guild's own dashboards.
+    dashboards = [{ id: 1, listing_uid: "SPRNT000000001" } as Partial<DashboardSummary>];
+    renderPage(MarketplaceBrowsePage);
+    expect(await screen.findByText("Installed")).toBeInTheDocument();
+  });
+
+  it("does not mark a listing whose uid nobody here pinned", async () => {
+    dashboards = [{ id: 1, listing_uid: "SMTHNG00000001" } as Partial<DashboardSummary>];
+    renderPage(MarketplaceBrowsePage);
+    await screen.findByText("Sprint health");
+    expect(screen.queryByText("Installed")).toBeNull();
+  });
+
+  it("does not mark a dashboard that was authored here", async () => {
+    dashboards = [{ id: 1, listing_uid: null } as Partial<DashboardSummary>];
+    renderPage(MarketplaceBrowsePage);
+    await screen.findByText("Sprint health");
+    expect(screen.queryByText("Installed")).toBeNull();
+  });
+
+  it("searches the catalog rather than filtering the page", async () => {
+    // Paging means the answer is not all on screen, so the query has to reach
+    // the server.
+    const user = userEvent.setup();
+    renderPage(MarketplaceBrowsePage);
+    await user.type(await screen.findByRole("textbox"), "burndown");
+
+    await waitFor(() =>
+      expect(listingsFor).toHaveBeenCalledWith(expect.objectContaining({ q: "burndown" }))
+    );
+  });
+
+  it("says so when a search matches nothing", async () => {
+    listingsFor.mockReturnValue({ data: { items: [], total: 0 }, isLoading: false });
+    renderPage(MarketplaceBrowsePage);
+    expect(await screen.findByText(/nothing here yet|no matches/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
@@ -11,22 +11,19 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderPage } from "@/__tests__/helpers/render";
-import type {
-  DashboardSummary,
-  MarketplaceListingSummary,
-} from "@/api/generated/initiativeAPI.schemas";
+import type { MarketplaceListingSummary } from "@/api/generated/initiativeAPI.schemas";
 
 import { MarketplaceBrowsePage } from "./MarketplaceBrowsePage";
 
 const listingsFor = vi.fn();
-let dashboards: Partial<DashboardSummary>[] = [];
+let installed: Record<string, number> = {};
 
 vi.mock("@/hooks/useMarketplace", () => ({
   useMarketplaceListings: (params: unknown) => listingsFor(params),
 }));
 
 vi.mock("@/hooks/useDashboards", () => ({
-  useDashboardsList: () => ({ data: { items: dashboards } }),
+  useInstalledListings: () => ({ data: { counts: installed } }),
 }));
 
 const listing = (overrides: Partial<MarketplaceListingSummary> = {}) =>
@@ -49,7 +46,7 @@ const listing = (overrides: Partial<MarketplaceListingSummary> = {}) =>
   }) as MarketplaceListingSummary;
 
 beforeEach(() => {
-  dashboards = [];
+  installed = {};
   listingsFor.mockReturnValue({
     data: { items: [listing()], total: 1 },
     isLoading: false,
@@ -70,22 +67,16 @@ describe("MarketplaceBrowsePage", () => {
   });
 
   it("marks a listing this guild already installed", async () => {
-    // Matched on the uid an install pins — the catalog says nothing about who
-    // installed what, so this can only come from the guild's own dashboards.
-    dashboards = [{ id: 1, listing_uid: "SPRNT000000001" } as Partial<DashboardSummary>];
+    // Counted server-side over every dashboard. Deriving this from the
+    // paginated dashboard list would mark some installs and miss the rest once
+    // a guild has more dashboards than fit on a page.
+    installed = { SPRNT000000001: 1 };
     renderPage(MarketplaceBrowsePage);
     expect(await screen.findByText("Installed")).toBeInTheDocument();
   });
 
   it("does not mark a listing whose uid nobody here pinned", async () => {
-    dashboards = [{ id: 1, listing_uid: "SMTHNG00000001" } as Partial<DashboardSummary>];
-    renderPage(MarketplaceBrowsePage);
-    await screen.findByText("Sprint health");
-    expect(screen.queryByText("Installed")).toBeNull();
-  });
-
-  it("does not mark a dashboard that was authored here", async () => {
-    dashboards = [{ id: 1, listing_uid: null } as Partial<DashboardSummary>];
+    installed = { SMTHNG00000001: 2 };
     renderPage(MarketplaceBrowsePage);
     await screen.findByText("Sprint health");
     expect(screen.queryByText("Installed")).toBeNull();
@@ -101,6 +92,14 @@ describe("MarketplaceBrowsePage", () => {
     await waitFor(() =>
       expect(listingsFor).toHaveBeenCalledWith(expect.objectContaining({ q: "burndown" }))
     );
+  });
+
+  it("does not present a failed catalog as an empty one", async () => {
+    // "Nothing to offer" would send someone looking for listings that exist.
+    listingsFor.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    renderPage(MarketplaceBrowsePage);
+    expect(await screen.findByText(/marketplace unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByText(/nothing here yet/i)).toBeNull();
   });
 
   it("says so when a search matches nothing", async () => {

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
@@ -9,15 +9,15 @@
  * matched up client-side.
  */
 
-import { SearchX } from "lucide-react";
-import { useMemo, useState } from "react";
+import { CloudOff, SearchX } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { MarketplaceCard } from "@/components/marketplace/MarketplaceCard";
 import { StatusMessage } from "@/components/StatusMessage";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useDashboardsList } from "@/hooks/useDashboards";
+import { useInstalledListings } from "@/hooks/useDashboards";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useMarketplaceListings } from "@/hooks/useMarketplace";
 
@@ -39,17 +39,11 @@ export function MarketplaceBrowsePage() {
     page_size: PAGE_SIZE,
   });
 
-  // Which of these this guild already has. A count, not a boolean: a guild may
-  // hold several installs of one listing, at different versions.
-  const dashboardsQuery = useDashboardsList();
-  const installedByUid = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const dashboard of dashboardsQuery.data?.items ?? []) {
-      if (!dashboard.listing_uid) continue;
-      counts.set(dashboard.listing_uid, (counts.get(dashboard.listing_uid) ?? 0) + 1);
-    }
-    return counts;
-  }, [dashboardsQuery.data]);
+  // Which of these this guild already has, counted server-side over every
+  // dashboard rather than over a page of them. A count, not a boolean: a guild
+  // may hold several installs of one listing, at different versions.
+  const installedQuery = useInstalledListings();
+  const installedByUid = installedQuery.data?.counts ?? {};
 
   const listings = listingsQuery.data?.items ?? [];
 
@@ -68,7 +62,15 @@ export function MarketplaceBrowsePage() {
         className="max-w-md"
       />
 
-      {listingsQuery.isLoading ? (
+      {listingsQuery.isError ? (
+        // A catalog that failed to answer is not a catalog with nothing in it,
+        // and saying so would send someone looking for listings that exist.
+        <StatusMessage
+          icon={<CloudOff />}
+          title={t("unavailable.title")}
+          description={t("unavailable.description")}
+        />
+      ) : listingsQuery.isLoading ? (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {SKELETON_KEYS.map((key) => (
             <Skeleton key={key} className="h-32 w-full rounded-xl" />
@@ -80,7 +82,7 @@ export function MarketplaceBrowsePage() {
             <MarketplaceCard
               key={listing.public_id}
               listing={listing}
-              installedCount={installedByUid.get(listing.uid) ?? 0}
+              installedCount={installedByUid[listing.uid] ?? 0}
             />
           ))}
         </div>

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
@@ -42,8 +42,12 @@ export function MarketplaceBrowsePage() {
   // Which of these this guild already has, counted server-side over every
   // dashboard rather than over a page of them. A count, not a boolean: a guild
   // may hold several installs of one listing, at different versions.
+  //
+  // Left undefined when that request failed, rather than defaulted to an empty
+  // map: "we do not know" and "you have none of these" look identical on a card,
+  // and only one of them is true. The notice below says which.
   const installedQuery = useInstalledListings();
-  const installedByUid = installedQuery.data?.counts ?? {};
+  const installedByUid = installedQuery.isError ? undefined : installedQuery.data?.counts;
 
   const listings = listingsQuery.data?.items ?? [];
 
@@ -77,15 +81,20 @@ export function MarketplaceBrowsePage() {
           ))}
         </div>
       ) : listings.length ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {listings.map((listing) => (
-            <MarketplaceCard
-              key={listing.public_id}
-              listing={listing}
-              installedCount={installedByUid[listing.uid] ?? 0}
-            />
-          ))}
-        </div>
+        <>
+          {installedQuery.isError && (
+            <p className="text-muted-foreground text-sm">{t("installedUnknown")}</p>
+          )}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {listings.map((listing) => (
+              <MarketplaceCard
+                key={listing.public_id}
+                listing={listing}
+                installedCount={installedByUid?.[listing.uid] ?? 0}
+              />
+            ))}
+          </div>
+        </>
       ) : (
         <StatusMessage
           icon={<SearchX />}

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
@@ -1,0 +1,98 @@
+/**
+ * The marketplace, as a place you browse.
+ *
+ * A searchable card grid rather than a menu: listings are products with artwork,
+ * a publisher, and a description, and picking one is a decision worth a page.
+ *
+ * The catalog is platform-level, so this asks it nothing about this guild. What
+ * is already installed here comes from the guild's own dashboards list and is
+ * matched up client-side.
+ */
+
+import { SearchX } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { MarketplaceCard } from "@/components/marketplace/MarketplaceCard";
+import { StatusMessage } from "@/components/StatusMessage";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useDashboardsList } from "@/hooks/useDashboards";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useMarketplaceListings } from "@/hooks/useMarketplace";
+
+const PAGE_SIZE = 24;
+/** Stable keys for the loading placeholders — they never reorder, and an index
+ *  key on a list that can change is the lint rule this avoids. */
+const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
+
+export function MarketplaceBrowsePage() {
+  const { t } = useTranslation("marketplace");
+  const [query, setQuery] = useState("");
+  // The catalog is a network call per keystroke otherwise, and the grid keeps
+  // the previous page while the next one loads.
+  const search = useDebouncedValue(query, 250);
+
+  const listingsQuery = useMarketplaceListings({
+    kind: "dashboard",
+    q: search.trim() || undefined,
+    page_size: PAGE_SIZE,
+  });
+
+  // Which of these this guild already has. A count, not a boolean: a guild may
+  // hold several installs of one listing, at different versions.
+  const dashboardsQuery = useDashboardsList();
+  const installedByUid = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const dashboard of dashboardsQuery.data?.items ?? []) {
+      if (!dashboard.listing_uid) continue;
+      counts.set(dashboard.listing_uid, (counts.get(dashboard.listing_uid) ?? 0) + 1);
+    }
+    return counts;
+  }, [dashboardsQuery.data]);
+
+  const listings = listingsQuery.data?.items ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="font-semibold text-3xl tracking-tight">{t("title")}</h1>
+        <p className="text-muted-foreground text-sm">{t("subtitle")}</p>
+      </div>
+
+      <Input
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder={t("searchPlaceholder")}
+        aria-label={t("searchPlaceholder")}
+        className="max-w-md"
+      />
+
+      {listingsQuery.isLoading ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {SKELETON_KEYS.map((key) => (
+            <Skeleton key={key} className="h-32 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : listings.length ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {listings.map((listing) => (
+            <MarketplaceCard
+              key={listing.public_id}
+              listing={listing}
+              installedCount={installedByUid.get(listing.uid) ?? 0}
+            />
+          ))}
+        </div>
+      ) : (
+        <StatusMessage
+          icon={<SearchX />}
+          title={search ? t("noResults.title") : t("empty.title")}
+          description={
+            search ? t("noResults.description", { query: search }) : t("empty.description")
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -1,0 +1,186 @@
+/**
+ * One listing's page: what it is, what it looks like, and how to get it.
+ *
+ * The preview is the real thing — the listing's definition rendered by the same
+ * canvas a live dashboard uses, read-only, over sample data. Someone deciding
+ * whether to install sees what they would get rather than a description of it.
+ */
+
+import { Link, useParams } from "@tanstack/react-router";
+import { Download, SearchX } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { DashboardCanvas } from "@/components/initiativeTools/dashboards/DashboardCanvas";
+import { InstallListingDialog } from "@/components/marketplace/InstallListingDialog";
+import { StatusMessage } from "@/components/StatusMessage";
+import { Badge } from "@/components/ui/badge";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useWidgetCatalog } from "@/hooks/useDashboards";
+import { useMarketplaceListing } from "@/hooks/useMarketplace";
+import { useGuildPath } from "@/lib/guildUrl";
+import { readConfig, readDefinition } from "@/lib/widgets/definition";
+
+export function MarketplaceListingPage() {
+  const { t } = useTranslation("marketplace");
+  const { publicId } = useParams({ strict: false }) as { publicId: string };
+  const gp = useGuildPath();
+
+  const listingQuery = useMarketplaceListing(publicId ?? null);
+  const catalogQuery = useWidgetCatalog();
+  const [installing, setInstalling] = useState(false);
+
+  const listing = listingQuery.data;
+
+  if (listingQuery.isError) {
+    return (
+      <StatusMessage
+        icon={<SearchX />}
+        title={t("detail.notFound")}
+        description={t("detail.notFoundDescription")}
+        backTo={gp("/marketplace")}
+        backLabel={t("backToMarketplace")}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to={gp("/marketplace")}>{t("title")}</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            {listing ? (
+              <BreadcrumbPage>{listing.name}</BreadcrumbPage>
+            ) : (
+              <Skeleton className="h-4 w-32" />
+            )}
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="flex flex-wrap items-start gap-4">
+        {listing ? (
+          <img
+            src={listing.avatar_url}
+            alt=""
+            aria-hidden
+            className="h-16 w-16 shrink-0 rounded-xl object-cover"
+          />
+        ) : (
+          <Skeleton className="h-16 w-16 rounded-xl" />
+        )}
+
+        <div className="min-w-0 flex-1 space-y-1">
+          {listing ? (
+            <>
+              <h1 className="font-semibold text-3xl tracking-tight">{listing.name}</h1>
+              <p className="text-muted-foreground text-sm">
+                {t("detail.by", { publisher: listing.publisher })}
+              </p>
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                {listing.latest_version && (
+                  <Badge variant="secondary">
+                    {t("card.version", { version: listing.latest_version.version })}
+                  </Badge>
+                )}
+                <span className="text-muted-foreground text-xs">
+                  {t("detail.installs", { count: listing.installs_count })}
+                </span>
+              </div>
+            </>
+          ) : (
+            <Skeleton className="h-9 w-56" />
+          )}
+        </div>
+
+        {listing && (
+          <div className="flex flex-col items-end gap-1">
+            <Button onClick={() => setInstalling(true)} disabled={!listing.installable}>
+              <Download className="mr-1.5 h-4 w-4" />
+              {t("detail.install")}
+            </Button>
+            {!listing.installable && (
+              <span className="text-muted-foreground text-xs">
+                {listing.available ? t("detail.needsUpdate") : t("detail.withdrawn")}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {listing?.long_description && (
+        <p className="max-w-3xl whitespace-pre-line text-sm leading-relaxed">
+          {listing.long_description}
+        </p>
+      )}
+
+      {listing?.images?.length ? (
+        <div className="flex gap-3 overflow-x-auto pb-2">
+          {listing.images.map((image) => (
+            <img
+              key={image}
+              src={image}
+              alt=""
+              aria-hidden
+              className="h-48 shrink-0 rounded-lg border object-cover"
+              loading="lazy"
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        <h2 className="font-medium text-sm">{t("detail.preview")}</h2>
+        {listing?.definition ? (
+          // The same canvas a live dashboard renders, read-only: `canEdit` false
+          // means static tiles, no drag handles, and no layout writes.
+          <DashboardCanvas
+            definition={readDefinition(listing.definition)}
+            config={readConfig({})}
+            catalog={catalogQuery.data}
+            initiativeId={undefined}
+            canEdit={false}
+            onLayoutChange={() => {}}
+          />
+        ) : (
+          <Skeleton className="h-64 w-full rounded-lg" />
+        )}
+      </div>
+
+      {listing && listing.versions.length > 1 && (
+        <div className="space-y-2">
+          <h2 className="font-medium text-sm">{t("detail.versions")}</h2>
+          <ul className="space-y-2 text-sm">
+            {listing.versions.map((version) => (
+              <li key={version.version} className="flex flex-wrap items-baseline gap-2">
+                <span className="font-medium">{version.version}</span>
+                {version.release_notes && (
+                  <span className="text-muted-foreground">{version.release_notes}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {listing && (
+        <InstallListingDialog listing={listing} open={installing} onOpenChange={setInstalling} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -51,6 +51,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdCounterGroupsRouteImport } 
 import { Route as ServerRequiredAuthenticatedGGuildIdDashboardsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/dashboards'
 import { Route as ServerRequiredAuthenticatedGGuildIdDocumentsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/documents'
 import { Route as ServerRequiredAuthenticatedGGuildIdInitiativesRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/initiatives'
+import { Route as ServerRequiredAuthenticatedGGuildIdMarketplaceRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/marketplace'
 import { Route as ServerRequiredAuthenticatedGGuildIdProjectsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/projects'
 import { Route as ServerRequiredAuthenticatedGGuildIdQueuesRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/queues'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings'
@@ -72,6 +73,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdDashboardsDashboardIdRouteI
 import { Route as ServerRequiredAuthenticatedGGuildIdDashboardsGalleryRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/dashboards_.gallery'
 import { Route as ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/documents_.$documentId'
 import { Route as ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/initiatives_.$initiativeId'
+import { Route as ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/marketplace_.$publicId'
 import { Route as ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/projects_.$projectId'
 import { Route as ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/queues_.$queueId'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsIndexRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/index'
@@ -341,6 +343,12 @@ const ServerRequiredAuthenticatedGGuildIdInitiativesRoute =
     path: '/initiatives',
     getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
   } as any)
+const ServerRequiredAuthenticatedGGuildIdMarketplaceRoute =
+  ServerRequiredAuthenticatedGGuildIdMarketplaceRouteImport.update({
+    id: '/marketplace',
+    path: '/marketplace',
+    getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
+  } as any)
 const ServerRequiredAuthenticatedGGuildIdProjectsRoute =
   ServerRequiredAuthenticatedGGuildIdProjectsRouteImport.update({
     id: '/projects',
@@ -465,6 +473,12 @@ const ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute =
   ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRouteImport.update({
     id: '/initiatives_/$initiativeId',
     path: '/initiatives/$initiativeId',
+    getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
+  } as any)
+const ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute =
+  ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRouteImport.update({
+    id: '/marketplace_/$publicId',
+    path: '/marketplace/$publicId',
     getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
   } as any)
 const ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute =
@@ -662,6 +676,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/dashboards': typeof ServerRequiredAuthenticatedGGuildIdDashboardsRoute
   '/g/$guildId/documents': typeof ServerRequiredAuthenticatedGGuildIdDocumentsRoute
   '/g/$guildId/initiatives': typeof ServerRequiredAuthenticatedGGuildIdInitiativesRoute
+  '/g/$guildId/marketplace': typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRoute
   '/g/$guildId/projects': typeof ServerRequiredAuthenticatedGGuildIdProjectsRoute
   '/g/$guildId/queues': typeof ServerRequiredAuthenticatedGGuildIdQueuesRoute
   '/g/$guildId/settings': typeof ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren
@@ -684,6 +699,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/dashboards/gallery': typeof ServerRequiredAuthenticatedGGuildIdDashboardsGalleryRoute
   '/g/$guildId/documents/$documentId': typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
   '/g/$guildId/initiatives/$initiativeId': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute
+  '/g/$guildId/marketplace/$publicId': typeof ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute
   '/g/$guildId/projects/$projectId': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute
   '/g/$guildId/queues/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
@@ -744,6 +760,7 @@ export interface FileRoutesByTo {
   '/g/$guildId/dashboards': typeof ServerRequiredAuthenticatedGGuildIdDashboardsRoute
   '/g/$guildId/documents': typeof ServerRequiredAuthenticatedGGuildIdDocumentsRoute
   '/g/$guildId/initiatives': typeof ServerRequiredAuthenticatedGGuildIdInitiativesRoute
+  '/g/$guildId/marketplace': typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRoute
   '/g/$guildId/projects': typeof ServerRequiredAuthenticatedGGuildIdProjectsRoute
   '/g/$guildId/queues': typeof ServerRequiredAuthenticatedGGuildIdQueuesRoute
   '/settings/admin/access': typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
@@ -765,6 +782,7 @@ export interface FileRoutesByTo {
   '/g/$guildId/dashboards/gallery': typeof ServerRequiredAuthenticatedGGuildIdDashboardsGalleryRoute
   '/g/$guildId/documents/$documentId': typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
   '/g/$guildId/initiatives/$initiativeId': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute
+  '/g/$guildId/marketplace/$publicId': typeof ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute
   '/g/$guildId/projects/$projectId': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute
   '/g/$guildId/queues/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
@@ -832,6 +850,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/dashboards': typeof ServerRequiredAuthenticatedGGuildIdDashboardsRoute
   '/_serverRequired/_authenticated/g/$guildId/documents': typeof ServerRequiredAuthenticatedGGuildIdDocumentsRoute
   '/_serverRequired/_authenticated/g/$guildId/initiatives': typeof ServerRequiredAuthenticatedGGuildIdInitiativesRoute
+  '/_serverRequired/_authenticated/g/$guildId/marketplace': typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRoute
   '/_serverRequired/_authenticated/g/$guildId/projects': typeof ServerRequiredAuthenticatedGGuildIdProjectsRoute
   '/_serverRequired/_authenticated/g/$guildId/queues': typeof ServerRequiredAuthenticatedGGuildIdQueuesRoute
   '/_serverRequired/_authenticated/g/$guildId/settings': typeof ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren
@@ -854,6 +873,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/dashboards_/gallery': typeof ServerRequiredAuthenticatedGGuildIdDashboardsGalleryRoute
   '/_serverRequired/_authenticated/g/$guildId/documents_/$documentId': typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
   '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute
+  '/_serverRequired/_authenticated/g/$guildId/marketplace_/$publicId': typeof ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute
   '/_serverRequired/_authenticated/g/$guildId/projects_/$projectId': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute
   '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
@@ -920,6 +940,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/dashboards'
     | '/g/$guildId/documents'
     | '/g/$guildId/initiatives'
+    | '/g/$guildId/marketplace'
     | '/g/$guildId/projects'
     | '/g/$guildId/queues'
     | '/g/$guildId/settings'
@@ -942,6 +963,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/dashboards/gallery'
     | '/g/$guildId/documents/$documentId'
     | '/g/$guildId/initiatives/$initiativeId'
+    | '/g/$guildId/marketplace/$publicId'
     | '/g/$guildId/projects/$projectId'
     | '/g/$guildId/queues/$queueId'
     | '/g/$guildId/settings/advanced-tool'
@@ -1002,6 +1024,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/dashboards'
     | '/g/$guildId/documents'
     | '/g/$guildId/initiatives'
+    | '/g/$guildId/marketplace'
     | '/g/$guildId/projects'
     | '/g/$guildId/queues'
     | '/settings/admin/access'
@@ -1023,6 +1046,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/dashboards/gallery'
     | '/g/$guildId/documents/$documentId'
     | '/g/$guildId/initiatives/$initiativeId'
+    | '/g/$guildId/marketplace/$publicId'
     | '/g/$guildId/projects/$projectId'
     | '/g/$guildId/queues/$queueId'
     | '/g/$guildId/settings/advanced-tool'
@@ -1089,6 +1113,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/dashboards'
     | '/_serverRequired/_authenticated/g/$guildId/documents'
     | '/_serverRequired/_authenticated/g/$guildId/initiatives'
+    | '/_serverRequired/_authenticated/g/$guildId/marketplace'
     | '/_serverRequired/_authenticated/g/$guildId/projects'
     | '/_serverRequired/_authenticated/g/$guildId/queues'
     | '/_serverRequired/_authenticated/g/$guildId/settings'
@@ -1111,6 +1136,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/dashboards_/gallery'
     | '/_serverRequired/_authenticated/g/$guildId/documents_/$documentId'
     | '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId'
+    | '/_serverRequired/_authenticated/g/$guildId/marketplace_/$publicId'
     | '/_serverRequired/_authenticated/g/$guildId/projects_/$projectId'
     | '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId'
     | '/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool'
@@ -1437,6 +1463,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
     }
+    '/_serverRequired/_authenticated/g/$guildId/marketplace': {
+      id: '/_serverRequired/_authenticated/g/$guildId/marketplace'
+      path: '/marketplace'
+      fullPath: '/g/$guildId/marketplace'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
+    }
     '/_serverRequired/_authenticated/g/$guildId/projects': {
       id: '/_serverRequired/_authenticated/g/$guildId/projects'
       path: '/projects'
@@ -1582,6 +1615,13 @@ declare module '@tanstack/react-router' {
       path: '/initiatives/$initiativeId'
       fullPath: '/g/$guildId/initiatives/$initiativeId'
       preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
+    }
+    '/_serverRequired/_authenticated/g/$guildId/marketplace_/$publicId': {
+      id: '/_serverRequired/_authenticated/g/$guildId/marketplace_/$publicId'
+      path: '/marketplace/$publicId'
+      fullPath: '/g/$guildId/marketplace/$publicId'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
     }
     '/_serverRequired/_authenticated/g/$guildId/projects_/$projectId': {
@@ -1907,6 +1947,7 @@ interface ServerRequiredAuthenticatedGGuildIdRouteChildren {
   ServerRequiredAuthenticatedGGuildIdDashboardsRoute: typeof ServerRequiredAuthenticatedGGuildIdDashboardsRoute
   ServerRequiredAuthenticatedGGuildIdDocumentsRoute: typeof ServerRequiredAuthenticatedGGuildIdDocumentsRoute
   ServerRequiredAuthenticatedGGuildIdInitiativesRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesRoute
+  ServerRequiredAuthenticatedGGuildIdMarketplaceRoute: typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRoute
   ServerRequiredAuthenticatedGGuildIdProjectsRoute: typeof ServerRequiredAuthenticatedGGuildIdProjectsRoute
   ServerRequiredAuthenticatedGGuildIdQueuesRoute: typeof ServerRequiredAuthenticatedGGuildIdQueuesRoute
   ServerRequiredAuthenticatedGGuildIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren
@@ -1918,6 +1959,7 @@ interface ServerRequiredAuthenticatedGGuildIdRouteChildren {
   ServerRequiredAuthenticatedGGuildIdDashboardsGalleryRoute: typeof ServerRequiredAuthenticatedGGuildIdDashboardsGalleryRoute
   ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute: typeof ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute
   ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute
+  ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute: typeof ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute
   ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute: typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute
   ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute: typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   ServerRequiredAuthenticatedGGuildIdTagsTagIdRoute: typeof ServerRequiredAuthenticatedGGuildIdTagsTagIdRoute
@@ -1945,6 +1987,8 @@ const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedGGuildIdDocumentsRoute,
     ServerRequiredAuthenticatedGGuildIdInitiativesRoute:
       ServerRequiredAuthenticatedGGuildIdInitiativesRoute,
+    ServerRequiredAuthenticatedGGuildIdMarketplaceRoute:
+      ServerRequiredAuthenticatedGGuildIdMarketplaceRoute,
     ServerRequiredAuthenticatedGGuildIdProjectsRoute:
       ServerRequiredAuthenticatedGGuildIdProjectsRoute,
     ServerRequiredAuthenticatedGGuildIdQueuesRoute:
@@ -1967,6 +2011,8 @@ const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedGGuildIdDocumentsDocumentIdRoute,
     ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute:
       ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdRoute,
+    ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute:
+      ServerRequiredAuthenticatedGGuildIdMarketplacePublicIdRoute,
     ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute:
       ServerRequiredAuthenticatedGGuildIdProjectsProjectIdRoute,
     ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/marketplace")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/marketplace/MarketplaceBrowsePage").then((m) => ({
+      default: m.MarketplaceBrowsePage,
+    }))
+  ),
+});

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace_.$publicId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace_.$publicId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+  "/_serverRequired/_authenticated/g/$guildId/marketplace_/$publicId"
+)({
+  component: lazyRouteComponent(() =>
+    import("@/pages/marketplace/MarketplaceListingPage").then((m) => ({
+      default: m.MarketplaceListingPage,
+    }))
+  ),
+});

--- a/frontend/src/types/i18next.d.ts
+++ b/frontend/src/types/i18next.d.ts
@@ -18,6 +18,7 @@ import type importNs from "../../public/locales/en/import.json";
 import type importsNs from "../../public/locales/en/imports.json";
 import type initiatives from "../../public/locales/en/initiatives.json";
 import type landing from "../../public/locales/en/landing.json";
+import type marketplace from "../../public/locales/en/marketplace.json";
 import type nav from "../../public/locales/en/nav.json";
 import type notifications from "../../public/locales/en/notifications.json";
 import type projects from "../../public/locales/en/projects.json";
@@ -42,6 +43,7 @@ declare module "i18next" {
       command: typeof command;
       common: typeof common;
       counterGroups: typeof counterGroups;
+      marketplace: typeof marketplace;
       dashboard: typeof dashboard;
       dashboards: typeof dashboards;
       dates: typeof dates;


### PR DESCRIPTION
The catalog landed in #1089 with no way to see it. This is the surface: browse, read a listing, install it, and take a later version when one appears.

## Browse — `/g/{guildId}/marketplace`

A searchable card grid. Every card shows the listing's own artwork — listings ship custom art, so nothing falls back to a product icon and one listing never looks like another. Search is debounced and goes to the server, because paging means the answer isn't all on screen.

"Installed" comes from the guild's own dashboards, matched on the `listing_uid` an install pins — the catalog is platform-level and knows nothing about this guild, so that badge can only be derived client-side. It's a count, not a boolean: a guild may hold several installs of one listing at different versions.

## Detail — `/g/{guildId}/marketplace/{publicId}`

Artwork, publisher, install count, long description, screenshots, and version history. The preview is the real thing: the listing's own definition rendered through `DashboardCanvas` with `canEdit={false}`, so it's the same renderer a live dashboard uses — static tiles, no drag handles, no layout writes. Someone deciding whether to install sees what they'd get rather than a description of it.

When a listing can't be installed here the button is disabled with the reason underneath — withdrawn, or needs a newer app.

## Install

A dialog asking which initiative, offering only the ones where the viewer may create dashboards — the same permission the create flow uses and the server checks, so the list is what the install will actually accept. Pre-selects the initiative the viewer arrived from. The request sends `listing_uid` and a name; the definition is never client-supplied.

## Updates

`DashboardUpdateBadge` on an installed dashboard's page, shown only when its listing publishes a version it can run that isn't the pinned one. Applying is always a click and re-pins that dashboard alone. Someone with read access sees the version as text rather than a button.

## Backend

One new route: `GET /marketplace/listings/by-uid/{uid}`. An install stores the uid — the identity that's stable across deployments — so that's how it finds its listing. Declared before `/listings/{public_id}` so the literal segment wins; there's a test for that.

## Also

- Three SVG avatars under `public/marketplace/` for the built-in listings, which referenced paths that didn't exist yet
- Sidebar entry below the initiatives (browsing is open to every member; installing is where the gates are) and a "Browse the marketplace" link beside "New dashboard"
- New `marketplace` i18n namespace in all four locales, plus the `nav` and `dashboards` keys
- `useUpgradeDashboard`, and `useMarketplace` hooks keyed on the request alone since the catalog is guild-free

## Testing

14 new frontend tests: 7 on the update badge (each reason it must show nothing — authored here, listing gone, version incompatible, already current — plus that it only upgrades when clicked and degrades to text without write access), 7 on browse (install matching by uid rather than name, search reaching the server, empty states).

`tsc --noEmit`, `pnpm lint`, `pnpm build`, 564 frontend tests, `ruff check`/`format`, `ty check app`, and the 15 marketplace endpoint tests all clean.

Screenshots and multi-page paging are wired but unexercised by the built-ins, which ship no images and one version each.