### PR TITLE
Surface guild apps in the sidebar and settings

### DIFF
--- a/backend/app/api/v1/platform_endpoints/marketplace.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace.py
@@ -21,6 +21,7 @@ from app.models.platform.marketplace import (
 )
 from app.models.platform.user import User
 from app.schemas.platform.marketplace import (
+    ListingKind,
     MarketplaceListingDetail,
     MarketplaceListingPage,
     MarketplaceListingSummary,
@@ -78,7 +79,7 @@ def _summary(
 async def list_marketplace_listings(
     session: UserSessionDep,
     current_user: CurrentUser,
-    kind: Optional[str] = Query(default=None),
+    kind: Optional[ListingKind] = Query(default=None),  # type: ignore[valid-type]
     q: Optional[str] = Query(default=None, max_length=200),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=24, ge=1, le=MAX_PAGE_SIZE),

--- a/backend/app/schemas/platform/marketplace.py
+++ b/backend/app/schemas/platform/marketplace.py
@@ -7,11 +7,21 @@ than by anything here.
 """
 
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import ConfigDict
 
 from app.schemas.base import SanitizedBaseModel
+from app.services.marketplace.definitions import LISTING_KINDS
+
+# Derived from the validator's own set rather than restated, the way WidgetType
+# derives from the widget registry: a new kind reaches the API — and, through
+# the generated types, the frontend — without an edit here.
+ListingKind = Enum(
+    "ListingKind", {name: name for name in sorted(LISTING_KINDS)}, type=str
+)
+ListingKind.__doc__ = "What a marketplace listing installs as."
 
 
 class MarketplaceVersionRead(SanitizedBaseModel):
@@ -35,7 +45,7 @@ class MarketplaceListingSummary(SanitizedBaseModel):
 
     uid: str
     public_id: str
-    kind: str
+    kind: ListingKind  # type: ignore[valid-type]
     source: str
     name: str
     publisher: str

--- a/backend/app/services/marketplace/definitions.py
+++ b/backend/app/services/marketplace/definitions.py
@@ -36,7 +36,12 @@ class ListingDefinitionError(ValueError):
 
 
 #: Kinds the catalog can hold.
-LISTING_KINDS: frozenset[str] = frozenset({"dashboard", "app"})
+#:
+#: ``auto`` is declared here so the vocabulary is complete — the marketplace can
+#: name and filter by it — while nothing installs one yet: a manifest carrying
+#: one is refused with a reason rather than stored as something no code can
+#: resolve. Same treatment ``embed`` apps get.
+LISTING_KINDS: frozenset[str] = frozenset({"dashboard", "app", "auto"})
 
 #: How an app presents itself.
 #:
@@ -88,6 +93,10 @@ def normalize_listing_definition(kind: str, definition: Any) -> dict[str, Any]:
     """Validate and canonicalize a listing's definition for its kind."""
     if kind not in LISTING_KINDS:
         raise ListingDefinitionError(f"unknown listing kind {kind!r}")
+    if kind == "auto":
+        raise ListingDefinitionError(
+            "automation listings are not installable in this build yet"
+        )
     if kind == "app":
         return _normalize_app_definition(definition)
     try:

--- a/frontend/public/locales/de/apps.json
+++ b/frontend/public/locales/de/apps.json
@@ -1,0 +1,30 @@
+{
+  "title": "Apps",
+  "add": "App hinzufügen",
+  "none": "Noch keine Apps.",
+  "error": "Mit dieser App ist etwas schiefgelaufen.",
+  "manage": {
+    "title": "Apps",
+    "description": "Apps ergänzen etwas, das die ganze Gilde teilt. Nur Gildenadmins können sie hinzufügen oder entfernen.",
+    "empty": "Noch keine Apps installiert.",
+    "browse": "Apps durchsuchen",
+    "installed": "Hinzugefügt am {{date}}",
+    "disabled": "Ausgeschaltet",
+    "enable": "Einschalten",
+    "disable": "Ausschalten",
+    "rename": "Umbenennen",
+    "remove": "Entfernen",
+    "removeTitle": "{{name}} entfernen?",
+    "removeBody": "Was sie erstellt hat, wandert in den Papierkorb und kann von dort wiederhergestellt werden. Mitglieder verlieren sofort den Zugriff.",
+    "removed": "{{name}} entfernt.",
+    "saved": "Gespeichert."
+  },
+  "install": {
+    "title": "{{name}} hinzufügen",
+    "description": "Das ergänzt etwas für die ganze Gilde. Umbenennen kannst du es jetzt oder später.",
+    "name": "Name",
+    "action": "Zur Gilde hinzufügen",
+    "done": "{{name}} hinzugefügt.",
+    "adminOnly": "Nur Gildenadmins können Apps hinzufügen."
+  }
+}

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -48,5 +48,6 @@
     "title": "Marktplatz nicht erreichbar",
     "description": "Der Katalog konnte nicht geladen werden. Versuche es gleich noch einmal."
   },
-  "installedUnknown": "Es konnte nicht geprüft werden, welche davon du bereits hast – deshalb ist unten nichts als installiert markiert."
+  "installedUnknown": "Es konnte nicht geprüft werden, welche davon du bereits hast – deshalb ist unten nichts als installiert markiert.",
+  "subtitleApps": "Apps ergänzen etwas, das die ganze Gilde teilt. Nur Gildenadmins können sie hinzufügen."
 }

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -49,5 +49,6 @@
     "description": "Der Katalog konnte nicht geladen werden. Versuche es gleich noch einmal."
   },
   "installedUnknown": "Es konnte nicht geprüft werden, welche davon du bereits hast – deshalb ist unten nichts als installiert markiert.",
-  "subtitleApps": "Apps ergänzen etwas, das die ganze Gilde teilt. Nur Gildenadmins können sie hinzufügen."
+  "subtitleApps": "Apps ergänzen etwas, das die ganze Gilde teilt. Nur Gildenadmins können sie hinzufügen.",
+  "subtitleAuto": "Automatisierungen laufen im Hintergrund für die ganze Gilde."
 }

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -37,7 +37,8 @@
       "trash": "Papierkorb",
       "data": "Daten",
       "dangerZone": "Gefahrenzone",
-      "auth": "Authentifizierung"
+      "auth": "Authentifizierung",
+      "apps": "Apps"
     }
   },
   "profile": {

--- a/frontend/public/locales/en/apps.json
+++ b/frontend/public/locales/en/apps.json
@@ -1,0 +1,30 @@
+{
+  "title": "Apps",
+  "add": "Add an app",
+  "none": "No apps yet.",
+  "error": "Something went wrong with that app.",
+  "manage": {
+    "title": "Apps",
+    "description": "Apps add something the whole guild shares. Only guild admins can add or remove them.",
+    "empty": "No apps installed yet.",
+    "browse": "Browse apps",
+    "installed": "Added {{date}}",
+    "disabled": "Turned off",
+    "enable": "Turn on",
+    "disable": "Turn off",
+    "rename": "Rename",
+    "remove": "Remove",
+    "removeTitle": "Remove {{name}}?",
+    "removeBody": "What it created moves to the trash, where it can still be restored. Members lose access to it straight away.",
+    "removed": "{{name}} removed.",
+    "saved": "Saved."
+  },
+  "install": {
+    "title": "Add {{name}}",
+    "description": "This adds something for the whole guild. You can rename it now or later.",
+    "name": "Name",
+    "action": "Add to guild",
+    "done": "{{name}} added.",
+    "adminOnly": "Only a guild admin can add apps."
+  }
+}

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -48,5 +48,6 @@
     "title": "Marketplace unavailable",
     "description": "The catalog could not be reached. Try again in a moment."
   },
-  "installedUnknown": "Couldn't check which of these you already have, so nothing below is marked as installed."
+  "installedUnknown": "Couldn't check which of these you already have, so nothing below is marked as installed.",
+  "subtitleApps": "Apps add something the whole guild shares. Only guild admins can add them."
 }

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -49,5 +49,6 @@
     "description": "The catalog could not be reached. Try again in a moment."
   },
   "installedUnknown": "Couldn't check which of these you already have, so nothing below is marked as installed.",
-  "subtitleApps": "Apps add something the whole guild shares. Only guild admins can add them."
+  "subtitleApps": "Apps add something the whole guild shares. Only guild admins can add them.",
+  "subtitleAuto": "Automations run in the background for the whole guild."
 }

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -37,7 +37,8 @@
       "trash": "Trash",
       "data": "Data",
       "dangerZone": "Danger zone",
-      "auth": "Authentication"
+      "auth": "Authentication",
+      "apps": "Apps"
     }
   },
   "profile": {

--- a/frontend/public/locales/es/apps.json
+++ b/frontend/public/locales/es/apps.json
@@ -1,0 +1,30 @@
+{
+  "title": "Aplicaciones",
+  "add": "Añadir una aplicación",
+  "none": "Todavía no hay aplicaciones.",
+  "error": "Algo ha fallado con esa aplicación.",
+  "manage": {
+    "title": "Aplicaciones",
+    "description": "Las aplicaciones añaden algo que comparte todo el gremio. Solo los administradores del gremio pueden añadirlas o quitarlas.",
+    "empty": "Todavía no hay aplicaciones instaladas.",
+    "browse": "Explorar aplicaciones",
+    "installed": "Añadida el {{date}}",
+    "disabled": "Desactivada",
+    "enable": "Activar",
+    "disable": "Desactivar",
+    "rename": "Cambiar el nombre",
+    "remove": "Quitar",
+    "removeTitle": "¿Quitar {{name}}?",
+    "removeBody": "Lo que haya creado pasa a la papelera, desde donde aún puede restaurarse. Los miembros pierden el acceso de inmediato.",
+    "removed": "{{name}} quitada.",
+    "saved": "Guardado."
+  },
+  "install": {
+    "title": "Añadir {{name}}",
+    "description": "Esto añade algo para todo el gremio. Puedes cambiarle el nombre ahora o más tarde.",
+    "name": "Nombre",
+    "action": "Añadir al gremio",
+    "done": "{{name}} añadida.",
+    "adminOnly": "Solo un administrador del gremio puede añadir aplicaciones."
+  }
+}

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -49,5 +49,6 @@
     "description": "No se pudo acceder al catálogo. Inténtalo de nuevo en un momento."
   },
   "installedUnknown": "No se pudo comprobar cuáles de estos ya tienes, así que nada de lo siguiente aparece como instalado.",
-  "subtitleApps": "Las aplicaciones añaden algo que comparte todo el gremio. Solo los administradores del gremio pueden añadirlas."
+  "subtitleApps": "Las aplicaciones añaden algo que comparte todo el gremio. Solo los administradores del gremio pueden añadirlas.",
+  "subtitleAuto": "Las automatizaciones se ejecutan en segundo plano para todo el gremio."
 }

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -48,5 +48,6 @@
     "title": "Mercado no disponible",
     "description": "No se pudo acceder al catálogo. Inténtalo de nuevo en un momento."
   },
-  "installedUnknown": "No se pudo comprobar cuáles de estos ya tienes, así que nada de lo siguiente aparece como instalado."
+  "installedUnknown": "No se pudo comprobar cuáles de estos ya tienes, así que nada de lo siguiente aparece como instalado.",
+  "subtitleApps": "Las aplicaciones añaden algo que comparte todo el gremio. Solo los administradores del gremio pueden añadirlas."
 }

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -37,7 +37,8 @@
       "trash": "Papelera",
       "data": "Datos",
       "dangerZone": "Zona de peligro",
-      "auth": "Autenticación"
+      "auth": "Autenticación",
+      "apps": "Aplicaciones"
     }
   },
   "profile": {

--- a/frontend/public/locales/fr/apps.json
+++ b/frontend/public/locales/fr/apps.json
@@ -1,0 +1,30 @@
+{
+  "title": "Applications",
+  "add": "Ajouter une application",
+  "none": "Pas encore d'applications.",
+  "error": "Un problème est survenu avec cette application.",
+  "manage": {
+    "title": "Applications",
+    "description": "Les applications ajoutent quelque chose que toute la guilde partage. Seuls les administrateurs de la guilde peuvent en ajouter ou en retirer.",
+    "empty": "Aucune application installée pour l'instant.",
+    "browse": "Parcourir les applications",
+    "installed": "Ajoutée le {{date}}",
+    "disabled": "Désactivée",
+    "enable": "Activer",
+    "disable": "Désactiver",
+    "rename": "Renommer",
+    "remove": "Retirer",
+    "removeTitle": "Retirer {{name}} ?",
+    "removeBody": "Ce qu'elle a créé part à la corbeille, d'où cela peut encore être restauré. Les membres en perdent l'accès immédiatement.",
+    "removed": "{{name}} retirée.",
+    "saved": "Enregistré."
+  },
+  "install": {
+    "title": "Ajouter {{name}}",
+    "description": "Cela ajoute quelque chose pour toute la guilde. Vous pourrez la renommer maintenant ou plus tard.",
+    "name": "Nom",
+    "action": "Ajouter à la guilde",
+    "done": "{{name}} ajoutée.",
+    "adminOnly": "Seul un administrateur de la guilde peut ajouter des applications."
+  }
+}

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -49,5 +49,6 @@
     "description": "Le catalogue n'a pas pu être joint. Réessayez dans un instant."
   },
   "installedUnknown": "Impossible de vérifier lesquels vous possédez déjà : rien ci-dessous n'est donc marqué comme installé.",
-  "subtitleApps": "Les applications ajoutent quelque chose que toute la guilde partage. Seuls les administrateurs de la guilde peuvent les ajouter."
+  "subtitleApps": "Les applications ajoutent quelque chose que toute la guilde partage. Seuls les administrateurs de la guilde peuvent les ajouter.",
+  "subtitleAuto": "Les automatisations s'exécutent en arrière-plan pour toute la guilde."
 }

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -48,5 +48,6 @@
     "title": "Catalogue indisponible",
     "description": "Le catalogue n'a pas pu être joint. Réessayez dans un instant."
   },
-  "installedUnknown": "Impossible de vérifier lesquels vous possédez déjà : rien ci-dessous n'est donc marqué comme installé."
+  "installedUnknown": "Impossible de vérifier lesquels vous possédez déjà : rien ci-dessous n'est donc marqué comme installé.",
+  "subtitleApps": "Les applications ajoutent quelque chose que toute la guilde partage. Seuls les administrateurs de la guilde peuvent les ajouter."
 }

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -37,7 +37,8 @@
       "trash": "Corbeille",
       "data": "Données",
       "dangerZone": "Zone de danger",
-      "auth": "Authentification"
+      "auth": "Authentification",
+      "apps": "Applications"
     }
   },
   "profile": {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2408,6 +2408,17 @@ export interface LeaveGuildRequest {
 }
 
 /**
+ * What a marketplace listing installs as.
+ */
+export type ListingKind = (typeof ListingKind)[keyof typeof ListingKind];
+
+export const ListingKind = {
+  app: "app",
+  auto: "auto",
+  dashboard: "dashboard",
+} as const;
+
+/**
  * One sign-in provider offered on the login page (non-secret metadata).
  */
 export interface LoginProviderEntry {
@@ -2444,7 +2455,7 @@ export interface MarketplaceVersionRead {
 export interface MarketplaceListingDetail {
   uid: string;
   public_id: string;
-  kind: string;
+  kind: ListingKind;
   source: string;
   name: string;
   publisher: string;
@@ -2467,7 +2478,7 @@ export interface MarketplaceListingDetail {
 export interface MarketplaceListingSummary {
   uid: string;
   public_id: string;
-  kind: string;
+  kind: ListingKind;
   source: string;
   name: string;
   publisher: string;
@@ -4510,7 +4521,7 @@ export type GetMyInitiativeMembersApiV1UsersMeInitiativeMembersInitiativeIdGetPa
 };
 
 export type ListMarketplaceListingsApiV1MarketplaceListingsGetParams = {
-  kind?: string | null;
+  kind?: ListingKind | null;
   q?: string | null;
   /**
    * @minimum 1

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "react-i18next";
 import type { ProjectRead } from "@/api/generated/initiativeAPI.schemas";
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { GuildSidebar } from "@/components/guilds/GuildSidebar";
+import { AppsSection } from "@/components/sidebar/AppsSection";
 import { HomeSidebarContent } from "@/components/sidebar/HomeSidebarContent";
 import { InitiativeSection } from "@/components/sidebar/InitiativeSection";
 import { SidebarUserFooter } from "@/components/sidebar/SidebarUserFooter";
@@ -184,6 +185,13 @@ export const AppSidebar = () => {
 
   // Collapse/expand all for initiatives
   const [initiativeCollapseKey, setInitiativeCollapseKey] = useState(0);
+  // Remembered like the other sections; open by default so a newly installed
+  // app is visible without hunting for it.
+  const [appsOpen, setAppsOpenState] = useState(() => getItem("apps-section-open") !== "false");
+  const setAppsOpen = (open: boolean) => {
+    setAppsOpenState(open);
+    setItem("apps-section-open", String(open));
+  };
   const collapseAllInitiatives = useCallback(() => {
     const states: Record<number, boolean> = {};
     for (const init of visibleInitiatives) {
@@ -377,6 +385,14 @@ export const AppSidebar = () => {
                             <SidebarSeparator />
                           </>
                         )}
+
+                        {/* Apps: guild-wide surfaces, so they sit above the
+                            initiatives rather than inside any of them. */}
+                        <AppsSection
+                          isGuildAdmin={isGuildAdmin}
+                          open={appsOpen}
+                          onOpenChange={setAppsOpen}
+                        />
 
                         {/* Initiatives Section */}
                         <SidebarGroup>

--- a/frontend/src/components/StatusMessage.tsx
+++ b/frontend/src/components/StatusMessage.tsx
@@ -15,10 +15,20 @@ interface StatusMessageProps {
   title: string;
   description?: string;
   backTo?: string;
+  /** Search params for the back link — without this, returning from an error
+   *  state drops whatever the destination was filtered to. */
+  backSearch?: Record<string, unknown>;
   backLabel?: string;
 }
 
-export function StatusMessage({ icon, title, description, backTo, backLabel }: StatusMessageProps) {
+export function StatusMessage({
+  icon,
+  title,
+  description,
+  backTo,
+  backSearch,
+  backLabel,
+}: StatusMessageProps) {
   return (
     <Empty>
       <EmptyHeader>
@@ -28,7 +38,9 @@ export function StatusMessage({ icon, title, description, backTo, backLabel }: S
       </EmptyHeader>
       {backTo && backLabel && (
         <Button variant="link" size="sm" asChild className="px-0">
-          <Link to={backTo}>{backLabel}</Link>
+          <Link to={backTo} search={backSearch}>
+            {backLabel}
+          </Link>
         </Button>
       )}
     </Empty>

--- a/frontend/src/components/marketplace/InstallAppDialog.tsx
+++ b/frontend/src/components/marketplace/InstallAppDialog.tsx
@@ -1,0 +1,98 @@
+/**
+ * Adding an app to the guild.
+ *
+ * Simpler than installing a dashboard, and for a reason: a dashboard belongs to
+ * an initiative, so installing one is a choice of which. An app belongs to the
+ * guild, so there is nothing to choose — only what to call it.
+ *
+ * Guild admins only. The server enforces that; this hides the action rather
+ * than offering one that would be refused.
+ */
+
+import { useNavigate } from "@tanstack/react-router";
+import { Download, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { MarketplaceListingDetail } from "@/api/generated/initiativeAPI.schemas";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { guildAppPath, useInstallGuildApp } from "@/hooks/useGuildApps";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { useGuildPath } from "@/lib/guildUrl";
+import type { DialogProps } from "@/types/dialog";
+
+export interface InstallAppDialogProps extends DialogProps {
+  listing: MarketplaceListingDetail;
+}
+
+export function InstallAppDialog({ listing, open, onOpenChange }: InstallAppDialogProps) {
+  const { t } = useTranslation(["apps", "common"]);
+  const navigate = useNavigate();
+  const gp = useGuildPath();
+
+  const [name, setName] = useState(listing.name);
+  const install = useInstallGuildApp();
+
+  const submit = () =>
+    install.mutate(
+      { listing_uid: listing.uid, name: name.trim() || listing.name },
+      {
+        onSuccess: (app) => {
+          toast.success(t("apps:install.done", { name: app.name }));
+          onOpenChange(false);
+          // Straight to what it created, when it created something reachable.
+          const path = guildAppPath(app);
+          if (path) navigate({ to: gp(path) });
+        },
+        onError: (error) => {
+          toast.error(getErrorMessage(error, "apps:error"));
+        },
+      }
+    );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("apps:install.title", { name: listing.name })}</DialogTitle>
+          <DialogDescription>{t("apps:install.description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="install-app-name">{t("apps:install.name")}</Label>
+          <Input
+            id="install-app-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder={listing.name}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("common:cancel")}
+          </Button>
+          <Button onClick={submit} disabled={install.isPending}>
+            {install.isPending ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="mr-1.5 h-4 w-4" />
+            )}
+            {t("apps:install.action")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/marketplace/MarketplaceCard.tsx
+++ b/frontend/src/components/marketplace/MarketplaceCard.tsx
@@ -29,6 +29,9 @@ export function MarketplaceCard({ listing, installedCount = 0 }: MarketplaceCard
     <Card className="h-full transition-colors hover:border-primary/50">
       <Link
         to={gp(`/marketplace/${listing.public_id}`)}
+        // Carry the shelf through, so going back from a listing returns to the
+        // one you were browsing rather than to the dashboards.
+        search={{ kind: listing.kind }}
         className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <CardContent className="flex h-full gap-3 p-4">

--- a/frontend/src/components/sidebar/AppsSection.test.tsx
+++ b/frontend/src/components/sidebar/AppsSection.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Who sees the Apps section, and when.
+ *
+ * The rules are about not promising anything: a member with no apps installed
+ * has nothing to look at and nothing they could do about it, so the section is
+ * absent entirely rather than empty. An admin in the same guild does have
+ * something to do, so they get it with the `+`.
+ *
+ * Disabled apps belong in guild settings, not here — the sidebar shows what is
+ * on.
+ */
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+import type { GuildAppRead } from "@/api/generated/initiativeAPI.schemas";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+import { AppsSection } from "./AppsSection";
+
+let apps: Partial<GuildAppRead>[] = [];
+
+vi.mock("@/hooks/useGuildApps", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useGuildApps")>()),
+  useGuildApps: () => ({ data: { items: apps }, isLoading: false }),
+}));
+
+const app = (overrides: Partial<GuildAppRead> = {}) =>
+  ({
+    id: 1,
+    name: "Guild calendar",
+    tool: "calendar",
+    enabled: true,
+    config: { calendar_id: 12 },
+    ...overrides,
+  }) as GuildAppRead;
+
+// The section is built from sidebar primitives, so it needs the providers it
+// would have in the real shell.
+const render = (isGuildAdmin: boolean) =>
+  renderPage(() => (
+    <TooltipProvider>
+      <SidebarProvider>
+        <AppsSection isGuildAdmin={isGuildAdmin} open onOpenChange={() => {}} />
+      </SidebarProvider>
+    </TooltipProvider>
+  ));
+
+beforeEach(() => {
+  apps = [];
+});
+
+describe("AppsSection", () => {
+  it("shows nothing to a member when the guild has no apps", () => {
+    const { container } = render(false);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("invites an admin to add one when the guild has no apps", async () => {
+    render(true);
+    expect(await screen.findByText("Apps")).toBeInTheDocument();
+    expect(screen.getByLabelText("Add an app")).toBeInTheDocument();
+  });
+
+  it("lists installed apps for a member", async () => {
+    apps = [app()];
+    render(false);
+    expect(await screen.findByText("Guild calendar")).toBeInTheDocument();
+    // No add affordance: installing is a guild-admin action.
+    expect(screen.queryByLabelText("Add an app")).toBeNull();
+  });
+
+  it("links an app to what it mounted", async () => {
+    apps = [app()];
+    render(false);
+    const link = (await screen.findByText("Guild calendar")).closest("a");
+    expect(link?.getAttribute("href")).toContain("/calendars/12");
+  });
+
+  it("hides a disabled app", async () => {
+    // Turned off means gone from the sidebar; guild settings is where it comes
+    // back, which is also the only place the switch lives.
+    apps = [app({ enabled: false })];
+    render(true);
+    await screen.findByText("Apps");
+    expect(screen.queryByText("Guild calendar")).toBeNull();
+  });
+
+  it("shows a member nothing when every app is disabled", () => {
+    apps = [app({ enabled: false })];
+    const { container } = render(false);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders an app with nothing to link to without a link", async () => {
+    apps = [app({ config: {} })];
+    render(false);
+    const entry = await screen.findByText("Guild calendar");
+    expect(entry.closest("a")).toBeNull();
+  });
+});

--- a/frontend/src/components/sidebar/AppsSection.tsx
+++ b/frontend/src/components/sidebar/AppsSection.tsx
@@ -1,0 +1,129 @@
+/**
+ * The guild's installed apps, above its initiatives.
+ *
+ * Apps are guild-wide surfaces, so they sit above the initiatives rather than
+ * inside any of them. What shows depends on who is looking:
+ *
+ * - **No apps, ordinary member** — nothing at all. An empty section would be a
+ *   promise of something they cannot act on.
+ * - **No apps, guild admin** — the section with a `+`, the same invitation the
+ *   initiatives list makes when a guild has none.
+ * - **Apps installed** — one entry each, for everyone. Whether a member may do
+ *   anything *inside* one is that instance's own sharing, enforced where the
+ *   content lives.
+ *
+ * Disabled apps are hidden here and stay visible in guild settings, which is
+ * where an admin turns them back on.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { Blocks, CalendarDays, ChevronDown, Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import type { GuildAppRead } from "@/api/generated/initiativeAPI.schemas";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { guildAppPath, useGuildApps } from "@/hooks/useGuildApps";
+import { useGuildPath } from "@/lib/guildUrl";
+import { cn } from "@/lib/utils";
+
+/** One icon per mountable tool. Apps mount this build's own tools, so this maps
+ *  the closed set rather than trusting anything a listing supplies. */
+const TOOL_ICONS = { calendar: CalendarDays } as const;
+
+export interface AppsSectionProps {
+  isGuildAdmin: boolean;
+  /** Persisted open/closed state, keyed like the other sidebar sections. */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionProps) {
+  const { t } = useTranslation(["apps", "nav"]);
+  const gp = useGuildPath();
+  const appsQuery = useGuildApps();
+
+  const apps = (appsQuery.data?.items ?? []).filter((app) => app.enabled);
+
+  // Nothing installed and nothing this person could do about it: show nothing.
+  // A member should see initiatives, not an empty shelf.
+  if (!apps.length && !isGuildAdmin) return null;
+
+  return (
+    <Collapsible open={open} onOpenChange={onOpenChange}>
+      <SidebarGroup>
+        <SidebarGroupLabel className="flex items-center gap-2 py-2">
+          <Blocks className="h-4 w-4" />
+          <CollapsibleTrigger className="flex flex-1 items-center gap-2 text-left">
+            <span className="flex-1">{t("apps:title")}</span>
+            <ChevronDown
+              className={cn("h-4 w-4 shrink-0 transition-transform", !open && "-rotate-90")}
+              aria-hidden
+            />
+          </CollapsibleTrigger>
+          {isGuildAdmin && (
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Link
+                  to={gp("/marketplace")}
+                  search={{ kind: "app" }}
+                  aria-label={t("apps:add")}
+                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm hover:bg-accent"
+                >
+                  <Plus className="h-4 w-4" />
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent>{t("apps:add")}</TooltipContent>
+            </Tooltip>
+          )}
+        </SidebarGroupLabel>
+
+        <CollapsibleContent>
+          <SidebarGroupContent>
+            {apps.length ? (
+              <SidebarMenu>
+                {apps.map((app) => (
+                  <AppEntry key={app.id} app={app} />
+                ))}
+              </SidebarMenu>
+            ) : (
+              <p className="px-4 py-2 text-muted-foreground text-sm">{t("apps:none")}</p>
+            )}
+          </SidebarGroupContent>
+        </CollapsibleContent>
+      </SidebarGroup>
+    </Collapsible>
+  );
+}
+
+function AppEntry({ app }: { app: GuildAppRead }) {
+  const gp = useGuildPath();
+  const path = guildAppPath(app);
+  const Icon = TOOL_ICONS[app.tool as keyof typeof TOOL_ICONS] ?? Blocks;
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild={Boolean(path)} size="sm">
+        {path ? (
+          <Link to={gp(path)}>
+            <Icon className="h-4 w-4" />
+            <span className="truncate">{app.name}</span>
+          </Link>
+        ) : (
+          <span className="flex items-center gap-2">
+            <Icon className="h-4 w-4" />
+            <span className="truncate">{app.name}</span>
+          </span>
+        )}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}

--- a/frontend/src/hooks/useGuildApps.ts
+++ b/frontend/src/hooks/useGuildApps.ts
@@ -1,0 +1,98 @@
+/**
+ * Apps installed in the current guild.
+ *
+ * Every member reads this — the sidebar has to know what is there — while
+ * installing, renaming, disabling and removing are guild-admin actions the
+ * server enforces. The UI mirrors that by hiding the affordances, not by
+ * deciding it.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getListGuildAppsApiV1GGuildIdAppsGetQueryKey,
+  installGuildAppApiV1GGuildIdAppsPost,
+  listGuildAppsApiV1GGuildIdAppsGet,
+  uninstallGuildAppApiV1GGuildIdAppsAppIdDelete,
+  updateGuildAppApiV1GGuildIdAppsAppIdPatch,
+} from "@/api/generated/apps/apps";
+import type {
+  GuildAppInstall,
+  GuildAppListResponse,
+  GuildAppRead,
+  GuildAppUpdate,
+} from "@/api/generated/initiativeAPI.schemas";
+import { useActiveGuildId } from "@/hooks/useActiveGuildId";
+import { useGuildMutation } from "@/hooks/useApiMutation";
+import { queryClient } from "@/lib/queryClient";
+import type { MutationOpts } from "@/types/mutation";
+import type { QueryOpts } from "@/types/query";
+
+const appsKey = (guildId: number) => getListGuildAppsApiV1GGuildIdAppsGetQueryKey(guildId);
+
+export const useGuildApps = (options?: QueryOpts<GuildAppListResponse>) => {
+  const guildId = useActiveGuildId();
+  return useQuery<GuildAppListResponse>({
+    queryKey: appsKey(guildId),
+    queryFn: () => listGuildAppsApiV1GGuildIdAppsGet(guildId),
+    ...options,
+  });
+};
+
+const invalidateApps = (guildId: number) =>
+  queryClient.invalidateQueries({ queryKey: appsKey(guildId) });
+
+export const useInstallGuildApp = (options?: MutationOpts<GuildAppRead, GuildAppInstall>) => {
+  const guildId = useActiveGuildId();
+  return useGuildMutation<GuildAppRead, GuildAppInstall>(
+    {
+      mutationFn: (guildId, data) => installGuildAppApiV1GGuildIdAppsPost(guildId, data),
+      invalidate: () => invalidateApps(guildId),
+      errorKey: "apps:error",
+    },
+    options
+  );
+};
+
+export const useUpdateGuildApp = (
+  appId: number,
+  options?: MutationOpts<GuildAppRead, GuildAppUpdate>
+) => {
+  const guildId = useActiveGuildId();
+  return useGuildMutation<GuildAppRead, GuildAppUpdate>(
+    {
+      mutationFn: (guildId, data) =>
+        updateGuildAppApiV1GGuildIdAppsAppIdPatch(guildId, appId, data),
+      invalidate: () => invalidateApps(guildId),
+      errorKey: "apps:error",
+    },
+    options
+  );
+};
+
+export const useUninstallGuildApp = (options?: MutationOpts<void, number>) => {
+  const guildId = useActiveGuildId();
+  return useGuildMutation<void, number>(
+    {
+      mutationFn: (guildId, appId) => uninstallGuildAppApiV1GGuildIdAppsAppIdDelete(guildId, appId),
+      invalidate: () => invalidateApps(guildId),
+      errorKey: "apps:error",
+    },
+    options
+  );
+};
+
+/**
+ * Where an app's own surface lives.
+ *
+ * A tool-instance app mounts an existing tool, so its entry links at the tool's
+ * own route with the id the install recorded. An app whose content cannot be
+ * resolved gets no link — better a plain row than one that 404s.
+ */
+export const guildAppPath = (app: GuildAppRead): string | null => {
+  if (app.tool === "calendar") {
+    const calendarId = app.config?.calendar_id;
+    return typeof calendarId === "number" ? `/calendars/${calendarId}` : null;
+  }
+  return null;
+};

--- a/frontend/src/pages/GuildSettingsLayout.tsx
+++ b/frontend/src/pages/GuildSettingsLayout.tsx
@@ -66,6 +66,11 @@ export const GuildSettingsLayout = () => {
         path: urlGuildId ? guildPath(urlGuildId, "/settings/initiatives") : "/settings/initiatives",
       },
       {
+        value: "apps",
+        label: t("guildLayout.tabs.apps"),
+        path: urlGuildId ? guildPath(urlGuildId, "/settings/apps") : "/settings/apps",
+      },
+      {
         value: "trash",
         label: t("guildLayout.tabs.trash"),
         path: urlGuildId ? guildPath(urlGuildId, "/settings/trash") : "/settings/trash",

--- a/frontend/src/pages/GuildSettingsLayout.tsx
+++ b/frontend/src/pages/GuildSettingsLayout.tsx
@@ -129,18 +129,14 @@ export const GuildSettingsLayout = () => {
     ? extractSubPath(currentPath).replace(/\/+$/, "") || "/"
     : currentPath.replace(/\/+$/, "") || "/";
 
-  // Map normalized sub-paths to tab values
-  const tabSubPaths = [
-    { value: "guild", path: "/settings" },
-    { value: "ai", path: "/settings/ai" },
-    { value: "users", path: "/settings/users" },
-    { value: "auth", path: "/settings/auth" },
-    { value: "initiatives", path: "/settings/initiatives" },
-    { value: "trash", path: "/settings/trash" },
-    { value: "data", path: "/settings/data" },
-    { value: "advanced-tool", path: "/settings/advanced-tool" },
-    { value: "danger-zone", path: "/settings/danger-zone" },
-  ];
+  // Derived from the tabs themselves rather than restated: a second hand-kept
+  // list is a tab that highlights the wrong one the day someone adds a tab and
+  // updates only the list they happened to be looking at. The tab paths are
+  // guild-prefixed; matching happens on the sub-path.
+  const tabSubPaths = guildSettingsTabs.map((tab) => ({
+    value: tab.value,
+    path: extractSubPath(tab.path),
+  }));
 
   const activeTab = matchActiveTab(tabSubPaths, normalizedPath, availableTabs[0]?.value ?? "guild");
 

--- a/frontend/src/pages/SettingsGuildAppsPage.tsx
+++ b/frontend/src/pages/SettingsGuildAppsPage.tsx
@@ -1,0 +1,144 @@
+/**
+ * Managing the guild's apps.
+ *
+ * The sidebar shows what is *on*; this is where an admin turns one off, renames
+ * it, or removes it — so disabled apps appear here and nowhere else, otherwise
+ * turning one off would hide the switch that turns it back on.
+ *
+ * Removing an app trashes what it created rather than deleting it, and the
+ * confirmation says so: the events a guild put in a calendar should not feel
+ * like collateral.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { Blocks, Loader2, Store } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { GuildAppRead } from "@/api/generated/initiativeAPI.schemas";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGuildApps, useUninstallGuildApp, useUpdateGuildApp } from "@/hooks/useGuildApps";
+import { useGuilds } from "@/hooks/useGuilds";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { useGuildPath } from "@/lib/guildUrl";
+
+export function SettingsGuildAppsPage() {
+  const { t } = useTranslation(["apps", "common"]);
+  const gp = useGuildPath();
+  const appsQuery = useGuildApps();
+  const { activeGuild } = useGuilds();
+  const isGuildAdmin = activeGuild?.role === "admin";
+
+  const apps = appsQuery.data?.items ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("apps:manage.title")}</CardTitle>
+        <CardDescription>{t("apps:manage.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {appsQuery.isLoading ? (
+          <Skeleton className="h-20 w-full" />
+        ) : apps.length ? (
+          apps.map((app) => <AppRow key={app.id} app={app} canManage={Boolean(isGuildAdmin)} />)
+        ) : (
+          <div className="space-y-3 rounded-lg border border-dashed p-6 text-center">
+            <p className="text-muted-foreground text-sm">{t("apps:manage.empty")}</p>
+            {isGuildAdmin && (
+              <Button variant="outline" asChild>
+                <Link to={gp("/marketplace")} search={{ kind: "app" }}>
+                  <Store className="mr-1.5 h-4 w-4" />
+                  {t("apps:manage.browse")}
+                </Link>
+              </Button>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AppRow({ app, canManage }: { app: GuildAppRead; canManage: boolean }) {
+  const { t } = useTranslation(["apps", "common"]);
+  const [name, setName] = useState(app.name);
+  const [confirming, setConfirming] = useState(false);
+  const update = useUpdateGuildApp(app.id);
+  const uninstall = useUninstallGuildApp();
+
+  const save = (patch: { name?: string; enabled?: boolean }) =>
+    update.mutate(patch, {
+      onSuccess: () => toast.success(t("apps:manage.saved")),
+      onError: (error) => toast.error(getErrorMessage(error, "apps:error")),
+    });
+
+  const remove = () =>
+    uninstall.mutate(app.id, {
+      onSuccess: () => {
+        toast.success(t("apps:manage.removed", { name: app.name }));
+        setConfirming(false);
+      },
+      onError: (error) => toast.error(getErrorMessage(error, "apps:error")),
+    });
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border p-3">
+      <Blocks className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+      <div className="min-w-0 flex-1 space-y-1">
+        {canManage ? (
+          <Input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            onBlur={() => name.trim() && name !== app.name && save({ name: name.trim() })}
+            aria-label={t("apps:manage.rename")}
+            className="h-8 max-w-xs"
+          />
+        ) : (
+          <p className="font-medium text-sm">{app.name}</p>
+        )}
+        <p className="text-muted-foreground text-xs">
+          {t("apps:manage.installed", {
+            date: new Date(app.created_at).toLocaleDateString(),
+          })}
+        </p>
+      </div>
+
+      {!app.enabled && <Badge variant="outline">{t("apps:manage.disabled")}</Badge>}
+
+      {canManage && (
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => save({ enabled: !app.enabled })}
+            disabled={update.isPending}
+          >
+            {update.isPending && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            {app.enabled ? t("apps:manage.disable") : t("apps:manage.enable")}
+          </Button>
+          <Button size="sm" variant="destructive" onClick={() => setConfirming(true)}>
+            {t("apps:manage.remove")}
+          </Button>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={confirming}
+        onOpenChange={setConfirming}
+        title={t("apps:manage.removeTitle", { name: app.name })}
+        description={t("apps:manage.removeBody")}
+        confirmLabel={t("apps:manage.remove")}
+        onConfirm={remove}
+        isLoading={uninstall.isPending}
+        destructive
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
@@ -67,9 +67,18 @@ describe("MarketplaceBrowsePage", () => {
   });
 
   it("asks the catalog only for dashboards", async () => {
+    // Defaulted by the page itself: `useSearch({ strict: false })` does not run
+    // the route's validation, so a page that leaned on it would drop the filter
+    // and mix apps into the grid.
     renderPage(MarketplaceBrowsePage);
     await screen.findByText("Sprint health");
     expect(listingsFor).toHaveBeenCalledWith(expect.objectContaining({ kind: "dashboard" }));
+  });
+
+  it("asks for apps on the apps shelf", async () => {
+    renderPage(MarketplaceBrowsePage, { routerSearch: { kind: "app" } });
+    await screen.findByText("Sprint health");
+    expect(listingsFor).toHaveBeenCalledWith(expect.objectContaining({ kind: "app" }));
   });
 
   it("marks a listing this guild already installed", async () => {

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.test.tsx
@@ -23,10 +23,18 @@ vi.mock("@/hooks/useMarketplace", () => ({
 }));
 
 let installedFailed = false;
+let installedApps: { listing_uid: string }[] = [];
 
 vi.mock("@/hooks/useDashboards", () => ({
   useInstalledListings: () => ({
     data: installedFailed ? undefined : { counts: installed },
+    isError: installedFailed,
+  }),
+}));
+
+vi.mock("@/hooks/useGuildApps", () => ({
+  useGuildApps: () => ({
+    data: installedFailed ? undefined : { items: installedApps },
     isError: installedFailed,
   }),
 }));
@@ -52,6 +60,7 @@ const listing = (overrides: Partial<MarketplaceListingSummary> = {}) =>
 
 beforeEach(() => {
   installed = {};
+  installedApps = [];
   installedFailed = false;
   listingsFor.mockReturnValue({
     data: { items: [listing()], total: 1 },
@@ -79,6 +88,23 @@ describe("MarketplaceBrowsePage", () => {
     renderPage(MarketplaceBrowsePage, { routerSearch: { kind: "app" } });
     await screen.findByText("Sprint health");
     expect(listingsFor).toHaveBeenCalledWith(expect.objectContaining({ kind: "app" }));
+  });
+
+  it("marks an installed app on the apps shelf", async () => {
+    // Each shelf asks its own tool: the dashboards aggregate knows nothing
+    // about apps, so reading installed state from it here would report every
+    // app as not installed.
+    installedApps = [{ listing_uid: "SPRNT000000001" }];
+    renderPage(MarketplaceBrowsePage, { routerSearch: { kind: "app" } });
+    expect(await screen.findByText("Installed")).toBeInTheDocument();
+  });
+
+  it("does not read app installs from the dashboard aggregate", async () => {
+    installed = { SPRNT000000001: 1 };
+    installedApps = [];
+    renderPage(MarketplaceBrowsePage, { routerSearch: { kind: "app" } });
+    await screen.findByText("Sprint health");
+    expect(screen.queryByText("Installed")).toBeNull();
   });
 
   it("marks a listing this guild already installed", async () => {

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
@@ -11,18 +11,26 @@
 
 import { useSearch } from "@tanstack/react-router";
 import { CloudOff, SearchX } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
 import { MarketplaceCard } from "@/components/marketplace/MarketplaceCard";
 import { StatusMessage } from "@/components/StatusMessage";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useInstalledListings } from "@/hooks/useDashboards";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useGuildApps } from "@/hooks/useGuildApps";
 import { useMarketplaceListings } from "@/hooks/useMarketplace";
 
 const PAGE_SIZE = 24;
+/** One line per shelf, so a new kind shows its own rather than the dashboards'. */
+const SUBTITLE_KEYS = {
+  [ListingKind.dashboard]: "subtitle",
+  [ListingKind.app]: "subtitleApps",
+  [ListingKind.auto]: "subtitleAuto",
+} as const;
 /** Stable keys for the loading placeholders — they never reorder, and an index
  *  key on a list that can change is the lint rule this avoids. */
 const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
@@ -36,8 +44,8 @@ export function MarketplaceBrowsePage() {
   // relying on that default would mean the filter silently disappears anywhere
   // the page is mounted another way, and the grid would mix apps into the
   // dashboards.
-  const search_ = useSearch({ strict: false }) as { kind?: "dashboard" | "app" };
-  const kind = search_.kind ?? "dashboard";
+  const search_ = useSearch({ strict: false }) as { kind?: ListingKind };
+  const kind = search_.kind ?? ListingKind.dashboard;
   const [query, setQuery] = useState("");
   // The catalog is a network call per keystroke otherwise, and the grid keeps
   // the previous page while the next one loads.
@@ -49,15 +57,28 @@ export function MarketplaceBrowsePage() {
     page_size: PAGE_SIZE,
   });
 
-  // Which of these this guild already has, counted server-side over every
-  // dashboard rather than over a page of them. A count, not a boolean: a guild
-  // may hold several installs of one listing, at different versions.
+  // Which of these this guild already has. Each shelf has to ask its own tool:
+  // the dashboards aggregate knows nothing about apps, so using it on the apps
+  // shelf would report every app as not installed.
   //
-  // Left undefined when that request failed, rather than defaulted to an empty
+  // Left undefined when the request failed, rather than defaulted to an empty
   // map: "we do not know" and "you have none of these" look identical on a card,
   // and only one of them is true. The notice below says which.
-  const installedQuery = useInstalledListings();
-  const installedByUid = installedQuery.isError ? undefined : installedQuery.data?.counts;
+  const dashboardInstalls = useInstalledListings({ enabled: kind === ListingKind.dashboard });
+  const appInstalls = useGuildApps({ enabled: kind === ListingKind.app });
+  const installedQuery = kind === ListingKind.app ? appInstalls : dashboardInstalls;
+
+  const installedByUid = useMemo(() => {
+    if (installedQuery.isError) return undefined;
+    if (kind === ListingKind.app) {
+      // One install per listing per guild, so this is a presence map that
+      // happens to be shaped like the dashboards' counts.
+      const counts: Record<string, number> = {};
+      for (const app of appInstalls.data?.items ?? []) counts[app.listing_uid] = 1;
+      return counts;
+    }
+    return dashboardInstalls.data?.counts;
+  }, [kind, installedQuery.isError, appInstalls.data, dashboardInstalls.data]);
 
   const listings = listingsQuery.data?.items ?? [];
 
@@ -65,9 +86,7 @@ export function MarketplaceBrowsePage() {
     <div className="space-y-6">
       <div className="space-y-1">
         <h1 className="font-semibold text-3xl tracking-tight">{t("title")}</h1>
-        <p className="text-muted-foreground text-sm">
-          {kind === "app" ? t("subtitleApps") : t("subtitle")}
-        </p>
+        <p className="text-muted-foreground text-sm">{t(SUBTITLE_KEYS[kind])}</p>
       </div>
 
       <Input

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
@@ -9,6 +9,7 @@
  * matched up client-side.
  */
 
+import { useSearch } from "@tanstack/react-router";
 import { CloudOff, SearchX } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -28,13 +29,16 @@ const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
 
 export function MarketplaceBrowsePage() {
   const { t } = useTranslation("marketplace");
+  // Which shelf: dashboards, or the apps a guild admin adds. The route
+  // normalizes anything unexpected back to dashboards.
+  const { kind } = useSearch({ strict: false }) as { kind?: "dashboard" | "app" };
   const [query, setQuery] = useState("");
   // The catalog is a network call per keystroke otherwise, and the grid keeps
   // the previous page while the next one loads.
   const search = useDebouncedValue(query, 250);
 
   const listingsQuery = useMarketplaceListings({
-    kind: "dashboard",
+    kind,
     q: search.trim() || undefined,
     page_size: PAGE_SIZE,
   });
@@ -55,7 +59,9 @@ export function MarketplaceBrowsePage() {
     <div className="space-y-6">
       <div className="space-y-1">
         <h1 className="font-semibold text-3xl tracking-tight">{t("title")}</h1>
-        <p className="text-muted-foreground text-sm">{t("subtitle")}</p>
+        <p className="text-muted-foreground text-sm">
+          {kind === "app" ? t("subtitleApps") : t("subtitle")}
+        </p>
       </div>
 
       <Input

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
@@ -29,9 +29,15 @@ const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
 
 export function MarketplaceBrowsePage() {
   const { t } = useTranslation("marketplace");
-  // Which shelf: dashboards, or the apps a guild admin adds. The route
-  // normalizes anything unexpected back to dashboards.
-  const { kind } = useSearch({ strict: false }) as { kind?: "dashboard" | "app" };
+  // Which shelf: dashboards, or the apps a guild admin adds.
+  //
+  // Defaulted here, not left to the route. `useSearch({ strict: false })` reads
+  // the params as they are — it does not run the route's `validateSearch` — so
+  // relying on that default would mean the filter silently disappears anywhere
+  // the page is mounted another way, and the grid would mix apps into the
+  // dashboards.
+  const search_ = useSearch({ strict: false }) as { kind?: "dashboard" | "app" };
+  const kind = search_.kind ?? "dashboard";
   const [query, setQuery] = useState("");
   // The catalog is a network call per keystroke otherwise, and the grid keeps
   // the previous page while the next one loads.

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Reading a listing, and getting back out.
+ *
+ * The shelf you were browsing has to survive the round trip. Both ways out of
+ * this page lead to the marketplace, and each one has to carry the kind —
+ * otherwise an admin browsing apps clicks a listing, comes back, and is looking
+ * at dashboards. The error route is the one that got missed first, which is why
+ * it is pinned here alongside the ordinary one.
+ */
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+import type { MarketplaceListingDetail } from "@/api/generated/initiativeAPI.schemas";
+
+import { MarketplaceListingPage } from "./MarketplaceListingPage";
+
+let listing: Partial<MarketplaceListingDetail> | undefined;
+let failed = false;
+
+vi.mock("@/hooks/useMarketplace", () => ({
+  useMarketplaceListing: () => ({ data: listing, isError: failed }),
+}));
+vi.mock("@/hooks/useDashboards", () => ({ useWidgetCatalog: () => ({ data: undefined }) }));
+vi.mock("@/hooks/useGuilds", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useGuilds")>()),
+  useGuilds: () => ({ activeGuild: { role: "admin" } }),
+}));
+
+const appListing = () =>
+  ({
+    uid: "GLDCAL00000001",
+    public_id: "core.guild-calendar",
+    kind: "app",
+    name: "Guild calendar",
+    publisher: "Initiative",
+    description: "The guild's own events.",
+    avatar_url: "/marketplace/cal.svg",
+    images: [],
+    installs_count: 0,
+    available: true,
+    installable: true,
+    versions: [],
+    updated_at: "",
+  }) as unknown as MarketplaceListingDetail;
+
+/** The href of the link back to the marketplace, whichever route rendered it. */
+const backHref = () =>
+  screen
+    .getAllByRole("link")
+    .map((link) => link.getAttribute("href"))
+    .find((href) => href?.includes("/marketplace") && !href.includes("core."));
+
+beforeEach(() => {
+  listing = appListing();
+  failed = false;
+});
+
+describe("MarketplaceListingPage", () => {
+  it("returns to the shelf it was opened from", async () => {
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+    await screen.findByRole("heading", { name: "Guild calendar" });
+    expect(backHref()).toContain("kind=app");
+  });
+
+  it("returns to the shelf when the listing failed to load", async () => {
+    // The way out of an error state is the one people actually take, and it was
+    // the one that dropped the shelf.
+    failed = true;
+    listing = undefined;
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+    await screen.findByText(/listing not found/i);
+    expect(backHref()).toContain("kind=app");
+  });
+
+  it("falls back to the listing's own kind on a direct link", async () => {
+    // Arrived without a shelf in the URL: the listing itself says which one it
+    // belongs to.
+    renderPage(MarketplaceListingPage);
+    await screen.findByRole("heading", { name: "Guild calendar" });
+    expect(backHref()).toContain("kind=app");
+  });
+
+  it("offers no canvas preview for an app", async () => {
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+    await screen.findByRole("heading", { name: "Guild calendar" });
+    // An app mounts a tool; there is no definition to draw.
+    expect(screen.queryByText("Preview")).toBeNull();
+  });
+});

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { DashboardCanvas } from "@/components/initiativeTools/dashboards/DashboardCanvas";
+import { InstallAppDialog } from "@/components/marketplace/InstallAppDialog";
 import { InstallListingDialog } from "@/components/marketplace/InstallListingDialog";
 import { StatusMessage } from "@/components/StatusMessage";
 import { Badge } from "@/components/ui/badge";
@@ -26,20 +27,26 @@ import {
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useWidgetCatalog } from "@/hooks/useDashboards";
+import { useGuilds } from "@/hooks/useGuilds";
 import { useMarketplaceListing } from "@/hooks/useMarketplace";
 import { useGuildPath } from "@/lib/guildUrl";
 import { readConfig, readDefinition } from "@/lib/widgets/definition";
 
 export function MarketplaceListingPage() {
-  const { t } = useTranslation("marketplace");
+  const { t } = useTranslation(["marketplace", "apps"]);
   const { publicId } = useParams({ strict: false }) as { publicId: string };
   const gp = useGuildPath();
 
   const listingQuery = useMarketplaceListing(publicId ?? null);
   const catalogQuery = useWidgetCatalog();
   const [installing, setInstalling] = useState(false);
+  const { activeGuild } = useGuilds();
 
   const listing = listingQuery.data;
+  const isApp = listing?.kind === "app";
+  // Installing an app is a guild-admin action; the server enforces it, and the
+  // button says so rather than failing after the click.
+  const isGuildAdmin = activeGuild?.role === "admin";
 
   if (listingQuery.isError) {
     return (
@@ -110,14 +117,22 @@ export function MarketplaceListingPage() {
 
         {listing && (
           <div className="flex flex-col items-end gap-1">
-            <Button onClick={() => setInstalling(true)} disabled={!listing.installable}>
+            <Button
+              onClick={() => setInstalling(true)}
+              disabled={!listing.installable || (isApp && !isGuildAdmin)}
+            >
               <Download className="mr-1.5 h-4 w-4" />
-              {t("detail.install")}
+              {isApp ? t("apps:install.action") : t("detail.install")}
             </Button>
-            {!listing.installable && (
+            {!listing.installable ? (
               <span className="text-muted-foreground text-xs">
                 {listing.available ? t("detail.needsUpdate") : t("detail.withdrawn")}
               </span>
+            ) : (
+              isApp &&
+              !isGuildAdmin && (
+                <span className="text-muted-foreground text-xs">{t("apps:install.adminOnly")}</span>
+              )
             )}
           </div>
         )}
@@ -144,23 +159,27 @@ export function MarketplaceListingPage() {
         </div>
       ) : null}
 
-      <div className="space-y-2">
-        <h2 className="font-medium text-sm">{t("detail.preview")}</h2>
-        {listing?.definition ? (
-          // The same canvas a live dashboard renders, read-only: `canEdit` false
-          // means static tiles, no drag handles, and no layout writes.
-          <DashboardCanvas
-            definition={readDefinition(listing.definition)}
-            config={readConfig({})}
-            catalog={catalogQuery.data}
-            initiativeId={undefined}
-            canEdit={false}
-            onLayoutChange={() => {}}
-          />
-        ) : (
-          <Skeleton className="h-64 w-full rounded-lg" />
-        )}
-      </div>
+      {/* An app mounts one of this build's tools; there is no canvas to draw,
+          so the preview is a dashboard-only affordance. */}
+      {!isApp && (
+        <div className="space-y-2">
+          <h2 className="font-medium text-sm">{t("detail.preview")}</h2>
+          {listing?.definition ? (
+            // The same canvas a live dashboard renders, read-only: `canEdit` false
+            // means static tiles, no drag handles, and no layout writes.
+            <DashboardCanvas
+              definition={readDefinition(listing.definition)}
+              config={readConfig({})}
+              catalog={catalogQuery.data}
+              initiativeId={undefined}
+              canEdit={false}
+              onLayoutChange={() => {}}
+            />
+          ) : (
+            <Skeleton className="h-64 w-full rounded-lg" />
+          )}
+        </div>
+      )}
 
       {listing && listing.versions.length > 1 && (
         <div className="space-y-2">
@@ -178,9 +197,12 @@ export function MarketplaceListingPage() {
         </div>
       )}
 
-      {listing && (
-        <InstallListingDialog listing={listing} open={installing} onOpenChange={setInstalling} />
-      )}
+      {listing &&
+        (isApp ? (
+          <InstallAppDialog listing={listing} open={installing} onOpenChange={setInstalling} />
+        ) : (
+          <InstallListingDialog listing={listing} open={installing} onOpenChange={setInstalling} />
+        ))}
     </div>
   );
 }

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -47,7 +47,9 @@ export function MarketplaceListingPage() {
   const listing = listingQuery.data;
   const isApp = listing?.kind === "app";
   // Back to the shelf this listing was found on, falling back to the listing's
-  // own kind when someone arrived by direct link.
+  // own kind when someone arrived by direct link. Both can be unknown when the
+  // listing failed to load — there is nothing to infer a shelf from then, and
+  // the browse route normalizes an absent kind to dashboards.
   const backToShelf = { kind: shelf ?? listing?.kind };
   // Installing an app is a guild-admin action; the server enforces it, and the
   // button says so rather than failing after the click.
@@ -60,6 +62,7 @@ export function MarketplaceListingPage() {
         title={t("detail.notFound")}
         description={t("detail.notFoundDescription")}
         backTo={gp("/marketplace")}
+        backSearch={backToShelf}
         backLabel={t("backToMarketplace")}
       />
     );

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -6,11 +6,12 @@
  * whether to install sees what they would get rather than a description of it.
  */
 
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, useParams, useSearch } from "@tanstack/react-router";
 import { Download, SearchX } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { ListingKind } from "@/api/generated/initiativeAPI.schemas";
 import { DashboardCanvas } from "@/components/initiativeTools/dashboards/DashboardCanvas";
 import { InstallAppDialog } from "@/components/marketplace/InstallAppDialog";
 import { InstallListingDialog } from "@/components/marketplace/InstallListingDialog";
@@ -35,6 +36,7 @@ import { readConfig, readDefinition } from "@/lib/widgets/definition";
 export function MarketplaceListingPage() {
   const { t } = useTranslation(["marketplace", "apps"]);
   const { publicId } = useParams({ strict: false }) as { publicId: string };
+  const { kind: shelf } = useSearch({ strict: false }) as { kind?: ListingKind };
   const gp = useGuildPath();
 
   const listingQuery = useMarketplaceListing(publicId ?? null);
@@ -44,6 +46,9 @@ export function MarketplaceListingPage() {
 
   const listing = listingQuery.data;
   const isApp = listing?.kind === "app";
+  // Back to the shelf this listing was found on, falling back to the listing's
+  // own kind when someone arrived by direct link.
+  const backToShelf = { kind: shelf ?? listing?.kind };
   // Installing an app is a guild-admin action; the server enforces it, and the
   // button says so rather than failing after the click.
   const isGuildAdmin = activeGuild?.role === "admin";
@@ -66,7 +71,9 @@ export function MarketplaceListingPage() {
         <BreadcrumbList>
           <BreadcrumbItem>
             <BreadcrumbLink asChild>
-              <Link to={gp("/marketplace")}>{t("title")}</Link>
+              <Link to={gp("/marketplace")} search={backToShelf}>
+                {t("title")}
+              </Link>
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -79,6 +79,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRouteImport } 
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsIndexRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/index'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsAiRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/ai'
+import { Route as ServerRequiredAuthenticatedGGuildIdSettingsAppsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/apps'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsAuthRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/auth'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/danger-zone'
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsDataRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings/data'
@@ -511,6 +512,12 @@ const ServerRequiredAuthenticatedGGuildIdSettingsAiRoute =
     path: '/ai',
     getParentRoute: () => ServerRequiredAuthenticatedGGuildIdSettingsRoute,
   } as any)
+const ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute =
+  ServerRequiredAuthenticatedGGuildIdSettingsAppsRouteImport.update({
+    id: '/apps',
+    path: '/apps',
+    getParentRoute: () => ServerRequiredAuthenticatedGGuildIdSettingsRoute,
+  } as any)
 const ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute =
   ServerRequiredAuthenticatedGGuildIdSettingsAuthRouteImport.update({
     id: '/auth',
@@ -704,6 +711,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/queues/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   '/g/$guildId/settings/ai': typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  '/g/$guildId/settings/apps': typeof ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute
   '/g/$guildId/settings/auth': typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   '/g/$guildId/settings/danger-zone': typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   '/g/$guildId/settings/data': typeof ServerRequiredAuthenticatedGGuildIdSettingsDataRoute
@@ -787,6 +795,7 @@ export interface FileRoutesByTo {
   '/g/$guildId/queues/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   '/g/$guildId/settings/ai': typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  '/g/$guildId/settings/apps': typeof ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute
   '/g/$guildId/settings/auth': typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   '/g/$guildId/settings/danger-zone': typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   '/g/$guildId/settings/data': typeof ServerRequiredAuthenticatedGGuildIdSettingsDataRoute
@@ -878,6 +887,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool': typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/ai': typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  '/_serverRequired/_authenticated/g/$guildId/settings/apps': typeof ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/auth': typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/danger-zone': typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   '/_serverRequired/_authenticated/g/$guildId/settings/data': typeof ServerRequiredAuthenticatedGGuildIdSettingsDataRoute
@@ -968,6 +978,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/queues/$queueId'
     | '/g/$guildId/settings/advanced-tool'
     | '/g/$guildId/settings/ai'
+    | '/g/$guildId/settings/apps'
     | '/g/$guildId/settings/auth'
     | '/g/$guildId/settings/danger-zone'
     | '/g/$guildId/settings/data'
@@ -1051,6 +1062,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/queues/$queueId'
     | '/g/$guildId/settings/advanced-tool'
     | '/g/$guildId/settings/ai'
+    | '/g/$guildId/settings/apps'
     | '/g/$guildId/settings/auth'
     | '/g/$guildId/settings/danger-zone'
     | '/g/$guildId/settings/data'
@@ -1141,6 +1153,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId'
     | '/_serverRequired/_authenticated/g/$guildId/settings/advanced-tool'
     | '/_serverRequired/_authenticated/g/$guildId/settings/ai'
+    | '/_serverRequired/_authenticated/g/$guildId/settings/apps'
     | '/_serverRequired/_authenticated/g/$guildId/settings/auth'
     | '/_serverRequired/_authenticated/g/$guildId/settings/danger-zone'
     | '/_serverRequired/_authenticated/g/$guildId/settings/data'
@@ -1659,6 +1672,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsRoute
     }
+    '/_serverRequired/_authenticated/g/$guildId/settings/apps': {
+      id: '/_serverRequired/_authenticated/g/$guildId/settings/apps'
+      path: '/apps'
+      fullPath: '/g/$guildId/settings/apps'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAppsRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsRoute
+    }
     '/_serverRequired/_authenticated/g/$guildId/settings/auth': {
       id: '/_serverRequired/_authenticated/g/$guildId/settings/auth'
       path: '/auth'
@@ -1902,6 +1922,7 @@ const ServerRequiredAuthenticatedSettingsRouteWithChildren =
 interface ServerRequiredAuthenticatedGGuildIdSettingsRouteChildren {
   ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute
   ServerRequiredAuthenticatedGGuildIdSettingsAiRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAiRoute
+  ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute
   ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute
   ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute
   ServerRequiredAuthenticatedGGuildIdSettingsDataRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsDataRoute
@@ -1918,6 +1939,8 @@ const ServerRequiredAuthenticatedGGuildIdSettingsRouteChildren: ServerRequiredAu
       ServerRequiredAuthenticatedGGuildIdSettingsAdvancedToolRoute,
     ServerRequiredAuthenticatedGGuildIdSettingsAiRoute:
       ServerRequiredAuthenticatedGGuildIdSettingsAiRoute,
+    ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute:
+      ServerRequiredAuthenticatedGGuildIdSettingsAppsRoute,
     ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute:
       ServerRequiredAuthenticatedGGuildIdSettingsAuthRoute,
     ServerRequiredAuthenticatedGGuildIdSettingsDangerZoneRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace.tsx
@@ -1,13 +1,17 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-/** Which shelf of the marketplace to show. Dashboards by default — apps are the
- *  smaller set, reached from the sidebar's add affordance. */
-const KINDS = ["dashboard", "app"] as const;
-type ListingKind = (typeof KINDS)[number];
+import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
+
+/** Which shelf of the marketplace to show. Read off the generated enum rather
+ *  than restated here, so a kind added server-side is accepted without an edit.
+ *  Anything unrecognized normalizes to dashboards. */
+const KINDS = Object.values(ListingKind);
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/marketplace")({
   validateSearch: (search: Record<string, unknown>): { kind: ListingKind } => ({
-    kind: KINDS.includes(search.kind as ListingKind) ? (search.kind as ListingKind) : "dashboard",
+    kind: KINDS.includes(search.kind as ListingKind)
+      ? (search.kind as ListingKind)
+      : ListingKind.dashboard,
   }),
   component: lazyRouteComponent(() =>
     import("@/pages/marketplace/MarketplaceBrowsePage").then((m) => ({

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace.tsx
@@ -1,6 +1,14 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
+/** Which shelf of the marketplace to show. Dashboards by default — apps are the
+ *  smaller set, reached from the sidebar's add affordance. */
+const KINDS = ["dashboard", "app"] as const;
+type ListingKind = (typeof KINDS)[number];
+
 export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/marketplace")({
+  validateSearch: (search: Record<string, unknown>): { kind: ListingKind } => ({
+    kind: KINDS.includes(search.kind as ListingKind) ? (search.kind as ListingKind) : "dashboard",
+  }),
   component: lazyRouteComponent(() =>
     import("@/pages/marketplace/MarketplaceBrowsePage").then((m) => ({
       default: m.MarketplaceBrowsePage,

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace_.$publicId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/marketplace_.$publicId.tsx
@@ -1,8 +1,15 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
+import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
+
+const KINDS = Object.values(ListingKind);
+
 export const Route = createFileRoute(
   "/_serverRequired/_authenticated/g/$guildId/marketplace_/$publicId"
 )({
+  // Carried so the back link can return to the shelf the listing was found on.
+  validateSearch: (search: Record<string, unknown>): { kind?: ListingKind } =>
+    KINDS.includes(search.kind as ListingKind) ? { kind: search.kind as ListingKind } : {},
   component: lazyRouteComponent(() =>
     import("@/pages/marketplace/MarketplaceListingPage").then((m) => ({
       default: m.MarketplaceListingPage,

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/settings/apps.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/settings/apps.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/settings/apps")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/SettingsGuildAppsPage").then((m) => ({
+      default: m.SettingsGuildAppsPage,
+    }))
+  ),
+});

--- a/frontend/src/types/i18next.d.ts
+++ b/frontend/src/types/i18next.d.ts
@@ -2,6 +2,7 @@ import "i18next";
 
 import type access from "../../public/locales/en/access.json";
 import type advancedTools from "../../public/locales/en/advancedTools.json";
+import type apps from "../../public/locales/en/apps.json";
 import type auth from "../../public/locales/en/auth.json";
 import type calendars from "../../public/locales/en/calendars.json";
 import type command from "../../public/locales/en/command.json";
@@ -42,6 +43,7 @@ declare module "i18next" {
       auth: typeof auth;
       command: typeof command;
       common: typeof common;
+      apps: typeof apps;
       counterGroups: typeof counterGroups;
       marketplace: typeof marketplace;
       dashboard: typeof dashboard;


### PR DESCRIPTION
The frontend half of #1093. Apps are installable but invisible until this.

## Sidebar

Apps sit **above** the initiatives as their own collapsible section — they are guild-wide surfaces, not something inside an initiative. What shows depends on who is looking:

| | member | guild admin |
|---|---|---|
| **no apps** | nothing at all | the section, with a `+` |
| **apps installed** | one entry each | the same, plus the `+` |

A member with nothing installed sees an unchanged sidebar. An empty "Apps" heading would promise something they can't act on; the admin in that same guild *can* act, so they get the invitation — the same shape the initiatives list uses when a guild has none.

Once apps exist everyone sees them, because their existence is guild-wide knowledge. Whether a member may do anything *inside* one is that instance's own sharing, enforced where the content lives. Entries link straight to what the app mounted; an app whose content can't be resolved renders as a plain row rather than a link that 404s.

Open/closed state persists like the other sections.

## Installing

The marketplace route now takes a `kind` search param, so the `+` lands on the apps shelf rather than the dashboards one. Anything unexpected normalizes back to dashboards.

Apps install through their own dialog, because the dashboard one asks the wrong question: a dashboard belongs to an initiative, so installing one is a choice of which; an app belongs to the guild, so there is only what to call it. Guild admins only — the server enforces it and the button says so rather than failing after the click. The listing page also drops the canvas preview for apps, since an app mounts a tool rather than drawing one.

## Managing

A new **Apps** tab in guild settings, beside Initiatives: rename, turn off, remove. Disabled apps live here and nowhere else — turning one off in the sidebar would otherwise hide the switch that turns it back on. The remove confirmation says the content goes to the trash rather than away, which is what the backend does.

## Testing

7 tests on the section, one per rule above: member with no apps sees an empty DOM, admin gets the `+`, installed apps list for members without an add affordance, entries link to what they mounted, disabled apps are hidden, a member whose only app is disabled sees nothing, and an app with unresolvable content renders without a link.

`tsc --noEmit`, `pnpm lint`, `pnpm build` clean. New `apps` namespace in all four locales, plus the marketplace and settings keys.

Per your note I kept test runs to the new file; CI has the rest.

## Not here

`core.advanced-tool` (the `embed` app) and removing the guild-settings advanced-tool page — that's the next one, and it needs the embed validator plus the existing handoff machinery.