### PR TITLE
Match the support console's handoff contract

### DIFF
--- a/frontend/src/pages/AdminDashboardGuildsPage.test.tsx
+++ b/frontend/src/pages/AdminDashboardGuildsPage.test.tsx
@@ -337,9 +337,13 @@ describe("AdminDashboardGuildsPage", () => {
       await userEvent.click(await screen.findByLabelText("Open billing for Capped Guild"));
 
       expect(mintHandoff).toHaveBeenCalledWith(7);
-      expect(location.href).toContain("https://billing.example.com/support?guild=7");
-      // The token rides in the fragment, so it never reaches the server.
-      expect(location.href).toContain("#handoff=tok-123");
+      // The console reads the guild off the session it exchanges, so the URL
+      // never names one; the token rides in the fragment, which is not sent to
+      // the server. The key is `support_handoff` — the console ignores the
+      // `handoff` the guild-admin flow uses.
+      const [path, fragment] = location.href.split("#");
+      expect(path).toBe("https://billing.example.com/support?lang=en");
+      expect(fragment).toBe("support_handoff=tok-123");
       expect(tab.opener).toBeNull();
 
       openSpy.mockRestore();

--- a/frontend/src/pages/AdminDashboardGuildsPage.tsx
+++ b/frontend/src/pages/AdminDashboardGuildsPage.tsx
@@ -209,9 +209,12 @@ const GuildBillingCell = ({ guild }: { guild: PlatformGuildStorageRead }) => {
           guild.id
         );
       const lang = i18n.resolvedLanguage ?? i18n.language;
-      const url = `${billing.url}/support?guild=${guild.id}&lang=${encodeURIComponent(
+      // The token rides in the fragment, which never leaves the browser. The
+      // console reads the guild off the exchanged session, so the URL does not
+      // name one — only the language carries over.
+      const url = `${billing.url}/support?lang=${encodeURIComponent(
         lang
-      )}#handoff=${encodeURIComponent(handoff_token)}`;
+      )}#support_handoff=${encodeURIComponent(handoff_token)}`;
       if (tab) tab.location.href = url;
       else window.open(url, "_blank", "noopener,noreferrer");
     } catch (err) {


### PR DESCRIPTION
## Problem

The admin Guilds tab already mints an operator handoff and opens the portal
(#1091), but it builds a URL the support console does not read, so the console
never sees the token and the operator lands unauthenticated.

Two mismatches against the console as it now ships:

- **Fragment key.** We send `#handoff=`; the console reads `#support_handoff=`.
  The guild-admin flow is the one that uses `#handoff=`, and the console
  deliberately anchors its pattern so the two cannot be confused.
- **Guild in the query string.** We append `?guild=<id>`. The console takes the
  guild from the session it exchanges and ignores the parameter — the URL is not
  allowed to name a guild there.

## Changes

- [AdminDashboardGuildsPage.tsx](frontend/src/pages/AdminDashboardGuildsPage.tsx):
  build `${BILLING_URL}/support?lang=<lang>#support_handoff=<token>`. `lang` stays
  (the portal deep-links its language off it); `guild` is dropped.
- Test now pins the URL exactly — path and fragment asserted separately, rather
  than a substring match that passed on the wrong key.

Nothing else moves: the mint endpoint, the token claims, the grant it names, and
the issuer/audience pair were already correct against the console's verifier.

## Testing

- `pnpm vitest run src/pages/AdminDashboardGuildsPage.test.tsx` — 25 passed
- `pnpm typecheck`, `pnpm lint` — clean

Frontend-only; no backend, schema, or generated-type changes.

## Notes

Verified against the billing service's `dev` at `b1e1f2b`: the console's
`takeSupportHandoff()` matches `/[#&]support_handoff=([^&]+)/`, its page
documents that the session names the guild, and its `support_handoff_issuer` /
`support_handoff_audience` (`initiative` / `initiative:billing-support`) already
match what we mint.

No CHANGELOG entry: billing integrations stay out of `CHANGELOG.md` and `docs/en/`.