### PR TITLE
Preview marketplace listings with sample data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Team activity dashboard in the marketplace.** A ready-made pulse of the initiative's people: work by person, the daily rhythm of completions, the open pile by priority, and the finished total as the headline. Installs in one step and needs no setup.
 - **Apps, and a marketplace to add them from.** The marketplace is a searchable shelf of ready-made dashboards you can install into an initiative in one step, and of apps that add something the whole guild shares rather than any one initiative. The first app is a guild calendar: an ordinary calendar that belongs to the guild, visible to every member from the moment it is added, with the same views, event editor and sharing as any other. Apps live above your initiatives in the sidebar and are managed under guild settings, where they can be renamed, turned off, or removed — removing one moves what it created to the trash rather than deleting it. Only guild admins can add or remove apps; a guild with none installed shows nothing to its members.
 
+### Changed
+
+- **The marketplace shows examples using sample data.** A listing's preview draws sample rows rather than reading anything from your guild.
+
 ### Removed
 
 - **The pre-0.53.5 copies of guild data in the shared database schema are gone.** Installs that predate 0.53.5 kept a frozen second copy of every project, task, document and so on from before guilds moved into their own database schemas. Nothing has read or written it since; upgrading now drops it. Guild data lives solely in that guild's own schema. Installs created on 0.53.5 or later never had these copies and are unaffected. **This upgrade cannot be rolled back** — take a backup first if you would rather keep the old rows around, and if you are upgrading from before 0.53.2, boot a 0.53.x release once on the way through as its startup notice instructs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Event planner dashboard in the marketplace.** The initiative's events laid out the way an organizer thinks: everything on a weekly timeline, with the full event list underneath. Installs in one step and needs no setup.
 - **Team activity dashboard in the marketplace.** A ready-made pulse of the initiative's people: work by person, the daily rhythm of completions, the open pile by priority, and the finished total as the headline. Installs in one step and needs no setup.
 - **Apps, and a marketplace to add them from.** The marketplace is a searchable shelf of ready-made dashboards you can install into an initiative in one step, and of apps that add something the whole guild shares rather than any one initiative. The first app is a guild calendar: an ordinary calendar that belongs to the guild, visible to every member from the moment it is added, with the same views, event editor and sharing as any other. Apps live above your initiatives in the sidebar and are managed under guild settings, where they can be renamed, turned off, or removed — removing one moves what it created to the trash rather than deleting it. Only guild admins can add or remove apps; a guild with none installed shows nothing to its members.
-
-### Changed
-
-- **The marketplace shows examples using sample data.** A listing's preview draws sample rows rather than reading anything from your guild.
+- **The marketplace shows examples using sample data.** A listing's preview draws sample rows, so you see the shape of what you would get without it reading anything from your guild.
 
 ### Removed
 

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -22,6 +22,7 @@
     "installs_other": "{{count}} Installationen",
     "install": "Zu einer Initiative hinzufügen",
     "preview": "Vorschau",
+    "previewIsSample": "Beispieldaten – eine nicht installierte Anwendung liest nichts aus deiner Gilde.",
     "versions": "Versionen",
     "needsUpdate": "Benötigt eine neuere Version der App.",
     "withdrawn": "Wird nicht mehr angeboten.",

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -22,7 +22,7 @@
     "installs_other": "{{count}} Installationen",
     "install": "Zu einer Initiative hinzufügen",
     "preview": "Vorschau",
-    "previewIsSample": "Beispieldaten – eine nicht installierte Anwendung liest nichts aus deiner Gilde.",
+    "previewIsSample": "Beispiel mit Beispieldaten",
     "versions": "Versionen",
     "needsUpdate": "Benötigt eine neuere Version der App.",
     "withdrawn": "Wird nicht mehr angeboten.",

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -22,6 +22,7 @@
     "installs_other": "{{count}} installs",
     "install": "Add to an initiative",
     "preview": "Preview",
+    "previewIsSample": "Sample data — a listing you haven't installed reads nothing from your guild.",
     "versions": "Versions",
     "needsUpdate": "Needs a newer version of the app.",
     "withdrawn": "No longer offered.",

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -22,7 +22,7 @@
     "installs_other": "{{count}} installs",
     "install": "Add to an initiative",
     "preview": "Preview",
-    "previewIsSample": "Sample data — a listing you haven't installed reads nothing from your guild.",
+    "previewIsSample": "Example shown with sample data",
     "versions": "Versions",
     "needsUpdate": "Needs a newer version of the app.",
     "withdrawn": "No longer offered.",

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -22,7 +22,7 @@
     "installs_other": "{{count}} instalaciones",
     "install": "Añadir a una iniciativa",
     "preview": "Vista previa",
-    "previewIsSample": "Datos de ejemplo: una publicación que no has instalado no lee nada de tu gremio.",
+    "previewIsSample": "Ejemplo con datos de muestra",
     "versions": "Versiones",
     "needsUpdate": "Necesita una versión más reciente de la aplicación.",
     "withdrawn": "Ya no está disponible.",

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -22,6 +22,7 @@
     "installs_other": "{{count}} instalaciones",
     "install": "Añadir a una iniciativa",
     "preview": "Vista previa",
+    "previewIsSample": "Datos de ejemplo: una publicación que no has instalado no lee nada de tu gremio.",
     "versions": "Versiones",
     "needsUpdate": "Necesita una versión más reciente de la aplicación.",
     "withdrawn": "Ya no está disponible.",

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -22,6 +22,7 @@
     "installs_other": "{{count}} installations",
     "install": "Ajouter à une initiative",
     "preview": "Aperçu",
+    "previewIsSample": "Données d'exemple — une annonce non installée ne lit rien dans votre guilde.",
     "versions": "Versions",
     "needsUpdate": "Nécessite une version plus récente de l'application.",
     "withdrawn": "N'est plus proposé.",

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -22,7 +22,7 @@
     "installs_other": "{{count}} installations",
     "install": "Ajouter à une initiative",
     "preview": "Aperçu",
-    "previewIsSample": "Données d'exemple — une annonce non installée ne lit rien dans votre guilde.",
+    "previewIsSample": "Exemple affiché avec des données d'exemple",
     "versions": "Versions",
     "needsUpdate": "Nécessite une version plus récente de l'application.",
     "withdrawn": "N'est plus proposé.",

--- a/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardCanvas.tsx
@@ -71,6 +71,9 @@ export interface DashboardCanvasProps {
   initiativeId: number | undefined;
   /** DAC write on this dashboard. Arranging is authoring. */
   canEdit: boolean;
+  /** Render every widget from the sample library instead of its binding — the
+   *  marketplace preview's mode. Nothing is fetched; see `DashboardWidget`. */
+  sampleData?: boolean;
   /** The dashboard row is still on its way. The canvas is the only region that
    *  shows this — the page around it is already correct and must not flicker. */
   isLoading?: boolean;
@@ -85,6 +88,7 @@ export function DashboardCanvas({
   catalog,
   initiativeId,
   canEdit,
+  sampleData,
   isLoading,
   onLayoutChange,
   onConfigureWidget,
@@ -212,6 +216,7 @@ export function DashboardCanvas({
                     binding={effectiveBinding(widget, config)}
                     initiativeId={initiativeId}
                     canEdit={canEdit}
+                    sampleData={sampleData}
                     onConfigure={onConfigureWidget}
                     onRemove={onRemoveWidget}
                   />

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Where a placed widget's data comes from.
+ *
+ * Two modes, and the difference is a boundary rather than a preference. A
+ * widget on a real dashboard resolves its binding through the ordinary
+ * RLS-gated hooks, scoped to that dashboard's initiative. A widget in the
+ * marketplace preview draws the sample library instead: the listing is not
+ * installed, so it has no initiative to read and must be given none — which is
+ * what these pin, at the seam where it would regress.
+ */
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/__tests__/helpers/render";
+import type { WidgetBinding } from "@/hooks/useWidgetData";
+import { emptyDataFor } from "@/lib/widgets/normalize";
+
+const useWidgetData = vi.hoisted(() => vi.fn());
+vi.mock("@/hooks/useWidgetData", () => ({ useWidgetData }));
+
+import { DashboardWidget } from "./DashboardWidget";
+
+const widget = { id: "w1", type: "stat", grid: { x: 0, y: 0, w: 3, h: 2 } };
+const binding: WidgetBinding = { source: "counter" };
+
+const render = (sampleData: boolean) => {
+  useWidgetData.mockReturnValue({
+    data: emptyDataFor("counter"),
+    isLoading: false,
+    isUnbound: true,
+  });
+  renderWithProviders(
+    <DashboardWidget
+      widget={widget}
+      binding={binding}
+      initiativeId={7}
+      canEdit={false}
+      sampleData={sampleData}
+    />
+  );
+};
+
+describe("DashboardWidget", () => {
+  it("resolves the binding against the dashboard's initiative", () => {
+    render(false);
+    expect(useWidgetData).toHaveBeenCalledWith(binding, 7);
+  });
+
+  it("reads no initiative at all in sample mode", () => {
+    // The hook still runs — hooks are unconditional — but without an
+    // initiative it fail-closes and issues no request. This is what keeps an
+    // uninstalled listing's preview from touching the guild's data.
+    render(true);
+    expect(useWidgetData).toHaveBeenCalledWith(binding, undefined);
+  });
+
+  it("draws the sample library rather than the resolved binding", async () => {
+    // The hook is returning an *unbound* envelope, which on a real dashboard
+    // renders the "configure me" notice. In sample mode the tile draws the
+    // sample instead, so the counter's name proves where the rows came from.
+    render(true);
+    expect(await screen.findByText("Beds made")).toBeInTheDocument();
+    expect(screen.queryByText(/choose what this widget shows/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
@@ -23,6 +23,7 @@ import { useWidgetData, type WidgetBinding } from "@/hooks/useWidgetData";
 import { useWidgetMeta } from "@/hooks/useWidgetMeta";
 import { cn } from "@/lib/utils";
 import { type DefinitionWidget, unboundSlots } from "@/lib/widgets/definition";
+import { SAMPLE_NOW, sampleFor } from "@/lib/widgets/sampleData";
 
 export interface DashboardWidgetProps {
   widget: DefinitionWidget;
@@ -30,6 +31,11 @@ export interface DashboardWidgetProps {
   /** The dashboard's own initiative — the only one its widgets read from. */
   initiativeId: number | undefined;
   canEdit: boolean;
+  /** Draw the sample library instead of resolving the binding — nothing is
+   *  fetched at all. This is the marketplace preview's mode: a listing that
+   *  isn't installed shows what it *looks like*, never anyone's data, so it
+   *  renders the same for every viewer. */
+  sampleData?: boolean;
   onConfigure?: (widgetId: string) => void;
   onRemove?: (widgetId: string) => void;
 }
@@ -39,12 +45,19 @@ export function DashboardWidget({
   binding,
   initiativeId,
   canEdit,
+  sampleData,
   onConfigure,
   onRemove,
 }: DashboardWidgetProps) {
   const { t } = useTranslation("dashboards");
   const { name } = useWidgetMeta(widget.type);
-  const { data, isLoading, isUnbound } = useWidgetData(binding, initiativeId);
+  // In sample mode the hook still runs (hooks are unconditional) but is handed
+  // no initiative, which fail-closes every query — a preview issues no
+  // requests, exactly like the widget picker's.
+  const live = useWidgetData(binding, sampleData ? undefined : initiativeId);
+  const data = sampleData ? sampleFor(binding.source, widget.type) : live.data;
+  const isLoading = sampleData ? false : live.isLoading;
+  const isUnbound = sampleData ? false : live.isUnbound;
 
   const title = widget.title || name;
   const missing = unboundSlots(binding);
@@ -104,6 +117,7 @@ export function DashboardWidget({
             data={data}
             config={widget.options}
             isLoading={isLoading}
+            now={sampleData ? SAMPLE_NOW : undefined}
             chromeless
           />
         )}

--- a/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
@@ -36,6 +36,10 @@ export interface WidgetTileProps {
   /** Drop the border and title — the canvas frames its own widgets, and two
    *  nested frames read as a bug. The scene still cannot escape its box. */
   chromeless?: boolean;
+  /** Freeze the widget's clock. Previews render frozen sample data and pass
+   *  the samples' own anchor here, so a clock-reading widget draws the same
+   *  picture every time; live tiles omit it and get the real minute. */
+  now?: number;
 }
 
 type State = { status: "loading" } | { status: "done"; outcome: WidgetRenderOutcome };
@@ -49,6 +53,7 @@ export function WidgetTile({
   source,
   isLoading,
   chromeless,
+  now,
 }: WidgetTileProps) {
   const [state, setState] = useState<State>({ status: "loading" });
 
@@ -68,14 +73,14 @@ export function WidgetTile({
     // blanking to a skeleton every time the data changes makes a live tile
     // flicker on each refetch. The scene already on screen stays until the new
     // one is ready.
-    renderWidget({ source: moduleSource, data, config: config ?? {} }).then((outcome) => {
+    renderWidget({ source: moduleSource, data, config: config ?? {}, now }).then((outcome) => {
       if (!cancelled) setState({ status: "done", outcome });
     });
 
     return () => {
       cancelled = true;
     };
-  }, [type, data, config, source]);
+  }, [type, data, config, source, now]);
 
   const body =
     isLoading || state.status === "loading" ? (

--- a/frontend/src/lib/widgets/sampleData.ts
+++ b/frontend/src/lib/widgets/sampleData.ts
@@ -17,6 +17,13 @@ const DAY = 86_400_000;
  *  calendar. Renders stay byte-identical across runs. */
 const T0 = Date.UTC(2026, 7, 3);
 
+/** The clock a preview runs under. Previews draw these frozen samples, so a
+ *  clock-reading widget (the gantt marking work late) must see a frozen "now"
+ *  that sits inside them — the real clock would drift past the samples and
+ *  shift how they read a little more each day. Live tiles never use this; the
+ *  host hands them the real minute. */
+export const SAMPLE_NOW = T0;
+
 export interface WidgetSample {
   source: WidgetSource;
   data: WidgetData;

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -1,12 +1,16 @@
 /**
  * One listing's page: what it is, what it looks like, and how to get it.
  *
- * The preview is the real thing — the listing's definition rendered by the same
- * canvas a live dashboard uses, read-only, bound to the guild's default
- * initiative (id 1, seeded with the guild and always present). Someone deciding
- * whether to install sees what they would get rather than a description of it;
- * tiles they can't read there render empty, which is what an install would show
- * them too.
+ * The preview runs the real pipeline — the listing's definition through the same
+ * canvas, sandbox, and renderer a live dashboard uses — over **sample rows**.
+ * A listing is not installed, so it has no initiative to read and is given
+ * none: the canvas is told to draw samples, which fetches nothing at all.
+ *
+ * That is the point rather than a convenience. What someone shopping needs to
+ * see is the *shape* of the dashboard, and a preview drawn from their own data
+ * would be misleading twice over: it would look empty for a new initiative that
+ * has nothing yet, and it would read as if the listing already knew about
+ * their work.
  */
 
 import { Link, useParams, useSearch } from "@tanstack/react-router";
@@ -176,7 +180,10 @@ export function MarketplaceListingPage() {
           so the preview is a dashboard-only affordance. */}
       {!isApp && (
         <div className="space-y-2">
-          <h2 className="font-medium text-sm">{t("detail.preview")}</h2>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <h2 className="font-medium text-sm">{t("detail.preview")}</h2>
+            <p className="text-muted-foreground text-xs">{t("detail.previewIsSample")}</p>
+          </div>
           {listing?.definition ? (
             // The same canvas a live dashboard renders, read-only: `canEdit` false
             // means static tiles, no drag handles, and no layout writes.
@@ -184,10 +191,10 @@ export function MarketplaceListingPage() {
               definition={readDefinition(listing.definition)}
               config={readConfig({})}
               catalog={catalogQuery.data}
-              // The guild's default initiative: seeded with the guild, so id 1
-              // always exists. Widgets are initiative-confined, so a preview
-              // has to name one — this is the one every guild has.
-              initiativeId={1}
+              // Sample rows, and therefore no initiative: an uninstalled
+              // listing reads nothing from this guild.
+              sampleData
+              initiativeId={undefined}
               canEdit={false}
               onLayoutChange={() => {}}
             />


### PR DESCRIPTION
## Problem

The marketplace listing preview rendered the listing's definition against the guild's default initiative (`initiativeId={1}`). A listing nobody has installed was therefore reading real guild content to draw itself, and it read badly two ways: in a new or quiet initiative every tile previewed empty, and where there *was* data the preview looked as though the listing already knew about someone's work.

An uninstalled listing should have no access to guild data. A preview's job is to show the dashboard's **shape**.

## Changes

- `DashboardWidget` gains `sampleData`: it draws `sampleFor(source, type)` — the same frozen sample library the widget picker previews with — instead of resolving the binding. `DashboardCanvas` passes it through.
- In that mode `useWidgetData` is handed **no initiative**, which fail-closes every query in the hook, so a preview issues no requests at all (the hook still runs — hooks are unconditional — it just has nothing to fetch).
- `MarketplaceListingPage` renders the preview with `sampleData` and `initiativeId={undefined}`; the `initiativeId={1}` binding is gone.
- The preview heading says so plainly: "Example shown with sample data", in all four locales (de/en/es/fr).
- Previews render under a frozen clock (`SAMPLE_NOW`, the samples' own anchor) so a clock-reading widget — the gantt marking work late — agrees with the sample dates instead of drifting past them. `WidgetTile` takes an optional `now`; live tiles are unchanged and still get the real minute.

Widget modules are untouched: they remain `meta` + `render`, and the sample library stays app-side.

Changelog: under **Added**, since the marketplace has not shipped yet.

## Testing

- New `DashboardWidget.test.tsx` pins the boundary: the binding resolves against the dashboard's initiative normally, sample mode passes `undefined` as the initiative, and the tile draws the sample rows even when the hook reports an unbound binding.
- `pnpm vitest run src/components/initiativeTools/dashboards src/lib/widgets src/pages/marketplace` — 47 + 194 passed.
- `pnpm typecheck`, `pnpm check` — clean.