### PR TITLE
Redirect from beforeLoad, not from render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Apps, and a marketplace to add them from.** The marketplace is a searchable shelf of ready-made dashboards you can install into an initiative in one step, and of apps that add something the whole guild shares rather than any one initiative. The first app is a guild calendar: an ordinary calendar that belongs to the guild, visible to every member from the moment it is added, with the same views, event editor and sharing as any other. Apps live above your initiatives in the sidebar and are managed under guild settings, where they can be renamed, turned off, or removed — removing one moves what it created to the trash rather than deleting it. Only guild admins can add or remove apps; a guild with none installed shows nothing to its members.
 - **The marketplace shows examples using sample data.** A listing's preview draws sample rows, so you see the shape of what you would get without it reading anything from your guild.
 
+### Changed
+
+- **Sign-in and server-connection redirects are now decided before a page renders.** Landing on an app page while signed out, signing out, or opening the mobile app before a server is set now hands you straight to the right screen instead of briefly mounting the app shell and bouncing out of it. The old approach depended on that shell tearing down at exactly the right moment — the failure behind the blank page in 0.61.0.
+
 ### Removed
 
 - **The pre-0.53.5 copies of guild data in the shared database schema are gone.** Installs that predate 0.53.5 kept a frozen second copy of every project, task, document and so on from before guilds moved into their own database schemas. Nothing has read or written it since; upgrading now drops it. Guild data lives solely in that guild's own schema. Installs created on 0.53.5 or later never had these copies and are unaffected. **This upgrade cannot be rolled back** — take a backup first if you would rather keep the old rows around, and if you are upgrading from before 0.53.2, boot a 0.53.x release once on the way through as its startup notice instructs.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
     "@radix-ui/react-tooltip": "^1.2.16",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/react-query": "^5.101.4",
-    "@tanstack/react-router": "1.170.18",
+    "@tanstack/react-router": "^1.170.25",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/react-table": "^9.1.2",
     "@tanstack/react-virtual": "^3.14.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -222,11 +222,11 @@ importers:
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-router':
-        specifier: 1.170.18
-        version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.170.25
+        version: 1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-router-devtools':
         specifier: ^1.167.1
-        version: 1.167.1(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.21)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.167.1(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.21)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-table':
         specifier: ^9.1.2
         version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -362,7 +362,7 @@ importers:
         version: 0.5.20(tailwindcss@4.3.3)
       '@tanstack/router-plugin':
         specifier: ^1.168.29
-        version: 1.168.29(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.1)(supports-color@5.5.0)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.1)(supports-color@5.5.0)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.10.0
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -2619,10 +2619,6 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/history@1.162.0':
-    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
-    engines: {node: '>=20.19'}
-
   '@tanstack/history@1.162.1':
     resolution: {integrity: sha512-DR9t6lfLVdrjgCwpglrR9DR7Ok8/HlXjcOE+goWXF3zyuLUO/ug7vMbSFxTqrQTtbRghJfyhmIZ0S6LhPIy44w==}
     engines: {node: '>=20.19'}
@@ -2647,8 +2643,8 @@ packages:
       '@tanstack/router-core':
         optional: true
 
-  '@tanstack/react-router@1.170.18':
-    resolution: {integrity: sha512-wpbGYZEp/fmz1q4bn7BD8VZ+/VZ7GBqSJv5V969pU+chP8y7dquWDmKTFMohvUegb9lg12m1uPVvD6kB2wORvQ==}
+  '@tanstack/react-router@1.170.25':
+    resolution: {integrity: sha512-XiWYvkLAGhcZHhV2xUvicpF/VfTVSnewP6CqviDONAjmD50tBob5x/93u2W8QZAc/JgkPd+jijCmu6t4NCzmew==}
     engines: {node: '>=20.19'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
@@ -2677,10 +2673,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/router-core@1.171.15':
-    resolution: {integrity: sha512-IILCDcLaItMZQ2jEmCABHY1Nhjjn5XUvwpQp3e4Nmu+vfg0BgYFuu/QASz2SwE2ZNbVMrvt8X/wxa+Gg5aErxA==}
-    engines: {node: '>=20.19'}
 
   '@tanstack/router-core@1.171.21':
     resolution: {integrity: sha512-t6xUHBO94nQDrPHPh6ag5UuKHWIkVjq9s63q2ctbxgzq3vtSoGKmAIdLD5o+NU6JUS1ppXRHgL0YGzEHvH32Ng==}
@@ -8947,8 +8939,6 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
-  '@tanstack/history@1.162.0': {}
-
   '@tanstack/history@1.162.1': {}
 
   '@tanstack/query-core@5.101.4': {}
@@ -8958,9 +8948,9 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       react: 19.2.8
 
-  '@tanstack/react-router-devtools@1.167.1(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.21)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-router-devtools@1.167.1(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.21)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-router': 1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-devtools-core': 1.168.1(@tanstack/router-core@1.171.21)(csstype@3.2.3)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -8969,11 +8959,11 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/history': 1.162.0
+      '@tanstack/history': 1.162.1
       '@tanstack/react-store': 0.9.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/router-core': 1.171.15
+      '@tanstack/router-core': 1.171.21
       isbot: 5.2.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -9006,13 +8996,6 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/router-core@1.171.15':
-    dependencies:
-      '@tanstack/history': 1.162.0
-      cookie-es: 3.1.1
-      seroval: 1.6.2
-      seroval-plugins: 1.6.2(seroval@1.6.2)
-
   '@tanstack/router-core@1.171.21':
     dependencies:
       '@tanstack/history': 1.162.1
@@ -9041,7 +9024,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.29(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.1)(supports-color@5.5.0)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.1)(supports-color@5.5.0)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/template': 7.29.7
@@ -9053,7 +9036,7 @@ snapshots:
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       zod: 4.4.3
     optionalDependencies:
-      '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-router': 1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'

--- a/frontend/src/hooks/useRouteGuardSync.test.tsx
+++ b/frontend/src/hooks/useRouteGuardSync.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { GuardAuthState, GuardServerState } from "@/lib/routeGuards";
+
+import { useRouteGuardSync } from "./useRouteGuardSync";
+
+const web: GuardServerState = {
+  loading: false,
+  isNativePlatform: false,
+  isServerConfigured: true,
+};
+
+const renderSync = (auth: GuardAuthState | undefined, server = web) => {
+  const router = { invalidate: vi.fn() };
+  const view = renderHook(
+    ({ auth: a, server: s }: { auth: GuardAuthState | undefined; server: GuardServerState }) =>
+      useRouteGuardSync(router, a, s),
+    { initialProps: { auth, server } }
+  );
+  return { router, view };
+};
+
+describe("useRouteGuardSync", () => {
+  it("does not invalidate on mount — the initial load already ran the guards", () => {
+    const { router } = renderSync({ loading: true, user: null });
+    expect(router.invalidate).not.toHaveBeenCalled();
+  });
+
+  it("invalidates when auth settles to signed out", () => {
+    const { router, view } = renderSync({ loading: true, user: null });
+    view.rerender({ auth: { loading: false, user: null }, server: web });
+    expect(router.invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates when auth settles to signed in", () => {
+    const { router, view } = renderSync({ loading: true, user: null });
+    view.rerender({ auth: { loading: false, user: { id: 3 } }, server: web });
+    expect(router.invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates on sign out", () => {
+    const { router, view } = renderSync({ loading: false, user: { id: 3 } });
+    view.rerender({ auth: { loading: false, user: null }, server: web });
+    expect(router.invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when an equivalent user object is swapped in", () => {
+    const { router, view } = renderSync({ loading: false, user: { id: 3 } });
+    view.rerender({ auth: { loading: false, user: { id: 3 } }, server: { ...web } });
+    view.rerender({ auth: { loading: false, user: { id: 3 } }, server: { ...web } });
+    expect(router.invalidate).not.toHaveBeenCalled();
+  });
+
+  it("invalidates once per transition, not once per render", () => {
+    const { router, view } = renderSync({ loading: true, user: null });
+    const settled = { loading: false, user: null };
+    view.rerender({ auth: settled, server: web });
+    view.rerender({ auth: { ...settled }, server: web });
+    view.rerender({ auth: { ...settled }, server: web });
+    expect(router.invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates when a native install gains a configured server", () => {
+    const auth = { loading: false, user: null };
+    const { router, view } = renderSync(auth, {
+      loading: false,
+      isNativePlatform: true,
+      isServerConfigured: false,
+    });
+    view.rerender({
+      auth,
+      server: { loading: false, isNativePlatform: true, isServerConfigured: true },
+    });
+    expect(router.invalidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useRouteGuardSync.ts
+++ b/frontend/src/hooks/useRouteGuardSync.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+
+import { type GuardAuthState, type GuardServerState, routeGuardSignature } from "@/lib/routeGuards";
+
+/** The slice of the router this hook needs — narrow so tests can pass a stub. */
+interface InvalidatableRouter {
+  invalidate: () => unknown;
+}
+
+/**
+ * Re-runs the layout `beforeLoad` guards whenever the state they read settles
+ * or changes (boot finishing, sign-in, sign-out, a native server being
+ * configured).
+ *
+ * `RouterProvider` merges the fresh context into the router during render, but
+ * merging alone doesn't re-evaluate anything; `invalidate()` marks the current
+ * matches stale and reloads them, which is what puts `beforeLoad` — and its
+ * `redirect()` — back in charge. Mount is skipped: the initial load already ran
+ * with that context.
+ */
+export function useRouteGuardSync(
+  router: InvalidatableRouter,
+  auth: GuardAuthState | undefined,
+  server: GuardServerState | undefined
+): void {
+  const signature = routeGuardSignature(auth, server);
+  const lastSignature = useRef(signature);
+
+  useEffect(() => {
+    if (lastSignature.current === signature) return;
+    lastSignature.current = signature;
+    void router.invalidate();
+  }, [router, signature]);
+}

--- a/frontend/src/lib/routeGuards.test.ts
+++ b/frontend/src/lib/routeGuards.test.ts
@@ -1,0 +1,124 @@
+import { isRedirect } from "@tanstack/react-router";
+import { describe, expect, it } from "vitest";
+
+import type { RouterContext } from "@/router";
+
+import { type GuardServerState, redirectToActiveGuild, routeGuardSignature } from "./routeGuards";
+
+/** Minimal router context — these guards only read `guilds.activeGuildId`. */
+const contextWithGuild = (activeGuildId: number | null) =>
+  ({ guilds: { activeGuildId } }) as unknown as RouterContext;
+
+describe("redirectToActiveGuild", () => {
+  it("forwards to the active guild's copy of the route", () => {
+    const guard = redirectToActiveGuild("/g/$guildId/projects");
+    try {
+      guard({ context: contextWithGuild(42) });
+      expect.unreachable("guard must throw a redirect");
+    } catch (error) {
+      expect(isRedirect(error)).toBe(true);
+      expect(
+        (error as { options: { to: string; params: { guildId: string } } }).options
+      ).toMatchObject({ to: "/g/$guildId/projects", params: { guildId: "42" } });
+    }
+  });
+
+  it("carries the route's search params across", () => {
+    const guard = redirectToActiveGuild("/g/$guildId/tasks");
+    try {
+      guard({ context: contextWithGuild(7), search: { status: "open" } });
+      expect.unreachable("guard must throw a redirect");
+    } catch (error) {
+      expect((error as { options: { search: unknown } }).options.search).toEqual({
+        status: "open",
+      });
+    }
+  });
+
+  it("falls back to home when no guild is active", () => {
+    const guard = redirectToActiveGuild("/g/$guildId/documents");
+    try {
+      guard({ context: contextWithGuild(null) });
+      expect.unreachable("guard must throw a redirect");
+    } catch (error) {
+      expect(isRedirect(error)).toBe(true);
+      expect((error as { options: { to: string } }).options.to).toBe("/");
+    }
+  });
+});
+
+const web: GuardServerState = {
+  loading: false,
+  isNativePlatform: false,
+  isServerConfigured: true,
+};
+
+/**
+ * The signature decides when the router re-evaluates its `beforeLoad` guards.
+ * Miss a transition and a signed-out visitor keeps the authenticated shell;
+ * fire on unrelated churn and every context update reloads the whole match
+ * tree. Tests here pin both edges.
+ */
+describe("routeGuardSignature", () => {
+  it("distinguishes loading from settled-anonymous", () => {
+    const loading = routeGuardSignature({ loading: true, user: null }, web);
+    const anonymous = routeGuardSignature({ loading: false, user: null }, web);
+    expect(loading).not.toBe(anonymous);
+  });
+
+  it("distinguishes settled-anonymous from signed in", () => {
+    const anonymous = routeGuardSignature({ loading: false, user: null }, web);
+    const signedIn = routeGuardSignature({ loading: false, user: { id: 7 } }, web);
+    expect(anonymous).not.toBe(signedIn);
+  });
+
+  it("changes when the signed-in user changes", () => {
+    const alice = routeGuardSignature({ loading: false, user: { id: 1 } }, web);
+    const bob = routeGuardSignature({ loading: false, user: { id: 2 } }, web);
+    expect(alice).not.toBe(bob);
+  });
+
+  it("is stable when the user object is replaced with an equivalent one", () => {
+    // `refreshUser()` swaps in a fresh object on every poll; that must not
+    // invalidate the router.
+    const first = routeGuardSignature({ loading: false, user: { id: 4 } }, web);
+    const second = routeGuardSignature({ loading: false, user: { id: 4 } }, { ...web });
+    expect(first).toBe(second);
+  });
+
+  it("changes when a native install gains a configured server", () => {
+    const auth = { loading: false, user: { id: 1 } };
+    const unconfigured = routeGuardSignature(auth, {
+      loading: false,
+      isNativePlatform: true,
+      isServerConfigured: false,
+    });
+    const configured = routeGuardSignature(auth, {
+      loading: false,
+      isNativePlatform: true,
+      isServerConfigured: true,
+    });
+    expect(unconfigured).not.toBe(configured);
+  });
+
+  it("ignores server values while the server context is still loading", () => {
+    const auth = { loading: false, user: { id: 1 } };
+    const a = routeGuardSignature(auth, {
+      loading: true,
+      isNativePlatform: true,
+      isServerConfigured: false,
+    });
+    const b = routeGuardSignature(auth, {
+      loading: true,
+      isNativePlatform: false,
+      isServerConfigured: true,
+    });
+    expect(a).toBe(b);
+  });
+
+  it("treats an absent context as its own state", () => {
+    const absent = routeGuardSignature(undefined, undefined);
+    expect(absent).not.toBe(routeGuardSignature({ loading: true, user: null }, web));
+    expect(absent).toBe(routeGuardSignature(undefined, undefined));
+  });
+});

--- a/frontend/src/lib/routeGuards.ts
+++ b/frontend/src/lib/routeGuards.ts
@@ -28,3 +28,58 @@ export function redirectToActiveGuild(to: string) {
     throw redirect({ to: "/" });
   };
 }
+
+/**
+ * Keeps the layout route guards (`_serverRequired`, `_authenticated`) authoritative.
+ *
+ * Those guards live in `beforeLoad` and throw `redirect()`, which the router
+ * resolves at the navigation layer. But `beforeLoad` only runs when the router
+ * loads: at boot, auth and server state are still `loading`, so the guards pass
+ * and the layouts mount. When that state settles moments later there is nothing
+ * to make the router look again — which is why the layouts used to redirect by
+ * rendering `<Navigate>` instead, a fallback that re-navigates on every render
+ * and only terminates because the layout unmounts.
+ *
+ * The signature below captures exactly what those guards branch on. When it
+ * changes, `useRouteGuardSync` invalidates the router so `beforeLoad` re-runs
+ * and the redirect is decided in one place, at the navigation layer.
+ */
+
+export interface GuardAuthState {
+  loading: boolean;
+  user: { id: number } | null;
+}
+
+export interface GuardServerState {
+  loading: boolean;
+  isNativePlatform: boolean;
+  isServerConfigured: boolean;
+}
+
+/**
+ * Serializes the guard-relevant slice of the router context.
+ *
+ * Deliberately narrow: only the fields the guards read are included, so
+ * unrelated context churn (a refreshed user object, a guild list reorder)
+ * doesn't trigger a router-wide re-evaluation. While a slice is still
+ * `loading` its concrete values are omitted — the guards don't act on them
+ * yet, and including them would invalidate for a decision nobody makes.
+ */
+export function routeGuardSignature(
+  auth: GuardAuthState | undefined,
+  server: GuardServerState | undefined
+): string {
+  const authPart = !auth
+    ? "auth:absent"
+    : auth.loading
+      ? "auth:loading"
+      : `auth:${auth.user?.id ?? "anonymous"}`;
+  const serverPart = !server
+    ? "server:absent"
+    : server.loading
+      ? "server:loading"
+      : `server:${server.isNativePlatform ? "native" : "web"}:${
+          server.isServerConfigured ? "configured" : "unconfigured"
+        }`;
+  return `${authPart}|${serverPart}`;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -15,6 +15,7 @@ import { AuthProvider, useAuth } from "@/hooks/useAuth";
 import { GuildProvider, useGuilds } from "@/hooks/useGuilds";
 import { KeepScreenAwakeProvider } from "@/hooks/useKeepScreenAwake";
 import { PrideProvider } from "@/hooks/usePride";
+import { useRouteGuardSync } from "@/hooks/useRouteGuardSync";
 import { ServerProvider, useServer } from "@/hooks/useServer";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { queryClient } from "@/lib/queryClient";
@@ -31,6 +32,11 @@ const InnerApp = () => {
   const auth = useAuth();
   const guilds = useGuilds();
   const server = useServer();
+
+  // Auth and server state settle after the first router load, so ask the router
+  // to re-run its `beforeLoad` guards when they do — that keeps redirects at the
+  // navigation layer instead of the render path.
+  useRouteGuardSync(router, auth, server);
 
   return (
     <>

--- a/frontend/src/routes/_serverRequired.tsx
+++ b/frontend/src/routes/_serverRequired.tsx
@@ -1,10 +1,16 @@
-import { createFileRoute, Navigate, Outlet, redirect, useSearch } from "@tanstack/react-router";
+import { createFileRoute, Outlet, redirect, useSearch } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 
 import { NativeUpdateRequiredDialog } from "@/components/NativeUpdateRequiredDialog";
 import { VersionDialog } from "@/components/VersionDialog";
 import { useNativeUpdate } from "@/hooks/useNativeUpdate";
 import { useServer } from "@/hooks/useServer";
+
+const FullScreenLoader = () => (
+  <div className="flex min-h-screen items-center justify-center">
+    <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+  </div>
+);
 
 /**
  * Layout route that requires a server to be configured on native platforms.
@@ -47,16 +53,16 @@ function ServerRequiredLayout() {
 
   // Show loading state while server context initializes
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <FullScreenLoader />;
   }
 
-  // On native, if no server is configured (and we didn't just connect), redirect to connect page
+  // On native with no server configured (and we didn't just connect), the
+  // redirect belongs to `beforeLoad` above, which re-runs once the server
+  // context settles (``useRouteGuardSync``). Hold the loader until it lands
+  // rather than redirecting from the render path — a rendered `<Navigate>`
+  // re-navigates on every render and stops only because this layout unmounts.
   if (isNativePlatform && !isServerConfigured && !justConnected) {
-    return <Navigate to="/connect" replace />;
+    return <FullScreenLoader />;
   }
 
   return (

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -1,11 +1,4 @@
-import {
-  createFileRoute,
-  Link,
-  Navigate,
-  Outlet,
-  redirect,
-  useLocation,
-} from "@tanstack/react-router";
+import { createFileRoute, Link, Outlet, redirect, useLocation } from "@tanstack/react-router";
 import { Loader2, LogOut, Plus, Search, Settings, Ticket, UserCog } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -37,7 +30,6 @@ import {
   useClearRecentViews,
   useRecents,
 } from "@/hooks/useRecents";
-import { useServer } from "@/hooks/useServer";
 import { useVersionCheck } from "@/hooks/useVersionCheck";
 import { isJustSignedIn } from "@/lib/authTransition";
 import { chooseNoGuildLayout } from "@/lib/noGuildLayout";
@@ -83,7 +75,6 @@ function AppLayout() {
   // ALL hooks must be called before any conditional returns
   const { t } = useTranslation("command");
   const { user, loading, logout } = useAuth();
-  const { isNativePlatform } = useServer();
   const isMac = useMemo(
     () => typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent),
     []
@@ -116,12 +107,15 @@ function AppLayout() {
     return <FullScreenLoader />;
   }
 
-  // Redirect to login/welcome if not authenticated. The just-signed-in
-  // window covers the render before the auth context commits the new user;
-  // logout clears it, so signing out always leaves the authenticated shell.
+  // Not authenticated: the redirect belongs to `beforeLoad` above, which
+  // re-runs as soon as the auth context settles (``useRouteGuardSync``). Hold
+  // the loader for the render or two before that lands rather than redirecting
+  // from the render path — a rendered `<Navigate>` re-navigates on every render
+  // and stops only because this layout unmounts. The just-signed-in window
+  // covers the render before the auth context commits the new user; logout
+  // clears it, so signing out always leaves the authenticated shell.
   if (!user && !isJustSignedIn()) {
-    const redirectTo = isNativePlatform ? "/login" : "/welcome";
-    return <Navigate to={redirectTo} replace />;
+    return <FullScreenLoader />;
   }
 
   // No-guild empty-state branch. The user-scoped settings routes


### PR DESCRIPTION
## Problem

Follow-up 2 from #1072.

The `_serverRequired` and `_authenticated` layouts both redirected by rendering `<Navigate>`. That pattern only terminates because the layout unmounts — `Navigate` re-navigates on every render (its `previousPropsRef` identity check never holds, since `props` is a fresh object each time). When the router stopped settling the redirect promptly, that became the unbounded loop behind the blank signed-out page in 0.61.0.

Both layouts *already* had `beforeLoad` `redirect()` guards, which resolve at the navigation layer and are immune to this. But `beforeLoad` only runs when the router **loads**: at boot, `auth.loading` and `server.loading` are still true, so the guards pass and the layouts mount. Nothing told the router to look again once that state settled — which is exactly why the render-path fallback existed.

So the fix isn't "move the guard to `beforeLoad`" (it's there); it's closing the gap that made the render fallback necessary.

## Changes

- **[routeGuards.ts](frontend/src/lib/routeGuards.ts)** — `routeGuardSignature()` serializes exactly what the two guards branch on: auth `loading`/`user.id`, server `loading`/`isNativePlatform`/`isServerConfigured`. Deliberately narrow, so a refreshed user object or a guild-list reorder doesn't reload the whole match tree. While a slice is still `loading`, its concrete values are omitted — the guards don't act on them yet.
- **[useRouteGuardSync.ts](frontend/src/hooks/useRouteGuardSync.ts)** — calls `router.invalidate()` when the signature changes, which marks the matches stale and reloads them, putting `beforeLoad` (and its `redirect()`) back in charge. Mount is skipped: the initial load already ran the guards with that context. Called from [main.tsx](frontend/src/main.tsx) in `InnerApp`.

  Worth stating explicitly: `RouterProvider` merges fresh context into the router during render, but merging alone re-evaluates nothing. `invalidate()` is the only thing that re-runs `beforeLoad`.
- **[_authenticated.tsx](frontend/src/routes/_serverRequired/_authenticated.tsx)** and **[_serverRequired.tsx](frontend/src/routes/_serverRequired.tsx)** — the `<Navigate>` branches now hold a full-screen loader for the render or two before the redirect lands. `Navigate` is gone from both, along with the now-unused `useServer()` call in `AppLayout`.

### Scope left alone (deliberately)

- **`g/$guildId.tsx`** suspended-guild pin — also a rendered `<Navigate>`, but converting it means invalidating on guild-list changes, and that `beforeLoad` calls `syncGuildFromUrl`, which mutates guild state. That is a plausible feedback loop and deserves its own change rather than riding along here.
- **Page-level `<Navigate>`s** (`InitiativeDetailPage`, `TagDetailPage`, `InitiativeSettingsPage`, `PlatformSettingsLayout`, `AdminDashboardLayout`) — those fire after a data query resolves inside a page component, not from router context; converting them needs route loaders. Different shape from the failure reported in #1072.

Follow-up 3 (unpinning `@tanstack/react-router`) is still open and unaffected by this.

## Testing

17 new tests across two new files. `redirectToActiveGuild` shared `routeGuards.ts` and had no coverage, so it got tests too.

```
cd frontend
pnpm typecheck                # clean
pnpm biome check <changed>    # clean
./scripts/test-changed.sh     # 101 files, 1395/1395 passed
pnpm build                    # ✓ built
```

Not covered by tests: the real browser sequence (boot → auth settles → redirect). Worth a signed-out load and a sign-out before merge.