### PR TITLE
Show backlog and started work in Focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The pre-0.53.5 copies of guild data in the shared database schema are gone.** Installs that predate 0.53.5 kept a frozen second copy of every project, task, document and so on from before guilds moved into their own database schemas. Nothing has read or written it since; upgrading now drops it. Guild data lives solely in that guild's own schema. Installs created on 0.53.5 or later never had these copies and are unaffected. **This upgrade cannot be rolled back** — take a backup first if you would rather keep the old rows around, and if you are upgrading from before 0.53.2, boot a 0.53.x release once on the way through as its startup notice instructs.
 
+### Fixed
+
+- **The Focus list on My Tasks stayed empty even with overdue work waiting.** It only counted tasks someone had moved to To Do or In Progress, and Backlog is where a new task starts — so on an ordinary setup it had nothing to show. It now looks at every unfinished task, whatever column it sits in. It also reads dates the way the task table beneath it does: work whose start date has arrived belongs on the list even if nobody gave it a due date.
+
 ## [0.61.3] - 2026-08-11
 
 ### Fixed

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -125,7 +125,7 @@
     "pin": "An Fokus anheften",
     "unpin": "Aus Fokus entfernen",
     "settings": "Fokus-Einstellungen",
-    "dueWithinLabel": "Fällige Arbeit anzeigen",
+    "dueWithinLabel": "Fällige oder beginnende Arbeit anzeigen",
     "dueWithin": {
       "0": "Heute",
       "2": "Nächste 2 Tage",

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -125,7 +125,7 @@
     "pin": "Pin to Focus",
     "unpin": "Remove from Focus",
     "settings": "Focus settings",
-    "dueWithinLabel": "Show work due",
+    "dueWithinLabel": "Show work due or starting",
     "dueWithin": {
       "0": "Today",
       "2": "Next 2 days",

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -125,7 +125,7 @@
     "pin": "Fijar en Enfoque",
     "unpin": "Quitar de Enfoque",
     "settings": "Ajustes de Enfoque",
-    "dueWithinLabel": "Mostrar trabajo con vencimiento",
+    "dueWithinLabel": "Mostrar trabajo que vence o comienza",
     "dueWithin": {
       "0": "Hoy",
       "2": "Próximos 2 días",

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -125,7 +125,7 @@
     "pin": "Épingler au Focus",
     "unpin": "Retirer du Focus",
     "settings": "Paramètres du Focus",
-    "dueWithinLabel": "Afficher le travail à échéance",
+    "dueWithinLabel": "Afficher le travail à échéance ou qui commence",
     "dueWithin": {
       "0": "Aujourd'hui",
       "2": "2 prochains jours",

--- a/frontend/src/components/tasks/FocusSummary.test.tsx
+++ b/frontend/src/components/tasks/FocusSummary.test.tsx
@@ -107,7 +107,7 @@ describe("FocusSummary", () => {
     expect(screen.getByText("1 of 3 done")).toBeInTheDocument();
   });
 
-  it("asks for due-soon work, urgent work, and today's completions in one query", async () => {
+  it("asks for due-soon work, started work, urgent work, and today's completions in one query", async () => {
     mockMyTasks({});
     renderFocus({ dueWithinDays: 2, includeHighPriority: true });
 
@@ -117,16 +117,24 @@ describe("FocusSummary", () => {
     expect(conditions).toHaveLength(1);
     expect(conditions[0].logic).toBe("or");
 
-    const stillOpen = { field: "status_category", op: "in_", value: ["todo", "in_progress"] };
-    const [dueLeg, urgentLeg, doneLeg] = conditions[0].conditions;
+    const stillOpen = {
+      field: "status_category",
+      op: "in_",
+      value: ["backlog", "todo", "in_progress"],
+    };
+    const [dueLeg, startLeg, urgentLeg, doneLeg] = conditions[0].conditions;
 
-    // Due-soon OR urgent, as sibling AND legs. Two things ride on this shape:
-    // an AND between date and priority would empty the list on exactly the days
-    // it matters most, and a third level of nesting is rejected outright by the
-    // API's group-depth cap.
+    // Due-soon OR started OR urgent, as sibling AND legs. Two things ride on
+    // this shape: an AND between date and priority would empty the list on
+    // exactly the days it matters most, and a third level of nesting is
+    // rejected outright by the API's group-depth cap.
     expect(dueLeg.conditions).toEqual([
       stillOpen,
       { field: "due_date", op: "lte", value: expect.any(String) },
+    ]);
+    expect(startLeg.conditions).toEqual([
+      stillOpen,
+      { field: "start_date", op: "lte", value: expect.any(String) },
     ]);
     expect(urgentLeg.conditions).toEqual([
       stillOpen,
@@ -137,10 +145,60 @@ describe("FocusSummary", () => {
       { field: "completed_at", op: "gte", value: expect.any(String) },
     ]);
 
+    // Both dates are measured to the same edge of the window, so the setting
+    // means one thing rather than two.
+    expect(startLeg.conditions[1].value).toBe(dueLeg.conditions[1].value);
+
     // The list spans every guild the user belongs to and answers only to its
     // own settings — it is not scoped by the guild you happen to be viewing,
     // nor by the task table's filters.
     expect(captured[0].get("conditions")).not.toContain("guild_id");
+  });
+
+  it("asks for backlog work too, not just what someone moved to To Do", async () => {
+    // Backlog is the default status of a newly created task, so excluding it
+    // empties the section on an ordinary install — overdue tasks included.
+    mockMyTasks({});
+    renderFocus();
+
+    await waitFor(() => expect(captured.length).toBeGreaterThan(0));
+    const conditions = JSON.parse(captured[0].get("conditions") ?? "[]");
+
+    const openValues = conditions[0].conditions
+      .flatMap((leg: { conditions: { field: string; value: unknown }[] }) => leg.conditions)
+      .filter((c: { field: string }) => c.field === "status_category")
+      .map((c: { value: unknown }) => c.value);
+
+    for (const value of openValues) {
+      expect(value).not.toEqual(["todo", "in_progress"]);
+    }
+    expect(openValues).toContainEqual(["backlog", "todo", "in_progress"]);
+  });
+
+  it("shows a started task that carries no due date", async () => {
+    // The table below groups this as "Today" off its start date alone; the
+    // section agrees rather than needing a deadline before it will look.
+    mockMyTasks({
+      rules: buildTaskListResponse([
+        buildTask({
+          id: 1,
+          title: "Draft the launch post",
+          start_date: "2026-08-10T09:00:00Z",
+          due_date: null,
+        }),
+        buildTask({ id: 2, title: "Sign the contract", due_date: "2026-08-11T09:00:00Z" }),
+      ]),
+    });
+
+    renderFocus();
+
+    expect(await screen.findByText("Draft the launch post")).toBeInTheDocument();
+    // Dated work still leads: a deadline outranks work that merely started.
+    const titles = screen
+      .getAllByRole("link")
+      .map((link) => link.textContent)
+      .filter((title) => title === "Draft the launch post" || title === "Sign the contract");
+    expect(titles).toEqual(["Sign the contract", "Draft the launch post"]);
   });
 
   it("never nests condition groups deeper than the API accepts", async () => {

--- a/frontend/src/hooks/useFocusSummary.ts
+++ b/frontend/src/hooks/useFocusSummary.ts
@@ -43,7 +43,12 @@ export const FOCUS_DEFAULTS: FocusPreferences = {
 
 export const FOCUS_DUE_WITHIN_CHOICES = [0, 2, 7] as const;
 
-const OPEN_CATEGORIES = ["todo", "in_progress"];
+/**
+ * Everything that is not finished. `backlog` belongs here as much as the other
+ * two: it is the default status for a newly created task, so leaving it out
+ * hides the bulk of most people's work — including tasks that are overdue.
+ */
+const OPEN_CATEGORIES = ["backlog", "todo", "in_progress"];
 const URGENT_PRIORITIES = ["urgent", "high"];
 /**
  * The API's per-page maximum. There is deliberately no display cap on top of
@@ -56,18 +61,24 @@ const pinKey = (guildId: number | null | undefined, taskId: number) =>
   `${guildId ?? "none"}:${taskId}`;
 
 /**
- * Conditions for the rule-driven half of the section: open work that is due
- * soon or explicitly urgent, plus anything finished today so completions stay
- * visible instead of vanishing the moment they're checked off.
+ * Conditions for the rule-driven half of the section: open work that has come
+ * due (or already started) within the window, or is explicitly urgent, plus
+ * anything finished today so completions stay visible instead of vanishing the
+ * moment they're checked off.
+ *
+ * The window applies to `start_date` as well as `due_date`, matching how the
+ * task table below groups by date (`getTaskDateStatus`): a task whose start
+ * date has passed is work in hand even if nobody put a deadline on it.
  *
  * Exported for testing — the OR nesting is the part worth pinning down.
  */
 export function buildFocusConditions({
-  dueBefore,
+  horizon,
   includeHighPriority,
   completedSince,
 }: {
-  dueBefore: Date;
+  /** Far edge of the date window; both start and due dates are measured to it. */
+  horizon: Date;
   includeHighPriority: boolean;
   completedSince: Date;
 }): FilterGroup[] {
@@ -77,14 +88,18 @@ export function buildFocusConditions({
     value: OPEN_CATEGORIES,
   };
 
-  // "Open AND (due soon OR urgent)" is written out as two AND legs rather than
-  // nesting an OR inside the AND: the API caps condition nesting at two group
-  // levels and rejects a third outright. Distributing the shared leg costs one
-  // duplicated leaf and keeps the same meaning.
+  // "Open AND (due soon OR started OR urgent)" is written out as sibling AND
+  // legs rather than nesting an OR inside the AND: the API caps condition
+  // nesting at two group levels and rejects a third outright. Distributing the
+  // shared leg costs one duplicated leaf per branch and keeps the same meaning.
   const legs: FilterGroup[] = [
     {
       logic: "and",
-      conditions: [stillOpen, { field: "due_date", op: "lte", value: dueBefore.toISOString() }],
+      conditions: [stillOpen, { field: "due_date", op: "lte", value: horizon.toISOString() }],
+    },
+    {
+      logic: "and",
+      conditions: [stillOpen, { field: "start_date", op: "lte", value: horizon.toISOString() }],
     },
   ];
 
@@ -117,8 +132,16 @@ const completedOnOrAfter = (task: TaskListRead, since: number) =>
 
 const byDueDate = (a: TaskListRead, b: TaskListRead) => {
   // Undated work sorts last: it has no clock pressure, so it should never
-  // displace something with a deadline from a capped list.
-  if (!a.due_date && !b.due_date) return a.id - b.id;
+  // displace something with a deadline. Within that group, work that has
+  // already started leads — it is in hand, whatever the table says about it.
+  if (!a.due_date && !b.due_date) {
+    if (a.start_date && b.start_date) {
+      return a.start_date.localeCompare(b.start_date) || a.id - b.id;
+    }
+    if (a.start_date) return -1;
+    if (b.start_date) return 1;
+    return a.id - b.id;
+  }
   if (!a.due_date) return 1;
   if (!b.due_date) return -1;
   return a.due_date.localeCompare(b.due_date);
@@ -163,7 +186,7 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
   const ruleParams = useMemo<ListMyTasksApiV1MeTasksGetParams>(
     () => ({
       conditions: buildFocusConditions({
-        dueBefore: endOfDay(addDays(new Date(today), prefs.dueWithinDays)),
+        horizon: endOfDay(addDays(new Date(today), prefs.dueWithinDays)),
         includeHighPriority: prefs.includeHighPriority,
         completedSince: new Date(today),
       }),


### PR DESCRIPTION
## Problem

The Focus list at the top of My Tasks rendered its empty state ("Nothing needs your attention right now") on a production instance that had a full page of overdue tasks in the table directly below it.

Two mismatches between Focus and that table:

1. **Status.** Focus matched `status_category` in `["todo", "in_progress"]` only. `backlog` is a real fourth category and is the **default status for every new task** — [`task_statuses.py:37`](backend/app/services/tenant/task_statuses.py#L37) seeds `Backlog` with `is_default=True`. So on an ordinary install nothing ever qualified. The table doesn't have this problem: its default status filter is `["backlog", "todo", "in_progress"]` ([`useGlobalTasksTable.ts:53`](frontend/src/hooks/useGlobalTasksTable.ts#L53)). This alone explains the empty section.

2. **Dates.** Focus looked at `due_date` only, while the table's date grouping ([`taskDateStatus.ts:40-65`](frontend/src/lib/taskDateStatus.ts#L40-L65), mirrored server-side by `_date_group_expression`) considers **start_date or due_date** — a task whose start date has passed is "Today" there. So started-but-undated work was invisible to Focus.

## Changes

- [`useFocusSummary.ts`](frontend/src/hooks/useFocusSummary.ts) — `OPEN_CATEGORIES` is now every unfinished category, `["backlog", "todo", "in_progress"]`.
- Added a `start_date <= horizon` leg as a fourth sibling AND branch of the OR group. Distributed rather than nested: the API caps condition nesting at two group levels and rejects a third outright, which is why the existing priority leg duplicates its `status_category` leaf too.
- Renamed the `buildFocusConditions` param `dueBefore` → `horizon`, since it now bounds both dates. Both legs are measured to the same value, so the `dueWithinDays` setting still means one thing rather than two.
- `byDueDate` now orders undated work by start date instead of arbitrarily by id. Dated work still sorts ahead of undated — that ranking was deliberate and is unchanged.
- Copy: `focus.dueWithinLabel` "Show work due" → "Show work due or starting", updated in all four locales (en/de/es/fr).

The `dueWithinDays` window is deliberately **not** replaced by the table's Overdue/Today buckets — it's a user setting (0 / 2 / 7 days) whose 2-day default is intentionally wider than Overdue+Today.

## Testing

- `cd frontend && pnpm test:run` — 101 files, 1397 tests passed.
- `cd frontend && ./scripts/test-changed.sh` — same, 1397 passed (the locale edits pull in the full suite, so `locale-keys.test.ts` confirms all four locales stay in sync).
- `cd frontend && pnpm typecheck` — clean.
- `cd frontend && pnpm lint` — clean (972 files).

New test coverage in [`FocusSummary.test.tsx`](frontend/src/components/tasks/FocusSummary.test.tsx):
- The query-shape test now asserts the `start_date` leg and that both date legs share one boundary value.
- "asks for backlog work too, not just what someone moved to To Do" — pins down the regression itself.
- "shows a started task that carries no due date" — covers the date-semantics gap, and asserts dated work still sorts first.

## Note for review

Including backlog means Focus will pull considerably more than it did as designed — on the instance that prompted this, every overdue backlog task now lands there. The `dueWithinDays: 0` setting is the intended lever if a list runs long. Worth eyeballing on a real instance before release.