### PR TITLE
Gate event delivery targets on the automation delegate

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -19,11 +19,17 @@ from app.core.role_context import (
     set_content_read_only_guild,
     set_override_sharing_initiatives,
 )
-from app.core.messages import AuthMessages, GuildMessages, UserMessages
+from app.core.messages import (
+    AuthMessages,
+    GuildMessages,
+    UserMessages,
+    WebhookSubscriptionMessages,
+)
 from app.core.security import (
     SESSION_COOKIE_NAME,
     AutoDelegationVerificationError,
     UploadTokenError,
+    auto_delegation_configured,
     decode_session_token,
     verify_auto_delegation_token,
     verify_upload_token,
@@ -590,6 +596,56 @@ def require_guild_roles(*roles: GuildRole) -> Callable:
         return context
 
     return dependency
+
+
+async def require_auto_delegate(
+    request: Request,
+    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+) -> GuildContext:
+    """Guild context for endpoints only the automation delegate may call.
+
+    Some surfaces belong to the deployment's automation delegate rather than to
+    the people in a guild — outbound event subscriptions are the case this was
+    written for: apps and users emit events, the delegate owns the delivery
+    targets. Returns the same ``GuildContext`` as ``get_guild_membership`` so an
+    endpoint gets its guild scoping *through* the gate and cannot hold one
+    without the other.
+
+    Three answers:
+
+    * **503** when no delegate is configured (no delegation public key). The
+      deployment has no automation delegate, so no caller can qualify; this is
+      an operator configuration state, not a caller fault, and it resolves
+      itself once a delegate is configured.
+    * **403** when the request authenticated as an ordinary user, session or
+      API key rather than over the delegation credential.
+    * the guild context when the request arrived over the delegation path and
+      its token names the guild in the URL path.
+
+    Authentication itself already happened in ``get_current_user`` —
+    ``_authenticate_auto_delegation`` verified the delegation JWT (signature,
+    audience, issuer, one-shot jti) and recorded its guild on the request. This
+    reads that state rather than verifying the token a second time. The
+    token-guild vs path-guild comparison is also made in
+    ``get_guild_membership``; it is repeated here so the gate holds on its own.
+    """
+    if not auto_delegation_configured():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=WebhookSubscriptionMessages.DELEGATE_NOT_CONFIGURED,
+        )
+    delegated_guild_id = getattr(request.state, "delegated_guild_id", None)
+    if delegated_guild_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=WebhookSubscriptionMessages.DELEGATE_REQUIRED,
+        )
+    if delegated_guild_id != guild_context.guild_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=GuildMessages.GUILD_ACCESS_DENIED,
+        )
+    return guild_context
 
 
 async def _apply_guild_session_context(

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions.py
@@ -1,10 +1,16 @@
 """Webhook subscription endpoints for initiative-auto.
 
-Authenticated via the standard ``get_current_user`` chain — auto
-calls these via delegation JWTs (RS256, public key verifier), so the
-acting user is always the workflow owner. Tenant isolation is by
-RLS on the table; the endpoint adds an explicit ``guild_id`` filter
-on every query as defense-in-depth.
+Delivery targets belong to the deployment's automation delegate: apps and
+users emit events, the delegate owns where they are delivered. Every route
+here therefore goes through ``require_auto_delegate`` — the caller must have
+authenticated over the delegation credential (RS256, public key verifier), and
+a deployment with no delegate configured refuses outright (503) rather than
+letting anyone register a target. The acting user is still a real user (the
+workflow owner the delegation names), so the per-row ownership rules below
+still mean something.
+
+Tenant isolation is by RLS on the table; the endpoint adds an explicit
+``guild_id`` filter on every query as defense-in-depth.
 
 Auto's flow:
 
@@ -16,10 +22,10 @@ Auto's flow:
   PATCH  /api/v1/auto/subscriptions/{id}
 
 All four are guild-scoped via the active session's ``guild_id``.
-Mutation routes (PATCH/DELETE) additionally require the caller to be
-either the subscription's creator or a guild admin — RLS keeps things
-inside the guild boundary, but it doesn't say *which* member can rewrite
-*another* member's webhook target.
+Mutation routes (PATCH/DELETE) additionally require the acting user to be
+either the subscription's creator or a guild admin — the delegate gate says
+*which service* may manage targets at all, and this says which of that
+service's users may rewrite a given one.
 """
 
 from __future__ import annotations
@@ -32,7 +38,7 @@ from app.api.deps import (
     GuildContext,
     RLSSessionDep,
     get_current_active_user,
-    get_guild_membership,
+    require_auto_delegate,
 )
 from app.core.messages import WebhookSubscriptionMessages
 from app.models.platform.guild import GuildRole
@@ -55,6 +61,10 @@ from app.services.webhook_target_url import (
 )
 
 router = APIRouter()
+
+# Guild context AND the delegate gate in one dependency: an endpoint here can't
+# take its guild scoping without also passing the gate.
+AutoDelegateGuildDep = Annotated[GuildContext, Depends(require_auto_delegate)]
 
 
 async def _validate_target_url(url: str) -> None:
@@ -87,7 +97,7 @@ async def create_subscription(
     payload: WebhookSubscriptionCreate,
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+    guild_context: AutoDelegateGuildDep,
 ) -> WebhookSubscriptionCreated:
     """Register a new webhook subscription.
 
@@ -95,10 +105,11 @@ async def create_subscription(
     reads omit it. The receiver must persist it from this response or
     rotate the subscription if they lose it.
 
-    Authorization: tenant isolation is enforced by the table's RLS
-    policy (``guild_isolation``) plus the explicit ``guild_id`` filter
-    in the service layer. The caller's guild comes from
-    ``GuildContext`` — the body never carries it.
+    Authorization: the automation delegate's credential (503 when no
+    delegate is configured, 403 for any other caller), then tenant
+    isolation enforced by the table's RLS policy plus the explicit
+    ``guild_id`` filter in the service layer. The caller's guild comes
+    from ``GuildContext`` — the body never carries it.
 
     Target policy: ``target_url`` must be https and resolve to a public
     unicast address; private, loopback and link-local addresses are
@@ -132,7 +143,7 @@ async def create_subscription(
 async def list_subscriptions(
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+    guild_context: AutoDelegateGuildDep,
 ) -> list[WebhookSubscriptionRead]:
     """List subscriptions in the caller's guild. ``hmac_secret`` is
     intentionally absent from the response."""
@@ -151,12 +162,12 @@ async def update_subscription(
     payload: WebhookSubscriptionUpdate,
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+    guild_context: AutoDelegateGuildDep,
 ) -> WebhookSubscriptionRead:
     """Partial-update target_url, event_types, or active flag.
 
-    Only the creator or a guild admin may mutate. ``target_url`` (when
-    provided) is re-validated against the SSRF allowlist.
+    Only the acting user who created it, or a guild admin, may mutate.
+    ``target_url`` (when provided) is re-validated against the SSRF allowlist.
     """
     if payload.target_url is not None:
         await _validate_target_url(str(payload.target_url))
@@ -193,7 +204,7 @@ async def delete_subscription(
     subscription_id: int,
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+    guild_context: AutoDelegateGuildDep,
 ) -> None:
     """Hard-delete a subscription. Cross-guild lookups 404; non-owner
     non-admin attempts 403."""

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
@@ -1,20 +1,36 @@
 """Integration tests for the webhook subscription endpoints.
 
-These cover the two properties the routes enforce on top of RLS:
-target-URL validation on ``target_url`` and the creator-or-admin gate on
-mutations. CRUD round-trips themselves are exercised by the dispatcher
-tests (which create rows via the same service layer).
+Three properties, layered:
+
+* **Who may call at all** — delivery targets belong to the configured
+  automation delegate, so every route requires the delegation credential,
+  and a deployment with no delegate configured refuses outright.
+* **Which of the delegate's users may rewrite a given row** — the acting
+  user (the workflow owner the delegation names) must be the creator, or a
+  guild admin.
+* **Where a target may point** — the SSRF checks on ``target_url``.
+
+The delegation JWTs here are minted the same way as in
+``auto_delegation_test.py`` / ``advanced_tool_run_test.py``: a per-module
+RSA keypair whose public half is monkeypatched into settings, and one fresh
+``jti`` per request (delegation tokens are one-shot).
 """
 
 from __future__ import annotations
 
+import secrets
 import socket
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import jwt
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import AsyncClient
 
+from app.core import config as config_module
 from app.models.platform.guild import GuildRole
 from app.testing import Actor
 
@@ -24,6 +40,57 @@ _WEBHOOK_HOST = "hooks.example.com"
 _FAKE_INFOS = [
     (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("93.184.216.34", 0))
 ]
+
+_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_PEM = _keypair.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+_PUBLIC_PEM = (
+    _keypair.public_key()
+    .public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_delegation(monkeypatch):
+    """Configure an automation delegate for the duration of each test here.
+
+    Without it every route answers 503 — which is its own test below, not the
+    baseline the rest of the file is written against.
+    """
+    monkeypatch.setattr(
+        config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _PUBLIC_PEM
+    )
+
+
+def _delegation_headers(*, user_id: int, guild_id: int) -> dict[str, str]:
+    """Mint a fresh (one-shot) delegation JWT for the user + guild."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "jti": secrets.token_hex(8),
+            "sub": str(user_id),
+            "aud": "initiative:auto-delegation",
+            "iss": "initiative-auto",
+            "iat": int(now.timestamp()),
+            "exp": now + timedelta(seconds=900),
+            "guild_id": guild_id,
+        },
+        _PRIVATE_PEM,
+        algorithm="RS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _as_delegate(actor: Actor) -> dict[str, str]:
+    """Delegation headers acting as ``actor`` inside ``actor``'s guild."""
+    return _delegation_headers(user_id=actor.user.id, guild_id=actor.guild.id)
 
 
 @contextmanager
@@ -48,9 +115,127 @@ def _mock_public_dns():
 
 
 async def _authed_post(client: AsyncClient, actor: Actor, body: dict):
+    """Create a subscription as the delegate, acting for ``actor``."""
     return await client.post(
-        actor.g("/auto/subscriptions"), json=body, headers=actor.headers
+        actor.g("/auto/subscriptions"), json=body, headers=_as_delegate(actor)
     )
+
+
+def _subscription_body(**overrides) -> dict:
+    return {
+        "target_url": "https://hooks.example.com/in",
+        "event_types": ["task.created"],
+        **overrides,
+    }
+
+
+# ── The delegate gate ─────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("post", "/auto/subscriptions", _subscription_body()),
+        ("get", "/auto/subscriptions", None),
+        ("patch", "/auto/subscriptions/1", {"active": False}),
+        ("delete", "/auto/subscriptions/1", None),
+    ],
+)
+async def test_ordinary_caller_is_refused_on_every_route(
+    client: AsyncClient, acting_user, method: str, path: str, body: dict | None
+):
+    """A guild admin — the most privileged ordinary caller — is still not the
+    automation delegate, on any of the four routes.
+
+    The ids in the mutation paths are deliberately nonexistent: the gate
+    decides before the row is ever looked up, so the answer is 403 rather
+    than 404.
+    """
+    a = await acting_user(guild_role=GuildRole.admin)
+
+    kwargs: dict = {"headers": a.headers}
+    if body is not None:
+        kwargs["json"] = body
+    with _mock_public_dns():
+        response = await getattr(client, method)(a.g(path), **kwargs)
+
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "AUTOMATION_DELEGATE_REQUIRED"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [("post", "/auto/subscriptions"), ("get", "/auto/subscriptions")],
+)
+async def test_no_delegate_configured_refuses_with_503(
+    client: AsyncClient, acting_user, monkeypatch, method: str, path: str
+):
+    """A deployment with no automation delegate has nothing that may own a
+    delivery target, so the routes are unavailable rather than forbidden —
+    503, which resolves itself once an operator configures a delegate."""
+    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    a = await acting_user(guild_role=GuildRole.admin)
+
+    kwargs: dict = {"headers": a.headers}
+    if method == "post":
+        kwargs["json"] = _subscription_body()
+    with _mock_public_dns():
+        response = await getattr(client, method)(a.g(path), **kwargs)
+
+    assert response.status_code == 503, response.text
+    assert response.json()["detail"] == "AUTOMATION_DELEGATE_NOT_CONFIGURED"
+
+
+@pytest.mark.integration
+async def test_delegation_token_for_another_guild_is_refused(
+    client: AsyncClient, acting_user
+):
+    """A delegation token is minted for exactly one guild, so a token naming
+    one guild can't manage another guild's delivery targets."""
+    a = await acting_user(guild_role=GuildRole.admin)
+    b = await acting_user(guild_role=GuildRole.admin)
+    # The token names b's guild; the path names a's, where the user is admin.
+    other_guild_token = _delegation_headers(user_id=a.user.id, guild_id=b.guild.id)
+
+    response = await client.get(a.g("/auto/subscriptions"), headers=other_guild_token)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "GUILD_ACCESS_DENIED"
+
+
+@pytest.mark.integration
+async def test_delegate_can_use_every_route(client: AsyncClient, acting_user):
+    """The happy path across all four routes on one subscription: the delegate
+    creates, lists, patches and deletes it."""
+    a = await acting_user(guild_role=GuildRole.member)
+
+    with _mock_public_dns():
+        created = await _authed_post(client, a, _subscription_body())
+    assert created.status_code == 201, created.text
+    sub_id = created.json()["id"]
+
+    listed = await client.get(a.g("/auto/subscriptions"), headers=_as_delegate(a))
+    assert listed.status_code == 200, listed.text
+    assert [row["id"] for row in listed.json()] == [sub_id]
+    # The one-time secret is never echoed on a read.
+    assert "hmac_secret" not in listed.json()[0]
+
+    patched = await client.patch(
+        a.g(f"/auto/subscriptions/{sub_id}"),
+        json={"active": False},
+        headers=_as_delegate(a),
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["active"] is False
+
+    deleted = await client.delete(
+        a.g(f"/auto/subscriptions/{sub_id}"), headers=_as_delegate(a)
+    )
+    assert deleted.status_code == 204, deleted.text
+
+
+# ── Target URL policy ─────────────────────────────────────────────────
 
 
 @pytest.mark.integration
@@ -59,12 +244,7 @@ async def test_create_rejects_loopback_target_url(client: AsyncClient, acting_us
     a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
-        client,
-        a,
-        body={
-            "target_url": "https://127.0.0.1/hook",
-            "event_types": ["task.created"],
-        },
+        client, a, _subscription_body(target_url="https://127.0.0.1/hook")
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "WEBHOOK_PRIVATE_TARGET_URL"
@@ -76,12 +256,7 @@ async def test_create_rejects_link_local_target(client: AsyncClient, acting_user
     a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
-        client,
-        a,
-        body={
-            "target_url": "https://169.254.169.254/",
-            "event_types": ["task.created"],
-        },
+        client, a, _subscription_body(target_url="https://169.254.169.254/")
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "WEBHOOK_PRIVATE_TARGET_URL"
@@ -94,12 +269,7 @@ async def test_create_rejects_plain_http(client: AsyncClient, acting_user):
     a = await acting_user(guild_role=GuildRole.admin)
 
     response = await _authed_post(
-        client,
-        a,
-        body={
-            "target_url": "http://hooks.example.com/in",
-            "event_types": ["task.created"],
-        },
+        client, a, _subscription_body(target_url="http://hooks.example.com/in")
     )
     assert response.status_code == 400
     assert response.json()["detail"] == "WEBHOOK_INVALID_TARGET_URL"
@@ -115,44 +285,52 @@ async def test_create_accepts_public_target_when_dns_resolves_public(
     a = await acting_user(guild_role=GuildRole.admin)
 
     with _mock_public_dns():
-        response = await _authed_post(
-            client,
-            a,
-            body={
-                "target_url": "https://hooks.example.com/in",
-                "event_types": ["task.created"],
-            },
-        )
+        response = await _authed_post(client, a, _subscription_body())
     assert response.status_code == 201, response.text
     body = response.json()
     assert body["target_url"] == "https://hooks.example.com/in"
+    # The delegation names a real user, so the row still records an owner.
     assert body["created_by_user_id"] == a.user.id
     assert "hmac_secret" in body  # one-time payload includes the secret
 
 
 @pytest.mark.integration
+async def test_patch_revalidates_target_url(client: AsyncClient, acting_user):
+    """Rewriting the target re-runs the same checks as registering one."""
+    a = await acting_user(guild_role=GuildRole.admin)
+
+    with _mock_public_dns():
+        created = await _authed_post(client, a, _subscription_body())
+    assert created.status_code == 201, created.text
+
+    response = await client.patch(
+        a.g(f"/auto/subscriptions/{created.json()['id']}"),
+        json={"target_url": "https://127.0.0.1/hook"},
+        headers=_as_delegate(a),
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "WEBHOOK_PRIVATE_TARGET_URL"
+
+
+# ── Ownership, on the delegated path ──────────────────────────────────
+
+
+@pytest.mark.integration
 async def test_non_owner_member_cannot_delete(client: AsyncClient, acting_user):
-    """A guild member who didn't create the subscription must not be
-    able to delete it. RLS keeps the row visible inside the guild but
-    that's not the same as authority to mutate it."""
+    """The delegate acts as a real user, so the creator-or-admin rule still
+    applies between two of its workflows: a member who didn't create the
+    subscription can't delete it, even over the delegation credential."""
     creator = await acting_user(guild_role=GuildRole.admin)
     other = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
 
     with _mock_public_dns():
-        created = await _authed_post(
-            client,
-            creator,
-            body={
-                "target_url": "https://hooks.example.com/in",
-                "event_types": ["task.created"],
-            },
-        )
+        created = await _authed_post(client, creator, _subscription_body())
     assert created.status_code == 201
     sub_id = created.json()["id"]
 
     response = await client.delete(
         other.g(f"/auto/subscriptions/{sub_id}"),
-        headers=other.headers,
+        headers=_as_delegate(other),
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "WEBHOOK_SUBSCRIPTION_NOT_OWNER"
@@ -166,21 +344,14 @@ async def test_non_owner_member_cannot_update(client: AsyncClient, acting_user):
     other = await acting_user(guild_role=GuildRole.member, guild=creator.guild)
 
     with _mock_public_dns():
-        created = await _authed_post(
-            client,
-            creator,
-            body={
-                "target_url": "https://hooks.example.com/in",
-                "event_types": ["task.created"],
-            },
-        )
+        created = await _authed_post(client, creator, _subscription_body())
     assert created.status_code == 201
     sub_id = created.json()["id"]
 
     response = await client.patch(
         other.g(f"/auto/subscriptions/{sub_id}"),
         json={"active": False},
-        headers=other.headers,
+        headers=_as_delegate(other),
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "WEBHOOK_SUBSCRIPTION_NOT_OWNER"
@@ -197,20 +368,12 @@ async def test_guild_admin_can_delete_others_subscription(
     admin = await acting_user(guild_role=GuildRole.admin, guild=creator.guild)
 
     with _mock_public_dns():
-        created = await _authed_post(
-            client,
-            creator,
-            body={
-                "target_url": "https://hooks.example.com/in",
-                "event_types": ["task.created"],
-            },
-        )
+        created = await _authed_post(client, creator, _subscription_body())
     assert created.status_code == 201
     sub_id = created.json()["id"]
 
     response = await client.delete(
-        admin.g(f"/auto/subscriptions/{sub_id}"),
-        headers=admin.headers,
+        admin.g(f"/auto/subscriptions/{sub_id}"), headers=_as_delegate(admin)
     )
     assert response.status_code == 204
 
@@ -221,21 +384,14 @@ async def test_creator_can_update_own_subscription(client: AsyncClient, acting_u
     a = await acting_user(guild_role=GuildRole.member)
 
     with _mock_public_dns():
-        created = await _authed_post(
-            client,
-            a,
-            body={
-                "target_url": "https://hooks.example.com/in",
-                "event_types": ["task.created"],
-            },
-        )
+        created = await _authed_post(client, a, _subscription_body())
     assert created.status_code == 201
     sub_id = created.json()["id"]
 
     response = await client.patch(
         a.g(f"/auto/subscriptions/{sub_id}"),
         json={"active": False},
-        headers=a.headers,
+        headers=_as_delegate(a),
     )
     assert response.status_code == 200
     assert response.json()["active"] is False

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -546,6 +546,13 @@ class WebhookSubscriptionMessages:
     PRIVATE_TARGET_URL = "WEBHOOK_PRIVATE_TARGET_URL"
     NOT_FOUND = "WEBHOOK_SUBSCRIPTION_NOT_FOUND"
     NOT_OWNER = "WEBHOOK_SUBSCRIPTION_NOT_OWNER"
+    # Delivery targets are owned by the configured automation delegate.
+    # No delegate is configured on this deployment, so there is nothing that
+    # may own one (503 — a configuration state, not a caller fault).
+    DELEGATE_NOT_CONFIGURED = "AUTOMATION_DELEGATE_NOT_CONFIGURED"
+    # The request authenticated as an ordinary user or API key rather than
+    # over the delegation credential.
+    DELEGATE_REQUIRED = "AUTOMATION_DELEGATE_REQUIRED"
 
 
 class AIMessages:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -505,6 +505,17 @@ class AutoDelegationVerificationError(Exception):
     """Raised when the inbound delegation JWT fails any check."""
 
 
+def auto_delegation_configured() -> bool:
+    """True when this deployment has an automation delegate.
+
+    The delegate is identified by the public half of its signing key, so the
+    presence of that key is what "a delegate exists here" means. Single source
+    of truth for every surface that is delegate-owned: the subscription
+    endpoints refuse without it and the outbound dispatcher stays inert.
+    """
+    return bool(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM)
+
+
 def verify_auto_delegation_token(token: str) -> AutoDelegationClaims:
     """Verify a delegation JWT minted by initiative-auto.
 

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -36,6 +36,7 @@ import httpx
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.security import auto_delegation_configured
 from app.models.tenant.webhook_subscription import WebhookSubscription
 from app.services.safe_http import request_public_target
 from app.services.webhook_target_url import (
@@ -47,6 +48,11 @@ logger = logging.getLogger(__name__)
 
 
 _TIMEOUT = httpx.Timeout(connect=3.0, read=5.0, write=5.0, pool=5.0)
+
+#: Whether this process has already said that dispatch is inert. Every write
+#: that produces an event calls the dispatcher, so the explanation is worth
+#: saying once per process and never per event.
+_inert_logged = False
 
 
 def _sign(secret: str, timestamp: str, body: bytes) -> str:
@@ -143,7 +149,22 @@ async def dispatch_event(
     all deliveries return or time out (5s each). For v0 that latency is
     acceptable because the typical case is zero or one subscriber.
     Move to a background queue when delivery counts climb.
+
+    With no automation delegate configured this returns immediately: the
+    delegate owns delivery targets, so on such a deployment there are none to
+    deliver to. Returning before the query keeps the cost of the feature at
+    zero on the write path rather than one query per event.
     """
+    if not auto_delegation_configured():
+        global _inert_logged
+        if not _inert_logged:
+            _inert_logged = True
+            logger.info(
+                "webhook dispatch inert: no automation delegate configured "
+                "(set AUTO_DELEGATION_PUBLIC_KEY_PEM to enable event delivery)"
+            )
+        return
+
     statement = select(WebhookSubscription).where(
         WebhookSubscription.guild_id == guild_id,
         WebhookSubscription.active.is_(True),

--- a/backend/app/services/tenant/webhook_dispatcher_test.py
+++ b/backend/app/services/tenant/webhook_dispatcher_test.py
@@ -2,7 +2,8 @@
 
 These cover the cryptographic contract — given a known secret and
 known body, the signature is deterministic and verifies — plus the
-matching rules that decide which subscriptions get a given event.
+matching rules that decide which subscriptions get a given event, and
+the delegate condition that decides whether any of it runs at all.
 HTTP delivery is mocked; we don't need a real socket to assert that
 the right URL was called with the right headers and body.
 """
@@ -13,12 +14,30 @@ import hashlib
 import hmac
 import json
 from datetime import datetime, timezone
+from typing import NoReturn
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.core import config as config_module
 from app.models.tenant.webhook_subscription import WebhookSubscription
+from app.services.tenant import webhook_dispatcher
 from app.services.tenant.webhook_dispatcher import _sign, dispatch_event
+
+# Delivery targets belong to the automation delegate, so the dispatcher only
+# runs on a deployment that has one. The setting is only tested for presence,
+# so a placeholder value is enough here.
+_DELEGATE_PEM = "-----BEGIN PUBLIC KEY-----\ntest-delegate\n-----END PUBLIC KEY-----"
+
+
+@pytest.fixture(autouse=True)
+def _delegate_configured(monkeypatch):
+    """Every test below assumes a configured delegate unless it says otherwise
+    — with none, dispatch is inert and there is nothing to assert about
+    matching or signing."""
+    monkeypatch.setattr(
+        config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _DELEGATE_PEM
+    )
 
 
 def _verify_signature(secret: str, timestamp: str, body: bytes, signature: str) -> bool:
@@ -334,3 +353,114 @@ async def test_dispatch_does_not_cross_guilds(session):
             payload={"id": 1},
         )
         assert mock_deliver.await_count == 0
+
+
+# ── The delegate condition ────────────────────────────────────────────
+
+
+class _ExplodingSession:
+    """A session that fails the test if it is touched at all.
+
+    Lets the inert path assert the *absence* of per-event database work,
+    not just the absence of a delivery.
+    """
+
+    def __getattr__(self, name: str) -> NoReturn:
+        raise AssertionError(f"dispatch queried the database (session.{name})")
+
+
+@pytest.mark.integration
+async def test_dispatch_delivers_when_a_delegate_is_configured(session):
+    """The baseline for the two tests below: with a delegate configured, a
+    matching subscription is delivered to."""
+    from app.testing.factories import create_guild, create_user
+
+    user = await create_user(session, email="dispatcher-configured@example.com")
+    guild = await create_guild(session, creator=user)
+    await _make_subscription(
+        session,
+        guild=guild,
+        user=user,
+        target_url="https://configured.example.com/hook",
+        event_types=["task.created"],
+    )
+
+    delivered_to: list[str] = []
+
+    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> None:
+        delivered_to.append(target_url)
+
+    with patch("app.services.tenant.webhook_dispatcher._deliver", new=fake_deliver):
+        await dispatch_event(
+            session,
+            event_type="task.created",
+            guild_id=guild.id,
+            payload={"id": 1},
+        )
+
+    assert delivered_to == ["https://configured.example.com/hook"]
+
+
+@pytest.mark.integration
+async def test_dispatch_is_inert_without_a_delegate(session, monkeypatch):
+    """No delegate, no delivery — and no work of any kind.
+
+    The delegate owns delivery targets, so a deployment without one has none
+    to deliver to. An existing subscription row (left from a deployment that
+    once had a delegate) does not change that, and the dispatcher returns
+    before it would query for one.
+    """
+    from app.testing.factories import create_guild, create_user
+
+    user = await create_user(session, email="dispatcher-inert@example.com")
+    guild = await create_guild(session, creator=user)
+    await _make_subscription(
+        session,
+        guild=guild,
+        user=user,
+        target_url="https://orphaned.example.com/hook",
+        event_types=["task.created"],
+    )
+
+    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    monkeypatch.setattr(webhook_dispatcher, "_inert_logged", False)
+
+    with patch(
+        "app.services.tenant.webhook_dispatcher._deliver", new=AsyncMock()
+    ) as mock_deliver:
+        await dispatch_event(
+            session,
+            event_type="task.created",
+            guild_id=guild.id,
+            payload={"id": 1},
+        )
+        assert mock_deliver.await_count == 0
+
+        # …and the matching row above was never even looked for.
+        await dispatch_event(
+            _ExplodingSession(),
+            event_type="task.created",
+            guild_id=guild.id,
+            payload={"id": 1},
+        )
+        assert mock_deliver.await_count == 0
+
+
+@pytest.mark.unit
+async def test_inert_dispatch_explains_itself_once_per_process(monkeypatch):
+    """Every write that produces an event calls the dispatcher, so the
+    "no delegate configured" explanation is logged once per process rather
+    than once per event."""
+    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    monkeypatch.setattr(webhook_dispatcher, "_inert_logged", False)
+
+    with patch.object(webhook_dispatcher.logger, "info") as mock_info:
+        for _ in range(3):
+            await dispatch_event(
+                _ExplodingSession(),
+                event_type="task.created",
+                guild_id=1,
+                payload={"id": 1},
+            )
+
+    assert mock_info.call_count == 1

--- a/backend/app/services/tenant/webhook_subscriptions.py
+++ b/backend/app/services/tenant/webhook_subscriptions.py
@@ -116,9 +116,8 @@ def _assert_can_mutate(
     is_guild_admin: bool,
 ) -> None:
     """Only the creator or a guild admin may mutate or delete a
-    subscription. Without this, any guild member could quietly redirect
-    or disable another member's webhook target — an authorization gap,
-    even when RLS already keeps things inside the guild boundary."""
+    subscription. RLS keeps subscriptions inside the guild boundary; this
+    decides which member within it owns a given delivery target."""
     if is_guild_admin or subscription.created_by_user_id == acting_user_id:
         return
     raise WebhookSubscriptionOwnershipError(

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -292,6 +292,8 @@
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Nur Gilden-Admins können gildenweite erweiterte Tools erstellen",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Gildenweite erweiterte Tools sind nur für Admins und können nicht geteilt werden",
   "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Läufe erweiterter Tools können nur vom Automatisierungsdienst gestartet werden",
+  "AUTOMATION_DELEGATE_NOT_CONFIGURED": "Für diese Bereitstellung ist kein Automatisierungsdienst konfiguriert, daher ist die Ereigniszustellung nicht verfügbar.",
+  "AUTOMATION_DELEGATE_REQUIRED": "Ereignis-Abonnements können nur vom Automatisierungsdienst verwaltet werden.",
   "AI_INVALID_BASE_URL": "Die Basis-URL ist nicht zulässig. Verwende einen öffentlichen Hostnamen.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama kann nur auf Plattformebene konfiguriert werden.",
   "fallback": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -292,6 +292,8 @@
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Only guild admins can create guild-wide advanced tools",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Guild-wide advanced tools are admin-only and can't be shared",
   "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Advanced tool runs can only be started by the automation service",
+  "AUTOMATION_DELEGATE_NOT_CONFIGURED": "No automation service is configured for this deployment, so event delivery is unavailable.",
+  "AUTOMATION_DELEGATE_REQUIRED": "Event subscriptions can only be managed by the automation service.",
   "AI_INVALID_BASE_URL": "Base URL is not allowed. Use a public hostname.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama can only be configured at the platform level.",
   "fallback": "Something went wrong. Please try again.",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -278,6 +278,8 @@
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Solo los administradores del gremio pueden crear herramientas avanzadas para todo el gremio",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Las herramientas avanzadas para todo el gremio son solo para administradores y no se pueden compartir",
   "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Las ejecuciones de herramientas avanzadas solo puede iniciarlas el servicio de automatización",
+  "AUTOMATION_DELEGATE_NOT_CONFIGURED": "No hay ningún servicio de automatización configurado en esta instalación, por lo que la entrega de eventos no está disponible.",
+  "AUTOMATION_DELEGATE_REQUIRED": "Las suscripciones a eventos solo puede gestionarlas el servicio de automatización.",
   "AI_INVALID_BASE_URL": "La URL base no está permitida. Use un nombre de host público.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama solo se puede configurar a nivel de plataforma.",
   "fallback": "Algo salió mal. Por favor intenta de nuevo.",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -278,6 +278,8 @@
   "ADVANCED_TOOL_GUILD_WIDE_REQUIRES_ADMIN": "Seuls les administrateurs de guilde peuvent créer des outils avancés à l’échelle de la guilde",
   "ADVANCED_TOOL_GUILD_WIDE_NOT_SHAREABLE": "Les outils avancés à l’échelle de la guilde sont réservés aux administrateurs et ne peuvent pas être partagés",
   "ADVANCED_TOOL_DELEGATED_RUN_ONLY": "Les exécutions d’outils avancés ne peuvent être lancées que par le service d’automatisation",
+  "AUTOMATION_DELEGATE_NOT_CONFIGURED": "Aucun service d’automatisation n’est configuré sur cette installation, la diffusion des événements est donc indisponible.",
+  "AUTOMATION_DELEGATE_REQUIRED": "Les abonnements aux événements ne peuvent être gérés que par le service d’automatisation.",
   "AI_INVALID_BASE_URL": "L'URL de base n'est pas autorisée. Utilisez un nom d'hôte public.",
   "AI_PROVIDER_NOT_ALLOWED": "Ollama ne peut être configuré qu'au niveau de la plateforme.",
   "fallback": "Une erreur s'est produite. Veuillez réessayer.",

--- a/frontend/src/api/generated/auto/auto.ts
+++ b/frontend/src/api/generated/auto/auto.ts
@@ -55,10 +55,11 @@ const withQueryKey = <T extends object, K>(query: T, queryKey: K): T & { queryKe
  * reads omit it. The receiver must persist it from this response or
  * rotate the subscription if they lose it.
  *
- * Authorization: tenant isolation is enforced by the table's RLS
- * policy (``guild_isolation``) plus the explicit ``guild_id`` filter
- * in the service layer. The caller's guild comes from
- * ``GuildContext`` — the body never carries it.
+ * Authorization: the automation delegate's credential (503 when no
+ * delegate is configured, 403 for any other caller), then tenant
+ * isolation enforced by the table's RLS policy plus the explicit
+ * ``guild_id`` filter in the service layer. The caller's guild comes
+ * from ``GuildContext`` — the body never carries it.
  *
  * Target policy: ``target_url`` must be https and resolve to a public
  * unicast address; private, loopback and link-local addresses are
@@ -323,8 +324,8 @@ export function useListSubscriptionsApiV1GGuildIdAutoSubscriptionsGet<
 /**
  * Partial-update target_url, event_types, or active flag.
  *
- * Only the creator or a guild admin may mutate. ``target_url`` (when
- * provided) is re-validated against the SSRF allowlist.
+ * Only the acting user who created it, or a guild admin, may mutate.
+ * ``target_url`` (when provided) is re-validated against the SSRF allowlist.
  * @summary Update Subscription
  */
 export const updateSubscriptionApiV1GGuildIdAutoSubscriptionsSubscriptionIdPatch = (


### PR DESCRIPTION
## Problem

`/api/v1/auto/subscriptions` is reachable by any authenticated guild member. But an outbound webhook subscription is a *delivery target*, and delivery targets belong to the deployment's configured automation delegate — apps and users emit events, the delegate owns where they are delivered. Any member being able to register or rewrite one is a gap between what the endpoint enforces and what the model intends.

A deployment with no delegate configured has the mirror-image problem: there is nothing that may own a target, yet the endpoints accept them and the dispatcher does per-event work that can never be delivered.

## Changes

- **`require_auto_delegate`** (`app/api/deps.py`) — returns the `GuildContext` itself, so all four routes take their guild scoping *through* the gate and cannot hold one without the other. It reads the delegation state `_authenticate_auto_delegation` already recorded on the request rather than verifying the JWT a second time.
  - `503 AUTOMATION_DELEGATE_NOT_CONFIGURED` — no delegate on this deployment (a configuration state, not a caller fault)
  - `403 AUTOMATION_DELEGATE_REQUIRED` — authenticated as an ordinary user, session or API key
  - `403 GUILD_ACCESS_DENIED` — token guild ≠ path guild (defence in depth; `get_guild_membership` already refuses this)
- **`auto_delegation_configured()`** (`app/core/security.py`) — one predicate for "this deployment has an automation delegate", so the endpoint gate and the dispatcher cannot drift apart by testing the same setting two different ways.
- **`dispatch_event()` is inert without a delegate** — returns before the subscription query, so an unconfigured deployment pays nothing on the write path (`task.created` calls this on every task creation). Logged once per process, never per event.
- Unchanged on purpose: SSRF `target_url` validation, guild scoping, and the creator-or-guild-admin ownership rule — this adds a gate, it does not replace one. The ownership rule is now exercised over the delegation path, so a delegation for one user still cannot rewrite another's target unless they are a guild admin.
- Reworded one pre-existing docstring that narrated an attack, per the repo's rule against security-sensitive comments in public source.

## Schema / env

No migration. No new settings — the gate keys off the existing `AUTO_DELEGATION_PUBLIC_KEY_PEM`. No OpenAPI change, so no Orval regeneration.

Note for deployments already using the automation service: the subscription routes now require the delegation credential, so anything calling them with an ordinary session token will start receiving 403. The service itself already calls them over delegation.

## Testing

```
cd backend && pytest app/api/v1/tenant_endpoints/auto_subscriptions_test.py \
                     app/services/tenant/webhook_dispatcher_test.py \
                     app/api/v1/tenant_endpoints/auto_delegation_test.py \
                     app/api/v1/tenant_endpoints/advanced_tool_run_test.py
# 49 passed
cd backend && ruff check app && ruff format app
```

`auto_subscriptions_test.py` now drives all four routes over delegation JWTs using the same keypair machinery as `auto_delegation_test.py`. `webhook_dispatcher_test.py` gained an autouse fixture that configures a delegate — without it every pre-existing delivery test would have silently passed against an inert dispatcher.

New error codes are in all four locales (de/en/es/fr).