### PR TITLE
Add manifest v2: service apps and required attribution

### DIFF
--- a/backend/alembic/versions/20260812_0168_marketplace_author_attribution.py
+++ b/backend/alembic/versions/20260812_0168_marketplace_author_attribution.py
@@ -1,0 +1,58 @@
+"""required author attribution on marketplace listings
+
+Every listing states who wrote it. ``author_name`` is NOT NULL so the
+requirement holds at the database as well as in the manifest validator;
+``author_url`` and ``author_contact`` are the optional ways to reach them.
+
+**Existing rows take the value as part of the ALTER, not as a later UPDATE.**
+``marketplace_listings`` carries ``FORCE ROW LEVEL SECURITY`` and a read-only
+policy, and a migration runs with no request context — so ordinary DML here
+would match no rows and report success. Adding the column with a server default
+fills every existing row as part of the DDL, which is not policy-bound, and the
+NOT NULL constraint is then verified by Postgres across the whole table rather
+than by a row count this connection cannot see. Every row that exists at this
+point is a ``core.*`` listing shipped in this build, so ``Initiative`` is the
+correct value for all of them.
+
+The default is dropped immediately afterwards: it exists to fill history, and
+leaving it in place would let a future insert quietly attribute a listing to
+Initiative instead of failing.
+
+Grants and policies are untouched — these are new columns on a table whose
+SELECT policy is unconditional and whose writes already belong to the system
+engine, so nothing about who may read or write it changes.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260812_0168"
+down_revision = "20260812_0167"
+branch_labels = None
+depends_on = None
+
+_TABLE = "marketplace_listings"
+
+#: What the listings that exist at this revision are: shipped built-ins.
+_BUILTIN_AUTHOR = "Initiative"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "author_name",
+            sa.Text(),
+            nullable=False,
+            server_default=_BUILTIN_AUTHOR,
+        ),
+    )
+    op.alter_column(_TABLE, "author_name", server_default=None)
+    op.add_column(_TABLE, sa.Column("author_url", sa.Text(), nullable=True))
+    op.add_column(_TABLE, sa.Column("author_contact", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column(_TABLE, "author_contact")
+    op.drop_column(_TABLE, "author_url")
+    op.drop_column(_TABLE, "author_name")

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -37,7 +37,10 @@ from app.schemas.tenant.guild_app import (
 )
 from app.services import rls as rls_service
 from app.services.marketplace import catalog as catalog_service
-from app.services.marketplace.definitions import APP_KINDS
+from app.services.marketplace.definitions import (
+    APP_KINDS,
+    GUILD_INSTALLABLE_APP_KINDS,
+)
 from app.services.platform import guilds as guilds_service
 from app.services.tenant import guild_apps as guild_apps_service
 
@@ -128,10 +131,20 @@ async def install_guild_app(
         )
 
     definition = dict(version.definition)
-    if definition.get("app_kind") not in APP_KINDS:
+    app_kind = definition.get("app_kind")
+    if app_kind not in APP_KINDS:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=GuildAppMessages.NOT_AN_APP,
+        )
+    # Being an app is not the same as being installable here: a service app is
+    # a valid listing this build can hold and describe, but mounting one needs
+    # machinery that arrives with the app platform. Refused by name rather than
+    # reaching an installer with no handler for it.
+    if app_kind not in GUILD_INSTALLABLE_APP_KINDS:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=GuildAppMessages.KIND_NOT_INSTALLABLE,
         )
 
     name = (payload.name or definition.get("default_name") or listing.name).strip()

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
@@ -380,3 +380,39 @@ class TestEmbedApp:
         assert (await client.get(a.g("/apps/"), headers=a.headers)).json()[
             "items"
         ] == []
+
+
+class TestKindsThisBuildCanMount:
+    """A listing can be a valid app without being something a guild can mount.
+
+    ``service`` apps are the case: the catalog validates, stores and describes
+    them, but mounting one needs the app platform's own machinery. The install
+    endpoint has to say so by name — reaching the installer with a kind it has
+    no handler for would answer a clear refusal with a 500.
+    """
+
+    async def test_a_service_app_is_refused_by_name(
+        self, client: AsyncClient, acting_user, session: AsyncSession
+    ):
+        await create_marketplace_listing(
+            session,
+            uid=marketplace_uid("servicekind"),
+            public_id="tests.service-kind",
+            kind="app",
+            name="A service app",
+            definition={
+                "app_kind": "service",
+                "service": {"public_id": "tests.service-kind"},
+                "features": [],
+            },
+        )
+        a = await acting_user(guild_role=GuildRole.admin)
+
+        response = await client.post(
+            a.g("/apps/"),
+            headers=a.headers,
+            json={"listing_uid": marketplace_uid("servicekind")},
+        )
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == GuildAppMessages.KIND_NOT_INSTALLABLE

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -539,6 +539,10 @@ class GuildAppMessages:
     #: This guild already has this listing installed. Apps mount one guild-wide
     #: surface each, so a second copy has nothing to be.
     ALREADY_INSTALLED = "GUILD_APP_ALREADY_INSTALLED"
+    #: A valid app of a kind this build does not mount into a guild yet — see
+    #: GUILD_INSTALLABLE_APP_KINDS. Publishable and browsable, not installable
+    #: here, and told so by name rather than half-mounted.
+    KIND_NOT_INSTALLABLE = "GUILD_APP_KIND_NOT_INSTALLABLE"
 
 
 class WebhookSubscriptionMessages:

--- a/backend/app/marketplace_catalog/core.advanced-tool.json
+++ b/backend/app/marketplace_catalog/core.advanced-tool.json
@@ -3,7 +3,9 @@
   "public_id": "core.advanced-tool",
   "kind": "app",
   "name": "Advanced tool",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "Bring {name} to the whole guild.",
   "long_description": "Adds a guild-wide entry for {name} — one place for the work that spans every initiative.\n\nYou're signed in automatically; there's no second account to manage. Each initiative still has its own view of {name} in its own menu.\n\nGuild admins only. Removing the app removes the entry here — {name} itself is untouched.",
   "avatar_url": "/marketplace/core-advanced-tool.svg",

--- a/backend/app/marketplace_catalog/core.counter-board.json
+++ b/backend/app/marketplace_catalog/core.counter-board.json
@@ -3,7 +3,9 @@
   "public_id": "core.counter-board",
   "kind": "dashboard",
   "name": "Counter board",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "Your counters, front and center.",
   "long_description": "Counters put where people look. One number as the headline, its progress toward the goal, and the rest of its group charted alongside — the scoreboard for whatever the initiative is tallying.\n\nAfter installing, point each widget at the counters you want: open the dashboard's configure step and it lists what this initiative has.",
   "avatar_url": "/marketplace/core-counter-board.svg",

--- a/backend/app/marketplace_catalog/core.delivery-timeline.json
+++ b/backend/app/marketplace_catalog/core.delivery-timeline.json
@@ -3,7 +3,9 @@
   "public_id": "core.delivery-timeline",
   "kind": "dashboard",
   "name": "Delivery timeline",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "Scheduled work on one timeline, with what is still ahead.",
   "long_description": "Puts every dated task in the initiative on a shared timeline, grouped into lanes, with the open count beside it and the full list below.\n\nTasks with no start or due date do not appear on the timeline — they are still counted, and still listed.",
   "avatar_url": "/marketplace/core-delivery-timeline.svg",

--- a/backend/app/marketplace_catalog/core.event-planner.json
+++ b/backend/app/marketplace_catalog/core.event-planner.json
@@ -3,7 +3,9 @@
   "public_id": "core.event-planner",
   "kind": "dashboard",
   "name": "Event planner",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "Everything on the calendar, read as a plan.",
   "long_description": "The initiative's events laid out the way an organizer thinks: every scheduled event on a weekly timeline, with the full list underneath for the details a bar can't carry.\n\nNothing here needs setting up — every widget reads the calendars of the initiative the dashboard lives on.",
   "avatar_url": "/marketplace/core-event-planner.svg",

--- a/backend/app/marketplace_catalog/core.guild-calendar.json
+++ b/backend/app/marketplace_catalog/core.guild-calendar.json
@@ -3,7 +3,9 @@
   "public_id": "core.guild-calendar",
   "kind": "app",
   "name": "Guild calendar",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "One shared calendar for the events your whole guild shows up to.",
   "long_description": "Give your guild a calendar of its own — for game nights, meetups, and anything else that belongs to everyone rather than to one initiative.\n\nEvery member sees it the moment it's added. Want only officers posting events? Adjust its sharing, same as any calendar.\n\nRemoving the app sends the calendar to the trash, so nothing is lost by accident.",
   "avatar_url": "/marketplace/core-guild-calendar.svg",

--- a/backend/app/marketplace_catalog/core.project-health.json
+++ b/backend/app/marketplace_catalog/core.project-health.json
@@ -3,7 +3,9 @@
   "public_id": "core.project-health",
   "kind": "dashboard",
   "name": "Project health",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "Where every project in this initiative stands, and what is still open.",
   "long_description": "A read-only overview of the initiative's projects. Shows how much of each project is done, how the open work splits across statuses, and the full project list underneath.\n\nNothing here needs setting up — every widget reads the initiative the dashboard lives on.",
   "avatar_url": "/marketplace/core-project-health.svg",

--- a/backend/app/marketplace_catalog/core.task-flow.json
+++ b/backend/app/marketplace_catalog/core.task-flow.json
@@ -3,7 +3,9 @@
   "public_id": "core.task-flow",
   "kind": "dashboard",
   "name": "Task flow",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "How work moves through its stages, and when it gets done.",
   "long_description": "A flow view of the initiative's work: the funnel from the widest stage to the narrowest, the same counts as a chart, and a calendar grid of day-by-day activity.\n\nUseful for spotting where work piles up rather than for tracking any one task.",
   "avatar_url": "/marketplace/core-task-flow.svg",

--- a/backend/app/marketplace_catalog/core.team-activity.json
+++ b/backend/app/marketplace_catalog/core.team-activity.json
@@ -3,7 +3,9 @@
   "public_id": "core.team-activity",
   "kind": "dashboard",
   "name": "Team activity",
-  "publisher": "Initiative",
+  "author": {
+    "name": "Initiative"
+  },
   "description": "Who is doing what, and when it gets done.",
   "long_description": "A read-only pulse of the initiative's people. How the work spreads across the team, the daily rhythm of what gets finished, and how the open pile leans by priority — with the finished total as the headline.\n\nNothing here needs setting up — every widget reads the initiative the dashboard lives on.",
   "avatar_url": "/marketplace/core-team-activity.svg",

--- a/backend/app/models/platform/marketplace.py
+++ b/backend/app/models/platform/marketplace.py
@@ -57,7 +57,23 @@ class MarketplaceListing(SQLModel, table=True):
     source: str = Field(sa_column=Column(String(16), nullable=False))
 
     name: str = Field(sa_column=Column(String(200), nullable=False))
+    # The namespace a listing publishes under. Defaults to the author's name;
+    # a registry binds this prefix to the key that signed the index.
     publisher: str = Field(sa_column=Column(String(200), nullable=False))
+    # Who wrote it. Required, so the question "who is this from?" is answered
+    # before install rather than after; NOT NULL, so the requirement holds at
+    # the database as well as in the validator. Always read together with
+    # `source` — the name is what a publisher claims, and `source` is how the
+    # listing actually reached this deployment.
+    author_name: str = Field(sa_column=Column(Text, nullable=False))
+    # Optional ways to reach them. Shown beside the name; never requested by
+    # the server.
+    author_url: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+    author_contact: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
     description: str = Field(sa_column=Column(String(500), nullable=False))
     long_description: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)

--- a/backend/app/services/marketplace/builtin_test.py
+++ b/backend/app/services/marketplace/builtin_test.py
@@ -26,6 +26,11 @@ from app.services.marketplace.builtin import (
     load_builtin_manifests,
     seed_builtin_listings,
 )
+from app.services.marketplace.definitions import (
+    RESERVED_PUBLIC_ID_PREFIX,
+    normalize_author,
+    normalize_listing_definition,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -55,6 +60,31 @@ async def _seeded(session) -> dict[str, MarketplaceListing]:
 
 
 class TestShippedManifests:
+    async def test_every_shipped_manifest_passes_the_validator(self):
+        """The manifest-level checks, on every file, with no database in the way.
+
+        Seeding logs and skips a manifest it cannot accept, so a shipped file
+        that stopped validating would be missing from the catalog rather than
+        loud. This runs the same checks directly, which is also what makes the
+        author requirement real for the listings we ship rather than only for
+        the ones other people write.
+        """
+        manifests = list(load_builtin_manifests())
+        assert manifests, "no manifests ship with this build"
+
+        for manifest in manifests:
+            public_id = manifest.get("public_id", "?")
+            author = normalize_author(manifest.get("author"))
+            assert author.name, f"{public_id} ships without an author"
+            normalize_listing_definition(
+                manifest.get("kind", ""), manifest.get("definition")
+            )
+            # Everything shipped here is, by definition, shipped here.
+            assert public_id.startswith(RESERVED_PUBLIC_ID_PREFIX), (
+                f"{public_id} is a built-in and should publish under "
+                f"{RESERVED_PUBLIC_ID_PREFIX}*"
+            )
+
     async def test_every_shipped_manifest_seeds(
         self, session, advanced_tool_configured
     ):

--- a/backend/app/services/marketplace/catalog.py
+++ b/backend/app/services/marketplace/catalog.py
@@ -9,8 +9,13 @@ Two audiences, and the split between them is the security shape of this module:
   (boot seeding today, the registry refresh later). No user request reaches it.
 
 Everything a publisher supplies is validated before it lands: the uid's shape,
-the ``public_id``'s, the version string's, and the definition's — the last by the
-same validator the guild-scoped API uses.
+the ``public_id``'s, the version string's, the attribution, and the definition's
+— the last by the same validator the guild-scoped API uses.
+
+Two of those checks are about *who* rather than *what*. Attribution is required,
+so nothing is published anonymously; and the ``core.*`` namespace is refused to
+any source but this build, so an id cannot imply a provenance the listing does
+not have.
 """
 
 from __future__ import annotations
@@ -31,9 +36,13 @@ from app.models.platform.marketplace import (
 )
 from app.services.marketplace.definitions import (
     LISTING_KINDS,
+    LISTING_SOURCES,
     ListingDefinitionError,
+    normalize_author,
     normalize_listing_definition,
+    reserved_prefix_problem,
 )
+from app.services.marketplace.manifest_values import check_public_id
 
 __all__ = [
     "CatalogError",
@@ -49,16 +58,11 @@ __all__ = [
     "version_is_compatible",
 ]
 
-#: Characters a ``public_id`` may use: ``<publisher>.<slug>``, lowercase.
-_PUBLIC_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789.-_")
-_MAX_PUBLIC_ID = 120
 #: Characters a version string may use. Deliberately an explicit set rather than
 #: a semver pattern — the catalog stores what the publisher published and only
 #: needs it to be a safe, short, comparable token.
 _VERSION_CHARS = frozenset("0123456789.-+abcdefghijklmnopqrstuvwxyz")
 _MAX_VERSION = 32
-
-_SOURCES = frozenset({"builtin", "registry"})
 
 
 class CatalogError(ValueError):
@@ -76,14 +80,12 @@ def _check_uid(uid: str) -> str:
 
 
 def _check_public_id(public_id: str) -> str:
-    if not public_id or len(public_id) > _MAX_PUBLIC_ID:
-        raise CatalogError("public_id must be 1..120 characters")
-    for char in public_id:
-        if char not in _PUBLIC_ID_CHARS:
-            raise CatalogError(f"public_id contains {char!r}, which is not allowed")
-    if "." not in public_id:
-        raise CatalogError("public_id must be '<publisher>.<slug>'")
-    return public_id
+    # One rule for the shape of a `<publisher>.<slug>` id, wherever it appears —
+    # a listing's own, or the one a service app names itself by.
+    try:
+        return check_public_id(public_id, what="public_id")
+    except ListingDefinitionError as exc:
+        raise CatalogError(str(exc)) from exc
 
 
 #: Characters an artwork path may use — an explicit allow-list, so a stored
@@ -247,11 +249,14 @@ async def upsert_listing(
     and vice versa, so a uid keeps meaning the listing it was first published
     for.
     """
-    if source not in _SOURCES:
+    if source not in LISTING_SOURCES:
         raise CatalogError(f"unknown listing source {source!r}")
 
     uid = _check_uid(str(manifest.get("uid", "")))
     public_id = _check_public_id(str(manifest.get("public_id", "")))
+    reserved = reserved_prefix_problem(public_id, source=source)
+    if reserved is not None:
+        raise CatalogError(f"{public_id}: {reserved}")
     kind = str(manifest.get("kind", ""))
     if kind not in LISTING_KINDS:
         raise CatalogError(f"unknown listing kind {kind!r}")
@@ -259,12 +264,20 @@ async def upsert_listing(
 
     try:
         definition = normalize_listing_definition(kind, manifest.get("definition"))
+        # Required on every ingestion path: seeding, an operator upload, a
+        # registry refresh. There is no path that publishes without one.
+        author = normalize_author(manifest.get("author"))
     except ListingDefinitionError as exc:
         raise CatalogError(f"{public_id}: {exc}") from exc
 
-    for required in ("name", "publisher", "description", "avatar_url"):
+    for required in ("name", "description", "avatar_url"):
         if not manifest.get(required):
             raise CatalogError(f"{public_id}: {required} is required")
+
+    # The namespace the listing publishes under, which is the author unless the
+    # manifest says otherwise — a publisher and an author differ only when
+    # someone publishes on someone else's behalf.
+    publisher = str(manifest.get("publisher") or author.name)
 
     _check_artwork_path(str(manifest["avatar_url"]), field=f"{public_id}: avatar_url")
 
@@ -297,7 +310,10 @@ async def upsert_listing(
         "kind": kind,
         "source": source,
         "name": str(manifest["name"]),
-        "publisher": str(manifest["publisher"]),
+        "publisher": publisher,
+        "author_name": author.name,
+        "author_url": author.url,
+        "author_contact": author.contact,
         "description": str(manifest["description"]),
         "long_description": manifest.get("long_description"),
         "avatar_url": str(manifest["avatar_url"]),

--- a/backend/app/services/marketplace/catalog_test.py
+++ b/backend/app/services/marketplace/catalog_test.py
@@ -26,6 +26,7 @@ def _manifest(**overrides):
         "kind": "dashboard",
         "name": "Example",
         "publisher": "Tests",
+        "author": {"name": "Tests"},
         "description": "An example listing.",
         "avatar_url": "/marketplace/example.svg",
         "version": "1.0.0",
@@ -77,6 +78,77 @@ class TestIdentity:
             await service.upsert_listing(
                 session, _manifest(public_id="noslug"), source="builtin"
             )
+
+
+class TestAttribution:
+    """Who wrote it is part of what a listing *is*, so it is settled here rather
+    than left to whatever surface happens to display the listing."""
+
+    async def test_a_listing_without_an_author_is_not_published(self, session):
+        manifest = _manifest()
+        del manifest["author"]
+        with pytest.raises(CatalogError, match="author is required"):
+            await service.upsert_listing(session, manifest, source="builtin")
+
+    async def test_the_author_lands_on_the_row(self, session):
+        listing = await service.upsert_listing(
+            session,
+            _manifest(
+                author={
+                    "name": "Widget Co",
+                    "url": "https://widget.test",
+                    "contact": "hello@widget.test",
+                }
+            ),
+            source="builtin",
+        )
+        assert listing.author_name == "Widget Co"
+        assert listing.author_url == "https://widget.test"
+        assert listing.author_contact == "hello@widget.test"
+
+    async def test_the_publisher_defaults_to_the_author(self, session):
+        """A manifest that states one name states it once."""
+        manifest = _manifest(author={"name": "Widget Co"})
+        del manifest["publisher"]
+        listing = await service.upsert_listing(session, manifest, source="builtin")
+        assert listing.publisher == "Widget Co"
+
+    async def test_a_manifest_may_still_name_its_own_publisher(self, session):
+        # They differ when someone publishes on someone else's behalf, which is
+        # also the prefix a signed registry binds to a key.
+        listing = await service.upsert_listing(
+            session,
+            _manifest(publisher="Widget Co", author={"name": "A. Developer"}),
+            source="builtin",
+        )
+        assert (listing.publisher, listing.author_name) == ("Widget Co", "A. Developer")
+
+
+class TestReservedNamespace:
+    """``core.*`` says "shipped in this repository", so only a built-in holds one.
+
+    A name can be typed by anyone; the namespace cannot, which is what keeps an
+    unverified listing from reading as a first-party one.
+    """
+
+    @pytest.mark.parametrize("source", ["operator", "registry"])
+    async def test_no_other_source_may_claim_it(self, session, source):
+        with pytest.raises(CatalogError, match="reserved"):
+            await service.upsert_listing(
+                session, _manifest(public_id="core.impostor"), source=source
+            )
+
+    async def test_a_built_in_publishes_under_it(self, session):
+        listing = await service.upsert_listing(
+            session, _manifest(public_id="core.example"), source="builtin"
+        )
+        assert listing.public_id == "core.example"
+
+    async def test_other_namespaces_stay_open(self, session):
+        listing = await service.upsert_listing(
+            session, _manifest(public_id="widgetco.thing"), source="registry"
+        )
+        assert listing.source == "registry"
 
 
 class TestDefinitions:
@@ -199,6 +271,37 @@ class TestDefinitions:
             "tool": "calendar",
             "default_name": "Guild calendar",
         }
+
+    async def test_a_service_app_reaches_the_catalog_as_data(self, session):
+        """The widest thing a publisher can send, through the ordinary path:
+        what lands is the canonical document, with the keys this build has no
+        use for gone — including anything that looks like an address, since
+        where an app lives is the deployment's statement, not the listing's."""
+        listing = await service.upsert_listing(
+            session,
+            _manifest(
+                kind="app",
+                definition={
+                    "app_kind": "service",
+                    "service": {
+                        "public_id": "tests.widget-co",
+                        "default_url": "https://widget.test",
+                    },
+                    "features": ["embeds"],
+                    "embeds": [
+                        {"id": "main", "path": "/embed/main", "name": {"en": "Main"}}
+                    ],
+                },
+            ),
+            source="builtin",
+        )
+        version = await service.get_listing_version(session, listing.latest_version_id)
+        assert version.definition["app_kind"] == "service"
+        assert version.definition["service"] == {
+            "public_id": "tests.widget-co",
+            "protocol": 1,
+        }
+        assert version.definition["embeds"][0]["path"] == "/embed/main"
 
 
 class TestArtwork:

--- a/backend/app/services/marketplace/definitions.py
+++ b/backend/app/services/marketplace/definitions.py
@@ -1,39 +1,69 @@
 """What a listing is allowed to publish, per kind.
 
-A listing arriving from anywhere — a shipped data file today, a signed remote
-manifest later — carries a definition, and that definition is stored and later
-copied into a guild's schema. This module is the one place that decides whether
-a body is acceptable, and it does so by handing off to the *same* validator the
-guild-scoped API uses: a downloaded dashboard is normalized by
-``dashboard_definition``, exactly like one authored by hand.
+A listing arriving from anywhere — a shipped data file today, an operator upload
+or a signed remote manifest later — carries a definition, and that definition is
+stored and later copied into a guild's schema. This module is the one place that
+decides whether a body is acceptable, and for a dashboard it does so by handing
+off to the *same* validator the guild-scoped API uses: a downloaded dashboard is
+normalized by ``normalize_dashboard_definition``, exactly like one authored by
+hand.
 
 That reuse is the point: catalog content is held to the same widget and binding
 vocabulary as anything authored in the app, by the same code.
+
+The pieces this file leans on live beside it, because a service app's manifest is
+too large a vocabulary to read in one sitting:
+
+* ``manifest_values`` — the bounded primitives every value goes through.
+* ``widget_meta`` — the server-side reading of the rules the browser applies to
+  a widget's own strings.
+* ``service_apps`` — the ``app_kind: "service"`` manifest.
+
+Two rules span all of them. **Attribution is required**: a listing states who
+wrote it or it is not published. And **``core.*`` belongs to this repository**:
+an id in that namespace is only ever claimed by a listing shipped in this build.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Optional
 
+from app.services.marketplace.manifest_values import (
+    MAX_AUTHOR_NAME_LENGTH,
+    MAX_CONTACT_LENGTH,
+    MAX_NAME_LENGTH,
+    ListingDefinitionError,
+    check_single_line,
+    check_url,
+    clean_text,
+    fail,
+    require_mapping,
+)
+from app.services.marketplace.service_apps import (
+    app_widget_type,
+    normalize_service_app_definition,
+)
 from app.services.tenant.dashboard_definition import (
     DashboardDefinitionError,
     normalize_dashboard_definition,
 )
 
 __all__ = [
+    "ListingAuthor",
     "ListingDefinitionError",
     "LISTING_KINDS",
+    "LISTING_SOURCES",
     "APP_KINDS",
+    "GUILD_INSTALLABLE_APP_KINDS",
     "EMBED_TARGETS",
     "MOUNTABLE_TOOLS",
+    "RESERVED_PUBLIC_ID_PREFIX",
+    "app_widget_type",
+    "normalize_author",
     "normalize_listing_definition",
+    "reserved_prefix_problem",
 ]
-
-
-class ListingDefinitionError(ValueError):
-    """A listing body this build cannot accept. The message names the reason in
-    plain terms — these are read by an operator seeding a catalog, not surfaced
-    to an end user."""
 
 
 #: Kinds the catalog can hold.
@@ -44,13 +74,30 @@ class ListingDefinitionError(ValueError):
 #: resolve.
 LISTING_KINDS: frozenset[str] = frozenset({"dashboard", "app", "auto"})
 
+#: How a listing reached this deployment. This is the provenance shown beside an
+#: author's name, and the reason a name alone never has to be taken on faith.
+#:
+#: ``builtin`` shipped in this build. ``operator`` was added by whoever runs the
+#: deployment. ``registry`` arrived from a remote index this deployment trusts.
+LISTING_SOURCES: frozenset[str] = frozenset({"builtin", "operator", "registry"})
+
 #: How an app presents itself.
 #:
 #: ``tool_instance`` mounts one of the app's own tools at guild scope — the app
 #: creates an ordinary row in an ordinary table and the existing UI renders it.
 #: ``embed`` hosts an external surface in an iframe, driven by the signed handoff
-#: machinery.
-APP_KINDS: frozenset[str] = frozenset({"tool_instance", "embed"})
+#: machinery. ``service`` declares features a container the operator runs will
+#: serve.
+APP_KINDS: frozenset[str] = frozenset({"tool_instance", "embed", "service"})
+
+#: The app kinds the guild install path can mount **today**.
+#:
+#: A ``service`` app's definition is publishable and storable — that is what this
+#: module validates — but installing one needs the registration, connection and
+#: proxy machinery that arrives with the app platform. Until then the install
+#: endpoint refuses it by name rather than half-mounting something it cannot
+#: serve.
+GUILD_INSTALLABLE_APP_KINDS: frozenset[str] = frozenset({"tool_instance", "embed"})
 
 #: Where an embed's target comes from.
 #:
@@ -70,16 +117,92 @@ EMBED_TARGETS: frozenset[str] = frozenset({"advanced_tool"})
 #: planned to be).
 MOUNTABLE_TOOLS: frozenset[str] = frozenset({"calendar"})
 
+#: The namespace this repository's own listings publish under.
+RESERVED_PUBLIC_ID_PREFIX = "core."
+
+#: Sources allowed to claim it.
+RESERVED_PREFIX_SOURCES: frozenset[str] = frozenset({"builtin"})
+
+
+# --- attribution ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ListingAuthor:
+    """Who wrote a listing, as the catalog records it."""
+
+    name: str
+    url: Optional[str] = None
+    contact: Optional[str] = None
+
+
+def normalize_author(raw: Any) -> ListingAuthor:
+    """The author block, required on every ingestion path.
+
+    Attribution is a trust signal people act on before installing, so a listing
+    that states none is refused rather than published as anonymous. What the
+    author *claims* is bounded here; the catalog separately records how the
+    listing arrived, and the two are shown together — a name never stands in for
+    provenance.
+    """
+    if raw is None:
+        fail("author is required: a listing states who wrote it")
+    author = require_mapping(raw, "author")
+
+    name = clean_text(
+        author.get("name"), what="author.name", limit=MAX_AUTHOR_NAME_LENGTH
+    )
+    check_single_line(name or "", what="author.name")
+
+    url = author.get("url")
+    contact = clean_text(
+        author.get("contact"),
+        what="author.contact",
+        limit=MAX_CONTACT_LENGTH,
+        required=False,
+    )
+    if contact is not None:
+        check_single_line(contact, what="author.contact")
+
+    return ListingAuthor(
+        name=name or "",
+        url=check_url(url, what="author.url") if url is not None else None,
+        contact=contact,
+    )
+
+
+def reserved_prefix_problem(public_id: str, *, source: str) -> Optional[str]:
+    """Why this source may not publish under this id, or ``None``.
+
+    ``core.*`` names listings shipped in this repository, so the id itself
+    carries the same answer the provenance badge does. Anything arriving from an
+    operator upload or a registry publishes under its own publisher prefix.
+    """
+    if not public_id.startswith(RESERVED_PUBLIC_ID_PREFIX):
+        return None
+    if source in RESERVED_PREFIX_SOURCES:
+        return None
+    return (
+        f"the {RESERVED_PUBLIC_ID_PREFIX!r} prefix is reserved for listings "
+        f"shipped with this build; a {source!r} listing publishes under its "
+        "own publisher prefix"
+    )
+
+
+# --- definitions ------------------------------------------------------------
+
 
 def _normalize_app_definition(definition: Any) -> dict[str, Any]:
     """An app's body: which kind it is, and what that kind needs.
 
-    Deliberately narrow. An app definition names a *kind* and then one thing:
-    which of this build's tools to mount, or which configured embed target to
-    open. It carries no code and no URL — an embed target names a slot in the
-    deployment's own configuration, which is where the address comes from.
-    Unknown keys are dropped rather than stored, so a definition always has
-    canonical shape.
+    ``tool_instance`` and ``embed`` are deliberately narrow — a kind and one
+    thing, either which of this build's tools to mount or which configured embed
+    target to open. Neither carries code or a URL: an embed target names a slot
+    in the deployment's own configuration, which is where the address comes from.
+
+    ``service`` is the wide one, and it keeps the same rule (see
+    ``service_apps``): paths, never addresses. Unknown keys are dropped rather
+    than stored, so a definition always has canonical shape.
     """
     if not isinstance(definition, dict):
         raise ListingDefinitionError("app definition must be an object")
@@ -87,6 +210,9 @@ def _normalize_app_definition(definition: Any) -> dict[str, Any]:
     app_kind = definition.get("app_kind")
     if app_kind not in APP_KINDS:
         raise ListingDefinitionError(f"unknown app kind {app_kind!r}")
+
+    if app_kind == "service":
+        return normalize_service_app_definition(definition)
 
     cleaned: dict[str, Any] = {"app_kind": app_kind}
     if app_kind == "embed":
@@ -105,9 +231,14 @@ def _normalize_app_definition(definition: Any) -> dict[str, Any]:
 
     # A starting name for what the install produces; the guild renames it
     # afterwards like anything else.
-    default_name = definition.get("default_name")
-    if isinstance(default_name, str) and default_name.strip():
-        cleaned["default_name"] = default_name.strip()[:255]
+    default_name = clean_text(
+        definition.get("default_name"),
+        what="default_name",
+        limit=MAX_NAME_LENGTH,
+        required=False,
+    )
+    if default_name is not None:
+        cleaned["default_name"] = default_name
     return cleaned
 
 

--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -1,0 +1,661 @@
+"""What a listing may declare, and what it is refused for.
+
+These are pure-function tests: no database, no session, nothing to seed. The
+validator is the whole boundary between a manifest someone wrote and a document
+this build stores and later hands to a guild, so most of what matters is
+expressed as "this is refused, by name" and "what is stored is canonical".
+
+Three properties get the most attention, because they are the ones an
+implementation could quietly lose:
+
+* a definition never carries an address — only paths, joined later to a base URL
+  the deployment supplies;
+* what a manifest *declares* and what it *ships* cannot disagree;
+* content this build assigns no meaning to (widget modules, sample rows, the
+  automation block) is bounded and stored verbatim, never interpreted.
+"""
+
+import pytest
+
+from app.services.marketplace import service_apps
+from app.services.marketplace.definitions import (
+    APP_KINDS,
+    GUILD_INSTALLABLE_APP_KINDS,
+    LISTING_SOURCES,
+    ListingDefinitionError,
+    app_widget_type,
+    normalize_author,
+    normalize_listing_definition,
+    reserved_prefix_problem,
+)
+from app.services.marketplace.manifest_values import IDENTIFIER_CHARS
+
+pytestmark = pytest.mark.unit
+
+
+def _label(text: str = "A label") -> dict[str, str]:
+    return {"en": text}
+
+
+def _service(**overrides) -> dict:
+    """A minimal service app: declares nothing, ships nothing, and is valid.
+
+    An app with no local features is a legitimate install — an integration that
+    exists to give an external system a foothold in a guild has nothing to
+    render — so the smallest valid manifest is the right starting point.
+    """
+    definition = {
+        "app_kind": "service",
+        "service": {"public_id": "tests.widget-co", "protocol": 1},
+        "features": [],
+    }
+    definition.update(overrides)
+    return definition
+
+
+def _normalize(**overrides) -> dict:
+    return normalize_listing_definition("app", _service(**overrides))
+
+
+class TestAttribution:
+    """Every listing states who wrote it."""
+
+    def test_a_listing_without_an_author_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="author is required"):
+            normalize_author(None)
+
+    def test_an_author_without_a_name_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="author.name"):
+            normalize_author({"url": "https://example.test"})
+
+    def test_a_blank_name_is_not_a_name(self):
+        with pytest.raises(ListingDefinitionError, match="author.name"):
+            normalize_author({"name": "   "})
+
+    def test_a_name_may_not_span_lines(self):
+        # It is rendered on one line beside the listing; a value carrying its
+        # own line breaks is refused rather than displayed however it lands.
+        with pytest.raises(ListingDefinitionError, match="single line"):
+            normalize_author({"name": "Widget Co\nby someone else"})
+
+    def test_contact_and_url_are_optional(self):
+        author = normalize_author({"name": "Widget Co"})
+        assert (author.name, author.url, author.contact) == ("Widget Co", None, None)
+
+    def test_a_url_must_be_a_link(self):
+        for value in ("example.test", "javascript:alert(1)", "/relative"):
+            with pytest.raises(ListingDefinitionError, match="author.url"):
+                normalize_author({"name": "Widget Co", "url": value})
+
+    def test_a_link_is_kept_as_written(self):
+        author = normalize_author(
+            {
+                "name": "  Widget Co  ",
+                "url": "https://widget.test/about",
+                "contact": "hello@widget.test",
+            }
+        )
+        assert author.name == "Widget Co"
+        assert author.url == "https://widget.test/about"
+        assert author.contact == "hello@widget.test"
+
+
+class TestReservedNamespace:
+    """``core.*`` names listings shipped in this repository."""
+
+    def test_a_built_in_may_use_it(self):
+        assert reserved_prefix_problem("core.project-health", source="builtin") is None
+
+    @pytest.mark.parametrize("source", sorted(LISTING_SOURCES - {"builtin"}))
+    def test_no_other_source_may_claim_it(self, source):
+        problem = reserved_prefix_problem("core.impostor", source=source)
+        assert problem is not None
+        assert "reserved" in problem
+
+    def test_other_namespaces_are_open_to_everyone(self):
+        for source in sorted(LISTING_SOURCES):
+            assert reserved_prefix_problem("widgetco.thing", source=source) is None
+
+    def test_the_prefix_is_matched_at_the_boundary(self):
+        # 'coreutils.x' is somebody else's publisher, not the reserved one.
+        assert reserved_prefix_problem("coreutils.x", source="registry") is None
+
+
+class TestAppKinds:
+    def test_service_is_publishable(self):
+        assert "service" in APP_KINDS
+
+    def test_service_is_not_installable_into_a_guild_yet(self):
+        """Publishable and storable, but nothing mounts one here yet — the
+        install path refuses it by name rather than half-mounting it."""
+        assert "service" not in GUILD_INSTALLABLE_APP_KINDS
+        assert GUILD_INSTALLABLE_APP_KINDS < APP_KINDS
+
+    def test_an_unknown_kind_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="unknown app kind"):
+            normalize_listing_definition("app", {"app_kind": "daemon"})
+
+
+class TestServiceIdentity:
+    def test_a_service_names_itself(self):
+        with pytest.raises(ListingDefinitionError, match="service.public_id"):
+            normalize_listing_definition(
+                "app", {"app_kind": "service", "service": {}, "features": []}
+            )
+
+    def test_the_service_id_is_publisher_scoped(self):
+        with pytest.raises(ListingDefinitionError, match="publisher"):
+            _normalize(service={"public_id": "noslug"})
+
+    def test_a_protocol_this_build_does_not_speak_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="protocol"):
+            _normalize(service={"public_id": "tests.widget-co", "protocol": 99})
+
+    def test_the_protocol_defaults_to_the_one_this_build_speaks(self):
+        definition = normalize_listing_definition(
+            "app",
+            {
+                "app_kind": "service",
+                "service": {"public_id": "tests.widget-co"},
+                "features": [],
+            },
+        )
+        assert definition["service"]["protocol"] == 1
+
+
+class TestFeaturesMatchBlocks:
+    """A declaration and a manifest body cannot disagree, in either direction."""
+
+    def test_declaring_a_feature_with_no_block_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="is declared but"):
+            _normalize(features=["widgets"])
+
+    def test_shipping_a_block_without_declaring_it_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="is not declared"):
+            _normalize(
+                events=["app.tests.widget-co.thing_happened"],
+            )
+
+    def test_an_unknown_feature_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="unknown feature"):
+            _normalize(features=["telemetry"])
+
+    def test_an_app_may_offer_no_local_features(self):
+        definition = _normalize()
+        assert definition["features"] == []
+        assert "widgets" not in definition
+
+    def test_features_are_stored_in_a_stable_order(self):
+        definition = _normalize(
+            features=["events", "automations", "events"],
+            events=["app.tests.widget-co.thing_happened"],
+            automation={"graph": []},
+        )
+        assert definition["features"] == ["automations", "events"]
+
+    @pytest.mark.parametrize("feature", sorted(service_apps.FEATURES))
+    def test_every_feature_names_a_block(self, feature):
+        # The cross-check is only as complete as this map, so a feature added
+        # without one would silently stop being checked.
+        assert feature in service_apps.FEATURE_BLOCKS
+
+
+class TestConnections:
+    def test_a_static_connection_needs_something_to_supply(self):
+        with pytest.raises(ListingDefinitionError, match="at least one field"):
+            _normalize(
+                connections=[
+                    {"id": "shop", "scope": "static", "label": _label(), "fields": []}
+                ]
+            )
+
+    def test_an_unknown_scope_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="unknown scope"):
+            _normalize(
+                connections=[{"id": "shop", "scope": "global", "label": _label()}]
+            )
+
+    def test_an_interactive_connection_declares_where_to_start(self):
+        with pytest.raises(ListingDefinitionError, match="connect_path"):
+            _normalize(
+                connections=[
+                    {"id": "account", "scope": "interactive", "label": _label()}
+                ]
+            )
+
+    def test_a_static_connection_has_nowhere_to_send_anyone(self):
+        with pytest.raises(ListingDefinitionError, match="connect_path"):
+            _normalize(
+                connections=[
+                    {
+                        "id": "shop",
+                        "scope": "static",
+                        "label": _label(),
+                        "connect_path": "/connect",
+                        "fields": [
+                            {"key": "token", "type": "secret", "label": _label()}
+                        ],
+                    }
+                ]
+            )
+
+    def test_a_connect_path_is_a_path_and_not_an_address(self):
+        for value in (
+            "https://widget.test/connect",
+            "//widget.test/connect",
+            "/connect/../../admin",
+            "connect",
+        ):
+            with pytest.raises(ListingDefinitionError, match="connect_path"):
+                _normalize(
+                    connections=[
+                        {
+                            "id": "account",
+                            "scope": "interactive",
+                            "label": _label(),
+                            "connect_path": value,
+                        }
+                    ]
+                )
+
+    def test_an_unknown_field_type_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="unknown field type"):
+            _normalize(
+                connections=[
+                    {
+                        "id": "shop",
+                        "scope": "static",
+                        "label": _label(),
+                        "fields": [
+                            {"key": "token", "type": "certificate", "label": _label()}
+                        ],
+                    }
+                ]
+            )
+
+    def test_a_select_field_offers_its_values(self):
+        with pytest.raises(ListingDefinitionError, match="at least one option"):
+            _normalize(
+                connections=[
+                    {
+                        "id": "shop",
+                        "scope": "static",
+                        "label": _label(),
+                        "fields": [
+                            {"key": "region", "type": "select", "label": _label()}
+                        ],
+                    }
+                ]
+            )
+
+    def test_two_connections_cannot_share_an_id(self):
+        connection = {
+            "id": "shop",
+            "scope": "static",
+            "label": _label(),
+            "fields": [{"key": "token", "type": "secret", "label": _label()}],
+        }
+        with pytest.raises(ListingDefinitionError, match="share the id"):
+            _normalize(connections=[connection, dict(connection)])
+
+    def test_a_connection_is_stored_canonically(self):
+        definition = _normalize(
+            connections=[
+                {
+                    "id": "shop",
+                    "scope": "static",
+                    "label": _label("Storefront"),
+                    "access_hint": {"api": "Storefront API", "scopes": ["read_items"]},
+                    "fields": [
+                        {
+                            "key": "token",
+                            "type": "secret",
+                            "required": True,
+                            "managed": True,
+                            "label": _label("Token"),
+                        }
+                    ],
+                    "unexpected": "dropped",
+                }
+            ]
+        )
+        assert definition["connections"] == [
+            {
+                "id": "shop",
+                "scope": "static",
+                "label": {"en": "Storefront"},
+                "fields": [
+                    {
+                        "key": "token",
+                        "type": "secret",
+                        "required": True,
+                        "label": {"en": "Token"},
+                        "managed": True,
+                    }
+                ],
+                "access_hint": {"api": "Storefront API", "scopes": ["read_items"]},
+            }
+        ]
+
+
+def _with_source(**source_overrides) -> dict:
+    """A service app with one connection and one data source that needs it."""
+    source = {
+        "id": "orders",
+        "path": "/v1/data/orders",
+        "requires": {"all_of": ["shop"]},
+    }
+    source.update(source_overrides)
+    return _normalize(
+        features=["data"],
+        connections=[
+            {
+                "id": "shop",
+                "scope": "static",
+                "label": _label(),
+                "fields": [{"key": "token", "type": "secret", "label": _label()}],
+            }
+        ],
+        data_sources=[source],
+    )
+
+
+class TestRequires:
+    def test_an_item_may_only_require_a_connection_that_exists(self):
+        with pytest.raises(ListingDefinitionError, match="unknown connection"):
+            _with_source(requires={"all_of": ["nope"]})
+
+    def test_one_operator_at_a_time(self):
+        with pytest.raises(ListingDefinitionError, match="exactly one"):
+            _with_source(requires={"all_of": ["shop"], "any_of": ["shop"]})
+
+    def test_an_empty_expression_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="names no connection"):
+            _with_source(requires={"any_of": []})
+
+    def test_omitting_it_means_always_available(self):
+        definition = _with_source(requires=None)
+        assert "requires" not in definition["data_sources"][0]
+
+    def test_a_repeated_term_is_stored_once(self):
+        definition = _with_source(requires={"any_of": ["shop", "shop"]})
+        assert definition["data_sources"][0]["requires"] == {"any_of": ["shop"]}
+
+
+class TestDataSources:
+    def test_a_path_is_a_path_and_not_an_address(self):
+        for value in ("https://widget.test/v1/data", "/v1/../admin", "v1/data"):
+            with pytest.raises(ListingDefinitionError, match="path"):
+                _with_source(path=value)
+
+    def test_an_unknown_visibility_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="unknown visibility"):
+            _with_source(visibility="everyone")
+
+    def test_visibility_defaults_to_members_of_the_installing_guild(self):
+        assert _with_source()["data_sources"][0]["visibility"] == "member"
+
+    def test_a_cache_window_is_clamped_rather_than_refused(self):
+        definition = _with_source(cache_ttl_seconds=10_000_000)
+        ttl = definition["data_sources"][0]["cache_ttl_seconds"]
+        assert ttl == service_apps.MAX_CACHE_TTL_SECONDS
+
+    def test_a_parameter_cannot_be_a_secret(self):
+        # A credential is supplied once and held in custody; it is never
+        # restated as a query parameter.
+        assert "secret" not in service_apps.PARAM_TYPES
+        with pytest.raises(ListingDefinitionError, match="unknown field type"):
+            _with_source(
+                params_schema=[{"key": "token", "type": "secret", "label": _label()}]
+            )
+
+
+def _with_widget(**widget_overrides) -> dict:
+    widget = {
+        "id": "summary",
+        "meta": {"name": {"en": "Sales summary"}},
+        "module_source": "export const render = () => ({});",
+    }
+    widget.update(widget_overrides)
+    return _normalize(features=["widgets"], widgets=[widget])
+
+
+class TestWidgets:
+    def test_a_widget_names_itself(self):
+        with pytest.raises(ListingDefinitionError, match="meta must name"):
+            _with_widget(meta={"description": {"en": "no name"}})
+
+    def test_a_widget_ships_a_module(self):
+        with pytest.raises(ListingDefinitionError, match="module_source is required"):
+            _with_widget(module_source="")
+
+    def test_a_module_larger_than_the_cap_is_refused(self):
+        oversized = "x" * (service_apps.MAX_MODULE_SOURCE_BYTES + 1)
+        with pytest.raises(ListingDefinitionError, match="larger than"):
+            _with_widget(module_source=oversized)
+
+    def test_a_module_is_stored_exactly_as_published(self):
+        """Byte-for-byte: this build measures the module and stores it. What it
+        contains is the browser sandbox's business, not this validator's."""
+        source = "const render = (d) => ({ kind: 'metric', value: d.length });\n"
+        definition = _with_widget(module_source=source)
+        assert definition["widgets"][0]["module_source"] == source
+
+    def test_a_widget_may_only_bind_a_source_the_app_declares(self):
+        with pytest.raises(ListingDefinitionError, match="unknown data source"):
+            _with_widget(sources=["orders"])
+
+    def test_sample_rows_are_kept_only_for_declared_sources(self):
+        definition = _normalize(
+            features=["data", "widgets"],
+            data_sources=[{"id": "orders", "path": "/v1/data/orders"}],
+            widgets=[
+                {
+                    "id": "summary",
+                    "meta": {"name": {"en": "Sales summary"}},
+                    "module_source": "export const render = () => ({});",
+                    "sources": ["orders"],
+                    "sample_data": {"orders": [{"n": 1}], "elsewhere": [{"n": 2}]},
+                }
+            ],
+        )
+        assert definition["widgets"][0]["sample_data"] == {"orders": [{"n": 1}]}
+
+    def test_sample_rows_are_size_capped(self):
+        with pytest.raises(ListingDefinitionError, match="sample_data"):
+            _normalize(
+                features=["data", "widgets"],
+                data_sources=[{"id": "orders", "path": "/v1/data/orders"}],
+                widgets=[
+                    {
+                        "id": "summary",
+                        "meta": {"name": {"en": "Sales summary"}},
+                        "module_source": "export const render = () => ({});",
+                        "sources": ["orders"],
+                        "sample_data": {
+                            "orders": ["x" * service_apps.MAX_SAMPLE_DATA_BYTES]
+                        },
+                    }
+                ],
+            )
+
+    def test_two_widgets_cannot_share_an_id(self):
+        widget = {
+            "id": "summary",
+            "meta": {"name": {"en": "Sales summary"}},
+            "module_source": "export const render = () => ({});",
+        }
+        with pytest.raises(ListingDefinitionError, match="share the id"):
+            _normalize(features=["widgets"], widgets=[widget, dict(widget)])
+
+
+class TestWidgetTypeNamespacing:
+    def test_an_app_widget_carries_its_listing(self):
+        assert app_widget_type("K7M2QX8N4TVB9C", "summary") == (
+            "app:K7M2QX8N4TVB9C:summary"
+        )
+
+    def test_it_cannot_collide_with_a_built_in_type(self):
+        from app.services.tenant.dashboard_definition import WIDGET_TYPES
+
+        assert app_widget_type("K7M2QX8N4TVB9C", "stat") not in WIDGET_TYPES
+
+    def test_the_separator_is_outside_the_id_alphabet(self):
+        # Which is what keeps the three parts separable: no widget id can
+        # contain the character that joins them.
+        assert ":" not in IDENTIFIER_CHARS
+
+    def test_a_widget_id_is_checked_before_it_is_composed(self):
+        with pytest.raises(ListingDefinitionError, match="widget id"):
+            app_widget_type("K7M2QX8N4TVB9C", "sum:mary")
+
+
+class TestEmbeds:
+    def _embed(self, **overrides) -> dict:
+        embed = {
+            "id": "orders",
+            "path": "/embed/orders",
+            "visibility": "guild_admin",
+            "name": _label("Orders"),
+        }
+        embed.update(overrides)
+        return _normalize(features=["embeds"], embeds=[embed])
+
+    def test_an_embed_names_itself_for_the_sidebar(self):
+        with pytest.raises(ListingDefinitionError, match="label"):
+            self._embed(name=None)
+
+    def test_an_embed_declares_a_path_not_an_address(self):
+        with pytest.raises(ListingDefinitionError, match="path"):
+            self._embed(path="https://widget.test/embed/orders")
+
+    def test_an_embed_is_stored_canonically(self):
+        definition = self._embed()
+        assert definition["embeds"] == [
+            {
+                "id": "orders",
+                "path": "/embed/orders",
+                "visibility": "guild_admin",
+                "name": {"en": "Orders"},
+            }
+        ]
+
+
+class TestEvents:
+    def test_an_event_is_namespaced_under_the_app(self):
+        with pytest.raises(ListingDefinitionError, match="must start with"):
+            _normalize(features=["events"], events=["order_created"])
+
+    def test_an_app_cannot_announce_another_app_s_events(self):
+        with pytest.raises(ListingDefinitionError, match="must start with"):
+            _normalize(features=["events"], events=["app.someone.else.order_created"])
+
+    def test_the_namespace_alone_is_not_an_event(self):
+        with pytest.raises(ListingDefinitionError, match="must start with"):
+            _normalize(features=["events"], events=["app.tests.widget-co."])
+
+    def test_a_declared_event_is_kept(self):
+        definition = _normalize(
+            features=["events"],
+            events=[
+                "app.tests.widget-co.order_created",
+                "app.tests.widget-co.order_created",
+            ],
+        )
+        assert definition["events"] == ["app.tests.widget-co.order_created"]
+
+
+class TestAutomationIsOpaque:
+    def test_the_block_is_stored_verbatim(self):
+        """Initiative stores automation information and passes it through; the
+        service that owns automations is the only thing that reads it. So the
+        validator checks shape and size, and nothing about the contents."""
+        blob = {
+            "nodes": [{"anything": "at all", "nested": {"deeply": [1, 2, 3]}}],
+            "version": "whatever the service says",
+        }
+        definition = _normalize(features=["automations"], automation=blob)
+        assert definition["automation"] == blob
+
+    def test_it_must_still_be_an_object(self):
+        with pytest.raises(ListingDefinitionError, match="automation must be"):
+            _normalize(features=["automations"], automation=["not", "an", "object"])
+
+    def test_it_is_size_capped(self):
+        oversized = {"graph": "x" * service_apps.MAX_AUTOMATION_BYTES}
+        with pytest.raises(ListingDefinitionError, match="larger than"):
+            _normalize(features=["automations"], automation=oversized)
+
+
+class TestCanonicalShape:
+    def test_unknown_keys_are_dropped(self):
+        definition = _normalize(
+            default_name="Widget Co",
+            surprise="dropped",
+            base_url="https://widget.test",
+        )
+        assert set(definition) == {
+            "app_kind",
+            "service",
+            "features",
+            "default_name",
+        }
+
+    def test_a_definition_holds_no_address_anywhere(self):
+        """The governing rule, asserted on a manifest that tries: an app says
+        which route, and the deployment's registration says where."""
+        definition = _normalize(
+            features=["data", "embeds"],
+            service={
+                "public_id": "tests.widget-co",
+                "protocol": 1,
+                "default_url": "http://widget.test:8100",
+            },
+            connections=[
+                {
+                    "id": "shop",
+                    "scope": "interactive",
+                    "label": _label(),
+                    "connect_path": "/connect/shop",
+                }
+            ],
+            data_sources=[
+                {"id": "orders", "path": "/v1/data/orders", "base_url": "http://x.test"}
+            ],
+            embeds=[
+                {
+                    "id": "orders",
+                    "path": "/embed/orders",
+                    "name": _label(),
+                    "url": "https://widget.test/embed/orders",
+                }
+            ],
+        )
+        rendered = repr(definition)
+        assert "http://" not in rendered
+        assert "https://" not in rendered
+        assert "default_url" not in definition["service"]
+
+    def test_the_whole_document_is_size_capped(self):
+        # Each widget is under the per-module cap; together they are not.
+        module = "x" * (service_apps.MAX_MODULE_SOURCE_BYTES - 1)
+        widgets = [
+            {
+                "id": f"w{index}",
+                "meta": {"name": {"en": f"Widget {index}"}},
+                "module_source": module,
+            }
+            for index in range(service_apps.MAX_WIDGETS)
+        ]
+        with pytest.raises(ListingDefinitionError, match="service app definition"):
+            _normalize(features=["widgets"], widgets=widgets)
+
+    def test_a_block_longer_than_its_cap_is_refused_not_truncated(self):
+        with pytest.raises(ListingDefinitionError, match="more than"):
+            _normalize(
+                features=["embeds"],
+                embeds=[
+                    {"id": f"e{index}", "path": f"/embed/{index}", "name": _label()}
+                    for index in range(service_apps.MAX_EMBEDS + 1)
+                ],
+            )

--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -180,6 +180,20 @@ class TestFeaturesMatchBlocks:
         with pytest.raises(ListingDefinitionError, match="unknown feature"):
             _normalize(features=["telemetry"])
 
+    def test_an_empty_block_is_not_a_block(self):
+        """Empty means absent, the same way for every block.
+
+        An automation block that is present but empty describes nothing.
+        Storing it would be a second shape meaning "none" — and one the feature
+        cross-check could read differently from the way it was stored, letting a
+        manifest carry a block its own ``features`` never declared.
+        """
+        definition = _normalize(automation={})
+        assert "automation" not in definition
+
+        with pytest.raises(ListingDefinitionError, match="is declared but"):
+            _normalize(features=["automations"], automation={})
+
     def test_an_app_may_offer_no_local_features(self):
         definition = _normalize()
         assert definition["features"] == []

--- a/backend/app/services/marketplace/manifest_values.py
+++ b/backend/app/services/marketplace/manifest_values.py
@@ -1,0 +1,255 @@
+"""The bounded primitives every manifest value passes through.
+
+A manifest arrives from outside this build — a shipped data file today, an
+operator upload or a signed registry manifest later — so nothing it carries is
+taken on trust. Validation here is *total*: every string has a length cap, every
+list has a count cap, every identifier is checked against an explicit character
+set, and a key this build does not know is dropped rather than stored. What
+comes out has canonical shape, which is what makes a stored definition safe to
+copy into a guild's schema and render months later.
+
+The checks are deliberately dull and explicit — an allow-list of characters
+rather than a pattern — so what is accepted can be read straight off the page.
+
+One rule shapes the rest: **a listing declares capabilities, it does not supply
+addresses.** Anything a service is asked for is a *path*, joined at call time to
+a base URL that comes from the deployment's own registration. There is nowhere
+in a manifest to put a host, which is why nothing here needs to decide whether a
+host is trustworthy.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, NoReturn
+
+__all__ = [
+    "ListingDefinitionError",
+    "IDENTIFIER_CHARS",
+    "PATH_CHARS",
+    "PUBLIC_ID_CHARS",
+    "MAX_AUTHOR_NAME_LENGTH",
+    "MAX_CONTACT_LENGTH",
+    "MAX_HINT_LENGTH",
+    "MAX_IDENTIFIER_LENGTH",
+    "MAX_LABEL_LENGTH",
+    "MAX_NAME_LENGTH",
+    "MAX_PATH_LENGTH",
+    "MAX_PUBLIC_ID_LENGTH",
+    "MAX_URL_LENGTH",
+    "check_identifier",
+    "check_json_size",
+    "check_path",
+    "check_public_id",
+    "check_single_line",
+    "check_url",
+    "clean_text",
+    "fail",
+    "require_list",
+    "require_mapping",
+    "utf8_bytes",
+]
+
+
+class ListingDefinitionError(ValueError):
+    """A listing body this build cannot accept.
+
+    The message names the reason in plain terms — these are read by an operator
+    seeding a catalog or a publisher preparing a manifest, not surfaced to an
+    end user.
+    """
+
+
+# --- caps -------------------------------------------------------------------
+#
+# Every one of these bounds a value a publisher chooses. They are generous
+# enough that no honest manifest meets them and small enough that a stored
+# definition stays a document rather than a payload.
+
+MAX_IDENTIFIER_LENGTH = 64
+MAX_PUBLIC_ID_LENGTH = 120
+MAX_PATH_LENGTH = 200
+#: A display name for what an install produces; the guild renames it after.
+MAX_NAME_LENGTH = 255
+MAX_LABEL_LENGTH = 120
+MAX_AUTHOR_NAME_LENGTH = 120
+MAX_URL_LENGTH = 300
+MAX_CONTACT_LENGTH = 200
+#: An `access_hint` string — the API and permission names a connection asks for.
+MAX_HINT_LENGTH = 120
+
+#: What an id inside a manifest may use: connection, widget, data source, embed.
+#: Lowercase only, so two ids cannot differ by case alone.
+IDENTIFIER_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_-")
+
+#: What a `<publisher>.<slug>` id may use. Matches the catalog's own rule.
+PUBLIC_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789.-_")
+
+#: What a path may use. An explicit set, so a stored path is exactly what will
+#: be appended to a registered base URL.
+PATH_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-"
+)
+
+#: Schemes an author link may use. The server never requests these; they are
+#: shown to a person deciding whether to install.
+URL_SCHEMES = ("https://", "http://")
+
+
+def fail(message: str) -> NoReturn:
+    raise ListingDefinitionError(message)
+
+
+# --- structure --------------------------------------------------------------
+
+
+def require_mapping(value: Any, what: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{what} must be an object")
+    return value
+
+
+def require_list(value: Any, what: str, limit: int) -> list[Any]:
+    """A list, or an empty one when the key is absent. Never longer than
+    ``limit`` — a manifest that exceeds it is refused rather than truncated, so
+    a publisher learns their block was too big instead of quietly losing its
+    tail."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        fail(f"{what} must be a list")
+    if len(value) > limit:
+        fail(f"{what} holds more than {limit} entries")
+    return value
+
+
+# --- scalars ----------------------------------------------------------------
+
+
+def clean_text(
+    value: Any,
+    *,
+    what: str,
+    limit: int,
+    required: bool = True,
+) -> str | None:
+    """Plain text, trimmed and length-checked.
+
+    Non-strings are dropped rather than coerced, so a nested object cannot
+    smuggle itself into a rendered label. Over-length text is refused rather
+    than cut: silently publishing half a sentence is worse than saying so.
+    """
+    if not isinstance(value, str):
+        if required:
+            fail(f"{what} is required")
+        return None
+    stripped = value.strip()
+    if not stripped:
+        if required:
+            fail(f"{what} is required")
+        return None
+    if len(stripped) > limit:
+        fail(f"{what} is longer than {limit} characters")
+    return stripped
+
+
+def check_single_line(value: str, *, what: str) -> str:
+    """Text that will be shown on one line. Control characters, including line
+    breaks and tabs, are refused."""
+    for character in value:
+        if ord(character) < 32 or ord(character) == 127:
+            fail(f"{what} must be a single line of text")
+    return value
+
+
+def check_identifier(value: Any, *, what: str) -> str:
+    """An id used as a key and composed into other ids."""
+    if not isinstance(value, str) or not value:
+        fail(f"{what} is required")
+    if len(value) > MAX_IDENTIFIER_LENGTH:
+        fail(f"{what} is longer than {MAX_IDENTIFIER_LENGTH} characters")
+    for character in value:
+        if character not in IDENTIFIER_CHARS:
+            fail(f"{what} contains {character!r}, which is not allowed")
+    return value
+
+
+def check_public_id(value: Any, *, what: str) -> str:
+    """A ``<publisher>.<slug>`` identifier."""
+    if not isinstance(value, str) or not value:
+        fail(f"{what} is required")
+    if len(value) > MAX_PUBLIC_ID_LENGTH:
+        fail(f"{what} is longer than {MAX_PUBLIC_ID_LENGTH} characters")
+    for character in value:
+        if character not in PUBLIC_ID_CHARS:
+            fail(f"{what} contains {character!r}, which is not allowed")
+    if "." not in value:
+        fail(f"{what} must be '<publisher>.<slug>'")
+    return value
+
+
+def check_path(value: Any, *, what: str) -> str:
+    """A path on the app's own service, never an address.
+
+    The deployment joins this to the base URL its registration supplies, so a
+    manifest states *which route*, and the operator states *where*. A value that
+    could read as something other than a plain path — a scheme, a host, a parent
+    segment — is refused by name.
+    """
+    if not isinstance(value, str) or not value:
+        fail(f"{what} is required")
+    if len(value) > MAX_PATH_LENGTH:
+        fail(f"{what} is longer than {MAX_PATH_LENGTH} characters")
+    if not value.startswith("/"):
+        fail(f"{what} must be a path starting with '/'")
+    for character in value:
+        if character not in PATH_CHARS:
+            fail(f"{what} contains {character!r}, which is not allowed")
+    if "//" in value or ".." in value:
+        fail(f"{what} must be a plain path with no '//' or '..'")
+    return value
+
+
+def check_url(value: Any, *, what: str) -> str:
+    """A link shown beside a listing. Displayed, never requested by the server."""
+    text = clean_text(value, what=what, limit=MAX_URL_LENGTH)
+    if text is None:  # not reached: clean_text raises when the value is required
+        fail(f"{what} is required")
+    check_single_line(text, what=what)
+    if " " in text:
+        fail(f"{what} must not contain spaces")
+    for scheme in URL_SCHEMES:
+        if text.startswith(scheme) and len(text) > len(scheme):
+            return text
+    fail(f"{what} must start with 'https://' or 'http://'")
+
+
+# --- opaque bodies ----------------------------------------------------------
+
+
+def utf8_bytes(value: str, *, what: str) -> bytes:
+    """The UTF-8 encoding of a string this build only ever measures.
+
+    JSON permits escapes that do not encode, so this is where such a value is
+    refused — before anything downstream tries to store or ship it.
+    """
+    try:
+        return value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ListingDefinitionError(f"{what} is not valid UTF-8") from exc
+
+
+def check_json_size(value: Any, *, what: str, limit: int) -> None:
+    """Bound a body this build stores without interpreting.
+
+    Some manifest content is deliberately opaque — sample rows for a preview, a
+    block belonging to another service. Shape and size are the whole contract
+    for those, so this is the only check they get.
+    """
+    try:
+        encoded = json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError) as exc:
+        raise ListingDefinitionError(f"{what} must be plain JSON data") from exc
+    size = len(encoded.encode("utf-8"))
+    if size > limit:
+        fail(f"{what} is larger than {limit} bytes")

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -552,7 +552,10 @@ def _check_features(features: list[str], cleaned: dict[str, Any]) -> None:
     """
     declared = set(features)
     for feature, block in FEATURE_BLOCKS.items():
-        present = bool(cleaned.get(block))
+        # Membership, not truthiness: whether a block was stored is the question,
+        # and reading it as a value would let a stored-but-empty block count as
+        # absent here while still being persisted.
+        present = block in cleaned
         if feature in declared and not present:
             fail(
                 f"service app: the {feature!r} feature is declared but "
@@ -637,7 +640,11 @@ def normalize_service_app_definition(definition: Any) -> dict[str, Any]:
     if events:
         cleaned["events"] = events
     automation = _automation(body.get("automation"))
-    if automation is not None:
+    # Same rule as every block above: an empty one is left out rather than
+    # stored as a second way of saying "none". An automation block that is
+    # present but empty describes nothing, and storing it would let a manifest
+    # carry a block its `features` never declared.
+    if automation:
         cleaned["automation"] = automation
 
     default_name = clean_text(

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -1,0 +1,658 @@
+"""Service apps: what a manifest may declare, and nothing else.
+
+A ``service`` app is one whose features are realized by a container the operator
+runs. Its definition is the widest thing this build accepts from a publisher, so
+it is also the strictest: a closed vocabulary, an explicit cap on every string,
+list and opaque body, and unknown keys dropped rather than stored.
+
+Three properties hold by construction, and they are why a definition is safe to
+keep and later hand to a guild:
+
+* **It names capabilities, not addresses.** Every route an app offers is a
+  *path*; the base URL comes from a deployment-level registration. There is
+  nowhere in here to put a host.
+* **Nothing in it runs here.** ``module_source`` is a widget's browser-side
+  module: it is measured and stored as an opaque string, and this build has no
+  path that parses, compiles, imports, or evaluates it. The browser's sandbox is
+  the only thing that ever executes it.
+* **Blocks this build assigns no meaning to stay opaque.** The ``automation``
+  body belongs to the automation service; it is checked for shape and size and
+  passed through verbatim, with no vocabulary here describing its contents.
+
+Features are the app's own statement of what it contributes, and they are
+cross-checked against the blocks present in both directions so the statement
+cannot drift from the manifest. They inform install dialogs, deployment-fit
+messaging, and review — they never gate installation. An app may declare no
+local features at all: an integration that exists to give an external system a
+foothold in a guild is a legitimate install with nothing to render.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.marketplace.manifest_values import (
+    MAX_HINT_LENGTH,
+    MAX_LABEL_LENGTH,
+    MAX_NAME_LENGTH,
+    check_identifier,
+    check_json_size,
+    check_path,
+    check_public_id,
+    clean_text,
+    fail,
+    require_list,
+    require_mapping,
+    utf8_bytes,
+)
+from app.services.marketplace.widget_meta import (
+    MAX_TEXT_LENGTH,
+    localized_text,
+    validate_widget_meta,
+)
+
+__all__ = [
+    "APP_PROTOCOL_VERSIONS",
+    "APP_WIDGET_TYPE_PREFIX",
+    "CONNECTION_SCOPES",
+    "FEATURES",
+    "FEATURE_BLOCKS",
+    "FIELD_TYPES",
+    "PARAM_TYPES",
+    "VISIBILITIES",
+    "app_widget_type",
+    "normalize_service_app_definition",
+]
+
+# --- vocabulary -------------------------------------------------------------
+
+#: Capability classes an app can contribute. Closed: a manifest naming anything
+#: else is refused rather than stored as a claim nothing can act on.
+FEATURES: frozenset[str] = frozenset(
+    {"data", "widgets", "embeds", "events", "automations"}
+)
+
+#: Which block backs each feature. The single source for the cross-check that
+#: keeps a declaration and a manifest body from disagreeing.
+FEATURE_BLOCKS: dict[str, str] = {
+    "data": "data_sources",
+    "widgets": "widgets",
+    "embeds": "embeds",
+    "events": "events",
+    "automations": "automation",
+}
+
+#: Who supplies a connection's credential, which decides its scope.
+#:
+#: ``static`` — a guild admin types it in, and the whole guild uses it.
+#: ``interactive`` — the app runs a vendor flow behind its ``connect_path`` and
+#: each member connects their own account.
+CONNECTION_SCOPES: frozenset[str] = frozenset({"static", "interactive"})
+
+#: Field kinds a connection form can render. The same closed enum the automation
+#: service's node contract settled on, so one generic form renderer draws every
+#: app's settings page.
+FIELD_TYPES: frozenset[str] = frozenset(
+    {"string", "secret", "url", "bool", "select", "int"}
+)
+
+#: What a data source may take as a query parameter. ``secret`` is absent: a
+#: parameter travels with a request, and credentials are supplied once, held in
+#: custody, and never restated per call.
+PARAM_TYPES: frozenset[str] = FIELD_TYPES - {"secret"}
+
+#: Who may open a surface. ``member`` is any member of the installing guild;
+#: ``guild_admin`` narrows it to the guild's admins.
+VISIBILITIES: frozenset[str] = frozenset({"member", "guild_admin"})
+
+#: Protocol versions this build speaks to an app service. A manifest naming a
+#: newer one is refused by name — the version floor (`min_app_version`) is how a
+#: publisher says "this needs a newer Initiative".
+APP_PROTOCOL_VERSIONS: frozenset[int] = frozenset({1})
+
+#: Widget type ids from an app are namespaced, so an app's widget can never
+#: resolve to a built-in renderer (or the other way round). ``:`` is outside the
+#: identifier character set, so the three parts stay separable.
+APP_WIDGET_TYPE_PREFIX = "app:"
+
+#: Every event an app emits is namespaced under its own service id.
+EVENT_TYPE_PREFIX = "app."
+EVENT_TYPE_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
+
+# --- caps -------------------------------------------------------------------
+#
+# Counts first, then bodies. Together they bound what one published version can
+# weigh: the per-item caps bound a single widget or blob, and the whole-document
+# cap bounds the sum, so no combination of legal parts adds up to an illegal
+# document.
+
+MAX_CONNECTIONS = 20
+MAX_FIELDS_PER_CONNECTION = 12
+MAX_SELECT_OPTIONS = 24
+MAX_ACCESS_HINT_SCOPES = 24
+MAX_REQUIRES_TERMS = 10
+MAX_WIDGETS = 12
+MAX_WIDGET_SOURCES = 8
+MAX_DATA_SOURCES = 24
+MAX_PARAMS_PER_SOURCE = 12
+MAX_EMBEDS = 12
+MAX_EVENTS = 50
+MAX_EVENT_TYPE_LENGTH = 200
+#: A day. A source that wants a longer memory than that is asking for a stale
+#: dashboard rather than a cheaper one.
+MAX_CACHE_TTL_SECONDS = 86_400
+
+#: A widget's browser-side module. Never parsed here — only measured.
+MAX_MODULE_SOURCE_BYTES = 64 * 1024
+#: Rows powering a preview with no network call.
+MAX_SAMPLE_DATA_BYTES = 32 * 1024
+#: The automation service's own block, stored verbatim.
+MAX_AUTOMATION_BYTES = 64 * 1024
+#: The canonical definition, after normalization. Checked last, so a publisher
+#: is told the document is too large rather than which cap they happened to hit
+#: first.
+MAX_SERVICE_DEFINITION_BYTES = 512 * 1024
+
+
+# --- shared pieces ----------------------------------------------------------
+
+
+def _label(raw: Any, *, what: str, max_length: int = MAX_TEXT_LENGTH) -> dict[str, str]:
+    """A localized label, read by the same rules a widget's own strings are.
+
+    One rule for every human-readable string an app supplies, so an app names
+    its connections in as many languages as it names its widgets.
+    """
+    label = localized_text(raw, max_length)
+    if label is None:
+        fail(f"{what} must carry a label with at least one language")
+    return label
+
+
+def _requires(
+    raw: Any, *, connection_ids: set[str], what: str
+) -> dict[str, Any] | None:
+    """Which connections satisfy an item.
+
+    One level, one operator: ``all_of`` or ``any_of`` over connection ids, or
+    absent for "always available". Satisfaction is later evaluated from the
+    presence of values alone — this build never inspects a credential — so the
+    only thing checkable here is that every id names a connection the manifest
+    actually declares.
+    """
+    if raw is None:
+        return None
+    requires = require_mapping(raw, f"{what} requires")
+    named = [key for key in ("all_of", "any_of") if key in requires]
+    if len(named) != 1:
+        fail(f"{what}: requires must name exactly one of 'all_of' or 'any_of'")
+    key = named[0]
+    terms = require_list(requires[key], f"{what} requires.{key}", MAX_REQUIRES_TERMS)
+    cleaned: list[str] = []
+    for term in terms:
+        connection_id = check_identifier(term, what=f"{what} requires.{key} entry")
+        if connection_id not in connection_ids:
+            fail(f"{what}: requires names unknown connection {connection_id!r}")
+        if connection_id not in cleaned:
+            cleaned.append(connection_id)
+    if not cleaned:
+        fail(f"{what}: requires.{key} names no connection")
+    return {key: cleaned}
+
+
+def _visibility(raw: Any, *, what: str) -> str:
+    if raw is None:
+        return "member"
+    if raw not in VISIBILITIES:
+        fail(f"{what}: unknown visibility {raw!r}")
+    return raw
+
+
+def _field(
+    raw: Any,
+    *,
+    types: frozenset[str],
+    allow_managed: bool,
+    what: str,
+) -> dict[str, Any]:
+    """One typed input, in a connection form or a data source's parameters."""
+    field = require_mapping(raw, what)
+    key = check_identifier(field.get("key"), what=f"{what} key")
+    field_type = field.get("type")
+    if field_type not in types:
+        fail(f"{what} {key!r}: unknown field type {field_type!r}")
+
+    cleaned: dict[str, Any] = {
+        "key": key,
+        "type": field_type,
+        "required": field.get("required") is True,
+        "label": _label(field.get("label"), what=f"{what} {key!r}"),
+    }
+    if field_type == "select":
+        options = require_list(
+            field.get("options"), f"{what} {key!r} options", MAX_SELECT_OPTIONS
+        )
+        values = [
+            clean_text(option, what=f"{what} {key!r} option", limit=MAX_LABEL_LENGTH)
+            for option in options
+        ]
+        if not values:
+            fail(f"{what} {key!r}: a select field must offer at least one option")
+        cleaned["options"] = values
+    # Keys the app writes back itself, rather than the admin typing them: an
+    # interactive flow returns its result through the app's own write path.
+    if allow_managed and field.get("managed") is True:
+        cleaned["managed"] = True
+    return cleaned
+
+
+# --- connections ------------------------------------------------------------
+
+
+def _access_hint(raw: Any, *, what: str) -> dict[str, Any] | None:
+    """What a connection says it will use the credential for.
+
+    Display-only truth in advertising: the settings form names the API and the
+    permissions the app wants, so an admin can mint a minimal credential. No
+    other system's permissions can be enforced from here, and none is claimed
+    to be — this only makes least privilege the visible default.
+    """
+    if raw is None:
+        return None
+    hint = require_mapping(raw, f"{what} access_hint")
+    cleaned: dict[str, Any] = {}
+    api = clean_text(
+        hint.get("api"),
+        what=f"{what} access_hint.api",
+        limit=MAX_HINT_LENGTH,
+        required=False,
+    )
+    if api is not None:
+        cleaned["api"] = api
+    scopes = require_list(
+        hint.get("scopes"), f"{what} access_hint.scopes", MAX_ACCESS_HINT_SCOPES
+    )
+    named = [
+        clean_text(scope, what=f"{what} access_hint.scope", limit=MAX_HINT_LENGTH)
+        for scope in scopes
+    ]
+    if named:
+        cleaned["scopes"] = named
+    return cleaned or None
+
+
+def _connection(raw: Any) -> dict[str, Any]:
+    connection = require_mapping(raw, "connection")
+    connection_id = check_identifier(connection.get("id"), what="connection id")
+    what = f"connection {connection_id!r}"
+
+    scope = connection.get("scope")
+    if scope not in CONNECTION_SCOPES:
+        fail(f"{what}: unknown scope {scope!r}")
+
+    fields_raw = require_list(
+        connection.get("fields"), f"{what} fields", MAX_FIELDS_PER_CONNECTION
+    )
+    fields: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in fields_raw:
+        field = _field(
+            entry, types=FIELD_TYPES, allow_managed=True, what=f"{what} field"
+        )
+        if field["key"] in seen:
+            fail(f"{what}: two fields share the key {field['key']!r}")
+        seen.add(field["key"])
+        fields.append(field)
+
+    cleaned: dict[str, Any] = {
+        "id": connection_id,
+        "scope": scope,
+        "label": _label(connection.get("label"), what=what),
+        "fields": fields,
+    }
+
+    if scope == "static" and not fields:
+        # Nothing for the admin to supply, so nothing this connection could be.
+        fail(f"{what}: a static connection must declare at least one field")
+
+    connect_path = connection.get("connect_path")
+    if scope == "interactive":
+        # The route the member is sent to so the app can run the vendor's flow.
+        cleaned["connect_path"] = check_path(connect_path, what=f"{what} connect_path")
+    elif connect_path is not None:
+        fail(f"{what}: only an interactive connection has a connect_path")
+
+    hint = _access_hint(connection.get("access_hint"), what=what)
+    if hint is not None:
+        cleaned["access_hint"] = hint
+    return cleaned
+
+
+# --- what an app offers -----------------------------------------------------
+
+
+def _data_source(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
+    source = require_mapping(raw, "data source")
+    source_id = check_identifier(source.get("id"), what="data source id")
+    what = f"data source {source_id!r}"
+
+    params_raw = require_list(
+        source.get("params_schema"), f"{what} params_schema", MAX_PARAMS_PER_SOURCE
+    )
+    params: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in params_raw:
+        param = _field(
+            entry, types=PARAM_TYPES, allow_managed=False, what=f"{what} param"
+        )
+        if param["key"] in seen:
+            fail(f"{what}: two parameters share the key {param['key']!r}")
+        seen.add(param["key"])
+        params.append(param)
+
+    cleaned: dict[str, Any] = {
+        "id": source_id,
+        "path": check_path(source.get("path"), what=f"{what} path"),
+        "visibility": _visibility(source.get("visibility"), what=what),
+        "cache_ttl_seconds": _cache_ttl(source.get("cache_ttl_seconds"), what=what),
+    }
+    if params:
+        cleaned["params_schema"] = params
+    requires = _requires(
+        source.get("requires"), connection_ids=connection_ids, what=what
+    )
+    if requires is not None:
+        cleaned["requires"] = requires
+    return cleaned
+
+
+def _cache_ttl(raw: Any, *, what: str) -> int:
+    """How long a response may be reused. Clamped rather than refused: a number
+    out of range is a judgement about freshness, not a vocabulary this build
+    cannot resolve."""
+    if raw is None:
+        return 0
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        fail(f"{what}: cache_ttl_seconds must be a whole number of seconds")
+    return max(0, min(raw, MAX_CACHE_TTL_SECONDS))
+
+
+def _widget(
+    raw: Any, *, source_ids: set[str], connection_ids: set[str]
+) -> dict[str, Any]:
+    widget = require_mapping(raw, "widget")
+    widget_id = check_identifier(widget.get("id"), what="widget id")
+    what = f"widget {widget_id!r}"
+
+    meta = validate_widget_meta(widget.get("meta"))
+    if meta is None:
+        fail(f"{what}: meta must name the widget in at least one language")
+
+    module_source = widget.get("module_source")
+    if not isinstance(module_source, str) or not module_source.strip():
+        fail(f"{what}: module_source is required")
+    # Measured, never read: the module is a string to this build, and the
+    # browser's sandbox is the only thing that evaluates it.
+    encoded = utf8_bytes(module_source, what=f"{what} module_source")
+    if len(encoded) > MAX_MODULE_SOURCE_BYTES:
+        fail(f"{what}: module_source is larger than {MAX_MODULE_SOURCE_BYTES} bytes")
+
+    bound = require_list(widget.get("sources"), f"{what} sources", MAX_WIDGET_SOURCES)
+    sources: list[str] = []
+    for entry in bound:
+        source_id = check_identifier(entry, what=f"{what} source")
+        if source_id not in source_ids:
+            fail(f"{what}: binds unknown data source {source_id!r}")
+        if source_id not in sources:
+            sources.append(source_id)
+
+    cleaned: dict[str, Any] = {
+        "id": widget_id,
+        "meta": meta,
+        "module_source": module_source,
+    }
+    if sources:
+        cleaned["sources"] = sources
+
+    sample = _sample_data(widget.get("sample_data"), sources=sources, what=what)
+    if sample:
+        cleaned["sample_data"] = sample
+    requires = _requires(
+        widget.get("requires"), connection_ids=connection_ids, what=what
+    )
+    if requires is not None:
+        cleaned["requires"] = requires
+    return cleaned
+
+
+def _sample_data(raw: Any, *, sources: list[str], what: str) -> dict[str, Any]:
+    """Rows that let a preview render with no network call at all.
+
+    Keyed by the sources the widget declared; anything else is dropped, so a
+    sample cannot describe data the widget could never be handed. The rows
+    themselves are opaque — this build stores them for the browser to pass into
+    a render, and reads nothing out of them.
+    """
+    if raw is None:
+        return {}
+    supplied = require_mapping(raw, f"{what} sample_data")
+    allowed = set(sources)
+    sample = {key: value for key, value in supplied.items() if key in allowed}
+    check_json_size(sample, what=f"{what} sample_data", limit=MAX_SAMPLE_DATA_BYTES)
+    return sample
+
+
+def _embed(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
+    embed = require_mapping(raw, "embed")
+    embed_id = check_identifier(embed.get("id"), what="embed id")
+    what = f"embed {embed_id!r}"
+
+    cleaned: dict[str, Any] = {
+        "id": embed_id,
+        "path": check_path(embed.get("path"), what=f"{what} path"),
+        "visibility": _visibility(embed.get("visibility"), what=what),
+        "name": _label(embed.get("name"), what=what),
+    }
+    requires = _requires(
+        embed.get("requires"), connection_ids=connection_ids, what=what
+    )
+    if requires is not None:
+        cleaned["requires"] = requires
+    return cleaned
+
+
+def _events(raw: Any, *, service_public_id: str) -> list[str]:
+    """Event types the app emits, namespaced under its own service id.
+
+    The prefix is checked here and again at ingress against the emitting
+    registration, so an app can announce and emit only under its own name.
+    """
+    prefix = f"{EVENT_TYPE_PREFIX}{service_public_id}."
+    declared = require_list(raw, "events", MAX_EVENTS)
+    events: list[str] = []
+    for entry in declared:
+        if not isinstance(entry, str) or not entry:
+            fail("events must be a list of event type names")
+        if len(entry) > MAX_EVENT_TYPE_LENGTH:
+            fail(f"event type {entry[:40]!r}… is too long")
+        for character in entry:
+            if character not in EVENT_TYPE_CHARS:
+                fail(f"event type {entry!r} contains {character!r}")
+        if not entry.startswith(prefix) or len(entry) == len(prefix):
+            fail(f"event type {entry!r} must start with {prefix!r}")
+        if entry not in events:
+            events.append(entry)
+    return events
+
+
+def _automation(raw: Any) -> dict[str, Any] | None:
+    """The automation service's own block.
+
+    Opaque by design: this build checks that it is a JSON object within a size
+    cap and stores it verbatim. It holds no vocabulary describing what is inside
+    — descriptor shapes, triggers, and execution belong to the service that owns
+    automations, and duplicating any of it here would be a second definition of
+    a contract this repository does not own.
+    """
+    if raw is None:
+        return None
+    automation = require_mapping(raw, "automation")
+    check_json_size(automation, what="automation", limit=MAX_AUTOMATION_BYTES)
+    return automation
+
+
+# --- the definition ---------------------------------------------------------
+
+
+def app_widget_type(listing_uid: str, widget_id: str) -> str:
+    """The type id a listing's widget is offered under.
+
+    Namespaced with the catalog uid, so two apps can both ship a ``summary``
+    widget and neither can shadow a built-in type. ``:`` is outside the
+    identifier character set, so the parts stay unambiguous — and the id is
+    re-checked here, so that stays true wherever this is called from.
+    """
+    check_identifier(widget_id, what="widget id")
+    return f"{APP_WIDGET_TYPE_PREFIX}{listing_uid}:{widget_id}"
+
+
+def _service_block(raw: Any) -> dict[str, Any]:
+    service = require_mapping(raw, "service app: service")
+    public_id = check_public_id(
+        service.get("public_id"), what="service app: service.public_id"
+    )
+    protocol = service.get("protocol", 1)
+    if isinstance(protocol, bool) or not isinstance(protocol, int):
+        fail("service app: service.protocol must be a whole number")
+    if protocol not in APP_PROTOCOL_VERSIONS:
+        fail(
+            f"service app: protocol {protocol} is not one this build speaks "
+            f"({sorted(APP_PROTOCOL_VERSIONS)})"
+        )
+    return {"public_id": public_id, "protocol": protocol}
+
+
+def _features(raw: Any) -> list[str]:
+    declared = require_list(raw, "service app: features", len(FEATURES))
+    features: set[str] = set()
+    for entry in declared:
+        if entry not in FEATURES:
+            fail(f"service app: unknown feature {entry!r}")
+        features.add(entry)
+    # Sorted, so a re-publish of the same manifest produces the same document.
+    return sorted(features)
+
+
+def _check_features(features: list[str], cleaned: dict[str, Any]) -> None:
+    """Both directions, because either mismatch is a manifest that lies.
+
+    A feature declared with no block behind it would advertise something the app
+    cannot do; a block with no feature declared would ship a capability the
+    install dialog never disclosed and review never looked at.
+    """
+    declared = set(features)
+    for feature, block in FEATURE_BLOCKS.items():
+        present = bool(cleaned.get(block))
+        if feature in declared and not present:
+            fail(
+                f"service app: the {feature!r} feature is declared but "
+                f"{block} is missing"
+            )
+        if present and feature not in declared:
+            fail(
+                f"service app: {block} is present but the {feature!r} feature "
+                "is not declared"
+            )
+
+
+def normalize_service_app_definition(definition: Any) -> dict[str, Any]:
+    """Validate and canonicalize a service app's definition."""
+    body = require_mapping(definition, "service app definition")
+
+    service = _service_block(body.get("service"))
+
+    connections = [
+        _connection(entry)
+        for entry in require_list(
+            body.get("connections"), "service app: connections", MAX_CONNECTIONS
+        )
+    ]
+    connection_ids: set[str] = set()
+    for connection in connections:
+        if connection["id"] in connection_ids:
+            fail(f"service app: two connections share the id {connection['id']!r}")
+        connection_ids.add(connection["id"])
+
+    data_sources = [
+        _data_source(entry, connection_ids=connection_ids)
+        for entry in require_list(
+            body.get("data_sources"), "service app: data_sources", MAX_DATA_SOURCES
+        )
+    ]
+    source_ids: set[str] = set()
+    for source in data_sources:
+        if source["id"] in source_ids:
+            fail(f"service app: two data sources share the id {source['id']!r}")
+        source_ids.add(source["id"])
+
+    widgets = [
+        _widget(entry, source_ids=source_ids, connection_ids=connection_ids)
+        for entry in require_list(
+            body.get("widgets"), "service app: widgets", MAX_WIDGETS
+        )
+    ]
+    widget_ids: set[str] = set()
+    for widget in widgets:
+        if widget["id"] in widget_ids:
+            fail(f"service app: two widgets share the id {widget['id']!r}")
+        widget_ids.add(widget["id"])
+
+    embeds = [
+        _embed(entry, connection_ids=connection_ids)
+        for entry in require_list(body.get("embeds"), "service app: embeds", MAX_EMBEDS)
+    ]
+    embed_ids: set[str] = set()
+    for embed in embeds:
+        if embed["id"] in embed_ids:
+            fail(f"service app: two embeds share the id {embed['id']!r}")
+        embed_ids.add(embed["id"])
+
+    cleaned: dict[str, Any] = {
+        "app_kind": "service",
+        "service": service,
+        "features": _features(body.get("features")),
+    }
+    # Empty blocks are left out entirely, so "does this app offer widgets?" has
+    # one answer rather than two shapes that mean the same thing.
+    if connections:
+        cleaned["connections"] = connections
+    if data_sources:
+        cleaned["data_sources"] = data_sources
+    if widgets:
+        cleaned["widgets"] = widgets
+    if embeds:
+        cleaned["embeds"] = embeds
+
+    events = _events(body.get("events"), service_public_id=service["public_id"])
+    if events:
+        cleaned["events"] = events
+    automation = _automation(body.get("automation"))
+    if automation is not None:
+        cleaned["automation"] = automation
+
+    default_name = clean_text(
+        body.get("default_name"),
+        what="service app: default_name",
+        limit=MAX_NAME_LENGTH,
+        required=False,
+    )
+    if default_name is not None:
+        cleaned["default_name"] = default_name
+
+    _check_features(cleaned["features"], cleaned)
+    check_json_size(
+        cleaned,
+        what="service app definition",
+        limit=MAX_SERVICE_DEFINITION_BYTES,
+    )
+    return cleaned

--- a/backend/app/services/marketplace/service_apps_test.py
+++ b/backend/app/services/marketplace/service_apps_test.py
@@ -1,0 +1,173 @@
+"""Listing content is data here, and this is the test that keeps it that way.
+
+A service app ships ``module_source``: the JavaScript its widget renders with.
+This build's only jobs are to measure it, store it, and hand it to the browser,
+where it runs inside the zero-capability sandbox every widget uses. Nothing on
+the server parses, compiles, imports, or evaluates it — and "nothing does" is
+easy to believe and easy to lose, because it would take one convenience helper
+to change.
+
+So it is asserted structurally: every module in this package is parsed, and any
+call that could turn stored text into behaviour fails this test. A new one has
+to be argued for in review rather than merged quietly.
+
+The same guard covers the rest of a manifest for the same reason — sample rows,
+the automation block, and a widget's meta are all publisher-supplied text this
+build stores without interpreting.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.services.marketplace.definitions import normalize_listing_definition
+
+pytestmark = pytest.mark.unit
+
+_PACKAGE = Path(__file__).resolve().parent
+
+#: Calls that turn text into behaviour. Named rather than pattern-matched, so
+#: what is banned can be read off the page.
+_FORBIDDEN_CALLS = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "__import__",
+        "import_module",
+        "literal_eval",
+        "system",
+        "popen",
+        "Popen",
+        "check_output",
+    }
+)
+
+#: The one receiver allowed to own a method sharing a banned name: SQLModel
+#: spells its query call ``session.exec()``, which has nothing to do with the
+#: builtin. Kept as an explicit pairing rather than skipping every attribute
+#: call, so ``builtins.exec(...)`` still trips the guard.
+_ALLOWED_METHOD_CALLS = frozenset({("session", "exec")})
+
+#: Modules whose whole purpose is running something. None of them has any
+#: business on a path that handles catalog content.
+_FORBIDDEN_IMPORTS = frozenset(
+    {
+        "subprocess",
+        "importlib",
+        "marshal",
+        "pickle",
+        "runpy",
+        "ctypes",
+        "code",
+        "codeop",
+    }
+)
+
+
+def _sources() -> list[Path]:
+    """Every module in this package, tests excluded.
+
+    Globbed rather than listed, so a module added here is covered the day it
+    lands instead of the day someone remembers to add it.
+    """
+    paths = sorted(
+        path for path in _PACKAGE.glob("*.py") if not path.name.endswith("_test.py")
+    )
+    assert paths, "no marketplace modules found to check"
+    return paths
+
+
+def _called_name(node: ast.Call) -> str:
+    """The name a call invokes, or "" when it is allowed or unreadable.
+
+    Attribute calls count too — a banned name is banned however it is reached —
+    except for the receiver/method pairs named above.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        receiver = func.value.id if isinstance(func.value, ast.Name) else None
+        if (receiver, func.attr) in _ALLOWED_METHOD_CALLS:
+            return ""
+        return func.attr
+    return ""
+
+
+def _forbidden_calls_in(source: str, *, filename: str = "<test>") -> set[str]:
+    tree = ast.parse(source, filename=filename)
+    return {
+        _called_name(node) for node in ast.walk(tree) if isinstance(node, ast.Call)
+    } & _FORBIDDEN_CALLS
+
+
+class TestNothingExecutesListingContent:
+    @pytest.mark.parametrize("path", _sources(), ids=lambda path: path.name)
+    def test_no_module_can_turn_text_into_behaviour(self, path):
+        found = _forbidden_calls_in(
+            path.read_text(encoding="utf-8"), filename=str(path)
+        )
+        assert not found, f"{path.name} calls {sorted(found)}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "exec(src)",
+            "eval(src)",
+            "compile(src, '<s>', 'exec')",
+            "__import__('os')",
+            "builtins.exec(src)",
+            "__builtins__.exec(src)",
+            "importlib.import_module(name)",
+            "ast.literal_eval(src)",
+            "os.system(cmd)",
+            "subprocess.check_output(cmd)",
+            "obj.attr.exec(src)",
+        ],
+    )
+    def test_the_guard_catches_a_call_however_it_is_reached(self, source):
+        """The allow-list is one receiver/method pair, not a blanket pass for
+        attribute calls — so no spelling of these slips by."""
+        assert _forbidden_calls_in(source)
+
+    def test_the_allowed_pair_is_only_that_pair(self):
+        """SQLModel's query call is what the exemption is for, and nothing
+        inherits it: the same method on anything else still trips."""
+        assert not _forbidden_calls_in("session.exec(statement)")
+        assert _forbidden_calls_in("shell.exec(statement)")
+
+    @pytest.mark.parametrize("path", _sources(), ids=lambda path: path.name)
+    def test_no_module_imports_a_way_to_run_something(self, path):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+        found = imported & _FORBIDDEN_IMPORTS
+        assert not found, f"{path.name} imports {sorted(found)}"
+
+    def test_a_module_that_would_be_dangerous_to_run_is_simply_stored(self):
+        """The proof the guard is about something real: content that would do
+        damage if it were ever executed here goes in and comes out byte for
+        byte, because storing is all that happens to it."""
+        source = "__import__('os').system('echo nope')\n"
+        definition = normalize_listing_definition(
+            "app",
+            {
+                "app_kind": "service",
+                "service": {"public_id": "tests.widget-co"},
+                "features": ["widgets"],
+                "widgets": [
+                    {
+                        "id": "summary",
+                        "meta": {"name": {"en": "Summary"}},
+                        "module_source": source,
+                    }
+                ],
+            },
+        )
+        assert definition["widgets"][0]["module_source"] == source

--- a/backend/app/services/marketplace/widget_meta.py
+++ b/backend/app/services/marketplace/widget_meta.py
@@ -1,0 +1,158 @@
+"""What a widget calls itself — the server-side reading of the same rules.
+
+A widget module exports ``meta`` alongside ``render``, carrying its name, its
+description, and the labels for its own options in every language its author
+supports. The browser reads that meta out of the sandbox and rebuilds it with
+``validateWidgetMeta`` (``frontend/src/lib/widgets/widgetMeta.ts``); a listing
+carries the same structure as plain data, and this module is where that data is
+checked before it is stored.
+
+**This is a mirror, and mirrors drift.** The two implementations exist because
+they run in different places on different inputs — one on a sandbox return
+value, one on catalog content — and neither can call the other. So the limits
+below are pinned against the TypeScript file by a test that reads it
+(``definitions_guards_test.py``); changing one side without the other fails
+there rather than in production, where the symptom would be a widget accepted by
+the catalog and then re-trimmed differently in the browser.
+
+Rebuilt from checked parts rather than inspected in place: unknown keys, unusable
+locales, and over-long strings are dropped by construction, so what is stored is
+exactly what can be rendered.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "LOCALE_TAG_CHARS",
+    "MAX_DESCRIPTION_LENGTH",
+    "MAX_LOCALES",
+    "MAX_LOCALE_TAG_LENGTH",
+    "MAX_OPTIONS",
+    "MAX_TEXT_LENGTH",
+    "MAX_VALUES_PER_OPTION",
+    "localized_text",
+    "validate_widget_meta",
+]
+
+# --- limits (mirrored from META_LIMITS in widgetMeta.ts) --------------------
+
+MAX_TEXT_LENGTH = 120
+MAX_DESCRIPTION_LENGTH = 400
+#: Languages one string may be supplied in. Generous — the cap only stops a
+#: module from shipping a dictionary.
+MAX_LOCALES = 40
+MAX_OPTIONS = 12
+MAX_VALUES_PER_OPTION = 24
+#: `en`, `en-GB`, `pt-BR` — a language tag, not free text.
+MAX_LOCALE_TAG_LENGTH = 12
+
+#: Mirrored from LOCALE_TAG_CHARS. An explicit character check rather than a
+#: pattern: the set of things a language tag may contain is short enough to
+#: state outright.
+LOCALE_TAG_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-")
+
+
+def _is_locale_tag(value: str) -> bool:
+    if not value or len(value) > MAX_LOCALE_TAG_LENGTH:
+        return False
+    for character in value:
+        if character not in LOCALE_TAG_CHARS:
+            return False
+    return True
+
+
+def localized_text(raw: Any, max_length: int) -> dict[str, str] | None:
+    """A language-tag → text map, or ``None`` if nothing usable survives.
+
+    Trimmed and truncated rather than refused, matching the browser: meta is
+    presentation, and a widget with one over-long label should still name
+    itself. Entries past the locale cap stop the scan, exactly as the mirror
+    does, so both sides keep the same first forty.
+    """
+    if not isinstance(raw, dict):
+        return None
+    out: dict[str, str] = {}
+    count = 0
+    for tag, value in raw.items():
+        count += 1
+        if count > MAX_LOCALES:
+            break
+        if not isinstance(tag, str) or not _is_locale_tag(tag):
+            continue
+        if not isinstance(value, str):
+            continue
+        text = value.strip()[:max_length]
+        if text:
+            out[tag] = text
+    return out or None
+
+
+def _option_meta(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    label = localized_text(raw.get("label"), MAX_TEXT_LENGTH)
+    if label is None:
+        return None
+    entry: dict[str, Any] = {"label": label}
+
+    # Only a name-keyed object carries value labels; anything else is dropped
+    # rather than read positionally.
+    raw_values = raw.get("values")
+    if isinstance(raw_values, dict):
+        values: dict[str, dict[str, str]] = {}
+        count = 0
+        for value, raw_label in raw_values.items():
+            count += 1
+            if count > MAX_VALUES_PER_OPTION:
+                break
+            if not isinstance(value, str):
+                continue
+            value_label = localized_text(raw_label, MAX_TEXT_LENGTH)
+            if value_label is not None:
+                values[value] = value_label
+        if values:
+            entry["values"] = values
+    return entry
+
+
+def validate_widget_meta(raw: Any) -> dict[str, Any] | None:
+    """Rebuild a widget's meta from validated parts.
+
+    Returns ``None`` when there is no usable name — a widget without meta is not
+    an error in the browser, which falls back to the type id, so this never
+    raises. A *listing* holds its widgets to a higher bar (see
+    ``service_apps.py``): one that cannot name itself is refused at publish,
+    because a marketplace widget with no name is a tile nobody can identify.
+    """
+    if not isinstance(raw, dict):
+        return None
+
+    name = localized_text(raw.get("name"), MAX_TEXT_LENGTH)
+    if name is None:
+        return None
+
+    meta: dict[str, Any] = {"name": name}
+
+    description = localized_text(raw.get("description"), MAX_DESCRIPTION_LENGTH)
+    if description is not None:
+        meta["description"] = description
+
+    raw_options = raw.get("options")
+    if isinstance(raw_options, dict):
+        options: dict[str, Any] = {}
+        count = 0
+        for key, raw_option in raw_options.items():
+            count += 1
+            if count > MAX_OPTIONS:
+                break
+            if not isinstance(key, str):
+                continue
+            option = _option_meta(raw_option)
+            if option is not None:
+                options[key] = option
+        if options:
+            meta["options"] = options
+
+    return meta

--- a/backend/app/services/marketplace/widget_meta_test.py
+++ b/backend/app/services/marketplace/widget_meta_test.py
@@ -1,0 +1,191 @@
+"""The widget-meta mirror, and proof it still matches the browser's copy.
+
+Two implementations read the same structure: ``validateWidgetMeta`` in
+``frontend/src/lib/widgets/widgetMeta.ts`` reads it out of the sandbox, and
+``widget_meta.py`` reads it out of a listing. Neither can call the other, so the
+only thing keeping them equal is a test that fails when they stop being.
+
+``TestMirrorsTheFrontend`` is that test: it reads the TypeScript file and pins
+every limit against the Python constant. A limit changed on one side, or a new
+limit added to the frontend with no counterpart here, fails here — rather than
+in production, where the symptom would be a widget the catalog accepted and the
+browser then trimmed differently.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.services.marketplace import widget_meta
+from app.services.marketplace.widget_meta import (
+    localized_text,
+    validate_widget_meta,
+)
+
+pytestmark = pytest.mark.unit
+
+# backend/app/services/marketplace/<this file> -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FRONTEND = _REPO_ROOT / "frontend"
+_MIRROR = _FRONTEND / "src" / "lib" / "widgets" / "widgetMeta.ts"
+
+#: Every entry in the frontend's META_LIMITS, and the constant that mirrors it.
+#: The mapping is asserted to be exhaustive in both directions, so a limit added
+#: on either side has to be added here too.
+_MIRRORED_LIMITS = {
+    "maxTextLength": "MAX_TEXT_LENGTH",
+    "maxDescriptionLength": "MAX_DESCRIPTION_LENGTH",
+    "maxLocales": "MAX_LOCALES",
+    "maxOptions": "MAX_OPTIONS",
+    "maxValuesPerOption": "MAX_VALUES_PER_OPTION",
+    "maxLocaleTagLength": "MAX_LOCALE_TAG_LENGTH",
+}
+
+
+def _read_mirror() -> str:
+    if not _FRONTEND.is_dir():
+        pytest.skip("frontend tree not present in this checkout")
+    # Present but moved or renamed is a real failure: the mirror cannot be
+    # checked, and silently passing is how the two copies would drift.
+    assert _MIRROR.is_file(), f"widget meta mirror not found at {_MIRROR}"
+    return _MIRROR.read_text(encoding="utf-8")
+
+
+def _parse_limits(source: str) -> dict[str, int]:
+    """The numbers out of ``META_LIMITS = { … } as const``.
+
+    Deliberately a dull scan rather than a parser: the block is a flat list of
+    ``name: number`` lines, and anything that stops being flat should fail the
+    exhaustiveness check below rather than be silently reinterpreted.
+    """
+    _, _, rest = source.partition("META_LIMITS = {")
+    body, _, _ = rest.partition("} as const")
+    limits: dict[str, int] = {}
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("/", "*")) or ":" not in stripped:
+            continue
+        name, _, value = stripped.partition(":")
+        value = value.strip().rstrip(",").strip()
+        if value.isdigit():
+            limits[name.strip()] = int(value)
+    return limits
+
+
+def _parse_locale_chars(source: str) -> str:
+    _, _, rest = source.partition("LOCALE_TAG_CHARS = ")
+    value, _, _ = rest.partition("\n")
+    return value.strip().rstrip(";").strip().strip('"')
+
+
+class TestMirrorsTheFrontend:
+    def test_every_limit_matches(self):
+        limits = _parse_limits(_read_mirror())
+        assert limits, "could not read META_LIMITS out of the mirror"
+        for name, constant in _MIRRORED_LIMITS.items():
+            assert name in limits, f"{name} is gone from the frontend's META_LIMITS"
+            assert limits[name] == getattr(widget_meta, constant), (
+                f"{name} and {constant} disagree"
+            )
+
+    def test_no_limit_exists_on_only_one_side(self):
+        limits = _parse_limits(_read_mirror())
+        assert set(limits) == set(_MIRRORED_LIMITS), (
+            "the frontend's META_LIMITS and this mirror hold different limits"
+        )
+
+    def test_the_locale_alphabet_matches(self):
+        chars = _parse_locale_chars(_read_mirror())
+        assert chars, "could not read LOCALE_TAG_CHARS out of the mirror"
+        assert frozenset(chars) == widget_meta.LOCALE_TAG_CHARS
+
+
+class TestLocalizedText:
+    def test_a_widget_may_ship_one_language(self):
+        assert localized_text({"en": "Chart"}, 120) == {"en": "Chart"}
+
+    def test_text_is_trimmed_and_truncated_rather_than_refused(self):
+        # Meta is presentation: a widget with one over-long label should still
+        # name itself, which is what the browser does with the same input.
+        assert localized_text({"en": "  Chart  "}, 120) == {"en": "Chart"}
+        assert localized_text({"en": "abcdef"}, 3) == {"en": "abc"}
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "en_US",  # underscore is not a language tag separator
+            "en US",
+            "toolongalanguagetag",
+            "",
+            "en/../..",
+        ],
+    )
+    def test_a_key_that_is_not_a_language_tag_is_dropped(self, tag):
+        assert localized_text({tag: "Chart", "en": "Chart"}, 120) == {"en": "Chart"}
+
+    def test_a_non_string_value_is_dropped_rather_than_coerced(self):
+        assert localized_text({"en": {"nested": "object"}, "de": "Diagramm"}, 120) == {
+            "de": "Diagramm"
+        }
+
+    def test_nothing_usable_reads_as_nothing(self):
+        assert localized_text({}, 120) is None
+        assert localized_text({"en": "   "}, 120) is None
+        assert localized_text("Chart", 120) is None
+        assert localized_text(["Chart"], 120) is None
+
+    def test_the_scan_stops_at_the_locale_cap(self):
+        many = {f"l{index:03d}": "x" for index in range(widget_meta.MAX_LOCALES + 5)}
+        # Not language tags, so nothing survives — but the point is that the
+        # scan is bounded rather than proportional to what a module supplies.
+        assert localized_text({**many, "en": "Chart"}, 120) is None
+
+
+class TestValidateWidgetMeta:
+    def test_a_widget_without_a_name_has_no_usable_meta(self):
+        assert validate_widget_meta({"description": {"en": "no name"}}) is None
+        assert validate_widget_meta(None) is None
+        assert validate_widget_meta("Chart") is None
+
+    def test_meta_is_rebuilt_from_checked_parts(self):
+        meta = validate_widget_meta(
+            {
+                "name": {"en": "Chart", "de": "Diagramm"},
+                "description": {"en": "Draws a series."},
+                "options": {
+                    "mark": {
+                        "label": {"en": "Mark"},
+                        "values": {"bar": {"en": "Bar"}, "line": {"en": "Line"}},
+                    }
+                },
+                "render": "function () {}",
+                "__proto__": {"en": "nope"},
+            }
+        )
+        assert meta == {
+            "name": {"en": "Chart", "de": "Diagramm"},
+            "description": {"en": "Draws a series."},
+            "options": {
+                "mark": {
+                    "label": {"en": "Mark"},
+                    "values": {"bar": {"en": "Bar"}, "line": {"en": "Line"}},
+                }
+            },
+        }
+
+    def test_an_option_without_a_label_is_dropped(self):
+        meta = validate_widget_meta(
+            {"name": {"en": "Chart"}, "options": {"mark": {"values": {}}}}
+        )
+        assert meta == {"name": {"en": "Chart"}}
+
+    def test_option_values_must_be_named(self):
+        # A positional list cannot say which value it labels, so it is dropped
+        # rather than read by index.
+        meta = validate_widget_meta(
+            {
+                "name": {"en": "Chart"},
+                "options": {"mark": {"label": {"en": "Mark"}, "values": ["Bar"]}},
+            }
+        )
+        assert meta["options"] == {"mark": {"label": {"en": "Mark"}}}

--- a/backend/app/services/marketplace/widget_meta_test.py
+++ b/backend/app/services/marketplace/widget_meta_test.py
@@ -188,4 +188,5 @@ class TestValidateWidgetMeta:
                 "options": {"mark": {"label": {"en": "Mark"}, "values": ["Bar"]}},
             }
         )
+        assert meta is not None
         assert meta["options"] == {"mark": {"label": {"en": "Mark"}}}

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -939,6 +939,9 @@ async def create_marketplace_listing(
         "kind": kind,
         "name": overrides.pop("name", "Test listing"),
         "publisher": overrides.pop("publisher", "Tests"),
+        # Attribution is required on every ingestion path, so a test listing
+        # carries one too.
+        "author": overrides.pop("author", {"name": "Tests"}),
         "description": overrides.pop("description", "A listing for tests."),
         "avatar_url": overrides.pop("avatar_url", "/marketplace/test.svg"),
         "version": version,

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -375,5 +375,10 @@
   "MARKETPLACE_LISTING_UNAVAILABLE": "Dieser Eintrag wurde zurückgezogen und kann nicht mehr installiert werden.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "Dieser Eintrag benötigt eine neuere Version der App. Bitte eine Administratorin oder einen Administrator um ein Update und versuche es dann erneut.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "Das wurde hier erstellt und nicht installiert – es gibt also keinen Eintrag, von dem aus aktualisiert werden könnte.",
-  "MARKETPLACE_ALREADY_LATEST_VERSION": "Das ist bereits auf der neuesten Version."
+  "MARKETPLACE_ALREADY_LATEST_VERSION": "Das ist bereits auf der neuesten Version.",
+  "GUILD_APP_NOT_FOUND": "Diese App ist in dieser Gilde nicht installiert.",
+  "GUILD_APP_ADMIN_REQUIRED": "Nur Gildenadministratorinnen und -administratoren können Apps verwalten.",
+  "GUILD_APP_LISTING_NOT_AN_APP": "Dieser Eintrag kann nicht als App installiert werden.",
+  "GUILD_APP_ALREADY_INSTALLED": "Diese Gilde hat diese App bereits installiert.",
+  "GUILD_APP_KIND_NOT_INSTALLABLE": "Diese Art von App kann in dieser Version von Initiative noch nicht installiert werden."
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -375,5 +375,10 @@
   "MARKETPLACE_LISTING_UNAVAILABLE": "This listing has been withdrawn and can no longer be installed.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "This listing needs a newer version of the app. Ask an administrator to update, then try again.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "This was built here rather than installed, so there is no listing to update it from.",
-  "MARKETPLACE_ALREADY_LATEST_VERSION": "This is already on the latest version."
+  "MARKETPLACE_ALREADY_LATEST_VERSION": "This is already on the latest version.",
+  "GUILD_APP_NOT_FOUND": "That app isn't installed in this guild.",
+  "GUILD_APP_ADMIN_REQUIRED": "Only guild admins can manage apps.",
+  "GUILD_APP_LISTING_NOT_AN_APP": "That listing can't be installed as an app.",
+  "GUILD_APP_ALREADY_INSTALLED": "This guild already has that app installed.",
+  "GUILD_APP_KIND_NOT_INSTALLABLE": "This kind of app can't be installed on this version of Initiative yet."
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -375,5 +375,10 @@
   "MARKETPLACE_LISTING_UNAVAILABLE": "Este elemento se ha retirado y ya no se puede instalar.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "Este elemento necesita una versión más reciente de la aplicación. Pide a un administrador que la actualice y vuelve a intentarlo.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "Esto se creó aquí en lugar de instalarse, así que no hay ningún elemento desde el que actualizarlo.",
-  "MARKETPLACE_ALREADY_LATEST_VERSION": "Ya está en la última versión."
+  "MARKETPLACE_ALREADY_LATEST_VERSION": "Ya está en la última versión.",
+  "GUILD_APP_NOT_FOUND": "Esa aplicación no está instalada en este gremio.",
+  "GUILD_APP_ADMIN_REQUIRED": "Solo los administradores del gremio pueden gestionar aplicaciones.",
+  "GUILD_APP_LISTING_NOT_AN_APP": "Ese elemento no se puede instalar como aplicación.",
+  "GUILD_APP_ALREADY_INSTALLED": "Este gremio ya tiene esa aplicación instalada.",
+  "GUILD_APP_KIND_NOT_INSTALLABLE": "Este tipo de aplicación todavía no se puede instalar en esta versión de Initiative."
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -375,5 +375,10 @@
   "MARKETPLACE_LISTING_UNAVAILABLE": "Cette fiche a été retirée et ne peut plus être installée.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "Cette fiche nécessite une version plus récente de l'application. Demandez à une administratrice ou un administrateur de la mettre à jour, puis réessayez.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "Ceci a été créé ici plutôt qu'installé : il n'y a donc aucune fiche depuis laquelle le mettre à jour.",
-  "MARKETPLACE_ALREADY_LATEST_VERSION": "Ceci est déjà à la dernière version."
+  "MARKETPLACE_ALREADY_LATEST_VERSION": "Ceci est déjà à la dernière version.",
+  "GUILD_APP_NOT_FOUND": "Cette application n'est pas installée dans cette guilde.",
+  "GUILD_APP_ADMIN_REQUIRED": "Seules les administratrices et administrateurs de la guilde peuvent gérer les applications.",
+  "GUILD_APP_LISTING_NOT_AN_APP": "Cette fiche ne peut pas être installée en tant qu'application.",
+  "GUILD_APP_ALREADY_INSTALLED": "Cette guilde a déjà installé cette application.",
+  "GUILD_APP_KIND_NOT_INSTALLABLE": "Ce type d'application ne peut pas encore être installé sur cette version d'Initiative."
 }


### PR DESCRIPTION
## Problem

The catalog's vocabulary is the shipped-listing vocabulary: two app kinds, no attribution, and a definition shape that assumes whoever wrote it also wrote this repo. The apps platform needs listings to arrive from people we did not review line by line, which means the validator has to become the trust boundary — and it means a user must be able to answer "who wrote this?" before installing, not after.

## Changes

**Attribution is required and bounded.** Every listing states its author; one without `author.name` is refused on every ingestion path, and `author_name` is `NOT NULL` on `marketplace_listings`, so the requirement holds at the database layer as well as the validator. Because a name alone is a claim anyone can type, it is bounded by provenance: **`core.*` is reserved** to listings shipped in this repo, and a listing from any other source claiming one is refused by name.

**`app_kind: "service"`** — the app-platform shape, with a strict validator:

- `features[]` — closed vocabulary, **cross-validated against the blocks present in both directions**: declaring `widgets` with no `widgets[]` block fails, and shipping `widgets[]` without declaring the feature fails. One declaration, drift-checked, so what the install dialog promises is what the app can do.
- `connections[]` carrying `static` (guild-scoped) or `interactive` (per-member) scope, and `requires` evaluated over those ids.
- `widgets[]` whose `module_source` is an **opaque, size-capped string** — never parsed, compiled, or executed on the server — with localized meta validated by a Python mirror of the frontend's rules.
- `data_sources[]`, `embeds[]`, namespaced `events[]`, and an `automation` block stored as an **opaque blob this build never interprets**.
- Widget type ids namespaced `app:<uid>:<widget_id>`, so no app can shadow a built-in widget type.

**Validation is total** — closed vocabularies, unknown keys dropped, every string, list, and body capped (document ≤512 KiB, binding before 12×64 KiB widgets). A manifest still carries **no address**: paths only, joined later to a base URL that comes from a deployment-level registration.

## Points worth a reviewer's attention

- **The structural guard is the interesting test.** `service_apps_test.py` parses every module in the marketplace package and fails if any of them can turn stored text into behaviour. I tightened it during review: it now checks attribute calls too, exempting one explicit `(receiver, method)` pair for SQLModel's `session.exec()`, so `builtins.exec(...)`, `__builtins__.exec(...)` and `obj.attr.exec(...)` all still trip. Two tests pin that the exemption doesn't generalize. Paired with a test that a hostile `module_source` goes in and comes out byte for byte.
- **Three sibling modules, not a package.** `manifest_values` → `widget_meta` → `service_apps` → `definitions`, with `definitions.py` staying the public façade at ~250 lines, so **no import anywhere in the codebase changes**. Converting to a `definitions/` package later is a pure move.
- **`scope`, not `kind`, on connections** — the design doc's §7.1 example uses `kind`; this follows the agreed field name and accepts no alias. Worth reconciling the doc.
- **`service.default_url` is dropped** even though the design lists it as a form-prefill hint — "no absolute URLs in a manifest" won, and a test asserts no `http(s)://` survives anywhere in a normalized definition.
- **`requires` takes exactly one of `all_of`/`any_of`** — both present is refused rather than given invented AND-semantics. Fail-closed, trivially relaxed later.
- **The migration fills via DDL, not DML** — `ADD COLUMN … NOT NULL DEFAULT 'Initiative'`, then drop the default. DDL is not policy-bound, so the FORCE-RLS silent-zero-row backfill trap cannot apply, and `NOT NULL` is Postgres's own assertion over every row.
- **`publisher` now derives from `author.name`** when a manifest doesn't state one, so the shipped JSONs no longer say "Initiative" twice. A registry can still bind a publisher prefix distinct from the author. The API contract is unchanged.

## Schema / env

Migration `20260812_0168` (`down_revision = 20260812_0167`). Two other branches in this series also branch from `…0167`; whichever merges later gets its `down_revision` re-pointed.

**No OpenAPI change** — verified by exporting the spec on this branch and on `dev` and diffing: identical. Author is stored but not yet served, so no Orval regeneration. Exposing it on the API belongs with the UI phase that renders the provenance line.

## Testing

```
cd backend && pytest app/services/marketplace/ \
                     app/api/v1/tenant_endpoints/guild_apps_test.py \
                     app/api/v1/tenant_endpoints/dashboards_install_test.py \
                     app/api/v1/platform_endpoints/marketplace_test.py \
                     app/db/model_drift_test.py
# 225 passed
cd backend && pytest alembic/migrations_test.py   # 11 passed
cd backend && ruff check app && ruff format app
```

Includes the widget-meta drift test (reads the frontend validator and pins every limit and the locale alphabet), the structural no-execution guard, and a test that every shipped catalog JSON validates including its author.

Four `GUILD_APP_*` error codes that `guild_apps.py` already raised turned out to have **no locale entries at all**; they are now in all four locales along with the new one.

## Follow-up for the install-model branch

`guild_apps.py` still checks `definition.get("app_kind") not in APP_KINDS`, and `APP_KINDS` now contains `service`. That should become `GUILD_INSTALLABLE_APP_KINDS` with `GuildAppMessages.KIND_NOT_INSTALLABLE` (409). It is unreachable today — no service listing can enter the catalog in this branch — but it is a latent 500 in `create_app_content` the moment one can. Left alone here to avoid colliding with that branch.