### PR TITLE
Review the JSONB rotation sweep's dynamic SQL

### DIFF
--- a/backend/app/db/sql_injection_guard_test.py
+++ b/backend/app/db/sql_injection_guard_test.py
@@ -83,6 +83,10 @@ ALLOWED_DYNAMIC_SQL: dict[str, str] = {
         "admin rotation job; table/column names validated against an "
         "allow-list before interpolation"
     ),
+    "app/db/secret_key_rotation.py::_rotate_fernet_json_map": (
+        "same rotation job for JSONB-held ciphertexts; schema is int-derived "
+        "via guild_schema_name, table/column come from a module constant"
+    ),
     "app/services/storage_backfill.py::_persist": (
         "SET clause joined from literal 'col = :bind' fragments; all values bound"
     ),


### PR DESCRIPTION
Post-merge cleanup for the app-platform series. One real fix, and two checks that came back clean.

## The failure

`sql_injection_guard_test.py::test_no_unreviewed_dynamic_sql_sites` flagged a new site:

```
app/db/secret_key_rotation.py::_rotate_fernet_json_map
```

That is the arm added with the install model, which re-encrypts the ciphertexts held *inside* a JSONB map (an app declares many connection fields, so they cannot each have a column). It builds its statement the same way `_rotate_fernet_column` beside it already does, so the tripwire did exactly its job: a new string-built statement appeared and nobody had signed off on it.

Reviewed against the standard the allow-list states, and it holds:

- **schema** — `guild_schema_name(gid)`, derived from an int, never from a request
- **table / column** — from the module-level `_GUILD_SCHEMA_JSON_MAPS` constant, not a parameter
- every identifier is quoted, and the row values are bound

So it is recorded in `ALLOWED_DYNAMIC_SQL` with its reason rather than rewritten. This is the intended workflow for the guard — a human looks, then the site is named — not a suppression.

## The two checks that were clean

**Migration ordering.** `alembic heads` reports a single head, `20260812_0171`, and the chain is linear from `0164`:

```
0164 → 0165 → 0166 → 0167 → 0168 → 0169 → 0170 → 0171
```

The re-pointing done while the PRs were stacked survived the merges intact — no branch, no second head.

**Generated frontend types.** Re-ran `export_openapi.py` + `pnpm orval` + `biome format` against `dev`: no diff, so the committed output already matches the current backend schemas. `pnpm exec tsc --noEmit` passes.

## Merge integrity

Several pieces were at risk while these branches were merged into one another — a hunk collision had already deleted one endpoint and moved three message codes onto the wrong class mid-series. Confirmed present on `dev`:

- `POST /marketplace/operator-catalog/rescan`
- `OPERATOR_CATALOG_NOT_CONFIGURED` / `_DIR_MISSING` / `_SCAN_RUNNING` on `MarketplaceMessages` (not on `MarketplaceRegistryMessages`)
- the registry refresh worker in `background_tasks`

## Testing

```
cd backend && pytest app/db/sql_injection_guard_test.py   # 2 passed
cd backend && ruff check app && ruff format app
cd frontend && pnpm exec tsc --noEmit
```

Full suites left to CI.