### PR TITLE
Let an app service call back into Initiative

### DIFF
--- a/backend/alembic/versions/20260812_0173_app_service_nonces.py
+++ b/backend/alembic/versions/20260812_0173_app_service_nonces.py
@@ -1,0 +1,77 @@
+"""app service nonces
+
+The ``public`` table backing the replay guard on the app-service request-signing
+channel: one row per signed request an app has already spent, keyed by
+(registration, nonce) so each app has its own namespace.
+
+Access shape (system engine only):
+
+* the verifier inserts and reads on ``app_admin``; the shared jti janitor
+  deletes rows whose freshness window has passed.
+* every other role holds nothing. The schema default-grants the base/login
+  roles full DML on each new ``public`` table, so those are revoked here — no
+  request-path role has any business in the guard that protects a
+  machine-to-machine channel.
+* RLS is enabled and FORCEd with no policies, matching the registrations table
+  it hangs off: the grant layer and the policy layer both say no.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260812_0173"
+down_revision = "20260812_0172"
+branch_labels = None
+depends_on = None
+
+TABLE = "app_service_nonces"
+
+
+def _platform(role: str) -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_{role}"
+
+
+def _run(statements: list[str]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE,
+        sa.Column("registration_id", sa.Integer(), nullable=False),
+        sa.Column("nonce", sa.String(length=64), nullable=False),
+        sa.Column("seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["registration_id"],
+            ["app_service_registrations.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("registration_id", "nonce"),
+    )
+    # The janitor sweeps by expiry, so that is the column it reads.
+    op.create_index(f"ix_{TABLE}_expires_at", TABLE, ["expires_at"], unique=False)
+
+    base = _platform("base")
+    _run(
+        [
+            f"ALTER TABLE public.{TABLE} ENABLE ROW LEVEL SECURITY",
+            f"ALTER TABLE public.{TABLE} FORCE ROW LEVEL SECURITY",
+            f"REVOKE ALL ON TABLE public.{TABLE} "
+            f'FROM app_guild_base, "{base}", app_user',
+            f"GRANT SELECT, INSERT, DELETE ON TABLE public.{TABLE} TO app_admin",
+        ]
+    )
+
+
+def downgrade() -> None:
+    _run(
+        [
+            f"ALTER TABLE public.{TABLE} DISABLE ROW LEVEL SECURITY",
+        ]
+    )
+    op.drop_index(f"ix_{TABLE}_expires_at", table_name=TABLE)
+    op.drop_table(TABLE)

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -8,6 +8,12 @@ from fastapi import APIRouter
 #                          …), including the cross-guild "my" aggregates that read
 #                          them — the one place tenant data is read without a
 #                          single guild context (see /me routes below).
+#   app_service_endpoints/ — the channels an external app service calls back on.
+#                          Split by CALLER rather than by data: no user is
+#                          resolved, the caller is established from a request
+#                          signature, and which guild it may reach follows from
+#                          that.
+from app.api.v1 import app_service_endpoints
 from app.api.v1.tenant_endpoints import (
     advanced_tool,
     ai_settings,
@@ -91,6 +97,13 @@ api_router.include_router(settings.router, prefix="/settings", tags=["settings"]
 # like the catalog: a registration belongs to the deployment, never to a guild.
 api_router.include_router(
     app_services.router, prefix="/app-services", tags=["app-services"]
+)
+# The other half of that wiring: what a registered app service may call back on.
+# Authenticated by request signature against its registration's shared secret —
+# no user, no session, no guild in a header. The guild each call operates in is
+# named in the path and re-checked against the caller's own installs.
+api_router.include_router(
+    app_service_endpoints.router, prefix="/app-service", tags=["app-service"]
 )
 api_router.include_router(
     auth_providers.router, prefix="/settings/auth/providers", tags=["auth-providers"]

--- a/backend/app/api/v1/app_service_endpoints/__init__.py
+++ b/backend/app/api/v1/app_service_endpoints/__init__.py
@@ -1,0 +1,38 @@
+"""Endpoints an app service calls back into Initiative on.
+
+A third family beside ``platform_endpoints/`` and ``tenant_endpoints/``, split
+out by *who calls* rather than by what the data is: no user is ever resolved
+here, and no session cookie or bearer token is read. The caller is an external
+container proving it holds its registration's shared secret, and everything it
+may reach follows from which registration that is.
+
+The channels, all under ``/api/v1/app-service``:
+
+* ``GET /installs`` — which guilds have this app, at which pinned version.
+* ``GET /installs/{guild_id}/config`` — the decrypted configuration for one
+  install. The custody channel: the one place stored plaintext leaves.
+* ``GET /installs/{guild_id}/connections`` — the app's per-member connections,
+  by opaque reference, with status only.
+* ``PUT /installs/{guild_id}/connections/{connection_ref}`` — what a vendor flow
+  produced, written back into the platform's custody.
+* ``POST /installs/{guild_id}/status`` — the app's verdict on the configuration
+  it was handed.
+* ``POST /events`` — third-party events, re-emitted through the dispatcher the
+  automation delegate already subscribes to.
+
+Ingress is one-way. Apps emit events and never subscribe: delivery targets
+belong to the automation delegate, and nothing here creates one.
+"""
+
+from fastapi import APIRouter
+
+from app.api.v1.app_service_endpoints import events, installs
+
+# Not part of the OpenAPI document: this surface is consumed by app containers
+# implementing the app protocol, never by the SPA, and the generated frontend
+# client has no business carrying a channel no browser may call.
+router = APIRouter(include_in_schema=False)
+router.include_router(installs.router)
+router.include_router(events.router)
+
+__all__ = ["router"]

--- a/backend/app/api/v1/app_service_endpoints/channel_auth_test.py
+++ b/backend/app/api/v1/app_service_endpoints/channel_auth_test.py
@@ -1,0 +1,292 @@
+"""How an app service proves it is the app it says it is.
+
+Everything on this surface hangs off one question — which registration signed
+this request — so these tests hold that question rather than any route's answer.
+Four properties, and each is asserted through the real HTTP surface rather than
+against the verifier in isolation:
+
+**The secret is the identity.** A request signed with the wrong secret is
+refused, and so is one whose body changed after signing. The ``X-Initiative-App``
+header only says which key to check; it never establishes who is calling.
+
+**A signed request works once.** The same headers presented twice succeed and
+then fail, because the nonce is spent on first use. The guard is per app, so one
+app's traffic can never consume another's.
+
+**Freshness is bounded.** A signature made outside the window is refused whether
+or not the nonce is fresh, which is what keeps the guard's memory finite.
+
+**The operator's switch outranks the key.** A disabled registration is refused
+after its signature verifies — it is a state, not a failure to authenticate.
+"""
+
+import time
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import AppChannelMessages
+from app.services.marketplace.app_channel_auth import (
+    APP_HEADER,
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    SIGNATURE_WINDOW_SECONDS,
+    TIMESTAMP_HEADER,
+)
+from app.testing import (
+    APP_CHANNEL_SECRET,
+    channel_headers,
+    encode_body,
+    register_app_service,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.auth]
+
+INSTALLS = "/api/v1/app-service/installs"
+
+
+def _headers(**overrides) -> dict[str, str]:
+    return channel_headers(method="GET", path=INSTALLS, **overrides)
+
+
+async def test_a_signed_request_is_accepted(client: AsyncClient, session: AsyncSession):
+    """The baseline: a request signed with the registration's own secret
+    reaches the route. An app with no installs yet gets an empty list, which is
+    a correct answer rather than a refusal."""
+    await register_app_service(session)
+
+    response = await client.get(INSTALLS, headers=_headers())
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"items": []}
+
+
+async def test_an_unsigned_request_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    await register_app_service(session)
+
+    response = await client.get(INSTALLS)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.MISSING_SIGNATURE
+
+
+async def test_a_partially_signed_request_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    """Every signing header is required: dropping the nonce would leave a
+    signature that could be presented repeatedly."""
+    await register_app_service(session)
+    headers = _headers()
+    del headers[NONCE_HEADER]
+
+    response = await client.get(INSTALLS, headers=headers)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.MISSING_SIGNATURE
+
+
+async def test_the_wrong_secret_is_refused(client: AsyncClient, session: AsyncSession):
+    await register_app_service(session)
+
+    response = await client.get(INSTALLS, headers=_headers(secret="not-the-secret"))
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.INVALID_SIGNATURE
+
+
+async def test_a_body_changed_after_signing_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    """The signature covers a digest of the body, so a request whose payload was
+    swapped for another is not the request that was signed."""
+    await register_app_service(session)
+    path = "/api/v1/app-service/events"
+    signed = encode_body({"guild_id": 1, "event_type": "app.tests.shop.x"})
+    sent = encode_body({"guild_id": 2, "event_type": "app.tests.shop.x"})
+
+    response = await client.post(
+        path,
+        headers=channel_headers(method="POST", path=path, body=signed),
+        content=sent,
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.INVALID_SIGNATURE
+
+
+async def test_a_signature_for_another_path_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    """The path is signed too, so a signature captured from one route cannot be
+    replayed against another."""
+    await register_app_service(session)
+    headers = channel_headers(
+        method="GET", path="/api/v1/app-service/installs/1/config"
+    )
+
+    response = await client.get(INSTALLS, headers=headers)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.INVALID_SIGNATURE
+
+
+async def test_an_unknown_app_is_refused(client: AsyncClient, session: AsyncSession):
+    await register_app_service(session)
+
+    response = await client.get(INSTALLS, headers=_headers(public_id="tests.nobody"))
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.UNKNOWN_APP
+
+
+async def test_a_registration_without_a_secret_cannot_authenticate(
+    client: AsyncClient, session: AsyncSession
+):
+    """An operator may clear a secret without deleting the row. What is left
+    has nothing to verify a signature against, so nothing authenticates as it."""
+    await register_app_service(session, secret=None)
+
+    response = await client.get(INSTALLS, headers=_headers())
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.INVALID_SIGNATURE
+
+
+@pytest.mark.parametrize("offset", [-(SIGNATURE_WINDOW_SECONDS + 60), 3600])
+async def test_a_stale_timestamp_is_refused(
+    client: AsyncClient, session: AsyncSession, offset: int
+):
+    """Both directions: too old, and too far in the future. A signature that is
+    always acceptable would need a guard that remembers forever."""
+    await register_app_service(session)
+    stale = int(time.time()) + offset
+
+    response = await client.get(INSTALLS, headers=_headers(timestamp=stale))
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.STALE_TIMESTAMP
+
+
+async def test_an_unparseable_timestamp_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    await register_app_service(session)
+    headers = _headers()
+    headers[TIMESTAMP_HEADER] = "yesterday"
+
+    response = await client.get(INSTALLS, headers=headers)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.STALE_TIMESTAMP
+
+
+async def test_a_replayed_request_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    """The same signed request, sent twice. The first is served; the second is
+    refused because its nonce was spent on the first."""
+    await register_app_service(session)
+    headers = _headers()
+
+    first = await client.get(INSTALLS, headers=headers)
+    second = await client.get(INSTALLS, headers=headers)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 401
+    assert second.json()["detail"] == AppChannelMessages.REPLAYED_REQUEST
+
+
+async def test_the_replay_guard_is_scoped_to_one_app(
+    client: AsyncClient, session: AsyncSession
+):
+    """Two apps using the same nonce value both succeed: the guard is keyed by
+    (registration, nonce), so what one app spends is not taken from another."""
+    await register_app_service(session)
+    await register_app_service(
+        session,
+        public_id="tests.other",
+        listing_uid="TESTAPP0000002",
+        secret="other-secret",
+    )
+    shared_nonce = "the-same-value"
+
+    first = await client.get(INSTALLS, headers=_headers(nonce=shared_nonce))
+    second = await client.get(
+        INSTALLS,
+        headers=_headers(
+            nonce=shared_nonce, public_id="tests.other", secret="other-secret"
+        ),
+    )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+
+
+async def test_an_oversized_nonce_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    """Bounded while verifying, so a value the guard column could not hold is a
+    clean refusal rather than an error at the insert."""
+    await register_app_service(session)
+
+    response = await client.get(INSTALLS, headers=_headers(nonce="n" * 200))
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.MISSING_SIGNATURE
+
+
+async def test_a_disabled_registration_is_refused(
+    client: AsyncClient, session: AsyncSession
+):
+    """The operator's kill switch: the signature is fine, and the app still
+    reaches nothing."""
+    await register_app_service(session, enabled=False)
+
+    response = await client.get(INSTALLS, headers=_headers())
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == AppChannelMessages.APP_DISABLED
+
+
+async def test_a_disabled_registration_does_not_spend_a_nonce(
+    client: AsyncClient, session: AsyncSession
+):
+    """Refusing before the burn means re-enabling the app does not leave the
+    caller's in-flight retries poisoned."""
+    registration = await register_app_service(session, enabled=False)
+    headers = _headers()
+
+    refused = await client.get(INSTALLS, headers=headers)
+    assert refused.status_code == 403
+
+    registration.enabled = True
+    session.add(registration)
+    await session.commit()
+
+    accepted = await client.get(INSTALLS, headers=headers)
+    assert accepted.status_code == 200, accepted.text
+
+
+async def test_the_app_header_alone_establishes_nothing(
+    client: AsyncClient, session: AsyncSession
+):
+    """Naming one app while signing as another is refused. The header selects a
+    key; the signature is what decides."""
+    await register_app_service(session)
+    await register_app_service(
+        session,
+        public_id="tests.other",
+        listing_uid="TESTAPP0000002",
+        secret="other-secret",
+    )
+    headers = _headers(public_id="tests.other", secret=APP_CHANNEL_SECRET)
+    assert headers[APP_HEADER] == "tests.other"
+    assert headers[SIGNATURE_HEADER].startswith("sha256=")
+
+    response = await client.get(INSTALLS, headers=headers)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == AppChannelMessages.INVALID_SIGNATURE

--- a/backend/app/api/v1/app_service_endpoints/deps.py
+++ b/backend/app/api/v1/app_service_endpoints/deps.py
@@ -1,0 +1,98 @@
+"""Resolving the calling app, and turning a service refusal into an answer.
+
+Every route on this surface starts the same way: read the raw body, establish
+which registration signed it, and only then look at what the request asked for.
+The body is read before it is parsed because the signature covers the exact
+bytes that arrived — verifying a re-serialized copy would be verifying something
+the caller never sent.
+
+The session is the system engine throughout. Registrations and the replay guard
+carry no request-path grant, and no guild is known until the route says which
+one; guild content is then reached by routing that same session into one guild
+at a time (see :mod:`app.services.tenant.app_channels`).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Type, TypeVar
+
+from fastapi import Depends, HTTPException, Request, status
+from pydantic import BaseModel, ValidationError
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import AppChannelMessages
+from app.db.session import get_admin_session
+from app.services.marketplace.app_channel_auth import (
+    AppChannelAuthError,
+    CallingApp,
+    authenticate_caller,
+)
+from app.services.tenant.app_channels import AppChannelError
+
+__all__ = [
+    "AdminSessionDep",
+    "CallerDep",
+    "parse_body",
+    "raw_body",
+    "signed_caller",
+    "to_http",
+]
+
+AdminSessionDep = Annotated[AsyncSession, Depends(get_admin_session)]
+
+#: The raw request body, stashed on the request state by :func:`signed_caller`
+#: so a route can parse the same bytes the signature was checked over.
+_BODY_STATE_KEY = "app_channel_body"
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+def to_http(exc: AppChannelAuthError | AppChannelError) -> HTTPException:
+    """One mapping for both service-layer refusals: each carries the message
+    code to surface and the status it belongs to."""
+    return HTTPException(status_code=exc.status_code, detail=exc.code)
+
+
+async def signed_caller(request: Request, session: AdminSessionDep) -> CallingApp:
+    """The registration whose secret signed this request.
+
+    Raises before any route body runs, so an unauthenticated call never reaches
+    a guild lookup. The verified caller is the *only* statement of who is
+    calling — no route reads an app identity out of a payload.
+    """
+    body = await request.body()
+    setattr(request.state, _BODY_STATE_KEY, body)
+    try:
+        return await authenticate_caller(
+            session,
+            method=request.method,
+            path=request.url.path,
+            headers=request.headers,
+            body=body,
+        )
+    except AppChannelAuthError as exc:
+        raise to_http(exc) from exc
+
+
+CallerDep = Annotated[CallingApp, Depends(signed_caller)]
+
+
+def raw_body(request: Request) -> bytes:
+    """The exact bytes the signature was verified over."""
+    return getattr(request.state, _BODY_STATE_KEY, b"") or b""
+
+
+def parse_body(request: Request, model: Type[ModelT]) -> ModelT:
+    """Parse the bytes the signature covered into a request model.
+
+    Routes take no declared body parameter — FastAPI would parse one before the
+    dependency above ever sees the request — so parsing happens here, after the
+    caller is established, against the bytes already read.
+    """
+    try:
+        return model.model_validate_json(raw_body(request) or b"{}")
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=AppChannelMessages.INVALID_PAYLOAD,
+        ) from exc

--- a/backend/app/api/v1/app_service_endpoints/events.py
+++ b/backend/app/api/v1/app_service_endpoints/events.py
@@ -41,6 +41,11 @@ router = APIRouter()
 #: The whole request, with room for the envelope around a payload already capped
 #: at :data:`MAX_EVENT_PAYLOAD_BYTES`. Checked against the bytes the signature
 #: covered, before they are parsed.
+#:
+#: The transport refuses anything past this first (``body_limit``), so a body
+#: is never buffered unbounded for a caller who has not authenticated. This
+#: check stays because the middleware reads Content-Length and a chunked
+#: request carries none — and the two are asserted equal, so neither can drift.
 MAX_EVENT_REQUEST_BYTES = MAX_EVENT_PAYLOAD_BYTES + 8 * 1024
 
 

--- a/backend/app/api/v1/app_service_endpoints/events.py
+++ b/backend/app/api/v1/app_service_endpoints/events.py
@@ -1,0 +1,79 @@
+"""Third-party events entering the platform through an app.
+
+The shape of the trip: a vendor calls the app service, the app verifies that
+vendor's own signature and works out which of its installs the event belongs to,
+then posts it here. Initiative adds the half only it can — the event type is one
+the *pinned* definition declares, namespaced under the calling app, and the
+guild named has that app installed and switched on — and re-emits it through the
+dispatcher that already exists.
+
+Re-emitting rather than forwarding is what keeps one inbound trust relationship
+for the automation delegate: from the dispatcher on, an app's event is an
+ordinary event, matched by the same subscriptions and deduped in the same place
+as a task or a document change.
+
+**Ingress is one-way.** Apps emit; they never subscribe. Delivery targets are
+created and modified only by the automation delegate, so there is nothing on
+this router that registers one.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from app.api.v1.app_service_endpoints.deps import (
+    AdminSessionDep,
+    CallerDep,
+    parse_body,
+    raw_body,
+    to_http,
+)
+from app.core.messages import AppChannelMessages
+from app.schemas.tenant.app_channel import AppEventIngest
+from app.services.tenant import app_channels as channels_service
+from app.services.tenant.app_channels import (
+    MAX_EVENT_PAYLOAD_BYTES,
+    AppChannelError,
+)
+
+router = APIRouter()
+
+#: The whole request, with room for the envelope around a payload already capped
+#: at :data:`MAX_EVENT_PAYLOAD_BYTES`. Checked against the bytes the signature
+#: covered, before they are parsed.
+MAX_EVENT_REQUEST_BYTES = MAX_EVENT_PAYLOAD_BYTES + 8 * 1024
+
+
+@router.post("/events", status_code=status.HTTP_202_ACCEPTED)
+async def ingest_event(
+    request: Request, session: AdminSessionDep, caller: CallerDep
+) -> dict[str, str]:
+    """Re-emit one third-party event into a guild the calling app is installed in.
+
+    Answers ``202`` rather than ``200``: the platform has accepted the event and
+    handed it to the dispatcher. What subscribers do with it — and whether a
+    deployment has any — is not something the emitting app is told, which is the
+    same boundary that keeps it from learning who subscribes.
+    """
+    body = raw_body(request)
+    if len(body) > MAX_EVENT_REQUEST_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=AppChannelMessages.EVENT_TOO_LARGE,
+        )
+
+    payload = parse_body(request, AppEventIngest)
+    try:
+        app = await channels_service.load_install(
+            session, caller.registration, payload.guild_id
+        )
+        await channels_service.emit_event(
+            session,
+            app,
+            caller.registration,
+            event_type=payload.event_type,
+            payload=payload.payload,
+        )
+    except AppChannelError as exc:
+        raise to_http(exc) from exc
+    return {"status": "accepted"}

--- a/backend/app/api/v1/app_service_endpoints/events_test.py
+++ b/backend/app/api/v1/app_service_endpoints/events_test.py
@@ -17,6 +17,7 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.api.v1.app_service_endpoints.events import MAX_EVENT_REQUEST_BYTES
 from app.core.messages import AppChannelMessages
 from app.services.tenant import app_channels as channels_service
 from app.testing import (
@@ -291,3 +292,26 @@ async def test_an_unparseable_body_is_refused(
     assert response.status_code == 422
     assert response.json()["detail"] == AppChannelMessages.INVALID_PAYLOAD
     assert dispatched == []
+
+
+class TestTheTransportRefusesFirst:
+    """An oversized body is refused before it is buffered.
+
+    Every route on this surface has to read its body to check the signature
+    that covers it, which means an unauthenticated caller can make the worker
+    hold whatever they send. The ceiling therefore lives at the transport seam,
+    and the handler's exact cap stays as the check for a chunked request that
+    carries no Content-Length.
+    """
+
+    def test_the_transport_ceiling_matches_the_handler_cap(self):
+        from app.core.body_limit import APP_SERVICE_MAX_REQUEST_BYTES
+
+        assert APP_SERVICE_MAX_REQUEST_BYTES == MAX_EVENT_REQUEST_BYTES
+
+    def test_the_app_service_surface_has_a_transport_rule(self):
+        from app.core.body_limit import _RULES
+
+        assert any(
+            pattern.match("/api/v1/app-service/events") for pattern, _, _ in _RULES
+        ), "app-service routes buffer before authenticating and need a body ceiling"

--- a/backend/app/api/v1/app_service_endpoints/events_test.py
+++ b/backend/app/api/v1/app_service_endpoints/events_test.py
@@ -1,0 +1,293 @@
+"""Third-party events entering through an app.
+
+The platform's half of the trip is narrow and worth pinning exactly: the event
+type is one the *pinned* definition declares, it sits under the calling app's
+own namespace, the guild has that app installed and switched on, and the body is
+within a bound. Past those, it becomes an ordinary event — so the test that
+matters most is that a valid one reaches ``dispatch_event`` unchanged, because
+everything after that is machinery this phase did not build.
+
+The namespace check is deliberately independent of the declaration check. A
+manifest cannot get past the listing validator carrying another app's prefix,
+but a pinned definition is a stored snapshot, and the ingress refuses on the
+prefix in its own right rather than trusting that validation happened.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import AppChannelMessages
+from app.services.tenant import app_channels as channels_service
+from app.testing import (
+    channel_headers,
+    create_guild,
+    create_guild_app,
+    create_user,
+    encode_body,
+    register_app_service,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+EVENTS = "/api/v1/app-service/events"
+SHOP_UID = "TESTAPP0000001"
+ORDER_CREATED = "app.tests.shop.order_created"
+
+
+def _definition(public_id: str = "tests.shop", events: list[str] | None = None) -> dict:
+    return {
+        "app_kind": "service",
+        "service": {"public_id": public_id, "protocol": 1},
+        "features": ["events"],
+        "events": [ORDER_CREATED] if events is None else events,
+    }
+
+
+@pytest.fixture
+def dispatched(monkeypatch):
+    """What reached the dispatcher, without delivering anything.
+
+    Delivery targets belong to the automation delegate, and an unconfigured
+    deployment has none — so capturing the call is what says the event arrived
+    at the right seam.
+    """
+    calls: list[dict] = []
+
+    async def _capture(session, *, event_type, guild_id, payload, initiative_id=None):
+        calls.append(
+            {
+                "event_type": event_type,
+                "guild_id": guild_id,
+                "payload": payload,
+                "initiative_id": initiative_id,
+            }
+        )
+
+    monkeypatch.setattr(channels_service, "dispatch_event", _capture)
+    return calls
+
+
+async def _install(session: AsyncSession, *, definition=None, **overrides):
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    app = await create_guild_app(
+        session,
+        guild,
+        user,
+        definition=definition or _definition(),
+        listing_uid=overrides.pop("listing_uid", SHOP_UID),
+        **overrides,
+    )
+    return guild, app
+
+
+async def _emit(client: AsyncClient, payload, **kwargs):
+    body = encode_body(payload)
+    return await client.post(
+        EVENTS,
+        headers=channel_headers(method="POST", path=EVENTS, body=body, **kwargs),
+        content=body,
+    )
+
+
+async def test_a_declared_event_reaches_the_dispatcher(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(session)
+
+    response = await _emit(
+        client,
+        {
+            "guild_id": guild.id,
+            "event_type": ORDER_CREATED,
+            "payload": {"order_id": "1001"},
+        },
+    )
+
+    assert response.status_code == 202, response.text
+    assert dispatched == [
+        {
+            "event_type": ORDER_CREATED,
+            "guild_id": guild.id,
+            "payload": {"order_id": "1001"},
+            "initiative_id": None,
+        }
+    ]
+
+
+async def test_an_event_carries_no_initiative(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    """Apps see guilds, not initiatives, so an app's event is guild-scoped and
+    a field naming an initiative is simply not part of the shape."""
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(session)
+
+    response = await _emit(
+        client,
+        {
+            "guild_id": guild.id,
+            "event_type": ORDER_CREATED,
+            "payload": {},
+            "initiative_id": 7,
+        },
+    )
+
+    assert response.status_code == 202, response.text
+    assert dispatched[0]["initiative_id"] is None
+
+
+async def test_an_undeclared_event_type_is_refused(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(session)
+
+    response = await _emit(
+        client,
+        {
+            "guild_id": guild.id,
+            "event_type": "app.tests.shop.never_declared",
+            "payload": {},
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == AppChannelMessages.UNKNOWN_EVENT_TYPE
+    assert dispatched == []
+
+
+async def test_another_apps_namespace_is_refused(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    """Even a pinned definition that lists it: an app announces and emits only
+    under its own name, so the prefix is checked against the caller."""
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(
+        session, definition=_definition(events=["app.tests.other.order_created"])
+    )
+
+    response = await _emit(
+        client,
+        {
+            "guild_id": guild.id,
+            "event_type": "app.tests.other.order_created",
+            "payload": {},
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == AppChannelMessages.UNKNOWN_EVENT_TYPE
+    assert dispatched == []
+
+
+async def test_an_oversized_event_is_refused(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    """An event is a notification, not a transfer: an app with more to say
+    serves it from a data source the platform fetches on demand."""
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(session)
+    oversized = "x" * (channels_service.MAX_EVENT_PAYLOAD_BYTES + 1_000)
+
+    response = await _emit(
+        client,
+        {
+            "guild_id": guild.id,
+            "event_type": ORDER_CREATED,
+            "payload": {"note": oversized},
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == AppChannelMessages.EVENT_TOO_LARGE
+    assert dispatched == []
+
+
+async def test_a_body_beyond_the_request_bound_is_refused(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    """Checked against the bytes the signature covered, before they are parsed."""
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(session)
+
+    response = await _emit(
+        client,
+        {
+            "guild_id": guild.id,
+            "event_type": ORDER_CREATED,
+            "payload": {"note": "x" * (128 * 1024)},
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == AppChannelMessages.EVENT_TOO_LARGE
+    assert dispatched == []
+
+
+async def test_an_event_for_a_guild_without_the_install_is_refused(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    await register_app_service(session, listing_uid=SHOP_UID)
+    user = await create_user(session)
+    bare = await create_guild(session, creator=user)
+
+    response = await _emit(
+        client,
+        {"guild_id": bare.id, "event_type": ORDER_CREATED, "payload": {}},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == AppChannelMessages.INSTALL_NOT_FOUND
+    assert dispatched == []
+
+
+async def test_a_disabled_install_refuses_events(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(session, enabled=False)
+
+    response = await _emit(
+        client,
+        {"guild_id": guild.id, "event_type": ORDER_CREATED, "payload": {}},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == AppChannelMessages.INSTALL_DISABLED
+    assert dispatched == []
+
+
+async def test_a_disabled_registration_refuses_events(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    await register_app_service(session, listing_uid=SHOP_UID, enabled=False)
+    guild, _ = await _install(session)
+
+    response = await _emit(
+        client,
+        {"guild_id": guild.id, "event_type": ORDER_CREATED, "payload": {}},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == AppChannelMessages.APP_DISABLED
+    assert dispatched == []
+
+
+async def test_an_unparseable_body_is_refused(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    await register_app_service(session, listing_uid=SHOP_UID)
+    body = b"not json at all"
+
+    response = await client.post(
+        EVENTS,
+        headers=channel_headers(method="POST", path=EVENTS, body=body),
+        content=body,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == AppChannelMessages.INVALID_PAYLOAD
+    assert dispatched == []

--- a/backend/app/api/v1/app_service_endpoints/installs.py
+++ b/backend/app/api/v1/app_service_endpoints/installs.py
@@ -1,0 +1,179 @@
+"""An app service reading and reporting on its own installs.
+
+Four channels, and the split between them is the point:
+
+* **``/installs``** says where the app is installed and nothing else. It is what
+  an app reconciles against — an install that has disappeared from this list is
+  one whose credentials the app must let go of.
+* **``/installs/{guild_id}/config``** is the custody channel. Initiative holds
+  the credentials; the app that uses them pulls them here, over its own
+  authenticated connection, and caches them in memory. Every refusal on this
+  route — the operator's kill switch, the guild's own switch, an install that
+  is not this app's — stops that pull immediately, which is what makes revoking
+  real rather than advisory.
+* **``/installs/{guild_id}/connections``** reports which per-member handles are
+  live, by reference, carrying no values at all.
+* **``/installs/{guild_id}/status``** is the app answering the one question this
+  build cannot: whether the credentials it was given actually work.
+
+The guild is named in the path because one app serves many. The *app* is never
+named in a payload — it is established from the request signature before any of
+this runs.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from app.api.v1.app_service_endpoints.deps import (
+    AdminSessionDep,
+    CallerDep,
+    parse_body,
+    to_http,
+)
+from app.schemas.tenant.app_channel import (
+    AppConnectionRead,
+    AppConnectionsResponse,
+    AppConnectionWrite,
+    AppInstallConfigRead,
+    AppInstallRead,
+    AppInstallsResponse,
+    AppStatusRead,
+    AppStatusReport,
+)
+from app.services.tenant import app_channels as channels_service
+from app.services.tenant.app_channels import AppChannelError
+
+# Paths are declared without a trailing slash: a caller signs the path it sends,
+# so a redirect to a canonical spelling would arrive carrying a signature over
+# the other one.
+router = APIRouter(prefix="/installs")
+
+
+@router.get("", response_model=AppInstallsResponse)
+async def list_installs(
+    session: AdminSessionDep, caller: CallerDep
+) -> AppInstallsResponse:
+    """Every guild that has this app installed, and at which pinned version.
+
+    The source of truth an app reconciles against. Installs live in the guild
+    schema that holds them — the catalog records what was published, never who
+    installed it — so this walks the guilds this deployment has and reports the
+    ones whose install belongs to the calling app.
+    """
+    summaries = await channels_service.install_summaries(session, caller.registration)
+    return AppInstallsResponse(
+        items=[AppInstallRead(**summary) for summary in summaries]
+    )
+
+
+@router.get("/{guild_id}/config", response_model=AppInstallConfigRead)
+async def read_install_config(
+    guild_id: int, session: AdminSessionDep, caller: CallerDep
+) -> AppInstallConfigRead:
+    """The decrypted configuration for one install.
+
+    The one route in this build that returns stored plaintext, and it returns it
+    only to the app the values were supplied for: the guild-wide credentials an
+    admin typed, plus the per-member ones the app wrote back itself, each keyed
+    by the opaque reference it knows that member by.
+
+    Refused when the operator has turned the registration off, when the guild
+    has turned the app off, or when the install is not this app's — an app whose
+    access ended stops being able to pull at that moment.
+    """
+    try:
+        app = await channels_service.load_install(
+            session, caller.registration, guild_id
+        )
+        payload = await channels_service.config_payload(session, app)
+    except AppChannelError as exc:
+        raise to_http(exc) from exc
+    return AppInstallConfigRead(**payload)
+
+
+@router.get("/{guild_id}/connections", response_model=AppConnectionsResponse)
+async def list_install_connections(
+    guild_id: int, session: AdminSessionDep, caller: CallerDep
+) -> AppConnectionsResponse:
+    """The app's per-member connections for one guild.
+
+    Addressed by opaque reference and carrying status only. An app matching its
+    stored credentials against what the platform still holds does not need a
+    value to do it, and this route has none to give.
+    """
+    try:
+        app = await channels_service.load_install(
+            session, caller.registration, guild_id
+        )
+        rows = await channels_service.connection_payload(session, app)
+    except AppChannelError as exc:
+        raise to_http(exc) from exc
+    return AppConnectionsResponse(items=[AppConnectionRead(**row) for row in rows])
+
+
+@router.put(
+    "/{guild_id}/connections/{connection_ref}", response_model=AppConnectionRead
+)
+async def write_install_connection(
+    guild_id: int,
+    connection_ref: str,
+    request: Request,
+    session: AdminSessionDep,
+    caller: CallerDep,
+) -> AppConnectionRead:
+    """Store what a vendor flow produced for one member's connection.
+
+    The app runs the flow at its own URL — its callback is its own domain, which
+    is what vendors register — and writes the result back here. That is what
+    keeps custody on this side: a token rotated at 03:00 through this same route
+    is still revocable at 03:05. Refresh and first connect are the same call.
+
+    Bounded to the fields the pinned manifest marked ``managed``; a connection a
+    guild admin blocked is refused, since stopping that member's access is
+    precisely what the block was for.
+    """
+    payload = parse_body(request, AppConnectionWrite)
+    try:
+        app = await channels_service.load_install(
+            session, caller.registration, guild_id, for_write=True
+        )
+        row = await channels_service.write_connection_values(
+            session,
+            app,
+            connection_ref=connection_ref,
+            values=payload.values,
+            status=payload.status,
+            account_label=payload.account_label,
+        )
+    except AppChannelError as exc:
+        raise to_http(exc) from exc
+    return AppConnectionRead(**row)
+
+
+@router.post("/{guild_id}/status", response_model=AppStatusRead)
+async def report_install_status(
+    guild_id: int,
+    request: Request,
+    session: AdminSessionDep,
+    caller: CallerDep,
+) -> AppStatusRead:
+    """Record whether the configuration this guild supplied actually works.
+
+    Presence of values is what this build can know by itself; whether a
+    credential carries the permissions it needs is something only the vendor can
+    confirm. This is how that answer reaches the admin who pasted the token —
+    an install nothing reports on simply stays ``unverified``, and nothing
+    blocks waiting for it.
+    """
+    payload = parse_body(request, AppStatusReport)
+    try:
+        app = await channels_service.load_install(
+            session, caller.registration, guild_id, for_write=True
+        )
+        result = await channels_service.report_config_state(
+            session, app, state=payload.state, detail=payload.detail
+        )
+    except AppChannelError as exc:
+        raise to_http(exc) from exc
+    return AppStatusRead(**result)

--- a/backend/app/api/v1/app_service_endpoints/installs_test.py
+++ b/backend/app/api/v1/app_service_endpoints/installs_test.py
@@ -1,0 +1,610 @@
+"""What an app service may read and report about its own installs.
+
+Three things carry the weight here.
+
+**An app sees its own installs and nothing else.** The catalog records what was
+published, never who installed it, so "which guilds have me?" is answered by
+visiting guild schemas — and the filter that decides has to be exact. A
+registration reading a guild where a *different* app is installed gets the same
+answer as one reading a guild that never installed anything, because it is
+entitled to distinguish neither.
+
+**Plaintext leaves on exactly one route.** The config channel is the custody
+channel and returns decrypted values to the app that uses them; the connections
+route reports which handles are live and carries no value at all. Both are
+asserted against the whole response body rather than the one field somebody
+remembered to hide.
+
+**The app is the only party that can say whether credentials work.** Nothing in
+this build moves ``config_state`` off ``unverified``; the status route is what
+does, and an admin sees the answer without leaving Initiative.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.encryption import SALT_APP_CONFIG, encrypt_field
+from app.core.messages import AppChannelMessages, GuildAppMessages
+from app.models.tenant.guild_app import GuildApp
+from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
+from app.testing import (
+    channel_headers,
+    create_guild,
+    create_guild_app,
+    create_user,
+    encode_body,
+    register_app_service,
+    route_session_to_guild,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+BASE = "/api/v1/app-service"
+SHOP_UID = "TESTAPP0000001"
+OTHER_UID = "TESTAPP0000002"
+
+GUILD_TOKEN = "shpat_the_guilds_own_token"
+MEMBER_TOKEN = "gho_one_members_own_token"
+
+
+def _field(key: str, field_type: str, **extra) -> dict:
+    return {"key": key, "type": field_type, "label": {"en": key}, **extra}
+
+
+ADMIN_CONNECTION = {
+    "id": "admin",
+    "scope": "static",
+    "label": {"en": "Admin API"},
+    "fields": [
+        _field("shop_domain", "string", required=True),
+        _field("admin_token", "secret", required=True),
+    ],
+}
+
+MEMBER_CONNECTION = {
+    "id": "github",
+    "scope": "interactive",
+    "label": {"en": "GitHub"},
+    "connect_path": "/connect/github",
+    "fields": [_field("access_token", "secret", managed=True)],
+}
+
+
+def _definition(public_id: str = "tests.shop") -> dict:
+    return {
+        "app_kind": "service",
+        "service": {"public_id": public_id, "protocol": 1},
+        "features": ["events"],
+        "connections": [ADMIN_CONNECTION, MEMBER_CONNECTION],
+        "events": [f"app.{public_id}.order_created"],
+    }
+
+
+async def _install(
+    session: AsyncSession,
+    *,
+    definition: dict | None = None,
+    listing_uid: str = SHOP_UID,
+    with_values: bool = False,
+    **overrides,
+):
+    """A guild with a service app installed, optionally already configured."""
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    if with_values:
+        overrides.setdefault("config", {"admin": {"shop_domain": "example.test"}})
+        overrides.setdefault(
+            "config_secrets",
+            {"admin": {"admin_token": encrypt_field(GUILD_TOKEN, SALT_APP_CONFIG)}},
+        )
+    app = await create_guild_app(
+        session,
+        guild,
+        user,
+        definition=definition or _definition(),
+        listing_uid=listing_uid,
+        **overrides,
+    )
+    return guild, user, app
+
+
+async def _member_connection(
+    session: AsyncSession,
+    *,
+    guild,
+    app,
+    user,
+    connection_ref: str = "cr_member_one",
+    with_secret: bool = True,
+    blocked: bool = False,
+) -> GuildAppUserConnection:
+    await route_session_to_guild(session, guild.id)
+    row = GuildAppUserConnection(
+        guild_id=guild.id,
+        app_id=app.id,
+        connection_id="github",
+        user_id=user.id,
+        connection_ref=connection_ref,
+        config={},
+        config_secrets=(
+            {"access_token": encrypt_field(MEMBER_TOKEN, SALT_APP_CONFIG)}
+            if with_secret
+            else {}
+        ),
+        status="connected" if with_secret else "pending",
+    )
+    if blocked:
+        row.blocked_at = datetime.now(timezone.utc)
+        row.status = "blocked"
+        row.config_secrets = {}
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def _get(client: AsyncClient, path: str, **kwargs):
+    return await client.get(
+        path, headers=channel_headers(method="GET", path=path, **kwargs)
+    )
+
+
+async def _post(client: AsyncClient, path: str, payload, **kwargs):
+    body = encode_body(payload)
+    return await client.post(
+        path,
+        headers=channel_headers(method="POST", path=path, body=body, **kwargs),
+        content=body,
+    )
+
+
+async def _put(client: AsyncClient, path: str, payload, **kwargs):
+    body = encode_body(payload)
+    return await client.put(
+        path,
+        headers=channel_headers(method="PUT", path=path, body=body, **kwargs),
+        content=body,
+    )
+
+
+async def _reload(session: AsyncSession, guild_id: int, app_id: int) -> GuildApp:
+    await route_session_to_guild(session, guild_id)
+    session.expunge_all()
+    return (await session.exec(select(GuildApp).where(GuildApp.id == app_id))).one()
+
+
+# ---------------------------------------------------------------------------
+# Which installs an app can see
+# ---------------------------------------------------------------------------
+
+
+class TestInstalls:
+    async def test_installs_reports_the_guilds_that_have_this_app(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _, app = await _install(session)
+
+        response = await _get(client, f"{BASE}/installs")
+
+        assert response.status_code == 200, response.text
+        items = response.json()["items"]
+        assert len(items) == 1
+        assert items[0]["guild_id"] == guild.id
+        assert items[0]["install_id"] == app.id
+        assert items[0]["listing_version"] == "1.0.0"
+        assert items[0]["enabled"] is True
+        # Nothing about who is in the guild travels with an install summary.
+        assert "members" not in items[0]
+        assert "installed_by_id" not in items[0]
+
+    async def test_another_apps_install_is_not_listed(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        mine, _, _ = await _install(session)
+        await _install(
+            session,
+            definition=_definition("tests.other"),
+            listing_uid=OTHER_UID,
+        )
+
+        response = await _get(client, f"{BASE}/installs")
+
+        assert response.status_code == 200, response.text
+        assert [item["guild_id"] for item in response.json()["items"]] == [mine.id]
+
+    async def test_an_install_pinning_another_apps_definition_is_not_ours(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """Both statements have to agree. A row carrying this registration's
+        catalog uid but pinning a definition that names a different service is
+        not an install this caller may reach."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        await _install(session, definition=_definition("tests.someone-else"))
+
+        response = await _get(client, f"{BASE}/installs")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["items"] == []
+
+    async def test_a_registration_that_never_verified_has_no_installs(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """A handshake is what records which listing a registration speaks for.
+        Without one there is nothing to match an install against."""
+        await register_app_service(session, listing_uid=None)
+        await _install(session)
+
+        response = await _get(client, f"{BASE}/installs")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# The custody channel
+# ---------------------------------------------------------------------------
+
+
+class TestConfigChannel:
+    async def test_config_returns_the_decrypted_values(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session, with_values=True)
+        await _member_connection(session, guild=guild, app=app, user=user)
+
+        response = await _get(client, f"{BASE}/installs/{guild.id}/config")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["connections"]["admin"] == {
+            "shop_domain": "example.test",
+            "admin_token": GUILD_TOKEN,
+        }
+        member = body["member_connections"][0]
+        assert member["connection_ref"] == "cr_member_one"
+        assert member["values"] == {"access_token": MEMBER_TOKEN}
+        # The app is told which member by handle, and by nothing else.
+        assert "user_id" not in member
+        assert user.email not in response.text
+
+    async def test_a_blocked_members_values_are_not_served(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """A block ends that member's access; the tombstone it leaves must not
+        keep handing the app a credential to act with."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session, with_values=True)
+        await _member_connection(session, guild=guild, app=app, user=user, blocked=True)
+
+        response = await _get(client, f"{BASE}/installs/{guild.id}/config")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["member_connections"] == []
+
+    async def test_another_apps_install_is_unreadable(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """The whole point of the channel: one app's credentials are not
+        reachable by another, and the refusal says nothing about what is there."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        theirs, _, _ = await _install(
+            session,
+            definition=_definition("tests.other"),
+            listing_uid=OTHER_UID,
+            with_values=True,
+        )
+
+        response = await _get(client, f"{BASE}/installs/{theirs.id}/config")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == AppChannelMessages.INSTALL_NOT_FOUND
+        assert GUILD_TOKEN not in response.text
+
+    async def test_a_guild_that_never_installed_is_the_same_answer(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        user = await create_user(session)
+        bare = await create_guild(session, creator=user)
+
+        response = await _get(client, f"{BASE}/installs/{bare.id}/config")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == AppChannelMessages.INSTALL_NOT_FOUND
+
+    async def test_a_guild_that_does_not_exist_is_the_same_answer(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+
+        response = await _get(client, f"{BASE}/installs/999999/config")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == AppChannelMessages.INSTALL_NOT_FOUND
+
+    async def test_an_install_the_guild_turned_off_refuses(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """The guild's own switch stops the pull, exactly as the operator's
+        does — a disabled app holds no live credential channel."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _, _ = await _install(session, with_values=True, enabled=False)
+
+        response = await _get(client, f"{BASE}/installs/{guild.id}/config")
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == AppChannelMessages.INSTALL_DISABLED
+        assert GUILD_TOKEN not in response.text
+
+    async def test_a_disabled_registration_refuses(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID, enabled=False)
+        guild, _, _ = await _install(session, with_values=True)
+
+        response = await _get(client, f"{BASE}/installs/{guild.id}/config")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == AppChannelMessages.APP_DISABLED
+        assert GUILD_TOKEN not in response.text
+
+
+# ---------------------------------------------------------------------------
+# Who connected — status, never values
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionsChannel:
+    async def test_connections_report_state_and_never_a_value(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session, with_values=True)
+        await _member_connection(session, guild=guild, app=app, user=user)
+
+        response = await _get(client, f"{BASE}/installs/{guild.id}/connections")
+
+        assert response.status_code == 200, response.text
+        items = response.json()["items"]
+        assert len(items) == 1
+        assert items[0]["connection_ref"] == "cr_member_one"
+        assert items[0]["connection_id"] == "github"
+        assert items[0]["status"] == "connected"
+        assert items[0]["blocked"] is False
+        # Neither the member's own credential nor the guild's appears here.
+        assert MEMBER_TOKEN not in response.text
+        assert GUILD_TOKEN not in response.text
+        assert "values" not in items[0]
+
+    async def test_connections_never_name_the_member(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session)
+        await _member_connection(session, guild=guild, app=app, user=user)
+
+        response = await _get(client, f"{BASE}/installs/{guild.id}/connections")
+
+        assert response.status_code == 200, response.text
+        assert "user_id" not in response.text
+        assert user.email not in response.text
+        assert str(user.id) not in [
+            item["connection_ref"] for item in response.json()["items"]
+        ]
+
+    async def test_a_blocked_connection_is_reported_as_blocked(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """An app reconciling needs to know the handle is finished; that is the
+        whole of what a block tells it."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session)
+        await _member_connection(session, guild=guild, app=app, user=user, blocked=True)
+
+        response = await _get(client, f"{BASE}/installs/{guild.id}/connections")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["items"][0]["blocked"] is True
+
+    async def test_another_apps_connections_are_unreachable(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        theirs, user, app = await _install(
+            session, definition=_definition("tests.other"), listing_uid=OTHER_UID
+        )
+        await _member_connection(session, guild=theirs, app=app, user=user)
+
+        response = await _get(client, f"{BASE}/installs/{theirs.id}/connections")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == AppChannelMessages.INSTALL_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Writing back what a vendor flow produced
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionWriteBack:
+    async def test_a_managed_value_is_stored_and_served_only_on_config(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session)
+        row = await _member_connection(
+            session, guild=guild, app=app, user=user, with_secret=False
+        )
+
+        written = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/{row.connection_ref}",
+            {
+                "values": {"access_token": "gho_freshly_minted"},
+                "account_label": "@alice",
+            },
+        )
+
+        assert written.status_code == 200, written.text
+        assert written.json()["status"] == "connected"
+        assert written.json()["account_label"] == "@alice"
+        # The write-back answer reports state; the value comes back only where
+        # values are meant to.
+        assert "gho_freshly_minted" not in written.text
+
+        config = await _get(client, f"{BASE}/installs/{guild.id}/config")
+        assert config.status_code == 200, config.text
+        assert config.json()["member_connections"][0]["values"] == {
+            "access_token": "gho_freshly_minted"
+        }
+
+    async def test_a_refresh_replaces_the_stored_value(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """Rotation runs down the same path as first connect, which is what
+        keeps a token rotated at 03:00 revocable at 03:05."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session)
+        row = await _member_connection(session, guild=guild, app=app, user=user)
+        path = f"{BASE}/installs/{guild.id}/connections/{row.connection_ref}"
+
+        assert (
+            await _put(client, path, {"values": {"access_token": "gho_rotated"}})
+        ).status_code == 200
+
+        config = await _get(client, f"{BASE}/installs/{guild.id}/config")
+        assert config.json()["member_connections"][0]["values"] == {
+            "access_token": "gho_rotated"
+        }
+
+    async def test_a_blocked_connection_refuses_a_write_back(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session)
+        row = await _member_connection(
+            session, guild=guild, app=app, user=user, blocked=True
+        )
+
+        response = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/{row.connection_ref}",
+            {"values": {"access_token": "gho_sneaking_back"}},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == AppChannelMessages.CONNECTION_BLOCKED
+
+    async def test_an_unknown_reference_is_refused(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _, _ = await _install(session)
+
+        response = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/cr_not_a_handle",
+            {"values": {"access_token": "x"}},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == AppChannelMessages.CONNECTION_NOT_FOUND
+
+    async def test_a_field_the_definition_does_not_declare_is_refused(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session)
+        row = await _member_connection(session, guild=guild, app=app, user=user)
+
+        response = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/{row.connection_ref}",
+            {"values": {"not_a_field": "x"}},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == GuildAppMessages.CONFIG_UNKNOWN_FIELD
+
+
+# ---------------------------------------------------------------------------
+# The app's own verdict
+# ---------------------------------------------------------------------------
+
+
+class TestStatusReport:
+    async def test_reporting_ok_moves_the_state(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """Nothing else in this build writes ``ok``. Before the app reports,
+        an install has no verdict at all."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _, app = await _install(session, with_values=True)
+        assert app.config_state == "unverified"
+
+        response = await _post(
+            client, f"{BASE}/installs/{guild.id}/status", {"state": "ok"}
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["config_state"] == "ok"
+        stored = await _reload(session, guild.id, app.id)
+        assert stored.config_state == "ok"
+        assert stored.config_state_detail is None
+
+    async def test_reporting_invalid_carries_the_reason(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """An admin whose token lacks a scope should read that, not an empty
+        widget."""
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _, app = await _install(session, with_values=True)
+
+        response = await _post(
+            client,
+            f"{BASE}/installs/{guild.id}/status",
+            {"state": "invalid", "detail": "missing_read_orders"},
+        )
+
+        assert response.status_code == 200, response.text
+        stored = await _reload(session, guild.id, app.id)
+        assert stored.config_state == "invalid"
+        assert stored.config_state_detail == "missing_read_orders"
+
+    async def test_a_state_outside_the_vocabulary_is_refused(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _, app = await _install(session)
+
+        response = await _post(
+            client, f"{BASE}/installs/{guild.id}/status", {"state": "wonderful"}
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == AppChannelMessages.INVALID_PAYLOAD
+        stored = await _reload(session, guild.id, app.id)
+        assert stored.config_state == "unverified"
+
+    async def test_another_apps_install_cannot_be_reported_on(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        theirs, _, app = await _install(
+            session, definition=_definition("tests.other"), listing_uid=OTHER_UID
+        )
+
+        response = await _post(
+            client, f"{BASE}/installs/{theirs.id}/status", {"state": "ok"}
+        )
+
+        assert response.status_code == 404
+        stored = await _reload(session, theirs.id, app.id)
+        assert stored.config_state == "unverified"

--- a/backend/app/core/body_limit.py
+++ b/backend/app/core/body_limit.py
@@ -20,6 +20,11 @@ from typing import Awaitable, Callable
 
 from app.core.config import settings
 
+#: The most any app-service request may carry. Sized for the largest route on
+#: that surface — events — plus its envelope, and kept here rather than imported
+#: from the router so this module stays free of app-layer imports.
+APP_SERVICE_MAX_REQUEST_BYTES = 64 * 1024 + 8 * 1024
+
 # (path pattern, limit getter, machine-readable error code). Getters read
 # settings lazily — the limit is a property of request time, not boot time.
 _RULES: tuple[tuple[re.Pattern[str], Callable[[], int], str], ...] = (
@@ -34,6 +39,16 @@ _RULES: tuple[tuple[re.Pattern[str], Callable[[], int], str], ...] = (
         re.compile(r"^/api/v1/g/\d+/imports/backup$"),
         lambda: settings.IMPORT_MAX_BACKUP_UPLOAD_BYTES + 1_048_576,
         "IMPORT_TOO_LARGE",
+    ),
+    (
+        # Every app-service route buffers its body before authenticating —
+        # the signature covers those bytes, so they have to be read to check
+        # it. Without a ceiling here that read is unbounded and happens for a
+        # caller who has not proved anything yet, so the transport refuses an
+        # oversized body first and the handler's exact cap still applies after.
+        re.compile(r"^/api/v1/app-service(/|$)"),
+        lambda: APP_SERVICE_MAX_REQUEST_BYTES,
+        "APP_CHANNEL_EVENT_TOO_LARGE",
     ),
 )
 

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -668,6 +668,53 @@ class AppServiceMessages:
     SIGNATURE_MISMATCH = "APP_SERVICE_SIGNATURE_MISMATCH"
 
 
+class AppChannelMessages:
+    """Codes for the channels an app service calls back into Initiative on.
+
+    Read by an app author rather than by a person in the UI, so each names the
+    step that refused: an envelope this build will not accept, an install this
+    caller does not own, or a payload outside what the pinned manifest declared.
+    """
+
+    # --- the signed envelope ---
+    #: A required signing header is absent or unusably shaped.
+    MISSING_SIGNATURE = "APP_CHANNEL_MISSING_SIGNATURE"
+    #: The signed timestamp sits outside the freshness window.
+    STALE_TIMESTAMP = "APP_CHANNEL_STALE_TIMESTAMP"
+    #: No registration answers to the app id the request named.
+    UNKNOWN_APP = "APP_CHANNEL_UNKNOWN_APP"
+    #: The signature does not match what this registration's secret produces.
+    INVALID_SIGNATURE = "APP_CHANNEL_INVALID_SIGNATURE"
+    #: This nonce was already spent, so the request has been seen before.
+    REPLAYED_REQUEST = "APP_CHANNEL_REPLAYED_REQUEST"
+    #: The operator turned this registration off; every channel it backs stops.
+    APP_DISABLED = "APP_CHANNEL_APP_DISABLED"
+
+    # --- the install being addressed ---
+    #: No install of this app in that guild — never installed, uninstalled, or
+    #: the guild is not one this caller may see.
+    INSTALL_NOT_FOUND = "APP_CHANNEL_INSTALL_NOT_FOUND"
+    #: The install exists but the guild turned it off.
+    INSTALL_DISABLED = "APP_CHANNEL_INSTALL_DISABLED"
+    #: The guild is frozen, so this channel accepts no writes into it.
+    GUILD_READ_ONLY = "APP_CHANNEL_GUILD_READ_ONLY"
+    #: No connection on this install answers to that reference.
+    CONNECTION_NOT_FOUND = "APP_CHANNEL_CONNECTION_NOT_FOUND"
+    #: A guild admin stopped this member's connection; the app may not revive it.
+    CONNECTION_BLOCKED = "APP_CHANNEL_CONNECTION_BLOCKED"
+
+    # --- what the app sent ---
+    #: The body is not the JSON object this channel expects.
+    INVALID_PAYLOAD = "APP_CHANNEL_INVALID_PAYLOAD"
+    #: An event type the pinned definition does not declare, or one namespaced
+    #: under an app other than the caller.
+    UNKNOWN_EVENT_TYPE = "APP_CHANNEL_UNKNOWN_EVENT_TYPE"
+    #: The event body is larger than this build will carry.
+    EVENT_TOO_LARGE = "APP_CHANNEL_EVENT_TOO_LARGE"
+    #: A config state outside what an app may report.
+    INVALID_CONFIG_STATE = "APP_CHANNEL_INVALID_CONFIG_STATE"
+
+
 class WebhookSubscriptionMessages:
     INVALID_TARGET_URL = "WEBHOOK_INVALID_TARGET_URL"
     PRIVATE_TARGET_URL = "WEBHOOK_PRIVATE_TARGET_URL"

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -72,6 +72,7 @@ from app.models.platform.marketplace_registry import (
 )
 from app.models.platform.ai_connection import PlatformAIConnection
 from app.models.platform.app_service_registration import AppServiceRegistration
+from app.models.platform.app_service_nonce import AppServiceNonce
 from app.models.tenant.ai_connection import GuildAIConnection
 from app.models.tenant.ai_member_key import GuildAIMemberKey
 from app.models.tenant.ai_member_pref import GuildAIMemberPref
@@ -144,6 +145,7 @@ __all__ = [
     "TaskAssignmentDigestItem",
     "WebhookSubscription",
     "AppServiceRegistration",
+    "AppServiceNonce",
     "MarketplaceMedia",
     "MarketplaceRegistryState",
     "PlatformAIConnection",

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -35,6 +35,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.database]
 # Shared tables that carry (FORCEd) row-level security.
 _RLS_SHARED_TABLES = {
     "access_grants",
+    "app_service_nonces",
     "app_service_registrations",
     "app_settings",
     "auth_provider_secrets",

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -89,6 +89,11 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     # The row holds the shared-secret ciphertext, so it stays off the bare
     # login role entirely (below).
     "app_service_registrations": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # Replay guard for the app-service channel: the verifier reads and inserts,
+    # and the shared jti janitor prunes rows whose freshness window has passed
+    # (a request that old is refused before the guard is consulted, so pruning
+    # constrains nothing). Never updated — a spent nonce has one state.
+    "app_service_nonces": frozenset({"SELECT", "INSERT", "DELETE"}),
     # Registry client state: read and written by the refresh job alone. One row
     # per registry URL, recycled in place, so nothing is ever deleted.
     "marketplace_registry_state": frozenset({"SELECT", "INSERT", "UPDATE"}),
@@ -177,6 +182,9 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # the system engine and readable by the platform owner under RLS. The bare
     # pre-routing login role has no reason to see it, so it holds nothing.
     "app_service_registrations": None,
+    # The app-service replay guard is spent entirely on the system engine, like
+    # the billing blocklist; no request-path role reads or writes it.
+    "app_service_nonces": None,
     # Refresh bookkeeping — system engine only, surfaced to an operator through
     # a capability-gated endpoint rather than read on the request path.
     "marketplace_registry_state": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -87,6 +87,10 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # operator-conferred grants). Platform-wide by definition — one row per
         # app, never per guild — and owner-managed.
         "app_service_registrations",
+        # Spent one-shot nonces from the app-service request-signing channel.
+        # Hangs off a registration, which is platform-wide, and a single signed
+        # request may address any guild — so the guard cannot live in a schema.
+        "app_service_nonces",
         # Registry client state: what this deployment last accepted from a
         # signed index, and the artwork that index named, mirrored locally so
         # listing media is served from here. Operator/system state, no guild.

--- a/backend/app/models/platform/app_service_nonce.py
+++ b/backend/app/models/platform/app_service_nonce.py
@@ -1,0 +1,54 @@
+"""One-shot nonces spent by the app service request-signing channel.
+
+Every call an app service makes into Initiative carries a signature over its
+timestamp, a nonce, and the body. The signature proves the caller holds the
+registration's shared secret; this table is what makes each signed request
+usable exactly once, so a captured one cannot be presented again inside its
+freshness window.
+
+Two column choices carry the meaning:
+
+* **The key is (registration, nonce), not the nonce alone.** Each app has its
+  own namespace, so what one app spends never collides with — or consumes —
+  another's. The row goes with its registration (``ON DELETE CASCADE``): a
+  registration that no longer exists has no requests to guard.
+* **``expires_at`` mirrors the end of the request's freshness window.** A
+  request whose timestamp has aged out is refused before this table is
+  consulted, so a spent row past that point constrains nothing and the shared
+  jti janitor (:mod:`app.services.platform.jti_purge`) prunes it.
+
+Lives in ``public``: registrations are platform-wide and carry no guild data.
+Reached only by the system engine — the request path has no grant on it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlmodel import Field, SQLModel
+
+__all__ = ["AppServiceNonce"]
+
+
+class AppServiceNonce(SQLModel, table=True):
+    __tablename__ = "app_service_nonces"
+
+    registration_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("app_service_registrations.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    #: The value the caller sent, bounded to the column width so an oversized
+    #: one is refused while verifying rather than at the insert.
+    nonce: str = Field(sa_column=Column(String(length=64), primary_key=True))
+    # Explicit sa_column so the ORM emits TIMESTAMP WITH TIME ZONE, matching the
+    # migration and the TZ-aware values the verifier produces.
+    seen_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
+    )

--- a/backend/app/schemas/tenant/app_channel.py
+++ b/backend/app/schemas/tenant/app_channel.py
@@ -1,0 +1,179 @@
+"""What an app service sees of its own installs.
+
+These payloads serialize per-guild install state for the machine-to-machine
+channel an app calls back on, so they are shaped by two rules the browser-facing
+schemas in :mod:`app.schemas.tenant.guild_app` do not share:
+
+* **Credentials do appear here — in exactly one payload.**
+  :class:`AppInstallConfigRead` is the custody channel: the app is the party
+  that uses these values, so it is handed them decrypted. Every other payload,
+  the connections view included, carries state and never a value.
+* **Members are references.** A per-member connection is addressed by its
+  opaque ``connection_ref``; there is no user id, email, or display name in any
+  shape below.
+
+Values are typed ``Dict[str, Any]`` deliberately: a credential is opaque bytes
+to this build, so declaring it as text would invite sanitization that corrupts
+it, and the field types that *do* apply live in the pinned definition the
+service layer validates against.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import ConfigDict, Field
+
+from app.schemas.base import SanitizedBaseModel
+
+__all__ = [
+    "AppConnectionRead",
+    "AppConnectionsResponse",
+    "AppConnectionWrite",
+    "AppEventIngest",
+    "AppInstallConfigRead",
+    "AppInstallRead",
+    "AppInstallsResponse",
+    "AppMemberConfigRead",
+    "AppStatusReport",
+    "AppStatusRead",
+]
+
+
+class AppInstallRead(SanitizedBaseModel):
+    """One guild that has this app installed.
+
+    Ids and state only — which guild, which install, which version it is pinned
+    to, and whether the guild has it switched on. Nothing about the guild's
+    members, and nothing an app would need a second channel to be told.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    install_id: int
+    guild_id: int
+    listing_uid: str
+    listing_version: str
+    name: str
+    enabled: bool
+    #: The app's own last verdict, echoed back so it can tell what it reported.
+    config_state: str = "unverified"
+    config_state_detail: Optional[str] = None
+    #: Whether a guild admin still has a guild-wide connection to fill in.
+    needs_config: bool = False
+    updated_at: datetime
+
+
+class AppInstallsResponse(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    items: List[AppInstallRead] = []
+
+
+class AppMemberConfigRead(SanitizedBaseModel):
+    """One member's stored values, addressed by the handle the app knows."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    connection_id: str
+    connection_ref: str
+    status: str
+    values: Dict[str, Any] = {}
+
+
+class AppInstallConfigRead(SanitizedBaseModel):
+    """The decrypted configuration for one install — the custody channel.
+
+    ``connections`` holds the guild-wide values an admin typed, keyed by
+    connection id; ``member_connections`` holds the per-member values the app
+    itself wrote back, keyed by reference. Both are plaintext, and this is the
+    only payload in the build where that is true.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    guild_id: int
+    install_id: int
+    listing_uid: str
+    listing_version: str
+    enabled: bool
+    config_state: str = "unverified"
+    config_state_detail: Optional[str] = None
+    needs_config: bool = False
+    connections: Dict[str, Dict[str, Any]] = {}
+    member_connections: List[AppMemberConfigRead] = []
+
+
+class AppConnectionRead(SanitizedBaseModel):
+    """One member's connection, as the app reconciles it.
+
+    Enough to know which handles are live and which an admin has stopped, and
+    no more: an app matching its stored credentials against this list never
+    needs a value to do it.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    connection_id: str
+    connection_ref: str
+    status: str
+    blocked: bool = False
+    #: What the app itself reported the member connected as. Display only.
+    account_label: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AppConnectionsResponse(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    items: List[AppConnectionRead] = []
+
+
+class AppConnectionWrite(SanitizedBaseModel):
+    """What an app writes back after completing a vendor flow.
+
+    Only fields the pinned manifest marked ``managed`` may be set this way; a
+    key sent as ``null`` clears that value, and a key left out is untouched, so
+    a refresh that carries one rotated token does not disturb the rest.
+    """
+
+    values: Dict[str, Any] = {}
+    #: ``pending`` while a flow is still in progress; otherwise the stored
+    #: values decide, so an app cannot claim a connection it does not hold.
+    status: Optional[Literal["pending", "connected"]] = None
+    #: The vendor account the member connected as, e.g. ``@alice``.
+    account_label: Optional[str] = Field(default=None, max_length=200)
+
+
+class AppStatusReport(SanitizedBaseModel):
+    """The app's verdict on the configuration it was handed.
+
+    ``unverified`` is absent by design: it is this build's resting value for an
+    install nothing has reported on, not something an app asserts.
+    """
+
+    state: Literal["ok", "invalid"]
+    #: A short code shown beside an ``invalid`` state, e.g. ``missing_scope``.
+    detail: Optional[str] = Field(default=None, max_length=120)
+
+
+class AppStatusRead(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    guild_id: int
+    install_id: int
+    config_state: str
+    config_state_detail: Optional[str] = None
+
+
+class AppEventIngest(SanitizedBaseModel):
+    """A third-party event an app is re-emitting into a guild.
+
+    The guild is named because one app serves many; the *app* is not, because it
+    is established from the request's signature. ``event_type`` is checked
+    against the pinned definition and against the caller's own namespace.
+    """
+
+    guild_id: int
+    event_type: str = Field(max_length=200)
+    payload: Dict[str, Any] = {}

--- a/backend/app/schemas/tenant/guild_app.py
+++ b/backend/app/schemas/tenant/guild_app.py
@@ -128,6 +128,18 @@ class GuildAppRead(SanitizedBaseModel):
     embed_target: Optional[str] = None
     #: What a service app contributes, from its pinned definition.
     features: List[str] = []
+    #: The pinned definition itself, verbatim.
+    #:
+    #: A passthrough rather than a read: this build gives meaning to parts of it
+    #: (``connections``, ``app_kind``) and none at all to others — the
+    #: ``automation`` block belongs to the automation service, which parses it
+    #: against its own schema off this same payload rather than through an
+    #: endpoint that would have to understand it. Serving the snapshot the guild
+    #: pinned, not whatever the catalog holds today, is what lets a reader say
+    #: what *this* install actually is. It never carries a stored value: the
+    #: definition describes the form, and what was typed into it lives in
+    #: columns nothing here reads.
+    definition: Dict[str, Any] = {}
     #: Whether opening this app is a guild-admin action. Decided here, not by
     #: the client reading the kind: an entry a member cannot use should not be
     #: offered to them, and which apps those are is the server's call.
@@ -230,6 +242,7 @@ def serialize_guild_app(app: Any) -> GuildAppRead:
         tool=definition.get("tool"),
         embed_target=definition.get("embed_target"),
         features=list(features) if isinstance(features, list) else [],
+        definition=definition,
         admin_only=requires_guild_admin(definition),
         installed_by_id=app.installed_by_id,
         created_at=app.created_at,

--- a/backend/app/schemas/tenant/guild_app_test.py
+++ b/backend/app/schemas/tenant/guild_app_test.py
@@ -1,0 +1,112 @@
+"""What a guild-app read payload discloses.
+
+Two properties, pulling in opposite directions, and both are load-bearing.
+
+**The pinned definition travels.** A reader — the settings page, and the
+automation delegate on its delegated read — has to be able to say what *this*
+install is, including the blocks this build assigns no meaning to. Serving the
+snapshot the guild pinned rather than whatever the catalog holds today is what
+makes that answer true of the install rather than of the listing.
+
+**Stored values never do.** The definition describes the form; what was typed
+into it lives in columns this payload does not read. Serializing one alongside
+the other would be the single most natural way to leak a credential, so the test
+reads the whole payload rather than checking the field somebody remembered.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.tenant.guild_app import serialize_guild_app
+
+pytestmark = pytest.mark.unit
+
+SECRET_CIPHERTEXT = "gAAAAAB-not-a-real-token"
+
+DEFINITION = {
+    "app_kind": "service",
+    "service": {"public_id": "tests.shop", "protocol": 1},
+    "features": ["events", "automations"],
+    "connections": [
+        {
+            "id": "admin",
+            "scope": "static",
+            "fields": [{"key": "admin_token", "type": "secret", "required": True}],
+        }
+    ],
+    "events": ["app.tests.shop.order_created"],
+    # Opaque to this build by design: it belongs to the automation service,
+    # which parses it off this same payload.
+    "automation": {"nodes": [{"id": "low_stock"}]},
+}
+
+
+def _app(**overrides) -> SimpleNamespace:
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        **{
+            "id": 3,
+            "guild_id": 7,
+            "listing_uid": "TESTAPP0000001",
+            "listing_version": "1.2.0",
+            "app_kind": "service",
+            "name": "Shop",
+            "enabled": True,
+            "definition": DEFINITION,
+            "config": {},
+            "config_secrets": {"admin": {"admin_token": SECRET_CIPHERTEXT}},
+            "config_state": "ok",
+            "config_state_detail": None,
+            "artifacts": [],
+            "installed_by_id": 11,
+            "created_at": now,
+            "updated_at": now,
+            **overrides,
+        }
+    )
+
+
+def test_the_pinned_definition_is_passed_through_verbatim():
+    payload = serialize_guild_app(_app())
+
+    assert payload.definition == DEFINITION
+    # Including the block this build never interprets — the delegate reads it
+    # here rather than through an endpoint that would have to understand it.
+    assert payload.definition["automation"] == {"nodes": [{"id": "low_stock"}]}
+
+
+def test_the_config_state_the_app_reported_is_carried():
+    """Until an app reports, an install has no verdict; once it does, the
+    settings page can say whether the app is happy without leaving the app."""
+    assert serialize_guild_app(_app()).config_state == "ok"
+    assert (
+        serialize_guild_app(
+            _app(config_state="invalid", config_state_detail="missing_read_orders")
+        ).config_state_detail
+        == "missing_read_orders"
+    )
+    assert serialize_guild_app(_app(config_state="unverified")).config_state == (
+        "unverified"
+    )
+
+
+def test_no_stored_value_appears_anywhere_in_the_payload():
+    payload = serialize_guild_app(
+        _app(config={"admin": {"shop_domain": "example.test"}})
+    )
+
+    serialized = payload.model_dump_json()
+    assert SECRET_CIPHERTEXT not in serialized
+    assert "config_secrets" not in serialized
+    # The definition describes the field; it carries no value for it.
+    assert payload.definition["connections"][0]["fields"][0]["key"] == "admin_token"
+    assert "value" not in payload.definition["connections"][0]["fields"][0]
+
+
+def test_needs_config_still_reads_from_presence():
+    """A required guild-wide field with nothing in it is the one thing this
+    build can know by itself, and it is unaffected by the passthrough."""
+    assert serialize_guild_app(_app(config_secrets={})).needs_config is True
+    assert serialize_guild_app(_app()).needs_config is False

--- a/backend/app/services/marketplace/app_channel_auth.py
+++ b/backend/app/services/marketplace/app_channel_auth.py
@@ -1,0 +1,293 @@
+"""Authenticating an app service calling back into Initiative.
+
+An app holds one thing: the shared secret its registration was wired with. Every
+call it makes carries a signature computed from that secret over the request's
+method, path, timestamp, nonce, and body — so the caller is established by the
+signature rather than by anything it says about itself. The ``X-Initiative-App``
+header names which registration to check against; it selects a key, and a
+request that does not then verify under that key is refused. Nothing downstream
+reads an app identity out of a body field.
+
+Three properties the verifier keeps:
+
+* **Signed over the raw bytes, before any parsing.** The body is hashed exactly
+  as it arrived, so what was signed and what is acted on cannot differ.
+* **Bounded freshness.** A signed timestamp more than
+  :data:`SIGNATURE_WINDOW_SECONDS` from now is refused, which is what bounds how
+  long the replay guard has to remember anything.
+* **One use per nonce.** The (registration, nonce) pair is recorded on first
+  presentation and a second one is refused — the same one-shot pattern the
+  delegation and billing blocklists use, and rows are pruned by the shared jti
+  janitor once their window has passed.
+
+Order matters and is deliberate: shape, then freshness, then the signature, then
+the registration's own state, and only then the nonce burn. Nothing is written
+on behalf of a caller that has not proved it holds the secret.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.core.encryption import SALT_APP_SERVICE_SECRET, decrypt_field
+from app.core.messages import AppChannelMessages
+from app.models.platform.app_service_nonce import AppServiceNonce
+from app.models.platform.app_service_registration import AppServiceRegistration
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "APP_HEADER",
+    "NONCE_HEADER",
+    "SIGNATURE_HEADER",
+    "SIGNATURE_WINDOW_SECONDS",
+    "TIMESTAMP_HEADER",
+    "AppChannelAuthError",
+    "CallingApp",
+    "SignedEnvelope",
+    "app_channel_possible",
+    "authenticate_caller",
+    "read_envelope",
+    "sign_request",
+    "signing_material",
+]
+
+#: Names the registration whose secret the signature should verify under. A
+#: selector, not a claim: the request still has to verify under that key.
+APP_HEADER = "X-Initiative-App"
+#: Unix seconds at which the caller signed.
+TIMESTAMP_HEADER = "X-Initiative-Timestamp"
+#: A value the caller does not repeat. Spent once, then refused.
+NONCE_HEADER = "X-Initiative-Nonce"
+#: ``sha256=<hex>``, matching the shape the outbound webhook dispatcher uses.
+SIGNATURE_HEADER = "X-Initiative-Signature"
+
+#: How far a signed timestamp may sit from now, in either direction. Five
+#: minutes is the same allowance the outbound dispatcher documents for its own
+#: receivers and the billing envelope defaults to: wide enough for ordinary
+#: clock drift between two containers, narrow enough that the replay guard only
+#: has to remember a few minutes of traffic.
+SIGNATURE_WINDOW_SECONDS = 300
+
+#: What the nonce column stores. Checked while verifying so an oversized value
+#: is a clean refusal rather than an error at the insert.
+MAX_NONCE_LENGTH = 64
+#: An app id longer than the column it would be matched against cannot name a
+#: registration, so it is refused without a query.
+MAX_APP_ID_LENGTH = 120
+_SIGNATURE_PREFIX = "sha256="
+
+
+class AppChannelAuthError(Exception):
+    """The call did not authenticate. ``code`` is the message code the endpoint
+    surfaces, ``status_code`` the HTTP answer it belongs to."""
+
+    def __init__(self, code: str, status_code: int = 401) -> None:
+        super().__init__(code)
+        self.code = code
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class SignedEnvelope:
+    """What the headers claimed, after shape and freshness checks."""
+
+    public_id: str
+    timestamp: int
+    nonce: str
+    signature: str
+
+
+@dataclass(frozen=True)
+class CallingApp:
+    """A verified caller: the registration whose secret signed the request."""
+
+    registration: AppServiceRegistration
+    nonce: str
+
+
+def app_channel_possible() -> bool:
+    """Whether this deployment can have app services calling in at all.
+
+    Registrations arrive one of two ways — an operator wiring one up (which
+    requires the app-platform signing key) or a mounted config file the boot
+    reconciler reads. With neither present the table cannot have rows, so the
+    channel has nothing to authenticate and its replay guard nothing to hold.
+    """
+    return bool(
+        settings.APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM or settings.APP_SERVICES_CONFIG
+    )
+
+
+def signing_material(
+    *, method: str, path: str, timestamp: str, nonce: str, body: bytes
+) -> bytes:
+    """The bytes both sides run the MAC over.
+
+    Newline-joined fields, ending in a digest of the raw body: the same shape
+    the billing envelope uses, with the nonce folded in so the value that makes
+    a request one-shot is covered by the signature rather than swappable beside
+    it.
+    """
+    return "\n".join(
+        [
+            method.upper(),
+            path,
+            timestamp,
+            nonce,
+            hashlib.sha256(body).hexdigest(),
+        ]
+    ).encode("utf-8")
+
+
+def sign_request(
+    secret: str, *, method: str, path: str, timestamp: str, nonce: str, body: bytes
+) -> str:
+    """The header value a caller holding ``secret`` would send.
+
+    Lives here rather than only in the app-kit so this build can state the
+    contract exactly once — the verifier below and the tests both read it.
+    """
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        signing_material(
+            method=method, path=path, timestamp=timestamp, nonce=nonce, body=body
+        ),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{_SIGNATURE_PREFIX}{digest}"
+
+
+def read_envelope(headers: Mapping[str, str]) -> SignedEnvelope:
+    """Header shape and freshness. Pure — no database, no secrets."""
+    public_id = (headers.get(APP_HEADER) or "").strip().lower()
+    raw_timestamp = (headers.get(TIMESTAMP_HEADER) or "").strip()
+    nonce = (headers.get(NONCE_HEADER) or "").strip()
+    signature = (headers.get(SIGNATURE_HEADER) or "").strip().lower()
+
+    if not public_id or not raw_timestamp or not nonce or not signature:
+        raise AppChannelAuthError(AppChannelMessages.MISSING_SIGNATURE)
+    if len(public_id) > MAX_APP_ID_LENGTH or len(nonce) > MAX_NONCE_LENGTH:
+        raise AppChannelAuthError(AppChannelMessages.MISSING_SIGNATURE)
+    if not signature.startswith(_SIGNATURE_PREFIX):
+        raise AppChannelAuthError(AppChannelMessages.MISSING_SIGNATURE)
+
+    try:
+        timestamp = int(raw_timestamp)
+    except ValueError as exc:
+        raise AppChannelAuthError(AppChannelMessages.STALE_TIMESTAMP) from exc
+    if abs(time.time() - timestamp) > SIGNATURE_WINDOW_SECONDS:
+        raise AppChannelAuthError(AppChannelMessages.STALE_TIMESTAMP)
+
+    return SignedEnvelope(
+        public_id=public_id,
+        timestamp=timestamp,
+        nonce=nonce,
+        signature=signature,
+    )
+
+
+async def _registration_for(
+    session: AsyncSession, public_id: str
+) -> AppServiceRegistration:
+    row = (
+        await session.exec(
+            select(AppServiceRegistration).where(
+                AppServiceRegistration.public_id == public_id
+            )
+        )
+    ).first()
+    if row is None:
+        raise AppChannelAuthError(AppChannelMessages.UNKNOWN_APP)
+    return row
+
+
+def _registration_secret(row: AppServiceRegistration) -> str:
+    if not row.secret_encrypted:
+        # A registration with no stored secret has nothing to verify a
+        # signature against, so no request can authenticate as it.
+        raise AppChannelAuthError(AppChannelMessages.INVALID_SIGNATURE)
+    return decrypt_field(row.secret_encrypted, SALT_APP_SERVICE_SECRET)
+
+
+async def _burn_nonce(
+    session: AsyncSession, *, registration_id: int, nonce: str, expires_at: datetime
+) -> None:
+    """Spend this request's nonce, or refuse a second presentation.
+
+    Committed on its own before the endpoint does any work, so the request is
+    consumed whether or not the work that follows succeeds. A retry carries a
+    fresh nonce and a fresh timestamp, which is what a caller signs per attempt
+    anyway.
+    """
+    session.add(
+        AppServiceNonce(
+            registration_id=registration_id,
+            nonce=nonce,
+            seen_at=datetime.now(timezone.utc),
+            expires_at=expires_at,
+        )
+    )
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise AppChannelAuthError(AppChannelMessages.REPLAYED_REQUEST) from exc
+
+
+async def authenticate_caller(
+    session: AsyncSession,
+    *,
+    method: str,
+    path: str,
+    headers: Mapping[str, str],
+    body: bytes,
+) -> CallingApp:
+    """Resolve which app is calling, or refuse.
+
+    Runs on the system engine: ``app_service_registrations`` and the nonce guard
+    carry no request-path grant, and this happens before any guild is known.
+    """
+    envelope = read_envelope(headers)
+    registration = await _registration_for(session, envelope.public_id)
+    secret = _registration_secret(registration)
+
+    expected = sign_request(
+        secret,
+        method=method,
+        path=path,
+        timestamp=str(envelope.timestamp),
+        nonce=envelope.nonce,
+        body=body,
+    )
+    if not hmac.compare_digest(expected, envelope.signature):
+        raise AppChannelAuthError(AppChannelMessages.INVALID_SIGNATURE)
+
+    if not registration.enabled:
+        # The operator's kill switch: every channel this app has stops, and it
+        # is a state rather than a failure to authenticate.
+        raise AppChannelAuthError(AppChannelMessages.APP_DISABLED, status_code=403)
+
+    await _burn_nonce(
+        session,
+        registration_id=registration.id,
+        nonce=envelope.nonce,
+        expires_at=datetime.fromtimestamp(
+            envelope.timestamp + SIGNATURE_WINDOW_SECONDS, tz=timezone.utc
+        ),
+    )
+    logger.debug(
+        "app channel: authenticated %s for %s %s", registration.public_id, method, path
+    )
+    return CallingApp(registration=registration, nonce=envelope.nonce)

--- a/backend/app/services/marketplace/app_channel_auth_test.py
+++ b/backend/app/services/marketplace/app_channel_auth_test.py
@@ -1,0 +1,161 @@
+"""The signing scheme itself, checked without a database.
+
+The endpoint tests hold the behaviour an app sees; these hold the two pure
+pieces underneath it — what goes into the MAC, and what the header reader will
+accept before anything is looked up. Keeping them separate matters because the
+signing material is a published contract: an app-kit in another language has to
+reproduce it byte for byte, so a change here should read as a change to that
+contract rather than as an incidental test edit.
+"""
+
+import hashlib
+import time
+
+import pytest
+
+from app.core.messages import AppChannelMessages
+from app.services.marketplace.app_channel_auth import (
+    APP_HEADER,
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    SIGNATURE_WINDOW_SECONDS,
+    TIMESTAMP_HEADER,
+    AppChannelAuthError,
+    read_envelope,
+    sign_request,
+    signing_material,
+)
+
+pytestmark = pytest.mark.unit
+
+SECRET = "shared"
+ARGS = {
+    "method": "post",
+    "path": "/api/v1/app-service/events",
+    "timestamp": "1755000000",
+    "nonce": "abc123",
+    "body": b'{"guild_id":1}',
+}
+
+
+def _headers(**overrides) -> dict[str, str]:
+    stamp = str(overrides.pop("timestamp", int(time.time())))
+    headers = {
+        APP_HEADER: "tests.shop",
+        TIMESTAMP_HEADER: stamp,
+        NONCE_HEADER: "abc123",
+        SIGNATURE_HEADER: "sha256=" + "0" * 64,
+    }
+    headers.update(overrides)
+    return headers
+
+
+class TestSigningMaterial:
+    def test_the_material_is_the_documented_field_order(self):
+        """Method, path, timestamp, nonce, body digest — newline separated, with
+        the method upper-cased so a client's spelling does not decide."""
+        material = signing_material(**ARGS).decode()
+
+        assert material.split("\n") == [
+            "POST",
+            "/api/v1/app-service/events",
+            "1755000000",
+            "abc123",
+            hashlib.sha256(ARGS["body"]).hexdigest(),
+        ]
+
+    def test_the_body_enters_as_a_digest_not_verbatim(self):
+        """A large body costs the same to sign as a small one, and the material
+        stays a fixed length."""
+        small = signing_material(**{**ARGS, "body": b"x"})
+        large = signing_material(**{**ARGS, "body": b"x" * 100_000})
+
+        assert len(small) == len(large)
+        assert small != large
+
+    @pytest.mark.parametrize(
+        "changed",
+        [
+            {"method": "get"},
+            {"path": "/api/v1/app-service/installs"},
+            {"timestamp": "1755000001"},
+            {"nonce": "different"},
+            {"body": b'{"guild_id":2}'},
+        ],
+    )
+    def test_every_field_changes_the_signature(self, changed):
+        assert sign_request(SECRET, **ARGS) != sign_request(
+            SECRET, **{**ARGS, **changed}
+        )
+
+    def test_the_secret_changes_the_signature(self):
+        assert sign_request(SECRET, **ARGS) != sign_request("other", **ARGS)
+
+    def test_the_signature_is_prefixed_hex(self):
+        signature = sign_request(SECRET, **ARGS)
+
+        assert signature.startswith("sha256=")
+        assert len(signature) == len("sha256=") + 64
+        int(signature.removeprefix("sha256="), 16)
+
+
+class TestEnvelopeShape:
+    def test_a_complete_envelope_is_read(self):
+        envelope = read_envelope(_headers())
+
+        assert envelope.public_id == "tests.shop"
+        assert envelope.nonce == "abc123"
+
+    def test_the_app_id_is_normalized(self):
+        """One canonical spelling, because it is what a registration lookup and
+        a JWT audience are built from."""
+        envelope = read_envelope(_headers(**{APP_HEADER: "  Tests.Shop  "}))
+
+        assert envelope.public_id == "tests.shop"
+
+    @pytest.mark.parametrize(
+        "header", [APP_HEADER, TIMESTAMP_HEADER, NONCE_HEADER, SIGNATURE_HEADER]
+    )
+    def test_a_missing_header_is_refused(self, header):
+        headers = _headers()
+        del headers[header]
+
+        with pytest.raises(AppChannelAuthError) as exc:
+            read_envelope(headers)
+        assert exc.value.code == AppChannelMessages.MISSING_SIGNATURE
+
+    def test_a_signature_without_the_algorithm_prefix_is_refused(self):
+        with pytest.raises(AppChannelAuthError) as exc:
+            read_envelope(_headers(**{SIGNATURE_HEADER: "0" * 64}))
+        assert exc.value.code == AppChannelMessages.MISSING_SIGNATURE
+
+    def test_an_oversized_nonce_is_refused_before_any_lookup(self):
+        with pytest.raises(AppChannelAuthError) as exc:
+            read_envelope(_headers(**{NONCE_HEADER: "n" * 200}))
+        assert exc.value.code == AppChannelMessages.MISSING_SIGNATURE
+
+    @pytest.mark.parametrize(
+        "offset", [-(SIGNATURE_WINDOW_SECONDS + 1), SIGNATURE_WINDOW_SECONDS + 1]
+    )
+    def test_a_timestamp_outside_the_window_is_refused(self, offset):
+        with pytest.raises(AppChannelAuthError) as exc:
+            read_envelope(_headers(timestamp=int(time.time()) + offset))
+        assert exc.value.code == AppChannelMessages.STALE_TIMESTAMP
+
+    def test_a_timestamp_inside_the_window_is_read(self):
+        inside = int(time.time()) - (SIGNATURE_WINDOW_SECONDS - 5)
+
+        assert read_envelope(_headers(timestamp=inside)).timestamp == inside
+
+    def test_a_non_numeric_timestamp_is_refused(self):
+        with pytest.raises(AppChannelAuthError) as exc:
+            read_envelope(_headers(**{TIMESTAMP_HEADER: "recently"}))
+        assert exc.value.code == AppChannelMessages.STALE_TIMESTAMP
+
+    def test_the_refusal_carries_its_own_status(self):
+        """The endpoint layer maps a refusal by reading it, rather than keeping
+        a second table of codes to statuses."""
+        error = AppChannelAuthError(AppChannelMessages.APP_DISABLED, status_code=403)
+
+        assert error.code == AppChannelMessages.APP_DISABLED
+        assert error.status_code == 403

--- a/backend/app/services/platform/jti_purge.py
+++ b/backend/app/services/platform/jti_purge.py
@@ -1,18 +1,19 @@
-"""One periodic worker that prunes every one-shot ``jti`` replay-guard table.
+"""One periodic worker that prunes every one-shot replay-guard table.
 
-Both jti blocklists — the billing service JWT blocklist and the
-initiative-auto delegation blocklist — are the same maintenance concern:
-shared ``public`` tables of spent one-shot tokens that grow forever unless
-swept. They run on one hourly cadence, so one worker sweeps them all rather
-than a near-identical janitor per table (the per-table DELETE lives in
-:func:`app.db.jti_blocklist.purge_expired_jtis`).
+The guards — the billing service JWT blocklist, the initiative-auto delegation
+blocklist, and the nonces spent on the app-service channel — are the same
+maintenance concern: shared ``public`` tables of spent one-shot values that grow
+forever unless swept. They run on one hourly cadence, so one worker sweeps them
+all rather than a near-identical janitor per table (the per-table DELETE lives
+in :func:`app.db.jti_blocklist.purge_expired_jtis`).
 
 Each entry is gated by whether its integration is configured: on a self-host
-with neither wired, the worker is a strict no-op (no session opened). The
-sweep runs on the system engine (``app_admin`` holds DELETE on both tables);
-the request path never deletes. Pruning is always safe — an expired token is
-refused by its own ``exp`` at verification before its blocklist is consulted,
-so removing the spent row never re-opens a replay window.
+with none of them wired, the worker is a strict no-op (no session opened). The
+sweep runs on the system engine (``app_admin`` holds DELETE on each table); the
+request path never deletes. Pruning is always safe — a value that old is already
+refused at verification, by its own ``exp`` or by the signing freshness window,
+before its guard table is consulted, so removing the spent row never re-opens a
+replay window.
 """
 
 from __future__ import annotations
@@ -25,8 +26,10 @@ from sqlmodel import SQLModel
 
 from app.core.config import settings
 from app.db.jti_blocklist import purge_expired_jtis
+from app.models.platform.app_service_nonce import AppServiceNonce
 from app.models.platform.auto_delegation_jti import AutoDelegationJti
 from app.models.platform.billing import BillingJti
+from app.services.marketplace.app_channel_auth import app_channel_possible
 from app.services.platform.billing import billing_inbound_enabled
 
 logger = logging.getLogger(__name__)
@@ -46,10 +49,11 @@ def _auto_delegation_enabled() -> bool:
     return bool(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM)
 
 
-# One entry per jti blocklist. Add a table here and it is swept automatically.
+# One entry per replay guard. Add a table here and it is swept automatically.
 _BLOCKLISTS: tuple[_Blocklist, ...] = (
     _Blocklist(BillingJti, billing_inbound_enabled, "billing"),
     _Blocklist(AutoDelegationJti, _auto_delegation_enabled, "auto-delegation"),
+    _Blocklist(AppServiceNonce, app_channel_possible, "app-service"),
 )
 
 

--- a/backend/app/services/tenant/app_channels.py
+++ b/backend/app/services/tenant/app_channels.py
@@ -1,0 +1,534 @@
+"""What an app service may read and write about its own installs.
+
+An app knows its installs by pulling them: which guilds have it, the
+configuration each guild supplied, and which members connected their own
+accounts. This module is the guild-touching half of that channel — the caller
+has already been established from its signature
+(:mod:`app.services.marketplace.app_channel_auth`), and everything here answers
+in terms of *that* registration.
+
+Three rules run through all of it:
+
+* **An app only ever sees its own installs.** Every lookup is filtered by the
+  registration's catalog uid *and* by the pinned definition naming that same
+  app, so an install belonging to a different app is indistinguishable from one
+  that does not exist.
+* **Plaintext leaves in exactly one place.** :func:`config_payload` is the
+  custody channel: it decrypts what the guild and its members stored and hands
+  it to the app that needs it. The connections view carries status and nothing
+  else, so an app reconciling who is connected never pulls credentials to do it.
+* **People are addressed by reference.** Per-member rows are keyed by their
+  opaque ``connection_ref``; no user id, email, or name is ever in a payload
+  here.
+
+Guild content lives in per-guild schemas, so every read routes the system-engine
+session into one guild at a time as a guild admin — the app is acting with the
+install's authority, and ``SET ROLE`` drops the system engine's bypass, so the
+guild's own policies are what answer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional, Sequence
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import AppChannelMessages
+from app.db.session import set_rls_context
+from app.models.platform.app_service_registration import AppServiceRegistration
+from app.models.platform.guild import Guild, GuildStatus
+from app.models.tenant.guild_app import GuildApp
+from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
+from app.services.marketplace.service_apps import EVENT_TYPE_PREFIX
+from app.services.tenant import app_config as app_config_service
+from app.services.tenant.webhook_dispatcher import dispatch_event
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MAX_EVENT_PAYLOAD_BYTES",
+    "AppChannelError",
+    "config_payload",
+    "connection_payload",
+    "emit_event",
+    "install_summaries",
+    "load_install",
+    "report_config_state",
+    "write_connection_values",
+]
+
+#: What one event body may carry. An event is a notification that something
+#: happened, not a data transfer — an app with more to say serves it from a data
+#: source the platform fetches on demand.
+MAX_EVENT_PAYLOAD_BYTES = 64 * 1024
+
+#: The states an app may report about the configuration it was handed.
+#: ``unverified`` is this build's resting value and is not something an app
+#: asserts — it says nothing, or it says whether the credentials work.
+REPORTABLE_CONFIG_STATES: frozenset[str] = frozenset({"ok", "invalid"})
+
+#: Bound on the short code an app attaches to an ``invalid`` verdict, matching
+#: the column it lands in.
+MAX_CONFIG_STATE_DETAIL = 120
+
+
+class AppChannelError(Exception):
+    """A refusal on the app channel, as a message code plus its HTTP answer."""
+
+    def __init__(self, code: str, status_code: int = 400) -> None:
+        super().__init__(code)
+        self.code = code
+        self.status_code = status_code
+
+
+# --- which installs are this app's ------------------------------------------
+
+
+def _definition_service_id(definition: dict[str, Any] | None) -> Optional[str]:
+    service = (definition or {}).get("service")
+    if not isinstance(service, dict):
+        return None
+    public_id = service.get("public_id")
+    return public_id if isinstance(public_id, str) else None
+
+
+def owns_install(app: GuildApp, registration: AppServiceRegistration) -> bool:
+    """Whether this install is the calling app's.
+
+    Two independent statements have to agree: the install was made from the
+    listing this registration speaks for, and the definition the guild pinned
+    names this same app as its service. Either alone would be enough in the
+    ordinary case; requiring both means a registration re-pointed at another
+    listing still cannot reach installs it was not wired for.
+    """
+    if app.app_kind != "service":
+        return False
+    if not registration.listing_uid or app.listing_uid != registration.listing_uid:
+        return False
+    return _definition_service_id(app.definition) == registration.public_id
+
+
+async def _guild_ids(session: AsyncSession) -> list[int]:
+    """Every guild whose content this channel may reach, lowest id first.
+
+    Suspended guilds are left out: a suspended guild's content is frozen for
+    members and admins alike, and an app pulling for it would be reaching past
+    a hold the operator put there. It reappears when the guild does.
+    """
+    await set_rls_context(session)
+    rows = await session.exec(
+        select(Guild.id, Guild.status)
+        .where(Guild.status != GuildStatus.suspended.value)
+        .order_by(Guild.id.asc())
+    )
+    return [row[0] for row in rows]
+
+
+async def _route(session: AsyncSession, guild_id: int, *, read_only: bool) -> None:
+    """Point the system-engine session at one guild, with the install's
+    authority. ``SET ROLE`` drops the engine's bypass, so the guild's own
+    policies decide from here; a frozen guild is routed to its SELECT-only role
+    so no write can land in it whatever the caller asked for."""
+    session.expunge_all()
+    await set_rls_context(
+        session, guild_id=guild_id, guild_role="admin", read_only=read_only
+    )
+
+
+async def _guild_row(session: AsyncSession, guild_id: int) -> Optional[Guild]:
+    await set_rls_context(session)
+    return (await session.exec(select(Guild).where(Guild.id == guild_id))).first()
+
+
+async def install_summaries(
+    session: AsyncSession, registration: AppServiceRegistration
+) -> list[dict[str, Any]]:
+    """Every guild that has this app installed, and at which version.
+
+    Installs live in the guild schema that holds them — the catalog records what
+    was published, never who installed it — so this visits each guild in turn.
+    That cost tracks the number of guilds rather than the number of installs,
+    which is the price of the catalog carrying no index of who installed what.
+
+    A registration that has never verified names no listing, so it has no
+    installs to report.
+    """
+    if not registration.listing_uid:
+        return []
+
+    summaries: list[dict[str, Any]] = []
+    for guild_id in await _guild_ids(session):
+        await _route(session, guild_id, read_only=True)
+        rows = (
+            await session.exec(
+                select(GuildApp)
+                .where(GuildApp.listing_uid == registration.listing_uid)
+                .order_by(GuildApp.id.asc())
+            )
+        ).all()
+        summaries.extend(
+            _summarize(app) for app in rows if owns_install(app, registration)
+        )
+    return summaries
+
+
+def _summarize(app: GuildApp) -> dict[str, Any]:
+    """One install as the app is told about it.
+
+    Ids and state only: which guild, which install, which version it is pinned
+    to, and whether it is live. Nothing about who is in the guild, and nothing
+    about what anyone configured — those are the config and connections
+    channels, addressed one guild at a time.
+    """
+    state = app_config_service.config_state(app)
+    return {
+        "install_id": app.id,
+        "guild_id": app.guild_id,
+        "listing_uid": app.listing_uid,
+        "listing_version": app.listing_version,
+        "name": app.name,
+        "enabled": app.enabled,
+        "config_state": state.state,
+        "config_state_detail": state.detail,
+        "needs_config": state.needs_config,
+        "updated_at": app.updated_at,
+    }
+
+
+async def load_install(
+    session: AsyncSession,
+    registration: AppServiceRegistration,
+    guild_id: int,
+    *,
+    for_write: bool = False,
+) -> GuildApp:
+    """The calling app's install in one guild, with the session routed to it.
+
+    Everything that is not this app's install answers the same way — a guild
+    that does not exist, one that is suspended, one that never installed the
+    app, and one that installed a different app are one refusal, because the
+    caller is entitled to distinguish none of them.
+
+    ``for_write`` refuses a guild the operator has frozen, so a write is turned
+    away with a reason rather than failing against a read-only database role.
+    """
+    guild = await _guild_row(session, guild_id)
+    if guild is None or guild.status == GuildStatus.suspended.value:
+        raise AppChannelError(AppChannelMessages.INSTALL_NOT_FOUND, status_code=404)
+
+    frozen = guild.status == GuildStatus.read_only.value
+    if for_write and frozen:
+        raise AppChannelError(AppChannelMessages.GUILD_READ_ONLY, status_code=409)
+
+    await _route(session, guild_id, read_only=frozen or not for_write)
+    if not registration.listing_uid:
+        raise AppChannelError(AppChannelMessages.INSTALL_NOT_FOUND, status_code=404)
+
+    app = (
+        await session.exec(
+            select(GuildApp).where(GuildApp.listing_uid == registration.listing_uid)
+        )
+    ).first()
+    if app is None or not owns_install(app, registration):
+        raise AppChannelError(AppChannelMessages.INSTALL_NOT_FOUND, status_code=404)
+    if not app.enabled:
+        # The guild's own kill switch, beside the operator's: the install stays
+        # exactly as it is, and nothing flows through it until it is switched
+        # back on. Every channel stops here, the credential pull included.
+        raise AppChannelError(AppChannelMessages.INSTALL_DISABLED, status_code=409)
+    return app
+
+
+# --- the custody channel ----------------------------------------------------
+
+
+async def config_payload(session: AsyncSession, app: GuildApp) -> dict[str, Any]:
+    """The decrypted configuration for one install — the custody channel.
+
+    This is the one place stored plaintext leaves the platform, and it goes only
+    to the app that the values were supplied for. It carries both halves of what
+    an app holds credentials for: the guild-wide values an admin typed, and the
+    per-member values the app itself wrote back after a vendor flow, each keyed
+    by the opaque reference the app knows that member by.
+
+    Reading it here is what keeps custody real — the app caches in memory, and
+    revoking, rotating, or uninstalling on this side means the next pull simply
+    stops returning them.
+    """
+    connections: dict[str, dict[str, Any]] = {}
+    for connection in app_config_service.definition_connections(app.definition):
+        connection_id = connection.get("id")
+        if not isinstance(connection_id, str):
+            continue
+        if connection.get("scope") != "static":
+            # Per-member values are reported below, per connection reference —
+            # there is no guild-wide value for a credential a vendor issued to
+            # one person.
+            continue
+        values = dict((app.config or {}).get(connection_id) or {})
+        values.update(
+            app_config_service.decrypt_connection_secrets(
+                (app.config_secrets or {}).get(connection_id) or {}
+            )
+        )
+        if values:
+            connections[connection_id] = values
+
+    member_values = [
+        {
+            "connection_id": row.connection_id,
+            "connection_ref": row.connection_ref,
+            "status": row.status,
+            "values": {
+                **dict(row.config or {}),
+                **app_config_service.decrypt_connection_secrets(row.config_secrets),
+            },
+        }
+        for row in await _member_rows(session, app)
+        if row.blocked_at is None
+    ]
+
+    state = app_config_service.config_state(app)
+    return {
+        "guild_id": app.guild_id,
+        "install_id": app.id,
+        "listing_uid": app.listing_uid,
+        "listing_version": app.listing_version,
+        "enabled": app.enabled,
+        "config_state": state.state,
+        "config_state_detail": state.detail,
+        "needs_config": state.needs_config,
+        "connections": connections,
+        "member_connections": member_values,
+    }
+
+
+# --- who connected ----------------------------------------------------------
+
+
+async def _member_rows(
+    session: AsyncSession, app: GuildApp
+) -> Sequence[GuildAppUserConnection]:
+    return (
+        await session.exec(
+            select(GuildAppUserConnection)
+            .where(GuildAppUserConnection.app_id == app.id)
+            .order_by(
+                GuildAppUserConnection.connection_id,
+                GuildAppUserConnection.id,
+            )
+        )
+    ).all()
+
+
+async def connection_payload(
+    session: AsyncSession, app: GuildApp
+) -> list[dict[str, Any]]:
+    """The app's per-member connections for one guild, by reference alone.
+
+    Status and nothing more: an app reconciling which of its handles are still
+    live does not need a credential to do it, and this view never carries one.
+    Who the member is stays on this side — the reference is the whole of the
+    app's name for them.
+    """
+    return [
+        {
+            "connection_id": row.connection_id,
+            "connection_ref": row.connection_ref,
+            "status": row.status,
+            "blocked": row.blocked_at is not None,
+            "account_label": row.account_label,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+        }
+        for row in await _member_rows(session, app)
+    ]
+
+
+async def _row_by_ref(
+    session: AsyncSession, app: GuildApp, connection_ref: str
+) -> GuildAppUserConnection:
+    row = (
+        await session.exec(
+            select(GuildAppUserConnection).where(
+                GuildAppUserConnection.app_id == app.id,
+                GuildAppUserConnection.connection_ref == connection_ref,
+            )
+        )
+    ).first()
+    if row is None:
+        raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
+    return row
+
+
+# --- what an app reports back -----------------------------------------------
+
+
+async def report_config_state(
+    session: AsyncSession,
+    app: GuildApp,
+    *,
+    state: str,
+    detail: Optional[str] = None,
+) -> dict[str, Any]:
+    """Record the app's verdict on the configuration it was given.
+
+    Presence of values is all this build can know by itself; whether a
+    credential carries the permissions it needs is something only the vendor can
+    confirm, and this is how that answer gets back to the admin who pasted it.
+    An app that never reports leaves the install ``unverified`` — nothing blocks
+    on the round trip.
+    """
+    if state not in REPORTABLE_CONFIG_STATES:
+        raise AppChannelError(AppChannelMessages.INVALID_CONFIG_STATE)
+    cleaned = (detail or "").strip() or None
+    if cleaned is not None and len(cleaned) > MAX_CONFIG_STATE_DETAIL:
+        raise AppChannelError(AppChannelMessages.INVALID_CONFIG_STATE)
+    if state == "ok":
+        # A verdict of "working" carries no complaint to display beside it.
+        cleaned = None
+
+    app.config_state = state
+    app.config_state_detail = cleaned
+    app.updated_at = datetime.now(timezone.utc)
+    session.add(app)
+    await session.commit()
+    await session.refresh(app)
+    return {
+        "guild_id": app.guild_id,
+        "install_id": app.id,
+        "config_state": app.config_state,
+        "config_state_detail": app.config_state_detail,
+    }
+
+
+async def write_connection_values(
+    session: AsyncSession,
+    app: GuildApp,
+    *,
+    connection_ref: str,
+    values: dict[str, Any],
+    status: Optional[str] = None,
+    account_label: Optional[str] = None,
+) -> dict[str, Any]:
+    """Store what a vendor flow produced for one member's connection.
+
+    The app runs the flow at its own URL and writes the result here, which is
+    what makes Initiative the custodian of a credential the app obtained: the
+    same path serves a refresh, so a token rotated at 03:00 is still revocable
+    at 03:05. Only fields the manifest marked ``managed`` may be written this
+    way — everything else on a connection is typed by a person.
+
+    A connection an admin blocked is refused: the block exists precisely to stop
+    that member's access coming back.
+    """
+    row = await _row_by_ref(session, app, connection_ref)
+    if row.blocked_at is not None:
+        raise AppChannelError(AppChannelMessages.CONNECTION_BLOCKED, status_code=403)
+
+    connection = app_config_service.connection_by_id(app.definition, row.connection_id)
+    if connection is None:
+        # The install moved to a version that no longer declares this
+        # connection; its values are on their way out with it.
+        raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
+
+    try:
+        config, secrets = app_config_service.apply_connection_values(
+            connection,
+            values,
+            current=row.config or {},
+            current_secrets=row.config_secrets or {},
+            allow_managed=True,
+        )
+    except app_config_service.AppConfigError as exc:
+        raise AppChannelError(exc.code) from exc
+
+    row.config = config
+    row.config_secrets = secrets
+    if account_label is not None:
+        label = account_label.strip()
+        row.account_label = label or None
+    row.status = _resolved_status(status, config=config, secrets=secrets)
+    row.updated_at = datetime.now(timezone.utc)
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return {
+        "connection_id": row.connection_id,
+        "connection_ref": row.connection_ref,
+        "status": row.status,
+        "blocked": row.blocked_at is not None,
+        "account_label": row.account_label,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+
+def _resolved_status(
+    requested: Optional[str], *, config: dict[str, Any], secrets: dict[str, Any]
+) -> str:
+    """What a connection's status becomes after a write-back.
+
+    An app may say it is still mid-flow; otherwise the stored values decide, so
+    a write that clears everything leaves the row honest rather than claiming a
+    connection it no longer holds.
+    """
+    if requested == "pending":
+        return "pending"
+    return "connected" if (config or secrets) else "pending"
+
+
+# --- events in --------------------------------------------------------------
+
+
+def _payload_size(payload: dict[str, Any]) -> int:
+    try:
+        encoded = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError) as exc:
+        raise AppChannelError(AppChannelMessages.INVALID_PAYLOAD) from exc
+    return len(encoded.encode("utf-8"))
+
+
+async def emit_event(
+    session: AsyncSession,
+    app: GuildApp,
+    registration: AppServiceRegistration,
+    *,
+    event_type: str,
+    payload: dict[str, Any],
+) -> None:
+    """Re-emit a third-party event into this guild's own dispatcher.
+
+    The app has verified the third party's signature and worked out which of its
+    installs the event belongs to; what this adds is the platform's half —
+    the event type is one the *pinned* definition declares, namespaced under the
+    calling app, and the guild has that app installed and enabled.
+
+    From there it is an ordinary event: the existing dispatcher delivers it to
+    whatever the automation delegate subscribed to. Delivery targets are the
+    delegate's to own, which is why this is one-way — apps emit, and never
+    subscribe.
+    """
+    definition = app.definition if isinstance(app.definition, dict) else {}
+    declared = definition.get("events")
+    prefix = f"{EVENT_TYPE_PREFIX}{registration.public_id}."
+    if (
+        not isinstance(declared, list)
+        or event_type not in declared
+        or not event_type.startswith(prefix)
+    ):
+        raise AppChannelError(AppChannelMessages.UNKNOWN_EVENT_TYPE)
+
+    if _payload_size(payload) > MAX_EVENT_PAYLOAD_BYTES:
+        raise AppChannelError(AppChannelMessages.EVENT_TOO_LARGE, status_code=413)
+
+    await dispatch_event(
+        session,
+        event_type=event_type,
+        guild_id=app.guild_id,
+        payload=payload,
+    )

--- a/backend/app/services/tenant/app_channels_test.py
+++ b/backend/app/services/tenant/app_channels_test.py
@@ -1,0 +1,101 @@
+"""The two pure decisions behind the app channel.
+
+Everything else in this module reaches a database, and the endpoint tests hold
+that. What is worth pinning separately is the predicate that decides whether an
+install belongs to the calling app — it is the whole of the isolation between
+one app's credentials and another's — and the serializer that decides what an
+app is told about an install it does own.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.tenant.app_channels import _summarize, owns_install
+
+pytestmark = pytest.mark.unit
+
+SHOP_UID = "TESTAPP0000001"
+
+
+def _registration(public_id: str = "tests.shop", listing_uid: str | None = SHOP_UID):
+    return SimpleNamespace(public_id=public_id, listing_uid=listing_uid)
+
+
+def _app(
+    *,
+    listing_uid: str = SHOP_UID,
+    service_id: str = "tests.shop",
+    app_kind: str = "service",
+):
+    return SimpleNamespace(
+        id=1,
+        guild_id=2,
+        listing_uid=listing_uid,
+        listing_version="1.0.0",
+        name="Shop",
+        enabled=True,
+        app_kind=app_kind,
+        definition={
+            "app_kind": app_kind,
+            "service": {"public_id": service_id},
+            "connections": [],
+        },
+        config={},
+        config_secrets={},
+        config_state="unverified",
+        config_state_detail=None,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+class TestOwnsInstall:
+    def test_a_matching_uid_and_service_id_is_ours(self):
+        assert owns_install(_app(), _registration()) is True
+
+    def test_another_listings_install_is_not_ours(self):
+        theirs = _app(listing_uid="TESTAPP0000002")
+
+        assert owns_install(theirs, _registration()) is False
+
+    def test_an_install_pinning_another_service_is_not_ours(self):
+        """The second condition, on its own. A registration re-pointed at a
+        listing still cannot reach installs whose pinned definition names a
+        different app."""
+        assert owns_install(_app(service_id="tests.other"), _registration()) is False
+
+    def test_a_registration_that_never_verified_owns_nothing(self):
+        assert owns_install(_app(), _registration(listing_uid=None)) is False
+
+    def test_a_non_service_install_is_never_ours(self):
+        """An embed or a tool instance has no service behind it, so no
+        registration speaks for it however its uid lines up."""
+        assert owns_install(_app(app_kind="embed"), _registration()) is False
+
+    def test_a_definition_without_a_service_block_is_not_ours(self):
+        app = _app()
+        app.definition = {"app_kind": "service"}
+
+        assert owns_install(app, _registration()) is False
+
+
+class TestSummary:
+    def test_a_summary_carries_ids_and_state_only(self):
+        """What an app reconciles against. Anything about the guild's people
+        would be a second channel's answer arriving on this one."""
+        summary = _summarize(_app())
+
+        assert set(summary) == {
+            "install_id",
+            "guild_id",
+            "listing_uid",
+            "listing_version",
+            "name",
+            "enabled",
+            "config_state",
+            "config_state_detail",
+            "needs_config",
+            "updated_at",
+        }
+        assert summary["config_state"] == "unverified"

--- a/backend/app/testing/__init__.py
+++ b/backend/app/testing/__init__.py
@@ -11,6 +11,12 @@ guild's ``guild_<id>`` schema before touching the database (see
 """
 
 from app.testing.actor import Actor, make_actor
+from app.testing.app_channel import (
+    APP_CHANNEL_SECRET,
+    channel_headers,
+    encode_body,
+    register_app_service,
+)
 from app.testing.factories import (
     TOOL_FACTORIES,
     enable_all_tools,
@@ -54,6 +60,10 @@ from app.testing.factories import (
 from app.testing.schema_harness import route_session_to_guild
 
 __all__ = [
+    "APP_CHANNEL_SECRET",
+    "channel_headers",
+    "encode_body",
+    "register_app_service",
     "TOOL_FACTORIES",
     "enable_all_tools",
     "create_tool_entity",

--- a/backend/app/testing/app_channel.py
+++ b/backend/app/testing/app_channel.py
@@ -1,0 +1,121 @@
+"""Helpers for driving the app-service channel in tests.
+
+An app service authenticates by signing its request, so a test that wants to
+*be* an app has to sign like one. These build the same headers the app-kit will,
+through the same :func:`~app.services.marketplace.app_channel_auth.sign_request`
+the verifier is written against — so a test cannot pass by agreeing with a
+second, private idea of the scheme.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from typing import Any, Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.encryption import SALT_APP_SERVICE_SECRET, encrypt_field
+from app.models.platform.app_service_registration import (
+    AppServiceRegistration,
+    AppServiceStatus,
+)
+from app.services.marketplace.app_channel_auth import (
+    APP_HEADER,
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    sign_request,
+)
+
+__all__ = [
+    "APP_CHANNEL_SECRET",
+    "channel_headers",
+    "encode_body",
+    "register_app_service",
+]
+
+#: The shared secret a test registration is wired with.
+APP_CHANNEL_SECRET = "app-channel-shared-secret"
+
+
+async def register_app_service(
+    session: AsyncSession,
+    *,
+    public_id: str = "tests.shop",
+    listing_uid: str = "TESTAPP0000001",
+    secret: Optional[str] = APP_CHANNEL_SECRET,
+    base_url: str = "http://127.0.0.1:9300",
+    enabled: bool = True,
+    **overrides: Any,
+) -> AppServiceRegistration:
+    """A registration wired the way a verified handshake would leave one.
+
+    ``listing_uid`` is what a handshake records, and it is what ties the
+    registration to the installs it may reach — a registration created with
+    ``listing_uid=None`` models one that has never verified.
+    """
+    row = AppServiceRegistration(
+        public_id=public_id,
+        listing_uid=listing_uid,
+        base_url=base_url,
+        allowed_origins=[base_url],
+        secret_encrypted=(
+            encrypt_field(secret, SALT_APP_SERVICE_SECRET) if secret else None
+        ),
+        enabled=enabled,
+        status=overrides.pop("status", AppServiceStatus.OK),
+        **overrides,
+    )
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+def encode_body(payload: Any) -> bytes:
+    """Serialize a request body the way a client would send it.
+
+    The signature covers the exact bytes, so a test has to sign and send the
+    same ones — which means building them once here rather than letting the
+    HTTP client re-serialize.
+    """
+    if payload is None:
+        return b""
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
+def channel_headers(
+    *,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    secret: str = APP_CHANNEL_SECRET,
+    public_id: str = "tests.shop",
+    timestamp: Optional[int] = None,
+    nonce: Optional[str] = None,
+) -> dict[str, str]:
+    """The signing headers for one request.
+
+    ``path`` is the full request path, ``/api/v1/app-service/…``, because that is
+    what the server sees and therefore what both sides sign.
+    """
+    stamp = str(int(time.time()) if timestamp is None else timestamp)
+    value = nonce or secrets.token_urlsafe(12)
+    headers = {
+        APP_HEADER: public_id,
+        TIMESTAMP_HEADER: stamp,
+        NONCE_HEADER: value,
+        SIGNATURE_HEADER: sign_request(
+            secret,
+            method=method,
+            path=path,
+            timestamp=stamp,
+            nonce=value,
+            body=body,
+        ),
+    }
+    if body:
+        headers["Content-Type"] = "application/json"
+    return headers

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -425,5 +425,20 @@
   "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Diese Verbindung nutzt eine Zugangsberechtigung für die ganze Gilde, es gibt also kein Konto zu verbinden.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "Diese Verbindung gehört jedem Mitglied selbst und wird verbunden statt ausgefüllt.",
   "GUILD_APP_CONNECTION_BLOCKED": "Eine Gildenadministration hat dir diese Verbindung untersagt.",
-  "GUILD_APP_DISABLED": "Diese App ist ausgeschaltet, es läuft nichts über sie."
+  "GUILD_APP_DISABLED": "Diese App ist ausgeschaltet, es läuft nichts über sie.",
+  "APP_CHANNEL_MISSING_SIGNATURE": "Diese Anfrage eines App-Dienstes war nicht korrekt signiert.",
+  "APP_CHANNEL_STALE_TIMESTAMP": "Diese Anfrage eines App-Dienstes wurde vor zu langer Zeit signiert. Prüfe die Uhren auf beiden Seiten.",
+  "APP_CHANNEL_UNKNOWN_APP": "Unter diesem Namen ist kein App-Dienst registriert.",
+  "APP_CHANNEL_INVALID_SIGNATURE": "Die Signatur der Anfrage passt nicht zum gemeinsamen Geheimnis dieses App-Dienstes.",
+  "APP_CHANNEL_REPLAYED_REQUEST": "Diese Anfrage wurde bereits verwendet und lässt sich nicht wiederholen.",
+  "APP_CHANNEL_APP_DISABLED": "Dieser App-Dienst wurde abgeschaltet, es läuft nichts über ihn.",
+  "APP_CHANNEL_INSTALL_NOT_FOUND": "Diese App ist in dieser Gilde nicht installiert.",
+  "APP_CHANNEL_INSTALL_DISABLED": "Diese Gilde hat die App ausgeschaltet.",
+  "APP_CHANNEL_GUILD_READ_ONLY": "Diese Gilde ist eingefroren, derzeit kann nichts hineingeschrieben werden.",
+  "APP_CHANNEL_CONNECTION_NOT_FOUND": "Zu dieser Referenz gibt es in dieser Installation keine Verbindung.",
+  "APP_CHANNEL_CONNECTION_BLOCKED": "Eine Gildenadministration hat die Verbindung dieses Mitglieds gesperrt.",
+  "APP_CHANNEL_INVALID_PAYLOAD": "Dieser App-Dienst hat etwas gesendet, das diese Version nicht lesen kann.",
+  "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "Diesen Ereignistyp hat die App nicht angegeben.",
+  "APP_CHANNEL_EVENT_TOO_LARGE": "Dieses Ereignis ist größer, als diese Version übertragen kann.",
+  "APP_CHANNEL_INVALID_CONFIG_STATE": "Dieser App-Dienst hat einen Status gemeldet, den diese Version nicht kennt."
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -425,5 +425,20 @@
   "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "This connection uses one credential for the whole guild, so there's no account to connect.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "This connection is each member's own, so it's connected rather than filled in.",
   "GUILD_APP_CONNECTION_BLOCKED": "A guild admin has stopped you connecting this.",
-  "GUILD_APP_DISABLED": "This app is turned off, so nothing flows through it."
+  "GUILD_APP_DISABLED": "This app is turned off, so nothing flows through it.",
+  "APP_CHANNEL_MISSING_SIGNATURE": "That request from an app service wasn't signed properly.",
+  "APP_CHANNEL_STALE_TIMESTAMP": "That request from an app service was signed too long ago. Check the clock on both sides.",
+  "APP_CHANNEL_UNKNOWN_APP": "No app service is registered under that name.",
+  "APP_CHANNEL_INVALID_SIGNATURE": "That request's signature doesn't match this app service's shared secret.",
+  "APP_CHANNEL_REPLAYED_REQUEST": "That request has already been used once and can't be repeated.",
+  "APP_CHANNEL_APP_DISABLED": "This app service has been switched off, so nothing flows through it.",
+  "APP_CHANNEL_INSTALL_NOT_FOUND": "That app isn't installed in that guild.",
+  "APP_CHANNEL_INSTALL_DISABLED": "That guild has turned this app off.",
+  "APP_CHANNEL_GUILD_READ_ONLY": "That guild is frozen, so nothing can be written to it right now.",
+  "APP_CHANNEL_CONNECTION_NOT_FOUND": "No connection on that install matches that reference.",
+  "APP_CHANNEL_CONNECTION_BLOCKED": "A guild admin has blocked that member's connection.",
+  "APP_CHANNEL_INVALID_PAYLOAD": "That app service sent something this version can't read.",
+  "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "That event type isn't one this app declared.",
+  "APP_CHANNEL_EVENT_TOO_LARGE": "That event is larger than this version will carry.",
+  "APP_CHANNEL_INVALID_CONFIG_STATE": "That app service reported a status this version doesn't recognize."
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -425,5 +425,20 @@
   "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Esta conexión usa una sola credencial para todo el gremio, así que no hay ninguna cuenta que conectar.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "Esta conexión es la de cada miembro, así que se conecta en lugar de rellenarse.",
   "GUILD_APP_CONNECTION_BLOCKED": "Un administrador del gremio te ha impedido conectar esto.",
-  "GUILD_APP_DISABLED": "Esta aplicación está desactivada, así que no pasa nada por ella."
+  "GUILD_APP_DISABLED": "Esta aplicación está desactivada, así que no pasa nada por ella.",
+  "APP_CHANNEL_MISSING_SIGNATURE": "Esa petición de un servicio de aplicación no venía bien firmada.",
+  "APP_CHANNEL_STALE_TIMESTAMP": "Esa petición de un servicio de aplicación se firmó hace demasiado tiempo. Comprueba el reloj de ambos lados.",
+  "APP_CHANNEL_UNKNOWN_APP": "No hay ningún servicio de aplicación registrado con ese nombre.",
+  "APP_CHANNEL_INVALID_SIGNATURE": "La firma de la petición no coincide con el secreto compartido de este servicio de aplicación.",
+  "APP_CHANNEL_REPLAYED_REQUEST": "Esa petición ya se usó una vez y no puede repetirse.",
+  "APP_CHANNEL_APP_DISABLED": "Este servicio de aplicación está apagado, así que no pasa nada por él.",
+  "APP_CHANNEL_INSTALL_NOT_FOUND": "Esa aplicación no está instalada en ese gremio.",
+  "APP_CHANNEL_INSTALL_DISABLED": "Ese gremio ha desactivado esta aplicación.",
+  "APP_CHANNEL_GUILD_READ_ONLY": "Ese gremio está congelado, así que ahora mismo no se puede escribir nada en él.",
+  "APP_CHANNEL_CONNECTION_NOT_FOUND": "Ninguna conexión de esa instalación corresponde a esa referencia.",
+  "APP_CHANNEL_CONNECTION_BLOCKED": "Un administrador del gremio ha bloqueado la conexión de ese miembro.",
+  "APP_CHANNEL_INVALID_PAYLOAD": "Ese servicio de aplicación envió algo que esta versión no puede leer.",
+  "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "Ese tipo de evento no es uno de los que declaró esta aplicación.",
+  "APP_CHANNEL_EVENT_TOO_LARGE": "Ese evento es más grande de lo que esta versión puede transportar.",
+  "APP_CHANNEL_INVALID_CONFIG_STATE": "Ese servicio de aplicación informó de un estado que esta versión no reconoce."
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -425,5 +425,20 @@
   "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Cette connexion utilise un seul identifiant pour toute la guilde : il n'y a donc aucun compte à connecter.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "Cette connexion appartient à chaque membre : elle se connecte au lieu de se remplir.",
   "GUILD_APP_CONNECTION_BLOCKED": "L'administration de la guilde vous a interdit cette connexion.",
-  "GUILD_APP_DISABLED": "Cette application est désactivée : rien ne passe par elle."
+  "GUILD_APP_DISABLED": "Cette application est désactivée : rien ne passe par elle.",
+  "APP_CHANNEL_MISSING_SIGNATURE": "Cette requête d'un service applicatif n'était pas correctement signée.",
+  "APP_CHANNEL_STALE_TIMESTAMP": "Cette requête d'un service applicatif a été signée il y a trop longtemps. Vérifiez l'horloge des deux côtés.",
+  "APP_CHANNEL_UNKNOWN_APP": "Aucun service applicatif n'est enregistré sous ce nom.",
+  "APP_CHANNEL_INVALID_SIGNATURE": "La signature de la requête ne correspond pas au secret partagé de ce service applicatif.",
+  "APP_CHANNEL_REPLAYED_REQUEST": "Cette requête a déjà été utilisée une fois et ne peut pas être rejouée.",
+  "APP_CHANNEL_APP_DISABLED": "Ce service applicatif a été désactivé : rien ne passe par lui.",
+  "APP_CHANNEL_INSTALL_NOT_FOUND": "Cette application n'est pas installée dans cette guilde.",
+  "APP_CHANNEL_INSTALL_DISABLED": "Cette guilde a désactivé cette application.",
+  "APP_CHANNEL_GUILD_READ_ONLY": "Cette guilde est gelée : rien ne peut y être écrit pour le moment.",
+  "APP_CHANNEL_CONNECTION_NOT_FOUND": "Aucune connexion de cette installation ne correspond à cette référence.",
+  "APP_CHANNEL_CONNECTION_BLOCKED": "L'administration de la guilde a bloqué la connexion de ce membre.",
+  "APP_CHANNEL_INVALID_PAYLOAD": "Ce service applicatif a envoyé quelque chose que cette version ne sait pas lire.",
+  "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "Ce type d'évènement ne fait pas partie de ceux déclarés par cette application.",
+  "APP_CHANNEL_EVENT_TOO_LARGE": "Cet évènement dépasse ce que cette version peut transporter.",
+  "APP_CHANNEL_INVALID_CONFIG_STATE": "Ce service applicatif a signalé un état que cette version ne reconnaît pas."
 }

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2055,6 +2055,8 @@ export interface GuildAppConnectionSummary {
   member_count: number;
 }
 
+export type GuildAppDetailDefinition = { [key: string]: unknown };
+
 /**
  * An install plus its connections, for the settings page.
  *
@@ -2076,6 +2078,7 @@ export interface GuildAppDetail {
   tool: string | null;
   embed_target: string | null;
   features: string[];
+  definition: GuildAppDetailDefinition;
   admin_only: boolean;
   installed_by_id: number;
   created_at: string;
@@ -2095,6 +2098,8 @@ export interface GuildAppInstall {
   name?: string | null;
 }
 
+export type GuildAppReadDefinition = { [key: string]: unknown };
+
 export interface GuildAppRead {
   id: number;
   guild_id: number;
@@ -2110,6 +2115,7 @@ export interface GuildAppRead {
   tool: string | null;
   embed_target: string | null;
   features: string[];
+  definition: GuildAppReadDefinition;
   admin_only: boolean;
   installed_by_id: number;
   created_at: string;


### PR DESCRIPTION
## Problem

An app could be registered, installed, and configured — and then had no way to ask what it was installed into, collect the credentials a guild gave it, or report what happened. Phase 9 is the app-facing half of the protocol.

## Authentication

`HMAC-SHA256(secret, "METHOD\nPATH\nTIMESTAMP\nNONCE\nsha256(body)")`, constant-time compared, 300 s freshness window, nonce burned in `public.app_service_nonces` keyed `(registration_id, nonce)`.

Two properties worth stating, because they're the ones that make it hold:

- **The nonce is inside the signature**, not a sibling header. The value that makes a request one-shot is covered by the thing that proves authenticity, so it can't be swapped.
- **The caller is established from the signature and nowhere else.** `X-Initiative-App` only selects which key to check; naming one app while signing as another is refused, and there's a test for exactly that.

Order inside `authenticate_caller` is shape → freshness → signature → registration state → burn, so nothing is written for a caller that hasn't proved it holds the secret, and a **disabled registration is refused without spending the nonce**.

## The five routes (`/api/v1/app-service`)

| Route | What it is |
|---|---|
| `GET /installs` | Which guilds have this app, at which pinned version |
| `GET /installs/{guild_id}/config` | The **only** plaintext route — guild-wide values plus per-member values keyed by `connection_ref`, so an app can recover a member credential after a restart |
| `GET /installs/{guild_id}/connections` | Status only, addressed by opaque `connection_ref` — never a user id, never an email |
| `POST /installs/{guild_id}/status` | The app's own verdict; this is what finally moves `config_state` off `unverified` |
| `POST /events` | Validated against the **pinned** manifest, then re-emitted through the existing `dispatch_event` — apps emit, the delegate still owns delivery |

The optional write-back landed rather than being deferred: `PUT /installs/{guild_id}/connections/{connection_ref}` via `apply_connection_values(..., allow_managed=True)`, so first connect and refresh are the same call. A blocked connection is refused.

## Points worth a reviewer's attention

- **Sessions route per guild with `guild_role="admin"`** (`_ro` for reads and frozen guilds). `SET ROLE` drops the system engine's bypass, so the guild's own policies answer — which is what makes the own-row `guild_app_user_connections` rows reachable with the install's authority rather than by bypassing RLS.
- **Suspended vs frozen guilds differ deliberately:** suspended is indistinguishable from not-installed (404); frozen serves reads and refuses writes.
- **`GET /installs` costs one query per guild**, because the catalog deliberately holds no index of who installed what — that's the tenancy decision from §4.3, not an oversight. Documented in the function; the fix if it ever bites is cursor pagination, not a public installs table.
- **Tests sign through the real `sign_request`**, so they can't pass by agreeing with a private idea of the scheme.

## Schema / env

Migration `20260812_0173` (`down_revision = 0172`) adds `app_service_nonces` with `ENABLE` + `FORCE` RLS, the schema default grants revoked, a `system_grants` decision, `SHARED_TABLES` registration, and an entry in `_RLS_SHARED_TABLES`. Swept by the existing jti janitor. Generated types regenerated for the `GuildAppRead.definition` passthrough; the app-service router itself is `include_in_schema=False` (billing's precedent — no SPA consumer).

## Testing

```
cd backend && pytest app/api/v1/app_service_endpoints/ \
  app/services/marketplace/app_channel_auth_test.py \
  app/services/tenant/app_channels_test.py \
  app/schemas/tenant/guild_app_test.py \
  app/db/security_invariants_test.py app/db/system_grants_test.py \
  app/db/tenancy_test.py app/models/layout_test.py
# 201 passed
cd backend && pytest alembic/migrations_test.py   # 11 passed
cd backend && ruff check app && ruff format app && ty check app
```

All 15 new message codes are in all four locales, verified key-for-key.

## Two notes for the operator, not blockers

The event size cap is enforced in the handler (raw body > 72 KiB → 413 before parsing; payload JSON > 64 KiB → 413) rather than in `BodySizeLimitMiddleware`, to avoid touching `core/`. Adding a `_RULES` entry would move the first check to the transport seam if you'd prefer it there. Separately, the global IP rate limit applies to this surface, and an app service is one busy IP — worth a deployment note.