### PR TITLE
Ignore key material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 # General
+# Key material — the app platform, handoff signing and delegation all take a
+# PEM, and openssl writes one wherever it is run. Nothing here is tracked.
+*.pem
+*.key
 .DS_Store
 .env
 .env.*


### PR DESCRIPTION
`*.pem` / `*.key` were not ignored. Three settings take a PEM (app platform signing, handoff signing, auto delegation) and `openssl genrsa` writes wherever it is run, so a key generated in the working tree was one `git add -A` from being committed.

Nothing tracked matches either pattern.