### PR TITLE
Reach the marketplace from what it stocks

### DIFF
--- a/backend/app/services/marketplace/catalog.py
+++ b/backend/app/services/marketplace/catalog.py
@@ -95,6 +95,12 @@ _ARTWORK_CHARS = frozenset(
 )
 
 
+#: Shown for a listing that ships no artwork of its own. The app's own mark,
+#: which is the honest thing for it to say: nobody drew an icon for this one.
+#: Same-origin like every other artwork path, so it obeys the rule below.
+DEFAULT_AVATAR_URL = "/icons/logo.svg"
+
+
 def _check_artwork_path(value: str, *, field: str) -> str:
     """A listing's artwork must be a same-origin path — the shipped files live
     under ``/marketplace/``. A registry wanting third-party artwork mirrors it
@@ -270,11 +276,15 @@ async def upsert_listing(
     except ListingDefinitionError as exc:
         raise CatalogError(f"{public_id}: {exc}") from exc
 
-    for required in ("name", "description", "avatar_url"):
+    for required in ("name", "description"):
         if not manifest.get(required):
             raise CatalogError(f"{public_id}: {required} is required")
 
-    _check_artwork_path(str(manifest["avatar_url"]), field=f"{public_id}: avatar_url")
+    # Artwork is optional: a listing without one gets the app's own mark rather
+    # than being refused over a picture. A supplied one is still held to the
+    # same-origin rule — the default is not a way in for a remote URL.
+    avatar_url = str(manifest.get("avatar_url") or DEFAULT_AVATAR_URL)
+    _check_artwork_path(avatar_url, field=f"{public_id}: avatar_url")
 
     images = manifest.get("images") or []
     if not isinstance(images, list) or any(not isinstance(i, str) for i in images):
@@ -308,7 +318,7 @@ async def upsert_listing(
         "publisher": publisher,
         "description": str(manifest["description"]),
         "long_description": manifest.get("long_description"),
-        "avatar_url": str(manifest["avatar_url"]),
+        "avatar_url": avatar_url,
         "images": list(images),
         "available": True,
         "updated_at": now,

--- a/backend/app/services/marketplace/catalog_test.py
+++ b/backend/app/services/marketplace/catalog_test.py
@@ -190,6 +190,40 @@ class TestDefinitions:
                 source="builtin",
             )
 
+    async def test_a_listing_without_artwork_gets_the_app_mark(self, session):
+        """Artwork is optional. A listing that ships none is published with
+        Initiative's own mark rather than refused over a picture — and the
+        default is same-origin like everything else the catalog stores."""
+        manifest = _manifest(
+            kind="app",
+            definition={
+                "app_kind": "tool_instance",
+                "tool": "calendar",
+                "default_name": "Guild calendar",
+            },
+        )
+        manifest.pop("avatar_url", None)
+
+        listing = await service.upsert_listing(session, manifest, source="builtin")
+
+        assert listing.avatar_url == service.DEFAULT_AVATAR_URL
+        assert listing.avatar_url.startswith("/")
+
+    async def test_supplied_artwork_still_has_to_be_same_origin(self, session):
+        """The default is not a way in for a remote URL."""
+        manifest = _manifest(
+            kind="app",
+            definition={
+                "app_kind": "tool_instance",
+                "tool": "calendar",
+                "default_name": "Guild calendar",
+            },
+        )
+        manifest["avatar_url"] = "https://cdn.example.test/icon.svg"
+
+        with pytest.raises(CatalogError, match="same-origin"):
+            await service.upsert_listing(session, manifest, source="builtin")
+
     async def test_a_valid_app_listing_is_stored_canonically(self, session):
         listing = await service.upsert_listing(
             session,

--- a/backend/app/services/marketplace/registry.py
+++ b/backend/app/services/marketplace/registry.py
@@ -73,6 +73,7 @@ from app.models.platform.marketplace_registry import (
     MarketplaceRegistryState,
 )
 from app.services.marketplace.catalog import (
+    DEFAULT_AVATAR_URL,
     CatalogError,
     upsert_listing,
     withdraw_listing,
@@ -730,13 +731,18 @@ async def _ingest_listing(
     # manifest says its images are is discarded and replaced with the mirrored
     # copies, so a stored listing always points at this deployment.
     avatar_spec = entry.get("avatar")
-    if not isinstance(avatar_spec, Mapping):
+    if avatar_spec is None:
+        # No artwork published: the catalog gives it the app's own mark. Only a
+        # *malformed* spec is an error — a missing one is a choice.
+        manifest["avatar_url"] = DEFAULT_AVATAR_URL
+    elif not isinstance(avatar_spec, Mapping):
         raise RegistryError(
-            Codes.ARTIFACT_INVALID, f"{public_id}: the index names no avatar image"
+            Codes.ARTIFACT_INVALID, f"{public_id}: avatar must be an object"
         )
-    manifest["avatar_url"] = await _mirror_image(
-        session, index_url=index_url, spec=avatar_spec, now=now
-    )
+    else:
+        manifest["avatar_url"] = await _mirror_image(
+            session, index_url=index_url, spec=avatar_spec, now=now
+        )
 
     image_specs = entry.get("images") or []
     if not isinstance(image_specs, list):

--- a/frontend/public/locales/de/nav.json
+++ b/frontend/public/locales/de/nav.json
@@ -76,6 +76,5 @@
     "finalizing": "Weiterleitung wird abgeschlossen…",
     "goHome": "Zurück zur Startseite"
   },
-  "adminDashboard": "Administrator-Dashboard",
-  "marketplace": "Marktplatz"
+  "adminDashboard": "Administrator-Dashboard"
 }

--- a/frontend/public/locales/en/nav.json
+++ b/frontend/public/locales/en/nav.json
@@ -76,6 +76,5 @@
     "finalizing": "Finalizing redirect…",
     "goHome": "Go back home"
   },
-  "adminDashboard": "Admin dashboard",
-  "marketplace": "Marketplace"
+  "adminDashboard": "Admin dashboard"
 }

--- a/frontend/public/locales/es/nav.json
+++ b/frontend/public/locales/es/nav.json
@@ -76,6 +76,5 @@
   "allCounterGroups": "Todos los contadores",
   "createCounterGroup": "Nuevo grupo de contadores",
   "createExternally": "Se crea en {{name}}",
-  "adminDashboard": "Panel de administración",
-  "marketplace": "Mercado"
+  "adminDashboard": "Panel de administración"
 }

--- a/frontend/public/locales/fr/nav.json
+++ b/frontend/public/locales/fr/nav.json
@@ -76,6 +76,5 @@
   "allCounterGroups": "Tous les compteurs",
   "createCounterGroup": "Nouveau groupe de compteurs",
   "createExternally": "Créé dans {{name}}",
-  "adminDashboard": "Tableau de bord admin",
-  "marketplace": "Catalogue"
+  "adminDashboard": "Tableau de bord admin"
 }

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -9,7 +9,6 @@ import {
   ScrollText,
   Settings,
   Star,
-  Store,
   Tag,
   Users,
 } from "lucide-react";
@@ -513,23 +512,6 @@ export const AppSidebar = () => {
                                 </SidebarMenuItem>
                               </SidebarMenu>
                             )}
-                          </SidebarGroupContent>
-                        </SidebarGroup>
-
-                        {/* Guild-level, below the initiatives: browsing is open
-                            to every member — installing is where the gates are. */}
-                        <SidebarGroup>
-                          <SidebarGroupContent>
-                            <SidebarMenu>
-                              <SidebarMenuItem>
-                                <SidebarMenuButton asChild size="sm">
-                                  <Link to={gp("/marketplace")}>
-                                    <Store className="h-4 w-4" />
-                                    <span>{t("marketplace")}</span>
-                                  </Link>
-                                </SidebarMenuButton>
-                              </SidebarMenuItem>
-                            </SidebarMenu>
                           </SidebarGroupContent>
                         </SidebarGroup>
                       </SidebarContent>

--- a/frontend/src/pages/initiativeTools/dashboards/DashboardsPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/DashboardsPage.tsx
@@ -110,7 +110,7 @@ export const DashboardsView = ({ fixedInitiativeId, canCreate }: DashboardsViewP
               )}
               {canCreateDashboards && (
                 <Button size="sm" variant="ghost" asChild>
-                  <Link to={gp("/marketplace")}>
+                  <Link to={gp("/marketplace")} search={{ kind: "dashboard" }}>
                     <Store className="h-4 w-4" />
                     {t("browseMarketplace")}
                   </Link>
@@ -129,7 +129,7 @@ export const DashboardsView = ({ fixedInitiativeId, canCreate }: DashboardsViewP
             {t("createDashboard")}
           </Button>
           <Button variant="ghost" asChild>
-            <Link to={gp("/marketplace")}>
+            <Link to={gp("/marketplace")} search={{ kind: "dashboard" }}>
               <Store className="h-4 w-4" />
               {t("browseMarketplace")}
             </Link>


### PR DESCRIPTION
**Sidebar.** The standalone Marketplace entry is gone. A marketplace is only useful where it has a subject — apps are added from the Apps section, dashboards from the dashboards page — and both already had an entry point. Those dashboard links now carry `kind=dashboard` the way the Apps one carries `kind=app`, so each lands on its own shelf instead of the mixed one. The nav string and the icon import go with it.

**Artwork.** `avatar_url` becomes optional: a listing that ships none is published with the app's own mark (`/icons/logo.svg`) rather than refused over a picture. A supplied one is still held to the same-origin rule, so the default is not a way in for a remote URL. The registry path treats a missing avatar the same way; only a malformed one is still an error.

Found while testing a local operator listing — it was silently skipped with `avatar_url is required`, so the listing never entered the catalog and the install failed with a message about the wrong thing.

## Testing

Catalog, registry, operator-catalog and builtin suites — 109 passed, 2 new (default applied; supplied remote URL still refused). `ruff` / `ty` clean. `tsc` clean, 1407 frontend tests, `biome` clean. Verified against the running dev DB: a listing with no `avatar_url` publishes and stores `/icons/logo.svg`.