### PR TITLE
Accept a set of delegation verifying keys

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -10,7 +10,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.capabilities import Capability, user_has_capability
-from app.core.config import API_V1_STR, settings
+from app.core.config import API_V1_STR
 from app.core import auth_context
 from app.core.auth_context import set_satisfied_providers
 from app.core.pam_context import set_active_grant
@@ -94,7 +94,7 @@ async def _authenticate_auto_delegation(
     the user's memberships and must agree with the ``/g/{guild_id}`` path, so an
     auto workflow always acts in the guild its token was issued for.
     """
-    if not settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
+    if not auto_delegation_configured():
         return None  # delegation disabled — let other auth paths run
 
     try:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -590,6 +590,18 @@ class Settings(BaseSettings):
     # delegation auth is disabled and Initiative only accepts its own
     # session tokens / API keys.
     AUTO_DELEGATION_PUBLIC_KEY_PEM: str | None = None
+    # The same trust, expressed as a key set so the delegate can rotate
+    # without downtime: a JWKS document of the RSA public keys this
+    # deployment accepts a delegation JWT from — ``{"keys": [{"kty": "RSA",
+    # "alg": "RS256", "kid": "...", "n": "<base64url>", "e": "<base64url>"}]}``,
+    # the shape ``/api/v1/app-platform/jwks.json`` publishes. Add the new key
+    # in one release, let auto start stamping its ``kid``, drop the old one
+    # later.
+    #
+    # Either setting alone is enough, and both may be set at once (during a
+    # rotation away from the single-key form). The PEM carries no id, so it is
+    # tried whatever ``kid`` a token arrives with.
+    AUTO_DELEGATION_PUBLIC_KEYS: str | None = None
     AUTO_DELEGATION_AUDIENCE: str = "initiative:auto-delegation"
     AUTO_DELEGATION_ISSUER: str = "initiative-auto"
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -437,12 +437,13 @@ def create_billing_support_handoff_token(
 # Inbound delegation from initiative-auto
 #
 # When auto calls our API on behalf of a user, it presents a JWT signed
-# with its private key (RS256). We verify here using the public half
-# configured at AUTO_DELEGATION_PUBLIC_KEY_PEM and resolve the JWT to a
-# user_id that the auth dependency then loads as a User. From that
-# point on the request runs through our normal RLS + role-permission
-# stack — the delegation just answers "who is acting", not "what can
-# they do".
+# with its private key (RS256). We verify here using the public half —
+# AUTO_DELEGATION_PUBLIC_KEY_PEM for a single key, or
+# AUTO_DELEGATION_PUBLIC_KEYS for a set it can rotate through — and
+# resolve the JWT to a user_id that the auth dependency then loads as a
+# User. From that point on the request runs through our normal RLS +
+# role-permission stack — the delegation just answers "who is acting",
+# not "what can they do".
 # ──────────────────────────────────────────────────────────────────────────
 
 
@@ -461,38 +462,126 @@ class AutoDelegationVerificationError(Exception):
     """Raised when the inbound delegation JWT fails any check."""
 
 
+@dataclass(frozen=True)
+class _DelegationKey:
+    """One public key delegation JWTs are verified against.
+
+    ``kid`` is ``None`` for the single configured PEM, which predates the key
+    set and names no id.
+    """
+
+    kid: str | None
+    #: A ``PyJWK`` from the key set, or the PEM string. ``jwt.decode`` takes
+    #: either, so the two configuration forms need no separate code path.
+    key: Any
+
+
 def auto_delegation_configured() -> bool:
     """True when this deployment has an automation delegate.
 
     The delegate is identified by the public half of its signing key, so the
-    presence of that key is what "a delegate exists here" means. Single source
-    of truth for every surface that is delegate-owned: the subscription
-    endpoints refuse without it and the outbound dispatcher stays inert.
+    presence of a key is what "a delegate exists here" means — either form
+    counts. Deliberately does not parse the key set: this answers a
+    configuration question for surfaces that are delegate-owned (the
+    subscription endpoints refuse without it, the outbound dispatcher stays
+    inert), and a malformed document is a verification-time failure, not a
+    reason for those surfaces to disappear.
     """
-    return bool(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM)
+    return bool(
+        settings.AUTO_DELEGATION_PUBLIC_KEY_PEM or settings.AUTO_DELEGATION_PUBLIC_KEYS
+    )
+
+
+#: Parsed verification keys, rebuilt only when the configured values change.
+#: Parsing a JWKS per request would be waste on the hot auth path.
+_delegation_keys_cache: tuple[tuple[str, str], tuple[_DelegationKey, ...]] | None = None
+
+
+def _delegation_verification_keys() -> tuple[_DelegationKey, ...]:
+    """Every key a delegation JWT may be verified against, best candidate first.
+
+    The single PEM carries no id of its own, so it stays usable whatever
+    ``kid`` a token arrives stamped with — which is what keeps a deployment
+    that never configured a key set working once auto starts stamping one.
+    """
+    global _delegation_keys_cache
+
+    raw_pem = settings.AUTO_DELEGATION_PUBLIC_KEY_PEM or ""
+    raw_set = settings.AUTO_DELEGATION_PUBLIC_KEYS or ""
+    cache_key = (raw_pem, raw_set)
+    if _delegation_keys_cache is not None and _delegation_keys_cache[0] == cache_key:
+        return _delegation_keys_cache[1]
+
+    keys: list[_DelegationKey] = []
+    if raw_set.strip():
+        # PyJWT owns the parsing, as it does for the OIDC provider key sets
+        # (services/auth/oidc/jwks.py) — one JWKS reader, not a second one
+        # written here.
+        try:
+            key_set = jwt.PyJWKSet.from_json(raw_set)
+        except (jwt.PyJWTError, ValueError, AttributeError, TypeError) as exc:
+            raise AutoDelegationVerificationError(
+                f"AUTO_DELEGATION_PUBLIC_KEYS is not a usable key set: {exc}"
+            ) from exc
+        keys.extend(_DelegationKey(kid=key.key_id, key=key) for key in key_set.keys)
+    if raw_pem:
+        keys.append(_DelegationKey(kid=None, key=raw_pem))
+
+    # Only a clean parse is cached — a malformed document has to keep raising
+    # rather than being remembered as "this deployment has no keys".
+    resolved = tuple(keys)
+    _delegation_keys_cache = (cache_key, resolved)
+    return resolved
 
 
 def verify_auto_delegation_token(token: str) -> AutoDelegationClaims:
     """Verify a delegation JWT minted by initiative-auto.
 
-    Disabled when ``AUTO_DELEGATION_PUBLIC_KEY_PEM`` is unset — that
-    config gap surfaces as a verification error so the auth dep can
-    fall through to its other token paths instead of 500'ing.
+    Disabled when no verification key is configured — that config gap
+    surfaces as a verification error so the auth dep can fall through to its
+    other token paths instead of 500'ing.
+
+    A token's ``kid`` orders the configured keys so the one it names is tried
+    first. Every configured key is still tried, which is what lets a
+    deployment rotate without coordinating the exact moment the delegate
+    starts stamping a new id.
     """
-    if not settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
+    candidates = _delegation_verification_keys()
+    if not candidates:
         raise AutoDelegationVerificationError("delegation auth not configured")
 
     try:
-        payload = jwt.decode(
-            token,
-            settings.AUTO_DELEGATION_PUBLIC_KEY_PEM,
-            algorithms=["RS256"],
-            audience=settings.AUTO_DELEGATION_AUDIENCE,
-            issuer=settings.AUTO_DELEGATION_ISSUER,
-            options={"require": ["exp", "iat", "iss", "aud", "sub", "jti"]},
-        )
+        kid = jwt.get_unverified_header(token).get("kid")
     except jwt.PyJWTError as e:
-        raise AutoDelegationVerificationError(f"jwt verification failed: {e}") from e
+        raise AutoDelegationVerificationError(f"unreadable token header: {e}") from e
+    if isinstance(kid, str) and len(candidates) > 1:
+        candidates = tuple(
+            sorted(candidates, key=lambda candidate: candidate.kid != kid)
+        )
+
+    payload = None
+    first_error: jwt.PyJWTError | None = None
+    for candidate in candidates:
+        try:
+            payload = jwt.decode(
+                token,
+                candidate.key,
+                algorithms=["RS256"],
+                audience=settings.AUTO_DELEGATION_AUDIENCE,
+                issuer=settings.AUTO_DELEGATION_ISSUER,
+                options={"require": ["exp", "iat", "iss", "aud", "sub", "jti"]},
+            )
+            break
+        except jwt.PyJWTError as e:
+            # Keep the first failure. Candidates are ordered best-match first,
+            # so it is the one worth reporting — a later key's message would
+            # describe a key the token was never meant for.
+            if first_error is None:
+                first_error = e
+    if payload is None:
+        raise AutoDelegationVerificationError(
+            f"jwt verification failed: {first_error}"
+        ) from first_error
 
     try:
         user_id = int(payload["sub"])

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -8,12 +8,15 @@ covered separately in the endpoint tests.
 from __future__ import annotations
 
 import base64
+import json
 import uuid
 
 import jwt
 import pytest
 
-from datetime import timedelta
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from datetime import datetime, timedelta, timezone
 
 from app.core import security
 from app.core.config import settings
@@ -327,3 +330,224 @@ def test_decode_session_token_rejects_expired_legacy_token():
 def test_decode_session_token_rejects_garbage():
     with pytest.raises(jwt.PyJWTError):
         decode_session_token("not.a.jwt")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Inbound delegation: verifying against a key set
+#
+# The delegate rotates by having both keys trusted for a release, so these
+# cover which key a token resolves to and what a bad key set does.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+_DELEGATION_KEYPAIRS = [
+    rsa.generate_private_key(public_exponent=65537, key_size=2048) for _ in range(3)
+]
+
+
+def _delegation_private_pem(index: int) -> str:
+    return (
+        _DELEGATION_KEYPAIRS[index]
+        .private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        .decode()
+    )
+
+
+def _delegation_public_pem(index: int) -> str:
+    return (
+        _DELEGATION_KEYPAIRS[index]
+        .public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+
+
+def _delegation_jwks(*pairs: tuple[str, int], **overrides) -> str:
+    """A JWKS document naming the given ``(kid, keypair index)`` keys."""
+    keys = []
+    for kid, index in pairs:
+        numbers = _DELEGATION_KEYPAIRS[index].public_key().public_numbers()
+        entry = {
+            "kty": "RSA",
+            "use": "sig",
+            "alg": "RS256",
+            "kid": kid,
+            "n": _b64url_encode(
+                numbers.n.to_bytes((numbers.n.bit_length() + 7) // 8, "big")
+            ),
+            "e": _b64url_encode(
+                numbers.e.to_bytes((numbers.e.bit_length() + 7) // 8, "big")
+            ),
+        }
+        entry.update(overrides)
+        keys.append(entry)
+    return json.dumps({"keys": keys})
+
+
+def _mint_delegation(
+    *,
+    signed_by: int,
+    kid: str | None = None,
+    expires_in: int = 900,
+    user_id: int = 5,
+    guild_id: int = 9,
+) -> str:
+    now = datetime.now(timezone.utc)
+    return jwt.encode(
+        {
+            "jti": uuid.uuid4().hex,
+            "sub": str(user_id),
+            "aud": settings.AUTO_DELEGATION_AUDIENCE,
+            "iss": settings.AUTO_DELEGATION_ISSUER,
+            "iat": int(now.timestamp()),
+            "exp": now + timedelta(seconds=expires_in),
+            "guild_id": guild_id,
+        },
+        _delegation_private_pem(signed_by),
+        algorithm="RS256",
+        headers={"kid": kid} if kid else None,
+    )
+
+
+@pytest.fixture
+def delegation_keys(monkeypatch):
+    """Configure the delegation trust for one test, key set and/or PEM."""
+
+    def configure(*, key_set: str | None = None, pem: str | None = None):
+        monkeypatch.setattr(security.settings, "AUTO_DELEGATION_PUBLIC_KEYS", key_set)
+        monkeypatch.setattr(security.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", pem)
+
+    return configure
+
+
+@pytest.mark.unit
+def test_delegation_verifies_against_the_key_the_kid_names(delegation_keys):
+    """Both keys trusted at once — a token signed with either resolves."""
+    delegation_keys(key_set=_delegation_jwks(("2026-01", 0), ("2026-07", 1)))
+
+    for kid, index in (("2026-01", 0), ("2026-07", 1)):
+        claims = security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=index, kid=kid)
+        )
+        assert claims.user_id == 5
+        assert claims.guild_id == 9
+
+
+@pytest.mark.unit
+def test_delegation_verifies_a_trusted_key_under_an_unknown_kid(delegation_keys):
+    """The id orders the search, it does not decide it: a token whose ``kid``
+    matches nothing still verifies against a configured key. That is what lets
+    the two sides roll out a rotation independently."""
+    delegation_keys(key_set=_delegation_jwks(("2026-01", 0), ("2026-07", 1)))
+
+    claims = security.verify_auto_delegation_token(
+        _mint_delegation(signed_by=1, kid="an-id-this-side-has-not-heard-of")
+    )
+    assert claims.user_id == 5
+
+
+@pytest.mark.unit
+def test_delegation_refuses_a_key_that_is_not_configured(delegation_keys):
+    """Trusting a set is not trusting anything RS256: the third keypair was
+    never configured."""
+    delegation_keys(key_set=_delegation_jwks(("2026-01", 0), ("2026-07", 1)))
+
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=2, kid="2026-07")
+        )
+
+
+@pytest.mark.unit
+def test_single_pem_still_accepts_a_token_stamped_with_a_kid(delegation_keys):
+    """The pre-existing single-key form keeps working once the delegate starts
+    stamping ids — the PEM names none, so it is tried whatever arrives."""
+    delegation_keys(pem=_delegation_public_pem(0))
+
+    claims = security.verify_auto_delegation_token(
+        _mint_delegation(signed_by=0, kid="2026-07")
+    )
+    assert claims.user_id == 5
+
+
+@pytest.mark.unit
+def test_both_forms_together_accept_either_key(delegation_keys):
+    """The migration state: the old PEM and the new set configured at once."""
+    delegation_keys(
+        key_set=_delegation_jwks(("2026-07", 1)), pem=_delegation_public_pem(0)
+    )
+
+    assert security.verify_auto_delegation_token(_mint_delegation(signed_by=0)).user_id
+    assert security.verify_auto_delegation_token(
+        _mint_delegation(signed_by=1, kid="2026-07")
+    ).user_id
+
+
+@pytest.mark.unit
+def test_expired_token_reports_expiry_rather_than_the_next_key(delegation_keys):
+    """With several keys tried, the failure reported is the one from the key
+    the token named — not a signature error from an unrelated key."""
+    delegation_keys(key_set=_delegation_jwks(("2026-01", 0), ("2026-07", 1)))
+
+    with pytest.raises(security.AutoDelegationVerificationError) as excinfo:
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=1, kid="2026-07", expires_in=-30)
+        )
+    assert "expired" in str(excinfo.value).lower()
+
+
+@pytest.mark.unit
+def test_delegation_is_unconfigured_when_neither_form_is_set(delegation_keys):
+    delegation_keys()
+
+    assert security.auto_delegation_configured() is False
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(_mint_delegation(signed_by=0))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("form", ["pem", "key_set"])
+def test_either_form_alone_counts_as_configured(delegation_keys, form):
+    """Delegate-owned surfaces key off this, so a deployment that configured
+    only the set must not read as having no delegate."""
+    if form == "pem":
+        delegation_keys(pem=_delegation_public_pem(0))
+    else:
+        delegation_keys(key_set=_delegation_jwks(("2026-01", 0)))
+
+    assert security.auto_delegation_configured() is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "key_set",
+    ["{not json", '{"keys": []}', '{"keys": [{"kid": "a"}]}'],
+)
+def test_unreadable_key_set_is_reported_as_configuration(delegation_keys, key_set):
+    """A document that yields no usable key raises rather than resolving to an
+    empty trust set, so the mistake reads as configuration."""
+    delegation_keys(key_set=key_set)
+
+    with pytest.raises(security.AutoDelegationVerificationError) as excinfo:
+        security.verify_auto_delegation_token(_mint_delegation(signed_by=0))
+    assert "not a usable key set" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_key_set_ignores_a_key_of_the_wrong_algorithm(delegation_keys):
+    """An RS512 entry alongside a good one does not make its token verify."""
+    delegation_keys(
+        key_set=_delegation_jwks(("2026-01", 0), alg="RS512"),
+    )
+
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=0, kid="2026-01")
+        )

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -161,7 +161,8 @@ async def dispatch_event(
             _inert_logged = True
             logger.info(
                 "webhook dispatch inert: no automation delegate configured "
-                "(set AUTO_DELEGATION_PUBLIC_KEY_PEM to enable event delivery)"
+                "(set AUTO_DELEGATION_PUBLIC_KEY_PEM or "
+                "AUTO_DELEGATION_PUBLIC_KEYS to enable event delivery)"
             )
         return
 


### PR DESCRIPTION
## Problem

Initiative verifies the automation delegate's tokens against a single configured public key. Replacing that key means changing both sides at the same instant, and tokens already in flight break — so rotation needs an outage window, which is why it doesn't happen.

## Changes

- `AUTO_DELEGATION_PUBLIC_KEYS` — a JWKS document of RSA public keys, the same shape `/api/v1/app-platform/jwks.json` publishes. Several can be trusted at once, so a rotation is: add the new key, let the delegate start signing with it, drop the old one.
- A token's `kid` orders which key is tried first. Every configured key is still tried, so neither side has to coordinate the moment it switches.
- `AUTO_DELEGATION_PUBLIC_KEY_PEM` is unchanged and still sufficient on its own. Both may be set at once during a migration; the PEM names no id, so it stays usable whatever `kid` arrives.
- `deps.py` and the webhook dispatcher gate on `auto_delegation_configured()` rather than reading the PEM setting directly, so either form counts as "a delegate exists here".

Parsing is `jwt.PyJWKSet`, the same reader the OIDC provider path uses in `services/auth/oidc/jwks.py` — no second JWKS reader.

Public keys only — no new secret enters config, and nothing changes about what a verified token may do.

## Testing

- `pytest app/core/security_test.py` — 32 passed (13 new: kid selection, unknown-kid fallthrough, untrusted key refused, both forms together, error attribution, unreadable key sets, wrong-algorithm entry).
- `pytest app/api/v1/tenant_endpoints/auto_delegation_test.py app/api/v1/tenant_endpoints/auto_subscriptions_test.py` — 30 passed.
- `ruff check`, `ruff format`, `ty check` clean.
