### PR TITLE
Let peer signing keys rotate without downtime

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -10,7 +10,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.capabilities import Capability, user_has_capability
-from app.core.config import API_V1_STR, settings
+from app.core.config import API_V1_STR
 from app.core import auth_context
 from app.core.auth_context import set_satisfied_providers
 from app.core.pam_context import set_active_grant
@@ -94,7 +94,7 @@ async def _authenticate_auto_delegation(
     the user's memberships and must agree with the ``/g/{guild_id}`` path, so an
     auto workflow always acts in the guild its token was issued for.
     """
-    if not settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
+    if not auto_delegation_configured():
         return None  # delegation disabled — let other auth paths run
 
     try:

--- a/backend/app/api/v1/platform_endpoints/billing.py
+++ b/backend/app/api/v1/platform_endpoints/billing.py
@@ -66,12 +66,14 @@ async def _verify_and_parse(request: Request, model):
             body=body,
         )
     except BillingEnvelopeError as exc:
-        # Billing absent is the self-host default, not a caller fault: 503
-        # (fail closed, retryable) rather than 403.
+        # Billing absent is the self-host default, not a caller fault, and an
+        # unreadable key is this deployment's own misconfiguration: both answer
+        # 503 (fail closed, retryable) rather than 403.
         raise HTTPException(
             status_code=(
                 status.HTTP_503_SERVICE_UNAVAILABLE
-                if exc.code == BillingMessages.NOT_CONFIGURED
+                if exc.code
+                in (BillingMessages.NOT_CONFIGURED, BillingMessages.KEY_UNREADABLE)
                 else status.HTTP_403_FORBIDDEN
             ),
             detail=exc.code,

--- a/backend/app/api/v1/platform_endpoints/billing_test.py
+++ b/backend/app/api/v1/platform_endpoints/billing_test.py
@@ -66,6 +66,14 @@ _OTHER_PRIVATE_PEM = _OTHER_KEYPAIR.private_bytes(
     serialization.PrivateFormat.PKCS8,
     serialization.NoEncryption(),
 ).decode()
+_OTHER_PUBLIC_PEM = (
+    _OTHER_KEYPAIR.public_key()
+    .public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
 
 _HMAC_SECRET = "test-billing-hmac-secret"
 
@@ -599,3 +607,67 @@ async def test_usage_burns_jti(client: AsyncClient, session: AsyncSession):
     second = await _post(client, "usage", {"guild_id": guild.id}, token=token)
     assert second.status_code == 403
     assert second.json()["detail"] == "BILLING_REPLAYED_TOKEN"
+
+
+# --- rotating billing's signing key -----------------------------------------
+
+
+async def test_both_keys_verify_while_billing_rotates(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """BILLING_PUBLIC_KEY_PEM holds both blocks during a rotation, so calls
+    signed with either key are accepted and billing can switch on its own
+    schedule rather than in lockstep with a deploy here."""
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_PUBLIC_KEY_PEM",
+        _PUBLIC_PEM + _OTHER_PUBLIC_PEM,
+    )
+    guild = await create_guild(session)
+
+    for private_pem in (_PRIVATE_PEM, _OTHER_PRIVATE_PEM):
+        response = await _post(
+            client,
+            "guild-tier",
+            _tier_payload(guild.id),
+            token=_mint_token(private_pem=private_pem),
+        )
+        assert response.status_code == 200, response.text
+
+
+async def test_dropping_the_old_block_ends_its_access(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """Rotation finishes by removing the retired key, which must then stop
+    working — otherwise the bundle only ever grows."""
+    monkeypatch.setattr(
+        config_module.settings, "BILLING_PUBLIC_KEY_PEM", _OTHER_PUBLIC_PEM
+    )
+    guild = await create_guild(session)
+
+    response = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id),
+        token=_mint_token(private_pem=_PRIVATE_PEM),
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
+
+
+async def test_unreadable_key_answers_503_not_403(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    """A key this deployment cannot read is its own misconfiguration, so it
+    fails closed the way an unconfigured billing does — blaming the caller
+    with a 403 would send billing hunting for a fault on its side."""
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_PUBLIC_KEY_PEM",
+        _PUBLIC_PEM + "-----BEGIN PUBLIC KEY-----\nnope\n",
+    )
+    guild = await create_guild(session)
+
+    response = await _post(client, "guild-tier", _tier_payload(guild.id))
+    assert response.status_code == 503
+    assert response.json()["detail"] == "BILLING_KEY_UNREADABLE"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -589,6 +589,11 @@ class Settings(BaseSettings):
     # own private key. This is the matching public key. When unset,
     # delegation auth is disabled and Initiative only accepts its own
     # session tokens / API keys.
+    #
+    # Accepts more than one key, as concatenated PEM blocks, which is how the
+    # delegate rotates without downtime: append the new key, let auto start
+    # signing with it, then drop the old block. A token is accepted if any
+    # block verifies it.
     AUTO_DELEGATION_PUBLIC_KEY_PEM: str | None = None
     AUTO_DELEGATION_AUDIENCE: str = "initiative:auto-delegation"
     AUTO_DELEGATION_ISSUER: str = "initiative-auto"
@@ -644,6 +649,12 @@ class Settings(BaseSettings):
     # HMAC-SHA256 over METHOD\nPATH\nTIMESTAMP\nsha256(body) keyed by the
     # shared secret. Both must be configured or the /billing endpoints
     # refuse every request.
+    #
+    # The public key accepts more than one key, as concatenated PEM blocks, so
+    # billing can rotate its signing key without downtime: append the new key,
+    # let billing start signing with it, then drop the old block. A token is
+    # accepted if any block verifies it. (The shared secret takes one value —
+    # rotating it is a separate change on both sides.)
     BILLING_PUBLIC_KEY_PEM: str | None = None
     BILLING_HMAC_SECRET: str | None = None
     BILLING_AUDIENCE: str = "initiative:billing"

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -794,6 +794,9 @@ class BillingMessages:
     """
 
     NOT_CONFIGURED = "BILLING_NOT_CONFIGURED"
+    #: The configured verifying key could not be read. A deployment fault
+    #: rather than a caller fault, so it answers alongside NOT_CONFIGURED.
+    KEY_UNREADABLE = "BILLING_KEY_UNREADABLE"
     MISSING_SIGNATURE = "BILLING_MISSING_SIGNATURE"
     STALE_TIMESTAMP = "BILLING_STALE_TIMESTAMP"
     INVALID_SIGNATURE = "BILLING_INVALID_SIGNATURE"

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,14 +1,55 @@
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from typing import Any, Sequence
 
 import bcrypt
 import jwt
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerificationError, VerifyMismatchError
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
 from app.core.config import settings
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Verifying keys for the services that call us
+#
+# A peer's signing key has to be replaceable without arranging for both
+# sides to change in the same instant, so the settings that hold one take
+# concatenated PEM blocks and every block is trusted: append the new key,
+# let the peer start signing with it, drop the old block a release later.
+# ──────────────────────────────────────────────────────────────────────────
+
+#: Marks the start of each block in a concatenated PEM bundle.
+_PEM_HEADER = "-----BEGIN "
+
+
+class PublicKeyBundleError(Exception):
+    """A configured PEM bundle could not be read."""
+
+
+@lru_cache(maxsize=8)
+def load_verification_keys(pem_bundle: str) -> tuple[Any, ...]:
+    """Load the public keys in a configured PEM bundle, in order.
+
+    Keyed on the configured text and cached, so a bundle is parsed once rather
+    than on every call that verifies against it. A block that will not load
+    raises instead of being skipped — a silently dropped block leaves a
+    rotation looking configured while the key it added does nothing.
+    """
+    blocks = [_PEM_HEADER + rest for rest in pem_bundle.split(_PEM_HEADER)[1:]]
+    keys: list[Any] = []
+    for index, block in enumerate(blocks):
+        try:
+            keys.append(load_pem_public_key(block.encode("utf-8")))
+        except (ValueError, TypeError) as exc:
+            raise PublicKeyBundleError(
+                f"PEM block {index + 1} is not a readable public key: {exc}"
+            ) from exc
+    return tuple(keys)
+
 
 # Deliberately a constant, not a setting: every encode/verify in this module
 # assumes HS256, and a configurable JWT algorithm invites algorithm-confusion.
@@ -478,21 +519,43 @@ def verify_auto_delegation_token(token: str) -> AutoDelegationClaims:
     Disabled when ``AUTO_DELEGATION_PUBLIC_KEY_PEM`` is unset — that
     config gap surfaces as a verification error so the auth dep can
     fall through to its other token paths instead of 500'ing.
+
+    The setting holds one key normally and two while the delegate is rotating,
+    so the token is accepted if any configured key verifies it.
     """
-    if not settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
+    try:
+        keys = load_verification_keys(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM or "")
+    except PublicKeyBundleError as e:
+        raise AutoDelegationVerificationError(
+            f"AUTO_DELEGATION_PUBLIC_KEY_PEM is unusable: {e}"
+        ) from e
+    # Covers both an unset setting and one holding no PEM block at all.
+    if not keys:
         raise AutoDelegationVerificationError("delegation auth not configured")
 
-    try:
-        payload = jwt.decode(
-            token,
-            settings.AUTO_DELEGATION_PUBLIC_KEY_PEM,
-            algorithms=["RS256"],
-            audience=settings.AUTO_DELEGATION_AUDIENCE,
-            issuer=settings.AUTO_DELEGATION_ISSUER,
-            options={"require": ["exp", "iat", "iss", "aud", "sub", "jti"]},
-        )
-    except jwt.PyJWTError as e:
-        raise AutoDelegationVerificationError(f"jwt verification failed: {e}") from e
+    payload = None
+    first_error: jwt.PyJWTError | None = None
+    for key in keys:
+        try:
+            payload = jwt.decode(
+                token,
+                key,
+                algorithms=["RS256"],
+                audience=settings.AUTO_DELEGATION_AUDIENCE,
+                issuer=settings.AUTO_DELEGATION_ISSUER,
+                options={"require": ["exp", "iat", "iss", "aud", "sub", "jti"]},
+            )
+            break
+        except jwt.PyJWTError as e:
+            # Keep the first failure. A later key's message would describe a key
+            # the token was never signed with, which reads as a signature
+            # problem even when the real fault is expiry or a wrong audience.
+            if first_error is None:
+                first_error = e
+    if payload is None:
+        raise AutoDelegationVerificationError(
+            f"jwt verification failed: {first_error}"
+        ) from first_error
 
     try:
         user_id = int(payload["sub"])

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -13,7 +13,9 @@ import uuid
 import jwt
 import pytest
 
-from datetime import timedelta
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from datetime import datetime, timedelta, timezone
 
 from app.core import security
 from app.core.config import settings
@@ -327,3 +329,182 @@ def test_decode_session_token_rejects_expired_legacy_token():
 def test_decode_session_token_rejects_garbage():
     with pytest.raises(jwt.PyJWTError):
         decode_session_token("not.a.jwt")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Rotatable verifying keys
+#
+# The settings holding a peer's public key take concatenated PEM blocks, so
+# both the old and the new key are trusted while that peer rotates. These
+# cover the loader; the per-peer wiring is exercised beside each verifier.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+_KEYPAIRS = [
+    rsa.generate_private_key(public_exponent=65537, key_size=2048) for _ in range(3)
+]
+
+
+def private_pem(index: int) -> str:
+    return (
+        _KEYPAIRS[index]
+        .private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        .decode()
+    )
+
+
+def public_bundle(*indexes: int) -> str:
+    """A configured value trusting the given keypairs, in order."""
+    return "".join(
+        _KEYPAIRS[index]
+        .public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+        for index in indexes
+    )
+
+
+@pytest.mark.unit
+def test_loader_reads_every_block_in_order():
+    keys = security.load_verification_keys(public_bundle(0, 1, 2))
+    assert len(keys) == 3
+    assert [k.public_numbers().n for k in keys] == [
+        _KEYPAIRS[i].public_key().public_numbers().n for i in (0, 1, 2)
+    ]
+
+
+@pytest.mark.unit
+def test_loader_reads_a_single_block():
+    """The ordinary one-key case is the same code path."""
+    assert len(security.load_verification_keys(public_bundle(0))) == 1
+
+
+@pytest.mark.unit
+def test_loader_treats_empty_as_no_keys():
+    """An unset setting is "no peer", not an error — callers decide what that
+    means for them."""
+    assert security.load_verification_keys("") == ()
+
+
+@pytest.mark.unit
+def test_loader_refuses_an_unreadable_block_rather_than_skipping_it():
+    """A silently dropped block would leave a rotation looking configured
+    while the key it added does nothing."""
+    bundle = public_bundle(0) + "-----BEGIN PUBLIC KEY-----\nnope\n"
+    with pytest.raises(security.PublicKeyBundleError) as excinfo:
+        security.load_verification_keys(bundle)
+    assert "block 2" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_loader_refuses_a_private_key():
+    """Only the public half belongs in a verifying setting."""
+    with pytest.raises(security.PublicKeyBundleError):
+        security.load_verification_keys(private_pem(0))
+
+
+# --- delegation: which key a token is accepted under ------------------------
+
+
+def _mint_delegation(
+    *, signed_by: int, expires_in: int = 900, kid: str | None = None
+) -> str:
+    now = datetime.now(timezone.utc)
+    return jwt.encode(
+        {
+            "jti": uuid.uuid4().hex,
+            "sub": "5",
+            "aud": settings.AUTO_DELEGATION_AUDIENCE,
+            "iss": settings.AUTO_DELEGATION_ISSUER,
+            "iat": int(now.timestamp()),
+            "exp": now + timedelta(seconds=expires_in),
+            "guild_id": 9,
+        },
+        private_pem(signed_by),
+        algorithm="RS256",
+        headers={"kid": kid} if kid else None,
+    )
+
+
+@pytest.fixture
+def delegation_pem(monkeypatch):
+    def configure(bundle: str | None):
+        monkeypatch.setattr(security.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", bundle)
+
+    return configure
+
+
+@pytest.mark.unit
+def test_delegation_accepts_its_one_configured_key(delegation_pem):
+    delegation_pem(public_bundle(0))
+    claims = security.verify_auto_delegation_token(_mint_delegation(signed_by=0))
+    assert (claims.user_id, claims.guild_id) == (5, 9)
+
+
+@pytest.mark.unit
+def test_delegation_accepts_either_key_while_the_delegate_rotates(delegation_pem):
+    """The point of the bundle: both keys work, so the two sides can switch at
+    their own pace instead of in the same instant."""
+    delegation_pem(public_bundle(0, 1))
+    for index in (0, 1):
+        assert (
+            security.verify_auto_delegation_token(
+                _mint_delegation(signed_by=index)
+            ).user_id
+            == 5
+        )
+
+
+@pytest.mark.unit
+def test_delegation_refuses_a_key_that_is_not_configured(delegation_pem):
+    """Trusting two keys is not trusting any RS256 signer."""
+    delegation_pem(public_bundle(0, 1))
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(_mint_delegation(signed_by=2))
+
+
+@pytest.mark.unit
+def test_delegation_stops_accepting_a_dropped_key(delegation_pem):
+    """Rotation ends by removing a block, so that key must stop working."""
+    delegation_pem(public_bundle(1))
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(_mint_delegation(signed_by=0))
+
+
+@pytest.mark.unit
+def test_delegation_ignores_a_token_key_id(delegation_pem):
+    """The delegate stamps a ``kid``; nothing reads it. Pinned because that
+    header is unsigned, so it must not steer which key is used."""
+    delegation_pem(public_bundle(0, 1))
+    assert (
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=1, kid="names-the-other-key")
+        ).user_id
+        == 5
+    )
+
+
+@pytest.mark.unit
+def test_delegation_reports_expiry_rather_than_the_next_key(delegation_pem):
+    """With several keys tried, the reported failure is the real one."""
+    delegation_pem(public_bundle(0, 1))
+    with pytest.raises(security.AutoDelegationVerificationError) as excinfo:
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=0, expires_in=-30)
+        )
+    assert "expired" in str(excinfo.value).lower()
+
+
+@pytest.mark.unit
+def test_delegation_is_off_with_no_key(delegation_pem):
+    delegation_pem(None)
+    assert security.auto_delegation_configured() is False
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(_mint_delegation(signed_by=0))

--- a/backend/app/services/platform/billing.py
+++ b/backend/app/services/platform/billing.py
@@ -35,6 +35,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
 from app.core.messages import BillingMessages
+from app.core.security import PublicKeyBundleError, load_verification_keys
 from app.models.platform.billing import (
     BillingEventLog,
     BillingJti,
@@ -135,16 +136,34 @@ def verify_billing_envelope(
         raise BillingEnvelopeError(BillingMessages.INVALID_SIGNATURE)
 
     try:
-        payload = jwt.decode(
-            authorization[len("Bearer ") :],
-            settings.BILLING_PUBLIC_KEY_PEM,
-            algorithms=["RS256"],
-            audience=settings.BILLING_AUDIENCE,
-            issuer=settings.BILLING_ISSUER,
-            options={"require": ["exp", "iat", "iss", "aud", "jti"]},
-        )
-    except jwt.PyJWTError as exc:
-        raise BillingEnvelopeError(BillingMessages.INVALID_TOKEN) from exc
+        keys = load_verification_keys(settings.BILLING_PUBLIC_KEY_PEM)
+    except PublicKeyBundleError as exc:
+        # An unreadable key is this deployment's misconfiguration, not the
+        # caller's fault, so it surfaces like "not configured" rather than as
+        # a rejected token.
+        raise BillingEnvelopeError(BillingMessages.KEY_UNREADABLE) from exc
+    if not keys:
+        raise BillingEnvelopeError(BillingMessages.NOT_CONFIGURED)
+
+    token = authorization[len("Bearer ") :]
+    payload = None
+    first_error: jwt.PyJWTError | None = None
+    for key in keys:
+        try:
+            payload = jwt.decode(
+                token,
+                key,
+                algorithms=["RS256"],
+                audience=settings.BILLING_AUDIENCE,
+                issuer=settings.BILLING_ISSUER,
+                options={"require": ["exp", "iat", "iss", "aud", "jti"]},
+            )
+            break
+        except jwt.PyJWTError as exc:
+            if first_error is None:
+                first_error = exc
+    if payload is None:
+        raise BillingEnvelopeError(BillingMessages.INVALID_TOKEN) from first_error
 
     # Bound to the blocklist column (varchar 64) so an oversized jti is a
     # clean 403 instead of a database error at redemption time.

--- a/backend/app/services/platform/jti_purge.py
+++ b/backend/app/services/platform/jti_purge.py
@@ -24,7 +24,7 @@ from typing import Callable
 
 from sqlmodel import SQLModel
 
-from app.core.config import settings
+from app.core.security import auto_delegation_configured
 from app.db.jti_blocklist import purge_expired_jtis
 from app.models.platform.app_service_nonce import AppServiceNonce
 from app.models.platform.auto_delegation_jti import AutoDelegationJti
@@ -45,14 +45,12 @@ class _Blocklist:
     label: str
 
 
-def _auto_delegation_enabled() -> bool:
-    return bool(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM)
-
-
 # One entry per replay guard. Add a table here and it is swept automatically.
+# Each entry asks the peer's own module whether it is configured, so a guard and
+# its janitor can never disagree about whether that peer exists here.
 _BLOCKLISTS: tuple[_Blocklist, ...] = (
     _Blocklist(BillingJti, billing_inbound_enabled, "billing"),
-    _Blocklist(AutoDelegationJti, _auto_delegation_enabled, "auto-delegation"),
+    _Blocklist(AutoDelegationJti, auto_delegation_configured, "auto-delegation"),
     _Blocklist(AppServiceNonce, app_channel_possible, "app-service"),
 )
 


### PR DESCRIPTION
## Problem

Two settings hold a peer's verifying key, and each held exactly one:

- `AUTO_DELEGATION_PUBLIC_KEY_PEM` — verifies auto's delegation JWTs
- `BILLING_PUBLIC_KEY_PEM` — verifies billing's service JWTs

Replacing either means changing both sides in the same instant, and tokens already in flight break. A key that can only be rotated during an outage does not get rotated — which matters most in the case you'd want it: a key exposed through a backup, a log, or a stale image.

Every other credential in the system already rotates. App-service secrets are DB rows, the marketplace registry takes a signed key set, OIDC reads the provider's JWKS. These two were the gap.

## Changes

- Both settings accept **concatenated PEM blocks** and trust each one. A rotation becomes: append the new key, let the peer start signing with it, drop the old block a release later. Neither peer changes and no wire format moves — this is local config only.
- One loader, `load_verification_keys`, shared by both verifiers and cached on the configured text so a bundle parses once rather than per request.
- A block that will not load **raises** rather than being skipped, so a typo surfaces as configuration instead of a rotation that silently never took effect.
- An unreadable billing key answers **503, not 403** — it is this deployment's misconfiguration, and blaming the caller would send billing hunting for a fault on its side.
- Collapses the three separate answers to "is delegation configured" into one. `jti_purge` kept a private copy that gated whether the replay-blocklist janitor swept, and `deps.py` read the setting inline; both now call `auto_delegation_configured()`, so a guard and its janitor cannot drift apart. `deps.py`'s `settings` import existed only for that check and is gone.

Public keys only — no new secret enters config, and nothing changes about what a verified token may do.

**Deliberately not done:** no `kid`. The JWT header is unsigned, so it must not steer key selection; with it untrusted every key is tried anyway, leaving the identifier paying for nothing. `BILLING_HMAC_SECRET` still takes one value — it is the weaker of billing's two factors, and several live shared secrets is a different trade than several public keys.

## Testing

- `pytest app/core/security_test.py app/api/v1/tenant_endpoints/auto_delegation_test.py app/api/v1/platform_endpoints/billing_test.py` — 69 passed.
- Loader: reads every block in order; single block unchanged; empty means no keys; an unreadable block raises naming its position; a private key is refused.
- Per peer: one key verifies its own tokens; **both keys verify while rotating**; an unconfigured key is refused; **dropping the old block ends its access**; expiry is reported rather than a later key's signature error; a token `kid` is ignored.
- Billing additionally: an unreadable key answers 503 `BILLING_KEY_UNREADABLE`.
- `ruff check`, `ruff format`, `ty check` clean.
