### PR TITLE
Give each priority its own Focus window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Focus settings on My Tasks are now a window per priority.** Instead of one date range for everything plus an "always include urgent and high" switch, each priority gets its own slider: how many days ahead the Focus list looks for that priority, from today-and-overdue only up to a month out, or "any date" to keep that priority on the list whatever its deadline. Existing settings carry over.
+
 ## [0.62.1] - 2026-08-13
 
 ### Fixed

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -125,13 +125,14 @@
     "pin": "An Fokus anheften",
     "unpin": "Aus Fokus entfernen",
     "settings": "Fokus-Einstellungen",
-    "dueWithinLabel": "Fällige oder beginnende Arbeit anzeigen",
-    "dueWithin": {
-      "0": "Heute",
-      "2": "Nächste 2 Tage",
-      "7": "Diese Woche"
+    "horizonsLabel": "Wie weit im Voraus geschaut wird",
+    "horizonsHint": "Lege pro Priorität einen Zeitraum fest. Überfällige Arbeit wird immer angezeigt.",
+    "horizon": {
+      "today": "Heute",
+      "days_one": "{{count}} Tag",
+      "days_other": "{{count}} Tage",
+      "any": "Beliebiges Datum"
     },
-    "includeHighPriority": "Dringende und hohe Priorität immer einbeziehen",
     "loadError": "Fokusliste derzeit nicht verfügbar.",
     "truncated": "Die ersten {{shown}} werden angezeigt. Verkleinere den Zeitraum für eine kürzere Liste.",
     "settingsHint": "Angeheftete Aufgaben erscheinen immer, unabhängig von diesen Einstellungen."

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -125,13 +125,14 @@
     "pin": "Pin to Focus",
     "unpin": "Remove from Focus",
     "settings": "Focus settings",
-    "dueWithinLabel": "Show work due or starting",
-    "dueWithin": {
-      "0": "Today",
-      "2": "Next 2 days",
-      "7": "This week"
+    "horizonsLabel": "How far ahead to look",
+    "horizonsHint": "Set a window per priority. Overdue work always shows.",
+    "horizon": {
+      "today": "Today",
+      "days_one": "{{count}} day",
+      "days_other": "{{count}} days",
+      "any": "Any date"
     },
-    "includeHighPriority": "Always include urgent and high priority",
     "loadError": "Focus list unavailable right now.",
     "truncated": "Showing the first {{shown}}. Narrow the date window for a shorter list.",
     "settingsHint": "Pinned tasks always appear, whatever these settings say."

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -125,13 +125,14 @@
     "pin": "Fijar en Enfoque",
     "unpin": "Quitar de Enfoque",
     "settings": "Ajustes de Enfoque",
-    "dueWithinLabel": "Mostrar trabajo que vence o comienza",
-    "dueWithin": {
-      "0": "Hoy",
-      "2": "Próximos 2 días",
-      "7": "Esta semana"
+    "horizonsLabel": "Con cuánta antelación mirar",
+    "horizonsHint": "Define un intervalo por prioridad. El trabajo vencido siempre aparece.",
+    "horizon": {
+      "today": "Hoy",
+      "days_one": "{{count}} día",
+      "days_other": "{{count}} días",
+      "any": "Cualquier fecha"
     },
-    "includeHighPriority": "Incluir siempre prioridad urgente y alta",
     "loadError": "La lista de Enfoque no está disponible ahora.",
     "truncated": "Mostrando las primeras {{shown}}. Reduce el intervalo de fechas para una lista más corta.",
     "settingsHint": "Las tareas fijadas siempre aparecen, sea cual sea esta configuración."

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -125,13 +125,14 @@
     "pin": "Épingler au Focus",
     "unpin": "Retirer du Focus",
     "settings": "Paramètres du Focus",
-    "dueWithinLabel": "Afficher le travail à échéance ou qui commence",
-    "dueWithin": {
-      "0": "Aujourd'hui",
-      "2": "2 prochains jours",
-      "7": "Cette semaine"
+    "horizonsLabel": "Jusqu'où regarder à l'avance",
+    "horizonsHint": "Définissez une période par priorité. Le travail en retard apparaît toujours.",
+    "horizon": {
+      "today": "Aujourd'hui",
+      "days_one": "{{count}} jour",
+      "days_other": "{{count}} jours",
+      "any": "N'importe quelle date"
     },
-    "includeHighPriority": "Toujours inclure les priorités urgente et haute",
     "loadError": "Liste Focus indisponible pour le moment.",
     "truncated": "Affichage des {{shown}} premières. Réduisez la période pour une liste plus courte.",
     "settingsHint": "Les tâches épinglées apparaissent toujours, quels que soient ces paramètres."

--- a/frontend/src/__tests__/helpers/handlers/user.handlers.ts
+++ b/frontend/src/__tests__/helpers/handlers/user.handlers.ts
@@ -6,4 +6,11 @@ export const userHandlers = [
   http.get("/api/v1/users/me", () => {
     return HttpResponse.json(buildUser());
   }),
+  // View preference writes are debounced, and flushed again on unmount — which
+  // lands during cleanup, after a test's own handlers are gone. Answering the
+  // write here keeps that flush from surfacing as an unhandled rejection in
+  // whichever test happens to be running at the time.
+  http.put("/api/v1/user-view-preferences/:scopeKey", () => {
+    return HttpResponse.json({ items: {} });
+  }),
 ];

--- a/frontend/src/components/tasks/FocusSummary.test.tsx
+++ b/frontend/src/components/tasks/FocusSummary.test.tsx
@@ -9,6 +9,7 @@ import { createTestQueryClient, renderPage } from "@/__tests__/helpers/render";
 import { FocusSummary } from "@/components/tasks/FocusSummary";
 import {
   FOCUS_DEFAULTS,
+  FOCUS_HORIZON_ANY,
   FOCUS_PREFERENCES_KEY,
   type FocusPreferences,
   useFocusSummary,
@@ -45,10 +46,14 @@ function mockMyTasks({ rules, pins }: Payloads) {
   );
 }
 
-function renderFocus(prefs: Partial<FocusPreferences> = {}) {
+/**
+ * `stored` is the blob exactly as the preferences API would hand it back —
+ * used to seed shapes the current defaults would otherwise paper over.
+ */
+function renderFocus(prefs: Partial<FocusPreferences> = {}, stored?: unknown) {
   const queryClient = createTestQueryClient();
   queryClient.setQueryData(VIEW_PREFERENCES_QUERY_KEY, {
-    items: { [FOCUS_PREFERENCES_KEY]: { ...FOCUS_DEFAULTS, ...prefs } },
+    items: { [FOCUS_PREFERENCES_KEY]: stored ?? { ...FOCUS_DEFAULTS, ...prefs } },
   });
 
   const changeTaskStatus = vi.fn().mockResolvedValue(undefined);
@@ -107,9 +112,11 @@ describe("FocusSummary", () => {
     expect(screen.getByText("1 of 3 done")).toBeInTheDocument();
   });
 
-  it("asks for due-soon work, started work, urgent work, and today's completions in one query", async () => {
+  it("asks each priority for its own window, plus today's completions, in one query", async () => {
     mockMyTasks({});
-    renderFocus({ dueWithinDays: 2, includeHighPriority: true });
+    renderFocus({
+      horizons: { urgent: FOCUS_HORIZON_ANY, high: FOCUS_HORIZON_ANY, medium: 2, low: 0 },
+    });
 
     await waitFor(() => expect(captured.length).toBeGreaterThan(0));
     const conditions = JSON.parse(captured[0].get("conditions") ?? "[]");
@@ -122,32 +129,48 @@ describe("FocusSummary", () => {
       op: "in_",
       value: ["backlog", "todo", "in_progress"],
     };
-    const [dueLeg, startLeg, urgentLeg, doneLeg] = conditions[0].conditions;
+    const [lowDue, lowStart, mediumDue, mediumStart, alwaysLeg, doneLeg] = conditions[0].conditions;
 
-    // Due-soon OR started OR urgent, as sibling AND legs. Two things ride on
-    // this shape: an AND between date and priority would empty the list on
-    // exactly the days it matters most, and a third level of nesting is
-    // rejected outright by the API's group-depth cap.
-    expect(dueLeg.conditions).toEqual([
+    // Per priority: due-soon OR started, as sibling AND legs. Two things ride
+    // on this shape: an AND between the two dates would drop work carrying
+    // only one of them, and a third level of nesting is rejected outright by
+    // the API's group-depth cap.
+    expect(lowDue.conditions).toEqual([
       stillOpen,
+      { field: "priority", op: "in_", value: ["low"] },
       { field: "due_date", op: "lte", value: expect.any(String) },
     ]);
-    expect(startLeg.conditions).toEqual([
+    expect(lowStart.conditions).toEqual([
       stillOpen,
+      { field: "priority", op: "in_", value: ["low"] },
       { field: "start_date", op: "lte", value: expect.any(String) },
     ]);
-    expect(urgentLeg.conditions).toEqual([
+    expect(mediumDue.conditions[1]).toEqual({
+      field: "priority",
+      op: "in_",
+      value: ["medium"],
+    });
+    expect(mediumStart.conditions[2].field).toBe("start_date");
+
+    // Priorities set to "any date" share one leg and carry no date test at
+    // all — that is what keeps urgent work with a distant deadline on the list.
+    expect(alwaysLeg.conditions).toEqual([
       stillOpen,
       { field: "priority", op: "in_", value: ["urgent", "high"] },
     ]);
+
     expect(doneLeg.conditions).toEqual([
       { field: "status_category", op: "in_", value: ["done"] },
       { field: "completed_at", op: "gte", value: expect.any(String) },
     ]);
 
-    // Both dates are measured to the same edge of the window, so the setting
+    // Both dates are measured to the same edge of the window, so one slider
     // means one thing rather than two.
-    expect(startLeg.conditions[1].value).toBe(dueLeg.conditions[1].value);
+    expect(lowStart.conditions[2].value).toBe(lowDue.conditions[2].value);
+    // A wider window reaches further out than a narrower one.
+    expect(new Date(mediumDue.conditions[2].value).getTime()).toBeGreaterThan(
+      new Date(lowDue.conditions[2].value).getTime()
+    );
 
     // The list spans every guild the user belongs to and answers only to its
     // own settings — it is not scoped by the guild you happen to be viewing,
@@ -223,17 +246,77 @@ describe("FocusSummary", () => {
     expect(groupDepth(conditions)).toBeLessThanOrEqual(2);
   });
 
-  it("drops the priority leg when the user turns urgent work off", async () => {
+  it("holds a priority to overdue and today's work at the bottom of its range", async () => {
     mockMyTasks({});
-    renderFocus({ includeHighPriority: false });
+    renderFocus({ horizons: { urgent: 0, high: 0, medium: 0, low: 0 } });
 
     await waitFor(() => expect(captured.length).toBeGreaterThan(0));
     const conditions = JSON.parse(captured[0].get("conditions") ?? "[]");
 
-    const fields = conditions[0].conditions.flatMap((leg: { conditions: { field: string }[] }) =>
-      leg.conditions.map((c) => c.field)
+    // One shared window means one pair of legs, not one pair per priority.
+    const [dueLeg, startLeg, doneLeg] = conditions[0].conditions;
+    expect(conditions[0].conditions).toHaveLength(3);
+    expect(dueLeg.conditions[1].value).toEqual(["urgent", "high", "medium", "low"]);
+    expect(startLeg.conditions[2].field).toBe("start_date");
+    expect(doneLeg.conditions[0].value).toEqual(["done"]);
+
+    // The window still ends at tonight, so anything already overdue matches.
+    const endOfToday = new Date();
+    endOfToday.setHours(23, 59, 59, 999);
+    expect(new Date(dueLeg.conditions[2].value).getTime()).toBe(endOfToday.getTime());
+  });
+
+  it("carries the old single-window settings over to the per-priority ones", async () => {
+    // A blob written before the sliders still says what the user asked for:
+    // "everything due within a week, plus urgent and high whenever they land".
+    mockMyTasks({});
+    renderFocus({}, { open: true, dueWithinDays: 7, includeHighPriority: true, pins: [] });
+
+    await waitFor(() => expect(captured.length).toBeGreaterThan(0));
+    const conditions = JSON.parse(captured[0].get("conditions") ?? "[]");
+    const [dueLeg, startLeg, alwaysLeg] = conditions[0].conditions;
+
+    expect(dueLeg.conditions[1].value).toEqual(["medium", "low"]);
+    expect(startLeg.conditions[1].value).toEqual(["medium", "low"]);
+    expect(alwaysLeg.conditions).toEqual([
+      { field: "status_category", op: "in_", value: ["backlog", "todo", "in_progress"] },
+      { field: "priority", op: "in_", value: ["urgent", "high"] },
+    ]);
+
+    const weekOut = new Date();
+    weekOut.setDate(weekOut.getDate() + 7);
+    weekOut.setHours(23, 59, 59, 999);
+    expect(new Date(dueLeg.conditions[2].value).getTime()).toBe(weekOut.getTime());
+  });
+
+  it("narrows one priority's window from the settings without touching the others", async () => {
+    mockMyTasks({});
+    renderFocus({ horizons: { urgent: FOCUS_HORIZON_ANY, high: 7, medium: 2, low: 2 } });
+
+    await userEvent.click(await screen.findByLabelText("Focus settings"));
+
+    const high = await screen.findByRole("slider", { name: "High" });
+    expect(high).toHaveAttribute("aria-valuenow", "7");
+
+    high.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+
+    await waitFor(() => expect(high).toHaveAttribute("aria-valuenow", "6"));
+    // Its neighbours keep their own windows.
+    expect(screen.getByRole("slider", { name: "Medium" })).toHaveAttribute("aria-valuenow", "2");
+    expect(screen.getByRole("slider", { name: "Urgent" })).toHaveAttribute(
+      "aria-valuenow",
+      String(FOCUS_HORIZON_ANY)
     );
-    expect(fields).not.toContain("priority");
+
+    await waitFor(() => {
+      const latest = JSON.parse(captured.at(-1)?.get("conditions") ?? "[]");
+      const priorities = latest[0].conditions.flatMap(
+        (leg: { conditions: { field: string; value: unknown }[] }) =>
+          leg.conditions.filter((c) => c.field === "priority").map((c) => c.value)
+      );
+      expect(priorities).toContainEqual(["high"]);
+    });
   });
 
   it("shows every task that matches, with no cutoff", async () => {

--- a/frontend/src/components/tasks/FocusSummary.tsx
+++ b/frontend/src/components/tasks/FocusSummary.tsx
@@ -13,9 +13,9 @@ import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
-import { Switch } from "@/components/ui/switch";
+import { Slider } from "@/components/ui/slider";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { FOCUS_DUE_WITHIN_CHOICES, type useFocusSummary } from "@/hooks/useFocusSummary";
+import { FOCUS_HORIZON_ANY, FOCUS_PRIORITIES, type useFocusSummary } from "@/hooks/useFocusSummary";
 import { guildPath } from "@/lib/guildUrl";
 import { cn } from "@/lib/utils";
 
@@ -101,7 +101,14 @@ const FocusRow = ({
 
 const FocusSettings = ({ focus }: { focus: FocusSummaryData }) => {
   const { t } = useTranslation(["tasks", "common"]);
-  const { prefs, setPreference } = focus;
+  const { prefs, setHorizon } = focus;
+
+  /** What a slider stop means, in words: the same value the leg is built from. */
+  const horizonLabel = (days: number) => {
+    if (days >= FOCUS_HORIZON_ANY) return t("focus.horizon.any");
+    if (days === 0) return t("focus.horizon.today");
+    return t("focus.horizon.days", { count: days });
+  };
 
   return (
     <Popover>
@@ -110,33 +117,38 @@ const FocusSettings = ({ focus }: { focus: FocusSummaryData }) => {
           <Settings2 className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-72 space-y-4">
-        <div className="space-y-2">
-          <Label className="text-xs">{t("focus.dueWithinLabel")}</Label>
-          <div className="flex gap-1">
-            {FOCUS_DUE_WITHIN_CHOICES.map((days) => (
-              <Button
-                key={days}
-                variant={prefs.dueWithinDays === days ? "default" : "outline"}
-                size="sm"
-                className="flex-1"
-                onClick={() => setPreference("dueWithinDays", days)}
-              >
-                {t(`focus.dueWithin.${days}`)}
-              </Button>
-            ))}
-          </div>
+      <PopoverContent align="end" className="w-72 space-y-4 sm:w-80">
+        <div className="space-y-1">
+          <Label className="text-xs">{t("focus.horizonsLabel")}</Label>
+          <p className="text-muted-foreground text-xs">{t("focus.horizonsHint")}</p>
         </div>
 
-        <div className="flex items-center justify-between gap-3">
-          <Label htmlFor="focus-priority" className="text-xs leading-snug">
-            {t("focus.includeHighPriority")}
-          </Label>
-          <Switch
-            id="focus-priority"
-            checked={prefs.includeHighPriority}
-            onCheckedChange={(checked) => setPreference("includeHighPriority", checked)}
-          />
+        <div className="space-y-4">
+          {FOCUS_PRIORITIES.map((priority) => {
+            const days = prefs.horizons[priority];
+            const label = t(`priority.${priority}`);
+            return (
+              <div key={priority} className="space-y-2">
+                <div className="flex items-baseline justify-between gap-3">
+                  <Label className="text-xs capitalize">{label}</Label>
+                  <span className="text-muted-foreground text-xs tabular-nums">
+                    {horizonLabel(days)}
+                  </span>
+                </div>
+                <Slider
+                  value={[days]}
+                  min={0}
+                  max={FOCUS_HORIZON_ANY}
+                  step={1}
+                  thumbLabel={label}
+                  onValueChange={([next]) => setHorizon(priority, next)}
+                  // The whole track is draggable, so the padding is what makes
+                  // it a finger-sized target rather than a 4px line.
+                  className="py-1.5"
+                />
+              </div>
+            );
+          })}
         </div>
 
         <p className="text-muted-foreground text-xs">{t("focus.settingsHint")}</p>

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -1,0 +1,33 @@
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  /**
+   * Accessible name for the thumb. The thumb is the element carrying
+   * `role="slider"`, so a label on the root would not name the control.
+   */
+  thumbLabel?: string;
+};
+
+const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, SliderProps>(
+  ({ className, thumbLabel, ...props }, ref) => (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn("relative flex w-full touch-none select-none items-center", className)}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        aria-label={thumbLabel}
+        className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+      />
+    </SliderPrimitive.Root>
+  )
+);
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/frontend/src/hooks/useFocusSummary.ts
+++ b/frontend/src/hooks/useFocusSummary.ts
@@ -8,6 +8,7 @@ import type {
   ListMyTasksApiV1MeTasksGetParams,
   TaskListRead,
   TaskListResponse,
+  TaskPriority,
 } from "@/api/generated/initiativeAPI.schemas";
 import {
   getListMyTasksApiV1MeTasksGetQueryKey,
@@ -22,26 +23,107 @@ export type FocusPin = {
   task_id: number;
 };
 
+/** How far ahead the section looks, per priority. */
+export type FocusHorizons = Record<TaskPriority, number>;
+
 export type FocusPreferences = {
   /** Section expanded or collapsed. */
   open: boolean;
-  /** Include tasks due within this many days (0 = due today or overdue). */
-  dueWithinDays: number;
-  /** Also include urgent/high priority tasks regardless of their due date. */
-  includeHighPriority: boolean;
+  /**
+   * Days ahead to look, one window per priority: 0 keeps a priority to work
+   * that is due today or overdue, and `FOCUS_HORIZON_ANY` drops the date test
+   * altogether so the priority always appears.
+   */
+  horizons: FocusHorizons;
   pins: FocusPin[];
 };
+
+/** Highest first: the order the settings list them in. */
+export const FOCUS_PRIORITIES = [
+  "urgent",
+  "high",
+  "medium",
+  "low",
+] as const satisfies readonly TaskPriority[];
+
+/** Top of the dated range — a month out is as far as "soon" stretches. */
+export const FOCUS_HORIZON_MAX_DAYS = 30;
+
+/**
+ * One stop past the top of the range: match the priority whatever its dates
+ * say. This is what keeps urgent work on the list when its deadline is months
+ * away — the case a pure day window cannot express.
+ */
+export const FOCUS_HORIZON_ANY = FOCUS_HORIZON_MAX_DAYS + 1;
 
 export const FOCUS_PREFERENCES_KEY = "my-tasks:focus";
 
 export const FOCUS_DEFAULTS: FocusPreferences = {
   open: true,
-  dueWithinDays: 2,
-  includeHighPriority: true,
+  horizons: {
+    urgent: FOCUS_HORIZON_ANY,
+    high: FOCUS_HORIZON_ANY,
+    medium: 2,
+    low: 2,
+  },
   pins: [],
 };
 
-export const FOCUS_DUE_WITHIN_CHOICES = [0, 2, 7] as const;
+/** The shape stored before the windows became per-priority. */
+type LegacyFocusPreferences = {
+  dueWithinDays?: unknown;
+  includeHighPriority?: unknown;
+};
+
+const clampHorizon = (value: unknown, fallback: number) =>
+  typeof value === "number" && Number.isFinite(value)
+    ? Math.min(FOCUS_HORIZON_ANY, Math.max(0, Math.round(value)))
+    : fallback;
+
+/**
+ * Read the per-priority windows out of a stored blob, which may predate them
+ * and is user-writable via the preferences API.
+ *
+ * A blob written by the old single-window settings still says what the user
+ * asked for, so it is carried across rather than reset: its day count becomes
+ * every priority's window, and its "always include urgent and high" switch
+ * becomes `FOCUS_HORIZON_ANY` on those two.
+ */
+export function resolveHorizons(raw: unknown): FocusHorizons {
+  const blob = (raw ?? {}) as { horizons?: unknown } & LegacyFocusPreferences;
+  const stored = (blob.horizons ?? null) as Partial<Record<string, unknown>> | null;
+  const legacyDays =
+    stored === null && typeof blob.dueWithinDays === "number"
+      ? clampHorizon(blob.dueWithinDays, FOCUS_DEFAULTS.horizons.medium)
+      : null;
+  const legacyAlwaysUrgent = blob.includeHighPriority !== false;
+
+  return Object.fromEntries(
+    FOCUS_PRIORITIES.map((priority) => {
+      const fallback =
+        legacyDays === null
+          ? FOCUS_DEFAULTS.horizons[priority]
+          : legacyAlwaysUrgent && (priority === "urgent" || priority === "high")
+            ? FOCUS_HORIZON_ANY
+            : legacyDays;
+      return [priority, clampHorizon(stored?.[priority], fallback)];
+    })
+  ) as FocusHorizons;
+}
+
+/**
+ * A stored blob read back as the current shape. Fields are picked out rather
+ * than spread, so a legacy key is translated once and then dropped instead of
+ * riding along in every later write.
+ */
+const normalizePreferences = (raw: unknown): FocusPreferences => {
+  const blob = (raw ?? {}) as Partial<FocusPreferences>;
+  return {
+    open: typeof blob.open === "boolean" ? blob.open : FOCUS_DEFAULTS.open,
+    horizons: resolveHorizons(raw),
+    pins: Array.isArray(blob.pins) ? blob.pins : [],
+  };
+};
 
 /**
  * Everything that is not finished. `backlog` belongs here as much as the other
@@ -49,7 +131,6 @@ export const FOCUS_DUE_WITHIN_CHOICES = [0, 2, 7] as const;
  * hides the bulk of most people's work — including tasks that are overdue.
  */
 const OPEN_CATEGORIES = ["backlog", "todo", "in_progress"];
-const URGENT_PRIORITIES = ["urgent", "high"];
 /**
  * The API's per-page maximum. There is deliberately no display cap on top of
  * it: a task either meets the rules and belongs on the list, or it does not.
@@ -62,24 +143,28 @@ const pinKey = (guildId: number | null | undefined, taskId: number) =>
 
 /**
  * Conditions for the rule-driven half of the section: open work that has come
- * due (or already started) within the window, or is explicitly urgent, plus
- * anything finished today so completions stay visible instead of vanishing the
- * moment they're checked off.
+ * due (or already started) within its priority's window, plus anything
+ * finished today so completions stay visible instead of vanishing the moment
+ * they're checked off.
  *
- * The window applies to `start_date` as well as `due_date`, matching how the
+ * Each window applies to `start_date` as well as `due_date`, matching how the
  * task table below groups by date (`getTaskDateStatus`): a task whose start
  * date has passed is work in hand even if nobody put a deadline on it.
+ *
+ * Priorities sharing a window share a leg, so the common case of two or three
+ * distinct settings stays a short payload rather than one pair of legs per
+ * priority.
  *
  * Exported for testing — the OR nesting is the part worth pinning down.
  */
 export function buildFocusConditions({
-  horizon,
-  includeHighPriority,
+  today,
+  horizons,
   completedSince,
 }: {
-  /** Far edge of the date window; both start and due dates are measured to it. */
-  horizon: Date;
-  includeHighPriority: boolean;
+  /** Local midnight; each priority's window is measured forward from here. */
+  today: Date;
+  horizons: FocusHorizons;
   completedSince: Date;
 }): FilterGroup[] {
   const stillOpen: FilterCondition = {
@@ -88,25 +173,33 @@ export function buildFocusConditions({
     value: OPEN_CATEGORIES,
   };
 
-  // "Open AND (due soon OR started OR urgent)" is written out as sibling AND
-  // legs rather than nesting an OR inside the AND: the API caps condition
-  // nesting at two group levels and rejects a third outright. Distributing the
-  // shared leg costs one duplicated leaf per branch and keeps the same meaning.
-  const legs: FilterGroup[] = [
-    {
-      logic: "and",
-      conditions: [stillOpen, { field: "due_date", op: "lte", value: horizon.toISOString() }],
-    },
-    {
-      logic: "and",
-      conditions: [stillOpen, { field: "start_date", op: "lte", value: horizon.toISOString() }],
-    },
-  ];
+  const byWindow = new Map<number, TaskPriority[]>();
+  for (const priority of FOCUS_PRIORITIES) {
+    const days = horizons[priority];
+    byWindow.set(days, [...(byWindow.get(days) ?? []), priority]);
+  }
 
-  if (includeHighPriority) {
+  // "Open AND priority AND (due soon OR started)" is written out as sibling
+  // AND legs rather than nesting an OR inside the AND: the API caps condition
+  // nesting at two group levels and rejects a third outright. Distributing the
+  // shared leaves costs a little duplication and keeps the same meaning.
+  const legs: FilterGroup[] = [];
+  for (const [days, priorities] of [...byWindow].sort(([a], [b]) => a - b)) {
+    const atPriority: FilterCondition = { field: "priority", op: "in_", value: priorities };
+
+    if (days >= FOCUS_HORIZON_ANY) {
+      legs.push({ logic: "and", conditions: [stillOpen, atPriority] });
+      continue;
+    }
+
+    const horizon = endOfDay(addDays(today, days)).toISOString();
     legs.push({
       logic: "and",
-      conditions: [stillOpen, { field: "priority", op: "in_", value: URGENT_PRIORITIES }],
+      conditions: [stillOpen, atPriority, { field: "due_date", op: "lte", value: horizon }],
+    });
+    legs.push({
+      logic: "and",
+      conditions: [stillOpen, atPriority, { field: "start_date", op: "lte", value: horizon }],
     });
   }
 
@@ -165,14 +258,7 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
   );
 
   // A stored blob predates any later field, and is user-writable via the API.
-  const prefs = useMemo<FocusPreferences>(
-    () => ({
-      ...FOCUS_DEFAULTS,
-      ...prefsRaw,
-      pins: Array.isArray(prefsRaw?.pins) ? prefsRaw.pins : [],
-    }),
-    [prefsRaw]
-  );
+  const prefs = useMemo<FocusPreferences>(() => normalizePreferences(prefsRaw), [prefsRaw]);
 
   const timezone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
 
@@ -186,8 +272,8 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
   const ruleParams = useMemo<ListMyTasksApiV1MeTasksGetParams>(
     () => ({
       conditions: buildFocusConditions({
-        horizon: endOfDay(addDays(new Date(today), prefs.dueWithinDays)),
-        includeHighPriority: prefs.includeHighPriority,
+        today: new Date(today),
+        horizons: prefs.horizons,
         completedSince: new Date(today),
       }),
       page: 1,
@@ -195,7 +281,7 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
       sorting: [{ field: "due_date", dir: "asc" }],
       tz: timezone,
     }),
-    [today, prefs.dueWithinDays, prefs.includeHighPriority, timezone]
+    [today, prefs.horizons, timezone]
   );
 
   const ruleQuery = useQuery<TaskListResponse>({
@@ -239,14 +325,13 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
     (task: Pick<TaskListRead, "id" | "guild_id">) => {
       const key = pinKey(task.guild_id, task.id);
       setPrefs((prev) => {
-        const current = Array.isArray(prev?.pins) ? prev.pins : [];
-        const without = current.filter((pin) => pinKey(pin.guild_id, pin.task_id) !== key);
+        const current = normalizePreferences(prev);
+        const without = current.pins.filter((pin) => pinKey(pin.guild_id, pin.task_id) !== key);
         return {
-          ...FOCUS_DEFAULTS,
-          ...prev,
+          ...current,
           pins:
-            without.length === current.length
-              ? [...current, { guild_id: task.guild_id ?? null, task_id: task.id }]
+            without.length === current.pins.length
+              ? [...current.pins, { guild_id: task.guild_id ?? null, task_id: task.id }]
               : without,
         };
       });
@@ -256,7 +341,28 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
 
   const setPreference = useCallback(
     <K extends keyof FocusPreferences>(key: K, value: FocusPreferences[K]) => {
-      setPrefs((prev) => ({ ...FOCUS_DEFAULTS, ...prev, [key]: value }));
+      setPrefs((prev) => ({ ...normalizePreferences(prev), [key]: value }));
+    },
+    [setPrefs]
+  );
+
+  /**
+   * Widen or narrow one priority's window. Written off `prev` rather than the
+   * rendered value so dragging one slider never writes back a neighbour's
+   * pre-drag setting.
+   */
+  const setHorizon = useCallback(
+    (priority: TaskPriority, days: number) => {
+      setPrefs((prev) => {
+        const current = normalizePreferences(prev);
+        return {
+          ...current,
+          horizons: {
+            ...current.horizons,
+            [priority]: clampHorizon(days, current.horizons[priority]),
+          },
+        };
+      });
     },
     [setPrefs]
   );
@@ -322,13 +428,13 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
   useEffect(() => {
     if (!staleIds) return;
     const stale = new Set(staleIds.split("|"));
-    setPrefs((prev) => ({
-      ...FOCUS_DEFAULTS,
-      ...prev,
-      pins: (Array.isArray(prev?.pins) ? prev.pins : []).filter(
-        (pin) => !stale.has(pinKey(pin.guild_id, pin.task_id))
-      ),
-    }));
+    setPrefs((prev) => {
+      const current = normalizePreferences(prev);
+      return {
+        ...current,
+        pins: current.pins.filter((pin) => !stale.has(pinKey(pin.guild_id, pin.task_id))),
+      };
+    });
   }, [staleIds, setPrefs]);
 
   const remainingCount = derived.pinned.length + derived.upcoming.length;
@@ -341,6 +447,7 @@ export function useFocusSummary({ enabled = true }: { enabled?: boolean } = {}) 
     ...visible,
     prefs,
     setPreference,
+    setHorizon,
     isPinned,
     togglePin,
     /** Everything on today's list, done or not — the progress denominator. */


### PR DESCRIPTION
## Problem

The Focus section on My Tasks had a single date range applied to every task, plus an "always include urgent and high" switch. That pairing could express "the next two days", but not "urgent whenever it lands, low only once it's actually due" — the shape most people's triage actually takes.

## Changes

- [useFocusSummary.ts](frontend/src/hooks/useFocusSummary.ts) — `horizons` (a window per priority) replaces `dueWithinDays` + `includeHighPriority`. Adds `resolveHorizons` (reads the windows out of a stored blob, translating the old shape), `normalizePreferences`, and a `setHorizon` setter that writes off `prev` so dragging one slider can't write back a neighbour's pre-drag value.
- `buildFocusConditions` now emits one due leg + one start leg per **distinct** window, each carrying a `priority in_ […]` leaf. Priorities sharing a setting share a leg, so the payload stays short and the group nesting stays within the API's depth cap. A priority set to "any date" gets a single leg with no date test at all.
- [FocusSummary.tsx](frontend/src/components/tasks/FocusSummary.tsx) — the settings popover is now four labelled sliders (Urgent, High, Medium, Low), each showing what its stop means: "Today", "N days", or "Any date". Padded track for a finger-sized target; popover narrows on small screens.
- [slider.tsx](frontend/src/components/ui/slider.tsx) — new shadcn slider, with an optional `thumbLabel`. The thumb is the element carrying `role="slider"`, so a label on the root would not name the control.
- [user.handlers.ts](frontend/src/__tests__/helpers/handlers/user.handlers.ts) — global MSW handler for the view-preference PUT. Without it, the debounced write flushed on unmount during cleanup (after a test's own handlers are gone) and surfaced as an unhandled rejection attributed to whichever test happened to be running.
- Focus keys updated across all four locales (`en`/`de`/`es`/`fr`); `CHANGELOG.md` entry under `[Unreleased]`.

### Migration

Defaults map exactly to the old defaults (urgent/high = any date, medium/low = 2 days). A blob written by the old settings is translated on read — `dueWithinDays` becomes every priority's window, `includeHighPriority` becomes "any date" on urgent and high — and the legacy keys are dropped on the next write, so no one's settings reset.

## Testing

- `cd frontend && pnpm typecheck` — clean.
- `cd frontend && pnpm biome check <changed files>` — clean.
- `cd frontend && ./scripts/test-changed.sh` — shared test infra changed, so it ran the full suite: **105 files, 1409 tests passed**.
- New coverage in [FocusSummary.test.tsx](frontend/src/components/tasks/FocusSummary.test.tsx): per-priority legs and their windows, the shared-leg collapse when priorities agree, the bottom-of-range case still reaching overdue work, the legacy-blob migration, and adjusting one slider from the UI without disturbing its neighbours.

Backend untouched — no schema or generated-type changes.