### PR TITLE
Give installed apps somewhere to go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installed apps open again.** Clicking an app in the sidebar did nothing. An app with a page of its own now opens it — with a tab for each view where an app offers several — and an app that only needs an account connected opens that form where you clicked, rather than sending you to look for it in guild settings. Apps that just feed widgets into dashboards have no page to open, so they tuck under a “show more” instead of taking up a row. Each app is now shown with its own artwork.
+
+### Changed
+
+- **The sidebar drops “All Projects” and “All Documents”.** Both are a keystroke away in the command palette, and the space now belongs to your guild's apps. The apps list also matches the initiatives list above it — the same expand control, and “Add an app” sits at the bottom where “Add initiative” does.
+
 ## [0.62.1] - 2026-08-13
 
 ### Fixed

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -34,6 +34,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import (
     GuildContext,
@@ -98,6 +99,12 @@ def _require_guild_admin(guild_context: GuildContext) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail=GuildAppMessages.ADMIN_REQUIRED,
         )
+
+
+async def _app_avatar(session: AsyncSession, app: GuildApp) -> Optional[str]:
+    """The artwork for one install's listing."""
+    avatars = await catalog_service.listing_avatars(session, [app.listing_uid])
+    return avatars.get(app.listing_uid)
 
 
 async def _load(session: RLSSessionDep, app_id: int) -> GuildApp:
@@ -217,11 +224,15 @@ async def list_guild_apps(
     apps = (
         await session.exec(select(GuildApp).order_by(GuildApp.name, GuildApp.id))
     ).all()
+    avatars = await catalog_service.listing_avatars(
+        session, [app.listing_uid for app in apps]
+    )
     return GuildAppListResponse(
         items=[
             serialize_guild_app(
                 app,
                 install_state=await registration_lookup.install_state(app.definition),
+                avatar_url=avatars.get(app.listing_uid),
             )
             for app in apps
         ]
@@ -244,6 +255,7 @@ async def get_guild_app(
     app = await _load(session, app_id)
     return serialize_guild_app_detail(
         app,
+        avatar_url=await _app_avatar(session, app),
         member_rows=await _member_rows(session, app_id=app.id, user_id=current_user.id),
         install_state=await registration_lookup.install_state(app.definition),
     )
@@ -309,7 +321,9 @@ async def install_guild_app(
     await session.refresh(app)
 
     installed = serialize_guild_app(
-        app, install_state=await registration_lookup.install_state(app.definition)
+        app,
+        install_state=await registration_lookup.install_state(app.definition),
+        avatar_url=await _app_avatar(session, app),
     )
     await _count_install(listing.id)
     return installed
@@ -394,6 +408,7 @@ async def upgrade_guild_app(
     await session.refresh(app)
     return serialize_guild_app_detail(
         app,
+        avatar_url=await _app_avatar(session, app),
         member_rows=await _member_rows(session, app_id=app.id, user_id=current_user.id),
         install_state=await registration_lookup.install_state(app.definition),
     )
@@ -428,7 +443,9 @@ async def update_guild_app(
     await session.commit()
     await session.refresh(app)
     return serialize_guild_app(
-        app, install_state=await registration_lookup.install_state(app.definition)
+        app,
+        install_state=await registration_lookup.install_state(app.definition),
+        avatar_url=await _app_avatar(session, app),
     )
 
 
@@ -556,6 +573,7 @@ async def update_guild_app_config(
     await session.refresh(app)
     return serialize_guild_app_detail(
         app,
+        avatar_url=await _app_avatar(session, app),
         member_rows=await _member_rows(session, app_id=app.id, user_id=current_user.id),
         install_state=await registration_lookup.install_state(app.definition),
     )

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
@@ -114,6 +114,20 @@ class TestInstall:
         assert calendar.initiative_id is None
         assert calendar.guild_id == a.guild.id
 
+    async def test_the_list_carries_the_listing_artwork(
+        self, client: AsyncClient, acting_user, calendar_app
+    ):
+        """The sidebar draws an install from its listing's picture, so the LIST
+        payload has to carry it — a field added only to the detail read would
+        leave every sidebar entry blank."""
+        a = await acting_user(guild_role=GuildRole.admin)
+        await _install(client, a)
+
+        response = await client.get(a.g("/apps/"), headers=a.headers)
+        assert response.status_code == 200, response.text
+        (item,) = response.json()["items"]
+        assert item["avatar_url"] == "/marketplace/test.svg"
+
     async def test_the_name_can_be_chosen_at_install(
         self, client: AsyncClient, acting_user, session: AsyncSession, calendar_app
     ):

--- a/backend/app/schemas/tenant/guild_app.py
+++ b/backend/app/schemas/tenant/guild_app.py
@@ -124,6 +124,10 @@ class GuildAppRead(SanitizedBaseModel):
     #: Which tool this app mounts, when it mounts one. Read off the pinned
     #: definition so the client need not fetch the catalog to render an entry.
     tool: Optional[str] = None
+    #: The listing's artwork, so the sidebar can draw this install. Looked up
+    #: from the catalog rather than pinned: a publisher who changes their
+    #: picture changes it everywhere the app is shown.
+    avatar_url: Optional[str] = None
     #: What a service app contributes, from its pinned definition.
     features: List[str] = []
     #: The pinned definition itself, verbatim.
@@ -253,7 +257,10 @@ class GuildAppMembersResponse(SanitizedBaseModel):
 
 
 def serialize_guild_app(
-    app: Any, *, install_state: Optional[InstallState] = None
+    app: Any,
+    *,
+    install_state: Optional[InstallState] = None,
+    avatar_url: Optional[str] = None,
 ) -> GuildAppRead:
     """One install as the client sees it.
 
@@ -279,6 +286,7 @@ def serialize_guild_app(
         config_state=state.state,
         config_state_detail=state.detail,
         tool=definition.get("tool"),
+        avatar_url=avatar_url,
         features=list(features) if isinstance(features, list) else [],
         definition=definition,
         mandatory=service_state.mandatory,
@@ -339,9 +347,10 @@ def serialize_guild_app_detail(
     *,
     member_rows: Dict[str, Any],
     install_state: Optional[InstallState] = None,
+    avatar_url: Optional[str] = None,
 ) -> GuildAppDetail:
     """The install and its connections, from the viewer's own perspective."""
-    base = serialize_guild_app(app, install_state=install_state)
+    base = serialize_guild_app(app, install_state=install_state, avatar_url=avatar_url)
     connections = [
         serialize_connection(
             app, connection, member_row=member_rows.get(connection.get("id") or "")

--- a/backend/app/services/marketplace/catalog.py
+++ b/backend/app/services/marketplace/catalog.py
@@ -49,6 +49,7 @@ __all__ = [
     "list_listings",
     "get_listing",
     "get_listing_by_uid",
+    "listing_avatars",
     "get_listing_version",
     "resolve_installable_version",
     "listing_versions",
@@ -202,6 +203,24 @@ async def get_listing(
     ).first()
 
 
+async def listing_avatars(session: AsyncSession, uids: Sequence[str]) -> dict[str, str]:
+    """Artwork for the given listings, by uid.
+
+    Read rather than pinned into an install: a listing that changes its picture
+    should change everywhere it is drawn, and unlike a definition there is
+    nothing here an install needs held still.
+    """
+    unique = {uid for uid in uids if uid}
+    if not unique:
+        return {}
+    rows = await session.exec(
+        select(MarketplaceListing.uid, MarketplaceListing.avatar_url).where(
+            MarketplaceListing.uid.in_(unique)
+        )
+    )
+    return {uid: avatar for uid, avatar in rows if avatar}
+
+
 async def get_listing_by_uid(
     session: AsyncSession, uid: str
 ) -> Optional[MarketplaceListing]:
@@ -270,6 +289,7 @@ async def upsert_listing(
 
     try:
         definition = normalize_listing_definition(kind, manifest.get("definition"))
+
         # Required on every ingestion path: seeding, an operator upload, a
         # registry refresh. There is no path that publishes without one.
         publisher = normalize_publisher(manifest.get("publisher"))

--- a/frontend/public/locales/de/apps.json
+++ b/frontend/public/locales/de/apps.json
@@ -94,5 +94,20 @@
     "revokeAllTitle": "Verbindungen aller Mitglieder entziehen?",
     "revokeAllBody": "Die hinterlegten Zugangsdaten jedes Mitglieds werden gelöscht und die App wird aufgefordert, sie nicht mehr zu nutzen. Die App bleibt installiert und behält ihre Gildeneinstellungen. Mitglieder können sich danach neu verbinden.",
     "revokedAll": "Alle Verbindungen entzogen."
+  },
+  "showMore": "{{count}} weitere",
+  "showFewer": "Weniger anzeigen",
+  "settings": {
+    "description": "Lege fest, wie sich diese App verbindet."
+  },
+  "embed": {
+    "connecting": "Verbinden…",
+    "handoffFailed": "Diese App konnte nicht geöffnet werden. Versuche es gleich noch einmal.",
+    "failed": "Diese App konnte nicht geöffnet werden",
+    "notFound": "App nicht gefunden",
+    "disabled": "{{name}} ist deaktiviert",
+    "unavailable": "{{name}} ist auf diesem Server nicht eingerichtet",
+    "unavailableDescription": "Eine Administratorin oder ein Administrator muss den Dienst dieser App verbinden, bevor sie geöffnet werden kann.",
+    "noSurface": "{{name}} hat keine eigene Seite"
   }
 }

--- a/frontend/public/locales/de/nav.json
+++ b/frontend/public/locales/de/nav.json
@@ -4,8 +4,6 @@
   "initiatives": "Initiativen",
   "tags": "Tags",
   "favorites": "Favoriten",
-  "allProjects": "Alle Projekte",
-  "allDocuments": "Alle Dokumente",
   "noInitiativesAvailable": "Keine Initiativen verfügbar",
   "addInitiative": "Initiative hinzufügen",
   "noTagsCreated": "Noch keine Tags erstellt",

--- a/frontend/public/locales/en/apps.json
+++ b/frontend/public/locales/en/apps.json
@@ -94,5 +94,20 @@
     "revokeAllTitle": "Revoke every member's connection?",
     "revokeAllBody": "Every member's stored credential is deleted and the app is told to stop using it. The app stays installed and keeps its guild settings. Members can connect again afterwards.",
     "revokedAll": "Every connection revoked."
+  },
+  "showMore": "{{count}} more",
+  "showFewer": "Show fewer",
+  "settings": {
+    "description": "Set up how this app connects."
+  },
+  "embed": {
+    "connecting": "Connecting…",
+    "handoffFailed": "Could not open this app. Try again in a moment.",
+    "failed": "This app could not be opened",
+    "notFound": "App not found",
+    "disabled": "{{name}} is turned off",
+    "unavailable": "{{name}} is not set up on this server",
+    "unavailableDescription": "An administrator needs to connect this app's service before it can be opened.",
+    "noSurface": "{{name}} has no page of its own"
   }
 }

--- a/frontend/public/locales/en/nav.json
+++ b/frontend/public/locales/en/nav.json
@@ -4,8 +4,6 @@
   "initiatives": "Initiatives",
   "tags": "Tags",
   "favorites": "Favorites",
-  "allProjects": "All Projects",
-  "allDocuments": "All Documents",
   "noInitiativesAvailable": "No initiatives available",
   "addInitiative": "Add initiative",
   "noTagsCreated": "No tags created yet",

--- a/frontend/public/locales/es/apps.json
+++ b/frontend/public/locales/es/apps.json
@@ -94,5 +94,20 @@
     "revokeAllTitle": "¿Revocar la conexión de todos los miembros?",
     "revokeAllBody": "Se borra la credencial guardada de cada miembro y se le pide a la aplicación que deje de usarla. La aplicación sigue instalada y conserva los ajustes del gremio. Después los miembros pueden volver a conectarse.",
     "revokedAll": "Todas las conexiones revocadas."
+  },
+  "showMore": "{{count}} más",
+  "showFewer": "Mostrar menos",
+  "settings": {
+    "description": "Configura cómo se conecta esta aplicación."
+  },
+  "embed": {
+    "connecting": "Conectando…",
+    "handoffFailed": "No se pudo abrir esta aplicación. Inténtalo de nuevo en un momento.",
+    "failed": "No se pudo abrir esta aplicación",
+    "notFound": "Aplicación no encontrada",
+    "disabled": "{{name}} está desactivada",
+    "unavailable": "{{name}} no está configurada en este servidor",
+    "unavailableDescription": "Un administrador debe conectar el servicio de esta aplicación antes de poder abrirla.",
+    "noSurface": "{{name}} no tiene una página propia"
   }
 }

--- a/frontend/public/locales/es/nav.json
+++ b/frontend/public/locales/es/nav.json
@@ -4,8 +4,6 @@
   "initiatives": "Iniciativas",
   "tags": "Etiquetas",
   "favorites": "Favoritos",
-  "allProjects": "Todos los proyectos",
-  "allDocuments": "Todos los documentos",
   "noInitiativesAvailable": "No hay iniciativas disponibles",
   "addInitiative": "Agregar iniciativa",
   "noTagsCreated": "Aún no se han creado etiquetas",

--- a/frontend/public/locales/fr/apps.json
+++ b/frontend/public/locales/fr/apps.json
@@ -94,5 +94,20 @@
     "revokeAllTitle": "Révoquer la connexion de tous les membres ?",
     "revokeAllBody": "L'identifiant enregistré de chaque membre est supprimé et l'application est priée de cesser de s'en servir. L'application reste installée et conserve les réglages de la guilde. Les membres peuvent se reconnecter ensuite.",
     "revokedAll": "Toutes les connexions révoquées."
+  },
+  "showMore": "{{count}} de plus",
+  "showFewer": "Afficher moins",
+  "settings": {
+    "description": "Configurez la connexion de cette application."
+  },
+  "embed": {
+    "connecting": "Connexion…",
+    "handoffFailed": "Impossible d'ouvrir cette application. Réessayez dans un instant.",
+    "failed": "Impossible d'ouvrir cette application",
+    "notFound": "Application introuvable",
+    "disabled": "{{name}} est désactivée",
+    "unavailable": "{{name}} n'est pas configurée sur ce serveur",
+    "unavailableDescription": "Un administrateur doit connecter le service de cette application avant qu'elle puisse être ouverte.",
+    "noSurface": "{{name}} n'a pas de page dédiée"
   }
 }

--- a/frontend/public/locales/fr/nav.json
+++ b/frontend/public/locales/fr/nav.json
@@ -4,8 +4,6 @@
   "initiatives": "Initiatives",
   "tags": "Étiquettes",
   "favorites": "Favoris",
-  "allProjects": "Tous les projets",
-  "allDocuments": "Tous les documents",
   "noInitiativesAvailable": "Aucune initiative disponible",
   "addInitiative": "Ajouter une initiative",
   "noTagsCreated": "Aucune étiquette créée pour l'instant",

--- a/frontend/src/api/appConnections.ts
+++ b/frontend/src/api/appConnections.ts
@@ -76,8 +76,11 @@ export interface GuildAppDetail {
   config_state: "unverified" | "ok" | "invalid" | string;
   config_state_detail?: string | null;
   tool?: string | null;
-  embed_target?: string | null;
+  /** The listing's artwork, for drawing the app outside the marketplace. */
+  avatar_url?: string | null;
   features: string[];
+  /** The pinned definition, verbatim — what surfaces and connections it has. */
+  definition: Record<string, unknown>;
   admin_only: boolean;
   /** The platform provides this app: no remove, no turning it off. */
   mandatory: boolean;

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2037,6 +2037,7 @@ export interface GuildAppDetail {
   config_state: string;
   config_state_detail: string | null;
   tool: string | null;
+  avatar_url: string | null;
   features: string[];
   definition: GuildAppDetailDefinition;
   mandatory: boolean;
@@ -2090,6 +2091,7 @@ export interface GuildAppRead {
   config_state: string;
   config_state_detail: string | null;
   tool: string | null;
+  avatar_url: string | null;
   features: string[];
   definition: GuildAppReadDefinition;
   mandatory: boolean;

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -3,10 +3,8 @@ import {
   Check,
   ChevronsDownUp,
   ChevronsUpDown,
-  ListTodo,
   Pencil,
   Plus,
-  ScrollText,
   Settings,
   Star,
   Tag,
@@ -376,48 +374,18 @@ export const AppSidebar = () => {
                           </>
                         )}
 
-                        {/* All Projects & All Documents */}
+                        {/* Apps: guild-wide surfaces, so they sit above the
+                            initiatives rather than inside any of them. */}
                         {activeGuild && (
                           <>
-                            <SidebarGroup>
-                              <SidebarGroupContent>
-                                <SidebarMenu>
-                                  <SidebarMenuItem>
-                                    <SidebarMenuButton asChild>
-                                      <Link
-                                        to={gp("/projects")}
-                                        className="flex items-center gap-2"
-                                      >
-                                        <ListTodo className="h-4 w-4" />
-                                        <span>{t("allProjects")}</span>
-                                      </Link>
-                                    </SidebarMenuButton>
-                                  </SidebarMenuItem>
-                                  <SidebarMenuItem>
-                                    <SidebarMenuButton asChild>
-                                      <Link
-                                        to={gp("/documents")}
-                                        className="flex items-center gap-2"
-                                      >
-                                        <ScrollText className="h-4 w-4" />
-                                        <span>{t("allDocuments")}</span>
-                                      </Link>
-                                    </SidebarMenuButton>
-                                  </SidebarMenuItem>
-                                </SidebarMenu>
-                              </SidebarGroupContent>
-                            </SidebarGroup>
+                            <AppsSection
+                              isGuildAdmin={isGuildAdmin}
+                              open={appsOpen}
+                              onOpenChange={setAppsOpen}
+                            />
                             <SidebarSeparator />
                           </>
                         )}
-
-                        {/* Apps: guild-wide surfaces, so they sit above the
-                            initiatives rather than inside any of them. */}
-                        <AppsSection
-                          isGuildAdmin={isGuildAdmin}
-                          open={appsOpen}
-                          onOpenChange={setAppsOpen}
-                        />
 
                         {/* Initiatives Section */}
                         <SidebarGroup>

--- a/frontend/src/components/apps/AppSettingsDialog.tsx
+++ b/frontend/src/components/apps/AppSettingsDialog.tsx
@@ -1,0 +1,67 @@
+/**
+ * An app's own settings, opened from wherever the app is.
+ *
+ * For an app that has no page of its own — one whose whole purpose is a
+ * credential, like connecting your account at a vendor — this *is* the app. So
+ * it opens where the member clicked rather than sending them to hunt through
+ * guild settings for the same form.
+ *
+ * The form itself is the one the settings page already uses: an app's settings
+ * are its connections, and one renderer draws every app's from the fields its
+ * pinned definition declares.
+ */
+
+import { Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { AppConnectionsPanel } from "@/components/apps/AppConnectionsPanel";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useGuildAppDetail } from "@/hooks/useGuildAppDetail";
+
+export interface AppSettingsDialogProps {
+  appId: number;
+  /** Guild connections are an admin's to fill in; personal ones are everyone's. */
+  isGuildAdmin: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AppSettingsDialog({
+  appId,
+  isGuildAdmin,
+  open,
+  onOpenChange,
+}: AppSettingsDialogProps) {
+  const { t } = useTranslation(["apps", "common"]);
+  const detail = useGuildAppDetail(appId);
+  const app = detail.data;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{app?.name ?? t("apps:title")}</DialogTitle>
+          <DialogDescription>{t("apps:settings.description")}</DialogDescription>
+        </DialogHeader>
+        {detail.isLoading || !app ? (
+          <div className="flex items-center gap-2 py-6 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("common:loading")}
+          </div>
+        ) : (
+          <AppConnectionsPanel
+            appId={app.id}
+            connections={app.connections}
+            isGuildAdmin={isGuildAdmin}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/marketplace/InstallAppDialog.tsx
+++ b/frontend/src/components/marketplace/InstallAppDialog.tsx
@@ -27,7 +27,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { guildAppPath, useInstallGuildApp } from "@/hooks/useGuildApps";
+import { useInstallGuildApp } from "@/hooks/useGuildApps";
+import { guildAppPath } from "@/lib/appSurfaces";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";

--- a/frontend/src/components/sidebar/AppsSection.test.tsx
+++ b/frontend/src/components/sidebar/AppsSection.test.tsx
@@ -12,6 +12,10 @@
  * An admin-only app is hidden from members for the same reason an empty section
  * is: it has no sharing to widen, so the entry would refuse everyone who clicked
  * it. The server says which apps those are; this only honors the answer.
+ *
+ * And every visible entry leads somewhere: an app with a surface opens it, an
+ * app with a credential to supply opens that form, and an app with neither
+ * waits under "show more" rather than spending a row on a dead click.
  */
 import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -75,7 +79,7 @@ describe("AppsSection", () => {
   it("invites an admin to add one when the guild has no apps", async () => {
     render(true);
     expect(await screen.findByText("Apps")).toBeInTheDocument();
-    expect(screen.getByLabelText("Add an app")).toBeInTheDocument();
+    expect(screen.getByText("Add an app")).toBeInTheDocument();
   });
 
   it("lists installed apps for a member", async () => {
@@ -83,7 +87,7 @@ describe("AppsSection", () => {
     render(false);
     expect(await screen.findByText("Guild calendar")).toBeInTheDocument();
     // No add affordance: installing is a guild-admin action.
-    expect(screen.queryByLabelText("Add an app")).toBeNull();
+    expect(screen.queryByText("Add an app")).toBeNull();
   });
 
   it("links an app to what it mounted", async () => {
@@ -108,10 +112,66 @@ describe("AppsSection", () => {
     await expectNoSection();
   });
 
-  it("renders an app with nothing to link to without a link", async () => {
-    apps = [app({ artifacts: [] })];
+  it("opens a service app's own page", async () => {
+    apps = [
+      app({
+        id: 7,
+        name: "Automations",
+        tool: null,
+        artifacts: [],
+        definition: { embeds: [{ id: "automations", path: "/embed" }] },
+      }),
+    ];
+    render(false);
+    const link = (await screen.findByText("Automations")).closest("a");
+    expect(link?.getAttribute("href")).toContain("/apps/7");
+  });
+
+  it("draws the listing's artwork rather than a generic icon", async () => {
+    apps = [app({ avatar_url: "/marketplace/calendar.svg" })];
     render(false);
     const entry = await screen.findByText("Guild calendar");
+    const artwork = entry.closest("a")?.querySelector("img");
+    expect(artwork?.getAttribute("src")).toBe("/marketplace/calendar.svg");
+  });
+
+  it("folds an app with nothing to open under 'show more'", async () => {
+    // A calendar app whose row cannot be resolved has no surface and no
+    // credential, so it is not worth a row until asked for.
+    apps = [app({ artifacts: [] })];
+    render(false);
+    await screen.findByText("Apps");
+    expect(screen.queryByText("Guild calendar")).toBeNull();
+
+    (await screen.findByText("1 more")).click();
+    const entry = await screen.findByText("Guild calendar");
     expect(entry.closest("a")).toBeNull();
+  });
+
+  it("keeps the add affordance below the apps, 'show more' included", async () => {
+    // Same shape as the initiatives list: adding one is always in the same
+    // place, whether or not the collapsed apps are expanded.
+    apps = [app(), app({ id: 2, name: "Widgets only", tool: null, artifacts: [] })];
+    render(true);
+    const add = await screen.findByText("Add an app");
+    const more = await screen.findByText("1 more");
+    // eslint-disable-next-line no-bitwise -- DOCUMENT_POSITION_FOLLOWING
+    expect(more.compareDocumentPosition(add) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps an app that only has a credential to supply in the list", async () => {
+    apps = [
+      app({
+        id: 9,
+        name: "GitHub",
+        tool: null,
+        artifacts: [],
+        definition: { connections: [{ id: "token", scope: "interactive" }] },
+      }),
+    ];
+    render(false);
+    // Listed, and not behind "show more" — there is something to open.
+    expect(await screen.findByText("GitHub")).toBeInTheDocument();
+    expect(screen.queryByText("1 more")).toBeNull();
   });
 });

--- a/frontend/src/components/sidebar/AppsSection.tsx
+++ b/frontend/src/components/sidebar/AppsSection.tsx
@@ -21,13 +21,23 @@
  * where an admin turns them back on. So are apps whose service is not set up on
  * this server — an entry that opens nothing is worse than no entry, and guild
  * settings is where that state is explained.
+ *
+ * **Every entry does something.** An app with a surface opens it; an app with
+ * only a credential to supply opens that form where it stands, because "set up
+ * my GitHub account" is the app, not a detour through settings. An app that is
+ * neither — one contributing widgets or data to somewhere else — has nothing to
+ * open, so it sits under a "show more" rather than spending a row on a click
+ * that would go nowhere.
  */
 
 import { Link } from "@tanstack/react-router";
-import { Blocks, CalendarDays, ChevronDown, Plus, Workflow } from "lucide-react";
+import { Blocks, ChevronDown, ChevronsDownUp, ChevronsUpDown, Plus } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GuildAppRead } from "@/api/generated/initiativeAPI.schemas";
+import { AppSettingsDialog } from "@/components/apps/AppSettingsDialog";
+import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
   SidebarGroup,
@@ -38,13 +48,10 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { guildAppPath, useGuildApps } from "@/hooks/useGuildApps";
+import { useGuildApps } from "@/hooks/useGuildApps";
+import { appHasConnections, guildAppPath } from "@/lib/appSurfaces";
 import { useGuildPath } from "@/lib/guildUrl";
 import { cn } from "@/lib/utils";
-
-/** One icon per mountable tool. Apps mount this build's own tools, so this maps
- *  the closed set rather than trusting anything a listing supplies. */
-const TOOL_ICONS = { calendar: CalendarDays } as const;
 
 export interface AppsSectionProps {
   isGuildAdmin: boolean;
@@ -57,6 +64,7 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
   const { t } = useTranslation(["apps", "nav"]);
   const gp = useGuildPath();
   const appsQuery = useGuildApps();
+  const [showInert, setShowInert] = useState(false);
 
   // `available` is false when an app's service is not set up on this server, or
   // the operator switched it off: there is nothing behind the entry, so it does
@@ -64,6 +72,14 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
   const apps = (appsQuery.data?.items ?? []).filter(
     (app) => app.enabled && app.available !== false
   );
+
+  // An app with somewhere to go leads; one with nothing to open waits under
+  // "show more" so a guild that installs many widget providers still has a
+  // readable sidebar.
+  const actionable = apps.filter(
+    (app) => guildAppPath(app) !== null || appHasConnections(app.definition)
+  );
+  const inert = apps.filter((app) => !actionable.includes(app));
 
   // Nothing installed and nothing this person could do about it: show nothing.
   // A member should see initiatives, not an empty shelf.
@@ -74,26 +90,30 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
       <SidebarGroup>
         <SidebarGroupLabel className="flex items-center gap-2 py-2">
           <Blocks className="h-4 w-4" />
-          <CollapsibleTrigger className="flex flex-1 items-center gap-2 text-left">
+          <CollapsibleTrigger className="flex flex-1 items-center text-left">
             <span className="flex-1">{t("apps:title")}</span>
-            <ChevronDown
-              className={cn("h-4 w-4 shrink-0 transition-transform", !open && "-rotate-90")}
-              aria-hidden
-            />
           </CollapsibleTrigger>
-          {isGuildAdmin && (
+          {apps.length > 0 && (
             <Tooltip delayDuration={300}>
               <TooltipTrigger asChild>
-                <Link
-                  to={gp("/marketplace")}
-                  search={{ kind: "app" }}
-                  aria-label={t("apps:add")}
-                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm hover:bg-accent"
-                >
-                  <Plus className="h-4 w-4" />
-                </Link>
+                <CollapsibleTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-5 shrink-0"
+                    aria-label={open ? t("nav:collapseAll") : t("nav:expandAll")}
+                  >
+                    {open ? (
+                      <ChevronsDownUp className="h-3.5 w-3.5" />
+                    ) : (
+                      <ChevronsUpDown className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </CollapsibleTrigger>
               </TooltipTrigger>
-              <TooltipContent>{t("apps:add")}</TooltipContent>
+              <TooltipContent side="bottom">
+                <p>{open ? t("nav:collapseAll") : t("nav:expandAll")}</p>
+              </TooltipContent>
             </Tooltip>
           )}
         </SidebarGroupLabel>
@@ -102,12 +122,50 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
           <SidebarGroupContent>
             {apps.length ? (
               <SidebarMenu>
-                {apps.map((app) => (
-                  <AppEntry key={app.id} app={app} />
+                {actionable.map((app) => (
+                  <AppEntry key={app.id} app={app} isGuildAdmin={isGuildAdmin} />
                 ))}
+                {showInert &&
+                  inert.map((app) => (
+                    <AppEntry key={app.id} app={app} isGuildAdmin={isGuildAdmin} />
+                  ))}
+                {inert.length > 0 && (
+                  <SidebarMenuItem>
+                    <SidebarMenuButton
+                      size="sm"
+                      onClick={() => setShowInert((shown) => !shown)}
+                      className="text-muted-foreground"
+                    >
+                      <ChevronDown
+                        className={cn("h-4 w-4 transition-transform", !showInert && "-rotate-90")}
+                        aria-hidden
+                      />
+                      <span className="truncate">
+                        {showInert
+                          ? t("apps:showFewer")
+                          : t("apps:showMore", { count: inert.length })}
+                      </span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                )}
               </SidebarMenu>
             ) : (
               <p className="px-4 py-2 text-muted-foreground text-sm">{t("apps:none")}</p>
+            )}
+
+            {/* Last, below "show more" as well, so adding one is always in the
+                same place — the same shape the initiatives list uses. */}
+            {isGuildAdmin && (
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild size="sm">
+                    <Link to={gp("/marketplace")} search={{ kind: "app" }}>
+                      <Plus className="h-4 w-4" />
+                      <span>{t("apps:add")}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
             )}
           </SidebarGroupContent>
         </CollapsibleContent>
@@ -116,25 +174,62 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
   );
 }
 
-function AppEntry({ app }: { app: GuildAppRead }) {
+function AppEntry({ app, isGuildAdmin }: { app: GuildAppRead; isGuildAdmin: boolean }) {
   const gp = useGuildPath();
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const path = guildAppPath(app);
-  const Icon = TOOL_ICONS[app.tool as keyof typeof TOOL_ICONS] ?? Blocks;
+  // The listing's own artwork, small. Every listing has one — a listing that
+  // ships none is published with the app's own mark — so there is nothing to
+  // fall back to.
+  const icon = app.avatar_url ? (
+    <img
+      src={app.avatar_url}
+      alt=""
+      aria-hidden
+      className="h-4 w-4 shrink-0 rounded-sm object-cover"
+      loading="lazy"
+    />
+  ) : (
+    <Blocks className="h-4 w-4" />
+  );
+
+  if (path) {
+    return (
+      <SidebarMenuItem>
+        <SidebarMenuButton asChild size="sm">
+          <Link to={gp(path)}>
+            {icon}
+            <span className="truncate">{app.name}</span>
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    );
+  }
+
+  // No surface, but something to connect: the form opens here rather than
+  // sending the member to a settings page to find it.
+  if (appHasConnections(app.definition)) {
+    return (
+      <SidebarMenuItem>
+        <SidebarMenuButton size="sm" onClick={() => setSettingsOpen(true)}>
+          {icon}
+          <span className="truncate">{app.name}</span>
+        </SidebarMenuButton>
+        <AppSettingsDialog
+          appId={app.id}
+          isGuildAdmin={isGuildAdmin}
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+        />
+      </SidebarMenuItem>
+    );
+  }
 
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton asChild={Boolean(path)} size="sm">
-        {path ? (
-          <Link to={gp(path)}>
-            <Icon className="h-4 w-4" />
-            <span className="truncate">{app.name}</span>
-          </Link>
-        ) : (
-          <span className="flex items-center gap-2">
-            <Icon className="h-4 w-4" />
-            <span className="truncate">{app.name}</span>
-          </span>
-        )}
+      <SidebarMenuButton size="sm" className="cursor-default hover:bg-transparent">
+        {icon}
+        <span className="truncate">{app.name}</span>
       </SidebarMenuButton>
     </SidebarMenuItem>
   );

--- a/frontend/src/hooks/useGuildApps.ts
+++ b/frontend/src/hooks/useGuildApps.ts
@@ -81,31 +81,3 @@ export const useUninstallGuildApp = (options?: MutationOpts<void, number>) => {
     options
   );
 };
-
-/**
- * Where an app's own surface lives.
- *
- * A tool-instance app mounts an existing tool, so its entry links at the tool's
- * own route with the id the install recorded — the calendar an app created is
- * just a calendar. An app with no content of its own has nothing to link at, so
- * it gets a page of its own instead. An app whose content cannot be resolved
- * gets no link at all — better a plain row than one that 404s.
- *
- * What an install produced is a *list*, since one install may produce several
- * things; the sidebar links at the first artifact of the tool the app mounts.
- * Typed structurally rather than against the generated read so this keeps
- * working for both the list and detail payloads.
- */
-export interface AppSurface {
-  id: number;
-  tool?: string | null;
-  artifacts?: { type: string; id: number }[];
-}
-
-export const guildAppPath = (app: AppSurface): string | null => {
-  if (app.tool === "calendar") {
-    const calendar = (app.artifacts ?? []).find((artifact) => artifact.type === "calendar");
-    return calendar ? `/calendars/${calendar.id}` : null;
-  }
-  return null;
-};

--- a/frontend/src/lib/appSurfaces.ts
+++ b/frontend/src/lib/appSurfaces.ts
@@ -1,0 +1,60 @@
+/**
+ * What an installed app offers a member, read off its pinned definition.
+ *
+ * Three shapes, and the sidebar treats each differently:
+ *
+ * - **A surface** — one or more embedded pages. Opens a page of its own.
+ * - **Something to connect** — no page, but a credential the member or an
+ *   admin supplies. Opens a dialog where they do that.
+ * - **Neither** — it contributes widgets or data to somewhere else. There is
+ *   nothing to open, so it does not take a row of its own.
+ */
+
+import type { LocalizedText } from "@/api/appConnections";
+
+export interface AppEmbed {
+  id: string;
+  path: string;
+  visibility?: string;
+  name?: LocalizedText;
+}
+
+/** Loose shape so this reads both the list and detail payloads. */
+export interface AppSurfaceSource {
+  tool?: string | null;
+  artifacts?: { type: string; id: number }[];
+  definition?: Record<string, unknown> | null;
+}
+
+/** The embedded surfaces an app declared, if any. */
+export const appEmbeds = (definition?: Record<string, unknown> | null): AppEmbed[] => {
+  const embeds = definition?.embeds;
+  if (!Array.isArray(embeds)) return [];
+  return embeds.filter(
+    (embed): embed is AppEmbed =>
+      typeof embed === "object" &&
+      embed !== null &&
+      typeof (embed as AppEmbed).id === "string" &&
+      typeof (embed as AppEmbed).path === "string"
+  );
+};
+
+/** Whether the app declares any credential to fill in or connect. */
+export const appHasConnections = (definition?: Record<string, unknown> | null): boolean =>
+  Array.isArray(definition?.connections) && definition.connections.length > 0;
+
+/**
+ * Where an app's entry leads.
+ *
+ * A tool-instance app mounts an existing tool, so it links at the tool's own
+ * route — the calendar an app created is just a calendar. A service app with
+ * embedded surfaces gets a page. Anything else has no route, and the caller
+ * decides what to do with the row.
+ */
+export const guildAppPath = (app: AppSurfaceSource & { id: number }): string | null => {
+  if (app.tool === "calendar") {
+    const calendar = (app.artifacts ?? []).find((artifact) => artifact.type === "calendar");
+    return calendar ? `/calendars/${calendar.id}` : null;
+  }
+  return appEmbeds(app.definition).length ? `/apps/${app.id}` : null;
+};

--- a/frontend/src/pages/apps/GuildAppPage.test.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Which token reaches which frame.
+ *
+ * A handoff names one surface and is spent on first use, so the page re-mints
+ * when a reloading embed asks again. That re-mint is asynchronous, and the tabs
+ * of one app all share an origin — so if the reader switches surfaces while it
+ * is in flight, the origin check cannot tell the arriving token from a correct
+ * one. The delivery has to be dropped instead.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+
+const mint = vi.fn();
+
+vi.mock("@/api/generated/apps/apps", () => ({
+  createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost: (
+    _guildId: number,
+    _appId: number,
+    surfaceId: string
+  ) => mint(surfaceId),
+}));
+
+const detail = {
+  id: 1,
+  name: "Automations",
+  enabled: true,
+  available: true,
+  definition: {
+    embeds: [
+      { id: "one", path: "/embed/one", name: { en: "One" } },
+      { id: "two", path: "/embed/two", name: { en: "Two" } },
+    ],
+  },
+};
+
+vi.mock("@/hooks/useGuildAppDetail", () => ({
+  useGuildAppDetail: () => ({ data: detail, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useActiveGuildId", () => ({ useActiveGuildId: () => 3 }));
+
+const handoff = (surfaceId: string) => ({
+  handoff_token: `token-for-${surfaceId}`,
+  expires_in_seconds: 60,
+  embed_url: `https://app.example.com/embed/${surfaceId}`,
+  allowed_origins: ["https://app.example.com"],
+  audience: "initiative-app:acme.demo",
+  surface_id: surfaceId,
+});
+
+/** Every token this page handed to a frame, ignoring the locale nudges. */
+const delivered = () =>
+  postSpy.mock.calls
+    .map(([message]) => message as { type: string; handoff_token?: string })
+    .filter((message) => message.type === "initiative-app:handoff")
+    .map((message) => message.handoff_token);
+
+let postSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mint.mockReset();
+  postSpy = vi.fn();
+  // Every iframe in the page reports the same window, which is the worst case:
+  // nothing about the target distinguishes one surface's frame from another's.
+  Object.defineProperty(HTMLIFrameElement.prototype, "contentWindow", {
+    configurable: true,
+    get: () => ({ postMessage: postSpy }),
+  });
+});
+
+const ready = () =>
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      origin: "https://app.example.com",
+      data: { type: "initiative-app:ready" },
+    })
+  );
+
+describe("GuildAppPage", () => {
+  it("hands the first surface's token to the frame that asked", async () => {
+    mint.mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
+    const { GuildAppPage } = await import("./GuildAppPage");
+    renderPage(() => <GuildAppPage appId={1} />);
+
+    await screen.findByTitle("Automations");
+    ready();
+    await waitFor(() => expect(delivered()).toEqual(["token-for-one"]));
+  });
+
+  it("drops a re-mint that resolves after the surface changed", async () => {
+    // First surface mints immediately; the re-mint it triggers is held open so
+    // the tab can change underneath it.
+    let releaseStale: (value: unknown) => void = () => {};
+    mint
+      .mockImplementationOnce((surfaceId: string) => Promise.resolve(handoff(surfaceId)))
+      .mockImplementationOnce(() => new Promise((resolve) => (releaseStale = resolve)))
+      .mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
+
+    const { GuildAppPage } = await import("./GuildAppPage");
+    renderPage(() => <GuildAppPage appId={1} />);
+
+    await screen.findByTitle("Automations");
+    ready(); // spends the first token
+    await waitFor(() => expect(delivered()).toEqual(["token-for-one"]));
+
+    ready(); // the embed reloaded: starts the re-mint that will go stale
+    (await screen.findByText("Two")).click();
+    await waitFor(() => expect(mint).toHaveBeenCalledWith("two"));
+
+    // The held re-mint now answers, for a surface nobody is looking at.
+    releaseStale(handoff("one"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Unchanged: the stale token was dropped rather than handed to the frame
+    // now showing the other surface. Surface two has minted but not been asked,
+    // so nothing has been delivered for it either.
+    expect(delivered()).toEqual(["token-for-one"]);
+  });
+});

--- a/frontend/src/pages/apps/GuildAppPage.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.tsx
@@ -1,0 +1,235 @@
+/**
+ * An app's own surface, in an iframe.
+ *
+ * The security shape, which mirrors what the mint endpoint already enforces:
+ *
+ * 1. The server decides whether a surface may be opened — the install must be
+ *    enabled, its registration live, and the manifest's `visibility` must admit
+ *    the caller. A refusal never reaches the app.
+ * 2. The token is delivered by `postMessage` to the iframe's own origin, never
+ *    in the URL, so it stays out of history, referrers and proxy logs.
+ * 3. Inbound messages are ignored unless `event.origin` is one the registration
+ *    listed.
+ * 4. The token is one-shot, so a reloading embed asks again and gets a fresh
+ *    one rather than being stuck until the page is reloaded.
+ */
+
+import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost } from "@/api/generated/apps/apps";
+import type { GuildAppHandoff } from "@/api/generated/initiativeAPI.schemas";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useActiveGuildId } from "@/hooks/useActiveGuildId";
+import { useGuildAppDetail } from "@/hooks/useGuildAppDetail";
+import { appEmbeds } from "@/lib/appSurfaces";
+import { cn } from "@/lib/utils";
+import { localized } from "@/lib/widgets/widgetMeta";
+
+/** The message names an embed and this host agree on. */
+const READY = "initiative-app:ready";
+const HANDOFF = "initiative-app:handoff";
+const ERROR = "initiative-app:error";
+const LOCALE = "initiative-app:locale";
+
+export function GuildAppPage({ appId }: { appId: number }) {
+  const { t, i18n } = useTranslation(["apps", "common"]);
+  const guildId = useActiveGuildId();
+  const detail = useGuildAppDetail(appId);
+  const app = detail.data;
+
+  const embeds = useMemo(() => appEmbeds(app?.definition), [app?.definition]);
+  const [surfaceId, setSurfaceId] = useState<string | null>(null);
+  const active = embeds.find((embed) => embed.id === surfaceId) ?? embeds[0] ?? null;
+
+  const [handoff, setHandoff] = useState<GuildAppHandoff | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  // Whether the token we hold has already been handed over. A later `ready`
+  // means the embed reloaded itself and the old token is spent, so the next
+  // one is minted fresh.
+  const spentRef = useRef(false);
+
+  const mint = useCallback(
+    () =>
+      createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost(
+        guildId,
+        appId,
+        active?.id ?? ""
+      ) as unknown as Promise<GuildAppHandoff>,
+    [guildId, appId, active?.id]
+  );
+
+  // Mint for the surface being opened. Re-runs when the surface changes, which
+  // is also when the iframe is replaced.
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    setHandoff(null);
+    setError(null);
+    spentRef.current = false;
+    void mint()
+      .then((fresh) => {
+        if (!cancelled) setHandoff(fresh);
+      })
+      .catch(() => {
+        if (!cancelled) setError(t("apps:embed.handoffFailed"));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, mint, t]);
+
+  const origin = useMemo(() => {
+    if (!handoff?.embed_url) return null;
+    try {
+      return new URL(handoff.embed_url).origin;
+    } catch {
+      return null;
+    }
+  }, [handoff?.embed_url]);
+
+  const allowed = useMemo(
+    () => new Set(handoff?.allowed_origins ?? []),
+    [handoff?.allowed_origins]
+  );
+
+  // Hold the translator in a ref so a language change cannot re-attach the
+  // listener mid-exchange.
+  const tRef = useRef(t);
+  tRef.current = t;
+  const localeRef = useRef(i18n.language);
+  localeRef.current = i18n.language;
+
+  useEffect(() => {
+    if (!origin || !handoff) return;
+
+    const send = (target: Window, token: GuildAppHandoff) => {
+      target.postMessage(
+        {
+          type: HANDOFF,
+          handoff_token: token.handoff_token,
+          expires_in_seconds: token.expires_in_seconds,
+          audience: token.audience,
+          surface_id: token.surface_id,
+          locale: localeRef.current,
+        },
+        // Never "*": that would hand the token to whatever happens to be
+        // loaded in the frame.
+        origin
+      );
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (!allowed.has(event.origin)) return;
+      const data = event.data;
+      if (!data || typeof data !== "object" || typeof data.type !== "string") return;
+
+      if (data.type === READY) {
+        const target = iframeRef.current?.contentWindow;
+        if (!target) return;
+        if (!spentRef.current) {
+          send(target, handoff);
+          spentRef.current = true;
+          return;
+        }
+        void mint()
+          .then((fresh) => send(target, fresh))
+          .catch(() => setError(tRef.current("apps:embed.handoffFailed")));
+      } else if (data.type === ERROR) {
+        setError(
+          typeof data.message === "string" ? data.message : tRef.current("apps:embed.failed")
+        );
+      }
+    };
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [origin, allowed, handoff, mint]);
+
+  // Keep the embed in step with a language change.
+  useEffect(() => {
+    if (!origin) return;
+    const target = iframeRef.current?.contentWindow;
+    if (!target) return;
+    target.postMessage({ type: LOCALE, locale: i18n.language }, origin);
+  }, [origin, i18n.language]);
+
+  if (detail.isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground text-sm">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {t("common:loading")}
+      </div>
+    );
+  }
+
+  if (!app) return <Notice title={t("apps:embed.notFound")} />;
+  if (!app.enabled) return <Notice title={t("apps:embed.disabled", { name: app.name })} />;
+  if (!app.available)
+    return (
+      <Notice
+        title={t("apps:embed.unavailable", { name: app.name })}
+        description={t("apps:embed.unavailableDescription")}
+      />
+    );
+  if (!active) return <Notice title={t("apps:embed.noSurface", { name: app.name })} />;
+  if (error) return <Notice title={t("apps:embed.failed")} description={error} />;
+
+  return (
+    <div className="flex h-full flex-col">
+      {embeds.length > 1 && (
+        <div className="flex shrink-0 gap-1 border-b px-2">
+          {embeds.map((embed) => (
+            <button
+              key={embed.id}
+              type="button"
+              onClick={() => setSurfaceId(embed.id)}
+              className={cn(
+                "border-b-2 px-3 py-2 text-sm",
+                embed.id === active.id
+                  ? "border-primary font-medium"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {localized(embed.name, i18n.language) || embed.id}
+            </button>
+          ))}
+        </div>
+      )}
+      {handoff?.embed_url ? (
+        <iframe
+          // Keyed by surface so switching tabs mounts a fresh frame rather
+          // than reusing one that already spent its token.
+          key={active.id}
+          ref={iframeRef}
+          src={handoff.embed_url}
+          title={app.name}
+          className="block h-full w-full flex-1 border-0 bg-background"
+          // Notably absent: allow-top-navigation, allow-modals,
+          // allow-popups-to-escape-sandbox.
+          sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"
+          referrerPolicy="no-referrer"
+          allow="clipboard-read; clipboard-write"
+        />
+      ) : (
+        <div className="flex flex-1 items-center gap-2 p-4 text-muted-foreground text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {t("apps:embed.connecting")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Notice({ title, description }: { title: string; description?: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description ? <CardDescription>{description}</CardDescription> : null}
+      </CardHeader>
+    </Card>
+  );
+}

--- a/frontend/src/pages/apps/GuildAppPage.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.tsx
@@ -42,6 +42,10 @@ export function GuildAppPage({ appId }: { appId: number }) {
   const embeds = useMemo(() => appEmbeds(app?.definition), [app?.definition]);
   const [surfaceId, setSurfaceId] = useState<string | null>(null);
   const active = embeds.find((embed) => embed.id === surfaceId) ?? embeds[0] ?? null;
+  // The surface as a plain id, so a refetch that hands back an equal-but-new
+  // definition does not read as a surface change and mint a token nobody asked
+  // for.
+  const activeId = active?.id ?? null;
 
   const [handoff, setHandoff] = useState<GuildAppHandoff | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -56,15 +60,15 @@ export function GuildAppPage({ appId }: { appId: number }) {
       createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost(
         guildId,
         appId,
-        active?.id ?? ""
+        activeId ?? ""
       ) as unknown as Promise<GuildAppHandoff>,
-    [guildId, appId, active?.id]
+    [guildId, appId, activeId]
   );
 
   // Mint for the surface being opened. Re-runs when the surface changes, which
   // is also when the iframe is replaced.
   useEffect(() => {
-    if (!active) return;
+    if (!activeId) return;
     let cancelled = false;
     setHandoff(null);
     setError(null);
@@ -79,7 +83,7 @@ export function GuildAppPage({ appId }: { appId: number }) {
     return () => {
       cancelled = true;
     };
-  }, [active, mint, t]);
+  }, [activeId, mint, t]);
 
   const origin = useMemo(() => {
     if (!handoff?.embed_url) return null;
@@ -104,6 +108,13 @@ export function GuildAppPage({ appId }: { appId: number }) {
 
   useEffect(() => {
     if (!origin || !handoff) return;
+
+    // A token names one surface, and switching tabs replaces the iframe. So a
+    // re-mint still in flight when that happens must not deliver: its token is
+    // for the surface that was open when it was asked for, and the frame now
+    // waiting shows a different one. Same app, same origin, so the origin check
+    // cannot tell them apart.
+    let cancelled = false;
 
     const send = (target: Window, token: GuildAppHandoff) => {
       target.postMessage(
@@ -135,8 +146,15 @@ export function GuildAppPage({ appId }: { appId: number }) {
           return;
         }
         void mint()
-          .then((fresh) => send(target, fresh))
-          .catch(() => setError(tRef.current("apps:embed.handoffFailed")));
+          .then((fresh) => {
+            // Dropped if the surface changed while this was in flight, or if
+            // the frame that asked is no longer the mounted one.
+            if (cancelled || iframeRef.current?.contentWindow !== target) return;
+            send(target, fresh);
+          })
+          .catch(() => {
+            if (!cancelled) setError(tRef.current("apps:embed.handoffFailed"));
+          });
       } else if (data.type === ERROR) {
         setError(
           typeof data.message === "string" ? data.message : tRef.current("apps:embed.failed")
@@ -145,7 +163,10 @@ export function GuildAppPage({ appId }: { appId: number }) {
     };
 
     window.addEventListener("message", onMessage);
-    return () => window.removeEventListener("message", onMessage);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("message", onMessage);
+    };
   }, [origin, allowed, handoff, mint]);
 
   // Keep the embed in step with a language change.

--- a/frontend/src/pages/apps/GuildAppRoute.tsx
+++ b/frontend/src/pages/apps/GuildAppRoute.tsx
@@ -1,0 +1,11 @@
+import { useParams } from "@tanstack/react-router";
+
+import { GuildAppPage } from "@/pages/apps/GuildAppPage";
+
+/** Reads the install id off the route so the page itself takes a plain prop. */
+export function GuildAppRoute() {
+  const { appId } = useParams({ strict: false }) as { appId?: string };
+  const parsed = Number(appId);
+  if (!Number.isFinite(parsed)) return null;
+  return <GuildAppPage appId={parsed} />;
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -67,6 +67,7 @@ import { Route as ServerRequiredAuthenticatedSettingsPlatformAuthRouteImport } f
 import { Route as ServerRequiredAuthenticatedSettingsPlatformBrandingRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/branding'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformEmailRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/email'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformStorageRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/storage'
+import { Route as ServerRequiredAuthenticatedGGuildIdAppsAppIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/apps_.$appId'
 import { Route as ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/calendar-events_.$eventId'
 import { Route as ServerRequiredAuthenticatedGGuildIdCalendarsCalendarIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/calendars_.$calendarId'
 import { Route as ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/counter-groups_.$groupId'
@@ -439,6 +440,12 @@ const ServerRequiredAuthenticatedSettingsPlatformStorageRoute =
     path: '/storage',
     getParentRoute: () => ServerRequiredAuthenticatedSettingsPlatformRoute,
   } as any)
+const ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute =
+  ServerRequiredAuthenticatedGGuildIdAppsAppIdRouteImport.update({
+    id: '/apps_/$appId',
+    path: '/apps/$appId',
+    getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
+  } as any)
 const ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute =
   ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRouteImport.update({
     id: '/calendar-events_/$eventId',
@@ -691,6 +698,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
   '/settings/admin/': typeof ServerRequiredAuthenticatedSettingsAdminIndexRoute
   '/settings/platform/': typeof ServerRequiredAuthenticatedSettingsPlatformIndexRoute
+  '/g/$guildId/apps/$appId': typeof ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute
   '/g/$guildId/calendar-events/$eventId': typeof ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute
   '/g/$guildId/calendars/$calendarId': typeof ServerRequiredAuthenticatedGGuildIdCalendarsCalendarIdRoute
   '/g/$guildId/counter-groups/$groupId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdRoute
@@ -774,6 +782,7 @@ export interface FileRoutesByTo {
   '/g/$guildId': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
   '/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminIndexRoute
   '/settings/platform': typeof ServerRequiredAuthenticatedSettingsPlatformIndexRoute
+  '/g/$guildId/apps/$appId': typeof ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute
   '/g/$guildId/calendar-events/$eventId': typeof ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute
   '/g/$guildId/calendars/$calendarId': typeof ServerRequiredAuthenticatedGGuildIdCalendarsCalendarIdRoute
   '/g/$guildId/counter-groups/$groupId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdRoute
@@ -865,6 +874,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
   '/_serverRequired/_authenticated/settings/admin/': typeof ServerRequiredAuthenticatedSettingsAdminIndexRoute
   '/_serverRequired/_authenticated/settings/platform/': typeof ServerRequiredAuthenticatedSettingsPlatformIndexRoute
+  '/_serverRequired/_authenticated/g/$guildId/apps_/$appId': typeof ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute
   '/_serverRequired/_authenticated/g/$guildId/calendar-events_/$eventId': typeof ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute
   '/_serverRequired/_authenticated/g/$guildId/calendars_/$calendarId': typeof ServerRequiredAuthenticatedGGuildIdCalendarsCalendarIdRoute
   '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdRoute
@@ -955,6 +965,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/'
     | '/settings/admin/'
     | '/settings/platform/'
+    | '/g/$guildId/apps/$appId'
     | '/g/$guildId/calendar-events/$eventId'
     | '/g/$guildId/calendars/$calendarId'
     | '/g/$guildId/counter-groups/$groupId'
@@ -1038,6 +1049,7 @@ export interface FileRouteTypes {
     | '/g/$guildId'
     | '/settings/admin'
     | '/settings/platform'
+    | '/g/$guildId/apps/$appId'
     | '/g/$guildId/calendar-events/$eventId'
     | '/g/$guildId/calendars/$calendarId'
     | '/g/$guildId/counter-groups/$groupId'
@@ -1128,6 +1140,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/'
     | '/_serverRequired/_authenticated/settings/admin/'
     | '/_serverRequired/_authenticated/settings/platform/'
+    | '/_serverRequired/_authenticated/g/$guildId/apps_/$appId'
     | '/_serverRequired/_authenticated/g/$guildId/calendar-events_/$eventId'
     | '/_serverRequired/_authenticated/g/$guildId/calendars_/$calendarId'
     | '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId'
@@ -1573,6 +1586,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsPlatformStorageRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedSettingsPlatformRoute
     }
+    '/_serverRequired/_authenticated/g/$guildId/apps_/$appId': {
+      id: '/_serverRequired/_authenticated/g/$guildId/apps_/$appId'
+      path: '/apps/$appId'
+      fullPath: '/g/$guildId/apps/$appId'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdAppsAppIdRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
+    }
     '/_serverRequired/_authenticated/g/$guildId/calendar-events_/$eventId': {
       id: '/_serverRequired/_authenticated/g/$guildId/calendar-events_/$eventId'
       path: '/calendar-events/$eventId'
@@ -1953,6 +1973,7 @@ interface ServerRequiredAuthenticatedGGuildIdRouteChildren {
   ServerRequiredAuthenticatedGGuildIdQueuesRoute: typeof ServerRequiredAuthenticatedGGuildIdQueuesRoute
   ServerRequiredAuthenticatedGGuildIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren
   ServerRequiredAuthenticatedGGuildIdIndexRoute: typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
+  ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute: typeof ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute
   ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute: typeof ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute
   ServerRequiredAuthenticatedGGuildIdCalendarsCalendarIdRoute: typeof ServerRequiredAuthenticatedGGuildIdCalendarsCalendarIdRoute
   ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdRoute: typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdRoute
@@ -1997,6 +2018,8 @@ const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren,
     ServerRequiredAuthenticatedGGuildIdIndexRoute:
       ServerRequiredAuthenticatedGGuildIdIndexRoute,
+    ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute:
+      ServerRequiredAuthenticatedGGuildIdAppsAppIdRoute,
     ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute:
       ServerRequiredAuthenticatedGGuildIdCalendarEventsEventIdRoute,
     ServerRequiredAuthenticatedGGuildIdCalendarsCalendarIdRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/apps_.$appId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/apps_.$appId.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/g/$guildId/apps_/$appId")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/apps/GuildAppRoute").then((m) => ({
+      default: m.GuildAppRoute,
+    }))
+  ),
+});


### PR DESCRIPTION
## Problem

Clicking an installed app in the sidebar did nothing.

Nothing was missing on the backend: [the mint endpoint](backend/app/api/v1/tenant_endpoints/guild_apps.py) enforces the manifest's `visibility` under the caller's own session and returns `embed_url`, `allowed_origins`, `audience` and a 60-second token; `GuildAppRead.definition` already ships `embeds[]`; and CSP already accepts registered app origins.

It had no caller. `guildAppPath()` returned a route only for a mounted calendar, so every service app fell through to a plain `<span>`, and no page existed to host one. The function's own docstring already promised the answer — *"An app with no content of its own has nothing to link at, so it gets a page of its own instead"* — the page was just never written.

## Changes

**The surface.** A page per install that mints per surface, delivers the token by `postMessage` to the iframe's own origin (never the URL), ignores messages from any origin the registration didn't list, and re-mints when a reloading embed asks again — the token is one-shot, so without that an embed that reloads itself is stuck until the parent page is. Apps declaring several surfaces get a tab each. Sandbox and referrer policy follow the reviewed advanced-tool host this generalizes.

**Every entry leads somewhere.** An app with a surface opens it. An app with only a credential to supply opens that form where it stands — "connect my account" *is* the app, not a detour through guild settings — reusing the existing `AppConnectionsPanel` rather than a second form. An app with neither contributes widgets elsewhere, so it waits under "show more" instead of spending a row on a dead click.

**Artwork instead of a generic block.** Entries draw the listing's own picture, looked up from the catalog rather than pinned into the install, so a publisher who changes it changes it everywhere — including for installs that pinned their definition before this. No new manifest field: every listing already has `avatar_url`, and one that ships none is published with the Initiative mark.

**The section matches the initiatives row:** no `+` in the header, the same expand/collapse control, and adding one sits below the list including after "show more". Drops **All Projects** and **All Documents** — the command palette already covers both — and puts apps in that slot.

## Testing

- `pytest app/api/v1/tenant_endpoints/guild_apps*.py app/services/marketplace/` — 405 passed, including a new one asserting the artwork reaches the **list** payload (a field added only to the detail read would leave every sidebar entry blank).
- `vitest src/components/sidebar src/components/marketplace src/pages/marketplace` — 41 passed. New: a service app opens its own page, artwork is drawn rather than an icon, an app with nothing to open folds under "show more", an app with only a credential stays in the list, and the add affordance sits below everything.
- `biome check` (9 warnings, down from 10 on dev — none new), `tsc --noEmit`, `pnpm build`, `ruff check`, `ruff format`, `ty check` all clean.
