### PR TITLE
Let every member browse the app store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Everyone can see the app store now.** The Apps section shows for every member, not only guild admins. A member gets “Browse the app store” where an admin gets “Add an app” — the same shelf, where each listing is tagged if your guild already has it, and one it does not says to ask a guild admin for it. Adding an app is still an admin's to do.
 - **The sidebar drops “All Projects” and “All Documents”.** Both are a keystroke away in the command palette, and the space now belongs to your guild's apps. The apps list also matches the initiatives list above it — the same expand control, and “Add an app” sits at the bottom where “Add initiative” does.
 - **Focus settings on My Tasks are now a window per priority.** Instead of one date range for everything plus an "always include urgent and high" switch, each priority gets its own slider: how many days ahead the Focus list looks for that priority, from today-and-overdue only up to a month out, or "any date" to keep that priority on the list whatever its deadline. Existing settings carry over.
 

--- a/frontend/public/locales/de/apps.json
+++ b/frontend/public/locales/de/apps.json
@@ -33,7 +33,8 @@
     "name": "Name",
     "action": "Zur Gilde hinzufügen",
     "done": "{{name}} hinzugefügt.",
-    "adminOnly": "Bitte eine Guild-Administratorin oder einen Guild-Administrator, diese App hinzuzufügen."
+    "adminOnly": "Bitte eine Guild-Administratorin oder einen Guild-Administrator, diese App hinzuzufügen.",
+    "unknownState": "Es konnte nicht geprüft werden, ob diese App bereits hinzugefügt wurde."
   },
   "page": {
     "notFound": "App nicht gefunden",

--- a/frontend/public/locales/de/apps.json
+++ b/frontend/public/locales/de/apps.json
@@ -33,7 +33,7 @@
     "name": "Name",
     "action": "Zur Gilde hinzufügen",
     "done": "{{name}} hinzugefügt.",
-    "adminOnly": "Nur Gildenadmins können Apps hinzufügen."
+    "adminOnly": "Bitte eine Guild-Administratorin oder einen Guild-Administrator, diese App hinzuzufügen."
   },
   "page": {
     "notFound": "App nicht gefunden",
@@ -109,5 +109,6 @@
     "unavailable": "{{name}} ist auf diesem Server nicht eingerichtet",
     "unavailableDescription": "Eine Administratorin oder ein Administrator muss den Dienst dieser App verbinden, bevor sie geöffnet werden kann.",
     "noSurface": "{{name}} hat keine eigene Seite"
-  }
+  },
+  "browse": "App-Store durchsuchen"
 }

--- a/frontend/public/locales/en/apps.json
+++ b/frontend/public/locales/en/apps.json
@@ -33,7 +33,8 @@
     "name": "Name",
     "action": "Add to guild",
     "done": "{{name}} added.",
-    "adminOnly": "Ask a guild admin to add this app."
+    "adminOnly": "Ask a guild admin to add this app.",
+    "unknownState": "Could not check whether this app is already added."
   },
   "page": {
     "notFound": "App not found",

--- a/frontend/public/locales/en/apps.json
+++ b/frontend/public/locales/en/apps.json
@@ -33,7 +33,7 @@
     "name": "Name",
     "action": "Add to guild",
     "done": "{{name}} added.",
-    "adminOnly": "Only a guild admin can add apps."
+    "adminOnly": "Ask a guild admin to add this app."
   },
   "page": {
     "notFound": "App not found",
@@ -109,5 +109,6 @@
     "unavailable": "{{name}} is not set up on this server",
     "unavailableDescription": "An administrator needs to connect this app's service before it can be opened.",
     "noSurface": "{{name}} has no page of its own"
-  }
+  },
+  "browse": "Browse the app store"
 }

--- a/frontend/public/locales/es/apps.json
+++ b/frontend/public/locales/es/apps.json
@@ -1,7 +1,7 @@
 {
   "title": "Aplicaciones",
   "add": "Añadir una aplicación",
-  "none": "Todavía no hay aplicaciones.",
+  "none": "Aún no hay aplicaciones.",
   "error": "Algo ha fallado con esa aplicación.",
   "manage": {
     "title": "Aplicaciones",
@@ -33,7 +33,7 @@
     "name": "Nombre",
     "action": "Añadir al gremio",
     "done": "{{name}} añadida.",
-    "adminOnly": "Solo un administrador del gremio puede añadir aplicaciones."
+    "adminOnly": "Pide a un administrador del gremio que añada esta aplicación."
   },
   "page": {
     "notFound": "Aplicación no encontrada",
@@ -109,5 +109,6 @@
     "unavailable": "{{name}} no está configurada en este servidor",
     "unavailableDescription": "Un administrador debe conectar el servicio de esta aplicación antes de poder abrirla.",
     "noSurface": "{{name}} no tiene una página propia"
-  }
+  },
+  "browse": "Explorar la tienda de aplicaciones"
 }

--- a/frontend/public/locales/es/apps.json
+++ b/frontend/public/locales/es/apps.json
@@ -33,7 +33,8 @@
     "name": "Nombre",
     "action": "Añadir al gremio",
     "done": "{{name}} añadida.",
-    "adminOnly": "Pide a un administrador del gremio que añada esta aplicación."
+    "adminOnly": "Pide a un administrador del gremio que añada esta aplicación.",
+    "unknownState": "No se pudo comprobar si esta aplicación ya está añadida."
   },
   "page": {
     "notFound": "Aplicación no encontrada",

--- a/frontend/public/locales/fr/apps.json
+++ b/frontend/public/locales/fr/apps.json
@@ -33,7 +33,8 @@
     "name": "Nom",
     "action": "Ajouter à la guilde",
     "done": "{{name}} ajoutée.",
-    "adminOnly": "Demandez à un administrateur de guilde d'ajouter cette application."
+    "adminOnly": "Demandez à un administrateur de guilde d'ajouter cette application.",
+    "unknownState": "Impossible de vérifier si cette application est déjà ajoutée."
   },
   "page": {
     "notFound": "Application introuvable",

--- a/frontend/public/locales/fr/apps.json
+++ b/frontend/public/locales/fr/apps.json
@@ -1,7 +1,7 @@
 {
   "title": "Applications",
   "add": "Ajouter une application",
-  "none": "Pas encore d'applications.",
+  "none": "Aucune application pour l'instant.",
   "error": "Un problème est survenu avec cette application.",
   "manage": {
     "title": "Applications",
@@ -33,7 +33,7 @@
     "name": "Nom",
     "action": "Ajouter à la guilde",
     "done": "{{name}} ajoutée.",
-    "adminOnly": "Seul un administrateur de la guilde peut ajouter des applications."
+    "adminOnly": "Demandez à un administrateur de guilde d'ajouter cette application."
   },
   "page": {
     "notFound": "Application introuvable",
@@ -109,5 +109,6 @@
     "unavailable": "{{name}} n'est pas configurée sur ce serveur",
     "unavailableDescription": "Un administrateur doit connecter le service de cette application avant qu'elle puisse être ouverte.",
     "noSurface": "{{name}} n'a pas de page dédiée"
-  }
+  },
+  "browse": "Parcourir la boutique d'applications"
 }

--- a/frontend/src/components/sidebar/AppsSection.test.tsx
+++ b/frontend/src/components/sidebar/AppsSection.test.tsx
@@ -1,10 +1,9 @@
 /**
  * Who sees the Apps section, and when.
  *
- * The rules are about not promising anything: a member with no apps installed
- * has nothing to look at and nothing they could do about it, so the section is
- * absent entirely rather than empty. An admin in the same guild does have
- * something to do, so they get it with the `+`.
+ * The section shows for everyone, because everyone can do something with it:
+ * an admin adds an app, and a member browses the same shelf to see what exists
+ * and who to ask for it. What differs is the invitation at the bottom.
  *
  * Disabled apps belong in guild settings, not here — the sidebar shows what is
  * on.
@@ -55,31 +54,25 @@ const render = (isGuildAdmin: boolean) =>
     </TooltipProvider>
   ));
 
-/**
- * Absence, waited for.
- *
- * The page renders through a router, so it renders nothing synchronously —
- * asserting an empty DOM the moment `render` returns passes before the section
- * has had a chance to appear, and would pass just as well if it were broken.
- * This waits for the section instead, and requires that it never arrives.
- */
-const expectNoSection = () =>
-  expect(screen.findByText("Apps", {}, { timeout: 400 })).rejects.toThrow();
-
 beforeEach(() => {
   apps = [];
 });
 
 describe("AppsSection", () => {
-  it("shows nothing to a member when the guild has no apps", async () => {
+  it("points a member at the store when the guild has no apps", async () => {
+    // They cannot add one, but they can look and ask, so the shelf is worth
+    // pointing at rather than hiding.
     render(false);
-    await expectNoSection();
+    expect(await screen.findByText("Apps")).toBeInTheDocument();
+    expect(screen.getByText("Browse the app store")).toBeInTheDocument();
+    expect(screen.queryByText("Add an app")).toBeNull();
   });
 
   it("invites an admin to add one when the guild has no apps", async () => {
     render(true);
     expect(await screen.findByText("Apps")).toBeInTheDocument();
     expect(screen.getByText("Add an app")).toBeInTheDocument();
+    expect(screen.queryByText("Browse the app store")).toBeNull();
   });
 
   it("lists installed apps for a member", async () => {
@@ -88,6 +81,7 @@ describe("AppsSection", () => {
     expect(await screen.findByText("Guild calendar")).toBeInTheDocument();
     // No add affordance: installing is a guild-admin action.
     expect(screen.queryByText("Add an app")).toBeNull();
+    expect(screen.getByText("Browse the app store")).toBeInTheDocument();
   });
 
   it("links an app to what it mounted", async () => {
@@ -106,10 +100,11 @@ describe("AppsSection", () => {
     expect(screen.queryByText("Guild calendar")).toBeNull();
   });
 
-  it("shows a member nothing when every app is disabled", async () => {
+  it("still offers the store to a member when every app is disabled", async () => {
     apps = [app({ enabled: false })];
     render(false);
-    await expectNoSection();
+    expect(await screen.findByText("Browse the app store")).toBeInTheDocument();
+    expect(screen.queryByText("Guild calendar")).toBeNull();
   });
 
   it("opens a service app's own page", async () => {

--- a/frontend/src/components/sidebar/AppsSection.tsx
+++ b/frontend/src/components/sidebar/AppsSection.tsx
@@ -4,13 +4,12 @@
  * Apps are guild-wide surfaces, so they sit above the initiatives rather than
  * inside any of them. What shows depends on who is looking:
  *
- * - **No apps, ordinary member** — nothing at all. An empty section would be a
- *   promise of something they cannot act on.
- * - **No apps, guild admin** — the section with a `+`, the same invitation the
- *   initiatives list makes when a guild has none.
  * - **Apps installed** — one entry each, for everyone. Whether a member may do
  *   anything *inside* one is that instance's own sharing, enforced where the
  *   content lives.
+ * - **No apps** — the section still shows, for everyone. A member cannot add
+ *   one, but they can look at what exists and ask for it, so the shelf is worth
+ *   pointing at; what differs is the invitation at the bottom.
  *
  * The exception is an app the server marks admin-only, which members do not see
  * at all: it has no sharing to widen, so an entry would refuse everyone who
@@ -31,7 +30,7 @@
  */
 
 import { Link } from "@tanstack/react-router";
-import { Blocks, ChevronDown, ChevronsDownUp, ChevronsUpDown, Plus } from "lucide-react";
+import { Blocks, ChevronDown, ChevronsDownUp, ChevronsUpDown, Plus, Store } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -80,10 +79,6 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
     (app) => guildAppPath(app) !== null || appHasConnections(app.definition)
   );
   const inert = apps.filter((app) => !actionable.includes(app));
-
-  // Nothing installed and nothing this person could do about it: show nothing.
-  // A member should see initiatives, not an empty shelf.
-  if (!apps.length && !isGuildAdmin) return null;
 
   return (
     <Collapsible open={open} onOpenChange={onOpenChange}>
@@ -153,20 +148,20 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
               <p className="px-4 py-2 text-muted-foreground text-sm">{t("apps:none")}</p>
             )}
 
-            {/* Last, below "show more" as well, so adding one is always in the
-                same place — the same shape the initiatives list uses. */}
-            {isGuildAdmin && (
-              <SidebarMenu>
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild size="sm">
-                    <Link to={gp("/marketplace")} search={{ kind: "app" }}>
-                      <Plus className="h-4 w-4" />
-                      <span>{t("apps:add")}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
-            )}
+            {/* Last, below "show more" as well, so it is always in the same
+                place — the same shape the initiatives list uses. An admin adds
+                one; everyone else browses the same shelf, where a listing says
+                who to ask. */}
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild size="sm">
+                  <Link to={gp("/marketplace")} search={{ kind: "app" }}>
+                    {isGuildAdmin ? <Plus className="h-4 w-4" /> : <Store className="h-4 w-4" />}
+                    <span>{isGuildAdmin ? t("apps:add") : t("apps:browse")}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
           </SidebarGroupContent>
         </CollapsibleContent>
       </SidebarGroup>

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.test.tsx
@@ -6,6 +6,10 @@
  * otherwise an admin browsing apps clicks a listing, comes back, and is looking
  * at dashboards. The error route is the one that got missed first, which is why
  * it is pinned here alongside the ordinary one.
+ *
+ * A member reads the same page as an admin. What changes is the ending: they
+ * cannot install, so the page names who can instead of offering a button that
+ * would be refused.
  */
 import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,6 +21,8 @@ import { MarketplaceListingPage } from "./MarketplaceListingPage";
 
 let listing: Partial<MarketplaceListingDetail> | undefined;
 let failed = false;
+let guildRole = "admin";
+let installedUids: string[] = [];
 
 vi.mock("@/hooks/useMarketplace", () => ({
   useMarketplaceListing: () => ({ data: listing, isError: failed }),
@@ -24,7 +30,14 @@ vi.mock("@/hooks/useMarketplace", () => ({
 vi.mock("@/hooks/useDashboards", () => ({ useWidgetCatalog: () => ({ data: undefined }) }));
 vi.mock("@/hooks/useGuilds", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/hooks/useGuilds")>()),
-  useGuilds: () => ({ activeGuild: { role: "admin" } }),
+  useGuilds: () => ({ activeGuild: { role: guildRole } }),
+}));
+vi.mock("@/hooks/useGuildApps", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useGuildApps")>()),
+  useGuildApps: () => ({
+    data: { items: installedUids.map((uid) => ({ listing_uid: uid })) },
+    isError: false,
+  }),
 }));
 
 const appListing = () =>
@@ -55,6 +68,8 @@ const backHref = () =>
 beforeEach(() => {
   listing = appListing();
   failed = false;
+  guildRole = "admin";
+  installedUids = [];
 });
 
 describe("MarketplaceListingPage", () => {
@@ -106,5 +121,32 @@ describe("MarketplaceListingPage", () => {
     await screen.findByRole("heading", { name: "Guild calendar" });
     // An app mounts a tool; there is no definition to draw.
     expect(screen.queryByText("Preview")).toBeNull();
+  });
+
+  it("tells a member who can add an app they cannot", async () => {
+    guildRole = "member";
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+
+    expect(await screen.findByText("Ask a guild admin to add this app.")).toBeInTheDocument();
+    // The button is present but refuses, rather than being hidden: seeing what
+    // the app offers is the point of letting them in here.
+    expect(screen.getByRole("button", { name: /Add to guild/ })).toBeDisabled();
+  });
+
+  it("says an app is already installed instead of offering it again", async () => {
+    installedUids = ["GLDCAL00000001"];
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+
+    expect(await screen.findByText("Installed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Add to guild/ })).toBeNull();
+  });
+
+  it("does not tell a member to ask for an app the guild already has", async () => {
+    guildRole = "member";
+    installedUids = ["GLDCAL00000001"];
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+
+    expect(await screen.findByText("Installed")).toBeInTheDocument();
+    expect(screen.queryByText("Ask a guild admin to add this app.")).toBeNull();
   });
 });

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.test.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.test.tsx
@@ -23,6 +23,7 @@ let listing: Partial<MarketplaceListingDetail> | undefined;
 let failed = false;
 let guildRole = "admin";
 let installedUids: string[] = [];
+let installsState: "ready" | "loading" | "error" = "ready";
 
 vi.mock("@/hooks/useMarketplace", () => ({
   useMarketplaceListing: () => ({ data: listing, isError: failed }),
@@ -35,8 +36,12 @@ vi.mock("@/hooks/useGuilds", async (importOriginal) => ({
 vi.mock("@/hooks/useGuildApps", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/hooks/useGuildApps")>()),
   useGuildApps: () => ({
-    data: { items: installedUids.map((uid) => ({ listing_uid: uid })) },
-    isError: false,
+    data:
+      installsState === "ready"
+        ? { items: installedUids.map((uid) => ({ listing_uid: uid })) }
+        : undefined,
+    isLoading: installsState === "loading",
+    isError: installsState === "error",
   }),
 }));
 
@@ -70,6 +75,7 @@ beforeEach(() => {
   failed = false;
   guildRole = "admin";
   installedUids = [];
+  installsState = "ready";
 });
 
 describe("MarketplaceListingPage", () => {
@@ -148,5 +154,40 @@ describe("MarketplaceListingPage", () => {
 
     expect(await screen.findByText("Installed")).toBeInTheDocument();
     expect(screen.queryByText("Ask a guild admin to add this app.")).toBeNull();
+  });
+
+  it("does not guess at installed state while it is still loading", async () => {
+    // Neither answer is known yet, so neither is claimed: no badge saying it is
+    // there, and no offer to add something the guild may already have.
+    installsState = "loading";
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+
+    await screen.findByRole("heading", { name: "Guild calendar" });
+    expect(screen.queryByText("Installed")).toBeNull();
+    expect(screen.getByRole("button", { name: /Add to guild/ })).toBeDisabled();
+    expect(screen.queryByText("Ask a guild admin to add this app.")).toBeNull();
+  });
+
+  it("says so when it could not check, rather than implying not installed", async () => {
+    installsState = "error";
+    guildRole = "member";
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+
+    expect(
+      await screen.findByText("Could not check whether this app is already added.")
+    ).toBeInTheDocument();
+    // The "go ask an admin" line asserts the guild does not have it, which is
+    // exactly what failed to load.
+    expect(screen.queryByText("Ask a guild admin to add this app.")).toBeNull();
+  });
+
+  it("does not offer an admin an install it cannot rule out as a duplicate", async () => {
+    // An admin *may* install, so only the unknown state holds the button back
+    // here — the guild may already have this, and the server would refuse.
+    installsState = "error";
+    renderPage(MarketplaceListingPage, { routerSearch: { kind: "app" } });
+
+    await screen.findByRole("heading", { name: "Guild calendar" });
+    expect(screen.getByRole("button", { name: /Add to guild/ })).toBeDisabled();
   });
 });

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -36,6 +36,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useWidgetCatalog } from "@/hooks/useDashboards";
+import { useGuildApps } from "@/hooks/useGuildApps";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useMarketplaceListing } from "@/hooks/useMarketplace";
 import { useGuildPath } from "@/lib/guildUrl";
@@ -62,6 +63,12 @@ export function MarketplaceListingPage() {
   // Installing an app is a guild-admin action; the server enforces it, and the
   // button says so rather than failing after the click.
   const isGuildAdmin = activeGuild?.role === "admin";
+  // Whether this guild already has it. Every member may read the installs, so
+  // this answers for the person asking as well as the one who could act.
+  const appInstalls = useGuildApps({ enabled: isApp });
+  const isInstalled = (appInstalls.data?.items ?? []).some(
+    (app) => app.listing_uid === listing?.uid
+  );
 
   if (listingQuery.isError) {
     return (
@@ -133,20 +140,25 @@ export function MarketplaceListingPage() {
 
         {listing && (
           <div className="flex flex-col items-end gap-1">
-            <Button
-              onClick={() => setInstalling(true)}
-              disabled={!listing.installable || (isApp && !isGuildAdmin)}
-            >
-              <Download className="mr-1.5 h-4 w-4" />
-              {isApp ? t("apps:install.action") : t("detail.install")}
-            </Button>
+            {isApp && isInstalled ? (
+              <Badge variant="secondary">{t("card.installed")}</Badge>
+            ) : (
+              <Button
+                onClick={() => setInstalling(true)}
+                disabled={!listing.installable || (isApp && !isGuildAdmin)}
+              >
+                <Download className="mr-1.5 h-4 w-4" />
+                {isApp ? t("apps:install.action") : t("detail.install")}
+              </Button>
+            )}
             {!listing.installable ? (
               <span className="text-muted-foreground text-xs">
                 {listing.available ? t("detail.needsUpdate") : t("detail.withdrawn")}
               </span>
             ) : (
               isApp &&
-              !isGuildAdmin && (
+              !isGuildAdmin &&
+              !isInstalled && (
                 <span className="text-muted-foreground text-xs">{t("apps:install.adminOnly")}</span>
               )
             )}

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -65,10 +65,16 @@ export function MarketplaceListingPage() {
   const isGuildAdmin = activeGuild?.role === "admin";
   // Whether this guild already has it. Every member may read the installs, so
   // this answers for the person asking as well as the one who could act.
+  //
+  // Three states, not two: undefined while the answer is still loading or the
+  // request failed. "We do not know" and "you do not have it" would otherwise
+  // render identically — as an install button and a note telling a member to go
+  // ask for something they may already have.
   const appInstalls = useGuildApps({ enabled: isApp });
-  const isInstalled = (appInstalls.data?.items ?? []).some(
-    (app) => app.listing_uid === listing?.uid
-  );
+  const isInstalled: boolean | undefined =
+    isApp && !appInstalls.isLoading && !appInstalls.isError
+      ? (appInstalls.data?.items ?? []).some((app) => app.listing_uid === listing?.uid)
+      : undefined;
 
   if (listingQuery.isError) {
     return (
@@ -140,12 +146,17 @@ export function MarketplaceListingPage() {
 
         {listing && (
           <div className="flex flex-col items-end gap-1">
-            {isApp && isInstalled ? (
+            {isInstalled ? (
               <Badge variant="secondary">{t("card.installed")}</Badge>
             ) : (
               <Button
                 onClick={() => setInstalling(true)}
-                disabled={!listing.installable || (isApp && !isGuildAdmin)}
+                // Unknown installed state disables it too: offering to add
+                // something the guild may already have is the one action this
+                // page should not take on a guess.
+                disabled={
+                  !listing.installable || (isApp && (!isGuildAdmin || isInstalled === undefined))
+                }
               >
                 <Download className="mr-1.5 h-4 w-4" />
                 {isApp ? t("apps:install.action") : t("detail.install")}
@@ -155,10 +166,14 @@ export function MarketplaceListingPage() {
               <span className="text-muted-foreground text-xs">
                 {listing.available ? t("detail.needsUpdate") : t("detail.withdrawn")}
               </span>
+            ) : isApp && appInstalls.isError ? (
+              <span className="text-muted-foreground text-xs">
+                {t("apps:install.unknownState")}
+              </span>
             ) : (
               isApp &&
               !isGuildAdmin &&
-              !isInstalled && (
+              isInstalled === false && (
                 <span className="text-muted-foreground text-xs">{t("apps:install.adminOnly")}</span>
               )
             )}


### PR DESCRIPTION
## Problem

The Apps section was hidden from anyone who could not install one — the reasoning being that an empty shelf promises something a member cannot act on.

But browsing *is* something they can act on. Seeing what exists, whether the guild already has it, and who to ask for it is most of what anyone wants from an app store. A member who never sees the section cannot even ask.

## Changes

- **The section shows for everyone.** An admin still gets **Add an app**; everyone else gets **Browse the app store**, pointing at the same shelf. It sits in the same place at the bottom of the list either way.
- **A listing the guild already has is tagged** — on the card, which already worked, and now on the listing's own page too, where an installed app shows *Installed* instead of an install button nobody needs.
- **A listing it does not have tells a member who can add it.** The note reads "Ask a guild admin to add this app." rather than the flatter "Only a guild admin can add apps.", and it is suppressed once the app is installed, where it would be noise.

Installing stays an admin action, enforced server-side exactly as before. Nothing here widens what a member may *do* — the install endpoint is unchanged, and the guild-app list this reads was already member-readable.

## Testing

- `vitest src/components/sidebar src/pages/marketplace src/components/marketplace src/pages/apps` — 46 passed.
- New: a member with no apps is pointed at the store rather than shown nothing; an admin still gets the add affordance and not the browse one; a member with only disabled apps still gets the store; a member is told who can add an uninstalled app and the button is disabled rather than hidden; an installed app shows the tag instead of the button; and an installed app does not tell a member to go asking for it.
- The old "shows a member nothing" tests are rewritten rather than deleted — the rule they encoded is the one being reversed, so they now pin the new intent.
- `tsc --noEmit`, `pnpm build`, `biome check` clean (one pre-existing warning in `InitiativeSection.tsx`, untouched here).
