### PR TITLE
Take a listing off the shelf when the build stops shipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The marketplace no longer offers an app that was removed.** A listing that ships with Initiative is taken off the shelf when a release stops carrying it, instead of lingering in the catalog of every instance that ever saw it — which is why the automation app could appear twice. A guild that already installed one keeps it; it simply stops being offered.
+- **A listing shows the version you would get, not a history.** One app, one current version. Which version an install is running, and updating it, stay in guild settings where the app lives.
 - **Installed apps open again.** Clicking an app in the sidebar did nothing. An app with a page of its own now opens it — with a tab for each view where an app offers several — and an app that only needs an account connected opens that form where you clicked, rather than sending you to look for it in guild settings. Apps that just feed widgets into dashboards have no page to open, so they tuck under a “show more” instead of taking up a row. Each app is now shown with its own artwork.
 
 ### Changed

--- a/backend/app/api/v1/platform_endpoints/marketplace.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace.py
@@ -135,7 +135,6 @@ async def _detail(session, listing: MarketplaceListing) -> MarketplaceListingDet
     latest = await catalog_service.get_listing_version(
         session, listing.latest_version_id
     )
-    versions = await catalog_service.listing_versions(session, listing.id)
     summary = _summary(listing, latest)
     return MarketplaceListingDetail(
         **summary.model_dump(),
@@ -143,7 +142,6 @@ async def _detail(session, listing: MarketplaceListing) -> MarketplaceListingDet
         # A preview of what installing would produce. The install path re-reads
         # the catalog itself, so this is display data, not an input.
         definition=dict(latest.definition) if latest else None,
-        versions=[read for v in versions if (read := _version_read(v))],
     )
 
 

--- a/backend/app/api/v1/platform_endpoints/marketplace_test.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace_test.py
@@ -117,7 +117,11 @@ class TestDetail:
         body = response.json()
         assert body["long_description"] == "A longer page for the detail view."
         assert body["definition"]["kind"] == "dashboard"
-        assert [v["version"] for v in body["versions"]] == ["1.0.0"]
+        # One app, one current version. The shelf offers the latest and
+        # nothing else; which version an install is running, and upgrading
+        # it, belong to guild settings.
+        assert body["latest_version"]["version"] == "1.0.0"
+        assert "versions" not in body
         assert body["installable"] is True
 
     async def test_a_uid_resolves_to_its_listing(self, client, acting_user, listing):

--- a/backend/app/schemas/platform/marketplace.py
+++ b/backend/app/schemas/platform/marketplace.py
@@ -83,7 +83,6 @@ class MarketplaceListingDetail(MarketplaceListingSummary):
     #: page renders. Installing does not send this back; the server re-reads the
     #: catalog, so nothing a client holds decides what gets stored.
     definition: Optional[Dict[str, Any]] = None
-    versions: List[MarketplaceVersionRead] = []
 
 
 class MarketplaceListingPage(SanitizedBaseModel):

--- a/backend/app/services/marketplace/builtin.py
+++ b/backend/app/services/marketplace/builtin.py
@@ -9,12 +9,11 @@ Seeding is idempotent and runs on the system engine. A file that fails validatio
 is logged and skipped — one malformed listing must not take the rest of the
 catalog, or the boot, with it.
 
-Most of what ships applies everywhere. One listing does not: an app that opens
-the deployment's own embed surface exists only where an operator configured one,
-so seeding asks that question per manifest and withdraws anything the deployment
-can no longer serve. That is the mechanism behind "a self-hosted install without
-the configuration never sees the app" — it is absent from the catalog rather than
-present and broken.
+Seeding is also what *removes* a shipped listing. The files are the whole truth
+about what this build offers, so anything in the catalog under ``builtin`` that
+no longer has a file is withdrawn on the next boot. Without that a listing
+dropped from the build stays on the shelf of every database that ever saw it.
+Withdrawn is not deleted: a guild that already installed it keeps its app.
 """
 
 from __future__ import annotations
@@ -29,6 +28,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.services.marketplace.catalog import (
     CatalogError,
     upsert_listing,
+    withdraw_builtins_except,
 )
 
 logger = logging.getLogger(__name__)
@@ -64,6 +64,12 @@ def load_builtin_manifests(directory: Path | None = None) -> Iterator[dict[str, 
         yield manifest
 
 
+def _manifest_file_count(directory: Path | None = None) -> int:
+    """How many listing files are on disk, readable or not."""
+    root = directory or CATALOG_DIR
+    return len(list(root.glob("*.json"))) if root.is_dir() else 0
+
+
 async def seed_builtin_listings(
     session: AsyncSession, directory: Path | None = None
 ) -> int:
@@ -72,16 +78,45 @@ async def seed_builtin_listings(
     Called from startup seeding on the system-engine session. Never raises: a bad
     manifest is a packaging bug to fix, not a reason to refuse to boot.
 
-    A listing this deployment cannot serve is withdrawn rather than skipped — an
-    operator who removes the configuration an app depends on has taken it away,
-    and the catalog has to stop offering it on the next boot rather than keep a
-    row nobody can use. Guilds that already installed it keep their app.
+    A shipped listing that is no longer shipped is withdrawn, so removing a file
+    from the build removes it from the shelf everywhere on the next boot rather
+    than leaving a row nobody can install. Guilds that already have it keep it.
     """
     seeded = 0
+    shipped: list[str] = []
+    read = 0
     for manifest in load_builtin_manifests(directory):
+        read += 1
+        # Recorded before the upsert, not after: a manifest this build ships but
+        # cannot validate is a packaging bug to fix, and withdrawing the working
+        # listing it replaces would turn that bug into data loss.
+        uid = manifest.get("uid")
+        if isinstance(uid, str) and uid:
+            shipped.append(uid)
         try:
             await upsert_listing(session, manifest, source="builtin")
             seeded += 1
         except CatalogError as exc:
             logger.warning("marketplace: skipping built-in listing: %s", exc)
+
+    # Whatever this build no longer ships stops being offered — but only when
+    # the whole shelf was readable. A file that could not be parsed leaves no
+    # uid behind, and sweeping on a partial list would withdraw a listing this
+    # build does ship.
+    on_disk = _manifest_file_count(directory)
+    if read < on_disk:
+        logger.warning(
+            "marketplace: %d of %d built-in listing files unreadable; "
+            "not withdrawing anything this pass",
+            on_disk - read,
+            on_disk,
+        )
+        return seeded
+
+    withdrawn = await withdraw_builtins_except(session, shipped)
+    if withdrawn:
+        logger.info(
+            "marketplace: withdrew %d built-in listing(s) this build no longer ships",
+            withdrawn,
+        )
     return seeded

--- a/backend/app/services/marketplace/builtin_test.py
+++ b/backend/app/services/marketplace/builtin_test.py
@@ -9,10 +9,12 @@ a listing shipped with a uid outside the alphabet and never appeared in the
 catalog at all, and nothing failed. So the manifests are seeded here for real
 and the result is counted.
 
-The second is the conditional listing. An app that opens the deployment's own
-embed surface is offered only where an operator configured one — absent, not
-broken, on an install without it — and taken back out of the catalog if that
-configuration goes away.
+The second is that the files are the whole truth. A listing dropped from the
+build has to leave the shelf everywhere, or it lingers in the catalog of every
+database that ever saw it — which is exactly what happened when the advanced
+tool was removed and its listing stayed, offered, alongside its replacement.
+Withdrawing has to be careful in the other direction too: a file this build
+ships but cannot read or validate must never take its own listing down.
 """
 
 import pytest
@@ -88,3 +90,86 @@ class TestShippedManifests:
                 session, listing
             )
             assert version is not None, f"{listing.public_id} is not installable"
+
+
+class TestWithdrawingWhatIsNoLongerShipped:
+    """The catalog follows the files, in both directions."""
+
+    async def _seed_dir(self, tmp_path, manifests: list[dict]) -> None:
+        import json
+
+        for manifest in manifests:
+            (tmp_path / f"{manifest['public_id']}.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+
+    def _manifest(self, *, uid: str, public_id: str) -> dict:
+        return {
+            "uid": uid,
+            "public_id": public_id,
+            "kind": "app",
+            "name": public_id,
+            "publisher": "Tests",
+            "description": "A shipped listing.",
+            "version": "1.0.0",
+            "definition": {"app_kind": "tool_instance", "tool": "calendar"},
+        }
+
+    async def test_a_listing_dropped_from_the_build_leaves_the_shelf(
+        self, session, tmp_path
+    ):
+        keep = self._manifest(uid="KEEP0000000001", public_id="core.keep")
+        drop = self._manifest(uid="DRPX0000000001", public_id="core.drop")
+        await self._seed_dir(tmp_path, [keep, drop])
+        await seed_builtin_listings(session, tmp_path)
+        assert (await _seeded(session))["core.drop"].available is True
+
+        # The next build ships only one of them.
+        (tmp_path / "core.drop.json").unlink()
+        await seed_builtin_listings(session, tmp_path)
+
+        listings = await _seeded(session)
+        assert listings["core.keep"].available is True
+        # Withdrawn, not deleted: an install that pinned it still resolves.
+        assert listings["core.drop"].available is False
+
+    async def test_a_listing_that_fails_to_validate_is_not_withdrawn(
+        self, session, tmp_path
+    ):
+        """A packaging bug must not become data loss. The file still ships, so
+        the listing it replaces stays on the shelf while someone fixes it."""
+        good = self._manifest(uid="KEEP0000000002", public_id="core.keep2")
+        await self._seed_dir(tmp_path, [good])
+        await seed_builtin_listings(session, tmp_path)
+
+        broken = {**good, "definition": {"app_kind": "nonsense"}}
+        await self._seed_dir(tmp_path, [broken])
+        await seed_builtin_listings(session, tmp_path)
+
+        assert (await _seeded(session))["core.keep2"].available is True
+
+    async def test_an_unreadable_file_withdraws_nothing_at_all(self, session, tmp_path):
+        """One corrupt file leaves no uid behind, so sweeping on what was read
+        would withdraw listings this build does ship. The pass is skipped."""
+        first = self._manifest(uid="KEEP0000000003", public_id="core.keep3")
+        second = self._manifest(uid="KEEP0000000004", public_id="core.keep4")
+        await self._seed_dir(tmp_path, [first, second])
+        await seed_builtin_listings(session, tmp_path)
+
+        (tmp_path / "core.keep4.json").write_text("{ not json", encoding="utf-8")
+        await seed_builtin_listings(session, tmp_path)
+
+        listings = await _seeded(session)
+        assert listings["core.keep3"].available is True
+        assert listings["core.keep4"].available is True
+
+    async def test_an_operator_listing_is_not_this_build_to_withdraw(
+        self, session, tmp_path
+    ):
+        """Only shipped listings follow the files. What an operator added is
+        theirs, and a build that ships nothing must not clear their catalog."""
+        theirs = self._manifest(uid="ACME0000000001", public_id="acme.theirs")
+        await catalog_service.upsert_listing(session, theirs, source="operator")
+        await seed_builtin_listings(session, tmp_path)
+
+        assert (await _seeded(session))["acme.theirs"].available is True

--- a/backend/app/services/marketplace/catalog.py
+++ b/backend/app/services/marketplace/catalog.py
@@ -55,6 +55,7 @@ __all__ = [
     "listing_versions",
     "upsert_listing",
     "withdraw_listing",
+    "withdraw_builtins_except",
     "bump_installs_count",
     "version_is_compatible",
 ]
@@ -432,6 +433,37 @@ async def listing_versions(
             .order_by(MarketplaceListingVersion.published_at.desc())
         )
     ).all()
+
+
+async def withdraw_builtins_except(
+    session: AsyncSession, keep_uids: Sequence[str]
+) -> int:
+    """Withdraw every shipped listing this build no longer carries.
+
+    Seeding upserts what it finds; without this, a listing whose file was
+    removed from the build stays in the catalog of every database that ever saw
+    it, still offered and still installable. The row is kept, so a guild that
+    already installed it is untouched — it simply stops being on the shelf.
+
+    Scoped to ``builtin``: an operator's own listings and anything from a
+    registry are not this build's to withdraw.
+    """
+    keep = {uid for uid in keep_uids if uid}
+    statement = select(MarketplaceListing).where(
+        MarketplaceListing.source == "builtin",
+        MarketplaceListing.available.is_(True),
+    )
+    withdrawn = 0
+    for listing in (await session.exec(statement)).all():
+        if listing.uid in keep:
+            continue
+        listing.available = False
+        listing.updated_at = datetime.now(timezone.utc)
+        session.add(listing)
+        withdrawn += 1
+    if withdrawn:
+        await session.flush()
+    return withdrawn
 
 
 async def bump_installs_count(session: AsyncSession, listing_id: int) -> None:

--- a/frontend/public/locales/de/marketplace.json
+++ b/frontend/public/locales/de/marketplace.json
@@ -26,7 +26,6 @@
     "install": "Zu einer Initiative hinzufügen",
     "preview": "Vorschau",
     "previewIsSample": "Beispiel mit Beispieldaten",
-    "versions": "Versionen",
     "needsUpdate": "Benötigt eine neuere Version der App.",
     "withdrawn": "Wird nicht mehr angeboten.",
     "notFound": "Eintrag nicht gefunden",

--- a/frontend/public/locales/en/marketplace.json
+++ b/frontend/public/locales/en/marketplace.json
@@ -26,7 +26,6 @@
     "install": "Add to an initiative",
     "preview": "Preview",
     "previewIsSample": "Example shown with sample data",
-    "versions": "Versions",
     "needsUpdate": "Needs a newer version of the app.",
     "withdrawn": "No longer offered.",
     "notFound": "Listing not found",

--- a/frontend/public/locales/es/marketplace.json
+++ b/frontend/public/locales/es/marketplace.json
@@ -26,7 +26,6 @@
     "install": "Añadir a una iniciativa",
     "preview": "Vista previa",
     "previewIsSample": "Ejemplo con datos de muestra",
-    "versions": "Versiones",
     "needsUpdate": "Necesita una versión más reciente de la aplicación.",
     "withdrawn": "Ya no está disponible.",
     "notFound": "Elemento no encontrado",

--- a/frontend/public/locales/fr/marketplace.json
+++ b/frontend/public/locales/fr/marketplace.json
@@ -26,7 +26,6 @@
     "install": "Ajouter à une initiative",
     "preview": "Aperçu",
     "previewIsSample": "Exemple affiché avec des données d'exemple",
-    "versions": "Versions",
     "needsUpdate": "Nécessite une version plus récente de l'application.",
     "withdrawn": "N'est plus proposé.",
     "notFound": "Fiche introuvable",

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2668,7 +2668,6 @@ export interface MarketplaceListingDetail {
   updated_at: string;
   long_description: string | null;
   definition: MarketplaceListingDetailDefinition;
-  versions: MarketplaceVersionRead[];
 }
 
 /**

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -230,22 +230,6 @@ export function MarketplaceListingPage() {
         </div>
       )}
 
-      {listing && listing.versions.length > 1 && (
-        <div className="space-y-2">
-          <h2 className="font-medium text-sm">{t("detail.versions")}</h2>
-          <ul className="space-y-2 text-sm">
-            {listing.versions.map((version) => (
-              <li key={version.version} className="flex flex-wrap items-baseline gap-2">
-                <span className="font-medium">{version.version}</span>
-                {version.release_notes && (
-                  <span className="text-muted-foreground">{version.release_notes}</span>
-                )}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
       {listing &&
         (isApp ? (
           <InstallAppDialog listing={listing} open={installing} onOpenChange={setInstalling} />


### PR DESCRIPTION
## Problem

Two "Automations" apps in the marketplace. Not a versioning bug — two listing rows:

| uid | public_id | source | available |
|---|---|---|---|
| `T9PZ3KVD6BWRSN` | `core.advanced-tool` | builtin | **true** |
| `5M8B51VRKB3XSY` | `morelitea.automations` | operator | true |

The first is the removed advanced tool's listing. Seeding upserts the manifests it finds and nothing else, so a listing dropped from a release stays in the catalog of every database that ever saw it — still offered, still installable.

`builtin.py`'s docstring already promised withdraw-on-absence. The call that did it hung off the advanced tool's own "can this deployment serve it" check and was deleted with the tool in `afc9300e`, leaving the promise without the mechanism — and taking out the one thing that would have withdrawn that very listing.

## Changes

Seeding withdraws any `builtin` listing this build no longer carries. Withdrawn, not deleted: a guild that already installed it keeps its app, its pinned definition and its provenance.

Two guards, because a wrong sweep is silent data loss:

- **A manifest that ships but fails to validate still counts as shipped.** Its uid is recorded before the upsert is attempted, so a packaging bug cannot withdraw the working listing it was meant to replace.
- **A file that cannot be read at all skips the entire pass.** It leaves no uid behind, and sweeping on a partial list would withdraw listings this build does ship.

Only `builtin` listings are touched — an operator's own and anything from a registry are not this build's to withdraw.

**Separately:** a listing page no longer lists past versions. Installing already resolves `latest_version_id` and nothing else, so the history only displayed versions that were never on offer. Which version an install is running, and upgrading it, already live in guild settings. The version rows stay in the database — installs pin one, so deleting them would orphan what an install is running.

## Testing

- `pytest app/services/marketplace/ app/api/v1/platform_endpoints/marketplace_test.py` — 402 passed. New: a dropped listing leaves the shelf and stays withdrawn-not-deleted; one that fails to validate is *not* withdrawn; one unreadable file withdraws nothing at all; an operator listing survives a build that ships none.
- `vitest src/pages/marketplace src/components/marketplace` — 31 passed.
- Verified against a real database — the one that had the duplicate. After re-seeding, `core.advanced-tool` is withdrawn and only `morelitea.automations` remains. Three shipped listings that fail validation there for unrelated reasons were correctly left alone, which exercised the first guard on live data.
