### PR TITLE
Let a surface say where it renders

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -597,7 +597,8 @@ async def create_guild_app_handoff(
     Whether the surface may be opened is decided here, under the caller's real
     session, so the app never makes that call and never sees a request from
     somebody who failed it. What the manifest declared as ``visibility``
-    governs: a surface marked ``guild_admin`` is admin-only, and everything
+    governs, read guild-wide: a surface naming any audience narrower than
+    ``member`` is reachable here only by the guild's admins, and everything
     else is open to every member of the installing guild.
 
     The token goes to the iframe by ``postMessage`` — never a query string —

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -608,6 +608,9 @@ async def create_guild_app_handoff(
     handoff = await handoff_service.mint_embed_handoff(
         app,
         surface_id=surface_id,
+        # This route reaches a guild, and names no initiative. A surface that
+        # renders only inside one is not offered here.
+        scope="guild",
         user_id=current_user.id,
         is_guild_admin=rls_service.is_guild_admin(guild_context.role),
     )

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -60,7 +60,7 @@ _SIGNING_KEY_PEM = (
 
 
 def _service_definition(**overrides) -> dict:
-    """A service app declaring one member surface and one admin surface."""
+    """A service app declaring one surface per rung of the visibility ladder."""
     definition = {
         "app_kind": "service",
         "service": {"public_id": SERVICE_ID, "protocol": 1},
@@ -77,6 +77,13 @@ def _service_definition(**overrides) -> dict:
                 "path": "/embed/console",
                 "visibility": "guild_admin",
                 "name": {"en": "Console"},
+            },
+            {
+                "id": "runs",
+                "path": "/embed/runs",
+                "scopes": ["guild", "initiative"],
+                "visibility": "initiative_manager",
+                "name": {"en": "Runs"},
             },
         ],
         "default_name": "WidgetCo",
@@ -317,6 +324,39 @@ class TestHandoff:
 
         response = await client.post(
             a.g(f"/apps/{app.id}/handoff/console"), headers=a.headers
+        )
+        assert response.status_code == 200, response.text
+
+    async def test_managing_an_initiative_does_not_open_the_guild_wide_entry(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        """This route names no initiative, so it cannot admit a manager of one.
+
+        The surface renders in both scopes, and its rung is read against where
+        it was opened: guild-wide there is nothing to manage, so the same
+        declaration that admits a manager inside their initiative admits only
+        admins out here.
+        """
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _installed(session, a)
+        pm = await acting_user(
+            guild_role=GuildRole.member, guild=a.guild, initiative=True
+        )
+
+        response = await client.post(
+            pm.g(f"/apps/{app.id}/handoff/runs"), headers=pm.headers
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == GuildAppMessages.SURFACE_ADMIN_ONLY
+
+    async def test_a_guild_admin_opens_it_guild_wide(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _installed(session, a)
+
+        response = await client.post(
+            a.g(f"/apps/{app.id}/handoff/runs"), headers=a.headers
         )
         assert response.status_code == 200, response.text
 

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -85,6 +85,13 @@ def _service_definition(**overrides) -> dict:
                 "visibility": "initiative_manager",
                 "name": {"en": "Runs"},
             },
+            {
+                "id": "inside",
+                "path": "/embed/inside",
+                "scopes": ["initiative"],
+                "visibility": "member",
+                "name": {"en": "Inside"},
+            },
         ],
         "default_name": "WidgetCo",
     }
@@ -326,6 +333,28 @@ class TestHandoff:
             a.g(f"/apps/{app.id}/handoff/console"), headers=a.headers
         )
         assert response.status_code == 200, response.text
+
+    async def test_a_surface_that_renders_only_inside_an_initiative_is_not_here(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        """``member`` means something different in each place, so the route has
+        to agree with the surface before the rung is read at all.
+
+        This route names no initiative, so a surface declared only for one has
+        no audience it could be measured against here — and a guild member who
+        belongs to no initiative would otherwise clear ``member`` and be handed
+        a token for it. Not offered here means not found here, for everyone.
+        """
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _installed(session, a)
+        member = await acting_user(guild_role=GuildRole.member, guild=a.guild)
+
+        for actor in (member, a):
+            response = await client.post(
+                actor.g(f"/apps/{app.id}/handoff/inside"), headers=actor.headers
+            )
+            assert response.status_code == 404, response.text
+            assert response.json()["detail"] == GuildAppMessages.SURFACE_NOT_FOUND
 
     async def test_managing_an_initiative_does_not_open_the_guild_wide_entry(
         self, client: AsyncClient, acting_user, session: AsyncSession, registration

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -629,8 +629,9 @@ class GuildAppMessages:
     SERVICE_NOT_REGISTERED = "GUILD_APP_SERVICE_NOT_REGISTERED"
     #: The pinned definition declares no surface under that id.
     SURFACE_NOT_FOUND = "GUILD_APP_SURFACE_NOT_FOUND"
-    #: The surface declares ``visibility: guild_admin`` and the caller is a
-    #: plain member.
+    #: The surface names an audience the caller is not in — declared for the
+    #: guild's admins, or for an initiative's managers where the caller manages
+    #: nothing.
     SURFACE_ADMIN_ONLY = "GUILD_APP_SURFACE_ADMIN_ONLY"
     #: An interactive connection whose pinned definition carries no
     #: ``connect_path``, so there is no vendor flow to send the member to.

--- a/backend/app/services/marketplace/app_data.py
+++ b/backend/app/services/marketplace/app_data.py
@@ -64,6 +64,7 @@ from app.models.platform.app_service_registration import (
 from app.models.tenant.guild_app import GuildApp
 from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
 from app.services.marketplace.context_jwt import mint_context_token
+from app.services.marketplace.service_apps import clears_visibility
 from app.services.safe_http import build_validated_request
 from app.services.tenant import app_config as app_config_service
 from app.services.webhook_target_url import (
@@ -665,7 +666,9 @@ async def fetch_app_source(
     if source is None or public_id is None:
         raise AppDataError(AppDataMessages.SOURCE_NOT_FOUND, 404)
 
-    if source.get("visibility") == "guild_admin" and not is_guild_admin:
+    # Measured against the same ladder a manifest declares on, so the two
+    # cannot come to mean different things.
+    if not clears_visibility(source.get("visibility"), is_guild_admin=is_guild_admin):
         raise AppDataError(AppDataMessages.ADMIN_ONLY, 403)
     if not app.enabled:
         raise AppDataError(AppDataMessages.APP_DISABLED, 409)

--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -537,10 +537,129 @@ class TestEmbeds:
             {
                 "id": "orders",
                 "path": "/embed/orders",
+                "scopes": ["guild"],
                 "visibility": "guild_admin",
                 "name": {"en": "Orders"},
             }
         ]
+
+
+class TestWhereASurfaceRenders:
+    """``scopes`` is not a choice between the two — it is a list.
+
+    A surface may ask for the guild-wide entry, an entry in each initiative, or
+    both; both is the interesting case, because it is one page reached from two
+    places rather than two surfaces to keep in step.
+    """
+
+    def _embed(self, **overrides) -> dict:
+        embed = {"id": "board", "path": "/embed", "name": _label("Board")}
+        embed.update(overrides)
+        return _normalize(features=["embeds"], embeds=[embed])["embeds"][0]
+
+    def test_saying_nothing_keeps_the_placement_embeds_already_had(self):
+        assert self._embed()["scopes"] == ["guild"]
+
+    def test_a_surface_may_render_in_both(self):
+        assert self._embed(scopes=["initiative", "guild"])["scopes"] == [
+            "guild",
+            "initiative",
+        ]
+
+    def test_a_surface_may_render_only_inside_initiatives(self):
+        assert self._embed(scopes=["initiative"])["scopes"] == ["initiative"]
+
+    def test_an_unknown_scope_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="unknown scope"):
+            self._embed(scopes=["project"])
+
+    def test_nowhere_to_render_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="nowhere to render"):
+            self._embed(scopes=[])
+
+    def test_a_repeated_scope_is_stored_once(self):
+        assert self._embed(scopes=["guild", "guild"])["scopes"] == ["guild"]
+
+
+class TestVisibilityIsALadder:
+    """A rung names the floor an audience clears, read against where it opens.
+
+    The ordering is declared once so a manifest and a request cannot come to
+    mean different things by the same word, and every rung is exercised here so
+    adding one forces a decision rather than defaulting to "refused".
+    """
+
+    def _embed(self, **overrides) -> dict:
+        embed = {
+            "id": "board",
+            "path": "/embed",
+            "name": _label("Board"),
+            "scopes": ["initiative"],
+        }
+        embed.update(overrides)
+        return _normalize(features=["embeds"], embeds=[embed])["embeds"][0]
+
+    def test_the_ladder_and_the_vocabulary_are_the_same_values(self):
+        assert set(service_apps.VISIBILITY_LADDER) == service_apps.VISIBILITIES
+        assert len(service_apps.VISIBILITY_LADDER) == len(service_apps.VISIBILITIES)
+
+    @pytest.mark.parametrize("rung", service_apps.VISIBILITY_LADDER)
+    def test_a_guild_admin_clears_every_rung(self, rung):
+        assert service_apps.clears_visibility(rung, is_guild_admin=True)
+
+    def test_a_member_clears_only_the_bottom_rung(self):
+        assert service_apps.clears_visibility("member", is_guild_admin=False)
+        assert not service_apps.clears_visibility(
+            "initiative_manager", is_guild_admin=False
+        )
+        assert not service_apps.clears_visibility("guild_admin", is_guild_admin=False)
+
+    def test_a_manager_clears_the_rung_named_for_them(self):
+        assert service_apps.clears_visibility(
+            "initiative_manager", is_guild_admin=False, is_initiative_manager=True
+        )
+
+    def test_managing_one_initiative_does_not_open_the_admin_rung(self):
+        assert not service_apps.clears_visibility(
+            "guild_admin", is_guild_admin=False, is_initiative_manager=True
+        )
+
+    def test_a_caller_with_no_initiative_in_hand_is_measured_without_it(self):
+        # The guild-wide route: nobody is a manager of nothing, so the rung
+        # falls through to the admins.
+        assert not service_apps.clears_visibility(
+            "initiative_manager", is_guild_admin=False
+        )
+        assert service_apps.clears_visibility("initiative_manager", is_guild_admin=True)
+
+    @pytest.mark.parametrize("required", [None, "member"])
+    def test_saying_nothing_admits_everyone_who_got_this_far(self, required):
+        assert service_apps.clears_visibility(required, is_guild_admin=False)
+
+    def test_a_value_this_build_does_not_know_is_refused(self):
+        # Nothing stores one today; the predicate fails closed anyway, so a
+        # rung added to the vocabulary and forgotten here denies rather than
+        # admits.
+        assert not service_apps.clears_visibility("everyone", is_guild_admin=False)
+
+    def test_an_unknown_visibility_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="unknown visibility"):
+            self._embed(visibility="everyone")
+
+    def test_an_initiative_surface_may_name_an_initiative_audience(self):
+        assert self._embed(visibility="initiative_manager")["visibility"] == (
+            "initiative_manager"
+        )
+
+    def test_a_guild_wide_surface_may_not(self):
+        # There is nothing to manage out here, so the value would be stored as
+        # a claim nothing could evaluate.
+        with pytest.raises(ListingDefinitionError, match="initiative audience"):
+            self._embed(scopes=["guild"], visibility="initiative_manager")
+
+    def test_a_data_source_may_not_either(self):
+        with pytest.raises(ListingDefinitionError, match="initiative audience"):
+            _with_source(visibility="initiative_manager")
 
 
 class TestEvents:

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -58,9 +58,13 @@ __all__ = [
     "FEATURES",
     "FEATURE_BLOCKS",
     "FIELD_TYPES",
+    "GUILD_WIDE_VISIBILITIES",
     "PARAM_TYPES",
+    "SURFACE_SCOPES",
     "VISIBILITIES",
+    "VISIBILITY_LADDER",
     "app_widget_type",
+    "clears_visibility",
     "normalize_service_app_definition",
 ]
 
@@ -101,9 +105,38 @@ FIELD_TYPES: frozenset[str] = frozenset(
 #: custody, and never restated per call.
 PARAM_TYPES: frozenset[str] = FIELD_TYPES - {"secret"}
 
-#: Who may open a surface. ``member`` is any member of the installing guild;
-#: ``guild_admin`` narrows it to the guild's admins.
-VISIBILITIES: frozenset[str] = frozenset({"member", "guild_admin"})
+#: Where a surface renders. Not a choice between the two: a surface may declare
+#: either, or both, and one that declares both gets a guild-wide entry *and* an
+#: entry inside each initiative — the same page, told which initiative it was
+#: opened in. Closed, and defaulting to ``["guild"]``, so an app that says
+#: nothing keeps the placement it already had.
+SURFACE_SCOPES: frozenset[str] = frozenset({"guild", "initiative"})
+
+#: Who may open a surface, in order. A ladder rather than a set: a value names
+#: the floor an audience has to clear, and each rung clears the ones below it.
+#: ``guild_admin`` is the guild's admins, who clear every rung — an admin's
+#: reach over their own guild is the same rule here as it is everywhere else.
+#:
+#: A rung is read against *where* the surface was opened, which is what lets one
+#: value serve a surface in both scopes:
+#:
+#: * ``member`` guild-wide is every member of the installing guild; inside an
+#:   initiative it is that initiative's members, and no one else's — the
+#:   initiative gate is what answers that, not a claim in a manifest.
+#: * ``initiative_manager`` inside an initiative is that initiative's managers;
+#:   guild-wide, where there is no initiative to manage, only the guild's
+#:   admins reach it.
+#:
+#: Deliberately coarser than a tool's permissions. A surface has no grants and
+#: no permission key to hang a per-role dial on, so it names one of three
+#: audiences rather than an arbitrary initiative role.
+VISIBILITY_LADDER: tuple[str, ...] = ("member", "initiative_manager", "guild_admin")
+VISIBILITIES: frozenset[str] = frozenset(VISIBILITY_LADDER)
+
+#: The rungs something opened without an initiative may ask for.
+#: ``initiative_manager`` is absent: outside an initiative there is nothing to
+#: manage, so the value would be stored as a claim nothing could ever evaluate.
+GUILD_WIDE_VISIBILITIES: frozenset[str] = VISIBILITIES - {"initiative_manager"}
 
 #: Protocol versions this build speaks to an app service. A manifest naming a
 #: newer one is refused by name — the version floor (`min_app_version`) is how a
@@ -200,12 +233,45 @@ def _requires(
     return {key: cleaned}
 
 
-def _visibility(raw: Any, *, what: str) -> str:
+def _visibility(raw: Any, *, what: str, allowed: frozenset[str] = VISIBILITIES) -> str:
+    """One rung of the ladder, or the default.
+
+    ``allowed`` narrows it for something with no initiative to name, so a value
+    is refused where it could not be evaluated rather than stored and quietly
+    read as something else later.
+    """
     if raw is None:
         return "member"
     if raw not in VISIBILITIES:
         fail(f"{what}: unknown visibility {raw!r}")
+    if raw not in allowed:
+        fail(
+            f"{what}: visibility {raw!r} names an initiative audience, and this "
+            "surface is not opened in an initiative"
+        )
     return raw
+
+
+def clears_visibility(
+    required: Any,
+    *,
+    is_guild_admin: bool,
+    is_initiative_manager: bool = False,
+) -> bool:
+    """Whether a caller reaches something declaring ``required``.
+
+    The ladder's ordering is written once, here, so what a manifest may declare
+    and what a request is measured against cannot drift apart. A caller with no
+    initiative in hand leaves ``is_initiative_manager`` false and is measured on
+    the rungs that remain. Anything unrecognized is refused.
+    """
+    if is_guild_admin:
+        return True
+    if required is None or required == "member":
+        return True
+    if required == "initiative_manager":
+        return is_initiative_manager
+    return False
 
 
 def _field(
@@ -353,7 +419,11 @@ def _data_source(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
     cleaned: dict[str, Any] = {
         "id": source_id,
         "path": check_path(source.get("path"), what=f"{what} path"),
-        "visibility": _visibility(source.get("visibility"), what=what),
+        # A source is fetched for a guild, not for an initiative, so the rungs
+        # that need one are not on offer here.
+        "visibility": _visibility(
+            source.get("visibility"), what=what, allowed=GUILD_WIDE_VISIBILITIES
+        ),
         "cache_ttl_seconds": _cache_ttl(source.get("cache_ttl_seconds"), what=what),
     }
     if params:
@@ -442,15 +512,45 @@ def _sample_data(raw: Any, *, sources: list[str], what: str) -> dict[str, Any]:
     return sample
 
 
+def _scopes(raw: Any, *, what: str) -> list[str]:
+    """Where a surface asked to render, canonically.
+
+    Absent means ``["guild"]`` — the placement every embed had before there was
+    anywhere else to put one. Sorted and de-duplicated, so re-publishing the
+    same manifest produces the same document.
+    """
+    if raw is None:
+        return ["guild"]
+    declared = require_list(raw, f"{what} scopes", len(SURFACE_SCOPES))
+    scopes: set[str] = set()
+    for entry in declared:
+        if entry not in SURFACE_SCOPES:
+            fail(f"{what}: unknown scope {entry!r}")
+        scopes.add(entry)
+    if not scopes:
+        fail(f"{what}: scopes names nowhere to render")
+    return sorted(scopes)
+
+
 def _embed(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
     embed = require_mapping(raw, "embed")
     embed_id = check_identifier(embed.get("id"), what="embed id")
     what = f"embed {embed_id!r}"
 
+    scopes = _scopes(embed.get("scopes"), what=what)
     cleaned: dict[str, Any] = {
         "id": embed_id,
         "path": check_path(embed.get("path"), what=f"{what} path"),
-        "visibility": _visibility(embed.get("visibility"), what=what),
+        "scopes": scopes,
+        "visibility": _visibility(
+            embed.get("visibility"),
+            what=what,
+            # An initiative audience is only namable by a surface that renders
+            # in one.
+            allowed=(
+                VISIBILITIES if "initiative" in scopes else GUILD_WIDE_VISIBILITIES
+            ),
+        ),
         "name": _label(embed.get("name"), what=what),
     }
     requires = _requires(

--- a/backend/app/services/tenant/app_handoff.py
+++ b/backend/app/services/tenant/app_handoff.py
@@ -73,17 +73,27 @@ class EmbedHandoff:
 
 
 def embed_by_id(
-    definition: dict[str, Any] | None, surface_id: str
+    definition: dict[str, Any] | None, surface_id: str, *, scope: str
 ) -> Optional[dict[str, Any]]:
-    """One declared embed surface from a pinned definition."""
+    """One declared embed surface from a pinned definition, if it renders here.
+
+    ``scope`` is where the surface is being opened from — the route's to state,
+    never the caller's. A surface that never asked to render there is not a
+    surface of that route, so it is simply not found. Definitions pinned before
+    a surface could say where it belongs carry no ``scopes``, and every one of
+    those is guild-wide.
+    """
     if not isinstance(definition, dict):
         return None
     embeds = definition.get("embeds")
     if not isinstance(embeds, list):
         return None
     for embed in embeds:
-        if isinstance(embed, dict) and embed.get("id") == surface_id:
-            return embed
+        if not isinstance(embed, dict) or embed.get("id") != surface_id:
+            continue
+        scopes = embed.get("scopes")
+        renders = scope in scopes if isinstance(scopes, list) else scope == "guild"
+        return embed if renders else None
     return None
 
 
@@ -133,16 +143,22 @@ async def mint_embed_handoff(
     app: GuildApp,
     *,
     surface_id: str,
+    scope: str,
     user_id: int,
     is_guild_admin: bool,
 ) -> EmbedHandoff:
-    """Authorize the caller for one surface, then mint its handoff."""
+    """Authorize the caller for one surface, then mint its handoff.
+
+    Resolving the surface is scoped to the route it was asked for, so the
+    visibility rung — which is read against where a surface was opened — is only
+    ever measured somewhere the surface agreed to appear.
+    """
     if not app.enabled:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT, detail=GuildAppMessages.DISABLED
         )
 
-    embed = embed_by_id(app.definition, surface_id)
+    embed = embed_by_id(app.definition, surface_id, scope=scope)
     if embed is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/services/tenant/app_handoff.py
+++ b/backend/app/services/tenant/app_handoff.py
@@ -41,6 +41,7 @@ from app.core.security import (
 )
 from app.models.tenant.guild_app import GuildApp
 from app.services.marketplace import registration_lookup
+from app.services.marketplace.service_apps import clears_visibility
 
 __all__ = [
     "APP_EMBED_HANDOFF_LIFETIME",
@@ -86,13 +87,24 @@ def embed_by_id(
     return None
 
 
-def _require_visibility(embed: dict[str, Any], *, is_guild_admin: bool) -> None:
-    """A surface an app declared for admins is opened by admins.
+def _require_visibility(
+    embed: dict[str, Any],
+    *,
+    is_guild_admin: bool,
+    is_initiative_manager: bool = False,
+) -> None:
+    """A surface is opened by the audience the app declared for it.
 
     ``member`` is the default the manifest validator applies, so an embed that
-    says nothing is open to every member of the installing guild.
+    says nothing is open to every member of the installing guild. The ordering
+    lives with the vocabulary that defines it, so this cannot drift from what a
+    manifest is allowed to say.
     """
-    if embed.get("visibility") == "guild_admin" and not is_guild_admin:
+    if not clears_visibility(
+        embed.get("visibility"),
+        is_guild_admin=is_guild_admin,
+        is_initiative_manager=is_initiative_manager,
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=GuildAppMessages.SURFACE_ADMIN_ONLY,

--- a/frontend/src/api/generated/apps/apps.ts
+++ b/frontend/src/api/generated/apps/apps.ts
@@ -1255,7 +1255,8 @@ export const useUpdateGuildAppConfigApiV1GGuildIdAppsAppIdConfigPut = <
  * Whether the surface may be opened is decided here, under the caller's real
  * session, so the app never makes that call and never sees a request from
  * somebody who failed it. What the manifest declared as ``visibility``
- * governs: a surface marked ``guild_admin`` is admin-only, and everything
+ * governs, read guild-wide: a surface naming any audience narrower than
+ * ``member`` is reachable here only by the guild's admins, and everything
  * else is open to every member of the installing guild.
  *
  * The token goes to the iframe by ``postMessage`` — never a query string —

--- a/frontend/src/lib/appSurfaces.test.ts
+++ b/frontend/src/lib/appSurfaces.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Which surfaces belong where.
+ *
+ * A definition pinned before surfaces could say where they belong carries no
+ * scopes, and every one of those is guild-wide — so the absent case is the one
+ * that matters most here. Getting it wrong would empty the app pages of every
+ * install that predates this.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { appEmbeds, guildAppPath } from "./appSurfaces";
+
+const embed = (id: string, scopes?: string[]) => ({
+  id,
+  path: `/embed/${id}`,
+  name: { en: id },
+  ...(scopes ? { scopes } : {}),
+});
+
+describe("appEmbeds", () => {
+  it("reads a surface that says nothing as guild-wide", () => {
+    const definition = { embeds: [embed("board")] };
+    expect(appEmbeds(definition).map((e) => e.id)).toEqual(["board"]);
+    expect(appEmbeds(definition, "initiative")).toEqual([]);
+  });
+
+  it("offers a surface in both places when it asked for both", () => {
+    const definition = { embeds: [embed("runs", ["guild", "initiative"])] };
+    expect(appEmbeds(definition, "guild").map((e) => e.id)).toEqual(["runs"]);
+    expect(appEmbeds(definition, "initiative").map((e) => e.id)).toEqual(["runs"]);
+  });
+
+  it("keeps an initiative-only surface off the guild page", () => {
+    const definition = { embeds: [embed("runs", ["initiative"])] };
+    expect(appEmbeds(definition, "guild")).toEqual([]);
+    expect(appEmbeds(definition, "initiative").map((e) => e.id)).toEqual(["runs"]);
+  });
+
+  it("ignores entries that are not surfaces", () => {
+    const definition = { embeds: [{ id: "no-path" }, null, "board", embed("real")] };
+    expect(appEmbeds(definition).map((e) => e.id)).toEqual(["real"]);
+  });
+
+  it("has nothing to offer when the app declares no embeds", () => {
+    expect(appEmbeds({})).toEqual([]);
+    expect(appEmbeds(null)).toEqual([]);
+  });
+});
+
+describe("guildAppPath", () => {
+  it("gives an app with a guild-wide surface a page", () => {
+    expect(guildAppPath({ id: 7, definition: { embeds: [embed("board")] } })).toBe("/apps/7");
+  });
+
+  it("gives an app with only initiative surfaces no guild page", () => {
+    expect(
+      guildAppPath({ id: 7, definition: { embeds: [embed("runs", ["initiative"])] } })
+    ).toBeNull();
+  });
+});

--- a/frontend/src/lib/appSurfaces.ts
+++ b/frontend/src/lib/appSurfaces.ts
@@ -15,9 +15,14 @@ import type { LocalizedText } from "@/api/appConnections";
 export interface AppEmbed {
   id: string;
   path: string;
+  /** Where it renders. Absent means guild-wide, the only placement there was. */
+  scopes?: string[];
   visibility?: string;
   name?: LocalizedText;
 }
+
+/** The places a surface can be reached from. */
+export type SurfaceScope = "guild" | "initiative";
 
 /** Loose shape so this reads both the list and detail payloads. */
 export interface AppSurfaceSource {
@@ -26,17 +31,29 @@ export interface AppSurfaceSource {
   definition?: Record<string, unknown> | null;
 }
 
-/** The embedded surfaces an app declared, if any. */
-export const appEmbeds = (definition?: Record<string, unknown> | null): AppEmbed[] => {
+/**
+ * The embedded surfaces an app declared for one place.
+ *
+ * A surface may declare either scope or both, so this is a filter rather than a
+ * partition — an app's guild-wide page and its per-initiative one are often the
+ * same surface reached from two places. Only the server decides who may open
+ * one; this decides what is worth offering.
+ */
+export const appEmbeds = (
+  definition?: Record<string, unknown> | null,
+  scope: SurfaceScope = "guild"
+): AppEmbed[] => {
   const embeds = definition?.embeds;
   if (!Array.isArray(embeds)) return [];
-  return embeds.filter(
-    (embed): embed is AppEmbed =>
-      typeof embed === "object" &&
-      embed !== null &&
-      typeof (embed as AppEmbed).id === "string" &&
-      typeof (embed as AppEmbed).path === "string"
-  );
+  return embeds.filter((embed): embed is AppEmbed => {
+    if (typeof embed !== "object" || embed === null) return false;
+    const candidate = embed as AppEmbed;
+    if (typeof candidate.id !== "string" || typeof candidate.path !== "string") return false;
+    // Definitions pinned before surfaces could say where they belong carry no
+    // scopes at all, and every one of them is guild-wide.
+    const scopes = Array.isArray(candidate.scopes) ? candidate.scopes : ["guild"];
+    return scopes.includes(scope);
+  });
 };
 
 /** Whether the app declares any credential to fill in or connect. */


### PR DESCRIPTION
An app's embedded surface has only ever had one placement: guild-wide. This adds the vocabulary for a second, without changing where anything renders yet — no app declares a scope, so nothing a user can see changes.

Groundwork for rendering an app inside each initiative as well as guild-wide.

## What changed

**`embeds[].scopes` is a list, not a choice.** A surface may declare `guild`, `initiative`, or both — and both is the ordinary case: one page reached from two places rather than two surfaces to keep in step. Absent means `["guild"]`, so every definition pinned before this reads exactly as it did.

**`visibility` becomes a ladder** — `member` → `initiative_manager` → `guild_admin` — read against *where* the surface was opened:

| value | guild-wide | inside an initiative |
|---|---|---|
| `member` | every member of the guild | that initiative's members, and no one else's |
| `initiative_manager` | guild admins only — nothing out here to manage | that initiative's managers |
| `guild_admin` | guild admins | guild admins |

That is what lets **one** value serve a surface in both scopes without the manifest declaring two surfaces or the app keeping them in step. A guild admin clears every rung, as everywhere else. `member` inside an initiative is answered by the initiative gate, not by anything in the manifest.

Deliberately coarser than a tool's permissions: a surface has no `resource_grants` and no permission key to hang a per-role dial on, so it names one of three audiences.

**One predicate, two enforcement sites.** `clears_visibility` holds the ordering, and both the handoff mint and the app-data fetch read it, so what a manifest may declare and what a request is measured against cannot drift apart. It fails closed on anything it does not recognize.

**An initiative audience is refused where there is no initiative to name** — a guild-only surface, or a data source — rather than stored as a claim nothing could evaluate.

**The guild app page filters to guild-scoped surfaces**, so an initiative-only one is never offered where it would refuse.

## Notable

- No schema change, no migration.
- `SURFACE_ADMIN_ONLY`'s comment now describes the ladder rather than one rung; the code itself is unchanged, so `errors.json` needs nothing.
- Regenerated API types: the handoff endpoint's docstring changed (one line in `apps.ts`).

## Testing

```
pytest app/services/marketplace/ app/api/v1/tenant_endpoints/guild_apps_platform_test.py \
       app/api/v1/tenant_endpoints/app_data_test.py app/api/v1/tenant_endpoints/guild_apps_test.py
# 465 passed

pnpm vitest run src/lib/appSurfaces.test.ts src/pages/apps/GuildAppPage.test.tsx
# 9 passed

ruff check app && ruff format app && ty check   # clean
pnpm lint                                       # 9 warnings, same as dev
```

New coverage: every rung of the ladder against every caller shape; a rung this build does not know is refused; an initiative audience refused on a guild-only surface and on a data source; scopes de-duplicated, defaulted, and refused when empty or unknown. End-to-end, a PM who is not a guild admin is refused the guild-wide entry of a both-scopes surface — verified discriminating by mutation (the test fails when the predicate ignores the manager flag).

No CHANGELOG entry: nothing user-visible until the rendering phase.