### PR TITLE
Stop the app page test losing its ready

### DIFF
--- a/frontend/src/pages/apps/GuildAppPage.test.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.test.tsx
@@ -79,6 +79,26 @@ const ready = () =>
     })
   );
 
+/**
+ * Announce until the page answers.
+ *
+ * `ready` is a one-shot with no retry: the page only listens once it holds a
+ * token for the mounted frame, and an announcement that lands before then is
+ * gone for good. A real embed cannot arrive early — it loads from the src the
+ * token produced — but a test dispatching by hand can, since the mounted frame
+ * and the listener that serves it settle in that order and a loaded machine can
+ * leave a gap between them. Delivery is synchronous inside the listener, so the
+ * announcement that lands is the only one that delivers.
+ */
+const announceReady = () =>
+  waitFor(
+    () => {
+      if (delivered().length === 0) ready();
+      expect(delivered()).toEqual(["token-for-one"]);
+    },
+    { timeout: 5000 }
+  );
+
 describe("GuildAppPage", () => {
   it("hands the first surface's token to the frame that asked", async () => {
     mint.mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
@@ -86,8 +106,7 @@ describe("GuildAppPage", () => {
     renderPage(() => <GuildAppPage appId={1} />);
 
     await screen.findByTitle("Automations");
-    ready();
-    await waitFor(() => expect(delivered()).toEqual(["token-for-one"]));
+    await announceReady();
   });
 
   it("drops a re-mint that resolves after the surface changed", async () => {
@@ -103,8 +122,7 @@ describe("GuildAppPage", () => {
     renderPage(() => <GuildAppPage appId={1} />);
 
     await screen.findByTitle("Automations");
-    ready(); // spends the first token
-    await waitFor(() => expect(delivered()).toEqual(["token-for-one"]));
+    await announceReady(); // spends the first token
 
     ready(); // the embed reloaded: starts the re-mint that will go stale
     (await screen.findByText("Two")).click();


### PR DESCRIPTION
## Problem

`GuildAppPage.test.tsx` is flaky in CI. It has failed three runs today — [dev push 20:40](https://github.com/Morelitea/initiative/actions/runs/31742015881), [dev push 21:32](https://github.com/Morelitea/initiative/actions/runs/31746095187), and the [release v0.62.2 PR](https://github.com/Morelitea/initiative/actions/runs/31746235540) — hitting both of its cases and always the same assertion:

```
AssertionError: expected [] to deeply equal [ 'token-for-one' ]
```

It passes in isolation every time (I ran it 6×) and in the full local suite.

The cause is in the test, not the page. `ready` is a one-shot with no retry: the page listens only once it holds a token for the mounted frame (`useEffect` on `[origin, allowed, handoff, mint]`), so an announcement that lands before that effect has run is gone for good — nothing ever asks again, and the `waitFor` then burns its default 1s and fails. The tests dispatched `ready()` the moment `findByTitle` saw the iframe, which is one settle earlier than the listener that serves it; a loaded runner is free to widen that gap. The failing CI DOM confirms it — the iframe is mounted with its `src` set, and nothing was ever delivered.

This is a test-only race. A real embed cannot announce early: it loads from the `src` the token produced, so its `ready` necessarily follows the commit that attached the listener.

## Changes

- [GuildAppPage.test.tsx](frontend/src/pages/apps/GuildAppPage.test.tsx) — added an `announceReady()` helper that re-announces until the page answers, and used it at both first-handoff sites. Delivery is synchronous inside the listener, so the announcement that lands is the only one that delivers; the assertions stay exact (`toEqual(["token-for-one"])`), and the second test's `mockImplementationOnce` sequencing is untouched because a lost announcement reaches no listener and mints nothing.

No source change — the page is correct as written.

## Testing

- Reproduced the mechanism: with `message` listeners deliberately attached 400ms late, the old single-dispatch pattern fails exactly as CI does and the new announce loop delivers. (Scaffold was temporary and is not in this PR.)
- `pnpm vitest run src/pages/apps/GuildAppPage.test.tsx` ×5 — 2 passed each
- `cd frontend && pnpm test:run` — 107 files, 1433 tests passed
- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check` on the changed file — clean

No changelog entry: test-only, nothing user-facing.