### PR TITLE
Show an app inside the initiatives it serves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Apps can now appear inside an initiative as well as guild-wide. An app that offers an initiative surface gets a row in each initiative's sidebar section, opening a page scoped to that initiative — the same install, told which initiative it is being read in.
+- App surfaces name who they are for: everyone in the guild, an initiative's managers, or guild admins. An entry only appears for a reader it is meant for.
+
 ## [0.62.2] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apps can now appear inside an initiative as well as guild-wide. An app that offers an initiative surface gets a row in each initiative's sidebar section, opening a page scoped to that initiative — the same install, told which initiative it is being read in.
 - App surfaces name who they are for: everyone in the guild, an initiative's managers, or guild admins. An entry only appears for a reader it is meant for.
 
+### Fixed
+
+- An initiative that renamed its managing role, or gave a second role manager standing, now sees the manager affordances it should: the sidebar reads the role's manager flag rather than looking for the built-in role by name.
+
 ## [0.62.2] - 2026-08-13
 
 ### Fixed

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -46,6 +46,7 @@ import { useCounterGroupCountsByInitiative } from "@/hooks/useCounters";
 import { useDashboardCountsByInitiative } from "@/hooks/useDashboards";
 import { compareVersions, useDockerHubVersion } from "@/hooks/useDockerHubVersion";
 import { useDocumentCountsByInitiative } from "@/hooks/useDocuments";
+import { useGuildApps } from "@/hooks/useGuildApps";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
@@ -189,6 +190,16 @@ export const AppSidebar = () => {
   const visibleInitiatives = useMemo(
     () => filterVisible(Array.isArray(initiativesQuery.data) ? initiativesQuery.data : []),
     [initiativesQuery.data, filterVisible]
+  );
+
+  // The same install list the Apps section reads, handed to each initiative so
+  // an app declaring a surface in one gets a row there too. Filtered to what is
+  // actually reachable, on the same terms the Apps section uses.
+  const guildAppsQuery = useGuildApps({ enabled: guildTreeEnabled });
+  const initiativeApps = useMemo(
+    () =>
+      (guildAppsQuery.data?.items ?? []).filter((app) => app.enabled && app.available !== false),
+    [guildAppsQuery.data]
   );
 
   // Initiative visibility + per-section permissions (membership, PAM grants,
@@ -447,6 +458,8 @@ export const AppSidebar = () => {
                                       activeProjectId={activeProjectId}
                                       userId={user?.id}
                                       access={getUserPermissions(initiative)}
+                                      apps={initiativeApps}
+                                      isGuildAdmin={isGuildAdmin}
                                       counts={{
                                         [Tool.project]: projects.length,
                                         [Tool.document]:

--- a/frontend/src/components/marketplace/InstallAppDialog.tsx
+++ b/frontend/src/components/marketplace/InstallAppDialog.tsx
@@ -54,7 +54,8 @@ export function InstallAppDialog({ listing, open, onOpenChange }: InstallAppDial
           toast.success(t("apps:install.done", { name: app.name }));
           onOpenChange(false);
           // Straight to what it created, when it created something reachable.
-          const path = guildAppPath(app);
+          // Only a guild admin installs, so every surface is open to them.
+          const path = guildAppPath(app, { isGuildAdmin: true });
           if (path) navigate({ to: gp(path) });
         },
         onError: (error) => {

--- a/frontend/src/components/sidebar/AppsSection.tsx
+++ b/frontend/src/components/sidebar/AppsSection.tsx
@@ -11,10 +11,10 @@
  *   one, but they can look at what exists and ask for it, so the shelf is worth
  *   pointing at; what differs is the invitation at the bottom.
  *
- * The exception is an app the server marks admin-only, which members do not see
- * at all: it has no sharing to widen, so an entry would refuse everyone who
- * clicked it. Which apps those are is the server's answer, not a kind the
- * sidebar interprets.
+ * A surface names the audience it is for, and an entry is only offered to a
+ * reader who is in it — an app whose only guild-wide surface is for admins does
+ * not take a row for a member. The mint settles the same question again under
+ * the caller's own session; this is about not pointing at a closed door.
  *
  * Disabled apps are hidden here and stay visible in guild settings, which is
  * where an admin turns them back on. So are apps whose service is not set up on
@@ -74,9 +74,10 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
 
   // An app with somewhere to go leads; one with nothing to open waits under
   // "show more" so a guild that installs many widget providers still has a
-  // readable sidebar.
+  // readable sidebar. A surface declared for the guild's admins is not
+  // somewhere a member can go, so for them it does not count as one.
   const actionable = apps.filter(
-    (app) => guildAppPath(app) !== null || appHasConnections(app.definition)
+    (app) => guildAppPath(app, { isGuildAdmin }) !== null || appHasConnections(app.definition)
   );
   const inert = apps.filter((app) => !actionable.includes(app));
 
@@ -172,7 +173,7 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
 function AppEntry({ app, isGuildAdmin }: { app: GuildAppRead; isGuildAdmin: boolean }) {
   const gp = useGuildPath();
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const path = guildAppPath(app);
+  const path = guildAppPath(app, { isGuildAdmin });
   // The listing's own artwork, small. Every listing has one — a listing that
   // ships none is published with the app's own mark — so there is nothing to
   // fall back to.

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -1,9 +1,13 @@
 import { Link } from "@tanstack/react-router";
-import { CircleChevronRight, MoreVertical, Settings } from "lucide-react";
+import { Blocks, CircleChevronRight, MoreVertical, Settings } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { InitiativeRead, ProjectRead } from "@/api/generated/initiativeAPI.schemas";
+import type {
+  GuildAppRead,
+  InitiativeRead,
+  ProjectRead,
+} from "@/api/generated/initiativeAPI.schemas";
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { ToolCreateButton } from "@/components/tools/ToolCreateButton";
 import { Button } from "@/components/ui/button";
@@ -18,6 +22,7 @@ import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import type { InitiativeToolAccess } from "@/hooks/useInitiativeAccess";
+import { initiativeAppPath } from "@/lib/appSurfaces";
 import { guildPath } from "@/lib/guildUrl";
 import { hasWriteAccess } from "@/lib/permissions";
 import { getItem, setItem } from "@/lib/storage";
@@ -35,6 +40,11 @@ export interface InitiativeSectionProps {
   /** Per-tool sidebar counts. Every in-app list tool shows one — the rows all
    *  present the same way; a hand-off (embedded) tool has no list to count. */
   counts: Partial<Record<Tool, number>>;
+  /** The guild's installed apps. Those declaring a surface for this reader
+   *  inside an initiative get a row here, drawn from the same one install. */
+  apps: GuildAppRead[];
+  /** Whether the reader is a guild admin, which clears every surface's rung. */
+  isGuildAdmin: boolean;
   activeGuildId: number | null;
   /** Changing this value re-syncs the open/closed state from storage. */
   collapseKey?: number;
@@ -49,6 +59,8 @@ export const InitiativeSection = memo(
     userId,
     access,
     counts,
+    apps,
+    isGuildAdmin,
     activeGuildId,
     collapseKey,
   }: InitiativeSectionProps) => {
@@ -66,6 +78,19 @@ export const InitiativeSection = memo(
 
     /** Whether to surface a create affordance for a tool. */
     const canCreateTool = (tool: Tool): boolean => access[tool].create;
+
+    // Apps offering this reader a surface inside *this* initiative. Managing
+    // one initiative says nothing about another, so the standing is resolved
+    // per section rather than once for the sidebar.
+    const appRows = apps
+      .map((app) => ({
+        app,
+        path: initiativeAppPath(app, initiative.id, {
+          isGuildAdmin,
+          isInitiativeManager: canManageInitiative,
+        }),
+      }))
+      .filter((row): row is { app: GuildAppRead; path: string } => row.path !== null);
 
     // Load initial state from storage, default to true if not found
     const [isOpen, setIsOpen] = useState(() => {
@@ -196,6 +221,30 @@ export const InitiativeSection = memo(
             forceMount
           >
             <SidebarMenu>
+              {/* Apps first, above the tools, the same way the guild's apps sit
+                  above its initiatives — and because the tool rows end with
+                  projects, whose list has to expand directly beneath them. */}
+              {appRows.map(({ app, path }) => (
+                <SidebarMenuItem key={`app-${app.id}`}>
+                  <SidebarMenuButton asChild size="sm" className="min-w-0">
+                    <Link to={gp(path)} className="flex min-w-0 items-center gap-2">
+                      {app.avatar_url ? (
+                        <img
+                          src={app.avatar_url}
+                          alt=""
+                          aria-hidden
+                          className="h-4 w-4 shrink-0 rounded-sm object-cover"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <Blocks className="h-4 w-4 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate">{app.name}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+
               {/* One row per tool, in SIDEBAR_TOOLS order (projects last so
                   the project list expands directly beneath their row). */}
               {SIDEBAR_TOOLS.filter(showTool).map((tool) => {

--- a/frontend/src/hooks/useInitiativeAccess.test.ts
+++ b/frontend/src/hooks/useInitiativeAccess.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { buildInitiative, buildUser } from "@/__tests__/factories";
+import { buildInitiative, buildInitiativeMember, buildUser } from "@/__tests__/factories";
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import type { GuildEntry } from "@/hooks/useGuilds";
 import {
@@ -150,5 +150,84 @@ describe("useGlobalCreateAccess", () => {
 
     const { result } = renderHook(() => useGlobalCreateAccess());
     expect(result.current).toEqual({ document: true, task: true });
+  });
+});
+
+describe("useInitiativeAccess canManage", () => {
+  const asMember = (user: ReturnType<typeof buildUser>) => {
+    mockUseAuth.mockReturnValue({ user });
+    mockUseGuilds.mockReturnValue({ activeGuild: { id: 1, role: "member" } });
+  };
+
+  /** One initiative, with this user holding the given role. */
+  const withRole = (
+    user: ReturnType<typeof buildUser>,
+    role: Partial<ReturnType<typeof buildInitiativeMember>>
+  ) =>
+    buildInitiative({
+      members: [
+        buildInitiativeMember({
+          user: { id: user.id, full_name: user.full_name, email: user.email },
+          ...role,
+        }),
+      ],
+    });
+
+  it("counts the built-in managing role", () => {
+    const user = buildUser();
+    asMember(user);
+    const initiative = withRole(user, {
+      role: "project_manager",
+      role_name: "project_manager",
+      is_manager: true,
+    });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    expect(result.current.canManage(initiative)).toBe(true);
+  });
+
+  it("counts a managing role the initiative named itself", () => {
+    // An initiative that renamed its managers, or added a second managing
+    // role: the flag is what the server reads, and the legacy `role` field
+    // reports `member` for anything but the built-in name.
+    const user = buildUser();
+    asMember(user);
+    const initiative = withRole(user, {
+      role: "member",
+      role_name: "lead",
+      role_display_name: "Lead",
+      is_manager: true,
+    });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    expect(result.current.canManage(initiative)).toBe(true);
+  });
+
+  it("does not count an ordinary member", () => {
+    const user = buildUser();
+    asMember(user);
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    expect(result.current.canManage(withRole(user, { is_manager: false }))).toBe(false);
+  });
+
+  it("does not count managing some other initiative", () => {
+    const user = buildUser();
+    asMember(user);
+    const elsewhere = buildInitiative({
+      members: [buildInitiativeMember({ is_manager: true })],
+    });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    expect(result.current.canManage(elsewhere)).toBe(false);
+  });
+
+  it("counts a guild admin everywhere", () => {
+    const user = buildUser();
+    mockUseAuth.mockReturnValue({ user });
+    mockUseGuilds.mockReturnValue({ activeGuild: { id: 1, role: "admin" } });
+
+    const { result } = renderHook(() => useInitiativeAccess());
+    expect(result.current.canManage(buildInitiative({ members: [] }))).toBe(true);
   });
 });

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -196,12 +196,18 @@ export function useInitiativeAccess() {
   );
 
   /** Whether the user can manage (PM/admin) a specific initiative. A grant
-   * never confers management — those operations are owner/PM-gated. */
+   * never confers management — those operations are owner/PM-gated.
+   *
+   * Read off `is_manager`, the flag an initiative role actually carries, rather
+   * than the legacy `role` field — which reports `project_manager` only for the
+   * built-in role of that name. An initiative that renamed its managers, or
+   * added a second managing role, has members the server treats as managers and
+   * this would not. */
   const canManage = useCallback(
     (initiative: InitiativeRead): boolean => {
       if (isGuildAdmin) return true;
       if (!user) return false;
-      return initiative.members.some((m) => m.user.id === user.id && m.role === "project_manager");
+      return initiative.members.some((m) => m.user.id === user.id && m.is_manager);
     },
     [user, isGuildAdmin]
   );

--- a/frontend/src/lib/appSurfaces.test.ts
+++ b/frontend/src/lib/appSurfaces.test.ts
@@ -1,61 +1,155 @@
 /**
- * Which surfaces belong where.
+ * Which surfaces belong where, and which are worth offering to whom.
  *
- * A definition pinned before surfaces could say where they belong carries no
- * scopes, and every one of those is guild-wide — so the absent case is the one
- * that matters most here. Getting it wrong would empty the app pages of every
- * install that predates this.
+ * Two readings that are easy to get wrong. A definition pinned before surfaces
+ * could say where they belong carries no scopes, and every one of those is
+ * guild-wide — getting that wrong would empty the app pages of every install
+ * that predates it. And a rung is read against *where* a surface was opened, so
+ * one declaration deliberately admits different people in each place.
  */
 
 import { describe, expect, it } from "vitest";
 
-import { appEmbeds, guildAppPath } from "./appSurfaces";
+import { appEmbeds, clearsVisibility, guildAppPath, initiativeAppPath } from "./appSurfaces";
 
-const embed = (id: string, scopes?: string[]) => ({
+const ADMIN = { isGuildAdmin: true };
+const MANAGER = { isGuildAdmin: false, isInitiativeManager: true };
+const MEMBER = { isGuildAdmin: false };
+
+const embed = (id: string, scopes?: string[], visibility?: string) => ({
   id,
   path: `/embed/${id}`,
   name: { en: id },
   ...(scopes ? { scopes } : {}),
+  ...(visibility ? { visibility } : {}),
+});
+
+describe("clearsVisibility", () => {
+  it("lets a guild admin past every rung", () => {
+    for (const rung of [undefined, "member", "initiative_manager", "guild_admin"]) {
+      expect(clearsVisibility(rung, ADMIN)).toBe(true);
+    }
+  });
+
+  it("reads the manager rung against the reader's own standing", () => {
+    expect(clearsVisibility("initiative_manager", MANAGER)).toBe(true);
+    expect(clearsVisibility("initiative_manager", MEMBER)).toBe(false);
+  });
+
+  it("keeps a manager off the rung above them", () => {
+    expect(clearsVisibility("guild_admin", MANAGER)).toBe(false);
+  });
+
+  it("admits everyone where nothing was named", () => {
+    expect(clearsVisibility(undefined, MEMBER)).toBe(true);
+    expect(clearsVisibility("member", MEMBER)).toBe(true);
+  });
+
+  it("does not offer a rung it cannot read", () => {
+    expect(clearsVisibility("everyone", MEMBER)).toBe(false);
+  });
 });
 
 describe("appEmbeds", () => {
   it("reads a surface that says nothing as guild-wide", () => {
     const definition = { embeds: [embed("board")] };
-    expect(appEmbeds(definition).map((e) => e.id)).toEqual(["board"]);
-    expect(appEmbeds(definition, "initiative")).toEqual([]);
+    expect(appEmbeds(definition, "guild", MEMBER).map((e) => e.id)).toEqual(["board"]);
+    expect(appEmbeds(definition, "initiative", MEMBER)).toEqual([]);
   });
 
   it("offers a surface in both places when it asked for both", () => {
     const definition = { embeds: [embed("runs", ["guild", "initiative"])] };
-    expect(appEmbeds(definition, "guild").map((e) => e.id)).toEqual(["runs"]);
-    expect(appEmbeds(definition, "initiative").map((e) => e.id)).toEqual(["runs"]);
+    expect(appEmbeds(definition, "guild", MEMBER).map((e) => e.id)).toEqual(["runs"]);
+    expect(appEmbeds(definition, "initiative", MEMBER).map((e) => e.id)).toEqual(["runs"]);
   });
 
   it("keeps an initiative-only surface off the guild page", () => {
     const definition = { embeds: [embed("runs", ["initiative"])] };
-    expect(appEmbeds(definition, "guild")).toEqual([]);
-    expect(appEmbeds(definition, "initiative").map((e) => e.id)).toEqual(["runs"]);
+    expect(appEmbeds(definition, "guild", ADMIN)).toEqual([]);
+    expect(appEmbeds(definition, "initiative", ADMIN).map((e) => e.id)).toEqual(["runs"]);
+  });
+
+  it("offers one declaration to different people in each place", () => {
+    // The automation shape: managers inside their initiative, admins guild-wide.
+    const definition = {
+      embeds: [embed("runs", ["guild", "initiative"], "initiative_manager")],
+    };
+    expect(appEmbeds(definition, "initiative", MANAGER).map((e) => e.id)).toEqual(["runs"]);
+    // Still described as a manager, but guild-wide there is nothing to manage,
+    // so the rung falls through to the admins — the mint reads it the same way.
+    expect(appEmbeds(definition, "guild", MANAGER)).toEqual([]);
+    expect(appEmbeds(definition, "guild", ADMIN).map((e) => e.id)).toEqual(["runs"]);
+    expect(appEmbeds(definition, "initiative", MEMBER)).toEqual([]);
+  });
+
+  it("does not offer a member an admin surface", () => {
+    const definition = { embeds: [embed("console", ["guild"], "guild_admin")] };
+    expect(appEmbeds(definition, "guild", MEMBER)).toEqual([]);
+    expect(appEmbeds(definition, "guild", ADMIN).map((e) => e.id)).toEqual(["console"]);
   });
 
   it("ignores entries that are not surfaces", () => {
     const definition = { embeds: [{ id: "no-path" }, null, "board", embed("real")] };
-    expect(appEmbeds(definition).map((e) => e.id)).toEqual(["real"]);
+    expect(appEmbeds(definition, "guild", MEMBER).map((e) => e.id)).toEqual(["real"]);
   });
 
   it("has nothing to offer when the app declares no embeds", () => {
-    expect(appEmbeds({})).toEqual([]);
-    expect(appEmbeds(null)).toEqual([]);
+    expect(appEmbeds({}, "guild", ADMIN)).toEqual([]);
+    expect(appEmbeds(null, "guild", ADMIN)).toEqual([]);
   });
 });
 
 describe("guildAppPath", () => {
   it("gives an app with a guild-wide surface a page", () => {
-    expect(guildAppPath({ id: 7, definition: { embeds: [embed("board")] } })).toBe("/apps/7");
+    expect(guildAppPath({ id: 7, definition: { embeds: [embed("board")] } }, MEMBER)).toBe(
+      "/apps/7"
+    );
   });
 
   it("gives an app with only initiative surfaces no guild page", () => {
     expect(
-      guildAppPath({ id: 7, definition: { embeds: [embed("runs", ["initiative"])] } })
+      guildAppPath({ id: 7, definition: { embeds: [embed("runs", ["initiative"])] } }, ADMIN)
+    ).toBeNull();
+  });
+
+  it("gives a member no page when every surface is for admins", () => {
+    const app = {
+      id: 7,
+      definition: { embeds: [embed("console", ["guild"], "guild_admin")] },
+    };
+    expect(guildAppPath(app, MEMBER)).toBeNull();
+    expect(guildAppPath(app, ADMIN)).toBe("/apps/7");
+  });
+
+  it("sends a tool-instance app to the tool it mounted", () => {
+    expect(
+      guildAppPath({ id: 7, tool: "calendar", artifacts: [{ type: "calendar", id: 3 }] }, MEMBER)
+    ).toBe("/calendars/3");
+  });
+});
+
+describe("initiativeAppPath", () => {
+  const app = (embeds: ReturnType<typeof embed>[]) => ({ id: 7, definition: { embeds } });
+
+  it("gives a manager a row inside their initiative", () => {
+    const declaration = app([embed("runs", ["initiative"], "initiative_manager")]);
+    expect(initiativeAppPath(declaration, 4, MANAGER)).toBe("/initiatives/4/apps/7");
+    expect(initiativeAppPath(declaration, 4, MEMBER)).toBeNull();
+    expect(initiativeAppPath(declaration, 4, ADMIN)).toBe("/initiatives/4/apps/7");
+  });
+
+  it("gives no row to an app with only a guild-wide surface", () => {
+    expect(initiativeAppPath(app([embed("board")]), 4, ADMIN)).toBeNull();
+  });
+
+  it("gives a tool-instance app no row of its own", () => {
+    // The tool it mounted already lives in an initiative.
+    expect(
+      initiativeAppPath(
+        { id: 7, tool: "calendar", artifacts: [{ type: "calendar", id: 3 }] },
+        4,
+        ADMIN
+      )
     ).toBeNull();
   });
 });

--- a/frontend/src/lib/appSurfaces.ts
+++ b/frontend/src/lib/appSurfaces.ts
@@ -8,6 +8,13 @@
  *   admin supplies. Opens a dialog where they do that.
  * - **Neither** — it contributes widgets or data to somewhere else. There is
  *   nothing to open, so it does not take a row of its own.
+ *
+ * A surface says where it renders and who it is for, and both are read against
+ * the reader: the same surface can be a guild-wide entry and an entry inside
+ * each initiative, admitting different people in each place. Nothing here
+ * decides access — the mint does that, under the caller's own session. This
+ * decides what is worth offering, so a reader is not handed a door that would
+ * not open.
  */
 
 import type { LocalizedText } from "@/api/appConnections";
@@ -24,6 +31,13 @@ export interface AppEmbed {
 /** The places a surface can be reached from. */
 export type SurfaceScope = "guild" | "initiative";
 
+/** Who is looking, as far as a surface is concerned. */
+export interface SurfaceViewer {
+  isGuildAdmin: boolean;
+  /** Only meaningful inside an initiative — there is nothing else to manage. */
+  isInitiativeManager?: boolean;
+}
+
 /** Loose shape so this reads both the list and detail payloads. */
 export interface AppSurfaceSource {
   tool?: string | null;
@@ -32,19 +46,39 @@ export interface AppSurfaceSource {
 }
 
 /**
- * The embedded surfaces an app declared for one place.
+ * Whether a reader clears the rung a surface named.
+ *
+ * The ladder, mirroring the manifest vocabulary: `member` ⊂ `initiative_manager`
+ * ⊂ `guild_admin`, and a guild admin clears every rung. A reader with no
+ * initiative in hand leaves `isInitiativeManager` unset and is measured on the
+ * rungs that remain, so the same value can mean an initiative's managers inside
+ * it and the guild's admins outside. Anything unrecognized is not offered.
+ */
+export const clearsVisibility = (required: string | undefined, viewer: SurfaceViewer): boolean => {
+  if (viewer.isGuildAdmin) return true;
+  if (!required || required === "member") return true;
+  if (required === "initiative_manager") return viewer.isInitiativeManager === true;
+  return false;
+};
+
+/**
+ * The embedded surfaces an app offers this reader, in one place.
  *
  * A surface may declare either scope or both, so this is a filter rather than a
  * partition — an app's guild-wide page and its per-initiative one are often the
- * same surface reached from two places. Only the server decides who may open
- * one; this decides what is worth offering.
+ * same surface reached from two places.
  */
 export const appEmbeds = (
-  definition?: Record<string, unknown> | null,
-  scope: SurfaceScope = "guild"
+  definition: Record<string, unknown> | null | undefined,
+  scope: SurfaceScope,
+  viewer: SurfaceViewer
 ): AppEmbed[] => {
   const embeds = definition?.embeds;
   if (!Array.isArray(embeds)) return [];
+  // Guild-wide there is no initiative to manage, so a reader is measured on the
+  // rungs that remain however they were described. Dropped here rather than
+  // trusted from each caller, so the mint and this cannot come to disagree.
+  const reader: SurfaceViewer = scope === "guild" ? { isGuildAdmin: viewer.isGuildAdmin } : viewer;
   return embeds.filter((embed): embed is AppEmbed => {
     if (typeof embed !== "object" || embed === null) return false;
     const candidate = embed as AppEmbed;
@@ -52,7 +86,7 @@ export const appEmbeds = (
     // Definitions pinned before surfaces could say where they belong carry no
     // scopes at all, and every one of them is guild-wide.
     const scopes = Array.isArray(candidate.scopes) ? candidate.scopes : ["guild"];
-    return scopes.includes(scope);
+    return scopes.includes(scope) && clearsVisibility(candidate.visibility, reader);
   });
 };
 
@@ -61,17 +95,38 @@ export const appHasConnections = (definition?: Record<string, unknown> | null): 
   Array.isArray(definition?.connections) && definition.connections.length > 0;
 
 /**
- * Where an app's entry leads.
+ * Where an app's guild-wide entry leads.
  *
  * A tool-instance app mounts an existing tool, so it links at the tool's own
  * route — the calendar an app created is just a calendar. A service app with
- * embedded surfaces gets a page. Anything else has no route, and the caller
- * decides what to do with the row.
+ * surfaces this reader can open gets a page. Anything else has no route, and
+ * the caller decides what to do with the row.
  */
-export const guildAppPath = (app: AppSurfaceSource & { id: number }): string | null => {
+export const guildAppPath = (
+  app: AppSurfaceSource & { id: number },
+  viewer: SurfaceViewer
+): string | null => {
   if (app.tool === "calendar") {
     const calendar = (app.artifacts ?? []).find((artifact) => artifact.type === "calendar");
     return calendar ? `/calendars/${calendar.id}` : null;
   }
-  return appEmbeds(app.definition).length ? `/apps/${app.id}` : null;
+  return appEmbeds(app.definition, "guild", viewer).length ? `/apps/${app.id}` : null;
+};
+
+/**
+ * Where an app's entry inside one initiative leads.
+ *
+ * The same install — there is one of it per guild, not one per initiative —
+ * opened somewhere narrower. A tool-instance app has none: the tool it mounted
+ * already lives in an initiative of its own.
+ */
+export const initiativeAppPath = (
+  app: AppSurfaceSource & { id: number },
+  initiativeId: number,
+  viewer: SurfaceViewer
+): string | null => {
+  if (app.tool) return null;
+  return appEmbeds(app.definition, "initiative", viewer).length
+    ? `/initiatives/${initiativeId}/apps/${app.id}`
+    : null;
 };

--- a/frontend/src/pages/apps/GuildAppPage.test.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.test.tsx
@@ -20,7 +20,13 @@ vi.mock("@/api/generated/apps/apps", () => ({
     _guildId: number,
     _appId: number,
     surfaceId: string
-  ) => mint(surfaceId),
+  ) => mint(surfaceId, { scope: "guild" }),
+  createInitiativeAppHandoffApiV1GGuildIdInitiativesInitiativeIdAppsAppIdHandoffSurfaceIdPost: (
+    _guildId: number,
+    initiativeId: number,
+    _appId: number,
+    surfaceId: string
+  ) => mint(surfaceId, { scope: "initiative", initiativeId }),
 }));
 
 const detail = {
@@ -32,9 +38,19 @@ const detail = {
     embeds: [
       { id: "one", path: "/embed/one", name: { en: "One" } },
       { id: "two", path: "/embed/two", name: { en: "Two" } },
+      {
+        id: "inside",
+        path: "/embed/inside",
+        name: { en: "Inside" },
+        scopes: ["initiative"],
+        visibility: "initiative_manager",
+      },
     ],
   },
 };
+
+/** A guild admin, who clears every rung wherever they are looking. */
+const ADMIN = { isGuildAdmin: true };
 
 vi.mock("@/hooks/useGuildAppDetail", () => ({
   useGuildAppDetail: () => ({ data: detail, isLoading: false }),
@@ -103,7 +119,7 @@ describe("GuildAppPage", () => {
   it("hands the first surface's token to the frame that asked", async () => {
     mint.mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
     const { GuildAppPage } = await import("./GuildAppPage");
-    renderPage(() => <GuildAppPage appId={1} />);
+    renderPage(() => <GuildAppPage appId={1} viewer={ADMIN} />);
 
     await screen.findByTitle("Automations");
     await announceReady();
@@ -119,14 +135,14 @@ describe("GuildAppPage", () => {
       .mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
 
     const { GuildAppPage } = await import("./GuildAppPage");
-    renderPage(() => <GuildAppPage appId={1} />);
+    renderPage(() => <GuildAppPage appId={1} viewer={ADMIN} />);
 
     await screen.findByTitle("Automations");
     await announceReady(); // spends the first token
 
     ready(); // the embed reloaded: starts the re-mint that will go stale
     (await screen.findByText("Two")).click();
-    await waitFor(() => expect(mint).toHaveBeenCalledWith("two"));
+    await waitFor(() => expect(mint).toHaveBeenCalledWith("two", expect.anything()));
 
     // The held re-mint now answers, for a surface nobody is looking at.
     releaseStale(handoff("one"));
@@ -136,5 +152,43 @@ describe("GuildAppPage", () => {
     // now showing the other surface. Surface two has minted but not been asked,
     // so nothing has been delivered for it either.
     expect(delivered()).toEqual(["token-for-one"]);
+  });
+});
+
+describe("GuildAppPage, read inside an initiative", () => {
+  beforeEach(() => {
+    mint.mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
+  });
+
+  it("offers the surfaces that asked to render here, and no others", async () => {
+    const { GuildAppPage } = await import("./GuildAppPage");
+    renderPage(() => <GuildAppPage appId={1} initiativeId={4} viewer={ADMIN} />);
+
+    await screen.findByTitle("Automations");
+    // The two guild-wide tabs belong to the other page. One surface left means
+    // no tab strip at all, so the name appears nowhere.
+    expect(screen.queryByText("One")).toBeNull();
+    expect(screen.queryByText("Two")).toBeNull();
+    await waitFor(() => expect(mint).toHaveBeenCalledWith("inside", expect.anything()));
+  });
+
+  it("mints through the route that names the initiative", async () => {
+    const { GuildAppPage } = await import("./GuildAppPage");
+    renderPage(() => <GuildAppPage appId={1} initiativeId={4} viewer={ADMIN} />);
+
+    await screen.findByTitle("Automations");
+    await waitFor(() =>
+      expect(mint).toHaveBeenCalledWith("inside", { scope: "initiative", initiativeId: 4 })
+    );
+  });
+
+  it("says so plainly when nothing here is for this reader", async () => {
+    // A plain member of the initiative: the only surface here names its
+    // managers, so there is nothing to open and nothing to mint.
+    const { GuildAppPage } = await import("./GuildAppPage");
+    renderPage(() => <GuildAppPage appId={1} initiativeId={4} viewer={{ isGuildAdmin: false }} />);
+
+    await screen.findByText(/nothing to show|no page of its own|has no page/i);
+    expect(mint).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/apps/GuildAppPage.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.tsx
@@ -18,12 +18,15 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost } from "@/api/generated/apps/apps";
+import {
+  createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost,
+  createInitiativeAppHandoffApiV1GGuildIdInitiativesInitiativeIdAppsAppIdHandoffSurfaceIdPost,
+} from "@/api/generated/apps/apps";
 import type { GuildAppHandoff } from "@/api/generated/initiativeAPI.schemas";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useGuildAppDetail } from "@/hooks/useGuildAppDetail";
-import { appEmbeds } from "@/lib/appSurfaces";
+import { appEmbeds, type SurfaceViewer } from "@/lib/appSurfaces";
 import { cn } from "@/lib/utils";
 import { localized } from "@/lib/widgets/widgetMeta";
 
@@ -33,13 +36,30 @@ const HANDOFF = "initiative-app:handoff";
 const ERROR = "initiative-app:error";
 const LOCALE = "initiative-app:locale";
 
-export function GuildAppPage({ appId }: { appId: number }) {
+export interface GuildAppPageProps {
+  appId: number;
+  /**
+   * The initiative this page is being read inside, if any. It selects the
+   * surfaces on offer, and it travels to the app in the minted token — so the
+   * app can scope what it shows without asking a second question.
+   */
+  initiativeId?: number;
+  /** Who is reading, so a surface they could not open is not offered. */
+  viewer: SurfaceViewer;
+}
+
+export function GuildAppPage({ appId, initiativeId, viewer }: GuildAppPageProps) {
   const { t, i18n } = useTranslation(["apps", "common"]);
   const guildId = useActiveGuildId();
   const detail = useGuildAppDetail(appId);
   const app = detail.data;
 
-  const embeds = useMemo(() => appEmbeds(app?.definition), [app?.definition]);
+  const scope = initiativeId === undefined ? "guild" : "initiative";
+  const { isGuildAdmin, isInitiativeManager } = viewer;
+  const embeds = useMemo(
+    () => appEmbeds(app?.definition, scope, { isGuildAdmin, isInitiativeManager }),
+    [app?.definition, scope, isGuildAdmin, isInitiativeManager]
+  );
   const [surfaceId, setSurfaceId] = useState<string | null>(null);
   const active = embeds.find((embed) => embed.id === surfaceId) ?? embeds[0] ?? null;
   // The surface as a plain id, so a refetch that hands back an equal-but-new
@@ -55,14 +75,24 @@ export function GuildAppPage({ appId }: { appId: number }) {
   // one is minted fresh.
   const spentRef = useRef(false);
 
+  // Two routes, because where a surface was opened is the route's to say: the
+  // initiative in the token is the one whose gate this request passed, not a
+  // value the page hands over.
   const mint = useCallback(
     () =>
-      createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost(
-        guildId,
-        appId,
-        activeId ?? ""
-      ) as unknown as Promise<GuildAppHandoff>,
-    [guildId, appId, activeId]
+      (initiativeId === undefined
+        ? createGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost(
+            guildId,
+            appId,
+            activeId ?? ""
+          )
+        : createInitiativeAppHandoffApiV1GGuildIdInitiativesInitiativeIdAppsAppIdHandoffSurfaceIdPost(
+            guildId,
+            initiativeId,
+            appId,
+            activeId ?? ""
+          )) as unknown as Promise<GuildAppHandoff>,
+    [guildId, initiativeId, appId, activeId]
   );
 
   // Mint for the surface being opened. Re-runs when the surface changes, which

--- a/frontend/src/pages/apps/GuildAppRoute.tsx
+++ b/frontend/src/pages/apps/GuildAppRoute.tsx
@@ -1,11 +1,47 @@
 import { useParams } from "@tanstack/react-router";
 
+import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
+import { useInitiatives } from "@/hooks/useInitiatives";
 import { GuildAppPage } from "@/pages/apps/GuildAppPage";
 
 /** Reads the install id off the route so the page itself takes a plain prop. */
 export function GuildAppRoute() {
   const { appId } = useParams({ strict: false }) as { appId?: string };
+  const { isGuildAdmin } = useInitiativeAccess();
   const parsed = Number(appId);
   if (!Number.isFinite(parsed)) return null;
-  return <GuildAppPage appId={parsed} />;
+  return <GuildAppPage appId={parsed} viewer={{ isGuildAdmin }} />;
+}
+
+/**
+ * The same install, read inside one initiative.
+ *
+ * Both ids come off the route, and so does the standing that decides which
+ * surfaces are on offer — a manager of *this* initiative, which says nothing
+ * about any other. The mint re-derives all of it under the caller's own
+ * session; this only keeps the page from offering a door that would not open.
+ */
+export function InitiativeAppRoute() {
+  const { appId, initiativeId } = useParams({ strict: false }) as {
+    appId?: string;
+    initiativeId?: string;
+  };
+  const initiatives = useInitiatives();
+  const { isGuildAdmin, canManage } = useInitiativeAccess();
+
+  const parsedApp = Number(appId);
+  const parsedInitiative = Number(initiativeId);
+  if (!Number.isFinite(parsedApp) || !Number.isFinite(parsedInitiative)) return null;
+
+  const initiative = (initiatives.data ?? []).find((one) => one.id === parsedInitiative);
+  return (
+    <GuildAppPage
+      appId={parsedApp}
+      initiativeId={parsedInitiative}
+      viewer={{
+        isGuildAdmin,
+        isInitiativeManager: initiative ? canManage(initiative) : false,
+      }}
+    />
+  );
 }

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -98,6 +98,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdSett
 import { Route as ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/projects_.$projectId_.settings'
 import { Route as ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/queues_.$queueId_.settings'
 import { Route as ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/counter-groups_.$groupId_.counter_.$counterId'
+import { Route as ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/initiatives_.$initiativeId_.apps_.$appId'
 
 const ServerRequiredRoute = ServerRequiredRouteImport.update({
   id: '/_serverRequired',
@@ -640,6 +641,14 @@ const ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRou
       getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
     } as any,
   )
+const ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute =
+  ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRouteImport.update(
+    {
+      id: '/initiatives_/$initiativeId_/apps_/$appId',
+      path: '/initiatives/$initiativeId/apps/$appId',
+      getParentRoute: () => ServerRequiredAuthenticatedGGuildIdRoute,
+    } as any,
+  )
 
 export interface FileRoutesByFullPath {
   '/': typeof ServerRequiredAuthenticatedIndexRoute
@@ -729,6 +738,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/projects/$projectId/settings': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   '/g/$guildId/queues/$queueId/settings': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
   '/g/$guildId/counter-groups/$groupId/counter/$counterId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
+  '/g/$guildId/initiatives/$initiativeId/apps/$appId': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof ServerRequiredAuthenticatedIndexRoute
@@ -813,6 +823,7 @@ export interface FileRoutesByTo {
   '/g/$guildId/projects/$projectId/settings': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   '/g/$guildId/queues/$queueId/settings': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
   '/g/$guildId/counter-groups/$groupId/counter/$counterId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
+  '/g/$guildId/initiatives/$initiativeId/apps/$appId': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -905,6 +916,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/projects_/$projectId_/settings': typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId_/settings': typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
   '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId_/counter_/$counterId': typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
+  '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/apps_/$appId': typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -996,6 +1008,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/projects/$projectId/settings'
     | '/g/$guildId/queues/$queueId/settings'
     | '/g/$guildId/counter-groups/$groupId/counter/$counterId'
+    | '/g/$guildId/initiatives/$initiativeId/apps/$appId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -1080,6 +1093,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/projects/$projectId/settings'
     | '/g/$guildId/queues/$queueId/settings'
     | '/g/$guildId/counter-groups/$groupId/counter/$counterId'
+    | '/g/$guildId/initiatives/$initiativeId/apps/$appId'
   id:
     | '__root__'
     | '/_serverRequired'
@@ -1171,6 +1185,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/projects_/$projectId_/settings'
     | '/_serverRequired/_authenticated/g/$guildId/queues_/$queueId_/settings'
     | '/_serverRequired/_authenticated/g/$guildId/counter-groups_/$groupId_/counter_/$counterId'
+    | '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/apps_/$appId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1803,6 +1818,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
     }
+    '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/apps_/$appId': {
+      id: '/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/apps_/$appId'
+      path: '/initiatives/$initiativeId/apps/$appId'
+      fullPath: '/g/$guildId/initiatives/$initiativeId/apps/$appId'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedGGuildIdRoute
+    }
   }
 }
 
@@ -1994,6 +2016,7 @@ interface ServerRequiredAuthenticatedGGuildIdRouteChildren {
   ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdProjectsProjectIdSettingsRoute
   ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute: typeof ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute
   ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute: typeof ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute
+  ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute: typeof ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute
 }
 
 const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthenticatedGGuildIdRouteChildren =
@@ -2060,6 +2083,8 @@ const ServerRequiredAuthenticatedGGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedGGuildIdQueuesQueueIdSettingsRoute,
     ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute:
       ServerRequiredAuthenticatedGGuildIdCounterGroupsGroupIdCounterCounterIdRoute,
+    ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute:
+      ServerRequiredAuthenticatedGGuildIdInitiativesInitiativeIdAppsAppIdRoute,
   }
 
 const ServerRequiredAuthenticatedGGuildIdRouteWithChildren =

--- a/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/initiatives_.$initiativeId_.apps_.$appId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/g/$guildId/initiatives_.$initiativeId_.apps_.$appId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+  "/_serverRequired/_authenticated/g/$guildId/initiatives_/$initiativeId_/apps_/$appId"
+)({
+  component: lazyRouteComponent(() =>
+    import("@/pages/apps/GuildAppRoute").then((m) => ({
+      default: m.InitiativeAppRoute,
+    }))
+  ),
+});


### PR DESCRIPTION
Phase 4 of initiative-scoped app surfaces, and the first one you can see. #1141 gave a surface a way to say it renders inside an initiative; #1144 gave it a route and a token that names which. Nothing rendered either.

Now an app offering an initiative surface takes a row in each initiative's sidebar section, and that row opens a page that mints through the initiative route — so the app is told which initiative it is being read in.

## What shows, and where

**Rows sit above the tool rows**, the same way the guild's apps sit above its initiatives — and because the tool rows end with projects, whose list has to expand directly beneath them.

**Standing is resolved per section**, not once for the sidebar. Managing one initiative says nothing about another, so each section asks about itself.

**The guild section now reads visibility too.** An app whose only guild-wide surface names the guild's admins doesn't take a row for a member, and the page offers only the tabs its reader can open. The mint settles the same question again under the caller's own session — this is about not pointing at a closed door.

## One test earned its keep

`appEmbeds` was honouring `isInitiativeManager` on a guild-wide read. The mint drops it there (guild-wide there is nothing to manage), so the sidebar would have offered a manager a row the server then refused. It now drops the flag itself rather than trusting each caller to omit it — the two readings can't drift.

`guildAppPath` and `appEmbeds` now require the reader as an argument, so a call site has to say who is looking instead of defaulting to everyone.

## Notable

- Frontend only — no backend change, no schema change, no migration.
- No new strings: rows use the app's own name, and the empty state reuses the existing `apps:embed.*` keys. Nothing to translate.
- New route `/g/$guildId/initiatives/$initiativeId/apps/$appId`; route tree regenerated.
- A tool-instance app gets no initiative row — the tool it mounted already lives in one.

## Not in this PR

The settings affordance on each app entry (design §5) and the admin's `placement` control (§4, the one schema change) are still to come. Without `placement`, an initiative surface shows in every initiative, which is the documented default.

## Testing

```
pnpm test:run    # 1455 passed
pnpm lint        # 9 warnings, same as dev
pnpm build       # clean
```

New coverage: the ladder against every reader shape; one declaration admitting managers inside an initiative and only admins guild-wide; a member offered neither an admin surface nor a manager one; an initiative-only surface kept off the guild page and vice versa; a tool-instance app given no initiative row; and on the page, that it offers only this scope's surfaces, mints through the route naming the initiative, and says so plainly when nothing here is for this reader.