### PR TITLE
Drop the legacy initiative role field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - An initiative that renamed its managing role, or gave a second role manager standing, now sees the manager affordances it should: the sidebar reads the role's manager flag rather than looking for the built-in role by name.
+- Pinning follows the same rule: a manager of an initiative can pin and unpin its projects whatever their role is called.
 
 ## [0.62.2] - 2026-08-13
 

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -853,7 +853,7 @@ async def admin_update_initiative_member_role(
     new_role = await initiatives_service.get_role_by_name(
         session,
         initiative_id=initiative_id,
-        role_name=payload.role.value,
+        role_name=payload.role,
     )
     if not new_role:
         raise HTTPException(

--- a/backend/app/api/v1/platform_endpoints/admin_test.py
+++ b/backend/app/api/v1/platform_endpoints/admin_test.py
@@ -459,3 +459,54 @@ async def test_admin_delete_guild_requires_blocked_user_id(
         f"/api/v1/admin/guilds/{guild.id}", headers=get_auth_headers(operator)
     )
     assert resp.status_code == 422
+
+
+@pytest.mark.integration
+async def test_admin_initiative_role_update_takes_any_role_the_initiative_defines(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The role switch names a role of that initiative — custom ones included;
+    a name the initiative doesn't define is a 404."""
+    from app.core.messages import AdminMessages
+    from app.models.platform.guild import GuildRole
+
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    role_response = await client.post(
+        admin.g(f"/initiatives/{admin.initiative.id}/roles"),
+        headers=admin.headers,
+        json={"name": "leads", "display_name": "Leads", "is_manager": True},
+    )
+    assert role_response.status_code == 201, role_response.text
+
+    operator = await create_user(
+        session, email="op-initiative-role@example.com", role=UserRole.operator
+    )
+    url = (
+        f"/api/v1/admin/initiatives/{admin.initiative.id}"
+        f"/members/{member.user.id}/role?guild_id={admin.guild.id}"
+    )
+
+    resp = await client.patch(
+        url, headers=get_auth_headers(operator), json={"role": "leads"}
+    )
+    assert resp.status_code == 204, resp.text
+
+    roster = await client.get(
+        admin.g(f"/initiatives/{admin.initiative.id}"), headers=admin.headers
+    )
+    assert roster.status_code == 200, roster.text
+    row = next(m for m in roster.json()["members"] if m["user"]["id"] == member.user.id)
+    assert row["role_name"] == "leads"
+    assert row["is_manager"] is True
+
+    resp = await client.patch(
+        url, headers=get_auth_headers(operator), json={"role": "no_such_role"}
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == AdminMessages.ROLE_NOT_FOUND

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -147,7 +147,7 @@ async def test_create_initiative_makes_creator_manager(
     data = response.json()
     assert len(data["members"]) == 1
     assert data["members"][0]["user"]["id"] == admin.user.id
-    assert data["members"][0]["role"] == "project_manager"
+    assert data["members"][0]["role_name"] == "project_manager"
 
 
 @pytest.mark.integration
@@ -649,8 +649,44 @@ async def test_update_initiative_member_role(
 
     assert response.status_code == 200
     data = response.json()
-    member_roles = {m["user"]["id"]: m["role"] for m in data["members"]}
+    member_roles = {m["user"]["id"]: m["role_name"] for m in data["members"]}
     assert member_roles[member.user.id] == "project_manager"
+
+
+@pytest.mark.integration
+async def test_member_roster_reports_a_custom_role_as_itself(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A member's row carries the role they actually hold — its own name,
+    display name, and manager standing — for custom roles too."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+
+    role_response = await client.post(
+        admin.g(f"/initiatives/{admin.initiative.id}/roles"),
+        headers=admin.headers,
+        json={"name": "leads", "display_name": "Leads", "is_manager": True},
+    )
+    assert role_response.status_code == 201, role_response.text
+
+    response = await client.patch(
+        admin.g(f"/initiatives/{admin.initiative.id}/members/{member.user.id}"),
+        headers=admin.headers,
+        json={"role_id": role_response.json()["id"]},
+    )
+
+    assert response.status_code == 200
+    row = next(
+        m for m in response.json()["members"] if m["user"]["id"] == member.user.id
+    )
+    assert row["role_name"] == "leads"
+    assert row["role_display_name"] == "Leads"
+    assert row["is_manager"] is True
 
 
 @pytest.mark.integration
@@ -718,7 +754,7 @@ async def test_guild_admin_can_be_assigned_manager_role(
 
     assert response.status_code == 200
     data = response.json()
-    member_roles = {m["user"]["id"]: m["role"] for m in data["members"]}
+    member_roles = {m["user"]["id"]: m["role_name"] for m in data["members"]}
     assert member_roles[target_admin.user.id] == "project_manager"
 
 

--- a/backend/app/models/tenant/initiative.py
+++ b/backend/app/models/tenant/initiative.py
@@ -27,12 +27,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from app.models.tenant.counter import CounterGroup
 
 
-# Legacy enum kept for backwards compatibility during migration
-class InitiativeRole(str, Enum):
-    project_manager = "project_manager"
-    member = "member"
-
-
 # Permission keys for role-based access control — fully derived from the Tool
 # enum: one `{plural}_enabled` + `create_{plural}` pair per tool
 # (documents_enabled, create_documents, …, counter_groups_enabled,

--- a/backend/app/schemas/platform/admin.py
+++ b/backend/app/schemas/platform/admin.py
@@ -7,7 +7,6 @@ from pydantic import ConfigDict, Field
 from app.schemas.base import SanitizedBaseModel
 
 from app.models.platform.guild import GuildRole
-from app.models.tenant.initiative import InitiativeRole
 from app.models.platform.user import UserRole
 from app.schemas.platform.user import ProjectBasic, UserPublic
 
@@ -76,6 +75,10 @@ class AdminGuildRoleUpdate(SanitizedBaseModel):
 
 
 class AdminInitiativeRoleUpdate(SanitizedBaseModel):
-    """Schema for updating a user's initiative role via admin endpoint."""
+    """Schema for updating a user's initiative role via admin endpoint.
 
-    role: InitiativeRole
+    ``role`` is the name of a role defined in that initiative — built-in
+    (``project_manager``, ``member``) or custom.
+    """
+
+    role: str = Field(..., min_length=1, max_length=100)

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -6,7 +6,6 @@ from pydantic import ConfigDict, EmailStr, Field, computed_field
 from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 from app.core.capabilities import Capability, capabilities_for
-from app.models.tenant.initiative import InitiativeRole
 from app.models.platform.user import UserRole, UserStatus
 from app.core.config import settings
 
@@ -233,7 +232,8 @@ class UserRead(UserBase):
 class UserInitiativeRole(SanitizedBaseModel):
     initiative_id: int
     initiative_name: str
-    role: InitiativeRole
+    # The role's own name; ``None`` when the role it pointed at was deleted.
+    role: Optional[str] = None
 
 
 class UserSelfUpdate(SanitizedBaseModel):

--- a/backend/app/schemas/tenant/initiative.py
+++ b/backend/app/schemas/tenant/initiative.py
@@ -6,7 +6,7 @@ from pydantic import ConfigDict, Field, create_model
 from app.core.tools import CORE_TOOLS, TOGGLEABLE_TOOLS, Tool
 from app.schemas.base import RichTextStr, SanitizedBaseModel
 
-from app.models.tenant.initiative import InitiativeRole, PermissionKey
+from app.models.tenant.initiative import PermissionKey
 from app.schemas.platform.user import UserPublic
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -160,8 +160,6 @@ class InitiativeMemberRead(_MemberToolFlags):
     role_display_name: Optional[str] = None
     is_manager: bool = False
     joined_at: datetime
-    # Legacy field for backward compatibility
-    role: InitiativeRole = InitiativeRole.member
     oidc_managed: bool = False
 
 
@@ -244,13 +242,6 @@ def serialize_initiative(initiative: "Initiative") -> InitiativeRead:
         role_ref = getattr(membership, "role_ref", None)
         role_name = role_ref.name if role_ref else None
 
-        # Determine legacy role for backward compatibility
-        legacy_role = (
-            InitiativeRole.project_manager
-            if role_name == "project_manager"
-            else InitiativeRole.member
-        )
-
         members.append(
             InitiativeMemberRead(
                 user=UserPublic.model_validate(membership.user),
@@ -259,7 +250,6 @@ def serialize_initiative(initiative: "Initiative") -> InitiativeRead:
                 role_display_name=role_ref.display_name if role_ref else None,
                 is_manager=role_ref.is_manager if role_ref else False,
                 joined_at=membership.joined_at,
-                role=legacy_role,
                 oidc_managed=membership.oidc_managed,
                 **member_tool_flags(initiative, membership),
             )

--- a/backend/app/services/platform/csv_export.py
+++ b/backend/app/services/platform/csv_export.py
@@ -53,7 +53,6 @@ def format_initiative_roles(user: User) -> str:
     parts = []
     for entry in roles:
         name = getattr(entry, "initiative_name", None) or ""
-        role = getattr(entry, "role", "")
-        role_value = role.value if hasattr(role, "value") else role
-        parts.append(f"{name}: {role_value}")
+        role = getattr(entry, "role", None) or ""
+        parts.append(f"{name}: {role}" if role else name)
     return "; ".join(parts)

--- a/backend/app/services/tenant/initiatives.py
+++ b/backend/app/services/tenant/initiatives.py
@@ -13,7 +13,6 @@ from app.core.messages import InitiativeMessages
 from app.models.tenant.initiative import (
     Initiative,
     InitiativeMember,
-    InitiativeRole,
     InitiativeRoleModel,
     InitiativeRolePermission,
     BUILTIN_ROLE_PERMISSIONS,
@@ -197,17 +196,11 @@ async def load_user_initiative_roles(
         user_id: [] for user_id in user_ids
     }
     for user_id, role_name, initiative_id, initiative_name in result.all():
-        # Convert role_name to legacy enum for backward compatibility
-        legacy_role = (
-            InitiativeRole.project_manager
-            if role_name == "project_manager"
-            else InitiativeRole.member
-        )
         assignments.setdefault(user_id, []).append(
             UserInitiativeRole(
                 initiative_id=initiative_id,
                 initiative_name=initiative_name,
-                role=legacy_role,
+                role=role_name,
             )
         )
     for user in users:

--- a/frontend/src/__tests__/factories/initiative.factory.ts
+++ b/frontend/src/__tests__/factories/initiative.factory.ts
@@ -14,7 +14,6 @@ export function buildInitiativeMember(
   counter++;
   return {
     user: buildUserPublic(),
-    role: "member",
     role_id: null,
     role_name: null,
     role_display_name: null,

--- a/frontend/src/api/generated/apps/apps.ts
+++ b/frontend/src/api/generated/apps/apps.ts
@@ -2245,12 +2245,10 @@ export const useRevokeAllMemberConnectionsApiV1GGuildIdAppsAppIdRevokeAllPost = 
  * but the surface is being opened somewhere narrower, and the token says so.
  *
  * Three gates, outermost first. The initiative must be one this caller can
- * reach at all, which the routed session answers: a member of another
- * initiative simply does not see the row. The manifest must declare the
- * surface for this scope. And the surface's ``visibility`` is then read
- * *here*, where ``member`` means this initiative's members and
- * ``initiative_manager`` means its managers — a guild admin clears both, as
- * they do everywhere in their own guild.
+ * reach. The manifest must declare the surface for this scope. And the
+ * surface's ``visibility`` is then read *here*, where ``member`` means this
+ * initiative's members and ``initiative_manager`` means its managers — a
+ * guild admin clears both, as they do everywhere in their own guild.
  *
  * The initiative in the minted token is this route's, never the caller's to
  * supply, so an app can scope what it shows without asking a second question

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -295,18 +295,18 @@ export interface AdminGuildRoleUpdate {
   role: GuildRole;
 }
 
-export type InitiativeRole = (typeof InitiativeRole)[keyof typeof InitiativeRole];
-
-export const InitiativeRole = {
-  project_manager: "project_manager",
-  member: "member",
-} as const;
-
 /**
  * Schema for updating a user's initiative role via admin endpoint.
+ *
+ * ``role`` is the name of a role defined in that initiative — built-in
+ * (``project_manager``, ``member``) or custom.
  */
 export interface AdminInitiativeRoleUpdate {
-  role: InitiativeRole;
+  /**
+   * @minLength 1
+   * @maxLength 100
+   */
+  role: string;
 }
 
 export type AdminUserDeleteRequestAction =
@@ -1665,7 +1665,6 @@ export interface InitiativeMemberRead {
   role_display_name: string | null;
   is_manager: boolean;
   joined_at: string;
-  role: InitiativeRole;
   oidc_managed: boolean;
 }
 
@@ -4215,7 +4214,7 @@ export interface UserCreate {
 export interface UserInitiativeRole {
   initiative_id: number;
   initiative_name: string;
-  role: InitiativeRole;
+  role?: string | null;
 }
 
 /**

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
@@ -59,7 +59,7 @@ type DisplayMember = {
   user: { id: number; full_name: string | null; email: string };
   role_id: number | null;
   role_display_name: string | null;
-  role: string;
+  role_name: string | null;
   oidc_managed: boolean;
   isGuildAdmin: boolean;
   // Whether this row holds a manager (project manager) initiative role.
@@ -122,7 +122,7 @@ export const InitiativeSettingsMembersTab = ({
       },
       role_id: member.role_id ?? null,
       role_display_name: member.role_display_name ?? null,
-      role: member.role,
+      role_name: member.role_name ?? null,
       oidc_managed: member.oidc_managed,
       isGuildAdmin: adminUserIds.has(member.user.id),
       isManager: member.is_manager ?? false,
@@ -142,7 +142,7 @@ export const InitiativeSettingsMembersTab = ({
         },
         role_id: null,
         role_display_name: null,
-        role: "member",
+        role_name: null,
         oidc_managed: false,
         isGuildAdmin: true,
         isManager: false,
@@ -245,8 +245,8 @@ export const InitiativeSettingsMembersTab = ({
       if (member.role_display_name) {
         return member.role_display_name;
       }
-      const roleFromList = roles?.find((role) => role.name === member.role)?.display_name;
-      return roleFromList ?? member.role;
+      const roleFromList = roles?.find((role) => role.name === member.role_name)?.display_name;
+      return roleFromList ?? member.role_name ?? "";
     };
 
     const adminMutationPending = addMember.isPending || removeMember.isPending;
@@ -286,7 +286,7 @@ export const InitiativeSettingsMembersTab = ({
         },
       },
       {
-        accessorKey: "role",
+        accessorKey: "role_name",
         header: t("settings.roleColumn"),
         cell: ({ row }) => {
           const member = row.original;

--- a/frontend/src/components/projects/ProjectPreview.test.ts
+++ b/frontend/src/components/projects/ProjectPreview.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInitiative,
+  buildInitiativeMember,
+  buildProject,
+  buildUserPublic,
+} from "@/__tests__/factories";
+import type { InitiativeMemberRead } from "@/api/generated/initiativeAPI.schemas";
+import { canPinProject } from "@/components/projects/ProjectPreview";
+
+const USER_ID = 7;
+
+/** A project whose initiative has this user holding the given role. */
+const projectWithRole = (role: Partial<InitiativeMemberRead>) =>
+  buildProject({
+    initiative: buildInitiative({
+      members: [buildInitiativeMember({ user: buildUserPublic({ id: USER_ID }), ...role })],
+    }),
+  });
+
+describe("canPinProject", () => {
+  it("counts the built-in managing role", () => {
+    const project = projectWithRole({ role_name: "project_manager", is_manager: true });
+    expect(canPinProject(project, USER_ID)).toBe(true);
+  });
+
+  it("counts a managing role the initiative named itself", () => {
+    // The flag is what the server reads, not the role's name: an initiative
+    // that renamed its managers, or added a second managing role, still has
+    // managers here.
+    const project = projectWithRole({
+      role_name: "lead",
+      role_display_name: "Lead",
+      is_manager: true,
+    });
+    expect(canPinProject(project, USER_ID)).toBe(true);
+  });
+
+  it("does not count an ordinary member", () => {
+    const project = projectWithRole({ role_name: "member", is_manager: false });
+    expect(canPinProject(project, USER_ID)).toBe(false);
+  });
+
+  it("counts a guild admin, member row or not", () => {
+    const project = buildProject({ initiative: buildInitiative({ members: [] }) });
+    expect(canPinProject(project, USER_ID, "admin")).toBe(true);
+  });
+
+  it("counts nobody when signed out", () => {
+    const project = projectWithRole({ is_manager: true });
+    expect(canPinProject(project, undefined, "admin")).toBe(false);
+  });
+});

--- a/frontend/src/components/projects/ProjectPreview.tsx
+++ b/frontend/src/components/projects/ProjectPreview.tsx
@@ -23,20 +23,25 @@ interface ProjectLinkProps {
 
 /**
  * Check if the user can pin/unpin a project.
- * Only guild admins and initiative project managers can pin projects.
+ * Only guild admins and initiative managers can pin projects.
  */
-const canPinProject = (project: ProjectRead, userId?: number, guildRole?: GuildRole): boolean => {
+export const canPinProject = (
+  project: ProjectRead,
+  userId?: number,
+  guildRole?: GuildRole
+): boolean => {
   if (!userId) return false;
 
   // Guild admins can always pin
   if (guildRole === "admin") return true;
 
-  // Check if user is initiative PM for this project's initiative
+  // Manager standing in this project's initiative — `is_manager` is the flag
+  // the role carries, so a renamed or additional managing role counts.
   const initiative = project.initiative;
   if (!initiative?.members) return false;
 
   const membership = initiative.members.find((m) => m.user.id === userId);
-  return membership?.role === "project_manager";
+  return Boolean(membership?.is_manager);
 };
 
 export const ProjectCardLink = ({ project, dragHandleProps, userId }: ProjectLinkProps) => {

--- a/frontend/src/hooks/useInitiativeAccess.test.ts
+++ b/frontend/src/hooks/useInitiativeAccess.test.ts
@@ -177,7 +177,6 @@ describe("useInitiativeAccess canManage", () => {
     const user = buildUser();
     asMember(user);
     const initiative = withRole(user, {
-      role: "project_manager",
       role_name: "project_manager",
       is_manager: true,
     });
@@ -188,12 +187,10 @@ describe("useInitiativeAccess canManage", () => {
 
   it("counts a managing role the initiative named itself", () => {
     // An initiative that renamed its managers, or added a second managing
-    // role: the flag is what the server reads, and the legacy `role` field
-    // reports `member` for anything but the built-in name.
+    // role: the flag is what the server reads, not the role's name.
     const user = buildUser();
     asMember(user);
     const initiative = withRole(user, {
-      role: "member",
       role_name: "lead",
       role_display_name: "Lead",
       is_manager: true,

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -198,11 +198,9 @@ export function useInitiativeAccess() {
   /** Whether the user can manage (PM/admin) a specific initiative. A grant
    * never confers management — those operations are owner/PM-gated.
    *
-   * Read off `is_manager`, the flag an initiative role actually carries, rather
-   * than the legacy `role` field — which reports `project_manager` only for the
-   * built-in role of that name. An initiative that renamed its managers, or
-   * added a second managing role, has members the server treats as managers and
-   * this would not. */
+   * Read off `is_manager`, the flag an initiative role actually carries, so an
+   * initiative that renamed its managers or added a second managing role counts
+   * the same members the server does. */
   const canManage = useCallback(
     (initiative: InitiativeRead): boolean => {
       if (isGuildAdmin) return true;

--- a/frontend/src/pages/InitiativeDetailPage.tsx
+++ b/frontend/src/pages/InitiativeDetailPage.tsx
@@ -71,7 +71,7 @@ export const InitiativeDetailPage = () => {
       : null;
   const isGuildAdmin = activeGuild?.role === "admin";
   const membership = initiative?.members.find((member) => member.user.id === user?.id) ?? null;
-  const isInitiativeManager = membership?.is_manager || membership?.role === "project_manager";
+  const isInitiativeManager = Boolean(membership?.is_manager);
   const canManageInitiative = Boolean(isGuildAdmin || isInitiativeManager);
 
   // A tool's tab renders when its permission allows viewing it (the backend
@@ -93,13 +93,11 @@ export const InitiativeDetailPage = () => {
 
   const memberCount = initiative?.members.length ?? 0;
 
-  const roleBadgeLabel = permissions?.role_display_name
-    ? permissions.role_display_name
-    : membership
-      ? (membership.role_display_name ?? membership.role)
-      : isGuildAdmin
-        ? guildAdminLabel
-        : null;
+  const roleBadgeLabel =
+    permissions?.role_display_name ??
+    membership?.role_display_name ??
+    membership?.role_name ??
+    (isGuildAdmin ? guildAdminLabel : null);
 
   if (!hasValidInitiativeId) {
     return <Navigate to="/initiatives" replace />;

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -64,8 +64,7 @@ export const InitiativeSettingsPage = () => {
 
   const isGuildAdmin = activeGuild?.role === "admin";
   const initiativeMembership = initiative?.members.find((member) => member.user.id === user?.id);
-  const isInitiativeManager =
-    initiativeMembership?.is_manager || initiativeMembership?.role === "project_manager";
+  const isInitiativeManager = Boolean(initiativeMembership?.is_manager);
   const canManageMembers = Boolean(isGuildAdmin || isInitiativeManager);
   const canDeleteInitiative = Boolean(isGuildAdmin);
 

--- a/frontend/src/pages/InitiativesPage.tsx
+++ b/frontend/src/pages/InitiativesPage.tsx
@@ -150,8 +150,8 @@ export const InitiativesPage = () => {
 
   const renderMembershipBadge = (initiative: InitiativeRead) => {
     const membership = initiative.members.find((member) => member.user.id === user?.id);
-    if (membership) {
-      const roleLabel = membership.role_display_name ?? membership.role;
+    const roleLabel = membership?.role_display_name ?? membership?.role_name;
+    if (roleLabel) {
       return <Badge variant="secondary">{roleLabel}</Badge>;
     }
     if (isGuildAdmin) {


### PR DESCRIPTION
## Problem

`InitiativeRole` was a migration-era compatibility shim: every member payload
carried a `role` of `project_manager` or `member`, derived from the role's
*name*. Initiative roles have carried their own `is_manager` flag for a long
time, and a custom role can hold manager standing under any name — so the
derived field reported `member` for members the server treats as managers, and
anything reading it disagreed with the backend.

The sidebar's `canManage` was fixed on its own in #1145. This removes the field
that made the mistake possible, and sweeps the callers that still read it.

## Changes

**Backend — the enum and everything that fed it are gone**

- [initiative.py](backend/app/models/tenant/initiative.py) — `InitiativeRole` deleted.
- [initiative.py](backend/app/schemas/tenant/initiative.py) — `InitiativeMemberRead.role` dropped, along with the `legacy_role` computation in `serialize_initiative`. `role_name`, `role_display_name` and `is_manager` already carry the truth.
- [user.py](backend/app/schemas/platform/user.py) — `UserInitiativeRole.role` now reports the role's own name (`Optional[str]`, `None` once the role it pointed at is deleted), so the guild CSV export names a custom role instead of flattening it to `member`.
- [admin.py](backend/app/schemas/platform/admin.py) — `AdminInitiativeRoleUpdate.role` is a role *name*, so the platform admin role switch reaches any role the initiative defines. Previously anything but the two built-ins was a 422; an undefined name is now a 404 (`ROLE_NOT_FOUND`), which the endpoint already returned.

**Frontend — five remaining name checks now read `is_manager`**

- [ProjectPreview.tsx](frontend/src/components/projects/ProjectPreview.tsx) — project pinning. A manager whose role is named anything else could not pin; `canPinProject` is exported so it can be tested directly.
- [InitiativeDetailPage.tsx](frontend/src/pages/InitiativeDetailPage.tsx), [InitiativeSettingsPage.tsx](frontend/src/pages/InitiativeSettingsPage.tsx) — manager gating, plus badge labels falling back to `role_name`.
- [InitiativesPage.tsx](frontend/src/pages/InitiativesPage.tsx), [InitiativeSettingsMembersTab.tsx](frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx) — role labels off `role_name`; the members table's row shape follows.

**Generated types** — regenerated per `CLAUDE.md`. This also picks up a
docstring hunk in [apps.ts](frontend/src/api/generated/apps/apps.ts): a
`guild_apps.py` docstring landed on `dev` without a regeneration, so the
committed output was already stale.

## Testing

- `pytest app/api/v1/tenant_endpoints/initiatives_test.py app/api/v1/platform_endpoints/admin_test.py app/services/platform/csv_export_test.py` — 61 passed. Three new cases: the roster reports a custom role as itself, and the admin switch takes a custom role name / 404s an undefined one.
- `pnpm vitest run src/components/projects/ProjectPreview.test.ts src/hooks/useInitiativeAccess.test.ts` — 22 passed. Five new cases on `canPinProject`; the custom-manager one fails if the name check comes back.
- `pnpm typecheck` — clean. `pnpm lint` — 9 pre-existing `noUnusedImports` warnings, unchanged from `dev`.
- `ruff check app` / `ruff format app` — clean.