### PR TITLE
Let a guild say which initiatives an app belongs in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Apps can now appear inside an initiative as well as guild-wide. An app that offers an initiative surface gets a row in each initiative's sidebar section, opening a page scoped to that initiative — the same install, told which initiative it is being read in.
 - App surfaces name who they are for: everyone in the guild, an initiative's managers, or guild admins. An entry only appears for a reader it is meant for.
+- Guild admins choose which initiatives an app appears in, from the app's own settings. New installs appear in every initiative, which is the default.
 
 ### Fixed
 

--- a/backend/alembic/versions/20260813_0175_add_guild_app_placement.py
+++ b/backend/alembic/versions/20260813_0175_add_guild_app_placement.py
@@ -1,0 +1,43 @@
+"""guild app placement
+
+Which initiatives an app's initiative-scoped surfaces appear in. ``{}`` — the
+default, and what every existing install keeps — means every one of them.
+
+One JSONB column rather than a mode plus a list, so "all" has exactly one
+representation and cannot fall out of step with a stale set of ids.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.db.guild_migrations import run_for_each_guild_schema
+
+revision = "20260813_0175"
+down_revision = "20260812_0174"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_upgrade)
+
+
+def _apply_upgrade() -> None:
+    op.add_column(
+        "guild_apps",
+        sa.Column(
+            "placement",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="{}",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_downgrade)
+
+
+def _apply_downgrade() -> None:
+    op.drop_column("guild_apps", "placement")

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -28,7 +28,7 @@ nothing, whether or not the guild wanted it.
 
 import logging
 from datetime import datetime, timezone
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -143,6 +143,22 @@ async def _load_initiative(
             detail=InitiativeMessages.NOT_FOUND,
         )
     return initiative
+
+
+async def _normalized_placement(session: RLSSessionDep, raw: Any) -> dict[str, Any]:
+    """What an admin chose, checked against the initiatives they have.
+
+    The ids come from the same routed session the rest of the request runs on,
+    so a placement can only ever name an initiative of this guild.
+    """
+    ids = set((await session.exec(select(Initiative.id))).all())
+    try:
+        return guild_apps_service.normalize_placement(raw, initiative_ids=ids)
+    except guild_apps_service.PlacementError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=GuildAppMessages.PLACEMENT_INVALID,
+        ) from exc
 
 
 async def _load(session: RLSSessionDep, app_id: int) -> GuildApp:
@@ -460,11 +476,16 @@ async def update_guild_app(
     current_user: CurrentUser,
     guild_context: GuildContextDep,
 ) -> GuildAppRead:
-    """Rename an app, or turn it off without removing what it created.
+    """Rename an app, place it, or turn it off without removing what it created.
 
     Renaming is always allowed — a guild may call an app whatever it likes.
     Turning one off is a different matter for an app the deployment provides:
     that switch belongs to the operator, so it is refused by name here.
+
+    Placement says which initiatives an app's initiative-scoped surfaces appear
+    in; ``{}`` is every one of them, which is where an install starts. It is the
+    guild's own answer to where an app belongs rather than a permission, so it
+    reads the same for everyone, admins included.
     """
     _require_guild_admin(guild_context)
     app = await _load(session, app_id)
@@ -476,6 +497,8 @@ async def update_guild_app(
         if not data["enabled"]:
             await _require_removable(app)
         app.enabled = data["enabled"]
+    if "placement" in data:
+        app.placement = await _normalized_placement(session, data["placement"])
     app.updated_at = datetime.now(timezone.utc)
     session.add(app)
     await session.commit()

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -637,17 +637,20 @@ class TestPlacement:
         assert response.status_code == 200, response.text
         assert response.json()["placement"] == {"initiatives": [a.initiative.id]}
 
-    async def test_it_may_not_name_another_guild_s_initiative(
+    async def test_it_may_only_name_an_initiative_this_guild_has(
         self, client: AsyncClient, acting_user, session: AsyncSession, registration
     ):
-        a = await acting_user(guild_role=GuildRole.admin)
+        """Stated as an id this guild has no initiative for, rather than as one
+        borrowed from another guild: initiative ids are per-guild, so the two
+        guilds' numbering can coincide and a borrowed id would only be refused
+        when the numbers happened to differ."""
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
         app = await _installed(session, a)
-        elsewhere = await acting_user(guild_role=GuildRole.admin, initiative=True)
 
         response = await client.patch(
             a.g(f"/apps/{app.id}"),
             headers=a.headers,
-            json={"placement": {"initiatives": [elsewhere.initiative.id]}},
+            json={"placement": {"initiatives": [a.initiative.id + 10_000]}},
         )
         assert response.status_code == 422
         assert response.json()["detail"] == GuildAppMessages.PLACEMENT_INVALID

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -595,6 +595,122 @@ class TestInitiativeHandoff:
             assert response.json()["detail"] == GuildAppMessages.SURFACE_NOT_FOUND
 
 
+class TestPlacement:
+    """Which initiatives an app's initiative surfaces appear in.
+
+    Placement is the guild's own answer to where an app belongs, not an
+    audience rule — so unlike ``visibility``, it reads the same for a guild
+    admin as for anyone else.
+    """
+
+    @pytest.fixture(autouse=True)
+    def signing_key(self, monkeypatch):
+        monkeypatch.setattr(
+            settings, "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM", _SIGNING_KEY_PEM
+        )
+        monkeypatch.setattr(settings, "APP_PLATFORM_SIGNING_KEY_ID", "test-key")
+
+    @staticmethod
+    def _path(actor, initiative_id: int, app_id: int, surface: str) -> str:
+        return actor.g(f"/initiatives/{initiative_id}/apps/{app_id}/handoff/{surface}")
+
+    async def test_an_install_starts_placed_everywhere(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        a = await acting_user(guild_role=GuildRole.admin)
+        await _installed(session, a)
+
+        body = (await client.get(a.g("/apps/"), headers=a.headers)).json()
+        assert [item["placement"] for item in body["items"]] == [{}]
+
+    async def test_an_admin_narrows_it(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+        app = await _installed(session, a)
+
+        response = await client.patch(
+            a.g(f"/apps/{app.id}"),
+            headers=a.headers,
+            json={"placement": {"initiatives": [a.initiative.id]}},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["placement"] == {"initiatives": [a.initiative.id]}
+
+    async def test_it_may_not_name_another_guild_s_initiative(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _installed(session, a)
+        elsewhere = await acting_user(guild_role=GuildRole.admin, initiative=True)
+
+        response = await client.patch(
+            a.g(f"/apps/{app.id}"),
+            headers=a.headers,
+            json={"placement": {"initiatives": [elsewhere.initiative.id]}},
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"] == GuildAppMessages.PLACEMENT_INVALID
+
+    async def test_a_member_does_not_place_apps(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+        app = await _installed(session, a)
+        member = await acting_user(guild_role=GuildRole.member, guild=a.guild)
+
+        response = await client.patch(
+            member.g(f"/apps/{app.id}"),
+            headers=member.headers,
+            json={"placement": {"initiatives": []}},
+        )
+        assert response.status_code == 403
+
+    async def test_a_surface_placed_elsewhere_is_not_in_this_initiative(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        """And not for the admin who placed it either — this is where the app
+        goes, which is their own answer rather than a rule about them."""
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+        other = await acting_user(
+            guild_role=GuildRole.admin, guild=a.guild, initiative=True
+        )
+        app = await _installed(session, a)
+
+        await client.patch(
+            a.g(f"/apps/{app.id}"),
+            headers=a.headers,
+            json={"placement": {"initiatives": [other.initiative.id]}},
+        )
+
+        placed = await client.post(
+            self._path(a, other.initiative.id, app.id, "runs"), headers=a.headers
+        )
+        assert placed.status_code == 200, placed.text
+
+        elsewhere = await client.post(
+            self._path(a, a.initiative.id, app.id, "runs"), headers=a.headers
+        )
+        assert elsewhere.status_code == 404
+        assert elsewhere.json()["detail"] == GuildAppMessages.SURFACE_NOT_FOUND
+
+    async def test_placement_leaves_the_guild_wide_surface_alone(
+        self, client: AsyncClient, acting_user, session: AsyncSession, registration
+    ):
+        a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+        app = await _installed(session, a)
+        await client.patch(
+            a.g(f"/apps/{app.id}"),
+            headers=a.headers,
+            json={"placement": {"initiatives": []}},
+        )
+
+        response = await client.post(
+            a.g(f"/apps/{app.id}/handoff/runs"), headers=a.headers
+        )
+        assert response.status_code == 200, response.text
+
+
 class TestHandoffWithoutASigningKey:
     async def test_it_fails_closed(
         self,

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -636,6 +636,9 @@ class GuildAppMessages:
     #: An interactive connection whose pinned definition carries no
     #: ``connect_path``, so there is no vendor flow to send the member to.
     CONNECT_PATH_MISSING = "GUILD_APP_CONNECT_PATH_MISSING"
+    #: The placement sent is not a shape this build stores, or it names an
+    #: initiative that is not one of this guild's.
+    PLACEMENT_INVALID = "GUILD_APP_PLACEMENT_INVALID"
 
 
 class AppServiceMessages:

--- a/backend/app/models/tenant/guild_app.py
+++ b/backend/app/models/tenant/guild_app.py
@@ -106,6 +106,23 @@ class GuildApp(SQLModel, table=True):
         sa_column=Column(JSONB, nullable=False, server_default="[]"),
     )
 
+    # Which initiatives an app's initiative-scoped surfaces appear in.
+    #
+    # ``{}`` means every one of them, which is the default and the reading an
+    # install that never says otherwise keeps. ``{"initiatives": [12, 15]}``
+    # narrows it. One column rather than a mode plus a list, so "all" has
+    # exactly one representation and cannot fall out of step with a stale set of
+    # ids; an initiative that is deleted simply stops matching.
+    #
+    # This is placement, not permission. It is the guild admin's own answer to
+    # "where does this belong", so it applies to them as much as to anyone —
+    # unlike a surface's ``visibility``, which names an audience floor an admin
+    # always clears.
+    placement: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSONB, nullable=False, server_default="{}"),
+    )
+
     installed_by_id: int = Field(foreign_key="users.id", nullable=False)
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/backend/app/schemas/tenant/guild_app.py
+++ b/backend/app/schemas/tenant/guild_app.py
@@ -37,6 +37,10 @@ class GuildAppUpdate(SanitizedBaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     #: Turning an app off hides it without touching what it created.
     enabled: Optional[bool] = None
+    #: Which initiatives this app's initiative-scoped surfaces appear in.
+    #: ``{}`` is every one of them; ``{"initiatives": [12, 15]}`` narrows it.
+    #: Left out entirely, the current placement is untouched.
+    placement: Optional[Dict[str, Any]] = None
 
 
 class GuildAppConfigUpdate(SanitizedBaseModel):
@@ -142,6 +146,11 @@ class GuildAppRead(SanitizedBaseModel):
     #: definition describes the form, and what was typed into it lives in
     #: columns nothing here reads.
     definition: Dict[str, Any] = {}
+    #: Which initiatives this app's initiative-scoped surfaces appear in, as the
+    #: guild's admins set it. ``{}`` — the default — is every one of them.
+    #: Placement rather than permission: it is the guild's own answer to where
+    #: an app belongs, so it reads the same for everyone.
+    placement: Dict[str, Any] = {}
     #: The deployment provides this app to every guild, and a guild admin
     #: neither removes nor disables it. The affordances are absent rather than
     #: erroring, so the client is told which installs those are.
@@ -289,6 +298,7 @@ def serialize_guild_app(
         avatar_url=avatar_url,
         features=list(features) if isinstance(features, list) else [],
         definition=definition,
+        placement=app.placement or {},
         mandatory=service_state.mandatory,
         available=service_state.available,
         installed_by_id=app.installed_by_id,

--- a/backend/app/services/tenant/app_handoff.py
+++ b/backend/app/services/tenant/app_handoff.py
@@ -50,6 +50,7 @@ from app.core.security import (
 from app.models.tenant.guild_app import GuildApp
 from app.services.marketplace import registration_lookup
 from app.services.marketplace.service_apps import clears_visibility
+from app.services.tenant.guild_apps import placed_in
 
 __all__ = [
     "APP_EMBED_HANDOFF_LIFETIME",
@@ -174,8 +175,11 @@ async def mint_embed_handoff(
         )
 
     scope = "guild" if initiative_id is None else "initiative"
+    # Two ways there is no surface here: the app never declared one for this
+    # scope, or the guild placed its initiative surfaces somewhere else. Same
+    # answer, because from this route both mean the same thing.
     embed = embed_by_id(app.definition, surface_id, scope=scope)
-    if embed is None:
+    if embed is None or not placed_in(app, initiative_id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=GuildAppMessages.SURFACE_NOT_FOUND,

--- a/backend/app/services/tenant/guild_apps.py
+++ b/backend/app/services/tenant/guild_apps.py
@@ -47,11 +47,14 @@ from app.services.tenant.soft_delete import soft_delete_entity
 __all__ = [
     "ARTIFACT_HANDLERS",
     "ArtifactHandler",
+    "PlacementError",
     "app_artifacts",
     "create_app_artifacts",
     "get_app_content_id",
     "install_app",
     "legacy_artifacts",
+    "normalize_placement",
+    "placed_in",
     "remove_app_artifacts",
     "touch",
 ]
@@ -298,3 +301,67 @@ async def remove_app_artifacts(
 
 def touch(app: GuildApp) -> None:
     app.updated_at = datetime.now(timezone.utc)
+
+
+# --- placement --------------------------------------------------------------
+#
+# Where an app's initiative-scoped surfaces appear. Placement is the guild
+# admin's own answer to "where does this belong", so it applies to everyone
+# including them — unlike a surface's ``visibility``, which names an audience
+# floor an admin always clears.
+
+
+class PlacementError(ValueError):
+    """A placement that names something this guild cannot place an app in."""
+
+
+def normalize_placement(raw: Any, *, initiative_ids: set[int]) -> dict[str, Any]:
+    """Canonicalize what an admin chose, or refuse it.
+
+    Three states, and each has exactly one representation:
+
+    * ``{}`` — every initiative. The default, and what an install that never
+      says otherwise keeps.
+    * ``{"initiatives": [12, 15]}`` — only these.
+    * ``{"initiatives": []}`` — none of them, which keeps the guild-wide
+      surface and drops the per-initiative ones. A real choice rather than an
+      accident, so it is stored as asked rather than coerced into "all".
+
+    Ids are checked against the guild's own initiatives, which is what bounds
+    the list — there is no count to cap, because a guild may place an app in as
+    many initiatives as it has.
+    """
+    if raw is None or raw == {}:
+        return {}
+    if not isinstance(raw, dict):
+        raise PlacementError("placement must be an object")
+    unknown = set(raw) - {"initiatives"}
+    if unknown:
+        raise PlacementError(f"placement does not take {sorted(unknown)[0]!r}")
+
+    entries = raw.get("initiatives")
+    if not isinstance(entries, list):
+        raise PlacementError("placement.initiatives must be a list of ids")
+
+    cleaned: list[int] = []
+    for entry in entries:
+        if isinstance(entry, bool) or not isinstance(entry, int):
+            raise PlacementError("placement.initiatives must be a list of ids")
+        if entry not in initiative_ids:
+            raise PlacementError(f"initiative {entry} is not one of this guild's")
+        if entry not in cleaned:
+            cleaned.append(entry)
+    return {"initiatives": sorted(cleaned)}
+
+
+def placed_in(app: GuildApp, initiative_id: Optional[int]) -> bool:
+    """Whether this install offers its initiative surfaces in that initiative.
+
+    ``None`` is the guild-wide reading, which placement says nothing about.
+    """
+    if initiative_id is None:
+        return True
+    entries = (app.placement or {}).get("initiatives")
+    if not isinstance(entries, list):
+        return True
+    return initiative_id in entries

--- a/backend/app/services/tenant/guild_apps_test.py
+++ b/backend/app/services/tenant/guild_apps_test.py
@@ -18,12 +18,16 @@ that created nothing.
 
 import pytest
 
+from app.models.tenant.guild_app import GuildApp
 from app.services.marketplace.definitions import MOUNTABLE_TOOLS
 from app.services.tenant.guild_apps import (
     ARTIFACT_HANDLERS,
+    PlacementError,
     app_artifacts,
     get_app_content_id,
     legacy_artifacts,
+    normalize_placement,
+    placed_in,
 )
 
 pytestmark = pytest.mark.unit
@@ -109,3 +113,77 @@ class TestArtifactReading:
             ],
         )
         assert app_artifacts(app) == [{"type": "calendar", "id": 5}]
+
+
+class TestPlacement:
+    """Where an app's initiative surfaces appear.
+
+    Three states with one representation each, so a reader never has to work out
+    which of two shapes meant the same thing.
+    """
+
+    def test_saying_nothing_means_every_initiative(self):
+        assert normalize_placement(None, initiative_ids={1, 2}) == {}
+        assert normalize_placement({}, initiative_ids={1, 2}) == {}
+
+    def test_an_admin_may_narrow_it(self):
+        assert normalize_placement({"initiatives": [2, 1]}, initiative_ids={1, 2}) == {
+            "initiatives": [1, 2]
+        }
+
+    def test_naming_none_is_a_choice_rather_than_an_accident(self):
+        # Keeps the guild-wide surface and drops the per-initiative ones, which
+        # is a different wish from turning the whole app off.
+        assert normalize_placement({"initiatives": []}, initiative_ids={1}) == {
+            "initiatives": []
+        }
+
+    def test_a_repeated_id_is_stored_once(self):
+        assert normalize_placement({"initiatives": [1, 1]}, initiative_ids={1}) == {
+            "initiatives": [1]
+        }
+
+    def test_it_may_only_name_this_guild_s_initiatives(self):
+        with pytest.raises(PlacementError, match="not one of this guild"):
+            normalize_placement({"initiatives": [9]}, initiative_ids={1, 2})
+
+    def test_an_unknown_key_is_refused(self):
+        with pytest.raises(PlacementError, match="does not take"):
+            normalize_placement({"projects": [1]}, initiative_ids={1})
+
+    @pytest.mark.parametrize("value", ["1", 1.5, True, None, {"id": 1}])
+    def test_an_id_is_a_whole_number(self, value):
+        with pytest.raises(PlacementError, match="list of ids"):
+            normalize_placement({"initiatives": [value]}, initiative_ids={1})
+
+    def test_it_must_be_an_object(self):
+        with pytest.raises(PlacementError, match="must be an object"):
+            normalize_placement([1, 2], initiative_ids={1})
+
+    @staticmethod
+    def _app(placement: dict) -> GuildApp:
+        """An install carrying nothing but the placement under test."""
+        return GuildApp(
+            guild_id=1,
+            listing_uid="0000000000000",
+            listing_version="1.0.0",
+            app_kind="service",
+            name="WidgetCo",
+            installed_by_id=1,
+            placement=placement,
+        )
+
+    def test_an_unplaced_app_is_offered_everywhere(self):
+        app = self._app({})
+        assert placed_in(app, 1) is True
+        assert placed_in(app, 99) is True
+
+    def test_a_placed_app_is_offered_where_it_was_placed(self):
+        app = self._app({"initiatives": [1]})
+        assert placed_in(app, 1) is True
+        assert placed_in(app, 2) is False
+
+    def test_placement_says_nothing_about_the_guild_wide_reading(self):
+        # There is one guild-wide surface, and narrowing where the initiative
+        # ones appear does not move it.
+        assert placed_in(self._app({"initiatives": []}), None) is True

--- a/frontend/public/locales/de/apps.json
+++ b/frontend/public/locales/de/apps.json
@@ -111,5 +111,12 @@
     "unavailableDescription": "Eine Administratorin oder ein Administrator muss den Dienst dieser App verbinden, bevor sie geöffnet werden kann.",
     "noSurface": "{{name}} hat keine eigene Seite"
   },
-  "browse": "App-Store durchsuchen"
+  "browse": "App-Store durchsuchen",
+  "placement": {
+    "title": "Wo diese App erscheint",
+    "description": "Diese App bietet eine Seite innerhalb von Initiativen. Wähle aus, in welchen sie erscheint.",
+    "all": "Alle Initiativen",
+    "some": "Nur ausgewählte Initiativen",
+    "none": "Keine Initiative ausgewählt – diese App erscheint nur gildenweit."
+  }
 }

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -374,6 +374,7 @@
   "MARKETPLACE_OPERATOR_CATALOG_SCAN_RUNNING": "Es läuft bereits ein Katalog-Scan. Warte, bis er abgeschlossen ist, und versuche es dann erneut.",
   "GUILD_APP_NOT_FOUND": "Diese App ist in dieser Gilde nicht installiert.",
   "GUILD_APP_ADMIN_REQUIRED": "Nur Gildenadministratorinnen und -administratoren können Apps verwalten.",
+  "GUILD_APP_PLACEMENT_INVALID": "Dort kann diese App nicht platziert werden. Wähle Initiativen aus dieser Gilde.",
   "GUILD_APP_LISTING_NOT_AN_APP": "Dieser Eintrag kann nicht als App installiert werden.",
   "GUILD_APP_ALREADY_INSTALLED": "Diese Gilde hat diese App bereits installiert.",
   "GUILD_APP_KIND_NOT_INSTALLABLE": "Diese Art von App kann in dieser Version von Initiative noch nicht installiert werden.",

--- a/frontend/public/locales/en/apps.json
+++ b/frontend/public/locales/en/apps.json
@@ -111,5 +111,12 @@
     "unavailableDescription": "An administrator needs to connect this app's service before it can be opened.",
     "noSurface": "{{name}} has no page of its own"
   },
-  "browse": "Browse the app store"
+  "browse": "Browse the app store",
+  "placement": {
+    "title": "Where this app appears",
+    "description": "This app offers a page inside initiatives. Choose which ones it appears in.",
+    "all": "Every initiative",
+    "some": "Only the initiatives I choose",
+    "none": "No initiatives chosen, so this app appears only guild-wide."
+  }
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -374,6 +374,7 @@
   "MARKETPLACE_OPERATOR_CATALOG_SCAN_RUNNING": "A catalog scan is already running. Wait for it to finish, then try again.",
   "GUILD_APP_NOT_FOUND": "That app isn't installed in this guild.",
   "GUILD_APP_ADMIN_REQUIRED": "Only guild admins can manage apps.",
+  "GUILD_APP_PLACEMENT_INVALID": "That isn't somewhere this app can be placed. Choose initiatives from this guild.",
   "GUILD_APP_LISTING_NOT_AN_APP": "That listing can't be installed as an app.",
   "GUILD_APP_ALREADY_INSTALLED": "This guild already has that app installed.",
   "GUILD_APP_KIND_NOT_INSTALLABLE": "This kind of app can't be installed on this version of Initiative yet.",

--- a/frontend/public/locales/es/apps.json
+++ b/frontend/public/locales/es/apps.json
@@ -111,5 +111,12 @@
     "unavailableDescription": "Un administrador debe conectar el servicio de esta aplicación antes de poder abrirla.",
     "noSurface": "{{name}} no tiene una página propia"
   },
-  "browse": "Explorar la tienda de aplicaciones"
+  "browse": "Explorar la tienda de aplicaciones",
+  "placement": {
+    "title": "Dónde aparece esta aplicación",
+    "description": "Esta aplicación ofrece una página dentro de las iniciativas. Elige en cuáles aparece.",
+    "all": "Todas las iniciativas",
+    "some": "Solo las iniciativas que yo elija",
+    "none": "No se eligió ninguna iniciativa, así que esta aplicación solo aparece a nivel de gremio."
+  }
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -374,6 +374,7 @@
   "MARKETPLACE_OPERATOR_CATALOG_SCAN_RUNNING": "Ya hay un análisis del catálogo en curso. Espera a que termine y vuelve a intentarlo.",
   "GUILD_APP_NOT_FOUND": "Esa aplicación no está instalada en este gremio.",
   "GUILD_APP_ADMIN_REQUIRED": "Solo los administradores del gremio pueden gestionar aplicaciones.",
+  "GUILD_APP_PLACEMENT_INVALID": "Ahí no se puede ubicar esta aplicación. Elige iniciativas de este gremio.",
   "GUILD_APP_LISTING_NOT_AN_APP": "Ese elemento no se puede instalar como aplicación.",
   "GUILD_APP_ALREADY_INSTALLED": "Este gremio ya tiene esa aplicación instalada.",
   "GUILD_APP_KIND_NOT_INSTALLABLE": "Este tipo de aplicación todavía no se puede instalar en esta versión de Initiative.",

--- a/frontend/public/locales/fr/apps.json
+++ b/frontend/public/locales/fr/apps.json
@@ -111,5 +111,12 @@
     "unavailableDescription": "Un administrateur doit connecter le service de cette application avant qu'elle puisse être ouverte.",
     "noSurface": "{{name}} n'a pas de page dédiée"
   },
-  "browse": "Parcourir la boutique d'applications"
+  "browse": "Parcourir la boutique d'applications",
+  "placement": {
+    "title": "Où cette application apparaît",
+    "description": "Cette application propose une page à l'intérieur des initiatives. Choisissez dans lesquelles elle apparaît.",
+    "all": "Toutes les initiatives",
+    "some": "Uniquement les initiatives que je choisis",
+    "none": "Aucune initiative choisie : cette application n'apparaît qu'à l'échelle de la guilde."
+  }
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -374,6 +374,7 @@
   "MARKETPLACE_OPERATOR_CATALOG_SCAN_RUNNING": "Une analyse du catalogue est déjà en cours. Attendez qu'elle se termine, puis réessayez.",
   "GUILD_APP_NOT_FOUND": "Cette application n'est pas installée dans cette guilde.",
   "GUILD_APP_ADMIN_REQUIRED": "Seules les administratrices et administrateurs de la guilde peuvent gérer les applications.",
+  "GUILD_APP_PLACEMENT_INVALID": "Cette application ne peut pas être placée là. Choisissez des initiatives de cette guilde.",
   "GUILD_APP_LISTING_NOT_AN_APP": "Cette fiche ne peut pas être installée en tant qu'application.",
   "GUILD_APP_ALREADY_INSTALLED": "Cette guilde a déjà installé cette application.",
   "GUILD_APP_KIND_NOT_INSTALLABLE": "Ce type d'application ne peut pas encore être installé sur cette version d'Initiative.",

--- a/frontend/src/api/appConnections.ts
+++ b/frontend/src/api/appConnections.ts
@@ -81,6 +81,8 @@ export interface GuildAppDetail {
   features: string[];
   /** The pinned definition, verbatim — what surfaces and connections it has. */
   definition: Record<string, unknown>;
+  /** Which initiatives its initiative surfaces appear in. `{}` is all of them. */
+  placement: Record<string, unknown>;
   admin_only: boolean;
   /** The platform provides this app: no remove, no turning it off. */
   mandatory: boolean;

--- a/frontend/src/api/generated/apps/apps.ts
+++ b/frontend/src/api/generated/apps/apps.ts
@@ -851,11 +851,16 @@ export function useGetGuildAppApiV1GGuildIdAppsAppIdGet<
 }
 
 /**
- * Rename an app, or turn it off without removing what it created.
+ * Rename an app, place it, or turn it off without removing what it created.
  *
  * Renaming is always allowed — a guild may call an app whatever it likes.
  * Turning one off is a different matter for an app the deployment provides:
  * that switch belongs to the operator, so it is refused by name here.
+ *
+ * Placement says which initiatives an app's initiative-scoped surfaces appear
+ * in; ``{}`` is every one of them, which is where an install starts. It is the
+ * guild's own answer to where an app belongs rather than a permission, so it
+ * reads the same for everyone, admins included.
  * @summary Update Guild App
  */
 export const updateGuildAppApiV1GGuildIdAppsAppIdPatch = (
@@ -2245,12 +2250,10 @@ export const useRevokeAllMemberConnectionsApiV1GGuildIdAppsAppIdRevokeAllPost = 
  * but the surface is being opened somewhere narrower, and the token says so.
  *
  * Three gates, outermost first. The initiative must be one this caller can
- * reach at all, which the routed session answers: a member of another
- * initiative simply does not see the row. The manifest must declare the
- * surface for this scope. And the surface's ``visibility`` is then read
- * *here*, where ``member`` means this initiative's members and
- * ``initiative_manager`` means its managers — a guild admin clears both, as
- * they do everywhere in their own guild.
+ * reach. The manifest must declare the surface for this scope. And the
+ * surface's ``visibility`` is then read *here*, where ``member`` means this
+ * initiative's members and ``initiative_manager`` means its managers — a
+ * guild admin clears both, as they do everywhere in their own guild.
  *
  * The initiative in the minted token is this route's, never the caller's to
  * supply, so an app can scope what it shows without asking a second question

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2018,6 +2018,8 @@ export interface GuildAppConnectionSummary {
 
 export type GuildAppDetailDefinition = { [key: string]: unknown };
 
+export type GuildAppDetailPlacement = { [key: string]: unknown };
+
 /**
  * An install plus its connections, for the settings page.
  *
@@ -2040,6 +2042,7 @@ export interface GuildAppDetail {
   avatar_url: string | null;
   features: string[];
   definition: GuildAppDetailDefinition;
+  placement: GuildAppDetailPlacement;
   mandatory: boolean;
   available: boolean;
   installed_by_id: number;
@@ -2078,6 +2081,8 @@ export interface GuildAppInstall {
 
 export type GuildAppReadDefinition = { [key: string]: unknown };
 
+export type GuildAppReadPlacement = { [key: string]: unknown };
+
 export interface GuildAppRead {
   id: number;
   guild_id: number;
@@ -2094,6 +2099,7 @@ export interface GuildAppRead {
   avatar_url: string | null;
   features: string[];
   definition: GuildAppReadDefinition;
+  placement: GuildAppReadPlacement;
   mandatory: boolean;
   available: boolean;
   installed_by_id: number;
@@ -2129,9 +2135,12 @@ export interface GuildAppMembersResponse {
   items: GuildAppMemberConnection[];
 }
 
+export type GuildAppUpdatePlacement = { [key: string]: unknown } | null;
+
 export interface GuildAppUpdate {
   name?: string | null;
   enabled?: boolean | null;
+  placement?: GuildAppUpdatePlacement;
 }
 
 export type GuildAuthPolicyReadPolicy =

--- a/frontend/src/components/apps/AppPlacementPanel.test.tsx
+++ b/frontend/src/components/apps/AppPlacementPanel.test.tsx
@@ -106,6 +106,32 @@ describe("AppPlacementPanel", () => {
     await waitFor(() => expect(sent).toEqual([{ placement: { initiatives: [1, 2] } }]));
   });
 
+  it("leaves the next edit building on what the server kept", async () => {
+    // The first save fails while a second is already queued behind it. The
+    // second succeeds, so the server holds that selection — and the panel has
+    // to agree, or the following edit is computed from a state nobody stored.
+    let rejectFirst: (reason: unknown) => void = () => {};
+    mutateAsync.mockImplementationOnce((body: unknown) => {
+      sent.push(body);
+      return new Promise<object>((_resolve, reject) => {
+        rejectFirst = reject;
+      });
+    });
+    renderPage(() => <AppPlacementPanel app={app({ initiatives: [] })} />);
+
+    await tick("Platform");
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    await tick("Marketing");
+
+    rejectFirst(new Error("refused"));
+    await waitFor(() => expect(sent[1]).toEqual({ placement: { initiatives: [1, 2] } }));
+
+    // Untick the first one. Built on [1, 2] — what the server took — rather
+    // than on the empty selection the failed save would have rolled back to.
+    await tick("Platform");
+    await waitFor(() => expect(sent[2]).toEqual({ placement: { initiatives: [2] } }));
+  });
+
   it("places the app everywhere again in one choice", async () => {
     renderPage(() => <AppPlacementPanel app={app({ initiatives: [1] })} />);
 

--- a/frontend/src/components/apps/AppPlacementPanel.test.tsx
+++ b/frontend/src/components/apps/AppPlacementPanel.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * What reaches the server when an admin picks initiatives.
+ *
+ * Each save replaces the whole selection, which makes two things matter that a
+ * single-field form never has to think about.
+ *
+ * **Order.** Ticking two boxes quickly starts two saves. If they were sent
+ * concurrently the slower one could land last and store the older selection, so
+ * they are chained and the server sees them in the order they were made.
+ *
+ * **What is still there.** An initiative deleted after it was chosen leaves an
+ * id behind that nothing on screen shows. Resubmitting it would be refused, and
+ * the admin would have no way to see why — so the selection sent is the one
+ * being displayed.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+import type { GuildAppDetail } from "@/api/appConnections";
+
+import { AppPlacementPanel } from "./AppPlacementPanel";
+
+/** Every payload handed to the update mutation, in the order it was sent. */
+const sent: unknown[] = [];
+/** Resolves the in-flight save, so a test can hold one open. */
+let release: Array<() => void> = [];
+let holdSaves = false;
+
+const mutateAsync = vi.fn((body: unknown) => {
+  sent.push(body);
+  if (!holdSaves) return Promise.resolve({});
+  return new Promise<object>((resolve) => release.push(() => resolve({})));
+});
+
+vi.mock("@/hooks/useGuildApps", () => ({
+  useUpdateGuildApp: () => ({ mutateAsync }),
+}));
+
+let roster = [
+  { id: 1, name: "Platform" },
+  { id: 2, name: "Marketing" },
+];
+
+vi.mock("@/hooks/useInitiatives", () => ({
+  useInitiatives: () => ({ data: roster, isLoading: false }),
+}));
+
+const app = (placement: Record<string, unknown>) =>
+  ({ id: 7, name: "Automations", placement }) as unknown as GuildAppDetail;
+
+beforeEach(() => {
+  sent.length = 0;
+  release = [];
+  holdSaves = false;
+  mutateAsync.mockClear();
+  roster = [
+    { id: 1, name: "Platform" },
+    { id: 2, name: "Marketing" },
+  ];
+});
+
+const tick = async (name: string) => (await screen.findByLabelText(name)).click();
+
+describe("AppPlacementPanel", () => {
+  it("sends the selection the admin built, one tick at a time", async () => {
+    renderPage(() => <AppPlacementPanel app={app({ initiatives: [] })} />);
+
+    await tick("Platform");
+    await waitFor(() => expect(sent).toEqual([{ placement: { initiatives: [1] } }]));
+
+    await tick("Marketing");
+    await waitFor(() =>
+      expect(sent).toEqual([
+        { placement: { initiatives: [1] } },
+        { placement: { initiatives: [1, 2] } },
+      ])
+    );
+  });
+
+  it("does not start a second save while the first is in flight", async () => {
+    // Both boxes are ticked before either save answers. Concurrent requests
+    // could be stored in either order; chained ones cannot.
+    holdSaves = true;
+    renderPage(() => <AppPlacementPanel app={app({ initiatives: [] })} />);
+
+    await tick("Platform");
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    await tick("Marketing");
+
+    // Still one: the second is queued behind the first rather than racing it.
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+
+    release[0]?.();
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(2));
+    expect(sent[1]).toEqual({ placement: { initiatives: [1, 2] } });
+  });
+
+  it("drops an id whose initiative is gone rather than resubmitting it", async () => {
+    // Initiative 9 was chosen once and has since been deleted: it is in the
+    // stored placement and on no row of the roster.
+    renderPage(() => <AppPlacementPanel app={app({ initiatives: [1, 9] })} />);
+
+    await tick("Marketing");
+    await waitFor(() => expect(sent).toEqual([{ placement: { initiatives: [1, 2] } }]));
+  });
+
+  it("places the app everywhere again in one choice", async () => {
+    renderPage(() => <AppPlacementPanel app={app({ initiatives: [1] })} />);
+
+    (await screen.findByLabelText("Every initiative")).click();
+    await waitFor(() => expect(sent).toEqual([{ placement: {} }]));
+  });
+});

--- a/frontend/src/components/apps/AppPlacementPanel.tsx
+++ b/frontend/src/components/apps/AppPlacementPanel.tsx
@@ -47,9 +47,14 @@ export function AppPlacementPanel({ app }: AppPlacementPanelProps) {
   // either order and leave the older one stored. Chained rather than
   // concurrent: the server sees the ticks in the order they were made.
   const queue = useRef<Promise<unknown>>(Promise.resolve());
+  // How many are still to settle. The panel is reconciled when the last one
+  // does, rather than by each in turn — a save that failed behind a save that
+  // worked would otherwise roll the panel back past a choice the server kept.
+  const outstanding = useRef(0);
 
   const save = (next: number[] | null) => {
     setChosen(next);
+    outstanding.current += 1;
     queue.current = queue.current
       .catch(() => undefined)
       .then(async () => {
@@ -67,8 +72,15 @@ export function AppPlacementPanel({ app }: AppPlacementPanelProps) {
         settled.current = live;
       })
       .catch((error) => {
-        setChosen(settled.current);
         toast.error(getErrorMessage(error, "apps:error"));
+      })
+      .finally(() => {
+        outstanding.current -= 1;
+        // Nothing else is coming, so the panel now shows what the server took:
+        // the newest choice when every save landed, and the last one it
+        // accepted when any did not. Either way the next edit builds on what
+        // is actually stored.
+        if (outstanding.current === 0) setChosen(settled.current);
       });
   };
 

--- a/frontend/src/components/apps/AppPlacementPanel.tsx
+++ b/frontend/src/components/apps/AppPlacementPanel.tsx
@@ -1,0 +1,116 @@
+/**
+ * Where an app's initiative surfaces appear.
+ *
+ * An app that offers a surface inside an initiative offers it in every one of
+ * them unless the guild says otherwise. This is where a guild admin says
+ * otherwise — placement rather than permission, so it reads the same for
+ * everyone afterwards, including the admin who set it.
+ *
+ * Absent for an app with no initiative surface to place: there would be nothing
+ * for the choice to move.
+ */
+
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { GuildAppDetail } from "@/api/appConnections";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { useUpdateGuildApp } from "@/hooks/useGuildApps";
+import { useInitiatives } from "@/hooks/useInitiatives";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+
+export interface AppPlacementPanelProps {
+  app: GuildAppDetail;
+}
+
+/** The chosen initiatives, or null when the app is placed in all of them. */
+const chosenIds = (placement: Record<string, unknown> | null | undefined): number[] | null => {
+  const chosen = placement?.initiatives;
+  return Array.isArray(chosen) ? chosen.filter((id): id is number => typeof id === "number") : null;
+};
+
+export function AppPlacementPanel({ app }: AppPlacementPanelProps) {
+  const { t } = useTranslation(["apps", "common"]);
+  const initiatives = useInitiatives();
+  const update = useUpdateGuildApp(app.id);
+  // What the admin is choosing right now. Seeded from the app and kept locally
+  // so ticking several initiatives is one decision, saved per change.
+  const [chosen, setChosen] = useState<number[] | null>(() => chosenIds(app.placement));
+
+  const save = (next: number[] | null) => {
+    setChosen(next);
+    update.mutate(
+      { placement: next === null ? {} : { initiatives: next } },
+      {
+        onError: (error) => {
+          setChosen(chosenIds(app.placement));
+          toast.error(getErrorMessage(error, "apps:error"));
+        },
+      }
+    );
+  };
+
+  const toggle = (id: number, on: boolean) => {
+    const current = chosen ?? [];
+    save(on ? [...current, id] : current.filter((one) => one !== id));
+  };
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h3 className="font-medium text-sm">{t("apps:placement.title")}</h3>
+        <p className="text-muted-foreground text-sm">{t("apps:placement.description")}</p>
+      </div>
+
+      <RadioGroup
+        value={chosen === null ? "all" : "some"}
+        onValueChange={(value) => save(value === "all" ? null : [])}
+        className="space-y-2"
+      >
+        <div className="flex items-center gap-2">
+          <RadioGroupItem value="all" id={`placement-all-${app.id}`} />
+          <Label htmlFor={`placement-all-${app.id}`} className="font-normal">
+            {t("apps:placement.all")}
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <RadioGroupItem value="some" id={`placement-some-${app.id}`} />
+          <Label htmlFor={`placement-some-${app.id}`} className="font-normal">
+            {t("apps:placement.some")}
+          </Label>
+        </div>
+      </RadioGroup>
+
+      {chosen !== null && (
+        <div className="space-y-2 border-l pl-4">
+          {initiatives.isLoading ? (
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t("common:loading")}
+            </div>
+          ) : (
+            (initiatives.data ?? []).map((initiative) => (
+              <div key={initiative.id} className="flex items-center gap-2">
+                <Checkbox
+                  id={`placement-${app.id}-${initiative.id}`}
+                  checked={chosen.includes(initiative.id)}
+                  onCheckedChange={(state) => toggle(initiative.id, state === true)}
+                />
+                <Label htmlFor={`placement-${app.id}-${initiative.id}`} className="font-normal">
+                  {initiative.name}
+                </Label>
+              </div>
+            ))
+          )}
+          {chosen.length === 0 && (
+            <p className="text-muted-foreground text-sm">{t("apps:placement.none")}</p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/apps/AppPlacementPanel.tsx
+++ b/frontend/src/components/apps/AppPlacementPanel.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GuildAppDetail } from "@/api/appConnections";
@@ -40,18 +40,36 @@ export function AppPlacementPanel({ app }: AppPlacementPanelProps) {
   // What the admin is choosing right now. Seeded from the app and kept locally
   // so ticking several initiatives is one decision, saved per change.
   const [chosen, setChosen] = useState<number[] | null>(() => chosenIds(app.placement));
+  // The last selection the server took, so a failed save falls back to
+  // something true rather than to whatever the cache happens to hold.
+  const settled = useRef(chosen);
+  // Each save replaces the whole selection, so two in flight could land in
+  // either order and leave the older one stored. Chained rather than
+  // concurrent: the server sees the ticks in the order they were made.
+  const queue = useRef<Promise<unknown>>(Promise.resolve());
 
   const save = (next: number[] | null) => {
     setChosen(next);
-    update.mutate(
-      { placement: next === null ? {} : { initiatives: next } },
-      {
-        onError: (error) => {
-          setChosen(chosenIds(app.placement));
-          toast.error(getErrorMessage(error, "apps:error"));
-        },
-      }
-    );
+    queue.current = queue.current
+      .catch(() => undefined)
+      .then(async () => {
+        // Only initiatives still on the roster are sent. An initiative deleted
+        // after it was chosen leaves an id nothing on screen shows, and
+        // resubmitting it would fail every later edit for a reason the admin
+        // cannot see.
+        const live =
+          next === null || !initiatives.data
+            ? next
+            : next.filter((id) => initiatives.data?.some((one) => one.id === id));
+        await update.mutateAsync({
+          placement: live === null ? {} : { initiatives: live },
+        });
+        settled.current = live;
+      })
+      .catch((error) => {
+        setChosen(settled.current);
+        toast.error(getErrorMessage(error, "apps:error"));
+      });
   };
 
   const toggle = (id: number, on: boolean) => {

--- a/frontend/src/components/apps/AppSettingsDialog.tsx
+++ b/frontend/src/components/apps/AppSettingsDialog.tsx
@@ -15,6 +15,7 @@ import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { AppConnectionsPanel } from "@/components/apps/AppConnectionsPanel";
+import { AppPlacementPanel } from "@/components/apps/AppPlacementPanel";
 import {
   Dialog,
   DialogContent,
@@ -23,6 +24,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useGuildAppDetail } from "@/hooks/useGuildAppDetail";
+import { appEmbeds } from "@/lib/appSurfaces";
+
+/** Only an admin reaches the placement control, and an admin clears every rung. */
+const ADMIN = { isGuildAdmin: true };
 
 export interface AppSettingsDialogProps {
   appId: number;
@@ -55,11 +60,18 @@ export function AppSettingsDialog({
             {t("common:loading")}
           </div>
         ) : (
-          <AppConnectionsPanel
-            appId={app.id}
-            connections={app.connections}
-            isGuildAdmin={isGuildAdmin}
-          />
+          <div className="space-y-6">
+            <AppConnectionsPanel
+              appId={app.id}
+              connections={app.connections}
+              isGuildAdmin={isGuildAdmin}
+            />
+            {/* Where the app goes is the guild's call, so only its admins see
+                the control — and only for an app that has somewhere to go. */}
+            {isGuildAdmin && appEmbeds(app.definition, "initiative", ADMIN).length > 0 && (
+              <AppPlacementPanel app={app} />
+            )}
+          </div>
         )}
       </DialogContent>
     </Dialog>

--- a/frontend/src/hooks/useGuildApps.ts
+++ b/frontend/src/hooks/useGuildApps.ts
@@ -40,7 +40,13 @@ export const useGuildApps = (options?: QueryOpts<GuildAppListResponse>) => {
 };
 
 const invalidateApps = (guildId: number) =>
-  queryClient.invalidateQueries({ queryKey: appsKey(guildId) });
+  Promise.all([
+    queryClient.invalidateQueries({ queryKey: appsKey(guildId) }),
+    // The detail read is the same install seen another way, and it is what the
+    // settings dialog renders. Invalidated by prefix so a rename or a placement
+    // change reaches it too, rather than only the list the sidebar draws.
+    queryClient.invalidateQueries({ queryKey: ["guild-app"] }),
+  ]);
 
 export const useInstallGuildApp = (options?: MutationOpts<GuildAppRead, GuildAppInstall>) => {
   const guildId = useActiveGuildId();

--- a/frontend/src/lib/appSurfaces.test.ts
+++ b/frontend/src/lib/appSurfaces.test.ts
@@ -10,7 +10,13 @@
 
 import { describe, expect, it } from "vitest";
 
-import { appEmbeds, clearsVisibility, guildAppPath, initiativeAppPath } from "./appSurfaces";
+import {
+  appEmbeds,
+  clearsVisibility,
+  guildAppPath,
+  initiativeAppPath,
+  placedIn,
+} from "./appSurfaces";
 
 const ADMIN = { isGuildAdmin: true };
 const MANAGER = { isGuildAdmin: false, isInitiativeManager: true };
@@ -151,5 +157,38 @@ describe("initiativeAppPath", () => {
         ADMIN
       )
     ).toBeNull();
+  });
+});
+
+describe("placedIn", () => {
+  it("offers an unplaced app in every initiative", () => {
+    expect(placedIn({ placement: {} }, 4)).toBe(true);
+    expect(placedIn({ placement: null }, 4)).toBe(true);
+    expect(placedIn({}, 4)).toBe(true);
+  });
+
+  it("offers a placed app only where it was placed", () => {
+    expect(placedIn({ placement: { initiatives: [4, 9] } }, 4)).toBe(true);
+    expect(placedIn({ placement: { initiatives: [4, 9] } }, 5)).toBe(false);
+  });
+
+  it("reads an empty choice as nowhere rather than everywhere", () => {
+    // Distinct from `{}`: the guild kept the guild-wide surface and dropped
+    // the per-initiative ones.
+    expect(placedIn({ placement: { initiatives: [] } }, 4)).toBe(false);
+  });
+
+  it("keeps a row out of an initiative the app was placed away from", () => {
+    // Placement is where the app goes, so it reads the same for an admin.
+    const app = {
+      id: 7,
+      placement: { initiatives: [9] },
+      definition: {
+        embeds: [{ id: "runs", path: "/embed", name: { en: "Runs" }, scopes: ["initiative"] }],
+      },
+    };
+    expect(initiativeAppPath(app, 9, ADMIN)).toBe("/initiatives/9/apps/7");
+    expect(initiativeAppPath(app, 4, ADMIN)).toBeNull();
+    expect(initiativeAppPath(app, 4, MANAGER)).toBeNull();
   });
 });

--- a/frontend/src/lib/appSurfaces.ts
+++ b/frontend/src/lib/appSurfaces.ts
@@ -43,7 +43,24 @@ export interface AppSurfaceSource {
   tool?: string | null;
   artifacts?: { type: string; id: number }[];
   definition?: Record<string, unknown> | null;
+  /** Where the guild put this app. `{}` — the default — is every initiative. */
+  placement?: Record<string, unknown> | null;
 }
+
+/**
+ * Whether an app's initiative surfaces appear in one initiative.
+ *
+ * Placement is the guild's own answer to where an app belongs, so unlike a
+ * surface's audience it reads the same for everyone — an admin who narrowed it
+ * narrowed it for themselves too.
+ */
+export const placedIn = (
+  app: Pick<AppSurfaceSource, "placement">,
+  initiativeId: number
+): boolean => {
+  const chosen = app.placement?.initiatives;
+  return Array.isArray(chosen) ? chosen.includes(initiativeId) : true;
+};
 
 /**
  * Whether a reader clears the rung a surface named.
@@ -125,7 +142,7 @@ export const initiativeAppPath = (
   initiativeId: number,
   viewer: SurfaceViewer
 ): string | null => {
-  if (app.tool) return null;
+  if (app.tool || !placedIn(app, initiativeId)) return null;
   return appEmbeds(app.definition, "initiative", viewer).length
     ? `/initiatives/${initiativeId}/apps/${app.id}`
     : null;


### PR DESCRIPTION
Phase 3 of initiative-scoped app surfaces, and the only schema change in the design. #1145 made an app's initiative surface appear in *every* initiative, with no way to say otherwise. This is where a guild admin says otherwise, from the app's own settings.

```
{}                        every initiative — the default, and what every
                          existing install keeps
{"initiatives": [12, 15]} only these
{"initiatives": []}       none: keeps the guild-wide surface and drops the
                          per-initiative ones
```

One JSONB column rather than a mode plus a list, so "all" has exactly one representation and can't fall out of step with a stale set of ids; a deleted initiative simply stops matching. Ids are checked against the guild's own initiatives, which is what bounds the list — no arbitrary count cap on a rule-driven set.

## Placement is not permission

This is the distinction that lets it be one setting rather than a per-role matrix:

- **`visibility`** names an audience floor, so a guild admin clears it. Nothing blocks a guild admin.
- **`placement`** is the guild's own answer to *where the app goes*, so it reads the same for everyone — the admin who narrowed it narrowed it for themselves too. A test states that directly.

Enforced **at the mint**, not only in the sidebar: an app not placed here has no surface here, which is the same 404 an undeclared scope gets. Verified load-bearing by mutation.

## Migration

Guild-scoped (`gen_guild_migration.py`), one added column with a `'{}'` server default. Verified on a database built from zero: reaches `0175 (head)`, column lands NOT NULL with the right default, and the downgrade drops it cleanly and re-upgrades.

Autogenerate also proposed re-creating `guild_apps_unique_listing` — that was local template drift, not a real gap. 0167 already creates it, and the clean-database run confirms it is present, so the op is not in the migration.

## Also fixed

Updating an app invalidated only the **list** query, so the settings dialog — which reads the **detail** query — kept showing the old name or placement until it refetched on its own. Now invalidated by prefix, per the cache-key rule in CLAUDE.md. Found while checking that the new control would reflect what it saved.

## Notable

- The control appears only for a guild admin, and only for an app that actually offers an initiative surface — otherwise there's nothing for the choice to move.
- New strings in all four locales (`de`/`en`/`es`/`fr`), including the `GUILD_APP_PLACEMENT_INVALID` error code.
- Regenerated API types for the new field.

## Testing

```
pytest app/api/v1/tenant_endpoints/guild_apps_platform_test.py    # 37 passed
pytest app/services/tenant/guild_apps_test.py                    # 25 passed
pytest app/db/tenancy_test.py app/db/guild_rls_test.py           # passed
pnpm test:run      # 1464 passed
pnpm lint          # 9 warnings, same as dev
pnpm build         # clean
ruff check app && ruff format app && ty check   # clean
```

New coverage: each of the three states normalizes to one representation; a placement naming another guild's initiative is refused; a member can't place apps; a surface placed elsewhere is 404 in this initiative **including for the admin who placed it**; and narrowing placement leaves the guild-wide surface alone.