### PR TITLE
Put the two new migrations back on one line

### DIFF
--- a/backend/alembic/versions/20260813_0176_app_service_embed_origin.py
+++ b/backend/alembic/versions/20260813_0176_app_service_embed_origin.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20260813_0176"
-down_revision = "20260812_0174"
+down_revision = "20260813_0175"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Problem

`dev` has two alembic heads:

```
$ alembic heads
20260813_0175 (head)
20260813_0176 (head)
```

`20260813_0175` (guild app placement, #1147) and `20260813_0176` (app service embed origin, #1148) were written on separate branches at the same time, both chained off `20260812_0174`, and both merged. `alembic upgrade head` now fails with "Multiple head revisions are present" — so a fresh install, a CI run that migrates, and any deployment off `dev` all stop there.

## Fix

`20260813_0176.down_revision` moves from `20260812_0174` to `20260813_0175`, putting them back in a line. One head again:

```
$ alembic heads
20260813_0176 (head)

$ alembic history | head -2
20260813_0175 -> 20260813_0176 (head), app service embed origin
20260812_0174 -> 20260813_0175, guild app placement
```

Editing the revision rather than adding a merge revision: both are unreleased (they landed on `dev` today and are still under `[Unreleased]`), so there is one correct chain to record rather than a permanent fork in the history.

The two are independent — `0176` adds a nullable column to `public.app_service_registrations`, `0175` adds one to `guild_apps` in every guild schema, and neither reads the other — so ordering them is free.

## Testing

```
cd backend && alembic heads          # one head
cd backend && alembic history        # 0174 -> 0175 -> 0176

# dropped the worker database first, so this migrates the whole chain from scratch
cd backend && PYTEST_XDIST_WORKER=headcheck pytest \
  app/services/marketplace/registrations_test.py \
  app/api/v1/platform_endpoints/app_services_test.py
# 48 passed
```

## For anyone with an existing local database

A database migrated off `dev` in the last few hours is stamped at whichever head it reached. If it is stamped `20260813_0176` but never ran `20260813_0175`, apply that one and re-stamp — or drop and recreate the local database, which is usually quicker.