### PR TITLE
Match widget type to the stats cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deleting a tool now names the thing being deleted, so the confirmation reads "Delete "Q3 Roadmap"?" instead of naming only its kind.
 - An app service can now be wired up with a separate browser address. Its base URL is where Initiative's own server calls the app, so it may be an address only your network resolves; the new browser address is where a member's browser loads that app's embedded surfaces and connection pages. Leave it blank — the default, and what every existing registration keeps — and one address serves both, exactly as before.
 - Guild admins choose which initiatives an app appears in, from the app's own settings. New installs appear in every initiative, which is the default.
+- **Dashboard widgets are set in the same type as the rest of the app.** A widget's headline number carries the weight the figures on My Stats do, and a number that reads as good, cautionary, or bad is the same green, yellow, or red wherever you meet it. Labels, captions, table headers, and chart axis ticks now sit at one legible size instead of shrinking a step per widget.
 
 ### Fixed
 

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
@@ -100,7 +100,7 @@ export function DashboardWidget({
 
   return (
     <section
-      className="flex h-full w-full flex-col overflow-hidden rounded-lg border bg-card"
+      className="flex h-full w-full flex-col overflow-hidden rounded-lg border bg-card text-card-foreground"
       aria-label={title}
     >
       <header
@@ -115,7 +115,7 @@ export function DashboardWidget({
         {canEdit && (
           <GripVertical className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
         )}
-        <h3 className="min-w-0 flex-1 truncate font-medium text-sm">{title}</h3>
+        <h3 className="min-w-0 flex-1 truncate font-semibold text-sm">{title}</h3>
         {canEdit && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
@@ -112,18 +112,18 @@ export function WidgetTile({
   if (chromeless) {
     // No label here: the canvas's own <section> already names this region, and
     // a second label on a plain div would only add noise for a screen reader.
-    return <div className={cn("h-full w-full", className)}>{body}</div>;
+    return <div className={cn("h-full w-full text-card-foreground", className)}>{body}</div>;
   }
 
   return (
     <section
       className={cn(
-        "flex h-full w-full flex-col overflow-hidden rounded-lg border bg-card p-3",
+        "flex h-full w-full flex-col overflow-hidden rounded-lg border bg-card p-3 text-card-foreground",
         className
       )}
       aria-label={title ?? type}
     >
-      {title && <h3 className="mb-2 shrink-0 truncate font-medium text-sm">{title}</h3>}
+      {title && <h3 className="mb-2 shrink-0 truncate font-semibold text-sm">{title}</h3>}
       <div className="min-h-0 flex-1">{body}</div>
     </section>
   );
@@ -137,13 +137,11 @@ function WidgetError({ code, detail }: { code: WidgetErrorCode; detail?: string 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-1 p-2 text-center">
       <AlertTriangle className="h-4 w-4 text-muted-foreground" aria-hidden />
-      <p className="text-muted-foreground text-xs">
+      <p className="text-muted-foreground text-sm">
         {t(`widgetError.${code}`, { defaultValue: t("widgetError.default") })}
       </p>
       {detail && (
-        <p className="max-w-full truncate font-mono text-[10px] text-muted-foreground/70">
-          {detail}
-        </p>
+        <p className="max-w-full truncate font-mono text-muted-foreground/70 text-xs">{detail}</p>
       )}
     </div>
   );

--- a/frontend/src/components/initiativeTools/dashboards/scene/MetricNode.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/MetricNode.tsx
@@ -11,10 +11,10 @@ type Node = Extract<SceneNode, { kind: "metric" }>;
  *  it wants treated as positive, because falling cycle time and falling revenue
  *  are the same arrow with opposite meanings. */
 const deltaTone = (delta: number, good: Node["deltaGood"]) => {
-  if (delta === 0) return "text-muted-foreground";
+  if (delta === 0) return toneTextClass("muted");
   const rising = delta > 0;
   const isGood = good === "down" ? !rising : rising;
-  return isGood ? "text-green-600 dark:text-green-400" : "text-destructive";
+  return toneTextClass(isGood ? "positive" : "negative");
 };
 
 export function MetricNode({ node }: { node: Node }) {
@@ -27,7 +27,7 @@ export function MetricNode({ node }: { node: Node }) {
           {node.label}
         </p>
       )}
-      <p className={cn("truncate font-semibold text-3xl tabular-nums", toneTextClass(node.tone))}>
+      <p className={cn("truncate font-bold text-3xl tabular-nums", toneTextClass(node.tone))}>
         {formatValue(node.value, node.format)}
       </p>
       <div className="flex items-center gap-2">

--- a/frontend/src/components/initiativeTools/dashboards/scene/SeriesNode.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/SeriesNode.tsx
@@ -48,7 +48,7 @@ const toRows = (node: Node) => {
 
 const axisProps = {
   stroke: "var(--muted-foreground)",
-  fontSize: 11,
+  fontSize: 12,
   tickLine: false,
   axisLine: false,
 } as const;

--- a/frontend/src/components/initiativeTools/dashboards/scene/TimelineNode.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/TimelineNode.tsx
@@ -50,7 +50,7 @@ export function TimelineNode({ node }: { node: Node }) {
         {ticks.map((tick, index) => (
           <span
             key={tick.at}
-            className="flex-1 text-[10px] text-muted-foreground"
+            className="flex-1 text-muted-foreground text-xs"
             style={{ textAlign: index === ticks.length - 1 ? "right" : "left" }}
           >
             {tick.label}

--- a/frontend/src/lib/widgets/tone.ts
+++ b/frontend/src/lib/widgets/tone.ts
@@ -14,7 +14,7 @@ const TONE_COLORS: Record<Tone, string> = {
   accent: "var(--primary)",
   positive: "var(--color-green-500)",
   negative: "var(--destructive)",
-  warning: "var(--color-amber-500)",
+  warning: "var(--color-yellow-500)",
   neutral: "var(--foreground)",
   muted: "var(--muted-foreground)",
   "series-1": "var(--chart-1)",
@@ -35,12 +35,14 @@ export const seriesColor = (index: number, tone?: Tone): string =>
   tone ? toneColor(tone) : toneColor(SERIES_TONES[index % SERIES_TONES.length]);
 
 /** Text tones map to classes so they inherit the theme's foreground handling
- *  rather than being painted a literal color. */
+ *  rather than being painted a literal color. The three semantic tones are the
+ *  same pairs the stats cards use, so a "good" number reads the same green
+ *  wherever the app shows one. */
 const TONE_TEXT_CLASSES: Record<Tone, string> = {
   accent: "text-primary",
   positive: "text-green-600 dark:text-green-400",
-  negative: "text-destructive",
-  warning: "text-amber-600 dark:text-amber-400",
+  negative: "text-red-600 dark:text-red-400",
+  warning: "text-yellow-600 dark:text-yellow-400",
   neutral: "text-foreground",
   muted: "text-muted-foreground",
   "series-1": "text-foreground",


### PR DESCRIPTION
## Problem

Dashboard widget text was set on its own scale rather than the app's. Three
concrete gaps against the My Stats cards, which already define this:

- The widget surfaces set `bg-card` but never the paired `text-card-foreground`
  that `Card` declares, so ink was inherited from whatever wrapped them.
- Secondary text sat a size below the rest of the app (`text-[10px]` timeline
  ticks, `text-xs` error copy, fontSize 11 chart axes) — legible as a group but
  washed out in a small tile.
- The semantic colors were chosen per component: `tone.ts` said amber/`destructive`
  while `StatsMetricCard` says yellow/red, and `MetricNode` carried its own
  green/red pair for delta arrows, so the same "good number" was two greens
  depending on where you read it.

## Changes

- Widget surfaces declare `bg-card text-card-foreground` like `Card` does —
  [DashboardWidget.tsx](frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx),
  [WidgetTile.tsx](frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx).
  Scene nodes inherit it instead of naming a color each.
- Semantic tones in [tone.ts](frontend/src/lib/widgets/tone.ts) now match
  `StatsMetricCard`'s variants exactly: negative `text-destructive` →
  `text-red-600 dark:text-red-400`, warning amber → yellow (fill included, so a
  warning bar and a warning number are one color).
- [MetricNode.tsx](frontend/src/components/initiativeTools/dashboards/scene/MetricNode.tsx)
  routes its delta colors through `toneTextClass` rather than repeating the
  pairs, and the headline value takes the stats cards' `font-bold`.
- Sizes raised to the app's floor: chart axis ticks 11 → 12, timeline ticks
  `text-[10px]` → `text-xs`, widget error copy → `text-sm`.
- Widget titles take `CardTitle`'s `font-semibold`.
- Changelog entry under `[Unreleased] / Changed`.

Muted stays where the stats page uses it — captions, table headers, axis ticks,
empty and error states. Contrast comes from weight and size, as it does there.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && ./scripts/test-changed.sh` — 111 files, 1477 tests passed
- `pnpm biome check src/components/initiativeTools/dashboards src/lib/widgets/tone.ts` — clean