### PR TITLE
Fill the page with an app's embedded surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- An app's embedded surface now fills the page instead of sitting in a short box at the top.
+
 ## [0.62.3] - 2026-08-13
 
 ### Added

--- a/frontend/src/pages/apps/GuildAppPage.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.tsx
@@ -257,7 +257,7 @@ export function GuildAppPage({ appId, initiativeId, viewer }: GuildAppPageProps)
           ref={iframeRef}
           src={handoff.embed_url}
           title={app.name}
-          className="block h-full w-full flex-1 border-0 bg-background"
+          className="block min-h-0 w-full flex-1 border-0 bg-background"
           // Notably absent: allow-top-navigation, allow-modals,
           // allow-popups-to-escape-sandbox.
           sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -210,7 +210,7 @@ function AppLayout() {
             }
           >
             <AppSidebar />
-            <div className="min-w-0 flex-1 bg-muted/50 md:pl-0">
+            <div className="flex min-w-0 flex-1 flex-col bg-muted/50 md:pl-0">
               <div
                 className="sticky top-0 z-50 flex flex-col bg-card/70 backdrop-blur supports-backdrop-filter:bg-card/60 lg:border-b"
                 style={{ paddingTop: "var(--safe-area-inset-top)" }}
@@ -245,7 +245,7 @@ function AppLayout() {
                 </div>
                 <GuildAccessBanner />
               </div>
-              <div className="flex justify-between">
+              <div className="flex flex-1 justify-between">
                 {/*<div
                   className="h-full w-full opacity-20 fixed"
                   style={{


### PR DESCRIPTION
## Problem

An app's embedded surface rendered in a short box at the top of the page instead of filling it.

The app shell never gave `<main>` a height: the content column beside the sidebar stacked its sticky header and content wrapper as plain blocks, so `main` collapsed to its content (~278px tall) and the embed's `h-full` had nothing to resolve against.

## Changes

- [_authenticated.tsx](frontend/src/routes/_serverRequired/_authenticated.tsx) — the content column beside the sidebar is now a flex column, and the wrapper around `<main>` takes the remaining height with `flex-1`, so `main` stretches to it as a flex item. Taller pages still grow past it and scroll the document exactly as before, and content stays top-aligned, so other pages are unaffected.
- [GuildAppPage.tsx](frontend/src/pages/apps/GuildAppPage.tsx) — the iframe drops `h-full` (which would overflow when the surface tab bar is present) for `min-h-0 flex-1`, filling whatever the column leaves it.

The embed fills down to the layout's `pb-24`, the global gutter reserved for the floating bottom nav / Create pill.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check src/routes/_serverRequired/_authenticated.tsx src/pages/apps/GuildAppPage.tsx` — clean
- `cd frontend && ./scripts/test-changed.sh` — 111 files, 1477 tests passed