### PR TITLE
Scope the widget runtime policy to its worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboards render on a deployed instance.** Widgets are evaluated by a WebAssembly runtime that the served content policy did not admit, so every widget on every dashboard failed with a runtime error. The runtime's own bundle is now served with a policy that admits it; the policy the rest of the app is served with is unchanged.
+
 ## [0.62.4] - 2026-08-13
 
 ### Fixed

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -355,6 +355,30 @@ class Settings(BaseSettings):
         return _format_csp(directives)
 
     @property
+    def widget_sandbox_content_security_policy(self) -> str:
+        """CSP for the widget sandbox worker bundle ONLY (applied per-response).
+
+        Dashboard widgets are evaluated by QuickJS compiled to WebAssembly
+        (``frontend/src/lib/widgets/runtime/sandbox.worker.ts``). A worker takes
+        its policy from the response that served its script rather than from the
+        document that started it, so the WebAssembly source expression is named
+        here — on that one built asset — and the app-wide policy above needs no
+        mention of it.
+
+        The worker is given the three things it uses and nothing else: its own
+        script, WebAssembly compilation, and a same-origin fetch for the
+        ``.wasm`` file. It has no DOM, loads no styles, images, or fonts, and
+        talks to nobody but the page that started it.
+        """
+        return _format_csp(
+            {
+                "default-src": ["'none'"],
+                "script-src": ["'self'", "'wasm-unsafe-eval'"],
+                "connect-src": ["'self'"],
+            }
+        )
+
+    @property
     def docs_content_security_policy(self) -> str:
         """Relaxed CSP for the Swagger ``/docs`` page ONLY (applied per-route).
 

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -262,6 +262,30 @@ def test_csp_allows_inline_styles_but_not_scripts():
     assert "'unsafe-inline'" not in _directive(csp, "script-src")
 
 
+def test_webassembly_is_named_only_on_the_widget_sandbox_policy():
+    # Dashboard widgets are evaluated by QuickJS compiled to WebAssembly, which
+    # needs a source expression the app-wide policy does not carry. It is named
+    # on the worker bundle's own response and nowhere else.
+    settings = _settings()
+    assert "'wasm-unsafe-eval'" not in settings.content_security_policy
+    assert "'wasm-unsafe-eval'" not in settings.docs_content_security_policy
+
+    sandbox = settings.widget_sandbox_content_security_policy
+    assert _directive(sandbox, "script-src") == "script-src 'self' 'wasm-unsafe-eval'"
+
+
+def test_widget_sandbox_policy_grants_only_what_the_worker_uses():
+    # Its own script, WebAssembly, and the same-origin fetch for the .wasm file.
+    # Everything else — DOM-adjacent fetches, frames, workers — falls to
+    # default-src 'none'.
+    sandbox = _settings().widget_sandbox_content_security_policy
+    assert {part.strip() for part in sandbox.split(";")} == {
+        "default-src 'none'",
+        "script-src 'self' 'wasm-unsafe-eval'",
+        "connect-src 'self'",
+    }
+
+
 def test_csp_websocket_scheme_follows_app_url():
     https = _settings(APP_URL="https://app.example.com").content_security_policy
     assert "wss:" in _directive(https, "connect-src")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -378,6 +378,25 @@ async def insufficient_privilege_handler(
 # Computed once — Settings are fixed for the process lifetime (pentest MED-001).
 _CONTENT_SECURITY_POLICY = settings.content_security_policy
 
+# The widget sandbox worker, and only it, is served with a policy that admits
+# WebAssembly. Vite emits worker bundles into `assets/workers/` with a content
+# hash (see `worker.rolldownOptions` in frontend/vite.config.ts), so the match is
+# by directory + stem; the literal is pinned by tests on both sides.
+_WIDGET_SANDBOX_ASSET_PREFIX = "assets/workers/sandbox.worker-"
+_WIDGET_SANDBOX_CSP = settings.widget_sandbox_content_security_policy
+
+
+def _is_widget_sandbox_asset(path: str) -> bool:
+    """True for the one built file that carries the widget sandbox policy.
+
+    The hash varies per build, so the tail is open — but only as far as the one
+    filename: anything nested below that name is an ordinary asset.
+    """
+    if not path.startswith(_WIDGET_SANDBOX_ASSET_PREFIX) or not path.endswith(".js"):
+        return False
+    return "/" not in path[len(_WIDGET_SANDBOX_ASSET_PREFIX) :]
+
+
 # Emit HSTS only when the public origin is HTTPS (pentest SEC-16): the header is
 # inert over plain HTTP and pinning a dev http:// origin to HTTPS would break it.
 # Two years + includeSubDomains is the preload-eligible baseline; computed once
@@ -677,10 +696,12 @@ async def serve_spa(request: Request, full_path: str) -> FileResponse:
     static_file = _resolve_static_file(full_path) if full_path else None
     if static_file:
         if full_path.startswith("assets/"):
-            return FileResponse(
-                static_file,
-                headers={"Cache-Control": "public, max-age=31536000, immutable"},
-            )
+            headers = {"Cache-Control": "public, max-age=31536000, immutable"}
+            # The middleware sets the app-wide policy with setdefault, so this
+            # per-asset one wins where it applies.
+            if _is_widget_sandbox_asset(full_path):
+                headers["Content-Security-Policy"] = _WIDGET_SANDBOX_CSP
+            return FileResponse(static_file, headers=headers)
         return FileResponse(
             static_file,
             headers={"Cache-Control": "public, max-age=3600"},

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -11,7 +11,7 @@ from fastapi.exceptions import RequestValidationError
 from httpx import ASGITransport, AsyncClient
 
 import app.main as main_module
-from app.core.config import API_V1_STR, Settings
+from app.core.config import API_V1_STR, Settings, settings
 from app.main import SecurityHeadersMiddleware, validation_exception_handler
 
 
@@ -99,7 +99,7 @@ async def test_only_the_widget_sandbox_asset_carries_its_policy(
 
     assert sandbox_resp.status_code == 200
     sandbox_csp = sandbox_resp.headers.get("content-security-policy", "")
-    assert sandbox_csp == Settings().widget_sandbox_content_security_policy
+    assert sandbox_csp == settings.widget_sandbox_content_security_policy
 
     assert other_resp.status_code == 200
     other_csp = other_resp.headers.get("content-security-policy", "")

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -60,6 +60,53 @@ async def test_responses_carry_content_security_policy(client: AsyncClient) -> N
     assert "object-src 'none'" in csp
 
 
+# --- Widget sandbox worker asset (WebAssembly is named on this one response) ---
+
+
+@pytest.mark.unit
+def test_widget_sandbox_match_names_one_file() -> None:
+    match = main_module._is_widget_sandbox_asset
+    assert match("assets/workers/sandbox.worker-DQURGIoN.js")
+
+    # Every other built file is an ordinary asset: a second worker, anything
+    # nested under a directory that merely starts with the name, the sourcemap,
+    # and the app's own chunks.
+    assert not match("assets/workers/other.worker-DQURGIoN.js")
+    assert not match("assets/workers/sandbox.worker-DQURGIoN/payload.js")
+    assert not match("assets/workers/sandbox.worker-DQURGIoN.js.map")
+    assert not match("assets/index-lSaaosYz.js")
+    assert not match("assets/workers/")
+
+
+@pytest.mark.integration
+async def test_only_the_widget_sandbox_asset_carries_its_policy(
+    client: AsyncClient,
+) -> None:
+    # End-to-end through the SPA file route: the worker bundle answers with the
+    # sandbox policy, and the chunk next to it answers with the app-wide one.
+    worker = main_module.static_path / "assets" / "workers" / "sandbox.worker-t3st.js"
+    ordinary = main_module.static_path / "assets" / "index-t3st.js"
+    worker.parent.mkdir(parents=True, exist_ok=True)
+    ordinary.parent.mkdir(parents=True, exist_ok=True)
+    worker.write_text("// widget sandbox worker\n")
+    ordinary.write_text("// app chunk\n")
+    try:
+        sandbox_resp = await client.get(f"/assets/workers/{worker.name}")
+        other_resp = await client.get(f"/assets/{ordinary.name}")
+    finally:
+        worker.unlink(missing_ok=True)
+        ordinary.unlink(missing_ok=True)
+
+    assert sandbox_resp.status_code == 200
+    sandbox_csp = sandbox_resp.headers.get("content-security-policy", "")
+    assert sandbox_csp == Settings().widget_sandbox_content_security_policy
+
+    assert other_resp.status_code == 200
+    other_csp = other_resp.headers.get("content-security-policy", "")
+    assert "'wasm-unsafe-eval'" not in other_csp
+    assert "script-src 'self'" in other_csp
+
+
 @pytest.mark.integration
 async def test_register_validation_error_omits_input(client: AsyncClient) -> None:
     # End-to-end: a 422 from a real endpoint must not echo the submitted value.

--- a/frontend/src/lib/widgets/runtime/host.test.ts
+++ b/frontend/src/lib/widgets/runtime/host.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Host-side behaviour that the sandbox itself cannot express: what is kept
+ * between calls. jsdom has no `Worker`, so these exercise the in-process path
+ * with the sandbox stubbed — the caching rule is the same either way.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readMetaInSandbox = vi.hoisted(() => vi.fn());
+
+vi.mock("./sandbox", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./sandbox")>()),
+  readMetaInSandbox,
+}));
+
+import { readWidgetMeta } from "./host";
+import { SandboxErrorCode } from "./sandbox";
+
+const META = { ok: true, value: { name: { en: "Summary" } } };
+
+describe("readWidgetMeta", () => {
+  beforeEach(() => {
+    // Counts are per case; each case uses its own source, so the module-level
+    // cache does not carry between them.
+    readMetaInSandbox.mockReset();
+  });
+
+  it("reads again after the runtime failed, and keeps what it then gets", async () => {
+    readMetaInSandbox
+      .mockResolvedValueOnce({ ok: false, code: SandboxErrorCode.UNAVAILABLE })
+      .mockResolvedValueOnce(META);
+    const source = "// runtime failure\nconst meta = { name: { en: 'Summary' } };";
+
+    expect(await readWidgetMeta(source)).toBeNull();
+    expect(await readWidgetMeta(source)).not.toBeNull();
+    expect(await readWidgetMeta(source)).not.toBeNull();
+    // Two reads, not three: the failure was retried, the answer was kept.
+    expect(readMetaInSandbox).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a failure the module itself causes", async () => {
+    readMetaInSandbox.mockResolvedValue({ ok: false, code: SandboxErrorCode.THREW });
+    const source = "// module failure\nthrow new Error('nope');";
+
+    expect(await readWidgetMeta(source)).toBeNull();
+    expect(await readWidgetMeta(source)).toBeNull();
+    expect(readMetaInSandbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a module that declares no meta", async () => {
+    readMetaInSandbox.mockResolvedValue({ ok: true, value: null });
+    const source = "// no meta\nconst render = () => ({ kind: 'empty' });";
+
+    expect(await readWidgetMeta(source)).toBeNull();
+    expect(await readWidgetMeta(source)).toBeNull();
+    expect(readMetaInSandbox).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/widgets/runtime/host.test.ts
+++ b/frontend/src/lib/widgets/runtime/host.test.ts
@@ -25,18 +25,21 @@ describe("readWidgetMeta", () => {
     readMetaInSandbox.mockReset();
   });
 
-  it("reads again after the runtime failed, and keeps what it then gets", async () => {
-    readMetaInSandbox
-      .mockResolvedValueOnce({ ok: false, code: SandboxErrorCode.UNAVAILABLE })
-      .mockResolvedValueOnce(META);
-    const source = "// runtime failure\nconst meta = { name: { en: 'Summary' } };";
+  // Each of these leaves the runtime in a different state than it read in:
+  // never booted, rebuilt after going quiet, or disposed by the memory cap.
+  it.each([SandboxErrorCode.UNAVAILABLE, SandboxErrorCode.TIMEOUT, SandboxErrorCode.OUT_OF_MEMORY])(
+    "reads again after %s, and keeps what it then gets",
+    async (code) => {
+      readMetaInSandbox.mockResolvedValueOnce({ ok: false, code }).mockResolvedValueOnce(META);
+      const source = `// ${code}\nconst meta = { name: { en: 'Summary' } };`;
 
-    expect(await readWidgetMeta(source)).toBeNull();
-    expect(await readWidgetMeta(source)).not.toBeNull();
-    expect(await readWidgetMeta(source)).not.toBeNull();
-    // Two reads, not three: the failure was retried, the answer was kept.
-    expect(readMetaInSandbox).toHaveBeenCalledTimes(2);
-  });
+      expect(await readWidgetMeta(source)).toBeNull();
+      expect(await readWidgetMeta(source)).not.toBeNull();
+      expect(await readWidgetMeta(source)).not.toBeNull();
+      // Two reads, not three: the failure was retried, the answer was kept.
+      expect(readMetaInSandbox).toHaveBeenCalledTimes(2);
+    }
+  );
 
   it("keeps a failure the module itself causes", async () => {
     readMetaInSandbox.mockResolvedValue({ ok: false, code: SandboxErrorCode.THREW });

--- a/frontend/src/lib/widgets/runtime/host.ts
+++ b/frontend/src/lib/widgets/runtime/host.ts
@@ -153,6 +153,15 @@ export async function renderWidget(request: RenderRequest): Promise<WidgetRender
 // rather than a stale entry.
 const metaCache = new Map<string, WidgetMeta | null>();
 
+/** Outcomes that describe the runtime rather than the module: a worker that
+ *  never booted, or one that stopped answering and was rebuilt. Reading again
+ *  can give a different answer, so these are the two the cache does not keep —
+ *  every other failure is a property of the source and would only repeat. */
+const RUNTIME_META_FAILURES: ReadonlySet<SandboxErrorCode> = new Set([
+  SandboxErrorCode.UNAVAILABLE,
+  SandboxErrorCode.TIMEOUT,
+]);
+
 /**
  * A widget's own name, description, and option labels.
  *
@@ -160,6 +169,10 @@ const metaCache = new Map<string, WidgetMeta | null>();
  * `validateWidgetMeta` — a module's metadata is untrusted input like anything
  * else it produces. Returns `null` when the module declares none, which is not
  * an error: callers fall back to the widget's type id.
+ *
+ * A widget that could not be read *this time* falls back to its type id for now
+ * and is read again on the next ask, rather than wearing that id for the rest of
+ * the session.
  */
 export async function readWidgetMeta(source: string): Promise<WidgetMeta | null> {
   const cached = metaCache.get(source);
@@ -170,6 +183,8 @@ export async function readWidgetMeta(source: string): Promise<WidgetMeta | null>
     () => readMetaInSandbox(source)
   );
   const meta = result.ok ? validateWidgetMeta(result.value) : null;
-  metaCache.set(source, meta);
+  if (result.ok || !RUNTIME_META_FAILURES.has(result.code)) {
+    metaCache.set(source, meta);
+  }
   return meta;
 }

--- a/frontend/src/lib/widgets/runtime/host.ts
+++ b/frontend/src/lib/widgets/runtime/host.ts
@@ -5,6 +5,10 @@
  * `SceneSpec` or a machine code for the error tile. Everything between —
  * spawning the worker, framing the request, and surviving a worker that stops
  * answering — lives here so components never touch the runtime directly.
+ *
+ * Every call goes to the worker, which is where the interpreter is compiled.
+ * The in-process path below serves environments with no `Worker` at all — jsdom
+ * under test; in a browser it resolves to `WIDGET_RUNTIME_UNAVAILABLE`.
  */
 
 import type { WidgetErrorCode } from "../errors";
@@ -93,12 +97,18 @@ export function disposeWidgetHost(): void {
   workerUnavailable = false;
 }
 
-async function evaluate(request: RenderRequest): Promise<SandboxResult> {
+/** Send one request to the worker and wait for its answer. `inline` is the same
+ *  work done in-process, for the no-`Worker` case described at the top. */
+async function evaluate(
+  frame: (id: number) => SandboxWorkerRequest,
+  inline: () => Promise<SandboxResult>,
+  timeoutMs = DEFAULT_LIMITS.timeoutMs
+): Promise<SandboxResult> {
   const host = getWorker();
-  if (!host) return renderInSandbox(request);
+  if (!host) return inline();
 
   const id = nextId++;
-  const budget = (request.limits?.timeoutMs ?? DEFAULT_LIMITS.timeoutMs) + WORKER_GRACE_MS;
+  const budget = timeoutMs + WORKER_GRACE_MS;
 
   return new Promise<SandboxResult>((resolve) => {
     const timer = setTimeout(() => {
@@ -107,8 +117,7 @@ async function evaluate(request: RenderRequest): Promise<SandboxResult> {
       resetWorker(SandboxErrorCode.TIMEOUT);
     }, budget);
     pending.set(id, { resolve, timer });
-    const message: SandboxWorkerRequest = { id, request };
-    host.postMessage(message);
+    host.postMessage(frame(id));
   });
 }
 
@@ -120,13 +129,18 @@ async function evaluate(request: RenderRequest): Promise<SandboxResult> {
  * renders as an error.
  */
 export async function renderWidget(request: RenderRequest): Promise<WidgetRenderOutcome> {
-  const result = await evaluate({
+  const framed: RenderRequest = {
     ...request,
     // Widgets that mark work late need to know "now". Rounding to the minute
     // keeps the render stable across re-renders — the sandbox default of 0 is
     // deliberately inert so tests state their own clock.
     now: request.now ?? Math.floor(Date.now() / 60_000) * 60_000,
-  });
+  };
+  const result = await evaluate(
+    (id) => ({ id, kind: "render", request: framed }),
+    () => renderInSandbox(framed),
+    framed.limits?.timeoutMs
+  );
   if (!result.ok) return { ok: false, code: result.code, detail: result.detail };
 
   const validation = validateScene(result.value);
@@ -151,7 +165,10 @@ export async function readWidgetMeta(source: string): Promise<WidgetMeta | null>
   const cached = metaCache.get(source);
   if (cached !== undefined) return cached;
 
-  const result = await readMetaInSandbox(source);
+  const result = await evaluate(
+    (id) => ({ id, kind: "meta", source }),
+    () => readMetaInSandbox(source)
+  );
   const meta = result.ok ? validateWidgetMeta(result.value) : null;
   metaCache.set(source, meta);
   return meta;

--- a/frontend/src/lib/widgets/runtime/host.ts
+++ b/frontend/src/lib/widgets/runtime/host.ts
@@ -154,12 +154,14 @@ export async function renderWidget(request: RenderRequest): Promise<WidgetRender
 const metaCache = new Map<string, WidgetMeta | null>();
 
 /** Outcomes that describe the runtime rather than the module: a worker that
- *  never booted, or one that stopped answering and was rebuilt. Reading again
- *  can give a different answer, so these are the two the cache does not keep —
- *  every other failure is a property of the source and would only repeat. */
+ *  never booted, one that stopped answering and was rebuilt, and a tripped
+ *  memory cap — which disposes the runtime, so the read after it starts on a
+ *  fresh one. Each can answer differently next time, so the cache does not keep
+ *  them; what remains is a property of the source and would only repeat. */
 const RUNTIME_META_FAILURES: ReadonlySet<SandboxErrorCode> = new Set([
   SandboxErrorCode.UNAVAILABLE,
   SandboxErrorCode.TIMEOUT,
+  SandboxErrorCode.OUT_OF_MEMORY,
 ]);
 
 /**

--- a/frontend/src/lib/widgets/runtime/sandbox.worker.test.ts
+++ b/frontend/src/lib/widgets/runtime/sandbox.worker.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Where this worker's bundle lands is part of its contract.
+ *
+ * The response that serves it carries its own Content-Security-Policy, which
+ * the backend attaches by matching the built file's path
+ * (`_WIDGET_SANDBOX_ASSET_PREFIX` in `backend/app/main.py`). Vite decides that
+ * path from two things — the worker output pattern and this file's name — so
+ * both are pinned here, and the backend pins the literal it matches. A rename
+ * on either side fails a test rather than quietly serving the wrong header.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/** Keep in step with `_WIDGET_SANDBOX_ASSET_PREFIX` in backend/app/main.py. */
+const WORKER_OUTPUT = "assets/workers/[name]-[hash].js";
+
+const resolve = (relative: string) => fileURLToPath(new URL(relative, import.meta.url));
+
+describe("widget sandbox worker asset", () => {
+  it("is emitted into the directory the backend matches", () => {
+    const config = readFileSync(resolve("../../../../vite.config.ts"), "utf8");
+    expect(config).toContain(`entryFileNames: "${WORKER_OUTPUT}"`);
+  });
+
+  it("keeps the entry name the backend matches", () => {
+    // `[name]` resolves to the worker entry's basename, so the built file is
+    // `assets/workers/sandbox.worker-<hash>.js`.
+    expect(existsSync(resolve("./sandbox.worker.ts"))).toBe(true);
+    expect(WORKER_OUTPUT.replace("[name]", "sandbox.worker")).toBe(
+      "assets/workers/sandbox.worker-[hash].js"
+    );
+  });
+});

--- a/frontend/src/lib/widgets/runtime/sandbox.worker.ts
+++ b/frontend/src/lib/widgets/runtime/sandbox.worker.ts
@@ -3,21 +3,29 @@
 /**
  * Worker wrapper around the sandbox.
  *
- * The sandbox is already capability-free on its own; running it here buys two
- * further things. A widget that spins cannot block paint, so a bad widget
- * degrades to one dead tile rather than a frozen canvas. And a hypothetical
- * QuickJS escape lands in a worker with no DOM instead of in the page.
+ * The sandbox is already capability-free on its own; running it here keeps a
+ * widget that spins from blocking paint, so a bad widget degrades to one dead
+ * tile rather than a frozen canvas.
+ *
+ * The interpreter is compiled in this context, and both sandbox entry points —
+ * rendering and reading a module's meta — are routed through here so it stays
+ * that way. The response that serves this file carries the policy that permits
+ * it (`backend/app/core/config.py`, `widget_sandbox_content_security_policy`).
  *
  * This file stays deliberately thin — all evaluation logic lives in
  * `sandbox.ts` so it can be tested directly, without worker plumbing.
  */
 
-import { type RenderRequest, renderInSandbox, type SandboxResult } from "./sandbox";
+import {
+  type RenderRequest,
+  readMetaInSandbox,
+  renderInSandbox,
+  type SandboxResult,
+} from "./sandbox";
 
-export interface SandboxWorkerRequest {
-  id: number;
-  request: RenderRequest;
-}
+export type SandboxWorkerRequest =
+  | { id: number; kind: "render"; request: RenderRequest }
+  | { id: number; kind: "meta"; source: string };
 
 export interface SandboxWorkerResponse {
   id: number;
@@ -25,8 +33,11 @@ export interface SandboxWorkerResponse {
 }
 
 self.onmessage = async (event: MessageEvent<SandboxWorkerRequest>) => {
-  const { id, request } = event.data;
-  const result = await renderInSandbox(request);
-  const response: SandboxWorkerResponse = { id, result };
+  const message = event.data;
+  const result =
+    message.kind === "meta"
+      ? await readMetaInSandbox(message.source)
+      : await renderInSandbox(message.request);
+  const response: SandboxWorkerResponse = { id: message.id, result };
   self.postMessage(response);
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,6 +47,18 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  worker: {
+    // Worker bundles land in their own directory so a served response can be
+    // matched by path. The backend keys the widget sandbox's policy off
+    // `assets/workers/sandbox.worker-` — see `_WIDGET_SANDBOX_ASSET` in
+    // backend/app/main.py, which is pinned by tests on both sides.
+    rolldownOptions: {
+      output: {
+        entryFileNames: "assets/workers/[name]-[hash].js",
+        chunkFileNames: "assets/workers/[name]-[hash].js",
+      },
+    },
+  },
   build: {
     rolldownOptions: {
       output: {


### PR DESCRIPTION
## Problem

Every widget on every dashboard failed with a runtime error on a deployed instance:

```
wasm streaming compile failed: CompileError: WebAssembly.instantiateStreaming():
Compiling or instantiating WebAssembly module violates the following Content
Security policy directive ... "script-src 'self'"
```

Widgets are evaluated by QuickJS compiled to WebAssembly, and compiling a module needs a source expression the app-wide policy does not carry. It goes unnoticed in local development because the Vite dev server sends no policy at all — only the FastAPI-served bundle does.

## Changes

- [config.py](backend/app/core/config.py) — new `widget_sandbox_content_security_policy`: `default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'` — the worker's own script, WebAssembly, and the same-origin fetch for the `.wasm` file. The app-wide policy is untouched.
- [main.py](backend/app/main.py) — `serve_spa` attaches it to responses matching `assets/workers/sandbox.worker-<hash>.js`, and only those. `_is_widget_sandbox_asset` matches one filename: a second worker, a nested path, or a sourcemap are ordinary assets.
- [vite.config.ts](frontend/vite.config.ts) — worker bundles emit into `assets/workers/`, so the served path is addressable without pinning a content hash.
- [sandbox.worker.ts](frontend/src/lib/widgets/runtime/sandbox.worker.ts) / [host.ts](frontend/src/lib/widgets/runtime/host.ts) — `readWidgetMeta` now goes through the worker alongside rendering, so the runtime has one home. It previously ran in the page, which would have left every widget showing its type id instead of its name. The in-process path stays for jsdom, where there is no `Worker`.

A worker takes its policy from the response that served its script rather than from the document that started it, which is what lets the expression live on one asset instead of on every response.

### Contract between the two sides

The built asset's path is now load-bearing, so it is pinned from both ends: [sandbox.worker.test.ts](frontend/src/lib/widgets/runtime/sandbox.worker.test.ts) pins the Vite output pattern and the worker's filename; `main_test.py` pins the literal the backend matches. A rename on either side fails a test.

## Testing

- `cd backend && pytest app/main_test.py app/core/config_test.py app/api/embed_csp_test.py` — 89 passed
- `cd frontend && pnpm vitest run src/lib/widgets src/components/initiativeTools/dashboards` — 217 passed
- `cd frontend && pnpm typecheck` — clean
- `cd backend && ruff check app` — clean; `pnpm biome check src/lib/widgets/runtime vite.config.ts` — clean
- `pnpm build`, then checked the emitted bundle against the backend matcher: of every `.js` in `dist`, exactly one matches, and it is the sandbox worker. A Capacitor build (`CAPACITOR_BUILD=true`) resolves the `.wasm` correctly from the new subdirectory (`../emscripten-module-<hash>.wasm`).

Still worth one real-browser confirmation on a deployed instance: open a dashboard and check the worker response carries the header.