### PR TITLE
Read one rule for whether an app is live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Dashboards render on a deployed instance.** Widgets are evaluated by a WebAssembly runtime that the served content policy did not admit, so every widget on every dashboard failed with a runtime error. The runtime's own bundle is now served with a policy that admits it; the policy the rest of the app is served with is unchanged.
+- An app whose service stops matching what this deployment registered now stops offering its embedded pages, not only its data — the two halves of an app go quiet together. Both return on the next successful verification, and the app reads as unavailable meanwhile instead of opening a surface that cannot load.
 
 ## [0.62.4] - 2026-08-13
 

--- a/backend/app/api/embed_csp_test.py
+++ b/backend/app/api/embed_csp_test.py
@@ -18,6 +18,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.embed_csp import parse_embed_path, resolve_frame_origins
 from app.core.config import settings
+from app.models.platform.app_service_registration import AppServiceStatus
 from app.models.platform.guild import GuildRole
 from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.testing import (
@@ -164,6 +165,39 @@ class TestResolvingOrigins:
         )
 
         registration.enabled = False
+        session.add(registration)
+        await session.commit()
+        invalidate_registrations()
+
+        assert (
+            await resolve_frame_origins(
+                guild_id=guild.id, app_id=app.id, user_id=user.id
+            )
+            == ()
+        )
+
+    async def test_an_unverified_registration_frames_nothing(
+        self, session: AsyncSession
+    ):
+        """The origins named here come from a manifest, so the header waits on
+        the verification that says which manifest this service serves."""
+        user = await create_user(session, email="drifted@example.com")
+        guild = await create_guild(session, creator=user)
+        await create_guild_membership(
+            session, user=user, guild=guild, role=GuildRole.admin
+        )
+        app = await create_guild_app(
+            session,
+            guild,
+            user,
+            definition=_definition(),
+            listing_uid=marketplace_uid("drifted"),
+        )
+        registration = await create_app_service_registration(
+            session, public_id=APP_ID, base_url="https://drifted.example.test"
+        )
+
+        registration.status = AppServiceStatus.MANIFEST_MISMATCH
         session.add(registration)
         await session.commit()
         invalidate_registrations()

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -37,6 +37,7 @@ from app.core.messages import (
     GuildAppMessages,
     InitiativeMessages,
 )
+from app.models.platform.app_service_registration import AppServiceStatus
 from app.models.platform.guild import GuildRole
 from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.testing import (
@@ -169,6 +170,32 @@ class TestInstallState:
         and the read says so rather than showing a working app."""
         a = await acting_user(guild_role=GuildRole.admin)
         await _installed(session, a)
+
+        items = (await client.get(a.g("/apps/"), headers=a.headers)).json()["items"]
+        assert [item["available"] for item in items] == [False]
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            AppServiceStatus.UNVERIFIED,
+            AppServiceStatus.UNREACHABLE,
+            AppServiceStatus.MANIFEST_MISMATCH,
+            AppServiceStatus.SIGNATURE_MISMATCH,
+        ],
+    )
+    async def test_only_a_verified_registration_is_available(
+        self,
+        client: AsyncClient,
+        acting_user,
+        session: AsyncSession,
+        registration,
+        status: str,
+    ):
+        """Availability tracks the last verification as well as the kill switch:
+        the app the deployment registered is the one that has to be answering."""
+        a = await acting_user(guild_role=GuildRole.admin)
+        await _installed(session, a)
+        await _mark(session, registration, status=status)
 
         items = (await client.get(a.g("/apps/"), headers=a.headers)).json()["items"]
         assert [item["available"] for item in items] == [False]
@@ -433,6 +460,36 @@ class TestHandoff:
     ):
         a = await acting_user(guild_role=GuildRole.admin)
         app = await _installed(session, a)
+        response = await client.post(
+            a.g(f"/apps/{app.id}/handoff/board"), headers=a.headers
+        )
+        assert response.status_code == 409
+        assert response.json()["detail"] == GuildAppMessages.SERVICE_NOT_REGISTERED
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            AppServiceStatus.UNVERIFIED,
+            AppServiceStatus.UNREACHABLE,
+            AppServiceStatus.MANIFEST_MISMATCH,
+            AppServiceStatus.SIGNATURE_MISMATCH,
+        ],
+    )
+    async def test_only_a_verified_registration_mints(
+        self,
+        client: AsyncClient,
+        acting_user,
+        session: AsyncSession,
+        registration,
+        status: str,
+    ):
+        """A surface is declared by a manifest, so the mint requires the last
+        verification to have confirmed which manifest this service serves. The
+        data plane already read it this way; this is the same rule."""
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _installed(session, a)
+        await _mark(session, registration, status=status)
+
         response = await client.post(
             a.g(f"/apps/{app.id}/handoff/board"), headers=a.headers
         )

--- a/backend/app/models/platform/app_service_registration.py
+++ b/backend/app/models/platform/app_service_registration.py
@@ -36,7 +36,9 @@ __all__ = [
     "AppServiceRegistration",
     "AppServiceStatus",
     "BrowserAddressed",
+    "ServiceState",
     "browser_base",
+    "is_live",
 ]
 
 
@@ -174,3 +176,27 @@ def browser_base(registration: BrowserAddressed) -> str:
     app reachable at a single address needs no second field to say so.
     """
     return registration.embed_origin or registration.base_url
+
+
+class ServiceState(Protocol):
+    """Anything carrying a registration's two state columns.
+
+    Like :class:`BrowserAddressed`, satisfied by both the row and the request
+    path's snapshot of it, so the rule below is written once and every channel
+    reads the same answer.
+    """
+
+    enabled: bool
+    status: str
+
+
+def is_live(registration: ServiceState) -> bool:
+    """Whether anything may flow through this app right now.
+
+    Two conditions, and both are the operator's: the kill switch is on, and the
+    last verification concluded that the service answering is the one this
+    deployment registered. A row that has never handshaken is ``unverified`` and
+    is not live — there is no confirmed manifest behind it to have declared
+    anything.
+    """
+    return registration.enabled and registration.status == AppServiceStatus.OK

--- a/backend/app/services/marketplace/app_data.py
+++ b/backend/app/services/marketplace/app_data.py
@@ -59,7 +59,7 @@ from app.core.security import (
 from app.db import session as db_session
 from app.models.platform.app_service_registration import (
     AppServiceRegistration,
-    AppServiceStatus,
+    is_live,
 )
 from app.models.tenant.guild_app import GuildApp
 from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
@@ -395,7 +395,7 @@ async def _load_registration(public_id: str) -> AppServiceRegistration:
         ).first()
     if row is None:
         raise AppDataError(AppDataMessages.SERVICE_NOT_REGISTERED, 404)
-    if not row.enabled or row.status != AppServiceStatus.OK:
+    if not is_live(row):
         raise AppDataError(AppDataMessages.SERVICE_DISABLED, 409)
     return row
 

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -30,6 +30,7 @@ from app.db import session as db_session
 from app.models.platform.app_service_registration import (
     AppServiceRegistration,
     browser_base,
+    is_live,
 )
 
 __all__ = [
@@ -73,8 +74,12 @@ class RegistrationSnapshot:
 
     @property
     def live(self) -> bool:
-        """Whether anything may flow through this app right now."""
-        return self.enabled
+        """Whether anything may flow through this app right now.
+
+        Defers to :func:`is_live` so the embed plane and the data plane answer
+        this from the same rule rather than each stating one.
+        """
+        return is_live(self)
 
     @property
     def browser_base(self) -> str:
@@ -194,7 +199,7 @@ async def install_state(definition: dict[str, Any] | None) -> InstallState:
         # Installed here, but this deployment has not wired the service up (or
         # no longer does). Nothing it offers can be reached.
         return InstallState(mandatory=False, available=False)
-    return InstallState(mandatory=snapshot.mandatory, available=snapshot.enabled)
+    return InstallState(mandatory=snapshot.mandatory, available=snapshot.live)
 
 
 async def mandatory_registrations() -> list[RegistrationSnapshot]:
@@ -202,6 +207,13 @@ async def mandatory_registrations() -> list[RegistrationSnapshot]:
 
     Only the enabled ones: a registration the operator switched off installs
     nowhere new, because the kill switch outranks the flag (§7.7).
+
+    Deliberately ``enabled`` rather than :attr:`RegistrationSnapshot.live`. An
+    install is a local row, and a mandatory app whose container has not booted
+    yet is the ordinary case on a fresh deployment — it discovers the guild on
+    its next ``/installs`` pull. Waiting for a handshake here would make guild
+    creation depend on a container being up. What the unverified state does stop
+    is everything that flows *through* the app, which is what ``live`` gates.
     """
     return [
         snapshot


### PR DESCRIPTION
## Problem

An `app_service_registrations` row carries two state columns — `enabled` (the operator's kill switch) and `status` (what the last verification concluded) — and the two planes read different subsets of them.

- The **data plane** required both: `app_data._load_registration` checks `enabled` and `status == ok`.
- The **embed plane** read only `enabled`, through `RegistrationSnapshot.live`. Its two consumers are the handoff mint (`app_handoff.require_live_registration`) and the frame policy (`embed_csp.resolve_frame_origins`).

So a registration whose re-verification concluded `manifest_mismatch`, `unreachable`, or `signature_mismatch` kept minting embed handoffs and kept its origins in that document's `frame-src`, while its data source calls were already being refused. A surface is declared by a manifest, so the mint has more reason to want a confirmed manifest than the data path does.

## Change

`is_live(registration)` moves onto the model beside `browser_base()`, following the same `Protocol` + free-function shape, so the row and the request path's snapshot answer from one rule:

```python
def is_live(registration: ServiceState) -> bool:
    return registration.enabled and registration.status == AppServiceStatus.OK
```

- `RegistrationSnapshot.live` defers to it.
- `app_data._load_registration` calls it instead of restating the condition.
- `install_state(...).available` follows `live`, so a client is told the app is unavailable rather than being offered a surface that will not open.

`mandatory_registrations()` deliberately still reads `enabled` alone, with a comment saying why: an install is a local row, and a mandatory app whose container has not booted is the ordinary case on a fresh deployment — it picks the guild up on its next `/installs` pull. Making guild creation wait on a handshake would be the wrong trade.

## Behavior change

A registration that has never completed a handshake is `unverified`, so its embeds now stay dark until it verifies. This affects declaratively wired registrations whose container starts after Initiative — in practice, dev testing. Confirmed as acceptable.

## Testing

```
pytest app/api/embed_csp_test.py app/api/v1/tenant_endpoints/guild_apps_platform_test.py   # 63 passed
pytest app/services/marketplace/ app/services/tenant/mandatory_apps_test.py \
       app/api/v1/platform_endpoints/app_services_test.py                                  # 428 passed
ruff check app && ruff format app
```

New coverage, parametrized over all four non-`ok` statuses:
- the handoff mint refuses (`409 SERVICE_NOT_REGISTERED`)
- the install reads as unavailable
- `resolve_frame_origins` returns `()`

No schema change, so no API type regeneration.