### PR TITLE
Grant an embed only the features it asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- An app's embedded page is granted only the browser features its manifest asks for, from a fixed list — camera, microphone, location, screen capture, clipboard, and fullscreen. A surface that asks for nothing runs with all of them denied. What an app requests is part of what it declares, so it can be read before installing.
+
 ### Fixed
 
 - **Dashboards render on a deployed instance.** Widgets are evaluated by a WebAssembly runtime that the served content policy did not admit, so every widget on every dashboard failed with a runtime error. The runtime's own bundle is now served with a policy that admits it; the policy the rest of the app is served with is unchanged.

--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -29,6 +29,7 @@ from app.services.marketplace.definitions import (
     reserved_prefix_problem,
 )
 from app.services.marketplace.manifest_values import IDENTIFIER_CHARS
+from app.services.marketplace.service_apps import EMBED_CAPABILITIES
 
 pytestmark = pytest.mark.unit
 
@@ -542,6 +543,48 @@ class TestEmbeds:
                 "name": {"en": "Orders"},
             }
         ]
+
+
+class TestWhatASurfaceMayAskItsFrameFor:
+    """``capabilities`` is the whole of what a frame is granted.
+
+    A manifest names browser features from a closed vocabulary, and a surface
+    that names none is stored with no such key — which is what every definition
+    pinned before this existed says, and what their frames now get.
+    """
+
+    def _embed(self, **overrides) -> dict:
+        embed = {"id": "board", "path": "/embed", "name": _label("Board")}
+        embed.update(overrides)
+        return _normalize(features=["embeds"], embeds=[embed])["embeds"][0]
+
+    def test_a_surface_asking_for_nothing_stores_nothing(self):
+        assert "capabilities" not in self._embed()
+
+    def test_a_surface_may_ask_for_what_it_needs(self):
+        assert self._embed(capabilities=["clipboard-write"])["capabilities"] == [
+            "clipboard-write"
+        ]
+
+    def test_capabilities_are_stored_canonically(self):
+        """Sorted and de-duplicated, so re-publishing the same manifest produces
+        the same document."""
+        asked = ["fullscreen", "clipboard-write", "fullscreen"]
+        assert self._embed(capabilities=asked)["capabilities"] == [
+            "clipboard-write",
+            "fullscreen",
+        ]
+
+    def test_a_capability_outside_the_vocabulary_is_refused(self):
+        with pytest.raises(ListingDefinitionError, match="not a capability"):
+            self._embed(capabilities=["midi"])
+
+    def test_payment_is_not_namable(self):
+        """The platform takes payment on its own pages, so an embedded surface
+        has no reading of this to request."""
+        assert "payment" not in EMBED_CAPABILITIES
+        with pytest.raises(ListingDefinitionError, match="not a capability"):
+            self._embed(capabilities=["payment"])
 
 
 class TestWhereASurfaceRenders:

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -55,6 +55,7 @@ __all__ = [
     "APP_PROTOCOL_VERSIONS",
     "APP_WIDGET_TYPE_PREFIX",
     "CONNECTION_SCOPES",
+    "EMBED_CAPABILITIES",
     "FEATURES",
     "FEATURE_BLOCKS",
     "FIELD_TYPES",
@@ -137,6 +138,33 @@ VISIBILITIES: frozenset[str] = frozenset(VISIBILITY_LADDER)
 #: ``initiative_manager`` is absent: outside an initiative there is nothing to
 #: manage, so the value would be stored as a claim nothing could ever evaluate.
 GUILD_WIDE_VISIBILITIES: frozenset[str] = VISIBILITIES - {"initiative_manager"}
+
+#: Browser features an embedded surface may ask its frame for.
+#:
+#: A frame is granted nothing it did not name here, so an app that says nothing
+#: gets a frame with every one of these denied. The vocabulary is closed for the
+#: same reason every other one in this module is: a value outside it is refused
+#: with a reason rather than stored as a request nothing resolves.
+#:
+#: These are Permissions-Policy feature names, and what a manifest asks for is
+#: what a guild admin is shown at install. ``payment`` is deliberately not
+#: namable — an embedded surface takes no money, and the platform processes
+#: payments on its own pages.
+EMBED_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "camera",
+        "clipboard-read",
+        "clipboard-write",
+        "display-capture",
+        "fullscreen",
+        "geolocation",
+        "microphone",
+    }
+)
+
+#: No surface has a use for the whole vocabulary at once; a manifest reaching
+#: this many is describing something other than an embedded page.
+MAX_EMBED_CAPABILITIES = 8
 
 #: Protocol versions this build speaks to an app service. A manifest naming a
 #: newer one is refused by name — the version floor (`min_app_version`) is how a
@@ -532,6 +560,27 @@ def _scopes(raw: Any, *, what: str) -> list[str]:
     return sorted(scopes)
 
 
+def _capabilities(raw: Any, *, what: str) -> list[str]:
+    """The browser features a surface asks its frame for.
+
+    Absent means none, which is also what a frame gets when the manifest names
+    nothing. Sorted and de-duplicated, so re-publishing the same manifest
+    produces the same document.
+    """
+    if raw is None:
+        return []
+    declared = require_list(raw, f"{what} capabilities", MAX_EMBED_CAPABILITIES)
+    capabilities: set[str] = set()
+    for entry in declared:
+        if entry not in EMBED_CAPABILITIES:
+            fail(
+                f"{what}: {entry!r} is not a capability a surface may request "
+                f"(one of {', '.join(sorted(EMBED_CAPABILITIES))})"
+            )
+        capabilities.add(entry)
+    return sorted(capabilities)
+
+
 def _embed(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
     embed = require_mapping(raw, "embed")
     embed_id = check_identifier(embed.get("id"), what="embed id")
@@ -553,6 +602,9 @@ def _embed(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
         ),
         "name": _label(embed.get("name"), what=what),
     }
+    capabilities = _capabilities(embed.get("capabilities"), what=what)
+    if capabilities:
+        cleaned["capabilities"] = capabilities
     requires = _requires(
         embed.get("requires"), connection_ids=connection_ids, what=what
     )

--- a/frontend/src/lib/appSurfaces.test.ts
+++ b/frontend/src/lib/appSurfaces.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 import {
   appEmbeds,
   clearsVisibility,
+  embedAllow,
   guildAppPath,
   initiativeAppPath,
   placedIn,
@@ -28,6 +29,26 @@ const embed = (id: string, scopes?: string[], visibility?: string) => ({
   name: { en: id },
   ...(scopes ? { scopes } : {}),
   ...(visibility ? { visibility } : {}),
+});
+
+describe("embedAllow", () => {
+  it("grants a surface exactly what it asked for", () => {
+    expect(embedAllow({ capabilities: ["clipboard-write", "fullscreen"] })).toBe(
+      "clipboard-write; fullscreen"
+    );
+  });
+
+  it("grants nothing to a surface that asked for nothing", () => {
+    expect(embedAllow({ capabilities: [] })).toBe("");
+  });
+
+  it("grants nothing to a definition pinned before surfaces could ask", () => {
+    expect(embedAllow({})).toBe("");
+  });
+
+  it("grants nothing when there is no surface open", () => {
+    expect(embedAllow(null)).toBe("");
+  });
 });
 
 describe("clearsVisibility", () => {

--- a/frontend/src/lib/appSurfaces.ts
+++ b/frontend/src/lib/appSurfaces.ts
@@ -26,7 +26,21 @@ export interface AppEmbed {
   scopes?: string[];
   visibility?: string;
   name?: LocalizedText;
+  /** Browser features the surface asked its frame for, from the closed
+   *  vocabulary the manifest validator checks. Absent means it asked for none. */
+  capabilities?: string[];
 }
+
+/**
+ * The `allow` attribute for a surface's frame.
+ *
+ * A frame is granted what its manifest named and nothing else, so a surface
+ * that named nothing gets an empty attribute — which is every feature denied.
+ * Each entry defaults to the frame's own origin, so a granted feature reaches
+ * the app itself and not whatever the app goes on to embed.
+ */
+export const embedAllow = (embed: Pick<AppEmbed, "capabilities"> | null | undefined): string =>
+  (embed?.capabilities ?? []).join("; ");
 
 /** The places a surface can be reached from. */
 export type SurfaceScope = "guild" | "initiative";

--- a/frontend/src/pages/apps/GuildAppPage.test.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.test.tsx
@@ -75,15 +75,20 @@ const delivered = () =>
     .map((message) => message.handoff_token);
 
 let postSpy: ReturnType<typeof vi.fn>;
+let frameWindow: { postMessage: ReturnType<typeof vi.fn> };
 
 beforeEach(() => {
   mint.mockReset();
   postSpy = vi.fn();
   // Every iframe in the page reports the same window, which is the worst case:
   // nothing about the target distinguishes one surface's frame from another's.
+  // Stable across reads, the way a real frame's is — the page compares this
+  // value against itself to decide what is still current, so a getter handing
+  // back a fresh object each time would answer those comparisons by accident.
+  frameWindow = { postMessage: postSpy };
   Object.defineProperty(HTMLIFrameElement.prototype, "contentWindow", {
     configurable: true,
-    get: () => ({ postMessage: postSpy }),
+    get: () => frameWindow,
   });
 });
 
@@ -92,6 +97,9 @@ const ready = () =>
     new MessageEvent("message", {
       origin: "https://app.example.com",
       data: { type: "initiative-app:ready" },
+      // An announcement says which window it came from; the page exchanges
+      // only with the frame it mounted.
+      source: frameWindow as unknown as Window,
     })
   );
 
@@ -122,6 +130,32 @@ describe("GuildAppPage", () => {
     renderPage(() => <GuildAppPage appId={1} viewer={ADMIN} />);
 
     await screen.findByTitle("Automations");
+    await announceReady();
+  });
+
+  it("ignores an announcement from a window it did not mount", async () => {
+    // An app may have other windows at its own origin — a popup it opened for
+    // a vendor flow — so the origin alone does not say the mounted frame is
+    // asking. Nothing is handed over, and the token stays unspent for the
+    // frame that does ask.
+    mint.mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
+    const { GuildAppPage } = await import("./GuildAppPage");
+    renderPage(() => <GuildAppPage appId={1} viewer={ADMIN} />);
+
+    await screen.findByTitle("Automations");
+    await waitFor(() => expect(mint).toHaveBeenCalledWith("one", expect.anything()));
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "https://app.example.com",
+        data: { type: "initiative-app:ready" },
+        source: { postMessage: vi.fn() } as unknown as Window,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(delivered()).toEqual([]);
+
+    // The real frame still gets its token.
     await announceReady();
   });
 

--- a/frontend/src/pages/apps/GuildAppPage.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.tsx
@@ -26,7 +26,7 @@ import type { GuildAppHandoff } from "@/api/generated/initiativeAPI.schemas";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useGuildAppDetail } from "@/hooks/useGuildAppDetail";
-import { appEmbeds, type SurfaceViewer } from "@/lib/appSurfaces";
+import { appEmbeds, embedAllow, type SurfaceViewer } from "@/lib/appSurfaces";
 import { cn } from "@/lib/utils";
 import { localized } from "@/lib/widgets/widgetMeta";
 
@@ -164,12 +164,15 @@ export function GuildAppPage({ appId, initiativeId, viewer }: GuildAppPageProps)
 
     const onMessage = (event: MessageEvent) => {
       if (!allowed.has(event.origin)) return;
+      // The mounted frame is the only window this page exchanges with. An app
+      // may have other windows at the same origin — a popup it opened for a
+      // vendor flow — and the origin alone does not tell them apart.
+      const target = iframeRef.current?.contentWindow;
+      if (!target || event.source !== target) return;
       const data = event.data;
       if (!data || typeof data !== "object" || typeof data.type !== "string") return;
 
       if (data.type === READY) {
-        const target = iframeRef.current?.contentWindow;
-        if (!target) return;
         if (!spentRef.current) {
           send(target, handoff);
           spentRef.current = true;
@@ -262,7 +265,9 @@ export function GuildAppPage({ appId, initiativeId, viewer }: GuildAppPageProps)
           // allow-popups-to-escape-sandbox.
           sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"
           referrerPolicy="no-referrer"
-          allow="clipboard-read; clipboard-write"
+          // Exactly what this surface's manifest asked for. A surface that
+          // asked for nothing gets an empty attribute, which denies the lot.
+          allow={embedAllow(active)}
         />
       ) : (
         <div className="flex flex-1 items-center gap-2 p-4 text-muted-foreground text-sm">


### PR DESCRIPTION
## Problem

Two narrow things about the frame an app's embedded surface runs in.

**The `allow` attribute was a fixed grant.** Every embed frame was built with `allow="clipboard-read; clipboard-write"`, regardless of what the app's manifest said. The design has embed frames deny-by-default with per-manifest opt-in and install-time disclosure; a fixed attribute is the opposite of that, and `clipboard-read` in particular is a capability nothing had asked for.

**A `ready` announcement was accepted from any window at an allowed origin.** The handler checked `event.origin` but took its target from `iframeRef.current.contentWindow`. An app may have other windows at its own origin — a popup it opened for a vendor flow — so an announcement from one of those triggered a mint. The token still went to the mounted frame, so this cost a spurious mint rather than a misdirected token.

## Change

**Manifest vocabulary.** An embed may declare `capabilities`, checked against a closed set in `service_apps.py`:

```
camera, clipboard-read, clipboard-write, display-capture,
fullscreen, geolocation, microphone
```

Stored sorted and de-duplicated; absent when empty, like every other block. `payment` is deliberately not namable — the platform takes payment on its own pages.

**The frame is built from it.** `embedAllow(embed)` in `appSurfaces.ts` joins what the surface named, so a surface that named nothing gets `allow=""`.

**The page answers one window.** `event.source` must be the mounted frame's `contentWindow`.

## Compatibility

No definition pinned today declares `capabilities`, so every existing embed frame moves from clipboard-only to nothing granted. That is the intended default, and it is currently free: no shipped app has an embed since the advanced tool was removed, and auto has not yet returned as an app. An app that wants clipboard access adds it to its manifest and publishes a version.

## A note on the test stub

`GuildAppPage.test.tsx` stubbed `contentWindow` with `get: () => ({ postMessage: postSpy })` — a **new object on every read**, which contradicted the comment above it saying every iframe reports the same window. The page compares that value against itself to decide what is still current, so those comparisons were being answered by object identity accident rather than by the logic under test; the re-mint drop assertion passed for the wrong reason.

The stub now holds one stable object, the way a real frame does, and `ready()` names it as `source`. The re-mint drop test now exercises the `cancelled` path it was written for. Side effect: the suite got about 6× faster, because the announcement lands first try instead of retrying inside a `waitFor`.

## Testing

```
pytest app/services/marketplace/definitions_test.py app/services/marketplace/catalog_test.py   # 146 passed
pnpm vitest run src/lib/appSurfaces.test.ts src/pages/apps/GuildAppPage.test.tsx               # 32 passed
ruff check app && ruff format app
pnpm lint    # 8 warnings, all pre-existing and in files this branch does not touch
```

New coverage: a surface asking for nothing stores nothing; canonical sorting and de-duplication; a capability outside the vocabulary refused by name; `payment` refused; `embedAllow` over each shape; and an announcement from a window the page did not mount being ignored while the real frame still gets its token.

No schema change, so no API type regeneration.

## Not in this PR

Showing the requested capabilities in the install dialog, and re-prompting when an upgrade widens the set. Both belong with the re-consent work, which needs the disclosure-set diff to exist first.