### PR TITLE
Give the guild app fake the field the serializer reads

### DIFF
--- a/backend/app/schemas/tenant/guild_app_test.py
+++ b/backend/app/schemas/tenant/guild_app_test.py
@@ -60,6 +60,9 @@ def _app(**overrides) -> SimpleNamespace:
             "config_state": "ok",
             "config_state_detail": None,
             "artifacts": [],
+            # Every initiative, which is what an install that never narrowed it
+            # says and what the serializer reads.
+            "placement": {},
             "installed_by_id": 11,
             "created_at": now,
             "updated_at": now,


### PR DESCRIPTION
## Problem

`app/schemas/tenant/guild_app_test.py` fails on `dev` — all four tests:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'placement'
  app/schemas/tenant/guild_app.py:301
```

`serialize_guild_app` began reading `app.placement` in #1147, when apps gained a placement. The `SimpleNamespace` that stands in for a `GuildApp` row in these tests did not grow the field, so every call through the serializer raises.

Reproducible on `dev` with no other changes:

```
pytest app/schemas/tenant/guild_app_test.py   # 4 failed
```

## Change

One key on the fake. No production code involved.

## Testing

```
pytest app/schemas/tenant/guild_app_test.py   # 4 passed
ruff check app && ruff format app
```

## Why this is its own PR

Found while getting CI green on #1159, which does not touch these files and inherits the failure. Fixing it there would have buried an unrelated repair inside a change to the app-service registration path, and this belongs on `dev` ahead of both open branches.