### PR TITLE
Refuse a capability entry that is not a name

### DIFF
--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -579,6 +579,16 @@ class TestWhatASurfaceMayAskItsFrameFor:
         with pytest.raises(ListingDefinitionError, match="not a capability"):
             self._embed(capabilities=["midi"])
 
+    @pytest.mark.parametrize(
+        "entry", [{"camera": True}, ["camera"], 7, None, True], ids=repr
+    )
+    def test_an_entry_that_is_not_a_name_is_refused(self, entry):
+        """A publisher gets the same validation error for any entry that is not
+        one of the names. Set membership is defined only for a hashable value,
+        so an entry is typed before it is looked up rather than after."""
+        with pytest.raises(ListingDefinitionError, match="not a capability"):
+            self._embed(capabilities=[entry])
+
     def test_payment_is_not_namable(self):
         """The platform takes payment on its own pages, so an embedded surface
         has no reading of this to request."""

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -572,7 +572,9 @@ def _capabilities(raw: Any, *, what: str) -> list[str]:
     declared = require_list(raw, f"{what} capabilities", MAX_EMBED_CAPABILITIES)
     capabilities: set[str] = set()
     for entry in declared:
-        if entry not in EMBED_CAPABILITIES:
+        # Typed before it is looked up: set membership is defined only for a
+        # hashable value, so a name is what this compares.
+        if not isinstance(entry, str) or entry not in EMBED_CAPABILITIES:
             fail(
                 f"{what}: {entry!r} is not a capability a surface may request "
                 f"(one of {', '.join(sorted(EMBED_CAPABILITIES))})"

--- a/frontend/src/lib/appSurfaces.ts
+++ b/frontend/src/lib/appSurfaces.ts
@@ -35,9 +35,8 @@ export interface AppEmbed {
  * The `allow` attribute for a surface's frame.
  *
  * A frame is granted what its manifest named and nothing else, so a surface
- * that named nothing gets an empty attribute — which is every feature denied.
- * Each entry defaults to the frame's own origin, so a granted feature reaches
- * the app itself and not whatever the app goes on to embed.
+ * that named nothing gets an empty attribute. Each entry defaults to the
+ * frame's own origin, which is the app's.
  */
 export const embedAllow = (embed: Pick<AppEmbed, "capabilities"> | null | undefined): string =>
   (embed?.capabilities ?? []).join("; ");

--- a/frontend/src/pages/apps/GuildAppPage.test.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.test.tsx
@@ -134,10 +134,9 @@ describe("GuildAppPage", () => {
   });
 
   it("ignores an announcement from a window it did not mount", async () => {
-    // An app may have other windows at its own origin — a popup it opened for
-    // a vendor flow — so the origin alone does not say the mounted frame is
-    // asking. Nothing is handed over, and the token stays unspent for the
-    // frame that does ask.
+    // An app may hold more than one window at its own address, so the page
+    // matches an announcement to the frame it mounted rather than to the
+    // origin. The token stays unspent for the frame that does ask.
     mint.mockImplementation((surfaceId: string) => Promise.resolve(handoff(surfaceId)));
     const { GuildAppPage } = await import("./GuildAppPage");
     renderPage(() => <GuildAppPage appId={1} viewer={ADMIN} />);

--- a/frontend/src/pages/apps/GuildAppPage.tsx
+++ b/frontend/src/pages/apps/GuildAppPage.tsx
@@ -9,9 +9,11 @@
  * 2. The token is delivered by `postMessage` to the iframe's own origin, never
  *    in the URL, so it stays out of history, referrers and proxy logs.
  * 3. Inbound messages are ignored unless `event.origin` is one the registration
- *    listed.
+ *    listed and `event.source` is the frame this page mounted.
  * 4. The token is one-shot, so a reloading embed asks again and gets a fresh
  *    one rather than being stuck until the page is reloaded.
+ * 5. The frame is granted the browser features the surface's manifest declared,
+ *    and no others.
  */
 
 import { Loader2 } from "lucide-react";
@@ -164,9 +166,9 @@ export function GuildAppPage({ appId, initiativeId, viewer }: GuildAppPageProps)
 
     const onMessage = (event: MessageEvent) => {
       if (!allowed.has(event.origin)) return;
-      // The mounted frame is the only window this page exchanges with. An app
-      // may have other windows at the same origin — a popup it opened for a
-      // vendor flow — and the origin alone does not tell them apart.
+      // This page exchanges with one window: the frame it mounted. An
+      // announcement is matched to it by window rather than by origin, since
+      // an app may hold more than one window at the same address.
       const target = iframeRef.current?.contentWindow;
       if (!target || event.source !== target) return;
       const data = event.data;
@@ -265,8 +267,8 @@ export function GuildAppPage({ appId, initiativeId, viewer }: GuildAppPageProps)
           // allow-popups-to-escape-sandbox.
           sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"
           referrerPolicy="no-referrer"
-          // Exactly what this surface's manifest asked for. A surface that
-          // asked for nothing gets an empty attribute, which denies the lot.
+          // Built from what this surface's manifest declared; empty when it
+          // declared none.
           allow={embedAllow(active)}
         />
       ) : (


### PR DESCRIPTION
Follow-up to #1160, addressing both findings from its review.

## 1. An entry that is not a name reached the lookup

`require_list` bounds a list's length but not its element types, so `entry not in EMBED_CAPABILITIES` was handed whatever the manifest carried. Set membership is defined only for a hashable value:

```python
>>> {'camera'} .__contains__({'a': 1})
TypeError: unhashable type: 'dict'
```

So `"capabilities": [{"camera": true}]` or `["camera"]]` raised past `ListingDefinitionError` — an ingestion fault rather than the validation error every other malformed field produces. Scalars (`7`, `None`, `True`) already answered correctly and were refused; only unhashable entries got there.

Entries are now typed before they are looked up, so all five shapes report the same error. Parametrized coverage added over `{...}`, `[...]`, `7`, `None`, `True`.

Worth noting the blast radius was small: this is reachable only by whoever supplies a manifest — a built-in catalog file, an operator upload or mounted directory, or a signature-verified registry entry — and the result was a 500 on ingestion, not a stored value. It is a validator that failed to speak its own error, not a way past it.

## 2. Comments described the scenario rather than the code

The review flagged the comments added around `event.source` and the frame's `allow` as describing a security scenario, which the repository guidance on security-sensitive comments rules out. That is a correct read and the guidance is explicit, so they are rewritten to state what the code does:

- the `onMessage` comment now says the page matches an announcement to the frame it mounted by window rather than by origin
- the `allow` comment says the attribute is built from what the manifest declared
- the same in the test comment and the `embedAllow` docstring
- the module docstring's numbered list picks up the two rules that changed in #1160 — it still described the origin check alone, and said nothing about frame capabilities

No behavior change in this half.

## Testing

```
pytest app/services/marketplace/definitions_test.py                              # 105 passed
pnpm vitest run src/lib/appSurfaces.test.ts src/pages/apps/GuildAppPage.test.tsx  # 33 passed
ruff check app && ruff format app
```