### PR TITLE
Make a registration the only delegation trust root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **An app is granted the power to act as your members individually.** Delegation now follows the app's own registration — its keys, its grant, its switch — instead of one setting shared by the whole deployment. Turning an app's delegation off, or turning the app off, ends what it can do straight away. Existing deployments keep working on the old setting while their apps are provisioned with keys of their own.
+- **An app is granted the power to act as your members individually.** Delegation follows the app's own registration — its keys, its grant, its switch — rather than one setting shared by the whole deployment. Turning an app's delegation off, or turning the app off, ends what it can do straight away.
 - An app service registration can hold the public keys its app signs delegation tokens with, as a JWKS — pasted into the registration form or declared in the app services file alongside the app's other settings. Two entries in one key set is how an app rotates its signing key without downtime, and clearing the field removes it.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **An app is granted the power to act as your members individually.** Delegation now follows the app's own registration — its keys, its grant, its switch — instead of one setting shared by the whole deployment. Turning an app's delegation off, or turning the app off, ends what it can do straight away. Existing deployments keep working on the old setting while their apps are provisioned with keys of their own.
 - An app service registration can hold the public keys its app signs delegation tokens with, as a JWKS — pasted into the registration form or declared in the app services file alongside the app's other settings. Two entries in one key set is how an app rotates its signing key without downtime, and clearing the field removes it.
 
 ### Changed

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -29,7 +29,7 @@ from app.core.security import (
     SESSION_COOKIE_NAME,
     AutoDelegationVerificationError,
     UploadTokenError,
-    auto_delegation_configured,
+    delegation_possible,
     delegation_token_kid,
     decode_session_token,
     verify_auto_delegation_token,
@@ -96,29 +96,28 @@ async def _authenticate_auto_delegation(
     the user's memberships and must agree with the ``/g/{guild_id}`` path, so an
     auto workflow always acts in the guild its token was issued for.
     """
-    if not auto_delegation_configured():
-        return None  # delegation disabled — let other auth paths run
+    if not delegation_possible():
+        return None  # no app platform here — let other auth paths run
 
     # Which app signed this decides which keys may verify it. The token names a
-    # `kid`; the registration that published it must be enabled and hold the
-    # `delegation` grant, so an operator turning either off ends the app's
-    # ability to act with an edit rather than a key rotation.
-    resolved = await registration_lookup.delegation_key_for(
+    # `kid`, and the registrations that published it must be enabled and hold
+    # the `delegation` grant, so an operator ends an app's ability to act with
+    # an edit rather than a key rotation. Resolving nothing ends the attempt:
+    # there is no other key this token could be held against.
+    candidates = await registration_lookup.delegation_keys_for(
         delegation_token_kid(token) or ""
     )
-    # No resolution falls through to the deployment-wide key for one release,
-    # while deployments move their delegate onto its own registration.
-    keys = [resolved.key] if resolved else None
 
     try:
-        claims = verify_auto_delegation_token(token, keys=keys)
+        claims = verify_auto_delegation_token(
+            token, keys=[candidate.key for candidate in candidates]
+        )
     except AutoDelegationVerificationError:
         # Could be a session JWT or API key arriving on the same header.
         # Returning None lets the caller try those instead of failing.
         return None
 
-    if resolved is not None:
-        request.state.delegating_app = resolved.registration.public_id
+    request.state.delegating_app = candidates[0].registration.public_id
 
     # Replay guard: a delegation JWT is one-shot. Even though the JWT is
     # technically valid for 15 minutes, a captured token must not be
@@ -645,7 +644,7 @@ async def require_auto_delegate(
     token-guild vs path-guild comparison is also made in
     ``get_guild_membership``; it is repeated here so the gate holds on its own.
     """
-    if not auto_delegation_configured():
+    if not await registration_lookup.any_delegate_registered():
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=WebhookSubscriptionMessages.DELEGATE_NOT_CONFIGURED,

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -30,6 +30,7 @@ from app.core.security import (
     AutoDelegationVerificationError,
     UploadTokenError,
     auto_delegation_configured,
+    delegation_token_kid,
     decode_session_token,
     verify_auto_delegation_token,
     verify_upload_token,
@@ -43,6 +44,7 @@ from app.models.platform.user import User, UserRole, UserStatus
 from app.schemas.platform.token import TokenPayload
 from app.services.platform import access_grants as access_grants_service
 from app.services.platform import api_keys as api_keys_service
+from app.services.marketplace import registration_lookup
 from app.services.platform import auto_delegation_blocklist
 from app.services.platform import guilds as guilds_service
 from app.services.platform import user_tokens
@@ -97,12 +99,26 @@ async def _authenticate_auto_delegation(
     if not auto_delegation_configured():
         return None  # delegation disabled — let other auth paths run
 
+    # Which app signed this decides which keys may verify it. The token names a
+    # `kid`; the registration that published it must be enabled and hold the
+    # `delegation` grant, so an operator turning either off ends the app's
+    # ability to act with an edit rather than a key rotation.
+    resolved = await registration_lookup.delegation_key_for(
+        delegation_token_kid(token) or ""
+    )
+    # No resolution falls through to the deployment-wide key for one release,
+    # while deployments move their delegate onto its own registration.
+    keys = [resolved.key] if resolved else None
+
     try:
-        claims = verify_auto_delegation_token(token)
+        claims = verify_auto_delegation_token(token, keys=keys)
     except AutoDelegationVerificationError:
         # Could be a session JWT or API key arriving on the same header.
         # Returning None lets the caller try those instead of failing.
         return None
+
+    if resolved is not None:
+        request.state.delegating_app = resolved.registration.public_id
 
     # Replay guard: a delegation JWT is one-shot. Even though the JWT is
     # technically valid for 15 minutes, a captured token must not be

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
@@ -1,80 +1,37 @@
-"""Delegation verified against the signing app's own registration.
+"""What a registration says about whether its app may act as a member.
 
-The companion file to ``auto_delegation_test.py``, which covers the same auth
-dep reading the deployment-wide key. Here the token names a ``kid``, and what
-decides it is the registration that published that key: it must be enabled and
-hold the ``delegation`` grant, so an operator ends an app's ability to act with
-an edit rather than a key rotation.
+The companion to ``auto_delegation_test.py``, which exercises the auth dep's
+own checks with a delegate already in place. Here the subject is the
+registration itself: the grant, the kill switch, and which key a ``kid``
+resolves to.
 """
 
 from __future__ import annotations
 
-import json
-import secrets
-from datetime import datetime, timedelta, timezone
-
-import jwt
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import AsyncClient
-from jwt.algorithms import RSAAlgorithm
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core import config as config_module
-from app.models.platform.app_service_registration import (
-    AppServiceRegistration,
-    AppServiceStatus,
-)
 from app.services.marketplace.registration_lookup import (
-    delegate_available,
+    any_delegate_registered,
+    delegation_keys_for,
     invalidate_registrations,
 )
 from app.testing import create_user
-
-PUBLIC_ID = "acme.auto"
-KID = f"{PUBLIC_ID}-delegation-1"
-
-_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-_PRIVATE_PEM = _keypair.private_bytes(
-    serialization.Encoding.PEM,
-    serialization.PrivateFormat.PKCS8,
-    serialization.NoEncryption(),
-).decode()
-
-
-def _jwks(kid: str = KID) -> dict:
-    entry = json.loads(RSAAlgorithm.to_jwk(_keypair.public_key()))
-    entry["kid"] = kid
-    return {"keys": [entry]}
-
-
-def _mint(*, user_id: int, guild_id: int, kid: str | None = KID) -> str:
-    now = datetime.now(timezone.utc)
-    return jwt.encode(
-        {
-            "jti": secrets.token_hex(8),
-            "sub": str(user_id),
-            "aud": "initiative:auto-delegation",
-            "iss": "initiative-auto",
-            "iat": int(now.timestamp()),
-            "exp": now + timedelta(seconds=900),
-            "guild_id": guild_id,
-        },
-        _PRIVATE_PEM,
-        algorithm="RS256",
-        headers={"kid": kid} if kid else None,
-    )
+from app.testing.delegation import (
+    DELEGATE_KID,
+    delegation_jwks,
+    foreign_jwks,
+    mint_delegation_token,
+    register_delegate,
+)
 
 
 @pytest.fixture(autouse=True)
-def _registration_is_the_only_trust_root(monkeypatch):
-    """No deployment-wide key: what verifies a token here is the registration.
-
-    The app-platform signing key stands in for "registrations are reachable on
-    this deployment", which is what the cheap gate in the auth dep reads.
-    """
-    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+def _app_platform_configured(monkeypatch):
+    """Registrations are reachable on this deployment, which is the cheap gate
+    the auth dep reads before it resolves anything."""
     monkeypatch.setattr(
         config_module.settings,
         "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
@@ -85,27 +42,14 @@ def _registration_is_the_only_trust_root(monkeypatch):
     invalidate_registrations()
 
 
-async def _register(
-    session: AsyncSession,
-    *,
-    grants: list[str],
-    enabled: bool = True,
-    key_set: dict | None = None,
-) -> AppServiceRegistration:
-    row = AppServiceRegistration(
-        public_id=PUBLIC_ID,
-        base_url="http://auto:8080",
-        allowed_origins=["http://auto:8080"],
-        secret_encrypted=None,
-        grants=grants,
-        delegation_jwks=_jwks() if key_set is None else key_set,
-        enabled=enabled,
-        status=AppServiceStatus.OK,
+async def _call_as_delegate(client: AsyncClient, user_id: int) -> int:
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={
+            "Authorization": f"Bearer {mint_delegation_token(user_id=user_id, guild_id=1)}"
+        },
     )
-    session.add(row)
-    await session.commit()
-    invalidate_registrations()
-    return row
+    return response.status_code
 
 
 @pytest.mark.integration
@@ -113,15 +57,9 @@ async def test_a_granted_registration_verifies_the_token(
     client: AsyncClient, session: AsyncSession
 ):
     user = await create_user(session, email="delegated@example.com")
-    await _register(session, grants=["delegation"])
+    await register_delegate(session)
 
-    response = await client.get(
-        "/api/v1/users/me",
-        headers={"Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1)}"},
-    )
-
-    assert response.status_code == 200, response.text
-    assert response.json()["email"] == "delegated@example.com"
+    assert await _call_as_delegate(client, user.id) == 200
 
 
 @pytest.mark.integration
@@ -129,14 +67,9 @@ async def test_the_kill_switch_ends_delegation(
     client: AsyncClient, session: AsyncSession
 ):
     user = await create_user(session, email="switched-off@example.com")
-    await _register(session, grants=["delegation"], enabled=False)
+    await register_delegate(session, enabled=False)
 
-    response = await client.get(
-        "/api/v1/users/me",
-        headers={"Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1)}"},
-    )
-
-    assert response.status_code == 401
+    assert await _call_as_delegate(client, user.id) == 401
 
 
 @pytest.mark.integration
@@ -145,14 +78,9 @@ async def test_keys_without_the_grant_verify_nothing(
 ):
     """The key set says who signs; the grant says whether that app may act."""
     user = await create_user(session, email="ungranted@example.com")
-    await _register(session, grants=[])
+    await register_delegate(session, grants=())
 
-    response = await client.get(
-        "/api/v1/users/me",
-        headers={"Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1)}"},
-    )
-
-    assert response.status_code == 401
+    assert await _call_as_delegate(client, user.id) == 401
 
 
 @pytest.mark.integration
@@ -160,21 +88,47 @@ async def test_a_kid_no_registration_published_verifies_nothing(
     client: AsyncClient, session: AsyncSession
 ):
     user = await create_user(session, email="unknown-kid@example.com")
-    await _register(session, grants=["delegation"])
+    await register_delegate(session, key_set=delegation_jwks("some-other-generation"))
 
-    response = await client.get(
-        "/api/v1/users/me",
-        headers={
-            "Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1, kid='rotated-away')}"
-        },
-    )
-
-    assert response.status_code == 401
+    assert await _call_as_delegate(client, user.id) == 401
 
 
 @pytest.mark.integration
-async def test_delegate_available_follows_the_registration(session: AsyncSession):
-    assert await delegate_available() is False
+async def test_a_shared_kid_does_not_shadow_the_app_that_signed(
+    client: AsyncClient, session: AsyncSession
+):
+    """A ``kid`` is an opaque label its owner picks, so two apps may choose the
+    same one. Every match is offered to the verifier, and the token belongs to
+    whichever key actually signed it."""
+    user = await create_user(session, email="shared-kid@example.com")
+    # A namesake registered first, publishing a different key under the same
+    # kid — the token is not its.
+    await register_delegate(
+        session,
+        public_id="aaa.namesake",
+        key_set=foreign_jwks(DELEGATE_KID),
+    )
+    await register_delegate(session)
 
-    await _register(session, grants=["delegation"])
-    assert await delegate_available() is True
+    assert await _call_as_delegate(client, user.id) == 200
+
+
+@pytest.mark.integration
+async def test_resolution_offers_every_registration_publishing_the_kid(
+    session: AsyncSession,
+):
+    await register_delegate(session, public_id="aaa.namesake")
+    await register_delegate(session)
+
+    assert len(await delegation_keys_for(DELEGATE_KID)) == 2
+    assert await delegation_keys_for("nobody-published-this") == ()
+
+
+@pytest.mark.integration
+async def test_any_delegate_registered_follows_the_registration(
+    session: AsyncSession,
+):
+    assert await any_delegate_registered() is False
+
+    await register_delegate(session)
+    assert await any_delegate_registered() is True

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
@@ -1,0 +1,180 @@
+"""Delegation verified against the signing app's own registration.
+
+The companion file to ``auto_delegation_test.py``, which covers the same auth
+dep reading the deployment-wide key. Here the token names a ``kid``, and what
+decides it is the registration that published that key: it must be enabled and
+hold the ``delegation`` grant, so an operator ends an app's ability to act with
+an edit rather than a key rotation.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import AsyncClient
+from jwt.algorithms import RSAAlgorithm
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core import config as config_module
+from app.models.platform.app_service_registration import (
+    AppServiceRegistration,
+    AppServiceStatus,
+)
+from app.services.marketplace.registration_lookup import (
+    delegate_available,
+    invalidate_registrations,
+)
+from app.testing import create_user
+
+PUBLIC_ID = "acme.auto"
+KID = f"{PUBLIC_ID}-delegation-1"
+
+_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_PEM = _keypair.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+
+
+def _jwks(kid: str = KID) -> dict:
+    entry = json.loads(RSAAlgorithm.to_jwk(_keypair.public_key()))
+    entry["kid"] = kid
+    return {"keys": [entry]}
+
+
+def _mint(*, user_id: int, guild_id: int, kid: str | None = KID) -> str:
+    now = datetime.now(timezone.utc)
+    return jwt.encode(
+        {
+            "jti": secrets.token_hex(8),
+            "sub": str(user_id),
+            "aud": "initiative:auto-delegation",
+            "iss": "initiative-auto",
+            "iat": int(now.timestamp()),
+            "exp": now + timedelta(seconds=900),
+            "guild_id": guild_id,
+        },
+        _PRIVATE_PEM,
+        algorithm="RS256",
+        headers={"kid": kid} if kid else None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _registration_is_the_only_trust_root(monkeypatch):
+    """No deployment-wide key: what verifies a token here is the registration.
+
+    The app-platform signing key stands in for "registrations are reachable on
+    this deployment", which is what the cheap gate in the auth dep reads.
+    """
+    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    monkeypatch.setattr(
+        config_module.settings,
+        "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
+        "-----BEGIN PRIVATE KEY-----",
+    )
+    invalidate_registrations()
+    yield
+    invalidate_registrations()
+
+
+async def _register(
+    session: AsyncSession,
+    *,
+    grants: list[str],
+    enabled: bool = True,
+    key_set: dict | None = None,
+) -> AppServiceRegistration:
+    row = AppServiceRegistration(
+        public_id=PUBLIC_ID,
+        base_url="http://auto:8080",
+        allowed_origins=["http://auto:8080"],
+        secret_encrypted=None,
+        grants=grants,
+        delegation_jwks=_jwks() if key_set is None else key_set,
+        enabled=enabled,
+        status=AppServiceStatus.OK,
+    )
+    session.add(row)
+    await session.commit()
+    invalidate_registrations()
+    return row
+
+
+@pytest.mark.integration
+async def test_a_granted_registration_verifies_the_token(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="delegated@example.com")
+    await _register(session, grants=["delegation"])
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["email"] == "delegated@example.com"
+
+
+@pytest.mark.integration
+async def test_the_kill_switch_ends_delegation(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="switched-off@example.com")
+    await _register(session, grants=["delegation"], enabled=False)
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1)}"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_keys_without_the_grant_verify_nothing(
+    client: AsyncClient, session: AsyncSession
+):
+    """The key set says who signs; the grant says whether that app may act."""
+    user = await create_user(session, email="ungranted@example.com")
+    await _register(session, grants=[])
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1)}"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_a_kid_no_registration_published_verifies_nothing(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="unknown-kid@example.com")
+    await _register(session, grants=["delegation"])
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={
+            "Authorization": f"Bearer {_mint(user_id=user.id, guild_id=1, kid='rotated-away')}"
+        },
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_delegate_available_follows_the_registration(session: AsyncSession):
+    assert await delegate_available() is False
+
+    await _register(session, grants=["delegation"])
+    assert await delegate_available() is True

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
@@ -17,10 +17,7 @@ blocklist + cross-claim consistency the dep enforces.
 
 from __future__ import annotations
 
-import secrets
-from datetime import datetime, timedelta, timezone
 
-import jwt
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -29,66 +26,36 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core import config as config_module
 from app.models.platform.user import UserStatus
+from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.testing import (
     create_guild,
     create_guild_membership,
     create_user,
 )
-
-
-# A fresh keypair per test session — keeps signatures from leaking between
-# tests if the same private key were reused via fixture caching.
-_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-_PRIVATE_PEM = _keypair.private_bytes(
-    serialization.Encoding.PEM,
-    serialization.PrivateFormat.PKCS8,
-    serialization.NoEncryption(),
-).decode()
-_PUBLIC_PEM = (
-    _keypair.public_key()
-    .public_bytes(
-        serialization.Encoding.PEM,
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    .decode()
-)
-
-
-def _mint_delegation(
-    *,
-    user_id: int,
-    guild_id: int,
-    initiative_id: int | None = None,
-    jti: str | None = None,
-    aud: str = "initiative:auto-delegation",
-    iss: str = "initiative-auto",
-    private_pem: str = _PRIVATE_PEM,
-    expires_in: int = 900,
-) -> str:
-    now = datetime.now(timezone.utc)
-    payload: dict = {
-        "jti": jti or secrets.token_hex(8),
-        "sub": str(user_id),
-        "aud": aud,
-        "iss": iss,
-        "iat": int(now.timestamp()),
-        "exp": now + timedelta(seconds=expires_in),
-        "guild_id": guild_id,
-    }
-    if initiative_id is not None:
-        payload["initiative_id"] = initiative_id
-    return jwt.encode(payload, private_pem, algorithm="RS256")
+from app.testing.delegation import mint_delegation_token, register_delegate
 
 
 @pytest.fixture(autouse=True)
-def _enable_delegation(monkeypatch):
-    """Configure the public key for the duration of each test in this file.
-    Without it, ``_authenticate_auto_delegation`` short-circuits to None
-    and the tests fall through to standard-JWT auth, which is not what
-    we're exercising here."""
-    monkeypatch.setattr(
-        config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _PUBLIC_PEM
-    )
+async def _enable_delegation(session: AsyncSession):
+    """Register the app whose tokens these tests expect to be accepted.
+
+    A delegation token is decided by the registration that published its
+    ``kid``, so the delegate is a row rather than a setting. The app-platform
+    key stands in for "registrations are reachable on this deployment", which
+    is the cheap gate the auth dep reads first.
+    """
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            config_module.settings,
+            "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
+            "-----BEGIN PRIVATE KEY-----",
+        )
+        await register_delegate(session)
+        yield
+    invalidate_registrations()
+
+
+_mint_delegation = mint_delegation_token
 
 
 @pytest.mark.integration
@@ -270,13 +237,15 @@ async def test_delegation_rejects_signature_from_other_key(
 
 
 @pytest.mark.integration
-async def test_delegation_disabled_when_public_key_unset(
+async def test_delegation_is_off_where_no_app_platform_is_configured(
     client: AsyncClient, session: AsyncSession, monkeypatch
 ):
-    """Operator hasn't configured the public key → delegation auth is
-    fully off and the request falls through to the standard 401 from
-    the JWT path. No 500 from a half-configured state."""
-    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    """No app platform means no registrations, so nothing can delegate here.
+    The request falls through to the standard 401 from the JWT path rather
+    than erroring on a half-configured state."""
+    monkeypatch.setattr(
+        config_module.settings, "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM", None
+    )
 
     user = await create_user(session, email="delegation-off@example.com")
     token = _mint_delegation(user_id=user.id, guild_id=1)

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
@@ -18,21 +18,20 @@ RSA keypair whose public half is monkeypatched into settings, and one fresh
 
 from __future__ import annotations
 
-import secrets
 import socket
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-import jwt
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import AsyncClient
+from sqlmodel import select
 
 from app.core import config as config_module
+from app.models.platform.app_service_registration import AppServiceRegistration
 from app.models.platform.guild import GuildRole
+from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.testing import Actor
+from app.testing.delegation import mint_delegation_token, register_delegate
 
 _WEBHOOK_HOST = "hooks.example.com"
 # A public unicast IPv4 (example.com) with a real stream socket type/proto, so
@@ -41,50 +40,37 @@ _FAKE_INFOS = [
     (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("93.184.216.34", 0))
 ]
 
-_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-_PRIVATE_PEM = _keypair.private_bytes(
-    serialization.Encoding.PEM,
-    serialization.PrivateFormat.PKCS8,
-    serialization.NoEncryption(),
-).decode()
-_PUBLIC_PEM = (
-    _keypair.public_key()
-    .public_bytes(
-        serialization.Encoding.PEM,
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    .decode()
-)
-
 
 @pytest.fixture(autouse=True)
-def _enable_delegation(monkeypatch):
-    """Configure an automation delegate for the duration of each test here.
+async def _enable_delegation(session):
+    """Register the delegate these tests act as.
 
-    Without it every route answers 503 — which is its own test below, not the
+    Without one every route answers 503 — which is its own test below, not the
     baseline the rest of the file is written against.
     """
-    monkeypatch.setattr(
-        config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _PUBLIC_PEM
-    )
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            config_module.settings,
+            "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
+            "-----BEGIN PRIVATE KEY-----",
+        )
+        await register_delegate(session)
+        yield
+    invalidate_registrations()
+
+
+async def _drop_the_delegate(session) -> None:
+    """Take the registration the autouse fixture put there back out, for the
+    tests about a deployment that has no delegate at all."""
+    for row in (await session.exec(select(AppServiceRegistration))).all():
+        await session.delete(row)
+    await session.commit()
+    invalidate_registrations()
 
 
 def _delegation_headers(*, user_id: int, guild_id: int) -> dict[str, str]:
     """Mint a fresh (one-shot) delegation JWT for the user + guild."""
-    now = datetime.now(timezone.utc)
-    token = jwt.encode(
-        {
-            "jti": secrets.token_hex(8),
-            "sub": str(user_id),
-            "aud": "initiative:auto-delegation",
-            "iss": "initiative-auto",
-            "iat": int(now.timestamp()),
-            "exp": now + timedelta(seconds=900),
-            "guild_id": guild_id,
-        },
-        _PRIVATE_PEM,
-        algorithm="RS256",
-    )
+    token = mint_delegation_token(user_id=user_id, guild_id=guild_id)
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -170,12 +156,12 @@ async def test_ordinary_caller_is_refused_on_every_route(
     [("post", "/auto/subscriptions"), ("get", "/auto/subscriptions")],
 )
 async def test_no_delegate_configured_refuses_with_503(
-    client: AsyncClient, acting_user, monkeypatch, method: str, path: str
+    client: AsyncClient, session, acting_user, method: str, path: str
 ):
-    """A deployment with no automation delegate has nothing that may own a
-    delivery target, so the routes are unavailable rather than forbidden —
-    503, which resolves itself once an operator configures a delegate."""
-    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    """A deployment with no delegate has nothing that may own a delivery
+    target, so the routes are unavailable rather than forbidden — 503, which
+    resolves itself once an operator grants an app the power."""
+    await _drop_the_delegate(session)
     a = await acting_user(guild_role=GuildRole.admin)
 
     kwargs: dict = {"headers": a.headers}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -606,19 +606,11 @@ class Settings(BaseSettings):
     # to pick the right verifying key — useful when rotating.
     HANDOFF_SIGNING_KEY_ID: str | None = None
 
-    # Inbound delegation from the automation service (initiative-auto).
-    # When auto needs to call Initiative on behalf of a user — either
-    # because the user is in the iframe right now, or because a workflow
-    # they own is firing — it presents a JWT signed with RS256 by its
-    # own private key. This is the matching public key. When unset,
-    # delegation auth is disabled and Initiative only accepts its own
-    # session tokens / API keys.
-    #
-    # Accepts more than one key, as concatenated PEM blocks, which is how the
-    # delegate rotates without downtime: append the new key, let auto start
-    # signing with it, then drop the old block. A token is accepted if any
-    # block verifies it.
-    AUTO_DELEGATION_PUBLIC_KEY_PEM: str | None = None
+    # Inbound delegation from an app service acting for one of its members.
+    # The app presents a JWT signed with its own private key (RS256); the
+    # public half lives on that app's registration, which is also what says
+    # whether it may delegate at all. These two are the envelope every such
+    # token is checked against.
     AUTO_DELEGATION_AUDIENCE: str = "initiative:auto-delegation"
     AUTO_DELEGATION_ISSUER: str = "initiative-auto"
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -503,33 +503,63 @@ class AutoDelegationVerificationError(Exception):
 
 
 def auto_delegation_configured() -> bool:
-    """True when this deployment has an automation delegate.
+    """True when this deployment could have a delegate at all.
 
-    The delegate is identified by the public half of its signing key, so the
-    presence of that key is what "a delegate exists here" means. Single source
-    of truth for every surface that is delegate-owned: the subscription
-    endpoints refuse without it and the outbound dispatcher stays inert.
+    A delegate is identified two ways now: by a key on its own registration —
+    the one an app is granted individually — or by the deployment-wide
+    ``AUTO_DELEGATION_PUBLIC_KEY_PEM``, which predates per-app keys and is read
+    for one release while deployments move across.
+
+    This is the cheap settings-only answer, for the callers that only need to
+    know whether the machinery is present: a registration is reachable exactly
+    when the app platform has its signing key. Whether some app *actually*
+    holds the grant is
+    :func:`app.services.marketplace.registration_lookup.any_delegate_registered`,
+    which reads the registrations.
     """
-    return bool(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM)
+    return bool(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM) or bool(
+        settings.APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM
+    )
 
 
-def verify_auto_delegation_token(token: str) -> AutoDelegationClaims:
-    """Verify a delegation JWT minted by initiative-auto.
+def delegation_token_kid(token: str) -> str | None:
+    """The ``kid`` a delegation token names, read before any verification.
 
-    Disabled when ``AUTO_DELEGATION_PUBLIC_KEY_PEM`` is unset — that
-    config gap surfaces as a verification error so the auth dep can
-    fall through to its other token paths instead of 500'ing.
-
-    The setting holds one key normally and two while the delegate is rotating,
-    so the token is accepted if any configured key verifies it.
+    Selecting a key is what a header is for, and nothing is trusted on the
+    strength of it: the key it resolves to is what decides the token.
     """
     try:
-        keys = load_verification_keys(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM or "")
-    except PublicKeyBundleError as e:
-        raise AutoDelegationVerificationError(
-            f"AUTO_DELEGATION_PUBLIC_KEY_PEM is unusable: {e}"
-        ) from e
-    # Covers both an unset setting and one holding no PEM block at all.
+        return jwt.get_unverified_header(token).get("kid")
+    except jwt.PyJWTError:
+        return None
+
+
+def verify_auto_delegation_token(
+    token: str, *, keys: Sequence[Any] | None = None
+) -> AutoDelegationClaims:
+    """Verify a delegation JWT and resolve it to the user it names.
+
+    ``keys`` is the verification material the caller resolved — in the ordinary
+    path, the key set on the registration of the app that signed it. Omitted,
+    this falls back to the deployment-wide
+    ``AUTO_DELEGATION_PUBLIC_KEY_PEM``, which is read for one release while
+    deployments provision per-app keys; an unset setting surfaces as a
+    verification error so the auth dep falls through to its other token paths
+    instead of 500'ing.
+
+    More than one key is accepted either way, because that is what a rotation
+    looks like from this side: the replacement is published alongside the
+    current one while tokens signed by the first drain out.
+    """
+    if keys is None:
+        try:
+            keys = load_verification_keys(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM or "")
+        except PublicKeyBundleError as e:
+            raise AutoDelegationVerificationError(
+                f"AUTO_DELEGATION_PUBLIC_KEY_PEM is unusable: {e}"
+            ) from e
+    # Covers an unset setting, one holding no PEM block, and a resolved
+    # registration whose key set turned out to be empty.
     if not keys:
         raise AutoDelegationVerificationError("delegation auth not configured")
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -477,10 +477,10 @@ def create_billing_support_handoff_token(
 # ──────────────────────────────────────────────────────────────────────────
 # Inbound delegation from initiative-auto
 #
-# When auto calls our API on behalf of a user, it presents a JWT signed
-# with its private key (RS256). We verify here using the public half
-# configured at AUTO_DELEGATION_PUBLIC_KEY_PEM and resolve the JWT to a
-# user_id that the auth dependency then loads as a User. From that
+# When an app calls our API on behalf of a user, it presents a JWT signed
+# with its private key (RS256). We verify here using the public half its
+# registration publishes, and resolve the JWT to a user_id that the auth
+# dependency then loads as a User. From that
 # point on the request runs through our normal RLS + role-permission
 # stack — the delegation just answers "who is acting", not "what can
 # they do".
@@ -502,24 +502,17 @@ class AutoDelegationVerificationError(Exception):
     """Raised when the inbound delegation JWT fails any check."""
 
 
-def auto_delegation_configured() -> bool:
+def delegation_possible() -> bool:
     """True when this deployment could have a delegate at all.
 
-    A delegate is identified two ways now: by a key on its own registration —
-    the one an app is granted individually — or by the deployment-wide
-    ``AUTO_DELEGATION_PUBLIC_KEY_PEM``, which predates per-app keys and is read
-    for one release while deployments move across.
-
-    This is the cheap settings-only answer, for the callers that only need to
-    know whether the machinery is present: a registration is reachable exactly
-    when the app platform has its signing key. Whether some app *actually*
-    holds the grant is
+    A delegate is an app service holding the ``delegation`` grant, so the
+    machinery is present exactly when the app platform has its signing key.
+    Whether an app *actually* holds the grant is
     :func:`app.services.marketplace.registration_lookup.any_delegate_registered`,
-    which reads the registrations.
+    which reads the registrations; this is the settings-only answer, for the
+    callers that only need to know whether the table could have rows.
     """
-    return bool(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM) or bool(
-        settings.APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM
-    )
+    return bool(settings.APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM)
 
 
 def delegation_token_kid(token: str) -> str | None:
@@ -535,33 +528,21 @@ def delegation_token_kid(token: str) -> str | None:
 
 
 def verify_auto_delegation_token(
-    token: str, *, keys: Sequence[Any] | None = None
+    token: str, *, keys: Sequence[Any]
 ) -> AutoDelegationClaims:
     """Verify a delegation JWT and resolve it to the user it names.
 
-    ``keys`` is the verification material the caller resolved — in the ordinary
-    path, the key set on the registration of the app that signed it. Omitted,
-    this falls back to the deployment-wide
-    ``AUTO_DELEGATION_PUBLIC_KEY_PEM``, which is read for one release while
-    deployments provision per-app keys; an unset setting surfaces as a
-    verification error so the auth dep falls through to its other token paths
-    instead of 500'ing.
+    ``keys`` is the verification material the caller resolved — the key set on
+    the registration of the app that signed this token. More than one is
+    accepted for two reasons: a rotation publishes the replacement alongside
+    the current key, and a ``kid`` is an opaque label two apps may both pick,
+    so the token belongs to whichever key verifies it.
 
-    More than one key is accepted either way, because that is what a rotation
-    looks like from this side: the replacement is published alongside the
-    current one while tokens signed by the first drain out.
+    An empty sequence raises rather than returning, so a caller that resolved
+    nothing gets the same "not a delegation token" answer as a bad signature.
     """
-    if keys is None:
-        try:
-            keys = load_verification_keys(settings.AUTO_DELEGATION_PUBLIC_KEY_PEM or "")
-        except PublicKeyBundleError as e:
-            raise AutoDelegationVerificationError(
-                f"AUTO_DELEGATION_PUBLIC_KEY_PEM is unusable: {e}"
-            ) from e
-    # Covers an unset setting, one holding no PEM block, and a resolved
-    # registration whose key set turned out to be empty.
     if not keys:
-        raise AutoDelegationVerificationError("delegation auth not configured")
+        raise AutoDelegationVerificationError("no verification key for this token")
 
     payload = None
     first_error: jwt.PyJWTError | None = None

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -340,6 +340,8 @@ def test_decode_session_token_rejects_garbage():
 # ──────────────────────────────────────────────────────────────────────────
 
 
+DELEGATE_KID_SHAPE = "acme.auto-delegation-1"
+
 _KEYPAIRS = [
     rsa.generate_private_key(public_exponent=65537, key_size=2048) for _ in range(3)
 ]
@@ -355,6 +357,11 @@ def private_pem(index: int) -> str:
         )
         .decode()
     )
+
+
+def public_key(index: int):
+    """One verifying key, as a caller that resolved it would hold it."""
+    return _KEYPAIRS[index].public_key()
 
 
 def public_bundle(*indexes: int) -> str:
@@ -433,78 +440,84 @@ def _mint_delegation(
     )
 
 
-@pytest.fixture
-def delegation_pem(monkeypatch):
-    def configure(bundle: str | None):
-        monkeypatch.setattr(security.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", bundle)
-
-    return configure
-
-
 @pytest.mark.unit
-def test_delegation_accepts_its_one_configured_key(delegation_pem):
-    delegation_pem(public_bundle(0))
-    claims = security.verify_auto_delegation_token(_mint_delegation(signed_by=0))
+def test_delegation_accepts_the_key_it_was_given():
+    claims = security.verify_auto_delegation_token(
+        _mint_delegation(signed_by=0), keys=[public_key(0)]
+    )
     assert (claims.user_id, claims.guild_id) == (5, 9)
 
 
 @pytest.mark.unit
-def test_delegation_accepts_either_key_while_the_delegate_rotates(delegation_pem):
-    """The point of the bundle: both keys work, so the two sides can switch at
-    their own pace instead of in the same instant."""
-    delegation_pem(public_bundle(0, 1))
+def test_delegation_accepts_either_key_while_the_delegate_rotates():
+    """The point of passing a set: both keys work, so an app can publish its
+    replacement and switch at its own pace rather than in one instant."""
     for index in (0, 1):
         assert (
             security.verify_auto_delegation_token(
-                _mint_delegation(signed_by=index)
+                _mint_delegation(signed_by=index), keys=[public_key(0), public_key(1)]
             ).user_id
             == 5
         )
 
 
 @pytest.mark.unit
-def test_delegation_refuses_a_key_that_is_not_configured(delegation_pem):
-    """Trusting two keys is not trusting any RS256 signer."""
-    delegation_pem(public_bundle(0, 1))
+def test_delegation_refuses_a_key_it_was_not_given():
+    """Holding two keys is not holding every RS256 signer."""
     with pytest.raises(security.AutoDelegationVerificationError):
-        security.verify_auto_delegation_token(_mint_delegation(signed_by=2))
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=2), keys=[public_key(0), public_key(1)]
+        )
 
 
 @pytest.mark.unit
-def test_delegation_stops_accepting_a_dropped_key(delegation_pem):
-    """Rotation ends by removing a block, so that key must stop working."""
-    delegation_pem(public_bundle(1))
+def test_delegation_refuses_when_nothing_resolved():
+    """An empty set is the "no registration published this kid" case, and it
+    answers the same way a bad signature does."""
     with pytest.raises(security.AutoDelegationVerificationError):
-        security.verify_auto_delegation_token(_mint_delegation(signed_by=0))
+        security.verify_auto_delegation_token(_mint_delegation(signed_by=0), keys=[])
 
 
 @pytest.mark.unit
-def test_delegation_ignores_a_token_key_id(delegation_pem):
-    """The delegate stamps a ``kid``; nothing reads it. Pinned because that
-    header is unsigned, so it must not steer which key is used."""
-    delegation_pem(public_bundle(0, 1))
+def test_delegation_stops_accepting_a_dropped_key():
+    """Rotation ends by dropping an entry, so that key must stop working."""
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=0), keys=[public_key(1)]
+        )
+
+
+@pytest.mark.unit
+def test_a_token_key_id_does_not_steer_verification():
+    """The ``kid`` selects which registration's keys are tried; within them it
+    decides nothing. A token stamped with a misleading one still stands or
+    falls on the key that actually signed it."""
     assert (
         security.verify_auto_delegation_token(
-            _mint_delegation(signed_by=1, kid="names-the-other-key")
+            _mint_delegation(signed_by=1, kid="names-the-other-key"),
+            keys=[public_key(0), public_key(1)],
         ).user_id
         == 5
     )
+    with pytest.raises(security.AutoDelegationVerificationError):
+        security.verify_auto_delegation_token(
+            _mint_delegation(signed_by=2, kid=DELEGATE_KID_SHAPE),
+            keys=[public_key(0), public_key(1)],
+        )
 
 
 @pytest.mark.unit
-def test_delegation_reports_expiry_rather_than_the_next_key(delegation_pem):
+def test_delegation_reports_expiry_rather_than_the_next_key():
     """With several keys tried, the reported failure is the real one."""
-    delegation_pem(public_bundle(0, 1))
     with pytest.raises(security.AutoDelegationVerificationError) as excinfo:
         security.verify_auto_delegation_token(
-            _mint_delegation(signed_by=0, expires_in=-30)
+            _mint_delegation(signed_by=0, expires_in=-30),
+            keys=[public_key(0), public_key(1)],
         )
     assert "expired" in str(excinfo.value).lower()
 
 
 @pytest.mark.unit
-def test_delegation_is_off_with_no_key(delegation_pem):
-    delegation_pem(None)
-    assert security.auto_delegation_configured() is False
-    with pytest.raises(security.AutoDelegationVerificationError):
-        security.verify_auto_delegation_token(_mint_delegation(signed_by=0))
+def test_delegation_is_off_where_no_app_platform_is_configured(monkeypatch):
+    monkeypatch.setattr(security.settings, "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM", None)
+    assert security.delegation_possible() is False

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -29,7 +29,6 @@ from typing import Any, Mapping, Optional
 from jwt import PyJWK
 from sqlmodel import select
 
-from app.core.config import settings
 from app.db import session as db_session
 from app.models.platform.app_service_registration import (
     AppServiceRegistration,
@@ -45,8 +44,7 @@ __all__ = [
     "InstallState",
     "RegistrationSnapshot",
     "any_delegate_registered",
-    "delegate_available",
-    "delegation_key_for",
+    "delegation_keys_for",
     "install_state",
     "invalidate_registrations",
     "load_registrations",
@@ -267,34 +265,39 @@ class DelegationKey:
     key: Any
 
 
-async def delegation_key_for(kid: str) -> Optional[DelegationKey]:
-    """The key a delegation token's ``kid`` names, if an app may delegate.
+async def delegation_keys_for(kid: str) -> tuple[DelegationKey, ...]:
+    """Every key a delegation token's ``kid`` could name.
 
-    Resolution is by ``kid`` rather than by parsing the app's name out of it:
-    a ``kid`` is an opaque label its owner chooses, and rotation means one app
-    publishes two at once.
+    Only from registrations that are ``enabled`` and hold the ``delegation``
+    grant, so an operator ends an app's ability to act with an edit rather than
+    a key rotation.
+
+    All matches rather than the first: a ``kid`` is an opaque label its owner
+    chooses, so two apps may pick the same one, and the token belongs to
+    whichever key verifies it. Resolution is by ``kid`` rather than by reading
+    an app's name out of it, for the same reason.
 
     Deliberately ``enabled`` rather than :attr:`RegistrationSnapshot.live` — a
-    delegate calls the API directly, so its ability to act should follow the
+    delegate calls the API directly, so its ability to act follows the
     operator's kill switch, not whether its manifest was reachable at the last
     handshake.
     """
     if not kid:
-        return None
-    for snapshot in (await load_registrations()).values():
-        if not snapshot.enabled or "delegation" not in snapshot.grants:
-            continue
-        key = snapshot.delegation_keys.get(kid)
-        if key is not None:
-            return DelegationKey(registration=snapshot, key=key)
-    return None
+        return ()
+    return tuple(
+        DelegationKey(registration=snapshot, key=key)
+        for snapshot in (await load_registrations()).values()
+        if snapshot.enabled and "delegation" in snapshot.grants
+        for key in (snapshot.delegation_keys.get(kid),)
+        if key is not None
+    )
 
 
 async def any_delegate_registered() -> bool:
     """Whether some app on this deployment may delegate and can be verified.
 
-    The accurate answer, for callers deciding whether a delegate exists at all
-    rather than whether this token resolves.
+    What every surface that is delegate-owned reads: the subscription
+    endpoints refuse without one and the outbound dispatcher stays inert.
     """
     return any(
         snapshot.enabled
@@ -302,19 +305,3 @@ async def any_delegate_registered() -> bool:
         and snapshot.delegation_keys
         for snapshot in (await load_registrations()).values()
     )
-
-
-async def delegate_available() -> bool:
-    """Whether this deployment has a delegate at all.
-
-    True for a registration that holds the grant and a key, and for the
-    deployment-wide ``AUTO_DELEGATION_PUBLIC_KEY_PEM`` while that is still the
-    trust root — a deployment that has not yet moved its delegate onto its own
-    registration must keep working, so both count for one release.
-
-    This is the answer for "does a delegate exist here", as distinct from
-    :func:`auto_delegation_configured`'s cheaper "could one".
-    """
-    if settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
-        return True
-    return await any_delegate_registered()

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -20,12 +20,16 @@ handle to a row:
 
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
 
+from jwt import PyJWK
 from sqlmodel import select
 
+from app.core.config import settings
 from app.db import session as db_session
 from app.models.platform.app_service_registration import (
     AppServiceRegistration,
@@ -33,10 +37,16 @@ from app.models.platform.app_service_registration import (
     is_live,
 )
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "CACHE_TTL_SECONDS",
+    "DelegationKey",
     "InstallState",
     "RegistrationSnapshot",
+    "any_delegate_registered",
+    "delegate_available",
+    "delegation_key_for",
     "install_state",
     "invalidate_registrations",
     "load_registrations",
@@ -66,6 +76,10 @@ class RegistrationSnapshot:
     allowed_origins: tuple[str, ...]
     #: Operator-conferred powers, for callers that gate on one.
     grants: tuple[str, ...]
+    #: Public verification keys this app signs delegation tokens with, by the
+    #: ``kid`` a token names. Parsed once when the snapshot is built rather than
+    #: per token. Empty on an app that has not been provisioned with one.
+    delegation_keys: Mapping[str, Any]
     #: The deployment installs this app in every guild (§7.7).
     mandatory: bool
     #: The operator's kill switch. False stops every channel this app has.
@@ -85,6 +99,28 @@ class RegistrationSnapshot:
     def browser_base(self) -> str:
         """The base to build an address a browser will be sent to."""
         return browser_base(self)
+
+
+def _parse_delegation_keys(row: AppServiceRegistration) -> Mapping[str, Any]:
+    """Build the ``kid`` → key index for one registration.
+
+    The keys were validated when they were stored, so anything unusable here
+    is a surprise worth logging rather than a case to model: the entry is left
+    out, and a token naming it finds no key.
+    """
+    key_set = row.delegation_jwks or {}
+    parsed: dict[str, Any] = {}
+    for entry in key_set.get("keys", []) or []:
+        kid = entry.get("kid") if isinstance(entry, dict) else None
+        if not kid:
+            continue
+        try:
+            parsed[kid] = PyJWK.from_dict(entry).key
+        except Exception:
+            logger.warning(
+                "app services: %s has an unusable delegation key %r", row.public_id, kid
+            )
+    return MappingProxyType(parsed)
 
 
 _cache: dict[str, RegistrationSnapshot] | None = None
@@ -126,6 +162,7 @@ async def load_registrations(*, force: bool = False) -> dict[str, RegistrationSn
             embed_origin=row.embed_origin,
             allowed_origins=tuple(row.allowed_origins or []),
             grants=tuple(row.grants or []),
+            delegation_keys=_parse_delegation_keys(row),
             mandatory=bool(row.mandatory),
             enabled=bool(row.enabled),
             status=row.status,
@@ -220,3 +257,64 @@ async def mandatory_registrations() -> list[RegistrationSnapshot]:
         for snapshot in (await load_registrations()).values()
         if snapshot.mandatory and snapshot.enabled
     ]
+
+
+@dataclass(frozen=True)
+class DelegationKey:
+    """A verification key, and the app whose registration published it."""
+
+    registration: RegistrationSnapshot
+    key: Any
+
+
+async def delegation_key_for(kid: str) -> Optional[DelegationKey]:
+    """The key a delegation token's ``kid`` names, if an app may delegate.
+
+    Resolution is by ``kid`` rather than by parsing the app's name out of it:
+    a ``kid`` is an opaque label its owner chooses, and rotation means one app
+    publishes two at once.
+
+    Deliberately ``enabled`` rather than :attr:`RegistrationSnapshot.live` — a
+    delegate calls the API directly, so its ability to act should follow the
+    operator's kill switch, not whether its manifest was reachable at the last
+    handshake.
+    """
+    if not kid:
+        return None
+    for snapshot in (await load_registrations()).values():
+        if not snapshot.enabled or "delegation" not in snapshot.grants:
+            continue
+        key = snapshot.delegation_keys.get(kid)
+        if key is not None:
+            return DelegationKey(registration=snapshot, key=key)
+    return None
+
+
+async def any_delegate_registered() -> bool:
+    """Whether some app on this deployment may delegate and can be verified.
+
+    The accurate answer, for callers deciding whether a delegate exists at all
+    rather than whether this token resolves.
+    """
+    return any(
+        snapshot.enabled
+        and "delegation" in snapshot.grants
+        and snapshot.delegation_keys
+        for snapshot in (await load_registrations()).values()
+    )
+
+
+async def delegate_available() -> bool:
+    """Whether this deployment has a delegate at all.
+
+    True for a registration that holds the grant and a key, and for the
+    deployment-wide ``AUTO_DELEGATION_PUBLIC_KEY_PEM`` while that is still the
+    trust root — a deployment that has not yet moved its delegate onto its own
+    registration must keep working, so both count for one release.
+
+    This is the answer for "does a delegate exist here", as distinct from
+    :func:`auto_delegation_configured`'s cheaper "could one".
+    """
+    if settings.AUTO_DELEGATION_PUBLIC_KEY_PEM:
+        return True
+    return await any_delegate_registered()

--- a/backend/app/services/platform/auto_delegation_blocklist_test.py
+++ b/backend/app/services/platform/auto_delegation_blocklist_test.py
@@ -25,6 +25,10 @@ from sqlalchemy.exc import DBAPIError
 from sqlmodel import select
 
 from app.core import config as config_module
+from app.testing.delegation import (
+    delegation_verification_keys,
+    register_delegate,
+)
 from app.core.security import (
     AutoDelegationVerificationError,
     verify_auto_delegation_token,
@@ -103,8 +107,11 @@ async def test_purged_jti_still_unreplayable(session, role_session, monkeypatch)
     """Pruning an expired jti never re-opens a replay window: the token's own
     exp refuses it at verification, before the blocklist is consulted."""
     monkeypatch.setattr(
-        config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _PUBLIC_PEM
+        config_module.settings,
+        "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
+        "-----BEGIN PRIVATE KEY-----",
     )
+    await register_delegate(session)
     jti = "deleg-purged"
     token = _mint(jti=jti, expires_in=-30)  # exp already in the past
 
@@ -122,4 +129,4 @@ async def test_purged_jti_still_unreplayable(session, role_session, monkeypatch)
 
     # Blocklist row gone, but the token's exp still refuses the replay.
     with pytest.raises(AutoDelegationVerificationError):
-        verify_auto_delegation_token(token)
+        verify_auto_delegation_token(token, keys=list(delegation_verification_keys()))

--- a/backend/app/services/platform/jti_purge.py
+++ b/backend/app/services/platform/jti_purge.py
@@ -24,7 +24,7 @@ from typing import Callable
 
 from sqlmodel import SQLModel
 
-from app.core.security import auto_delegation_configured
+from app.core.security import delegation_possible
 from app.db.jti_blocklist import purge_expired_jtis
 from app.models.platform.app_service_nonce import AppServiceNonce
 from app.models.platform.auto_delegation_jti import AutoDelegationJti
@@ -50,7 +50,7 @@ class _Blocklist:
 # its janitor can never disagree about whether that peer exists here.
 _BLOCKLISTS: tuple[_Blocklist, ...] = (
     _Blocklist(BillingJti, billing_inbound_enabled, "billing"),
-    _Blocklist(AutoDelegationJti, auto_delegation_configured, "auto-delegation"),
+    _Blocklist(AutoDelegationJti, delegation_possible, "auto-delegation"),
     _Blocklist(AppServiceNonce, app_channel_possible, "app-service"),
 )
 

--- a/backend/app/services/platform/jti_purge_test.py
+++ b/backend/app/services/platform/jti_purge_test.py
@@ -35,7 +35,7 @@ def _configure(monkeypatch, *, billing: bool, delegation: bool) -> None:
     )
     monkeypatch.setattr(
         config_module.settings,
-        "AUTO_DELEGATION_PUBLIC_KEY_PEM",
+        "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
         "pk" if delegation else None,
     )
 

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -37,6 +37,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.security import auto_delegation_configured
+from app.services.marketplace.registration_lookup import delegate_available
 from app.models.tenant.webhook_subscription import WebhookSubscription
 from app.services.safe_http import request_public_target
 from app.services.webhook_target_url import (
@@ -155,13 +156,14 @@ async def dispatch_event(
     deliver to. Returning before the query keeps the cost of the feature at
     zero on the write path rather than one query per event.
     """
-    if not auto_delegation_configured():
+    if not auto_delegation_configured() or not await delegate_available():
         global _inert_logged
         if not _inert_logged:
             _inert_logged = True
             logger.info(
                 "webhook dispatch inert: no automation delegate configured "
-                "(set AUTO_DELEGATION_PUBLIC_KEY_PEM to enable event delivery)"
+                "(grant an app service the delegation power and provision its "
+                "keys, or set AUTO_DELEGATION_PUBLIC_KEY_PEM)"
             )
         return
 

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -36,8 +36,7 @@ import httpx
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.security import auto_delegation_configured
-from app.services.marketplace.registration_lookup import delegate_available
+from app.services.marketplace.registration_lookup import any_delegate_registered
 from app.models.tenant.webhook_subscription import WebhookSubscription
 from app.services.safe_http import request_public_target
 from app.services.webhook_target_url import (
@@ -156,14 +155,14 @@ async def dispatch_event(
     deliver to. Returning before the query keeps the cost of the feature at
     zero on the write path rather than one query per event.
     """
-    if not auto_delegation_configured() or not await delegate_available():
+    if not await any_delegate_registered():
         global _inert_logged
         if not _inert_logged:
             _inert_logged = True
             logger.info(
-                "webhook dispatch inert: no automation delegate configured "
-                "(grant an app service the delegation power and provision its "
-                "keys, or set AUTO_DELEGATION_PUBLIC_KEY_PEM)"
+                "webhook dispatch inert: no delegate registered "
+                "(grant an app service the delegation power and provision the "
+                "keys it signs with)"
             )
         return
 

--- a/backend/app/services/tenant/webhook_dispatcher_test.py
+++ b/backend/app/services/tenant/webhook_dispatcher_test.py
@@ -19,24 +19,26 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.core import config as config_module
 from app.models.tenant.webhook_subscription import WebhookSubscription
 from app.services.tenant import webhook_dispatcher
 from app.services.tenant.webhook_dispatcher import _sign, dispatch_event
 
+
 # Delivery targets belong to the automation delegate, so the dispatcher only
 # runs on a deployment that has one. The setting is only tested for presence,
 # so a placeholder value is enough here.
-_DELEGATE_PEM = "-----BEGIN PUBLIC KEY-----\ntest-delegate\n-----END PUBLIC KEY-----"
-
-
 @pytest.fixture(autouse=True)
 def _delegate_configured(monkeypatch):
-    """Every test below assumes a configured delegate unless it says otherwise
-    — with none, dispatch is inert and there is nothing to assert about
-    matching or signing."""
+    """Every test below assumes a delegate exists unless it says otherwise —
+    with none, dispatch is inert and there is nothing to assert about matching
+    or signing.
+
+    Patched at the lookup rather than registered, because most of this file
+    never touches the database: what the dispatcher asks is one question, and
+    these tests are about what it does with the answer.
+    """
     monkeypatch.setattr(
-        config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", _DELEGATE_PEM
+        webhook_dispatcher, "any_delegate_registered", AsyncMock(return_value=True)
     )
 
 
@@ -422,7 +424,9 @@ async def test_dispatch_is_inert_without_a_delegate(session, monkeypatch):
         event_types=["task.created"],
     )
 
-    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    monkeypatch.setattr(
+        webhook_dispatcher, "any_delegate_registered", AsyncMock(return_value=False)
+    )
     monkeypatch.setattr(webhook_dispatcher, "_inert_logged", False)
 
     with patch(
@@ -451,7 +455,9 @@ async def test_inert_dispatch_explains_itself_once_per_process(monkeypatch):
     """Every write that produces an event calls the dispatcher, so the
     "no delegate configured" explanation is logged once per process rather
     than once per event."""
-    monkeypatch.setattr(config_module.settings, "AUTO_DELEGATION_PUBLIC_KEY_PEM", None)
+    monkeypatch.setattr(
+        webhook_dispatcher, "any_delegate_registered", AsyncMock(return_value=False)
+    )
     monkeypatch.setattr(webhook_dispatcher, "_inert_logged", False)
 
     with patch.object(webhook_dispatcher.logger, "info") as mock_info:

--- a/backend/app/testing/delegation.py
+++ b/backend/app/testing/delegation.py
@@ -1,0 +1,141 @@
+"""One delegate, for the suites that need a delegation token to be accepted.
+
+A delegation token is decided by the registration whose key set published its
+``kid``, so a test that wants one accepted registers an app rather than setting
+a value. This module holds the keypair, the JWKS built from it, the minting,
+and the registration — one place, so a suite states *which* app is delegating
+rather than restating how delegation is wired.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.platform.app_service_registration import (
+    AppServiceRegistration,
+    AppServiceStatus,
+)
+from app.services.marketplace.registration_lookup import invalidate_registrations
+
+__all__ = [
+    "DELEGATE_KID",
+    "DELEGATE_PUBLIC_ID",
+    "delegation_jwks",
+    "delegation_verification_keys",
+    "foreign_jwks",
+    "mint_delegation_token",
+    "register_delegate",
+]
+
+#: The app that delegates in tests, and the key it signs with. The shape
+#: mirrors what a real delegate publishes: its public id, then a generation
+#: suffix, because a rotation runs two entries in one key set.
+DELEGATE_PUBLIC_ID = "acme.auto"
+DELEGATE_KID = f"{DELEGATE_PUBLIC_ID}-delegation-1"
+
+# One keypair per test session. Generated rather than checked in so no test
+# depends on a fixed modulus, and cheap enough at 2048 bits to build once.
+_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_PEM = _keypair.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+
+
+def delegation_jwks(kid: str = DELEGATE_KID) -> dict[str, Any]:
+    """The public half, in the shape an operator provisions."""
+    entry = json.loads(RSAAlgorithm.to_jwk(_keypair.public_key()))
+    entry["kid"] = kid
+    return {"keys": [entry]}
+
+
+_foreign_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def foreign_jwks(kid: str = DELEGATE_KID) -> dict[str, Any]:
+    """A key set under the given ``kid`` belonging to a different keypair — for
+    the case where two apps happen to choose the same opaque label."""
+    entry = json.loads(RSAAlgorithm.to_jwk(_foreign_keypair.public_key()))
+    entry["kid"] = kid
+    return {"keys": [entry]}
+
+
+def mint_delegation_token(
+    *,
+    user_id: int,
+    guild_id: int,
+    initiative_id: Optional[int] = None,
+    jti: Optional[str] = None,
+    kid: Optional[str] = DELEGATE_KID,
+    aud: str = "initiative:auto-delegation",
+    iss: str = "initiative-auto",
+    private_pem: str = _PRIVATE_PEM,
+    expires_in: int = 900,
+) -> str:
+    """A delegation JWT as the delegate would mint it."""
+    now = datetime.now(timezone.utc)
+    payload: dict[str, Any] = {
+        "jti": jti or secrets.token_hex(8),
+        "sub": str(user_id),
+        "aud": aud,
+        "iss": iss,
+        "iat": int(now.timestamp()),
+        "exp": now + timedelta(seconds=expires_in),
+        "guild_id": guild_id,
+    }
+    if initiative_id is not None:
+        payload["initiative_id"] = initiative_id
+    return jwt.encode(
+        payload,
+        private_pem,
+        algorithm="RS256",
+        headers={"kid": kid} if kid else None,
+    )
+
+
+async def register_delegate(
+    session: AsyncSession,
+    *,
+    public_id: str = DELEGATE_PUBLIC_ID,
+    grants: tuple[str, ...] = ("delegation",),
+    enabled: bool = True,
+    key_set: Optional[dict[str, Any]] = None,
+) -> AppServiceRegistration:
+    """Wire up the app whose tokens the suite expects to be accepted.
+
+    Written straight to the table rather than through the registration service:
+    that path runs a handshake against the app, and there is no app here — only
+    the row the resolver reads.
+    """
+    row = AppServiceRegistration(
+        public_id=public_id,
+        base_url="http://auto.test:8080",
+        allowed_origins=["http://auto.test:8080"],
+        secret_encrypted=None,
+        grants=list(grants),
+        delegation_jwks=delegation_jwks() if key_set is None else key_set,
+        enabled=enabled,
+        status=AppServiceStatus.OK,
+    )
+    session.add(row)
+    await session.commit()
+    # The resolver reads a cached snapshot; a row written behind its back is
+    # not one it would notice on its own.
+    invalidate_registrations()
+    return row
+
+
+def delegation_verification_keys() -> tuple[Any, ...]:
+    """The public key itself, for a test calling the verifier directly rather
+    than through the auth dep that would resolve it from a registration."""
+    return (_keypair.public_key(),)


### PR DESCRIPTION
## Problem

§3 items 1–2 of `history/app-platform-hardening-design.md`. #1163 gave a registration
somewhere to hold its app's delegation keys; nothing read them. Verification went to
`AUTO_DELEGATION_PUBLIC_KEY_PEM` — one key for the whole deployment — so `grants` carried
`delegation` without any call site gating on it.

The design planned a transition window that kept the old setting readable for a release.
There is nothing to transition: no events are firing, and the only deployment is a demo.
So the setting is **removed**, not deprecated, and a registration is the only thing that
can verify a delegation token.

## Changes

- **`registration_lookup.py`** — the snapshot carries a `kid` → key index, parsed once when
  it is built rather than per token. `delegation_keys_for(kid)` returns **every** key
  published under that `kid` by a registration that is `enabled` and holds the `delegation`
  grant. All matches rather than the first: a `kid` is an opaque label its owner chooses,
  so two apps may pick the same one and the token belongs to whichever key verifies it.
- **`deps.py`** — resolution is the whole path. Nothing resolved means nothing verifies.
  The resolved app is recorded on `request.state.delegating_app`, and the subscription
  endpoints ask `any_delegate_registered()`.
- **`security.py`** — `verify_auto_delegation_token` takes the resolved keys and has no
  other source; `delegation_token_kid` reads the unverified header for selection only.
  `auto_delegation_configured()` → `delegation_possible()`, the settings-only "could there
  be a delegate here".
- **`config.py`** — `AUTO_DELEGATION_PUBLIC_KEY_PEM` deleted. `AUTO_DELEGATION_AUDIENCE`
  and `ISSUER` stay: they are the envelope every token is checked against either way.
- **`webhook_dispatcher.py`** and **`jti_purge.py`** follow the same split — the accurate
  question where it is worth a read, the cheap one where it is not.
- **`app/testing/delegation.py`** — one delegate for the suites that need one, so a test
  says *which app is delegating* rather than restating how delegation is wired. Six suites
  moved onto it.

`enabled` rather than `live`: a delegate calls the API directly, so its ability to act
follows the operator's kill switch, not whether its manifest was reachable at the last
handshake.

**Ordering requirement for infra:** auto's JWKS + `grants: ["delegation"]` must be on its
registration before this ships, since there is no other key its tokens can be held against.

## Testing

`auto_delegation_registration_test.py` covers the registration's side: a granted
registration verifies; the kill switch, a missing grant, and an unpublished `kid` each end
in 401; two apps sharing a `kid` both get offered to the verifier and the one that signed
wins.

- `pytest app/core/security_test.py app/api/v1/tenant_endpoints/auto_delegation*_test.py app/api/v1/tenant_endpoints/auto_subscriptions_test.py app/services/platform app/services/tenant/webhook_dispatcher_test.py app/services/marketplace` — **606 passed**
- `ruff check app` — clean
