### PR TITLE
Let an app act only where it was installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **An app acts only in the guilds that installed it.** A delegating app reaching a guild now needs that guild's install to be present and switched on, alongside the power its registration grants — so uninstalling an app, or turning the install off, ends what it can do there without touching any other guild.
 - **An app is granted the power to act as your members individually.** Delegation follows the app's own registration — its keys, its grant, its switch — rather than one setting shared by the whole deployment. Turning an app's delegation off, or turning the app off, ends what it can do straight away.
 - An app service registration can hold the public keys its app signs delegation tokens with, as a JWKS — pasted into the registration form or declared in the app services file alongside the app's other settings. Two entries in one key set is how an app rotates its signing key without downtime, and clearing the field removes it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - An app's embedded page is granted only the browser features its manifest asks for, from a fixed list — camera, microphone, location, screen capture, clipboard, and fullscreen. A surface that asks for nothing runs with all of them denied. What an app requests is part of what it declares, so it can be read before installing.
+- **A guild tells its members about the guild, and its admins about running it.** Everyone in a guild still sees its name, description, icon, member count, and whether content is currently read-only. The administration details — the storage and member limits set for the guild and its trash retention window — now reach guild admins only, matching the settings pages that are already theirs alone.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Initiative
 
-A self-hosted project management platform designed for friend groups, gaming communities, and small teams who want an intuitive way to organize projects, share documents, and track tasks — without the complexity of enterprise tools.
+Collaborative project management for people who never wanted to become project managers — small groups, small businesses, event coordinators, clubs, families, and anyone else who needs to organize work with other people.
 
 > **Pre-release software** — this project hasn't reached v1.0.0 yet. The API may change between minor releases.
 
@@ -10,52 +10,59 @@ A self-hosted project management platform designed for friend groups, gaming com
 
 ## What is Initiative?
 
-Initiative is project management for people who don't want to think about project management. It's built for groups that need to coordinate work, share information, and stay on the same page — whether you're running a tabletop campaign, organizing a community event, or managing a small team.
+Most project management software assumes you've already learned project management. Initiative doesn't. You can be productive on day one knowing exactly one thing: a **board with tasks on it**. Everything else waits until you need it.
 
-- **Guilds** keep each group's data completely separate — run multiple communities from one instance
-- **Initiatives** organize related projects and documents so nothing gets lost
-- **Drag-and-drop boards** make task tracking visual and immediate
-- **Collaborative documents** let your team write and edit together in real time
-- **Simple sharing** — control who sees what without needing a degree in access management
-- **Self-hosted with Docker** — your data stays on your hardware
+That matters because the people doing the coordinating usually aren't specialists. They're the owner of a five-person business who can't justify hiring a coordinator. The person running the neighborhood fundraiser. The parent keeping a household's plans in one place. The volunteer who ended up with the spreadsheet.
+
+Initiative is built on three ideas:
+
+- **It grows with you.** Start with one board. Add a calendar when you start scheduling, a document when you start writing things down, a dashboard when you start reporting. Nothing you haven't asked for gets in your way.
+- **You decide exactly who sees what.** Each group's data sits in its own database schema, and the layers inside it are enforced by the database itself — not just hidden in the interface. Someone who isn't part of an effort doesn't see a locked door; they see nothing at all.
+- **The tools come from the community.** The exact thing your group needs usually already exists, because someone with the same problem built it. Dashboards and apps are installed from a marketplace, not commissioned from a developer — and whoever runs your Initiative decides which ones it offers.
+
+And it's built in the open — publicly, with contributions and feedback shaping what gets made.
 
 ---
 
 ## Key Features
 
-### Guilds
+### Guilds — your group's own space
 
-Each guild is a completely separate workspace — your D&D group and your work team never see each other's data, even on the same server.
+A **guild** is one organization's space: a business, a club, a committee, a household. Everything that group works on lives inside it, and guilds never see each other — even on the same server.
 
-- **True data isolation**: PostgreSQL Row Level Security enforces guild boundaries at the database layer
-- **Switch between guilds instantly**: Join multiple guilds and move between them with one click
-- **Invite links**: Share links with optional expiry dates and usage limits
-- **Controlled creation**: Optionally restrict guild creation for hosted deployments
+- **A structural boundary, not a filter**: every guild gets its **own PostgreSQL schema**, provisioned when the guild is created. A request is routed into one guild's schema and cannot address another's tables at all
+- **Layered inside that**: within the schema, Row Level Security enforces the initiative, role, and sharing layers on every statement — so the boundary between two efforts in the *same* guild is a database boundary too
+- **Belong to as many as you like**: your work team and your volunteer committee are two guilds, one click apart
+- **Invite links**: share a link with an optional expiry date and usage limit
+- **Controlled creation**: optionally restrict who can create guilds
 
 **Guild settings:**
 <img width="1905" height="1050" alt="Guild settings" src="https://github.com/user-attachments/assets/656b7d08-0a91-48be-868c-29f545a32165" />
 
-### Initiatives & Projects
+### Initiatives — one effort at a time
 
-Initiatives group related projects and documents together — think of them as folders for an entire effort (a campaign, an event, a product).
+An **initiative** gathers everything belonging to a single effort: a product launch, a spring event, a client, a season. Projects, documents, calendars, and dashboards all live inside one.
 
-- **Everything in one place**: Bundle projects, documents, and team members under a single initiative
-- **Automatic scoping**: Members only see initiatives they belong to
-- **Custom project boards**: Drag-and-drop Kanban boards with customizable task statuses
-- **Color-coded organization**: Visual distinction with initiative-specific colors
+This is also the privacy boundary that matters most day to day. **If someone isn't in an initiative, its contents don't exist for them** — not greyed out, not "access denied," simply not there.
+
+- **Everything for one effort in one place**: projects, documents, tools, and the people involved
+- **Add only who belongs**: the summer event team never sees the spring event's budget
+- **Custom boards**: drag-and-drop Kanban with statuses you define
+- **Color-coded**: tell your efforts apart at a glance
 
 **Initiatives page:**
 <img width="1905" height="1049" alt="Initiatives page" src="https://github.com/user-attachments/assets/3ea4f727-4f84-4e75-b860-a5bb17cb9e49" />
 
-### Simple Sharing & Permissions
+### Sharing that reads like a sentence
 
-Sharing is straightforward: add people to a guild, add them to an initiative, then choose who can see or edit each project and document. No complicated admin panels required.
+Add someone to the guild. Add them to the initiative. Give them a role. Share the specific things they need. Each step narrows the last, and you can stop at any of them.
 
-- **Initiative roles**: Create roles like "player" or "DM" with different feature access
-- **Project & document sharing**: Set owner, write, or read access per user or per role
-- **Role-based grants**: Share with an entire role at once instead of adding people one by one
+- **Initiative roles**: bundle permissions into roles that match how your group actually works — "Coordinator," "Volunteer," "Client"
+- **Per-item sharing**: give view, edit, or owner access on a single project or document
+- **Share with a role**: hand access to a whole role at once instead of one person at a time
+- **Bulk edits**: select several items in a list and change who can reach them in one step
 
-For details on how access control is enforced under the hood, see [SECURITY.md](SECURITY.md).
+For how these boundaries are enforced under the hood, see [SECURITY.md](SECURITY.md).
 
 **Initiative role permissions:**
 <img width="1920" height="1080" alt="Initiative role permissions" src="https://github.com/user-attachments/assets/5ee163da-207a-4f57-a95c-659f423eb688" />
@@ -63,15 +70,17 @@ For details on how access control is enforced under the hood, see [SECURITY.md](
 **Project/Document access control:**
 <img width="1920" height="1079" alt="Project DAC permissions" src="https://github.com/user-attachments/assets/135a733e-3a2b-4cbc-aa66-b1eaf6234d75" />
 
-### Rich Task Management
+### Tasks, seen the way you think
 
-- **Multiple views**: Table, Kanban, and Calendar with row virtualization for large datasets
-- **Priority levels**: Low, medium, high, and urgent with visual indicators
-- **Flexible scheduling**: Start dates, due dates, and recurring tasks
-- **Subtasks**: Break down complex work with completion tracking
-- **Multiple assignees**: Assign tasks to multiple team members
-- **Server-side pagination & sorting**: Multi-column sort with advanced filtering
-- **My Tasks dashboard**: Personal cross-guild view with date grouping and timezone support
+The same work, shown however makes sense to you — a list, a board, or a calendar. No one has to adopt someone else's way of looking at it.
+
+- **Multiple views**: Table, Kanban, and Calendar, with row virtualization for large datasets
+- **Priority levels**: low, medium, high, and urgent with visual indicators
+- **Flexible scheduling**: start dates, due dates, and recurring tasks
+- **Subtasks**: break down bigger work with completion tracking
+- **Multiple assignees**: several people on one task, each finishing their own part
+- **Server-side pagination & sorting**: multi-column sort with advanced filtering
+- **My Tasks**: your own work from every guild, in one place
 
 **Project Kanban view (Table, Kanban, and Calendar views supported):**
 <img width="1905" height="1050" alt="Project Kanban view" src="https://github.com/user-attachments/assets/26d169c7-0415-4ea8-b81d-bd1b8f9a0576" />
@@ -79,44 +88,66 @@ For details on how access control is enforced under the hood, see [SECURITY.md](
 **Task details:**
 <img width="1905" height="1050" alt="Task details" src="https://github.com/user-attachments/assets/cdea8e20-a157-48cb-b5bb-2fdd1f5d5228" />
 
-### Collaborative Documents
+### Documents you write together
 
-- **Rich text editing**: Full-featured editor with JSONB storage
-- **Live collaboration**: Real-time multi-user editing via WebSocket
-- **File documents**: Upload and manage PDFs, DOCX, and other file types with permission-gated downloads
-- **Document templates**: Create reusable templates for common workflows
-- **Threaded comments**: Discuss documents with nested comment threads
+- **Rich text editing**: full-featured editor with JSONB storage
+- **Spreadsheets**: formulas, number formats, frozen headers, CSV/XLSX import and export
+- **Whiteboards**: a free-form Excalidraw canvas for diagrams and visual planning, with live multiplayer cursors and PNG/SVG export
+- **Live collaboration**: real-time multi-user editing over WebSocket
+- **File documents**: upload PDFs, DOCX, and more, with permission-gated downloads
+- **Templates**: save a starting point and reuse it
+- **Threaded comments**: discuss in place, in nested threads
 
 **Document editor:**
 <img width="1905" height="1050" alt="Document editor" src="https://github.com/user-attachments/assets/b7118ed4-01c1-4ac5-b6b7-c1185455e2a2" />
 
+### Tools you add when you need them
+
+Each initiative can turn on extra tools — none of them are in your way until you ask for them:
+
+- **Calendar & events** — schedule things, invite people, collect RSVPs, send reminders
+- **Queues** — track whose turn it is, for rotations, rosters, and running orders
+- **Counters** — track numbers that go up and down: scores, tallies, budgets
+- **Dashboards** — a canvas of charts, numbers, and timelines built from your own data
+
+### A marketplace of ready-made tools
+
+The dashboards and apps your group needs are usually the ones another group already needed. Initiative ships a **marketplace**: browse a listing, add it to an initiative or your guild, rename it, and it's yours. Every listing shows who published it, and updates are opt-in.
+
+**Every marketplace is curated.** A deployment offers the listings that ship with Initiative, plus the ones its **platform owner has added and approved** — nothing appears in your marketplace that the person running your server didn't put there. If you self-host, that person is you.
+
+- **Dashboards** — add a ready-made reporting canvas to an initiative
+- **Apps** — add something the whole guild shares; only guild admins can install them
+- **Sandboxed** — marketplace widgets run in an isolated runtime with no access to your credentials or the page around them
+- **Curate your own** — point Initiative at a directory of listing files and those listings appear alongside the built-ins, with no fork and no rebuild. Anyone can write one; what reaches your marketplace is your call (see [Publishing your own listings](docs/en/admin/publishing-listings.md))
+
 ### Command Center
 
-Press `Cmd+K` / `Ctrl+K` to instantly navigate to projects, tasks, documents, and pages with fuzzy search. Available via sidebar shortcut or 3-finger tap on mobile.
+Press `Cmd+K` / `Ctrl+K` to jump to any project, task, document, or page with fuzzy search. Also available from the sidebar, or a 3-finger tap on mobile.
 
 ### Authentication
 
-- **Email & password** or **OpenID Connect (OIDC) SSO** — connect your existing identity provider
-- **OIDC claim-to-role mapping**: Automatically assign guild and initiative memberships from identity provider claims
-- **Encryption at rest** for sensitive data — see [SECURITY.md](SECURITY.md) for the full security architecture
+- **Email & password** or **OpenID Connect (OIDC) SSO** — connect the identity provider you already use
+- **OIDC claim-to-role mapping**: assign guild and initiative memberships automatically from provider claims
+- **Encryption at rest** for sensitive data — see [SECURITY.md](SECURITY.md) for the full architecture
 
 ### Notifications
 
 - **Real-time updates**: WebSocket-based live updates for collaborative work
-- **Per-channel preferences**: Independent email and mobile push toggles per notification category
-- **Overdue task digests**: Configurable email digests for overdue tasks
-- **Mobile push**: Firebase Cloud Messaging support for iOS and Android
+- **Per-channel preferences**: independent email and mobile push toggles per category
+- **Overdue task digests**: configurable email digests
+- **Mobile push**: Firebase Cloud Messaging for iOS and Android
 
 ### AI Integration
 
-- **Bring Your Own Key (BYOK)**: Configure API keys for OpenAI, Anthropic, Ollama, or OpenAI-compatible APIs
-- **Hierarchical settings**: Platform, guild, and user-level AI configuration with override controls
-- **AI-powered tasks**: Generate task descriptions, subtasks, and document summaries
+- **Bring Your Own Key (BYOK)**: configure keys for OpenAI, Anthropic, Ollama, or OpenAI-compatible APIs
+- **Hierarchical settings**: platform, guild, and user-level configuration with override controls
+- **AI-assisted work**: generate task descriptions, subtasks, and document summaries
 
 ### Internationalization
 
-- Full i18n support with 16 translation namespaces
-- English and Spanish locales included (community translations welcome)
+- Full i18n support with a namespace per feature area
+- English, Spanish, German, and French locales included (community translations welcome)
 - Locale-aware AI content generation
 
 ---
@@ -148,9 +179,9 @@ docker-compose up -d
 
 **First-time setup:**
 
-1. The first user to register becomes the platform admin
+1. The first user to register becomes the platform owner
 2. Configure SMTP in the admin panel to enable email notifications
-3. Create your first guild and start inviting team members
+3. Create your first guild and start inviting people
 
 See [Key Environment Variables](#key-environment-variables) for full configuration options.
 
@@ -179,6 +210,7 @@ Images support `linux/amd64` and `linux/arm64` architectures.
 | `DISABLE_GUILD_CREATION` | Restrict guild creation to super admin | `false` |
 | `ENABLE_PUBLIC_REGISTRATION` | Allow registration without invite link | `true` |
 | `ENABLE_MCP` | Mount the in-app MCP server at `/api/v1/mcp/` for AI assistants (see [MCP Server](#mcp-server)) | `false` |
+| `MARKETPLACE_EXTRA_CATALOG_DIR` | Directory of your own marketplace listing files (see [Publishing your own listings](docs/en/admin/publishing-listings.md)) | - |
 | `CAPTCHA_PROVIDER` | Captcha vendor for registration: `hcaptcha`, `turnstile`, or `recaptcha` (v2 only). Unset / unrecognised disables the gate | - |
 | `CAPTCHA_SITE_KEY` | Public key sent to the SPA to render the widget | - |
 | `CAPTCHA_SECRET_KEY` | Server-side key for the provider's siteverify endpoint | - |
@@ -269,32 +301,45 @@ The surface is curated and **default-deny** — only the following are exposed. 
 
 ---
 
+## How we build
+
+Initiative is developed in public. The issues, the pull requests, the design discussions, and the mistakes are all here in the open, and the roadmap moves in response to what people actually ask for.
+
+Two commitments shape the work:
+
+- **Nobody should need a course to use this.** If a feature can't be explained in a sentence to someone who has never used project management software, it isn't finished.
+- **People think differently, and the software should meet them there.** The same work can be read as a board, a table, a calendar, or a timeline. Keyboard navigation, screen-reader labels, light and dark themes, plain-language documentation, and full localization are part of building a feature, not a follow-up to it.
+
+Improvements to the [help site](docs/en/index.md) are as welcome as improvements to the code.
+
+---
+
 ## Roadmap
 
-### Current Status
-- Most core features are implemented and functional:
-  - AGPL container: frontend + storage
-  - Rich task management (Kanban, Calendar, Table)
-  - Collaborative documents with real-time editing
-  - Notifications and AI integrations
-  - Additional tooling menu for initaitive based features such as calender and queues
-  - Self-hosted via Docker, multi-guild support
+### Current status
 
-### Focus for Upcoming Iterations
-- **Iterate and polish** existing features:
-  - Debugging, UX refinements, accessibility
-  - Standardize testing accross the board for stability between releases
-  - CI/CD improvements
+Most core features are implemented and in use:
 
-- **New minor features / improvements**:
-  - Whiteboard document type for collaborative visual planning
-  - Additional templates for documents and workflows
-  - Improved API endpoints for integrations
+- Task management across Kanban, Table, and Calendar views
+- Collaborative documents — rich text, spreadsheets, and whiteboards — with real-time editing
+- Calendars, queues, counters, and dashboards
+- A curated marketplace of ready-made dashboards and apps
+- Notifications and BYOK AI integration
+- Self-hosted via Docker, with multi-guild support
 
-### Long-Term / Philosophy
-- Maintain the AGPL container as fully open-source
-- Automation visuals, storage, and frontend exist in the container; the execution logic runs in a private, paid cloud instance
-- Initiative is designed for small teams, communities, and personal learning projects
+### Focus for upcoming iterations
+
+- **Iterate and polish** — debugging, UX refinements, accessibility
+- **Stability** — standardized testing across the board, CI/CD improvements
+- **Build your own add-on apps** — a published template for building and hosting an app of your own, so a self-hoster can extend Initiative the same way we do
+- **A richer marketplace** — more listings, and apps that connect Initiative securely to the other tools your group already uses
+- **More templates** and improved API endpoints for integrations
+
+### Long-term
+
+- The app in this repository is the whole app, and stays AGPL-licensed.
+- Some add-on apps are built to run as hosted services rather than inside the container, and are distributed separately. The app template above is how you build your own on the same footing.
+- Initiative stays aimed at small groups, small businesses, and communities — not at enterprises with a dedicated PMO.
 
 ---
 
@@ -319,6 +364,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full development setup, testing, code
 
 ## Documentation
 
+- **[Help site](docs/en/index.md)** — guides for everyone using Initiative, plus the administrator handbook
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — Development setup, testing, code style, submitting PRs
 - **[SECURITY.md](SECURITY.md)** — Security philosophy and vulnerability reporting
 - **[CHANGELOG.md](CHANGELOG.md)** — Release history

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,39 +2,91 @@
 
 ## Our Approach
 
-Initiative follows a principle of least privilege — every user should only have access to the minimum data required for their role. Despite being built for casual groups and small teams, we take data isolation seriously. Your gaming group's campaign notes shouldn't be visible to another group on the same instance.
+Initiative follows the principle of least privilege: every request should reach the minimum data its user is entitled to, and nothing else. Being built for small businesses, clubs, and community groups rather than enterprises makes that more important, not less — a committee's finances shouldn't be visible to the volunteers, and one group's data shouldn't be reachable from another group on the same server.
 
-This philosophy is enforced at multiple layers:
+The rule we hold ourselves to is that **authorization is enforced in the database**, not only in application code. The app and the database agree on who can see what, and the database has the final say.
 
-### Database-Level Isolation (Row Level Security)
+### Tenancy: a schema per guild
 
-PostgreSQL Row Level Security (RLS) enforces access boundaries at the database layer, not just in application code. Even if an application bug bypasses a check, the database itself prevents unauthorized data access.
+A guild is the tenancy boundary, and it is **structural**:
 
-- **Guild isolation**: Users can only see data in guilds they belong to. This is the primary tenancy boundary — each guild's data is invisible to other guilds.
-- **Initiative isolation**: A second restrictive RLS layer ensures users can only see data within initiatives they are members of, providing isolation between teams within the same guild. Guild admins and superadmins bypass this layer when needed for administration.
+- Every guild's content — initiatives, projects, tasks, documents, calendars, queues, counters, tags, comments — lives in its **own PostgreSQL schema** (`guild_<id>`), provisioned when the guild is created and dropped when it's deleted.
+- Shared identity and configuration (users, guild memberships, invites, app settings, access grants, OIDC mappings) lives in `public`. **`public` holds no guild content on any install.**
+- A request is routed into exactly one guild's schema with `SET ROLE`. The login role holds no standing access to any guild schema — the per-guild roles are granted `WITH INHERIT FALSE`, so a session must assume one explicitly and holds nothing until it does.
+
+Cross-guild separation is therefore a property of which schema a query can address at all, rather than of a filter applied to tables shared between groups.
+
+### The four gates
+
+Every read or write of guild data passes the same nested checks, outermost first:
+
+1. **Guild** — the schema boundary plus the per-request role above.
+2. **Initiative** — within a guild, content of an initiative you're not a member of is not reachable. This is the hard isolation boundary between efforts in the same guild, enforced by row-level security.
+3. **Initiative role** — which kinds of tools a member may use, and how.
+4. **Per-item sharing (DAC)** — the final privilege gate on a specific project, document, or other tool instance.
+
+Two deliberate overrides sit above them:
+
+- **Guild administrators** have full read/write within their own guild.
+- **Privileged access management (PAM)** — platform staff may be granted **time-bound, per-guild, audited** access. Never a standing bypass; see below.
+
+One visible consequence: a guild member who isn't in an initiative receives **404, not 403**, for that initiative's content — row-level security hides the rows rather than reporting their existence.
+
+### Row Level Security
+
+- Guild content tables carry per-command policies that defer to a **single access function**, which asks whether the current user is a member of the initiative, a guild admin, or acting under a valid PAM grant.
+- The application layer calls **the same function** for query-time filtering, so there is no parallel re-implementation to drift out of sync.
+- Shared `public` tables carry role-scoped policies per platform tier plus own-row predicates.
+- Tables use `FORCE ROW LEVEL SECURITY`, so even the role that owns them remains policy-bound for data access.
 
 ### Discretionary Access Control (DAC)
 
-Within an already-secured initiative, teams can fine-tune who sees what using project and document permissions:
+Within an initiative, teams decide who sees each individual item:
 
-- **Owner, write, and read levels** per user or per initiative role
-- **Independent per-resource** — projects and documents have separate permission tables, so access to one doesn't imply access to another
+- **Read, write, and owner** levels, recorded in a single polymorphic `resource_grants` table.
+- A grant's subject is **a user, an initiative role, or all initiative members** — so access can be handed to a whole role at once.
+- Grants are scoped per resource: access to one project or document never implies access to another.
 
-DAC is enforced through application-level permission checks (database rows), not through database policies. RLS guarantees the security boundary; DAC lets teams decide exactly who sees what within that boundary.
+DAC decides the final level in application code, over grant rows that are themselves protected by the initiative-level policies above. Row-level security guarantees the boundary; DAC decides who sees what inside it.
 
-### Separated Database Roles
+### Database roles
 
-- **`app_user`** — Used for all user-facing API queries. This role has no `BYPASSRLS` privilege, so RLS policies are always enforced.
-- **`app_admin`** — Used for migrations, startup seeding, and background jobs. Has `BYPASSRLS` for administrative operations.
+Initiative connects through **three PostgreSQL logins**, each least-privilege for its job:
 
-### Authentication
+| Role | Used for | Bypasses RLS? |
+| --- | --- | --- |
+| **`app_user`** | Every user-facing request | **No.** Assumes a scoped `guild_<id>` or `platform_<tier>` role per request |
+| **`app_admin`** | Background jobs, startup seeding, bootstrapping endpoints | Yes — the standard Postgres trusted-batch actor, bounded by enumerated per-table `GRANT`s, and never serving a user request as itself. Entering a guild schema requires `SET ROLE`, which **drops** the bypass |
+| **`app_provisioner`** | Migrations and DDL (`CREATE SCHEMA`, `CREATE ROLE`) | No — `NOSUPERUSER CREATEROLE`, and `FORCE ROW LEVEL SECURITY` keeps it policy-bound for data |
 
-- **HttpOnly cookie sessions**: Web sessions use `SameSite=Lax` cookies instead of `localStorage`, eliminating XSS token theft risk. Native (Capacitor) apps use device tokens stored in secure platform storage.
-- **OpenID Connect (OIDC) SSO**: Enterprise identity provider integration with PKCE support and automatic claim-to-role mapping.
-- **Encryption at rest**: Sensitive fields (AI API keys, OIDC secrets, SMTP passwords, email addresses) are encrypted using Fernet (AES-128-CBC) derived from `SECRET_KEY`.
-- **Minimal token scope**: JWTs carry only the claims needed for authentication; guild and role context is resolved server-side per request.
+**The application never holds Postgres superuser credentials.** A superuser `DATABASE_URL` is deprecated; the app logs a warning at boot, and a future release will refuse to start with one.
 
-When contributing, treat any path where a user could access data outside their scope as a security issue, not a bug.
+### No standing bypass, and no superuser account
+
+There is **no superadmin role** in Initiative. The former `app.is_superadmin` session flag and every policy branch that honored it were removed outright — not gated, removed. No user-facing role bypasses row-level security.
+
+Platform privileges are a five-rung ladder (`member → support → moderator → operator → owner`), each a real `platform_<tier>` Postgres role, with endpoints gated on **capabilities** rather than role names. Reaching a guild you don't belong to always requires an explicit, expiring, recorded grant:
+
+- **support / moderator** — request access; an approver grants or denies; it auto-expires. Read-only by default.
+- **operator / owner** — hold `data.bypass`, which is the right to **self-issue a break-glass grant** (created and self-approved in one step, short TTL, the row being the audit trail), not an ambient bypass. Removing the capability leaves no other route in.
+
+Either way the session is routed through that guild's own roles and PAM context — never through a bypass.
+
+### Authentication and secrets
+
+- **HttpOnly `SameSite=Lax` cookie sessions** rather than `localStorage`, so the session isn't readable by scripts in the page. Native (Capacitor) apps store device tokens in secure platform storage.
+- **Passwords** are a minimum of 12 characters and are never stored in recoverable form.
+- **OpenID Connect (OIDC) SSO** with PKCE, and optional claim-to-role mapping for guild and initiative membership.
+- **Encryption at rest** for sensitive fields (AI provider keys, OIDC secrets, SMTP passwords, email addresses) using Fernet (AES-128-CBC) with a key derived from `SECRET_KEY`, with support for key rotation.
+- **Minimal token scope** — tokens carry only what authentication needs; guild and role context is resolved server-side on every request.
+
+### Extension surfaces
+
+- **Marketplace widgets** run in an isolated sandbox with no capabilities, returning only a description of what to draw.
+- **Personal API keys** can be minted read-only and pinned to a single guild, and are revoked by deletion or by a password reset.
+- **The MCP server is off by default.** When enabled it is route-backed: every tool call runs through the real API as the key's user, under the same access rules as any other request.
+
+When contributing, treat any path where a user could reach data outside their scope as a security issue, not a bug.
 
 ## Supported Versions
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -108,16 +108,26 @@ async def _authenticate_auto_delegation(
         delegation_token_kid(token) or ""
     )
 
-    try:
-        claims = verify_auto_delegation_token(
-            token, keys=[candidate.key for candidate in candidates]
-        )
-    except AutoDelegationVerificationError:
-        # Could be a session JWT or API key arriving on the same header.
-        # Returning None lets the caller try those instead of failing.
+    # One candidate at a time, so the app this call is attributed to is the one
+    # whose key actually verified. Two apps may publish the same `kid` — it is
+    # an opaque label each picks — and everything downstream (which install must
+    # exist, which app acted) has to follow the signature, not the order.
+    claims = None
+    signer = None
+    for candidate in candidates:
+        try:
+            claims = verify_auto_delegation_token(token, keys=[candidate.key])
+        except AutoDelegationVerificationError:
+            # Could also be a session JWT or API key arriving on the same
+            # header; falling through lets the caller try those.
+            continue
+        signer = candidate
+        break
+
+    if claims is None or signer is None:
         return None
 
-    request.state.delegating_app = candidates[0].registration.public_id
+    request.state.delegating_app = signer.registration.public_id
 
     # Replay guard: a delegation JWT is one-shot. Even though the JWT is
     # technically valid for 15 minutes, a captured token must not be
@@ -125,6 +135,15 @@ async def _authenticate_auto_delegation(
     # path; the ``record_jti`` insert below is the actual race-safe
     # guarantee (unique-violation on the PK).
     if await auto_delegation_blocklist.is_jti_redeemed(session, claims.jti):
+        return None
+
+    # An app acts only in the guilds that installed it, and a token names
+    # exactly one. Checked against the claim rather than the path, so it holds
+    # for every route a delegated call can reach — including the cross-guild
+    # `/me/*` views, which have no path guild to check.
+    if not await registration_lookup.app_is_installed(
+        claims.guild_id, signer.registration.listing_uid
+    ):
         return None
 
     statement = select(User).where(User.id == claims.user_id)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -142,7 +142,7 @@ async def _authenticate_auto_delegation(
     # for every route a delegated call can reach — including the cross-guild
     # `/me/*` views, which have no path guild to check.
     if not await registration_lookup.app_is_installed(
-        claims.guild_id, signer.registration.listing_uid
+        claims.guild_id, signer.registration.public_id
     ):
         return None
 

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -65,6 +65,22 @@ def _serialize_guild(
     retention_days: int | None = None,
     member_count: int = 0,
 ) -> GuildRead:
+    """Build one entry of the caller's own guild list.
+
+    ``GuildRead`` carries two kinds of information and this is the single seam
+    that decides who gets which:
+
+    - **Everyone in the guild** — the guild's identity (name, description,
+      icon), the caller's own membership (role, position), the roster size, and
+      ``content_read_only`` so the UI can drop write affordances.
+    - **Guild admins only** — the administration fields: the operator-set caps
+      and plan label, the trash retention window, the lifecycle status, and the
+      per-guild sign-in entitlement. Each backs an admin-only surface (the whole
+      guild settings section is admin-gated, as is ``/g/{id}/storage/usage``,
+      the panel's other half), so a regular member's payload leaves them
+      ``None``.
+    """
+    is_admin = membership.role == GuildRole.admin
     return GuildRead(
         id=guild.id,
         name=guild.name,
@@ -74,26 +90,24 @@ def _serialize_guild(
         updated_at=guild.updated_at,
         role=membership.role,
         position=membership.position,
-        retention_days=retention_days,
+        # Trash retention window — set from the admin-only trash settings tab.
+        retention_days=retention_days if is_admin else None,
         member_count=member_count,
-        max_storage_bytes=guild.max_storage_bytes,
-        max_users=guild.max_users,
+        # Operator-set caps, shown against usage on the admin settings page.
+        max_storage_bytes=guild.max_storage_bytes if is_admin else None,
+        max_users=guild.max_users if is_admin else None,
         # Display-only plan label (never an enforcement input); the SPA shows
         # it only when a billing portal is configured.
-        tier_name=guild.tier_name,
+        tier_name=guild.tier_name if is_admin else None,
         # Only guild admins learn the lifecycle status (for the settings-page
         # chip); members get None so a moderation hold isn't disclosed to them.
-        status=(
-            GuildStatus(guild.status) if membership.role == GuildRole.admin else None
-        ),
+        status=GuildStatus(guild.status) if is_admin else None,
         # Every member learns the *effect* of a read_only hold (their writes
         # already fail at the DB role level) so the UI can drop write
         # affordances — without disclosing the status itself.
         content_read_only=(guild.status == GuildStatus.read_only.value),
         # Admins only: lets their settings UI show/hide the Authentication tab.
-        guild_auth_enabled=(
-            guild.guild_auth_enabled if membership.role == GuildRole.admin else None
-        ),
+        guild_auth_enabled=guild.guild_auth_enabled if is_admin else None,
     )
 
 

--- a/backend/app/api/v1/platform_endpoints/guilds_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_test.py
@@ -90,6 +90,95 @@ async def test_list_guilds_includes_role(client: AsyncClient, session: AsyncSess
     assert guild_roles["Member Guild"] == "member"
 
 
+#: The administration half of ``GuildRead`` — caps, plan label, retention
+#: window, lifecycle status, sign-in entitlement. Each backs an admin-only
+#: surface, so a plain member's entry carries ``None`` for all of them.
+ADMIN_ONLY_GUILD_FIELDS = (
+    "retention_days",
+    "max_storage_bytes",
+    "max_users",
+    "tier_name",
+    "status",
+    "guild_auth_enabled",
+)
+
+
+@pytest.mark.integration
+async def test_list_guilds_administration_fields_are_admin_only(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The guild list serves two audiences from one schema: every member gets
+    the guild's identity, their own membership and the roster size; only guild
+    admins get the administration fields."""
+    admin = await acting_user(guild_role=GuildRole.admin)
+    member = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
+
+    guild = await session.get(Guild, admin.guild.id)
+    guild.max_storage_bytes = 5_000_000
+    guild.max_users = 25
+    guild.tier_name = "Bespoke Plan"
+    guild.guild_auth_enabled = True
+    session.add(guild)
+    await session.commit()
+
+    async def entry(headers: dict[str, str]) -> dict:
+        resp = await client.get("/api/v1/guilds/", headers=headers)
+        assert resp.status_code == 200, resp.text
+        return next(g for g in resp.json() if g["id"] == admin.guild.id)
+
+    member_row = await entry(member.headers)
+    for field in ADMIN_ONLY_GUILD_FIELDS:
+        assert member_row[field] is None, f"{field} must not reach a plain member"
+    # What a member does get: the guild itself, their membership, the roster
+    # size, and whether content is frozen.
+    assert member_row["name"] == guild.name
+    assert member_row["role"] == "member"
+    assert member_row["member_count"] == 2
+    assert member_row["content_read_only"] is False
+
+    admin_row = await entry(admin.headers)
+    for field in ADMIN_ONLY_GUILD_FIELDS:
+        assert admin_row[field] is not None, f"{field} must reach the guild admin"
+    assert admin_row["max_storage_bytes"] == 5_000_000
+    assert admin_row["max_users"] == 25
+    assert admin_row["tier_name"] == "Bespoke Plan"
+    assert admin_row["retention_days"] == 90
+    assert admin_row["guild_auth_enabled"] is True
+
+
+@pytest.mark.integration
+async def test_accepted_invite_withholds_administration_fields(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Joining by invite answers with the same member-tier payload — the new
+    member is not an admin, so the administration fields come back ``None``."""
+    admin = await acting_user(guild_role=GuildRole.admin)
+    guild = await session.get(Guild, admin.guild.id)
+    guild.max_users = 25
+    guild.tier_name = "Bespoke Plan"
+    session.add(guild)
+    await session.commit()
+
+    invite = await client.post(
+        f"/api/v1/guilds/{guild.id}/invites",
+        headers=admin.headers,
+        json={},
+    )
+    assert invite.status_code == 201, invite.text
+
+    joiner = await create_user(session, email="joiner@example.com")
+    resp = await client.post(
+        "/api/v1/guilds/invite/accept",
+        headers=get_auth_headers(joiner),
+        json={"code": invite.json()["code"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["role"] == "member"
+    for field in ADMIN_ONLY_GUILD_FIELDS:
+        assert body[field] is None, f"{field} must not reach a plain member"
+
+
 @pytest.mark.integration
 async def test_list_guilds_shows_active_guild(
     client: AsyncClient, session: AsyncSession

--- a/backend/app/api/v1/platform_endpoints/guilds_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_test.py
@@ -114,6 +114,7 @@ async def test_list_guilds_administration_fields_are_admin_only(
     member = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
 
     guild = await session.get(Guild, admin.guild.id)
+    assert guild is not None
     guild.max_storage_bytes = 5_000_000
     guild.max_users = 25
     guild.tier_name = "Bespoke Plan"
@@ -154,6 +155,7 @@ async def test_accepted_invite_withholds_administration_fields(
     member is not an admin, so the administration fields come back ``None``."""
     admin = await acting_user(guild_role=GuildRole.admin)
     guild = await session.get(Guild, admin.guild.id)
+    assert guild is not None
     guild.max_users = 25
     guild.tier_name = "Bespoke Plan"
     session.add(guild)

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
@@ -19,8 +19,11 @@ from app.services.marketplace.registration_lookup import (
     invalidate_registrations,
 )
 from app.testing import create_guild, create_guild_membership, create_user
+from app.models.tenant.guild_app import GuildApp
+from app.testing.schema_harness import route_session_to_guild
 from app.testing.delegation import (
     DELEGATE_KID,
+    DELEGATE_LISTING_UID,
     install_delegate,
     delegation_jwks,
     foreign_jwks,
@@ -220,3 +223,48 @@ async def test_a_switched_off_install_stops_the_app(
         },
     )
     assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_a_token_naming_no_guild_is_refused_not_an_error(
+    client: AsyncClient, session: AsyncSession
+):
+    """A guild id naming no guild has no schema to read, and the call is
+    refused the way every other delegation refusal is rather than faulting."""
+    user = await create_user(session, email="absent-guild@example.com")
+    await register_delegate(session)
+
+    assert await _call_as_delegate(client, user.id, 9_999_999) == 401
+
+
+@pytest.mark.integration
+async def test_another_apps_install_does_not_let_this_one_act(
+    client: AsyncClient, session: AsyncSession
+):
+    """The install is matched on the service its pinned definition names. A
+    guild that installed some other app has not installed this one, whatever
+    listing the two happen to point at."""
+    user = await create_user(session, email="other-app@example.com")
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    await register_delegate(session)
+
+    # Same listing uid, a different app behind it.
+    await route_session_to_guild(session, guild.id)
+    session.add(
+        GuildApp(
+            guild_id=guild.id,
+            listing_uid=DELEGATE_LISTING_UID,
+            listing_version="1.0.0",
+            app_kind="service",
+            name="Someone else",
+            definition={
+                "app_kind": "service",
+                "service": {"public_id": "other.app"},
+            },
+            installed_by_id=user.id,
+        )
+    )
+    await session.commit()
+
+    assert await _call_as_delegate(client, user.id, guild.id) == 401

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
@@ -18,9 +18,10 @@ from app.services.marketplace.registration_lookup import (
     delegation_keys_for,
     invalidate_registrations,
 )
-from app.testing import create_user
+from app.testing import create_guild, create_guild_membership, create_user
 from app.testing.delegation import (
     DELEGATE_KID,
+    install_delegate,
     delegation_jwks,
     foreign_jwks,
     mint_delegation_token,
@@ -42,11 +43,26 @@ def _app_platform_configured(monkeypatch):
     invalidate_registrations()
 
 
-async def _call_as_delegate(client: AsyncClient, user_id: int) -> int:
+async def _acting_in_a_guild_that_installed_it(session: AsyncSession, email: str):
+    """A user, their guild, and that guild's install of the delegate.
+
+    Every case below varies one thing about the *registration*, so the install
+    side is held constant here rather than restated each time.
+    """
+    user = await create_user(session, email=email)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    await install_delegate(session, guild, creator=user)
+    return user, guild
+
+
+async def _call_as_delegate(client: AsyncClient, user_id: int, guild_id: int) -> int:
     response = await client.get(
         "/api/v1/users/me",
         headers={
-            "Authorization": f"Bearer {mint_delegation_token(user_id=user_id, guild_id=1)}"
+            "Authorization": (
+                f"Bearer {mint_delegation_token(user_id=user_id, guild_id=guild_id)}"
+            )
         },
     )
     return response.status_code
@@ -56,20 +72,24 @@ async def _call_as_delegate(client: AsyncClient, user_id: int) -> int:
 async def test_a_granted_registration_verifies_the_token(
     client: AsyncClient, session: AsyncSession
 ):
-    user = await create_user(session, email="delegated@example.com")
+    user, guild = await _acting_in_a_guild_that_installed_it(
+        session, "delegated@example.com"
+    )
     await register_delegate(session)
 
-    assert await _call_as_delegate(client, user.id) == 200
+    assert await _call_as_delegate(client, user.id, guild.id) == 200
 
 
 @pytest.mark.integration
 async def test_the_kill_switch_ends_delegation(
     client: AsyncClient, session: AsyncSession
 ):
-    user = await create_user(session, email="switched-off@example.com")
+    user, guild = await _acting_in_a_guild_that_installed_it(
+        session, "switched-off@example.com"
+    )
     await register_delegate(session, enabled=False)
 
-    assert await _call_as_delegate(client, user.id) == 401
+    assert await _call_as_delegate(client, user.id, guild.id) == 401
 
 
 @pytest.mark.integration
@@ -77,20 +97,24 @@ async def test_keys_without_the_grant_verify_nothing(
     client: AsyncClient, session: AsyncSession
 ):
     """The key set says who signs; the grant says whether that app may act."""
-    user = await create_user(session, email="ungranted@example.com")
+    user, guild = await _acting_in_a_guild_that_installed_it(
+        session, "ungranted@example.com"
+    )
     await register_delegate(session, grants=())
 
-    assert await _call_as_delegate(client, user.id) == 401
+    assert await _call_as_delegate(client, user.id, guild.id) == 401
 
 
 @pytest.mark.integration
 async def test_a_kid_no_registration_published_verifies_nothing(
     client: AsyncClient, session: AsyncSession
 ):
-    user = await create_user(session, email="unknown-kid@example.com")
+    user, guild = await _acting_in_a_guild_that_installed_it(
+        session, "unknown-kid@example.com"
+    )
     await register_delegate(session, key_set=delegation_jwks("some-other-generation"))
 
-    assert await _call_as_delegate(client, user.id) == 401
+    assert await _call_as_delegate(client, user.id, guild.id) == 401
 
 
 @pytest.mark.integration
@@ -98,11 +122,13 @@ async def test_a_shared_kid_does_not_shadow_the_app_that_signed(
     client: AsyncClient, session: AsyncSession
 ):
     """A ``kid`` is an opaque label its owner picks, so two apps may choose the
-    same one. Every match is offered to the verifier, and the token belongs to
-    whichever key actually signed it."""
-    user = await create_user(session, email="shared-kid@example.com")
-    # A namesake registered first, publishing a different key under the same
-    # kid — the token is not its.
+    same one. Every match is tried, and the call belongs to whichever key
+    actually signed it — including for the install it is then held to, which
+    the namesake here does not have."""
+    user, guild = await _acting_in_a_guild_that_installed_it(
+        session, "shared-kid@example.com"
+    )
+    # A namesake sorting first, publishing a different key under the same kid.
     await register_delegate(
         session,
         public_id="aaa.namesake",
@@ -110,7 +136,7 @@ async def test_a_shared_kid_does_not_shadow_the_app_that_signed(
     )
     await register_delegate(session)
 
-    assert await _call_as_delegate(client, user.id) == 200
+    assert await _call_as_delegate(client, user.id, guild.id) == 200
 
 
 @pytest.mark.integration
@@ -132,3 +158,65 @@ async def test_any_delegate_registered_follows_the_registration(
 
     await register_delegate(session)
     assert await any_delegate_registered() is True
+
+
+@pytest.mark.integration
+async def test_an_app_acts_only_where_it_was_installed(
+    client: AsyncClient, session: AsyncSession
+):
+    """The registration says the app may delegate; the install says this guild
+    chose it. Both are required, so uninstalling ends the app's reach — and it
+    ends it the way every other delegation refusal does, by not authenticating
+    the call at all."""
+    user = await create_user(session, email="uninstalled@example.com")
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    await register_delegate(session)
+
+    refused = await client.get(
+        f"/api/v1/g/{guild.id}/initiatives/",
+        headers={
+            "Authorization": (
+                f"Bearer {mint_delegation_token(user_id=user.id, guild_id=guild.id)}"
+            )
+        },
+    )
+    assert refused.status_code == 401
+
+    await install_delegate(session, guild)
+
+    allowed = await client.get(
+        f"/api/v1/g/{guild.id}/initiatives/",
+        headers={
+            "Authorization": (
+                f"Bearer {mint_delegation_token(user_id=user.id, guild_id=guild.id)}"
+            )
+        },
+    )
+    assert allowed.status_code == 200, allowed.text
+
+
+@pytest.mark.integration
+async def test_a_switched_off_install_stops_the_app(
+    client: AsyncClient, session: AsyncSession
+):
+    """An install turned off is not one the app may act through, the same as
+    one that was never made."""
+    user = await create_user(session, email="install-off@example.com")
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    await register_delegate(session)
+    install = await install_delegate(session, guild)
+    install.enabled = False
+    session.add(install)
+    await session.commit()
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/initiatives/",
+        headers={
+            "Authorization": (
+                f"Bearer {mint_delegation_token(user_id=user.id, guild_id=guild.id)}"
+            )
+        },
+    )
+    assert response.status_code == 401

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
@@ -32,7 +32,11 @@ from app.testing import (
     create_guild_membership,
     create_user,
 )
-from app.testing.delegation import mint_delegation_token, register_delegate
+from app.testing.delegation import (
+    install_delegate,
+    mint_delegation_token,
+    register_delegate,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -55,16 +59,34 @@ async def _enable_delegation(session: AsyncSession):
     invalidate_registrations()
 
 
+@pytest.fixture
+async def delegate_guild(session: AsyncSession):
+    """A guild that installed the delegate.
+
+    An app acts only where it was installed, so this is the ordinary
+    precondition for any delegated call — held constant here so each test
+    varies only its own subject.
+    """
+    installer = await create_user(session, email="installer@example.com")
+    guild = await create_guild(session, creator=installer)
+    await install_delegate(session, guild, creator=installer)
+    return guild
+
+
 _mint_delegation = mint_delegation_token
 
 
 @pytest.mark.integration
-async def test_delegation_token_is_one_shot(client: AsyncClient, session: AsyncSession):
+async def test_delegation_token_is_one_shot(
+    client: AsyncClient, session: AsyncSession, delegate_guild
+):
     """The same jti must succeed once and fail on the second presentation,
     regardless of the JWT's remaining lifetime. Without this, a 15-minute
     token captured in transit can be replayed indefinitely."""
     user = await create_user(session, email="user@example.com")
-    token = _mint_delegation(user_id=user.id, guild_id=1, jti="replay-target-001")
+    token = _mint_delegation(
+        user_id=user.id, guild_id=delegate_guild.id, jti="replay-target-001"
+    )
 
     first = await client.get(
         "/api/v1/users/me",
@@ -84,7 +106,7 @@ async def test_delegation_token_is_one_shot(client: AsyncClient, session: AsyncS
 
 @pytest.mark.integration
 async def test_delegation_token_guild_claim_pins_context(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
     """The token's guild_id claim IS the request's guild context — it takes
     precedence over whatever guild the human happens to be in, and it is
@@ -95,9 +117,10 @@ async def test_delegation_token_guild_claim_pins_context(
     user = await create_user(session, email="cross-guild@example.com")
     guild = await create_guild(session, creator=user)
     await create_guild_membership(session, user=user, guild=guild)
-    # The human is legitimately in their own guild...
-    # ...but the workflow's token names a guild they have no access to.
-    token = _mint_delegation(user_id=user.id, guild_id=guild.id + 999)
+    # The human is legitimately in their own guild, and the app is installed in
+    # the guild its token names — so what refuses this is the pin itself, not a
+    # missing install or an unknown guild.
+    token = _mint_delegation(user_id=user.id, guild_id=delegate_guild.id)
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/initiatives/",
@@ -109,7 +132,7 @@ async def test_delegation_token_guild_claim_pins_context(
 
 @pytest.mark.integration
 async def test_delegation_token_guild_claim_provides_context(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
     """A machine caller has no ambient guild context: the token's guild_id
     claim (validated against the user's memberships) supplies the guild for a
@@ -117,6 +140,7 @@ async def test_delegation_token_guild_claim_provides_context(
     user = await create_user(session, email="happy-path@example.com")
     guild = await create_guild(session, creator=user)
     await create_guild_membership(session, user=user, guild=guild)
+    await install_delegate(session, guild)
     token = _mint_delegation(user_id=user.id, guild_id=guild.id)
 
     response = await client.get(
@@ -128,12 +152,14 @@ async def test_delegation_token_guild_claim_provides_context(
 
 @pytest.mark.integration
 async def test_delegation_works_on_cross_guild_endpoints(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
-    """``/users/me`` is cross-guild; the pinned guild context is simply
-    unused there and the call succeeds."""
+    """``/users/me`` is cross-guild; the pinned guild context is simply unused
+    there and the call succeeds. The guild the token names still has to be one
+    that installed the app — that is what lets the app act at all, and it is
+    checked wherever the call lands."""
     user = await create_user(session, email="cross-guild-allowed@example.com")
-    token = _mint_delegation(user_id=user.id, guild_id=42)
+    token = _mint_delegation(user_id=user.id, guild_id=delegate_guild.id)
 
     response = await client.get(
         "/api/v1/users/me",
@@ -144,7 +170,7 @@ async def test_delegation_works_on_cross_guild_endpoints(
 
 @pytest.mark.integration
 async def test_delegation_rejects_deactivated_user(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
     """Workflows owned by deactivated users must stop working
     immediately — no grace period during which their old tokens still
@@ -155,7 +181,7 @@ async def test_delegation_rejects_deactivated_user(
     await session.commit()
     await session.refresh(user)
 
-    token = _mint_delegation(user_id=user.id, guild_id=1)
+    token = _mint_delegation(user_id=user.id, guild_id=delegate_guild.id)
 
     response = await client.get(
         "/api/v1/users/me",
@@ -166,12 +192,12 @@ async def test_delegation_rejects_deactivated_user(
 
 @pytest.mark.integration
 async def test_delegation_rejects_unknown_user(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
     """A delegation for a user_id that doesn't exist in the DB must
     fail — auto can't manufacture user identities Initiative didn't
     issue."""
-    token = _mint_delegation(user_id=9_999_999, guild_id=1)
+    token = _mint_delegation(user_id=9_999_999, guild_id=delegate_guild.id)
 
     response = await client.get(
         "/api/v1/users/me",
@@ -182,14 +208,14 @@ async def test_delegation_rejects_unknown_user(
 
 @pytest.mark.integration
 async def test_delegation_rejects_wrong_audience(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
     """A token with a different audience claim must not authenticate.
     Stops a regular session JWT (or any other audience) from being
     re-presented as a delegation."""
     user = await create_user(session, email="wrong-aud@example.com")
     token = _mint_delegation(
-        user_id=user.id, guild_id=1, aud="initiative:something-else"
+        user_id=user.id, guild_id=delegate_guild.id, aud="initiative:something-else"
     )
 
     response = await client.get(
@@ -201,11 +227,13 @@ async def test_delegation_rejects_wrong_audience(
 
 @pytest.mark.integration
 async def test_delegation_rejects_wrong_issuer(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
     """Issuer must match — defense in depth alongside the audience check."""
     user = await create_user(session, email="wrong-iss@example.com")
-    token = _mint_delegation(user_id=user.id, guild_id=1, iss="someone-else")
+    token = _mint_delegation(
+        user_id=user.id, guild_id=delegate_guild.id, iss="someone-else"
+    )
 
     response = await client.get(
         "/api/v1/users/me",
@@ -216,7 +244,7 @@ async def test_delegation_rejects_wrong_issuer(
 
 @pytest.mark.integration
 async def test_delegation_rejects_signature_from_other_key(
-    client: AsyncClient, session: AsyncSession
+    client: AsyncClient, session: AsyncSession, delegate_guild
 ):
     """A token signed with a different RSA key must fail signature
     verification — the load-bearing crypto property of the whole flow."""
@@ -227,7 +255,9 @@ async def test_delegation_rejects_signature_from_other_key(
         serialization.PrivateFormat.PKCS8,
         serialization.NoEncryption(),
     ).decode()
-    token = _mint_delegation(user_id=user.id, guild_id=1, private_pem=other_private)
+    token = _mint_delegation(
+        user_id=user.id, guild_id=delegate_guild.id, private_pem=other_private
+    )
 
     response = await client.get(
         "/api/v1/users/me",
@@ -238,7 +268,7 @@ async def test_delegation_rejects_signature_from_other_key(
 
 @pytest.mark.integration
 async def test_delegation_is_off_where_no_app_platform_is_configured(
-    client: AsyncClient, session: AsyncSession, monkeypatch
+    client: AsyncClient, session: AsyncSession, delegate_guild, monkeypatch
 ):
     """No app platform means no registrations, so nothing can delegate here.
     The request falls through to the standard 401 from the JWT path rather
@@ -248,7 +278,7 @@ async def test_delegation_is_off_where_no_app_platform_is_configured(
     )
 
     user = await create_user(session, email="delegation-off@example.com")
-    token = _mint_delegation(user_id=user.id, guild_id=1)
+    token = _mint_delegation(user_id=user.id, guild_id=delegate_guild.id)
 
     response = await client.get(
         "/api/v1/users/me",

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions_test.py
@@ -31,7 +31,11 @@ from app.models.platform.app_service_registration import AppServiceRegistration
 from app.models.platform.guild import GuildRole
 from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.testing import Actor
-from app.testing.delegation import mint_delegation_token, register_delegate
+from app.testing.delegation import (
+    install_delegate,
+    mint_delegation_token,
+    register_delegate,
+)
 
 _WEBHOOK_HOST = "hooks.example.com"
 # A public unicast IPv4 (example.com) with a real stream socket type/proto, so
@@ -72,6 +76,22 @@ def _delegation_headers(*, user_id: int, guild_id: int) -> dict[str, str]:
     """Mint a fresh (one-shot) delegation JWT for the user + guild."""
     token = mint_delegation_token(user_id=user_id, guild_id=guild_id)
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def acting_user(acting_user, session):
+    """Every actor's guild has the delegate installed.
+
+    An app acts only where it was installed, and these tests are about what the
+    subscription routes do for a delegate that has already got that far.
+    """
+
+    async def _with_the_app_installed(*args, **kwargs):
+        actor = await acting_user(*args, **kwargs)
+        await install_delegate(session, actor.guild)
+        return actor
+
+    return _with_the_app_installed
 
 
 def _as_delegate(actor: Actor) -> dict[str, str]:

--- a/backend/app/schemas/platform/guild.py
+++ b/backend/app/schemas/platform/guild.py
@@ -28,6 +28,20 @@ class GuildCreate(GuildBase):
 
 
 class GuildRead(GuildBase):
+    """A guild as its own members see it (``GET /guilds/`` and friends).
+
+    The payload has two tiers, decided in one place — ``_serialize_guild`` in
+    the guilds router:
+
+    - The fields below with no note are for **every member**: guild identity,
+      the caller's own membership, the roster size, ``content_read_only``.
+    - The ones marked ADMIN-ONLY are guild administration — caps, plan label,
+      retention window, lifecycle status, sign-in entitlement. They back
+      admin-gated surfaces, so a regular member's payload leaves them ``None``.
+      (Operators read the same underlying columns through
+      :class:`PlatformGuildStorageRead` instead, which is capability-gated.)
+    """
+
     model_config = ConfigDict(
         from_attributes=True, json_schema_serialization_defaults_required=True
     )
@@ -37,29 +51,33 @@ class GuildRead(GuildBase):
     position: int
     created_at: datetime
     updated_at: datetime
+    # ADMIN-ONLY. Trash retention window, set from the guild's trash settings tab.
     retention_days: Optional[int] = None
+    # ADMIN-ONLY. Operator-set caps, rendered against usage on the settings page
+    # (the usage half, /g/{id}/storage/usage, is guild-admin only too).
     max_storage_bytes: Optional[int] = None
     max_users: Optional[int] = None
     member_count: int = 0
-    # Display/audit label of the paid tier (NULL = none / self-hosted). Shown by
-    # the plan panel only when a billing portal is configured; it is DISPLAY
-    # metadata and is never read in an enforcement path (billing_foss_test
-    # scans for that). Enforcement reads max_storage_bytes / max_users / status.
+    # ADMIN-ONLY. Display/audit label of the paid tier (NULL = none /
+    # self-hosted). Shown by the plan panel only when a billing portal is
+    # configured; it is DISPLAY metadata and is never read in an enforcement
+    # path (billing_foss_test scans for that). Enforcement reads
+    # max_storage_bytes / max_users / status.
     tier_name: Optional[str] = None
-    # Lifecycle status, surfaced to guild ADMINS only (so their settings page can
-    # show a "contact your operator" chip). ``None`` for non-admin members — the
-    # moderation hold is never disclosed to them (suspended guilds are also
-    # filtered from their guild list entirely).
+    # ADMIN-ONLY. Lifecycle status, so their settings page can show a "contact
+    # your operator" chip. ``None`` for non-admin members — the moderation hold
+    # is never disclosed to them (suspended guilds are also filtered from their
+    # guild list entirely).
     status: Optional[GuildStatus] = None
     # True when content writes are frozen (read_only lifecycle status). Unlike
     # ``status`` this IS serialized to every member: writes fail at the
     # database role level regardless, so the UI must be able to drop its write
     # affordances — the flag discloses the effect, not the reason.
     content_read_only: bool = False
-    # Whether this guild may configure its own sign-in (operator entitlement).
-    # Surfaced to guild ADMINS only, so their settings UI can show/hide the
-    # Authentication tab; ``None`` for non-admin members (they never configure
-    # auth). Only meaningful under the per-guild AUTH_SCOPE posture.
+    # ADMIN-ONLY. Whether this guild may configure its own sign-in (operator
+    # entitlement), so their settings UI can show/hide the Authentication tab;
+    # ``None`` for non-admin members (they never configure auth). Only
+    # meaningful under the per-guild AUTH_SCOPE posture.
     guild_auth_enabled: Optional[bool] = None
 
 

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -27,6 +27,7 @@ from types import MappingProxyType
 from typing import Any, Mapping, Optional
 
 from jwt import PyJWK
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
 
 from app.db import session as db_session
@@ -308,36 +309,49 @@ async def any_delegate_registered() -> bool:
     )
 
 
-async def app_is_installed(guild_id: int, listing_uid: Optional[str]) -> bool:
+async def app_is_installed(guild_id: int, public_id: str) -> bool:
     """Whether the guild has this app installed and switched on.
 
     The install is what makes an app present in a guild, so it is also what
     bounds a delegate to the guilds that chose it — uninstalling ends that
     reach, which is the property §10.3 of the platform design claims.
 
+    Matched on the pinned definition's service id, the same identity
+    :func:`registration_for_definition` resolves an install by. A row's
+    ``listing_uid`` is re-recorded from the manifest on every handshake, so it
+    names the listing an app currently claims rather than the app itself.
+
     Read per call rather than cached: the registration snapshot can afford a
     TTL because an operator's kill switch is deployment-wide and rare, while an
     uninstall is a guild's own decision and is expected to bite at once.
-
-    A registration that has never completed a handshake names no listing, and
-    nothing can be installed from it — so it is not installed anywhere.
     """
-    if not listing_uid:
+    if not public_id:
         return False
 
     from app.models.tenant.guild_app import GuildApp
 
     async with db_session.AdminSessionLocal() as session:
-        # Guild content lives in the guild's own schema, so the read is routed
-        # there. `admin` because this asks what the guild has, not what any
-        # particular member may see.
-        await db_session.set_rls_context(session, guild_id=guild_id, guild_role="admin")
-        found = (
-            await session.exec(
-                select(GuildApp.id).where(
-                    GuildApp.listing_uid == listing_uid,
-                    GuildApp.enabled.is_(True),
-                )
+        try:
+            # Guild content lives in the guild's own schema, so the read is
+            # routed there. `admin` because this asks what the guild has, not
+            # what any particular member may see.
+            await db_session.set_rls_context(
+                session, guild_id=guild_id, guild_role="admin"
             )
-        ).first()
+            found = (
+                await session.exec(
+                    select(GuildApp.id).where(
+                        GuildApp.enabled.is_(True),
+                        GuildApp.definition["app_kind"].astext == "service",
+                        GuildApp.definition["service"]["public_id"].astext == public_id,
+                    )
+                )
+            ).first()
+        except SQLAlchemyError:
+            # A guild id naming no guild has no schema to route into, and
+            # nothing is installed in a guild that is not there.
+            logger.warning(
+                "app services: install check could not read guild %s", guild_id
+            )
+            return False
     return found is not None

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -44,6 +44,7 @@ __all__ = [
     "InstallState",
     "RegistrationSnapshot",
     "any_delegate_registered",
+    "app_is_installed",
     "delegation_keys_for",
     "install_state",
     "invalidate_registrations",
@@ -305,3 +306,38 @@ async def any_delegate_registered() -> bool:
         and snapshot.delegation_keys
         for snapshot in (await load_registrations()).values()
     )
+
+
+async def app_is_installed(guild_id: int, listing_uid: Optional[str]) -> bool:
+    """Whether the guild has this app installed and switched on.
+
+    The install is what makes an app present in a guild, so it is also what
+    bounds a delegate to the guilds that chose it — uninstalling ends that
+    reach, which is the property §10.3 of the platform design claims.
+
+    Read per call rather than cached: the registration snapshot can afford a
+    TTL because an operator's kill switch is deployment-wide and rare, while an
+    uninstall is a guild's own decision and is expected to bite at once.
+
+    A registration that has never completed a handshake names no listing, and
+    nothing can be installed from it — so it is not installed anywhere.
+    """
+    if not listing_uid:
+        return False
+
+    from app.models.tenant.guild_app import GuildApp
+
+    async with db_session.AdminSessionLocal() as session:
+        # Guild content lives in the guild's own schema, so the read is routed
+        # there. `admin` because this asks what the guild has, not what any
+        # particular member may see.
+        await db_session.set_rls_context(session, guild_id=guild_id, guild_role="admin")
+        found = (
+            await session.exec(
+                select(GuildApp.id).where(
+                    GuildApp.listing_uid == listing_uid,
+                    GuildApp.enabled.is_(True),
+                )
+            )
+        ).first()
+    return found is not None

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -273,7 +273,10 @@ async def list_memberships(
     user's membership context — a single cross-guild join would hit the empty
     public table and report NULL for everyone. ``guild_settings.id`` is a
     per-schema serial that collides across schemas, so each settings row is
-    detached after reading so a cached row can't shadow the next guild's.
+    detached after reading so a cached row can't shadow the next guild's. It is
+    read only where the caller is that guild's admin: retention is one of the
+    administration fields ``GuildRead`` withholds from ordinary members, so for
+    them it comes back ``None`` and costs no query.
 
     ``member_count`` is the total number of members in the guild. It's read
     inside the same per-guild loop because the ``guild_memberships_select`` RLS
@@ -309,15 +312,17 @@ async def list_memberships(
         ):
             continue
         await set_rls_context(session, user_id=user_id, guild_id=guild.id)
-        row = (
-            await session.exec(
-                select(GuildSetting).where(GuildSetting.guild_id == guild.id)
-            )
-        ).one_or_none()
-        # No row yet → the 90-day default; an explicit NULL is the user's "never".
-        retention = 90 if row is None else row.retention_days
-        if row is not None:
-            session.expunge(row)
+        retention: int | None = None
+        if membership.role == GuildRole.admin:
+            row = (
+                await session.exec(
+                    select(GuildSetting).where(GuildSetting.guild_id == guild.id)
+                )
+            ).one_or_none()
+            # No row yet → the 90-day default; an explicit NULL is the user's "never".
+            retention = 90 if row is None else row.retention_days
+            if row is not None:
+                session.expunge(row)
         member_count = await count_members(session, guild_id=guild.id)
         out.append((guild, membership, retention, member_count))
 

--- a/backend/app/testing/delegation.py
+++ b/backend/app/testing/delegation.py
@@ -30,7 +30,9 @@ __all__ = [
     "DELEGATE_KID",
     "DELEGATE_PUBLIC_ID",
     "delegation_jwks",
+    "DELEGATE_LISTING_UID",
     "delegation_verification_keys",
+    "install_delegate",
     "foreign_jwks",
     "mint_delegation_token",
     "register_delegate",
@@ -41,6 +43,9 @@ __all__ = [
 #: suffix, because a rotation runs two entries in one key set.
 DELEGATE_PUBLIC_ID = "acme.auto"
 DELEGATE_KID = f"{DELEGATE_PUBLIC_ID}-delegation-1"
+#: The listing the delegate's registration names, and therefore what a guild
+#: installs to let it act there.
+DELEGATE_LISTING_UID = "DELEGATE000001"
 
 # One keypair per test session. Generated rather than checked in so no test
 # depends on a fixed modulus, and cheap enough at 2048 bits to build once.
@@ -119,6 +124,7 @@ async def register_delegate(
     """
     row = AppServiceRegistration(
         public_id=public_id,
+        listing_uid=DELEGATE_LISTING_UID,
         base_url="http://auto.test:8080",
         allowed_origins=["http://auto.test:8080"],
         secret_encrypted=None,
@@ -139,3 +145,42 @@ def delegation_verification_keys() -> tuple[Any, ...]:
     """The public key itself, for a test calling the verifier directly rather
     than through the auth dep that would resolve it from a registration."""
     return (_keypair.public_key(),)
+
+
+async def install_delegate(session: AsyncSession, guild, creator=None) -> Any:
+    """Install the delegate in a guild, which is what lets it act there.
+
+    An app reaches a guild because that guild installed it, so a test that
+    expects a delegated call to succeed installs the app as well as registering
+    it — the two halves an operator and a guild admin each own.
+    """
+    from sqlmodel import select
+
+    from app.models.tenant.guild_app import GuildApp
+    from app.testing.factories import create_guild_app, create_user
+    from app.testing.schema_harness import route_session_to_guild
+
+    # Resolved before the session is routed: a user is a public row, and
+    # writing one on a guild-routed session is not a thing this should do.
+    installer = creator or await create_user(session)
+
+    await route_session_to_guild(session, guild.id)
+    existing = (
+        await session.exec(
+            select(GuildApp).where(GuildApp.listing_uid == DELEGATE_LISTING_UID)
+        )
+    ).first()
+    if existing is not None:
+        return existing
+
+    return await create_guild_app(
+        session,
+        guild,
+        installer,
+        definition={
+            "app_kind": "service",
+            "service": {"public_id": DELEGATE_PUBLIC_ID},
+        },
+        listing_uid=DELEGATE_LISTING_UID,
+        name="Delegate",
+    )

--- a/docs/en/admin/publishing-listings.md
+++ b/docs/en/admin/publishing-listings.md
@@ -9,7 +9,7 @@ Initiative's marketplace ships with a set of ready-made dashboards and apps. It'
 Nothing about this needs a fork, a code change, or a new build of Initiative. If you've designed a dashboard your group keeps rebuilding by hand, or someone has published a listing file you'd like to run, this is how it gets in.
 
 !!! info "Where the trust comes from"
-    Listings added this way are shown as **added by your administrator** — because that's exactly what happened. You control the directory, so a file being in it *is* your decision to publish it. Listings that ship with Initiative are shown as from Initiative, and there's no way for a listing you add to claim that badge (see [Reserved names](#names-you-cant-use)).
+    You control the directory, so a file being in it *is* your decision to publish it. Every listing is shown with the publisher named in its own file, wherever it appears — on the card, on its page, and in the dialog where someone adds it — so the question of who made it is answered at the moment of the decision. Listings that ship with Initiative are credited to Initiative, and a listing you add can't claim that credit (see [Reserved names](#names-you-cant-use)).
 
 ## Turning it on
 
@@ -180,4 +180,5 @@ Work down this list — the scan result above answers most of it directly.
 
 - [Configuration](configuration.md) — every setting, including `MARKETPLACE_EXTRA_CATALOG_DIR`.
 - [Platform roles](platform-roles.md) — who may trigger a rescan.
+- [Apps & the marketplace](../guides/apps-and-marketplace.md) — how your listings look to the people installing them.
 - [Tools](../guides/tools.md) — what a dashboard is, from a member's side.

--- a/docs/en/concepts/index.md
+++ b/docs/en/concepts/index.md
@@ -18,7 +18,7 @@ graph TD
   P1["📋 Project<br/>(a task board)"]
   P2["📋 Project"]
   D1["📄 Documents"]
-  T1["🛠️ Tools<br/>(calendar, queues, counters)"]
+  T1["🛠️ Tools<br/>(calendar, queues,<br/>counters, dashboards)"]
   TASK["✅ Tasks"]
 
   G --> I1
@@ -39,9 +39,12 @@ From biggest to smallest:
 
 Let's take them one at a time.
 
+!!! tip "You don't have to set all this up"
+    Creating a guild gives you an initiative and somewhere to put your first project straight away. Most groups run on one guild, one initiative, and a couple of projects for a long time — and only reach for the rest when a real need turns up.
+
 ## Guild — your group's workspace
 
-A **guild** is the outermost container: one separate space for one group of people. Your tabletop campaign, your work team, and your neighborhood association would each be their own guild.
+A **guild** is the outermost container: one separate space for one group of people. Your business, your volunteer committee, and your neighborhood association would each be their own guild.
 
 Guilds don't mix. Nothing in one guild is visible from another, even on the same server. You can belong to several guilds and switch between them from the guild rail down the left edge of the screen — but each is its own sealed world.
 
@@ -65,23 +68,32 @@ People are added to an initiative as **members**, and each member is given a **r
 
 ## Projects and tasks — getting work done
 
-A **project** is a board for tracking work. It holds **tasks** — the individual to-dos — and lets you see them in whatever way suits you: a simple **Table**, a drag-and-drop **Kanban** board, or a **Calendar**.
+A **project** is a board for tracking work. It holds **tasks** — the individual to-dos — and lets you see them in whatever way suits you: a simple **Table**, a drag-and-drop **Kanban** board, or a **Calendar**. The same work, three ways of looking at it, so nobody has to think about it the way someone else does.
 
 A **task** can have a description, a status (like "To Do" or "Done"), a priority, start and due dates, people assigned to it, subtasks, and tags. Tasks are where the day-to-day happens. See [Projects & tasks](../guides/projects-and-tasks.md).
 
 ## Documents — writing things down
 
-A **document** lives inside an initiative and holds knowledge: meeting notes, a plan, a script, a spreadsheet. Documents can be written and edited **together, in real time**, so two people can work on the same page at once. You can also upload files (PDFs, Word, images) as documents. See [Documents](../guides/documents.md).
+A **document** lives inside an initiative and holds knowledge: meeting notes, a plan, a script, a budget spreadsheet, or a **whiteboard** for the things that are easier drawn than written. Documents can be written and edited **together, in real time**, so two people can work on the same page — or the same canvas — at once. You can also upload files (PDFs, Word, images) as documents. See [Documents](../guides/documents.md).
 
-## Tools — for groups that need more
+## Tools — added when you need them
 
-Beyond projects and documents, each initiative can use a few extra **tools**:
+Beyond projects and documents, each initiative can use extra **tools**:
 
 - **Calendar & events** — schedule things, invite attendees, and send reminders.
-- **Queues** — keep track of whose turn it is (great for games and rotations).
-- **Counters** — track numbers that go up and down (scores, health, budgets).
+- **Queues** — keep track of whose turn it is (rotations, rosters, running orders).
+- **Counters** — track numbers that go up and down (tallies, scores, budgets).
+- **Dashboards** — a single screen of charts, numbers, and timelines built from your own data.
 
 You don't have to use any of these — they're there when you need them. See [Tools](../guides/tools.md).
+
+## Apps — what the community has already built
+
+Some of what a group needs isn't in the list above, and doesn't have to be. Initiative has a **marketplace** of ready-made **dashboards** and **apps** built by people solving the same problems. Adding one takes a couple of clicks: pick a listing, choose where it goes, name it.
+
+What's on offer is what ships with Initiative plus what the person running your server has approved — so the catalog is curated by someone you can ask about it.
+
+Dashboards land in an initiative like any other tool. Apps are added at the guild level by a guild admin, because they add something the whole guild shares. See [Apps & the marketplace](../guides/apps-and-marketplace.md).
 
 ## The other half: people and access
 
@@ -94,13 +106,14 @@ Everything above is about *where things live*. The other half of the picture is 
 | **Initiative role** | What kinds of tools are you allowed to use here? |
 | **Sharing** | For *this specific* project or document, can you view it, edit it, or own it? |
 
-Each layer sits inside the one above it. You can only reach a document if you're in its guild, *and* in its initiative, *and* it's been shared with you. We explain this in friendly detail in [Sharing & access](../sharing/index.md), and in technical depth in [Security & privacy](../security/index.md).
+Each layer sits inside the one above it. You can only reach a document if you're in its guild, *and* in its initiative, *and* it's been shared with you. The practical upshot: the only people who ever see something are the people you deliberately put in front of it. We explain this in friendly detail in [Sharing & access](../sharing/index.md), and in technical depth in [Security & privacy](../security/index.md).
 
 ??? techspec "For the technically minded — these four layers are enforced in the database"
-    The four layers above aren't just interface conveniences — they're enforced at the database level using PostgreSQL's row-level security, so a bug in the app can't quietly hand someone data they shouldn't see. There are also two overrides: a **guild administrator** always has full access within their own guild, and platform staff can be granted **temporary, time-limited, audited** access for support — never a standing back door. The full model is in [How your data is kept separate](../security/how-your-data-is-kept-separate.md).
+    The four layers above aren't just interface conveniences. The **guild** layer is structural: each guild's content lives in its own PostgreSQL schema, and a request is routed into one guild's schema and can't address another's. The **initiative**, **role**, and **sharing** layers are enforced inside that schema by PostgreSQL's row-level security, evaluated on every statement — so a bug in the app can't quietly hand someone data they shouldn't see. There are also two overrides: a **guild administrator** always has full access within their own guild, and platform staff can be granted **temporary, time-limited, audited** access for support — never a standing back door. The full model is in [How your data is kept separate](../security/how-your-data-is-kept-separate.md).
 
 ## Where to go next
 
 - Ready to *do* things? Head to the [how-to guides](../guides/index.md).
 - Curious who-can-see-what? Read [Sharing & access](../sharing/index.md).
+- Want more than the built-in tools? See [Apps & the marketplace](../guides/apps-and-marketplace.md).
 - Hit an unfamiliar word? The [glossary](../reference/glossary.md) has you covered.

--- a/docs/en/getting-started/index.md
+++ b/docs/en/getting-started/index.md
@@ -6,6 +6,8 @@ icon: lucide/rocket
 
 Welcome! This section gets you from "I've never used Initiative" to "I'm comfortable finding my way around." Take it in order, or jump to whatever you need.
 
+No prior experience with project management software is assumed, and none is needed. If you can write a to-do list, you can use Initiative.
+
 ## What you'll need
 
 - **A web browser** on a computer, tablet, or phone. Initiative runs in the browser — there's nothing to install to get started.

--- a/docs/en/getting-started/your-first-guild.md
+++ b/docs/en/getting-started/your-first-guild.md
@@ -24,7 +24,7 @@ That's all there is to it. The guild now appears on the **guild rail** down the 
 If you're starting fresh — setting up a space for your own group — you can create a guild yourself, as long as your server allows it.
 
 1. On the **guild rail** down the far-left edge of the screen, choose **Create guild** (look for an **add** / **+** control on the rail).
-2. Give it a **name** (for example, "Tuesday Night D&D" or "Marketing Team"). You can add an **icon** to make it easy to recognize.
+2. Give it a **name** — usually just the name of your group, business, or household ("Fairview Bakery," "PTA Committee," "The Nguyens"). You can add an **icon** to make it easy to recognize.
 3. Create it. You're now the guild's first **administrator**.
 
 !!! screenshot "Creating a guild"
@@ -49,10 +49,10 @@ We cover all of this in detail in [Using Initiative](../guides/index.md).
 
 ## Switching between guilds
 
-You can belong to as many guilds as you like — your gaming group, your volunteer committee, your workplace — and each stays completely separate. Use the **guild rail** on the far-left edge of the screen to move between them — click a guild's icon to switch. Switching changes everything else (the sidebar, initiatives, and projects) to that guild and opens its front page.
+You can belong to as many guilds as you like — your workplace, your volunteer committee, your family — and each stays completely separate. Use the **guild rail** on the far-left edge of the screen to move between them — click a guild's icon to switch. Switching changes everything else (the sidebar, initiatives, and projects) to that guild and opens its front page.
 
 ??? techspec "For the technically minded — guilds are a hard boundary"
-    A guild isn't just a label. Each guild's content lives in its own isolated area of the database, and the system enforces that you can only ever read or write guilds you belong to — at the database level, not just in the interface. Two browser tabs can even sit in two different guilds at once without leaking between them. This is the foundation of how Initiative keeps groups' data apart; see [How your data is kept separate](../security/how-your-data-is-kept-separate.md).
+    A guild isn't just a label. Each guild's content lives in its own database schema, created when the guild is created, and a request is routed into exactly one of them — so you can only ever read or write guilds you belong to, enforced at the database level rather than in the interface. Two browser tabs can even sit in two different guilds at once without leaking between them. This is the foundation of how Initiative keeps groups' data apart; see [How your data is kept separate](../security/how-your-data-is-kept-separate.md).
 
 ## Next
 

--- a/docs/en/guides/apps-and-marketplace.md
+++ b/docs/en/guides/apps-and-marketplace.md
@@ -1,0 +1,94 @@
+---
+icon: lucide/store
+---
+
+# Apps & the marketplace
+
+The tool your group needs has usually been needed before, by a group with the same problem. The **marketplace** is where those tools live: ready-made dashboards and apps you can add to your workspace in a couple of clicks, without a developer and without waiting for a new version of Initiative.
+
+Your marketplace holds the listings that ship with Initiative, plus any that the person running your server has added and approved. It isn't an open upload pool — nothing reaches your marketplace without them putting it there.
+
+Open it from **Browse the marketplace** on your dashboards list, or from the **Apps** section at the top of the sidebar.
+
+!!! screenshot "The marketplace"
+    **Show:** the marketplace browse page — the search box and a grid of listing cards, each with its artwork, name, publisher, and description.
+
+    Save as `en/images/marketplace/browse.png`, then use:
+    `![Browsing the marketplace](../images/marketplace/browse.png)`
+
+## Two kinds of listing
+
+| | **Dashboards** | **Apps** |
+|---|---|---|
+| What it adds | A screen of charts, numbers, and timelines | Something the whole guild shares |
+| Where it goes | Into one initiative | Into the guild |
+| Who can add it | Anyone who can create dashboards in that initiative | Guild admins only |
+
+Both are browsed the same way: search, open a listing to read what it does, then add it.
+
+## Adding a dashboard
+
+A **dashboard** displays your data on one canvas — task counts, project progress, upcoming calendar entries, counters. Dashboards are read-only by design: nothing you see on one can be edited from it.
+
+1. Open the listing and choose **Add to an initiative**.
+2. Pick the **initiative** it should live in.
+3. Give it a **name** — the listing's name is filled in, and you can change it now or later.
+
+It then appears under that initiative's **Dashboards**, exactly like one you built yourself. You can rename it, tag it, share it, and delete it like any other tool.
+
+!!! info "Don't see any initiative to choose?"
+    You can only add a dashboard where you're allowed to create one. If the list is empty, ask an initiative manager to give your role the dashboard permission — see [Initiative roles](../sharing/initiative-roles.md).
+
+### Previews
+
+A listing's page can show a **preview** of the dashboard, drawn with sample data so you can see the shape of it before you commit. What you add will show your group's real numbers instead.
+
+### Updates
+
+When the publisher releases a newer version, the dashboard shows **Version X available**. Updating is a choice you make — nothing changes underneath you. If a listing needs a newer version of Initiative than your server is running, it says so rather than half-working.
+
+## Adding an app
+
+An **app** adds something to the guild as a whole rather than to one effort — a shared surface, extra dashboard widgets, or a connection to a service your group already uses. Because it affects everyone, **only guild admins can add or remove one**.
+
+1. Switch the marketplace to the **Apps** shelf and open a listing.
+2. Choose **Add to guild** and name it.
+3. If the app needs setting up, it's marked **Needs setup** — open its settings to finish.
+
+Installed apps appear in the **Apps** section at the top of the sidebar, above your initiatives, and are managed under **Guild settings → Apps**.
+
+### Setting an app up
+
+Some apps need a credential before they can do anything — an API key, or a sign-in to another service. There are two kinds, and the difference matters:
+
+- **Guild credential** — set once by a guild admin, used for everyone. Good for a shared account the whole group works through.
+- **Your account** — each member supplies their own, and it's used only for them. Your credential is yours; other members can't see or use it.
+
+Each connection shows which service it uses and what it's allowed to do there, so you can decide before you supply anything.
+
+### Turning an app off, and removing it
+
+- **Turn off** hides an app from everyone while keeping its setup. Turn it back on and it picks up where it left off. Disabled apps stay visible in **Guild settings → Apps**, which is where an admin turns them back on.
+- **Remove** takes it out of the guild entirely. Anything it created moves to the **Trash**, where it can still be restored during the retention window. Every credential it held — the guild's and each member's — is deleted, and the app is told to stop using them.
+
+## Where listings come from, and what they can reach
+
+Every listing in your marketplace got there one of two ways:
+
+- It **ships with Initiative** — part of the built-in catalog, credited to Initiative. That credit can't be claimed by anything else.
+- Your **platform owner added it** — the person who runs your server chose that listing and published it to your deployment. If you run Initiative yourself, that person is you.
+
+There's no third way in. Anyone can write a listing, but reaching *your* marketplace is a decision your platform owner makes, one listing at a time. See [Publishing your own listings](../admin/publishing-listings.md).
+
+Every listing also shows **who published it** — on the card, on its page, and in the dialog where you add it — so the question is answered at the moment you're deciding.
+
+Two things stay true whatever you install:
+
+- **Your access rules still apply.** A dashboard shows *you* only the data you could already reach — the same guild, initiative, role, and sharing checks as everywhere else. Two people looking at the same dashboard can correctly see different numbers.
+- **Widgets run in a sandbox.** Marketplace widgets run in an isolated runtime that can only return something to draw. If one misbehaves, that tile shows an error and the rest of the page carries on.
+
+## Related
+
+- [Tools](tools.md) — the calendar, queues, counters, and dashboards built into every initiative.
+- [Sharing & access](../sharing/index.md) — who can see what you add.
+- [Publishing your own listings](../admin/publishing-listings.md) — for administrators adding listings to their server's marketplace.

--- a/docs/en/guides/documents.md
+++ b/docs/en/guides/documents.md
@@ -63,6 +63,17 @@ The spreadsheet supports the everyday essentials:
 - **Freeze** rows or columns so headers stay put as you scroll.
 - **Import and export** as CSV or Excel (XLSX).
 
+## Sketching on a whiteboard
+
+A **whiteboard** is a free-form canvas for the thinking that doesn't fit in a paragraph — a floor plan, a seating chart, a flow of who-does-what, boxes and arrows on a wall.
+
+- **Draw anything** — shapes, arrows, freehand lines, text, and images, arranged however you like.
+- **Work on it together** — everyone's pointer shows up live, labeled with their name, so you can point at the same thing at the same time.
+- **Go fullscreen** when the canvas needs the whole window.
+- **Export as a picture** — save a whiteboard as a **PNG** or **SVG** image to drop into a slide deck, an email, or a printout.
+
+Whiteboards autosave like everything else, and they're shared, tagged, and commented on exactly like any other document.
+
 ## Editing together, live
 
 Documents are built for collaboration:

--- a/docs/en/guides/index.md
+++ b/docs/en/guides/index.md
@@ -4,7 +4,7 @@ icon: lucide/book-open
 
 # Using Initiative
 
-These are the everyday how-to guides — the things you'll actually do in Initiative, explained step by step. Dip in wherever you need; you don't have to read them in order.
+These are the everyday how-to guides — the things you'll actually do in Initiative, explained step by step. Dip in wherever you need; you don't have to read them in order, and you don't need any of them to get started.
 
 If you're not sure how the pieces fit together yet, start with [How Initiative is organized](../concepts/index.md) and come back here.
 
@@ -30,21 +30,27 @@ If you're not sure how the pieces fit together yet, start with [How Initiative i
 
 -   :material-view-dashboard-outline: __Task views__
 
-    Table, Kanban, Calendar, and Timeline — pick the view that fits.
+    Table, Kanban, and Calendar — pick the view that fits.
 
     [:octicons-arrow-right-24: Task views](task-views.md)
 
 -   :material-file-document-edit-outline: __Documents__
 
-    Write together in real time, upload files, and leave comments.
+    Text, spreadsheets, and whiteboards — written together in real time.
 
     [:octicons-arrow-right-24: Documents](documents.md)
 
 -   :material-toolbox-outline: __Tools__
 
-    The calendar, queues, and counters for groups that need them.
+    The calendar, queues, counters, and dashboards, for when you need them.
 
     [:octicons-arrow-right-24: Tools](tools.md)
+
+-   :material-storefront-outline: __Apps & the marketplace__
+
+    Add ready-made dashboards and apps built by other groups.
+
+    [:octicons-arrow-right-24: Apps & the marketplace](apps-and-marketplace.md)
 
 -   :material-tag-multiple-outline: __Tags__
 

--- a/docs/en/guides/initiatives.md
+++ b/docs/en/guides/initiatives.md
@@ -45,7 +45,7 @@ People who aren't members of an initiative simply don't see it — it's not hidd
 
 Within an initiative, each member has a **role**. A role decides which *kinds of tools* that person can use here — for example, whether they can create projects, or only view them.
 
-Initiative comes with a **Manager** role (think project lead) whose permissions are fixed, and you can create your own roles on top — like "Director," "Cast," "Player," or "Guest" — each with its own mix of permissions.
+Initiative comes with a **Manager** role (think project lead) whose permissions are fixed, and you can create your own roles on top — like "Coordinator," "Volunteer," "Client," or "Guest" — each with its own mix of permissions. Name them after how your group actually talks about itself, not after anything Initiative expects.
 
 Permissions are grouped by tool:
 
@@ -56,8 +56,9 @@ Permissions are grouped by tool:
 | **Queues** | View, Create |
 | **Counters** | View, Create |
 | **Events** (calendar) | View, Create |
+| **Dashboards** | View, Create |
 
-So you might give "Cast" members permission to *view* projects and documents but not create them, while "Director" can create everything.
+So you might give "Volunteer" members permission to *view* projects and documents but not create them, while "Coordinator" can create everything.
 
 There's a full walkthrough of roles and how they combine with sharing in [Initiative roles](../sharing/initiative-roles.md).
 

--- a/docs/en/guides/projects-and-tasks.md
+++ b/docs/en/guides/projects-and-tasks.md
@@ -128,6 +128,6 @@ You can **export a project** (as a portable file) to keep an offline copy or mov
 
 ## Related
 
-- [Task views](task-views.md) — Table, Kanban, Calendar, and Timeline.
+- [Task views](task-views.md) — Table, Kanban, and Calendar.
 - [Tags](tags.md) — labeling and filtering.
 - [Your space](your-space.md) — see all your tasks across every project and guild.

--- a/docs/en/guides/tools.md
+++ b/docs/en/guides/tools.md
@@ -4,7 +4,9 @@ icon: lucide/wrench
 
 # Tools
 
-Beyond projects and documents, each initiative can use a few extra **tools**. They're optional — there if your group needs them, out of the way if it doesn't. You'll find them in the sidebar under the initiative, once your [role](../sharing/initiative-roles.md) allows it.
+Beyond projects and documents, each initiative can use a few extra **tools**: a **calendar**, **queues**, **counters**, and **dashboards**. They're optional — there if your group needs them, out of the way if it doesn't. You'll find them in the sidebar under the initiative, once your [role](../sharing/initiative-roles.md) allows it.
+
+Most groups don't turn any of these on for a while. Add one when a real need shows up: a shared calendar when scheduling starts to sprawl, a dashboard when someone asks how the work is going.
 
 !!! tip "Bulk-edit who can access them"
     You can select several **events, queues, or counters** in a list view and update **who can see or edit them** all at once — the same bulk access editing available for projects and documents. See [Sharing & access](../sharing/index.md).
@@ -38,7 +40,7 @@ The calendar shows your events by **day, week, month, year, or as a list**, and 
 
 ## Queues
 
-A **queue** keeps track of whose turn it is. It's ideal for anything that takes turns or rotates — initiative order in a game, a speaking rotation, a chore wheel, a support roster.
+A **queue** keeps track of whose turn it is. It's ideal for anything that takes turns or rotates — an on-call roster, a speaking order, a chore wheel, who's opening the shop this week, turn order in a game.
 
 A queue holds **items** (often people), and each item can have:
 
@@ -58,7 +60,7 @@ You can **Start** the queue, step through **Next turn** / **Previous turn**, **H
 
 ## Counters
 
-A **counter** tracks a number that goes up and down — a score, health points, a tally, a budget. **Counter groups** bundle related counters together (for example, the health of every character in a game).
+A **counter** tracks a number that goes up and down — a ticket tally, seats left, a budget, a score. **Counter groups** bundle related counters together (for example, one counter per table at a fundraiser).
 
 Each counter can have:
 
@@ -75,8 +77,25 @@ Each counter can have:
     Save as `en/images/tools/counters.png`, then use:
     `![A group of counters](../images/tools/counters.png)`
 
+## Dashboards
+
+A **dashboard** puts the answer to "how are we doing?" on one screen. It's a canvas of tiles — charts, single numbers, timelines — each reading from your own data: task counts, project progress, upcoming calendar entries, a counter's value.
+
+Dashboards **only display**. Nothing on one can be edited from it, so a dashboard is safe to leave open on a shared screen or hand to someone who only needs the overview.
+
+Each tile shows *you* only what you're already allowed to see, so two people can open the same dashboard and correctly see different numbers.
+
+You can build one from scratch, or add a ready-made one from the marketplace and adjust it — see [Apps & the marketplace](apps-and-marketplace.md).
+
+!!! screenshot "A dashboard"
+    **Show:** an initiative dashboard with a few tiles — a chart, a couple of single-number tiles, and a timeline.
+
+    Save as `en/images/tools/dashboard.png`, then use:
+    `![An initiative dashboard](../images/tools/dashboard.png)`
+
 ## Related
 
 - [Initiatives](initiatives.md) — tools live inside an initiative, and roles control who can use them.
+- [Apps & the marketplace](apps-and-marketplace.md) — ready-made dashboards and apps from other groups.
 - [Notifications](notifications.md) — event invites and reminders.
 - [Your space](your-space.md) — your combined calendar.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -4,7 +4,7 @@ icon: lucide/compass
 
 # Welcome to Initiative
 
-Initiative is a friendly home for your group's projects, tasks, documents, and plans. It's built for teams, clubs, gaming groups, and families who want to stay organized together without wrestling with complicated software.
+Initiative is where your group's projects, tasks, documents, and plans live together. It's made for small businesses, clubs, committees, event teams, families, and anyone else coordinating work with other people — without needing to learn project management first.
 
 !!! screenshot "The main screen, after signing in"
     **Show:** the whole app — the guild rail down the far left, the sidebar beside it (the guild's initiatives), and a project board open in the middle.
@@ -12,9 +12,13 @@ Initiative is a friendly home for your group's projects, tasks, documents, and p
     When you have the picture, save it to `en/images/home/overview.png` and replace this box with:
     `![The Initiative home screen](images/home/overview.png)`
 
+## Start small; it grows with you
+
+You can get real value on day one from a single board with tasks on it. Later, when your group needs a shared calendar, or a place to write things down, or a way to report on how the work is going, those are waiting — and until then they stay out of your way.
+
 ## New here? Start at the beginning
 
-If this is your first time, **Getting started** is the place to go. It covers creating your account, finding your way around, and joining or creating your first workspace.
+If this is your first time, **Getting started** covers creating your account, finding your way around, and joining or creating your first workspace.
 
 [Start with Getting started →](getting-started/index.md){ .md-button .md-button--primary }
 
@@ -40,9 +44,15 @@ If this is your first time, **Getting started** is the place to go. It covers cr
 
     [:octicons-arrow-right-24: How-to guides](guides/index.md)
 
+-   :material-storefront-outline: __Apps & the marketplace__
+
+    Add ready-made dashboards and apps built by other groups like yours.
+
+    [:octicons-arrow-right-24: Apps & the marketplace](guides/apps-and-marketplace.md)
+
 -   :material-account-multiple-check-outline: __Sharing & access__
 
-    Decide who can see and edit each project and document.
+    Decide exactly who can see and edit each project and document.
 
     [:octicons-arrow-right-24: Sharing & access](sharing/index.md)
 
@@ -60,8 +70,20 @@ If this is your first time, **Getting started** is the place to go. It covers cr
 
 </div>
 
+## You choose who sees what
+
+Nothing in Initiative is visible to "everyone" by default. Your group's space is separate from every other group's; inside it, each effort is visible only to the people you add to it; and individual projects and documents can be narrowed further still.
+
+That means a business owner can keep payroll planning away from the seasonal staff, and an event team can work on next year's programme without the volunteers seeing it — in the same workspace, with no extra setup. [How that works →](sharing/index.md)
+
 ??? techspec "For the technically minded — what Initiative is, briefly"
-    Initiative is a self-hosted web application. The interface is a single-page web app; it talks to a Python service backed by a PostgreSQL database. Each group ("guild") gets its own isolated area of the database, and who-can-see-what is enforced inside the database itself, not only in the app. There's a companion mobile app (iOS and Android) for notifications and on-the-go use. More in [Security & privacy](security/index.md) and the [administrator guide](admin/index.md).
+    Initiative is a web application you can run yourself. The interface is a single-page web app; it talks to a Python service backed by a PostgreSQL database. Each group ("guild") gets its **own database schema**, so a request in one guild can't address another guild's tables at all; the finer layers inside a guild — which effort, which role, which item — are enforced by the database's own row-level security rather than by the app alone. There's a companion mobile app (iOS and Android) for notifications and on-the-go use. More in [Security & privacy](security/index.md) and the [administrator guide](admin/index.md).
+
+## The tools come from people like you
+
+The thing your group needs has usually already been built by another group with the same problem. Initiative's **marketplace** lets you add ready-made dashboards and apps to your workspace in a couple of clicks — no developer, no custom build.
+
+It's curated, not a free-for-all: your marketplace holds what ships with Initiative plus what the person running your server has approved. See [Apps & the marketplace](guides/apps-and-marketplace.md).
 
 ## A note on the words we use
 
@@ -71,3 +93,7 @@ Initiative borrows a few everyday words and gives them a specific meaning. The t
 - An **initiative** is a folder for a big effort inside a guild. It gathers related projects and documents in one place.
 
 There's a full [glossary](reference/glossary.md) if you ever hit a word you don't recognize.
+
+## Built in the open
+
+Initiative is developed publicly, and the feedback of the people using it shapes what gets built next. If something here is unclear, wrong, or missing, that's worth telling us about — the [project on GitHub](https://github.com/Morelitea/initiative) is where it happens.

--- a/docs/en/reference/faq.md
+++ b/docs/en/reference/faq.md
@@ -6,6 +6,20 @@ icon: lucide/circle-help
 
 Short answers to the things people ask most. Each links to the fuller explanation.
 
+## Starting out
+
+### Do I need to know project management to use Initiative?
+
+No. A project is a board, a task is a to-do on it, and that's enough to run real work. Everything else — roles, tools, dashboards, apps — is there when a need for it turns up, and stays out of the way until then. See [Getting started](../getting-started/index.md).
+
+### There's a lot here. Where do I actually begin?
+
+Make a guild, open the **Default Initiative** it comes with, and create one project. Add tasks. That's a working setup. Come back for the rest when something feels missing. See [Your first guild](../getting-started/your-first-guild.md).
+
+### Can I add tools that aren't built in?
+
+Yes — the **marketplace** has ready-made dashboards and apps. Adding one takes a couple of clicks, and no code. What's on offer is what ships with Initiative plus what your platform owner has approved, so if something you want isn't there, they're who to ask. See [Apps & the marketplace](../guides/apps-and-marketplace.md).
+
 ## Getting in
 
 ### I didn't get my verification or password-reset email.
@@ -67,6 +81,14 @@ On the **guild rail**, open the guild's menu and choose **Leave guild**. If you'
 **Deactivating** is reversible — you're switched off but your data is kept. **Deleting** is permanent, and you choose whether your past contributions are anonymized or fully removed. See [Profile & preferences](../account/profile-and-preferences.md#closing-your-account).
 
 ## Privacy and data
+
+### Can everyone in my guild see everything in it?
+
+No. Being in a guild doesn't give you its contents — an **initiative** is only visible to the people added to it, and individual projects and documents can be narrowed further still. The one exception is a **guild admin**, who can see everything in their own guild. See [Sharing & access](../sharing/index.md).
+
+### How do I keep something visible to just two or three people?
+
+Put it in an initiative with only those people in it. That's the strongest everyday boundary and it needs no configuration — everyone else simply doesn't have it. To narrow within an initiative, share the specific project or document. See [Sharing projects & documents](../sharing/sharing-projects-and-documents.md).
 
 ### Can other groups on the same server see our stuff?
 

--- a/docs/en/reference/glossary.md
+++ b/docs/en/reference/glossary.md
@@ -20,7 +20,7 @@ The starter initiative every new guild comes with, so there's always somewhere t
 
 ### Project
 
-A **board for tracking work**, made of tasks. It can be viewed as a Table, Kanban board, Calendar, or Timeline. See [Projects & tasks](../guides/projects-and-tasks.md).
+A **board for tracking work**, made of tasks. It can be viewed as a Table, Kanban board, or Calendar. See [Projects & tasks](../guides/projects-and-tasks.md).
 
 ### Task
 
@@ -52,15 +52,35 @@ A **label** you attach to tasks, projects, documents, and events to group and fi
 
 ### Tools
 
-The optional extras inside an initiative: the **calendar/events**, **queues**, and **counters**. See [Tools](../guides/tools.md).
+The optional extras inside an initiative: the **calendar/events**, **queues**, **counters**, and **dashboards**. See [Tools](../guides/tools.md).
 
 ### Queue
 
-A tool for tracking **whose turn it is** — useful for games, rotations, and roster orders.
+A tool for tracking **whose turn it is** — useful for rotations, rosters, and running orders.
 
 ### Counter
 
-A tool for tracking a **number that changes** (a score, health, a budget), bundled into **counter groups**.
+A tool for tracking a **number that changes** (a tally, a budget, a score), bundled into **counter groups**.
+
+### Dashboard
+
+A tool that puts charts, single numbers, and timelines on **one screen**, drawn from your own data. Dashboards only display — nothing can be edited from one. See [Tools](../guides/tools.md#dashboards).
+
+### Marketplace
+
+The catalog of ready-made **dashboards** and **apps** you can add to your workspace. It holds what ships with Initiative plus what your platform owner has added and approved. See [Apps & the marketplace](../guides/apps-and-marketplace.md).
+
+### App
+
+Something added from the marketplace that serves the **whole guild** rather than one initiative. Only guild admins can add or remove one. See [Apps & the marketplace](../guides/apps-and-marketplace.md).
+
+### Widget
+
+A single tile on a dashboard. Widgets from the marketplace run in an isolated sandbox and can only return something to draw.
+
+### Listing
+
+One entry in the marketplace — a dashboard or an app, with its name, description, publisher, and version.
 
 ### Role (initiative role)
 

--- a/docs/en/security/index.md
+++ b/docs/en/security/index.md
@@ -4,7 +4,9 @@ icon: lucide/shield-check
 
 # Security & privacy
 
-"Is my stuff safe and private?" is a fair question to ask of any tool you trust with your group's information. Here's how Initiative protects your group's data, and where to find the details.
+"Is my stuff safe and private?" is a fair question to ask of any tool you trust with your group's information.
+
+The short answer: Initiative is built so that the only people who see something are the people you deliberately gave it to. That's not a setting you have to find and switch on — it's how the layers work by default, all the way down to the database. Here's what that means in practice, and where to find the details.
 
 - **This page** explains what security means for *you*, as someone using Initiative day to day.
 - **[How your data is kept separate](how-your-data-is-kept-separate.md)** is the technical explanation of multi-tenancy and how the boundaries are enforced — written for project managers, administrators, and anyone evaluating Initiative.
@@ -17,11 +19,13 @@ In everyday terms, Initiative is built so that:
 
 ### Your group's data is separate from every other group's
 
-Each guild is a sealed space. Another group using the same Initiative server cannot see your projects, documents, or tasks — and you can't see theirs. This separation isn't just a setting that could be toggled off by accident; it's built into the foundations (more in the technical pages).
+Each guild is a sealed space. Another group using the same Initiative server cannot see your projects, documents, or tasks — and you can't see theirs. This separation isn't a setting that could be toggled off by accident: every guild's content lives in its own dedicated area of the database (a separate *schema*), created with the guild and removed with it. The finer layers — which effort, which role, which item — are enforced inside that space by the database as well (more in the technical pages).
 
 ### Sensitive work stays with the people involved
 
-Inside a guild, an **initiative** is only visible to its members. So a small group can work on something private without the rest of the guild seeing it. And individual projects and documents can be narrowed further still — see [Sharing & access](../sharing/index.md).
+Inside a guild, an **initiative** is only visible to its members. So a small group can work on something private without the rest of the guild seeing it — a business's finances away from its seasonal staff, a hiring committee's notes away from the rest of the team. And individual projects and documents can be narrowed further still — see [Sharing & access](../sharing/index.md).
+
+This is the layer most groups rely on day to day, and it needs no configuration: someone who isn't in an initiative simply doesn't have it.
 
 ### Your sign-in is protected
 

--- a/docs/en/sharing/index.md
+++ b/docs/en/sharing/index.md
@@ -4,7 +4,9 @@ icon: lucide/users-round
 
 # Sharing & access
 
-"Who can see this?" is one of the most important questions in any shared tool — and one of the easiest to get wrong elsewhere. Initiative keeps it simple by building access up in **layers**, from the outside in. This section walks through those layers, then shows you how to share specific projects and documents.
+"Who can see this?" is one of the most important questions in any shared tool — and one of the easiest to get wrong elsewhere. Initiative keeps it simple by building access up in **layers**, from the outside in. Each layer narrows the one before it, so the people who end up seeing something are exactly the people you put in front of it.
+
+This section walks through those layers, then shows you how to share specific projects and documents.
 
 ## The simple version
 
@@ -19,7 +21,7 @@ graph LR
 ```
 
 1. **Are you in the guild?** If not, you don't see anything in it. Full stop.
-2. **Are you in the initiative?** Even inside a guild, an initiative is only visible to the people added to it. This is the big privacy boundary — it's how the "spring play" team can keep their work away from the "summer show" team.
+2. **Are you in the initiative?** Even inside a guild, an initiative is only visible to the people added to it. This is the big privacy boundary — it's how a business keeps its payroll planning away from seasonal staff, and how the "spring play" team keeps its work away from the "summer show" team, in the same workspace.
 3. **Does your role allow this kind of thing?** Your [initiative role](initiative-roles.md) decides which *tools* you can use — for example, whether you can create projects or only view them.
 4. **Is this particular item shared with you?** Finally, each project and document can be shared with specific people or roles, at a **view**, **edit**, or **own** level. See [Sharing projects & documents](sharing-projects-and-documents.md).
 
@@ -55,4 +57,4 @@ If you're not in an initiative, its projects and documents don't appear as locke
 </div>
 
 ??? techspec "For the technically minded — where these layers are enforced"
-    The four gates above are not just interface logic. The guild boundary is a separate database area per guild; the initiative boundary, role checks, and item-level sharing are enforced by the database's own row-level security, evaluated on every request. The result is that even a flaw in the application can't hand someone data the database wouldn't have given them. The full architecture, including the audited support-access path, is in [How your data is kept separate](../security/how-your-data-is-kept-separate.md).
+    The four gates above are not just interface logic. The guild boundary is structural — a separate database schema per guild, which a request is routed into and cannot reach outside of. The initiative boundary, role checks, and item-level sharing are enforced inside that schema by the database's own row-level security, evaluated on every statement. The result is that even a flaw in the application can't hand someone data the database wouldn't have given them. The full architecture, including the audited support-access path, is in [How your data is kept separate](../security/how-your-data-is-kept-separate.md).

--- a/docs/en/sharing/initiative-roles.md
+++ b/docs/en/sharing/initiative-roles.md
@@ -26,6 +26,7 @@ Permissions are grouped by tool. For each tool, a role can typically allow **vie
 | **Queues** | View, Create |
 | **Counters** | View, Create |
 | **Events** (calendar) | View, Create |
+| **Dashboards** | View, Create |
 
 So a "Contributor" role might be allowed to view and create projects and documents, while a "Guest" role can only view them, and has no access to queues or counters at all.
 

--- a/frontend/src/__tests__/factories/guild.factory.ts
+++ b/frontend/src/__tests__/factories/guild.factory.ts
@@ -26,7 +26,7 @@ export function buildGuild(overrides: Partial<GuildRead> = {}): GuildRead {
 
 export function buildGuildInviteStatus(
   overrides: Partial<GuildInviteStatus> = {}
-): GuildReadInviteStatus {
+): GuildInviteStatus {
   counter++;
   return {
     code: `invite-code-${counter}`,

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2264,6 +2264,20 @@ export interface GuildOrderUpdate {
   guildIds: number[];
 }
 
+/**
+ * A guild as its own members see it (``GET /guilds/`` and friends).
+ *
+ * The payload has two tiers, decided in one place — ``_serialize_guild`` in
+ * the guilds router:
+ *
+ * - The fields below with no note are for **every member**: guild identity,
+ *   the caller's own membership, the roster size, ``content_read_only``.
+ * - The ones marked ADMIN-ONLY are guild administration — caps, plan label,
+ *   retention window, lifecycle status, sign-in entitlement. They back
+ *   admin-gated surfaces, so a regular member's payload leaves them ``None``.
+ *   (Operators read the same underlying columns through
+ *   :class:`PlatformGuildStorageRead` instead, which is capability-gated.)
+ */
 export interface GuildRead {
   name: string;
   description: string | null;

--- a/frontend/src/components/guilds/GuildUsagePanel.test.tsx
+++ b/frontend/src/components/guilds/GuildUsagePanel.test.tsx
@@ -31,10 +31,14 @@ vi.mock("@/api/generated/guilds/guilds", () => ({
 
 import { GuildUsagePanel } from "./GuildUsagePanel";
 
+// The panel is a guild-admin surface: it lives on the admin-gated settings
+// page and renders fields the API sends to admins only, so every fixture here
+// is an admin's payload.
 describe("GuildUsagePanel", () => {
   beforeEach(() => {
     state.guild = buildGuild({
       id: 7,
+      role: "admin",
       max_storage_bytes: 1000,
       max_users: 10,
       member_count: 4,
@@ -63,6 +67,7 @@ describe("GuildUsagePanel", () => {
   it("renders unlimited caps without a hard limit", () => {
     state.guild = buildGuild({
       id: 7,
+      role: "admin",
       max_storage_bytes: null,
       max_users: null,
       member_count: 3,
@@ -71,11 +76,11 @@ describe("GuildUsagePanel", () => {
     expect(screen.getAllByText(/Unlimited/).length).toBeGreaterThan(0);
   });
 
-  it("member: anonymous upgrade link, no manage button", () => {
+  it("shows the plan label and both portal buttons when billing is configured", () => {
     state.billing = { url: "https://billing.example.com" };
     state.guild = buildGuild({
       id: 42,
-      role: "member",
+      role: "admin",
       max_storage_bytes: 1000,
       max_users: 10,
       member_count: 4,
@@ -84,9 +89,8 @@ describe("GuildUsagePanel", () => {
     renderWithProviders(<GuildUsagePanel />);
 
     expect(screen.getByText("gold")).toBeInTheDocument();
-    const upgrade = screen.getByText("Upgrade").closest("a");
-    expect(upgrade).toHaveAttribute("href", "https://billing.example.com/upgrade?guild=42&lang=en");
-    expect(screen.queryByText("Manage billing")).not.toBeInTheDocument();
+    expect(screen.getByText("Upgrade")).toBeInTheDocument();
+    expect(screen.getByText("Manage billing")).toBeInTheDocument();
   });
 
   it("admin: opens the portal with the minted token in the URL fragment", async () => {

--- a/frontend/src/components/guilds/GuildUsagePanel.tsx
+++ b/frontend/src/components/guilds/GuildUsagePanel.tsx
@@ -15,7 +15,12 @@ import { formatBytes } from "@/lib/fileUtils";
 const ratioPct = (used: number, max: number | null): number | null =>
   max && max > 0 ? Math.min(100, Math.round((used / max) * 100)) : null;
 
-/** Guild usage against its storage and member caps. */
+/** Guild usage against its storage and member caps.
+ *
+ * Guild admins only, and doubly so: it lives on the admin-gated guild settings
+ * page, and the numbers it renders are the administration half of `GuildRead`
+ * (caps, plan label), which the API sends to admins alone — as does the
+ * storage-usage endpoint below. */
 export const GuildUsagePanel = () => {
   const { t, i18n } = useTranslation(["guilds", "common"]);
   const { activeGuild } = useGuilds();
@@ -39,10 +44,6 @@ export const GuildUsagePanel = () => {
   const tierLabel = activeGuild.tier_name ?? t("usagePanel.selfHosted");
 
   const lang = i18n.resolvedLanguage ?? i18n.language;
-  const isAdmin = activeGuild.role === "admin";
-  const anonUpgradeUrl = billing
-    ? `${billing.url}/upgrade?guild=${activeGuild.id}&lang=${encodeURIComponent(lang)}`
-    : null;
 
   const openPortal = async (page: "manage" | "upgrade") => {
     if (!billing) return;
@@ -104,22 +105,12 @@ export const GuildUsagePanel = () => {
                 <span className="font-semibold">{tierLabel}</span>
               </p>
               <div className="flex gap-2">
-                {isAdmin ? (
-                  <>
-                    <Button size="sm" onClick={() => openPortal("upgrade")}>
-                      {t("usagePanel.upgrade")}
-                    </Button>
-                    <Button size="sm" variant="outline" onClick={() => openPortal("manage")}>
-                      {t("usagePanel.manageBilling")}
-                    </Button>
-                  </>
-                ) : (
-                  <Button asChild size="sm">
-                    <a href={anonUpgradeUrl ?? "#"} target="_blank" rel="noopener noreferrer">
-                      {t("usagePanel.upgrade")}
-                    </a>
-                  </Button>
-                )}
+                <Button size="sm" onClick={() => openPortal("upgrade")}>
+                  {t("usagePanel.upgrade")}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => openPortal("manage")}>
+                  {t("usagePanel.manageBilling")}
+                </Button>
               </div>
             </div>
           </>

--- a/zensical.toml
+++ b/zensical.toml
@@ -11,7 +11,7 @@
 [project]
 
 site_name = "Initiative Help"
-site_description = "Guides and reference for Initiative — projects, documents, and task boards for your whole group."
+site_description = "Guides and reference for Initiative — collaborative project management for small businesses, clubs, event teams, and families."
 site_author = "Morelitea"
 
 # The canonical URL for the published site (powers search, the sitemap, and
@@ -57,6 +57,7 @@ nav = [
     "en/guides/task-views.md",
     "en/guides/documents.md",
     "en/guides/tools.md",
+    "en/guides/apps-and-marketplace.md",
     "en/guides/tags.md",
     "en/guides/your-space.md",
     "en/guides/search-and-shortcuts.md",


### PR DESCRIPTION
## Problem

§3 item 3 of `history/app-platform-hardening-design.md`. #1164 made a delegation token
resolve to the app that signed it and checked that app's grant and switch — both
deployment-level. Nothing asked the guild.

So an app granted `delegation` could act for a member in **any** guild that member belongs
to, including guilds that never installed it. Uninstalling an app took away its surfaces
and its data plane but left this reach intact, which is the property §10.3 of the platform
design claims and did not have.

## Changes

- **[registration_lookup.py](backend/app/services/marketplace/registration_lookup.py)** —
  `app_is_installed(guild_id, listing_uid)` reads the guild's own schema for an enabled
  `guild_apps` row. Read per call rather than cached: the registration snapshot can afford
  a TTL because an operator's kill switch is deployment-wide and rare, while an uninstall
  is a guild's own decision and is expected to bite at once.
- **[deps.py](backend/app/api/deps.py)** — the gate runs at authentication, against the
  guild the **token** names rather than the guild in the path. A delegated call to
  `/me/tasks` has no path guild, and those views read across guilds, so a path-anchored
  check would have left them open.
- **Attribution follows the signature.** Candidates are now verified one at a time, so the
  app a call is attributed to is the one whose key actually verified — not the first
  match. With two apps publishing the same `kid` (an opaque label each picks), the
  previous code recorded `candidates[0]`, which is also the app the install would then
  have been checked against. Caught by the shared-`kid` test once it had an install to
  disagree about.
- **[app/testing/delegation.py](backend/app/testing/delegation.py)** — `install_delegate`
  joins `register_delegate`, so a suite states both halves: the operator granted the app,
  and the guild installed it.

An uninstalled app is refused the way every other delegation refusal works — the call is
not authenticated as delegated at all, so it ends at the standard 401 rather than a 403.

## Testing

- `test_an_app_acts_only_where_it_was_installed` — the same call refused before the
  install and accepted after it.
- `test_a_switched_off_install_stops_the_app` — an install turned off reads as no install.
- `test_a_shared_kid_does_not_shadow_the_app_that_signed` — now also proves the install is
  checked against the signer, since the namesake has none.
- `pytest app/api/v1/tenant_endpoints app/services/marketplace app/core/security_test.py`
- `ruff check app` — clean
