### PR TITLE
Export the app manifest as a JSON Schema

### DIFF
--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -1,0 +1,508 @@
+"""The app manifest as a JSON Schema, built from the validator's own vocabulary.
+
+An app author works in another repository, in another language, against a
+manifest this build accepts or refuses. Handing them a schema turns most of that
+refusal into an editor squiggle and a compile error — which is what the SDK
+generates its types from, and what an implementer in a stack we ship nothing for
+checks against.
+
+**Derived, never written twice.** Every enum, cap and character set here reads
+from the constants :mod:`app.services.marketplace.service_apps` and
+:mod:`app.services.marketplace.manifest_values` already declare. A cap raised
+there is raised here on the next export, so the schema cannot quietly describe a
+manifest the validator would reject. That is the whole reason this is generated
+rather than kept as a checked-in document somebody remembers to update.
+
+**The validator remains authoritative, and the schema says so.** Schema-valid is
+necessary, not sufficient. Four classes of rule cannot be expressed in JSON
+Schema and are enforced only by ``normalize_service_app_definition``:
+
+* **Cross-references** — a widget binding a data source that exists, a
+  ``requires`` term naming a declared connection, an event type prefixed with
+  the app's own service id.
+* **The features cross-check** — every declared feature backed by a block, and
+  every block declared as a feature, in both directions.
+* **Byte sizes** — the caps on ``module_source``, ``sample_data``, the
+  ``automation`` body and the whole document are measured in UTF-8 bytes, which
+  a character count cannot stand in for.
+* **Conditional vocabulary** — an embed may name ``initiative_manager`` only if
+  it also renders in an initiative, and ``connect_path`` belongs to an
+  interactive connection alone.
+
+Those are stated in the schema's own ``description`` too, so the limitation
+travels with the file rather than living only here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.marketplace.manifest_values import (
+    IDENTIFIER_CHARS,
+    MAX_HINT_LENGTH,
+    MAX_IDENTIFIER_LENGTH,
+    MAX_LABEL_LENGTH,
+    MAX_NAME_LENGTH,
+    MAX_PATH_LENGTH,
+    MAX_PUBLIC_ID_LENGTH,
+    PATH_CHARS,
+    PUBLIC_ID_CHARS,
+)
+from app.services.marketplace.service_apps import (
+    APP_PROTOCOL_VERSIONS,
+    CONNECTION_SCOPES,
+    EMBED_CAPABILITIES,
+    EVENT_TYPE_CHARS,
+    EVENT_TYPE_PREFIX,
+    FEATURES,
+    FIELD_TYPES,
+    GUILD_WIDE_VISIBILITIES,
+    MAX_ACCESS_HINT_SCOPES,
+    MAX_CACHE_TTL_SECONDS,
+    MAX_CONNECTIONS,
+    MAX_DATA_SOURCES,
+    MAX_EMBED_CAPABILITIES,
+    MAX_EMBEDS,
+    MAX_EVENT_TYPE_LENGTH,
+    MAX_EVENTS,
+    MAX_FIELDS_PER_CONNECTION,
+    MAX_PARAMS_PER_SOURCE,
+    MAX_REQUIRES_TERMS,
+    MAX_SELECT_OPTIONS,
+    MAX_WIDGET_SOURCES,
+    MAX_WIDGETS,
+    PARAM_TYPES,
+    SURFACE_SCOPES,
+    VISIBILITIES,
+)
+from app.services.marketplace.widget_meta import MAX_TEXT_LENGTH
+
+__all__ = ["SCHEMA_ID", "build_manifest_schema"]
+
+#: Where the schema says it lives. A stable, resolvable name an author can point
+#: a ``$schema`` at and a generator can key a cache on — not a URL this build
+#: serves, which would tie the contract to one deployment.
+SCHEMA_ID = "https://initiative.morels.me/schemas/app-manifest-v1.json"
+
+#: What schema-valid does not prove. Carried in the document so an implementer
+#: reading only the file still learns it.
+_AUTHORITY_NOTE = (
+    "A manifest that satisfies this schema is well-formed, not necessarily "
+    "acceptable. Cross-references (a widget's data sources, a requires term's "
+    "connection, an event's service prefix), the features/blocks cross-check in "
+    "both directions, UTF-8 byte-size caps, and the conditional rules for "
+    "connect_path and initiative visibility are enforced by the platform on "
+    "publish and are not expressible here."
+)
+
+
+def _char_class(chars: frozenset[str]) -> str:
+    """A character class over exactly the set the validator allows.
+
+    Built from the set rather than restated as a literal, so widening the
+    vocabulary in one place widens it here. Characters are escaped and ordered so
+    the output is stable across runs — the file is committed, and a diff should
+    mean somebody changed a rule.
+    """
+    return "[" + "".join(_escape(character) for character in sorted(chars)) + "]"
+
+
+def _pattern(chars: frozenset[str]) -> str:
+    """One or more of ``chars``, anchored."""
+    return f"^{_char_class(chars)}+$"
+
+
+def _escape(character: str) -> str:
+    """Escape for use inside a regex character class."""
+    return f"\\{character}" if character in {"\\", "]", "^", "-"} else character
+
+
+def _path_pattern() -> str:
+    """A plain path: leading slash, allowed characters, no ``//`` and no ``..``.
+
+    The two refusals are a lookahead rather than a second rule, so a path that
+    reads as something other than a route on the app's own service fails here as
+    it does in ``check_path``.
+    """
+    return f"^(?!.*(?://|\\.\\.))/{_char_class(PATH_CHARS)}*$"
+
+
+def _enum(values: frozenset[str]) -> list[str]:
+    """Sorted, so re-exporting an unchanged vocabulary produces no diff."""
+    return sorted(values)
+
+
+def _localized_text(max_length: int = MAX_TEXT_LENGTH) -> dict[str, Any]:
+    """A human-readable string in one or more languages, keyed by language tag."""
+    return {
+        "type": "object",
+        "description": (
+            "Localized text, keyed by language tag. At least one entry; the "
+            "platform falls back to the reader's language, then to any entry."
+        ),
+        "minProperties": 1,
+        "additionalProperties": {"type": "string", "maxLength": max_length},
+    }
+
+
+def _field(*, types: frozenset[str], allow_managed: bool) -> dict[str, Any]:
+    """One typed input, in a connection form or a data source's parameters."""
+    properties: dict[str, Any] = {
+        "key": {"type": "string", "$ref": "#/$defs/identifier"},
+        "type": {"enum": _enum(types)},
+        "required": {"type": "boolean", "default": False},
+        "label": {"$ref": "#/$defs/localizedText"},
+        "options": {
+            "type": "array",
+            "description": "Required when type is 'select'.",
+            "maxItems": MAX_SELECT_OPTIONS,
+            "minItems": 1,
+            "items": {"type": "string", "maxLength": MAX_LABEL_LENGTH},
+        },
+    }
+    if allow_managed:
+        properties["managed"] = {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "The app writes this value back itself when it finishes a vendor "
+                "flow; it is not typed into the settings form."
+            ),
+        }
+    return {
+        "type": "object",
+        "required": ["key", "type", "label"],
+        "additionalProperties": False,
+        "properties": properties,
+        # Expressible here, unlike the cross-reference rules: whether options are
+        # required follows from this object alone.
+        "if": {"properties": {"type": {"const": "select"}}, "required": ["type"]},
+        "then": {"required": ["options"]},
+    }
+
+
+def _requires() -> dict[str, Any]:
+    """Which connections satisfy an item — one level, one operator.
+
+    Exactly one of ``all_of`` / ``any_of``, expressed as
+    ``minProperties``/``maxProperties`` over a closed pair rather than a
+    ``oneOf``: the error an author gets from the former names the object they
+    wrote, and the latter reports every branch that failed.
+    """
+    terms = {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": MAX_REQUIRES_TERMS,
+        "items": {"$ref": "#/$defs/identifier"},
+    }
+    return {
+        "type": "object",
+        "description": (
+            "Connection ids that must hold a value before this is offered. "
+            "Exactly one of 'all_of' or 'any_of'; each id must name a connection "
+            "this manifest declares. Absent means always available."
+        ),
+        "additionalProperties": False,
+        "minProperties": 1,
+        "maxProperties": 1,
+        "properties": {"all_of": terms, "any_of": terms},
+    }
+
+
+def _connection() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["id", "scope", "label", "fields"],
+        "additionalProperties": False,
+        "properties": {
+            "id": {"$ref": "#/$defs/identifier"},
+            "scope": {
+                "enum": _enum(CONNECTION_SCOPES),
+                "description": (
+                    "'static' is one credential a guild admin supplies for the "
+                    "whole guild; 'interactive' is each member's own account, "
+                    "connected through the app's own vendor flow."
+                ),
+            },
+            "label": {"$ref": "#/$defs/localizedText"},
+            "fields": {
+                "type": "array",
+                "maxItems": MAX_FIELDS_PER_CONNECTION,
+                "items": {"$ref": "#/$defs/connectionField"},
+            },
+            "connect_path": {
+                "$ref": "#/$defs/path",
+                "description": (
+                    "Where the member is sent so the app can run the vendor's "
+                    "flow. Interactive connections only."
+                ),
+            },
+            "access_hint": {"$ref": "#/$defs/accessHint"},
+        },
+    }
+
+
+def _access_hint() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "description": (
+            "What the credential will be used for. Display-only: it is shown "
+            "beside the form so an admin can mint a minimal credential, and no "
+            "other system's permissions are enforced from it."
+        ),
+        "additionalProperties": False,
+        "properties": {
+            "api": {"type": "string", "maxLength": MAX_HINT_LENGTH},
+            "scopes": {
+                "type": "array",
+                "maxItems": MAX_ACCESS_HINT_SCOPES,
+                "items": {"type": "string", "maxLength": MAX_HINT_LENGTH},
+            },
+        },
+    }
+
+
+def _data_source() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["id", "path"],
+        "additionalProperties": False,
+        "properties": {
+            "id": {"$ref": "#/$defs/identifier"},
+            "path": {"$ref": "#/$defs/path"},
+            "visibility": {
+                "enum": _enum(GUILD_WIDE_VISIBILITIES),
+                "description": (
+                    "A source is fetched for a guild rather than an initiative, "
+                    "so the initiative rung is not on offer."
+                ),
+            },
+            "cache_ttl_seconds": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": MAX_CACHE_TTL_SECONDS,
+                "default": 0,
+                "description": "Clamped into range rather than refused.",
+            },
+            "params_schema": {
+                "type": "array",
+                "maxItems": MAX_PARAMS_PER_SOURCE,
+                "items": {"$ref": "#/$defs/sourceParam"},
+            },
+            "requires": {"$ref": "#/$defs/requires"},
+        },
+    }
+
+
+def _widget() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["id", "meta", "module_source"],
+        "additionalProperties": False,
+        "properties": {
+            "id": {"$ref": "#/$defs/identifier"},
+            "meta": {
+                "type": "object",
+                "description": (
+                    "The widget's own name and description, as the picker shows "
+                    "them. Must name the widget in at least one language."
+                ),
+            },
+            "module_source": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "The widget's browser-side module. Stored as an opaque "
+                    "string and executed only inside the sandbox; the platform "
+                    "never parses it. Capped in UTF-8 bytes, which this schema "
+                    "cannot express."
+                ),
+            },
+            "sources": {
+                "type": "array",
+                "maxItems": MAX_WIDGET_SOURCES,
+                "items": {"$ref": "#/$defs/identifier"},
+                "description": "Data source ids this manifest also declares.",
+            },
+            "sample_data": {
+                "type": "object",
+                "description": (
+                    "Rows keyed by declared source id, so a preview renders with "
+                    "no network call. Keys naming an undeclared source are "
+                    "dropped."
+                ),
+            },
+            "requires": {"$ref": "#/$defs/requires"},
+        },
+    }
+
+
+def _embed() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["id", "path", "name"],
+        "additionalProperties": False,
+        "properties": {
+            "id": {"$ref": "#/$defs/identifier"},
+            "path": {"$ref": "#/$defs/path"},
+            "name": {"$ref": "#/$defs/localizedText"},
+            "scopes": {
+                "type": "array",
+                "maxItems": len(SURFACE_SCOPES),
+                "items": {"enum": _enum(SURFACE_SCOPES)},
+                "default": ["guild"],
+                "description": (
+                    "Where the surface renders. Declaring both gives it a "
+                    "guild-wide entry and an entry inside each initiative."
+                ),
+            },
+            "visibility": {
+                "enum": _enum(VISIBILITIES),
+                "description": (
+                    "The floor an audience clears. 'initiative_manager' is only "
+                    "namable by a surface that also renders in an initiative — "
+                    "a rule the platform enforces, not this schema."
+                ),
+            },
+            "capabilities": {
+                "type": "array",
+                "maxItems": MAX_EMBED_CAPABILITIES,
+                "items": {"enum": _enum(EMBED_CAPABILITIES)},
+                "description": (
+                    "Browser features the frame is granted. A surface that names "
+                    "nothing is framed with all of them denied."
+                ),
+            },
+            "requires": {"$ref": "#/$defs/requires"},
+        },
+    }
+
+
+def build_manifest_schema() -> dict[str, Any]:
+    """The service-app manifest schema, as a JSON Schema 2020-12 document."""
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": SCHEMA_ID,
+        "title": "Initiative app manifest",
+        "description": (
+            "What a service app may declare at "
+            "/.well-known/initiative-app.json. Generated from the platform's "
+            f"own validator vocabulary. {_AUTHORITY_NOTE}"
+        ),
+        "type": "object",
+        "required": ["app_kind", "service", "features"],
+        "additionalProperties": False,
+        "properties": {
+            "app_kind": {
+                "const": "service",
+                "description": "The only kind that names a container to call.",
+            },
+            "service": {
+                "type": "object",
+                "required": ["public_id"],
+                "additionalProperties": False,
+                "properties": {
+                    "public_id": {
+                        "type": "string",
+                        "maxLength": MAX_PUBLIC_ID_LENGTH,
+                        # The dot is required, not merely allowed: a public id
+                        # without one is not '<publisher>.<slug>'.
+                        "pattern": (
+                            f"^{_char_class(PUBLIC_ID_CHARS)}*"
+                            f"\\.{_char_class(PUBLIC_ID_CHARS)}*$"
+                        ),
+                        "description": (
+                            "'<publisher>.<slug>'. The name the deployment's "
+                            "registration is matched by, and the namespace this "
+                            "app's events are emitted under."
+                        ),
+                    },
+                    "protocol": {
+                        "enum": sorted(APP_PROTOCOL_VERSIONS),
+                        "default": 1,
+                    },
+                },
+            },
+            "features": {
+                "type": "array",
+                "maxItems": len(FEATURES),
+                "items": {"enum": _enum(FEATURES)},
+                "description": (
+                    "What this app contributes. Cross-checked against the blocks "
+                    "present in both directions: a feature with no block, or a "
+                    "block with no feature, is refused."
+                ),
+            },
+            "default_name": {"type": "string", "maxLength": MAX_NAME_LENGTH},
+            "connections": {
+                "type": "array",
+                "maxItems": MAX_CONNECTIONS,
+                "items": {"$ref": "#/$defs/connection"},
+            },
+            "data_sources": {
+                "type": "array",
+                "maxItems": MAX_DATA_SOURCES,
+                "items": {"$ref": "#/$defs/dataSource"},
+            },
+            "widgets": {
+                "type": "array",
+                "maxItems": MAX_WIDGETS,
+                "items": {"$ref": "#/$defs/widget"},
+            },
+            "embeds": {
+                "type": "array",
+                "maxItems": MAX_EMBEDS,
+                "items": {"$ref": "#/$defs/embed"},
+            },
+            "events": {
+                "type": "array",
+                "maxItems": MAX_EVENTS,
+                "items": {
+                    "type": "string",
+                    "maxLength": MAX_EVENT_TYPE_LENGTH,
+                    "pattern": _pattern(EVENT_TYPE_CHARS),
+                    "description": (
+                        "Namespaced under the app's own service id — "
+                        f"'{EVENT_TYPE_PREFIX}<public_id>.<name>'. The prefix is "
+                        "checked against the emitting registration at ingress."
+                    ),
+                },
+            },
+            "automation": {
+                "type": "object",
+                "description": (
+                    "The automation service's own block. Opaque to the platform: "
+                    "checked for shape and size, stored verbatim, and described "
+                    "by no vocabulary here."
+                ),
+            },
+        },
+        "$defs": {
+            "identifier": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": MAX_IDENTIFIER_LENGTH,
+                "pattern": _pattern(IDENTIFIER_CHARS),
+            },
+            "path": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": MAX_PATH_LENGTH,
+                "pattern": _path_pattern(),
+                "description": (
+                    "A route on the app's own service, never an address. The "
+                    "deployment joins it to the base URL its registration "
+                    "supplies."
+                ),
+            },
+            "localizedText": _localized_text(),
+            "requires": _requires(),
+            "accessHint": _access_hint(),
+            "connectionField": _field(types=FIELD_TYPES, allow_managed=True),
+            "sourceParam": _field(types=PARAM_TYPES, allow_managed=False),
+            "connection": _connection(),
+            "dataSource": _data_source(),
+            "widget": _widget(),
+            "embed": _embed(),
+        },
+    }

--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -31,6 +31,19 @@ Schema and are enforced only by ``normalize_service_app_definition``:
 
 Those are stated in the schema's own ``description`` too, so the limitation
 travels with the file rather than living only here.
+
+**Where the two are allowed to differ.** The rule is one-directional: this schema
+must never reject a manifest the platform accepts *and acts on*. So it is
+deliberately permissive in three places where the platform takes a value rather
+than refusing it — an out-of-range ``cache_ttl_seconds`` is clamped into range, an
+over-long localized string is truncated, and an unrecognized property is dropped.
+Naming those as errors would tell an author their working manifest is broken, and
+the last one would also break forward compatibility: an app targeting a newer
+platform has to keep validating against an older copy of this file.
+
+The one exception is a value the platform discards *entirely*, which therefore
+has no effect at all: a localized entry whose value is not a string is skipped,
+and this schema does say so, because flagging something inert can only help.
 """
 
 from __future__ import annotations
@@ -133,15 +146,24 @@ def _enum(values: frozenset[str]) -> list[str]:
 
 
 def _localized_text(max_length: int = MAX_TEXT_LENGTH) -> dict[str, Any]:
-    """A human-readable string in one or more languages, keyed by language tag."""
+    """A human-readable string in one or more languages, keyed by language tag.
+
+    No ``maxLength``: the platform truncates an over-long entry to
+    ``max_length`` rather than refusing it, so asserting the bound here would
+    reject a manifest that installs. It is named in the description instead.
+    The value type *is* asserted — an entry that is not a string is discarded
+    outright, so it has no effect and is worth flagging.
+    """
     return {
         "type": "object",
         "description": (
-            "Localized text, keyed by language tag. At least one entry; the "
-            "platform falls back to the reader's language, then to any entry."
+            "Localized text, keyed by language tag. At least one usable entry; "
+            "the platform falls back to the reader's language, then to any "
+            f"entry. Text longer than {max_length} characters is truncated, and "
+            "entries past the locale cap are ignored."
         ),
         "minProperties": 1,
-        "additionalProperties": {"type": "string", "maxLength": max_length},
+        "additionalProperties": {"type": "string"},
     }
 
 
@@ -172,7 +194,6 @@ def _field(*, types: frozenset[str], allow_managed: bool) -> dict[str, Any]:
     return {
         "type": "object",
         "required": ["key", "type", "label"],
-        "additionalProperties": False,
         "properties": properties,
         # Expressible here, unlike the cross-reference rules: whether options are
         # required follows from this object alone.
@@ -202,7 +223,6 @@ def _requires() -> dict[str, Any]:
             "Exactly one of 'all_of' or 'any_of'; each id must name a connection "
             "this manifest declares. Absent means always available."
         ),
-        "additionalProperties": False,
         "minProperties": 1,
         "maxProperties": 1,
         "properties": {"all_of": terms, "any_of": terms},
@@ -213,7 +233,6 @@ def _connection() -> dict[str, Any]:
     return {
         "type": "object",
         "required": ["id", "scope", "label", "fields"],
-        "additionalProperties": False,
         "properties": {
             "id": {"$ref": "#/$defs/identifier"},
             "scope": {
@@ -250,7 +269,6 @@ def _access_hint() -> dict[str, Any]:
             "beside the form so an admin can mint a minimal credential, and no "
             "other system's permissions are enforced from it."
         ),
-        "additionalProperties": False,
         "properties": {
             "api": {"type": "string", "maxLength": MAX_HINT_LENGTH},
             "scopes": {
@@ -266,7 +284,6 @@ def _data_source() -> dict[str, Any]:
     return {
         "type": "object",
         "required": ["id", "path"],
-        "additionalProperties": False,
         "properties": {
             "id": {"$ref": "#/$defs/identifier"},
             "path": {"$ref": "#/$defs/path"},
@@ -279,10 +296,13 @@ def _data_source() -> dict[str, Any]:
             },
             "cache_ttl_seconds": {
                 "type": "integer",
-                "minimum": 0,
-                "maximum": MAX_CACHE_TTL_SECONDS,
                 "default": 0,
-                "description": "Clamped into range rather than refused.",
+                "description": (
+                    "How long a response may be reused. Clamped into "
+                    f"0..{MAX_CACHE_TTL_SECONDS} rather than refused, so a value "
+                    "outside that range is accepted and takes effect at the "
+                    "bound — which is why no range is asserted here."
+                ),
             },
             "params_schema": {
                 "type": "array",
@@ -298,7 +318,6 @@ def _widget() -> dict[str, Any]:
     return {
         "type": "object",
         "required": ["id", "meta", "module_source"],
-        "additionalProperties": False,
         "properties": {
             "id": {"$ref": "#/$defs/identifier"},
             "meta": {
@@ -341,7 +360,6 @@ def _embed() -> dict[str, Any]:
     return {
         "type": "object",
         "required": ["id", "path", "name"],
-        "additionalProperties": False,
         "properties": {
             "id": {"$ref": "#/$defs/identifier"},
             "path": {"$ref": "#/$defs/path"},
@@ -391,7 +409,6 @@ def build_manifest_schema() -> dict[str, Any]:
         ),
         "type": "object",
         "required": ["app_kind", "service", "features"],
-        "additionalProperties": False,
         "properties": {
             "app_kind": {
                 "const": "service",
@@ -400,7 +417,6 @@ def build_manifest_schema() -> dict[str, Any]:
             "service": {
                 "type": "object",
                 "required": ["public_id"],
-                "additionalProperties": False,
                 "properties": {
                     "public_id": {
                         "type": "string",

--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -41,9 +41,13 @@ Naming those as errors would tell an author their working manifest is broken, an
 the last one would also break forward compatibility: an app targeting a newer
 platform has to keep validating against an older copy of this file.
 
-The one exception is a value the platform discards *entirely*, which therefore
-has no effect at all: a localized entry whose value is not a string is skipped,
-and this schema does say so, because flagging something inert can only help.
+There is no exception. An earlier cut of this module made one for values the
+platform discards outright — a localized entry that is not a string — on the
+grounds that flagging something inert can only help. It cannot: the entry may be
+inert, but refusing it rejects the whole document, and a manifest that installs
+must never be reported as malformed. Catching a typo in an ignored value is a
+linter's job, and an SDK is free to tighten this schema for authoring; nothing
+downstream can loosen a published contract that refuses working input.
 """
 
 from __future__ import annotations
@@ -88,7 +92,7 @@ from app.services.marketplace.service_apps import (
     SURFACE_SCOPES,
     VISIBILITIES,
 )
-from app.services.marketplace.widget_meta import MAX_TEXT_LENGTH
+from app.services.marketplace.widget_meta import MAX_LOCALES, MAX_TEXT_LENGTH
 
 __all__ = ["SCHEMA_ID", "build_manifest_schema"]
 
@@ -148,22 +152,29 @@ def _enum(values: frozenset[str]) -> list[str]:
 def _localized_text(max_length: int = MAX_TEXT_LENGTH) -> dict[str, Any]:
     """A human-readable string in one or more languages, keyed by language tag.
 
-    No ``maxLength``: the platform truncates an over-long entry to
-    ``max_length`` rather than refusing it, so asserting the bound here would
-    reject a manifest that installs. It is named in the description instead.
-    The value type *is* asserted — an entry that is not a string is discarded
-    outright, so it has no effect and is worth flagging.
+    Neither the length nor the value type is asserted, because the platform
+    refuses neither: an over-long entry is truncated, and an entry that is not a
+    string — or one past the locale cap, which is never inspected at all — is
+    skipped while the rest of the object stands. Only ``minProperties`` survives,
+    which matches the one thing that does fail: an object with nothing usable in
+    it.
+
+    Losing the value type costs a generator some precision. That is the right
+    way round: a schema is a contract before it is a type source, and an SDK that
+    wants a stricter shape for *authoring* can tighten it locally, which nothing
+    downstream can do about a contract that rejects a working manifest.
     """
     return {
         "type": "object",
         "description": (
             "Localized text, keyed by language tag. At least one usable entry; "
             "the platform falls back to the reader's language, then to any "
-            f"entry. Text longer than {max_length} characters is truncated, and "
-            "entries past the locale cap are ignored."
+            f"entry. Values should be strings: text longer than {max_length} "
+            f"characters is truncated, and an entry that is not a string, is "
+            f"not a language tag, or falls past the first {MAX_LOCALES} is "
+            "ignored rather than refused."
         ),
         "minProperties": 1,
-        "additionalProperties": {"type": "string"},
     }
 
 

--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -205,10 +205,12 @@ def _field(*, types: frozenset[str], allow_managed: bool) -> dict[str, Any]:
 def _requires() -> dict[str, Any]:
     """Which connections satisfy an item — one level, one operator.
 
-    Exactly one of ``all_of`` / ``any_of``, expressed as
-    ``minProperties``/``maxProperties`` over a closed pair rather than a
-    ``oneOf``: the error an author gets from the former names the object they
-    wrote, and the latter reports every branch that failed.
+    ``oneOf`` over the two operators rather than a property count. The count
+    reads better in an error, but it counts *every* key: an unknown property
+    beside a valid operator would push the object to two, and the platform keeps
+    the operator and discards the unknown one. ``oneOf`` asks the question that
+    is actually being asked — is exactly one of these two present — and ignores
+    anything else in the object.
     """
     terms = {
         "type": "array",
@@ -223,9 +225,8 @@ def _requires() -> dict[str, Any]:
             "Exactly one of 'all_of' or 'any_of'; each id must name a connection "
             "this manifest declares. Absent means always available."
         ),
-        "minProperties": 1,
-        "maxProperties": 1,
         "properties": {"all_of": terms, "any_of": terms},
+        "oneOf": [{"required": ["all_of"]}, {"required": ["any_of"]}],
     }
 
 

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -1,0 +1,364 @@
+"""The schema describes the manifest the validator actually accepts.
+
+Two kinds of case, and the second is the one that earns its keep:
+
+* **Derivation** — every vocabulary and cap in the schema reads from the
+  constant it came from, so widening a rule in one place cannot leave the schema
+  describing the old one.
+* **Agreement** — a corpus of manifests run through both. Anything the validator
+  accepts must satisfy the schema, or an author would be told their working
+  manifest is wrong; anything the schema rejects for a reason it *can* express
+  must be refused by the validator too, or the schema would be inventing a rule.
+
+The asymmetry is deliberate and stated in the module: schema-valid is necessary,
+not sufficient. The cases at the bottom pin the specific rules that only the
+validator enforces, so that boundary is written down rather than discovered.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from app.services.marketplace.manifest_schema import (
+    SCHEMA_ID,
+    build_manifest_schema,
+)
+from app.services.marketplace.manifest_values import (
+    MAX_IDENTIFIER_LENGTH,
+    MAX_PATH_LENGTH,
+    MAX_PUBLIC_ID_LENGTH,
+)
+from app.services.marketplace.definitions import normalize_listing_definition
+from app.services.marketplace.service_apps import (
+    APP_PROTOCOL_VERSIONS,
+    CONNECTION_SCOPES,
+    EMBED_CAPABILITIES,
+    FEATURES,
+    FIELD_TYPES,
+    GUILD_WIDE_VISIBILITIES,
+    MAX_CONNECTIONS,
+    MAX_DATA_SOURCES,
+    MAX_EMBEDS,
+    MAX_WIDGETS,
+    PARAM_TYPES,
+    SURFACE_SCOPES,
+    VISIBILITIES,
+)
+
+
+def platform_accepts(manifest) -> None:
+    """Run a manifest through the whole app path, not the service normalizer.
+
+    `app_kind` is read by the dispatcher rather than by
+    `normalize_service_app_definition`, so a case that varies it has to enter
+    where a published manifest actually enters.
+    """
+    normalize_listing_definition("app", manifest)
+
+
+SCHEMA_FILE = Path(__file__).resolve().parents[3] / "schemas" / "app-manifest.json"
+
+
+@pytest.fixture(scope="module")
+def validator() -> Draft202012Validator:
+    schema = build_manifest_schema()
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _manifest(**overrides):
+    """A minimal manifest the platform accepts, for a case to vary one thing of."""
+    body = {
+        "app_kind": "service",
+        "service": {"public_id": "acme.tracker", "protocol": 1},
+        "features": [],
+    }
+    body.update(overrides)
+    return body
+
+
+# --- the schema is a schema -------------------------------------------------
+
+
+@pytest.mark.unit
+def test_the_schema_is_a_valid_2020_12_document():
+    Draft202012Validator.check_schema(build_manifest_schema())
+
+
+@pytest.mark.unit
+def test_every_ref_resolves():
+    """A `$ref` naming a definition that isn't there fails at use rather than at
+    load, so it would survive a test that only validated the happy path."""
+    schema = build_manifest_schema()
+    defs = set(schema["$defs"])
+
+    def walk(node):
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str):
+                assert ref.startswith("#/$defs/"), ref
+                assert ref.removeprefix("#/$defs/") in defs, ref
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(schema)
+
+
+@pytest.mark.unit
+def test_the_committed_file_matches_the_generator():
+    """CI regenerates and diffs; this says the same thing where it is cheap to
+    read, so a vocabulary change with no re-export fails beside the change."""
+    assert SCHEMA_FILE.exists(), f"{SCHEMA_FILE} is missing"
+    on_disk = json.loads(SCHEMA_FILE.read_text(encoding="utf-8"))
+    assert on_disk == build_manifest_schema()
+
+
+# --- derived, not restated --------------------------------------------------
+
+
+@pytest.mark.unit
+def test_vocabularies_come_from_the_validator():
+    schema = build_manifest_schema()
+    props = schema["properties"]
+    defs = schema["$defs"]
+
+    assert set(props["features"]["items"]["enum"]) == FEATURES
+    assert set(props["service"]["properties"]["protocol"]["enum"]) == (
+        APP_PROTOCOL_VERSIONS
+    )
+    assert set(defs["connection"]["properties"]["scope"]["enum"]) == CONNECTION_SCOPES
+    assert set(defs["connectionField"]["properties"]["type"]["enum"]) == FIELD_TYPES
+    assert set(defs["sourceParam"]["properties"]["type"]["enum"]) == PARAM_TYPES
+    assert set(defs["dataSource"]["properties"]["visibility"]["enum"]) == (
+        GUILD_WIDE_VISIBILITIES
+    )
+    assert set(defs["embed"]["properties"]["visibility"]["enum"]) == VISIBILITIES
+    assert set(defs["embed"]["properties"]["scopes"]["items"]["enum"]) == SURFACE_SCOPES
+    assert set(defs["embed"]["properties"]["capabilities"]["items"]["enum"]) == (
+        EMBED_CAPABILITIES
+    )
+
+
+@pytest.mark.unit
+def test_caps_come_from_the_validator():
+    props = build_manifest_schema()["properties"]
+    assert props["connections"]["maxItems"] == MAX_CONNECTIONS
+    assert props["data_sources"]["maxItems"] == MAX_DATA_SOURCES
+    assert props["widgets"]["maxItems"] == MAX_WIDGETS
+    assert props["embeds"]["maxItems"] == MAX_EMBEDS
+
+
+@pytest.mark.unit
+def test_a_secret_is_not_a_query_parameter():
+    """`secret` is a connection field type and deliberately not a param type;
+    the schema must not blur the two by sharing one field definition."""
+    defs = build_manifest_schema()["$defs"]
+    assert "secret" in defs["connectionField"]["properties"]["type"]["enum"]
+    assert "secret" not in defs["sourceParam"]["properties"]["type"]["enum"]
+    # And only a connection field is written back by the app.
+    assert "managed" in defs["connectionField"]["properties"]
+    assert "managed" not in defs["sourceParam"]["properties"]
+
+
+@pytest.mark.unit
+def test_lengths_come_from_the_validator():
+    defs = build_manifest_schema()["$defs"]
+    assert defs["identifier"]["maxLength"] == MAX_IDENTIFIER_LENGTH
+    assert defs["path"]["maxLength"] == MAX_PATH_LENGTH
+    assert (
+        build_manifest_schema()["properties"]["service"]["properties"]["public_id"][
+            "maxLength"
+        ]
+        == MAX_PUBLIC_ID_LENGTH
+    )
+
+
+@pytest.mark.unit
+def test_the_schema_names_itself_stably():
+    """The SDK keys generated types on this; a drifting `$id` invalidates them."""
+    assert build_manifest_schema()["$id"] == SCHEMA_ID
+
+
+# --- the two agree ----------------------------------------------------------
+
+ACCEPTED = [
+    pytest.param(_manifest(), id="minimal"),
+    pytest.param(
+        _manifest(
+            features=["data"],
+            connections=[
+                {
+                    "id": "api",
+                    "scope": "static",
+                    "label": {"en": "API key"},
+                    "fields": [
+                        {"key": "token", "type": "secret", "label": {"en": "Token"}}
+                    ],
+                    "access_hint": {"api": "GitHub", "scopes": ["repo:read"]},
+                }
+            ],
+            data_sources=[
+                {
+                    "id": "issues",
+                    "path": "/data/issues",
+                    "visibility": "member",
+                    "cache_ttl_seconds": 300,
+                    "params_schema": [
+                        {
+                            "key": "state",
+                            "type": "select",
+                            "label": {"en": "State"},
+                            "options": ["open", "closed"],
+                        }
+                    ],
+                    "requires": {"all_of": ["api"]},
+                }
+            ],
+        ),
+        id="static-connection-and-source",
+    ),
+    pytest.param(
+        _manifest(
+            features=["embeds"],
+            connections=[
+                {
+                    "id": "account",
+                    "scope": "interactive",
+                    "label": {"en": "Your account"},
+                    "fields": [],
+                    "connect_path": "/connect/start",
+                }
+            ],
+            embeds=[
+                {
+                    "id": "board",
+                    "path": "/embed/board",
+                    "name": {"en": "Board"},
+                    "scopes": ["guild", "initiative"],
+                    "visibility": "initiative_manager",
+                    "capabilities": ["clipboard-write", "fullscreen"],
+                    "requires": {"any_of": ["account"]},
+                }
+            ],
+        ),
+        id="interactive-connection-and-embed",
+    ),
+    pytest.param(
+        _manifest(
+            features=["events", "automations"],
+            events=["app.acme.tracker.issue-opened"],
+            automation={"nodes": [{"anything": "the service understands"}]},
+        ),
+        id="events-and-opaque-automation",
+    ),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("manifest", ACCEPTED)
+def test_what_the_platform_accepts_satisfies_the_schema(manifest, validator):
+    """The direction that matters most: an author whose manifest installs must
+    never be told by the schema that it is malformed."""
+    platform_accepts(manifest)
+    assert list(validator.iter_errors(manifest)) == []
+
+
+REFUSED_BY_BOTH = [
+    pytest.param(
+        {"service": {"public_id": "acme.x"}, "features": []}, id="no-app-kind"
+    ),
+    pytest.param(_manifest(app_kind="tool_instance"), id="wrong-app-kind"),
+    pytest.param(
+        _manifest(service={"public_id": "no-dot"}), id="public-id-without-dot"
+    ),
+    pytest.param(_manifest(service={"public_id": "Acme.Tracker"}), id="uppercase-id"),
+    pytest.param(_manifest(features=["telepathy"]), id="unknown-feature"),
+    pytest.param(
+        _manifest(service={"public_id": "acme.x", "protocol": 99}),
+        id="unspoken-protocol",
+    ),
+    pytest.param(
+        _manifest(
+            features=["data"],
+            data_sources=[{"id": "s", "path": "https://elsewhere.test/data"}],
+        ),
+        id="path-that-is-an-address",
+    ),
+    pytest.param(
+        _manifest(features=["data"], data_sources=[{"id": "s", "path": "/a/../b"}]),
+        id="path-climbing-out",
+    ),
+    pytest.param(
+        _manifest(features=["data"], data_sources=[{"id": "UPPER", "path": "/x"}]),
+        id="identifier-out-of-charset",
+    ),
+    pytest.param(
+        _manifest(
+            features=["embeds"],
+            embeds=[
+                {
+                    "id": "e",
+                    "path": "/e",
+                    "name": {"en": "E"},
+                    "capabilities": ["payment"],
+                }
+            ],
+        ),
+        id="capability-not-on-offer",
+    ),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("manifest", REFUSED_BY_BOTH)
+def test_what_the_schema_refuses_the_platform_refuses_too(manifest, validator):
+    """The other direction, for the rules a schema *can* express: the schema
+    must not invent a constraint the platform would have allowed."""
+    assert list(validator.iter_errors(manifest)) != [], "schema accepted it"
+    with pytest.raises(ValueError):
+        platform_accepts(manifest)
+
+
+# --- where the schema stops -------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "manifest,why",
+    [
+        (
+            _manifest(features=["data"]),
+            "a declared feature with no block behind it",
+        ),
+        (
+            _manifest(
+                features=["widgets", "data"],
+                data_sources=[{"id": "known", "path": "/d"}],
+                widgets=[
+                    {
+                        "id": "w",
+                        "meta": {"name": {"en": "W"}},
+                        "module_source": "export default () => ({})",
+                        "sources": ["absent"],
+                    }
+                ],
+            ),
+            "a widget binding a data source that does not exist",
+        ),
+        (
+            _manifest(features=["events"], events=["app.someone-else.thing"]),
+            "an event namespaced under another app",
+        ),
+    ],
+)
+def test_the_platform_enforces_what_the_schema_cannot(manifest, why, validator):
+    """Schema-valid is necessary, not sufficient — written down as cases so the
+    boundary is a fact about this build rather than a caveat in a docstring."""
+    assert list(validator.iter_errors(manifest)) == [], f"schema caught it: {why}"
+    with pytest.raises(ValueError):
+        platform_accepts(manifest)

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -31,6 +31,7 @@ from app.services.marketplace.manifest_values import (
     MAX_PUBLIC_ID_LENGTH,
 )
 from app.services.marketplace.definitions import normalize_listing_definition
+from app.services.marketplace.widget_meta import MAX_TEXT_LENGTH
 from app.services.marketplace.service_apps import (
     APP_PROTOCOL_VERSIONS,
     CONNECTION_SCOPES,
@@ -258,6 +259,34 @@ ACCEPTED = [
         ),
         id="events-and-opaque-automation",
     ),
+    # The three the platform takes rather than refuses. Each was a real
+    # over-strict rule in the first cut of this schema, caught in review: a
+    # schema that rejects any of these tells an author their working manifest
+    # is broken.
+    pytest.param(
+        _manifest(
+            features=["data"],
+            data_sources=[{"id": "s", "path": "/d", "cache_ttl_seconds": 10_000_000}],
+        ),
+        id="cache-ttl-clamped-not-refused",
+    ),
+    pytest.param(
+        _manifest(
+            features=["data"],
+            data_sources=[{"id": "s", "path": "/d", "invented_by_a_newer_app": 1}],
+            some_future_block={"whatever": True},
+        ),
+        id="unknown-keys-dropped-not-refused",
+    ),
+    pytest.param(
+        _manifest(
+            features=["embeds"],
+            embeds=[
+                {"id": "e", "path": "/e", "name": {"en": "N" * (MAX_TEXT_LENGTH + 50)}}
+            ],
+        ),
+        id="over-long-label-truncated-not-refused",
+    ),
 ]
 
 
@@ -324,6 +353,18 @@ def test_what_the_schema_refuses_the_platform_refuses_too(manifest, validator):
     assert list(validator.iter_errors(manifest)) != [], "schema accepted it"
     with pytest.raises(ValueError):
         platform_accepts(manifest)
+
+
+@pytest.mark.unit
+def test_the_schema_flags_a_localized_value_the_platform_discards(validator):
+    """The one place it is stricter on purpose: a non-string entry is dropped
+    outright, so it has no effect, and saying so can only help."""
+    manifest = _manifest(
+        features=["embeds"],
+        embeds=[{"id": "e", "path": "/e", "name": {"en": "N", "fr": 7}}],
+    )
+    platform_accepts(manifest)  # the bad entry is skipped, the good one stands
+    assert list(validator.iter_errors(manifest)) != []
 
 
 # --- where the schema stops -------------------------------------------------

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -31,7 +31,7 @@ from app.services.marketplace.manifest_values import (
     MAX_PUBLIC_ID_LENGTH,
 )
 from app.services.marketplace.definitions import normalize_listing_definition
-from app.services.marketplace.widget_meta import MAX_TEXT_LENGTH
+from app.services.marketplace.widget_meta import MAX_LOCALES, MAX_TEXT_LENGTH
 from app.services.marketplace.service_apps import (
     APP_PROTOCOL_VERSIONS,
     CONNECTION_SCOPES,
@@ -402,15 +402,39 @@ def test_what_the_schema_refuses_the_platform_refuses_too(manifest, validator):
 
 
 @pytest.mark.unit
-def test_the_schema_flags_a_localized_value_the_platform_discards(validator):
-    """The one place it is stricter on purpose: a non-string entry is dropped
-    outright, so it has no effect, and saying so can only help."""
+@pytest.mark.parametrize(
+    "name,why",
+    [
+        ({"en": "N", "fr": 7}, "a value that is not a string is skipped"),
+        ({"en": "N", "not a tag": "x"}, "a key that is not a language tag is skipped"),
+        (
+            {"en": "N", **{f"x{i}": "y" for i in range(MAX_LOCALES + 5)}},
+            "entries past the locale cap are never inspected",
+        ),
+    ],
+)
+def test_a_localized_entry_the_platform_ignores_is_not_an_error(name, why, validator):
+    """Ignored is not refused. The object stands on its usable entries, so the
+    document installs — and a schema that rejected it would be telling an author
+    their working manifest is broken."""
     manifest = _manifest(
         features=["embeds"],
-        embeds=[{"id": "e", "path": "/e", "name": {"en": "N", "fr": 7}}],
+        embeds=[{"id": "e", "path": "/e", "name": name}],
     )
-    platform_accepts(manifest)  # the bad entry is skipped, the good one stands
+    platform_accepts(manifest)
+    assert list(validator.iter_errors(manifest)) == [], why
+
+
+@pytest.mark.unit
+def test_a_localized_object_with_nothing_usable_is_refused(validator):
+    """The one thing that does fail, and the only rule left on the type."""
+    manifest = _manifest(
+        features=["embeds"],
+        embeds=[{"id": "e", "path": "/e", "name": {}}],
+    )
     assert list(validator.iter_errors(manifest)) != []
+    with pytest.raises(ValueError):
+        platform_accepts(manifest)
 
 
 # --- where the schema stops -------------------------------------------------

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -61,8 +61,10 @@ def platform_accepts(manifest) -> None:
 SCHEMA_FILE = Path(__file__).resolve().parents[3] / "schemas" / "app-manifest.json"
 
 
+# Unannotated on purpose: `jsonschema` builds its validator classes at runtime,
+# so the name is not a type the checker can resolve.
 @pytest.fixture(scope="module")
-def validator() -> Draft202012Validator:
+def validator():
     schema = build_manifest_schema()
     Draft202012Validator.check_schema(schema)
     return Draft202012Validator(schema)

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -287,6 +287,30 @@ ACCEPTED = [
         ),
         id="over-long-label-truncated-not-refused",
     ),
+    pytest.param(
+        _manifest(
+            features=["data"],
+            connections=[
+                {
+                    "id": "api",
+                    "scope": "static",
+                    "label": {"en": "API"},
+                    "fields": [{"key": "t", "type": "secret", "label": {"en": "T"}}],
+                }
+            ],
+            data_sources=[
+                {
+                    "id": "s",
+                    "path": "/d",
+                    # One operator plus a key from a newer manifest revision.
+                    # The platform reads the operator and drops the rest, so a
+                    # rule that counted properties would refuse this.
+                    "requires": {"all_of": ["api"], "from_a_newer_revision": True},
+                }
+            ],
+        ),
+        id="requires-alongside-an-unknown-key",
+    ),
 ]
 
 
@@ -341,6 +365,28 @@ REFUSED_BY_BOTH = [
             ],
         ),
         id="capability-not-on-offer",
+    ),
+    # The two shapes `oneOf` has to keep refusing now that the object no longer
+    # counts its properties.
+    pytest.param(
+        _manifest(
+            features=["data"],
+            data_sources=[
+                {
+                    "id": "s",
+                    "path": "/d",
+                    "requires": {"all_of": ["a"], "any_of": ["b"]},
+                }
+            ],
+        ),
+        id="requires-naming-both-operators",
+    ),
+    pytest.param(
+        _manifest(
+            features=["data"],
+            data_sources=[{"id": "s", "path": "/d", "requires": {}}],
+        ),
+        id="requires-naming-no-operator",
     ),
 ]
 

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -1,0 +1,464 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://initiative.morels.me/schemas/app-manifest-v1.json",
+  "title": "Initiative app manifest",
+  "description": "What a service app may declare at /.well-known/initiative-app.json. Generated from the platform's own validator vocabulary. A manifest that satisfies this schema is well-formed, not necessarily acceptable. Cross-references (a widget's data sources, a requires term's connection, an event's service prefix), the features/blocks cross-check in both directions, UTF-8 byte-size caps, and the conditional rules for connect_path and initiative visibility are enforced by the platform on publish and are not expressible here.",
+  "type": "object",
+  "required": [
+    "app_kind",
+    "service",
+    "features"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "app_kind": {
+      "const": "service",
+      "description": "The only kind that names a container to call."
+    },
+    "service": {
+      "type": "object",
+      "required": [
+        "public_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "public_id": {
+          "type": "string",
+          "maxLength": 120,
+          "pattern": "^[\\-.0123456789_abcdefghijklmnopqrstuvwxyz]*\\.[\\-.0123456789_abcdefghijklmnopqrstuvwxyz]*$",
+          "description": "'<publisher>.<slug>'. The name the deployment's registration is matched by, and the namespace this app's events are emitted under."
+        },
+        "protocol": {
+          "enum": [
+            1
+          ],
+          "default": 1
+        }
+      }
+    },
+    "features": {
+      "type": "array",
+      "maxItems": 5,
+      "items": {
+        "enum": [
+          "automations",
+          "data",
+          "embeds",
+          "events",
+          "widgets"
+        ]
+      },
+      "description": "What this app contributes. Cross-checked against the blocks present in both directions: a feature with no block, or a block with no feature, is refused."
+    },
+    "default_name": {
+      "type": "string",
+      "maxLength": 255
+    },
+    "connections": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "$ref": "#/$defs/connection"
+      }
+    },
+    "data_sources": {
+      "type": "array",
+      "maxItems": 24,
+      "items": {
+        "$ref": "#/$defs/dataSource"
+      }
+    },
+    "widgets": {
+      "type": "array",
+      "maxItems": 12,
+      "items": {
+        "$ref": "#/$defs/widget"
+      }
+    },
+    "embeds": {
+      "type": "array",
+      "maxItems": 12,
+      "items": {
+        "$ref": "#/$defs/embed"
+      }
+    },
+    "events": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "type": "string",
+        "maxLength": 200,
+        "pattern": "^[\\-.0123456789_abcdefghijklmnopqrstuvwxyz]+$",
+        "description": "Namespaced under the app's own service id \u2014 'app.<public_id>.<name>'. The prefix is checked against the emitting registration at ingress."
+      }
+    },
+    "automation": {
+      "type": "object",
+      "description": "The automation service's own block. Opaque to the platform: checked for shape and size, stored verbatim, and described by no vocabulary here."
+    }
+  },
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[\\-0123456789_abcdefghijklmnopqrstuvwxyz]+$"
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "pattern": "^(?!.*(?://|\\.\\.))/[\\-./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz]*$",
+      "description": "A route on the app's own service, never an address. The deployment joins it to the base URL its registration supplies."
+    },
+    "localizedText": {
+      "type": "object",
+      "description": "Localized text, keyed by language tag. At least one entry; the platform falls back to the reader's language, then to any entry.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "maxLength": 120
+      }
+    },
+    "requires": {
+      "type": "object",
+      "description": "Connection ids that must hold a value before this is offered. Exactly one of 'all_of' or 'any_of'; each id must name a connection this manifest declares. Absent means always available.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "all_of": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "any_of": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        }
+      }
+    },
+    "accessHint": {
+      "type": "object",
+      "description": "What the credential will be used for. Display-only: it is shown beside the form so an admin can mint a minimal credential, and no other system's permissions are enforced from it.",
+      "additionalProperties": false,
+      "properties": {
+        "api": {
+          "type": "string",
+          "maxLength": 120
+        },
+        "scopes": {
+          "type": "array",
+          "maxItems": 24,
+          "items": {
+            "type": "string",
+            "maxLength": 120
+          }
+        }
+      }
+    },
+    "connectionField": {
+      "type": "object",
+      "required": [
+        "key",
+        "type",
+        "label"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "$ref": "#/$defs/identifier"
+        },
+        "type": {
+          "enum": [
+            "bool",
+            "int",
+            "secret",
+            "select",
+            "string",
+            "url"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "label": {
+          "$ref": "#/$defs/localizedText"
+        },
+        "options": {
+          "type": "array",
+          "description": "Required when type is 'select'.",
+          "maxItems": 24,
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "maxLength": 120
+          }
+        },
+        "managed": {
+          "type": "boolean",
+          "default": false,
+          "description": "The app writes this value back itself when it finishes a vendor flow; it is not typed into the settings form."
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "select"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "required": [
+          "options"
+        ]
+      }
+    },
+    "sourceParam": {
+      "type": "object",
+      "required": [
+        "key",
+        "type",
+        "label"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "$ref": "#/$defs/identifier"
+        },
+        "type": {
+          "enum": [
+            "bool",
+            "int",
+            "select",
+            "string",
+            "url"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "label": {
+          "$ref": "#/$defs/localizedText"
+        },
+        "options": {
+          "type": "array",
+          "description": "Required when type is 'select'.",
+          "maxItems": 24,
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "maxLength": 120
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "select"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "required": [
+          "options"
+        ]
+      }
+    },
+    "connection": {
+      "type": "object",
+      "required": [
+        "id",
+        "scope",
+        "label",
+        "fields"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "scope": {
+          "enum": [
+            "interactive",
+            "static"
+          ],
+          "description": "'static' is one credential a guild admin supplies for the whole guild; 'interactive' is each member's own account, connected through the app's own vendor flow."
+        },
+        "label": {
+          "$ref": "#/$defs/localizedText"
+        },
+        "fields": {
+          "type": "array",
+          "maxItems": 12,
+          "items": {
+            "$ref": "#/$defs/connectionField"
+          }
+        },
+        "connect_path": {
+          "$ref": "#/$defs/path",
+          "description": "Where the member is sent so the app can run the vendor's flow. Interactive connections only."
+        },
+        "access_hint": {
+          "$ref": "#/$defs/accessHint"
+        }
+      }
+    },
+    "dataSource": {
+      "type": "object",
+      "required": [
+        "id",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "visibility": {
+          "enum": [
+            "guild_admin",
+            "member"
+          ],
+          "description": "A source is fetched for a guild rather than an initiative, so the initiative rung is not on offer."
+        },
+        "cache_ttl_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 86400,
+          "default": 0,
+          "description": "Clamped into range rather than refused."
+        },
+        "params_schema": {
+          "type": "array",
+          "maxItems": 12,
+          "items": {
+            "$ref": "#/$defs/sourceParam"
+          }
+        },
+        "requires": {
+          "$ref": "#/$defs/requires"
+        }
+      }
+    },
+    "widget": {
+      "type": "object",
+      "required": [
+        "id",
+        "meta",
+        "module_source"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "meta": {
+          "type": "object",
+          "description": "The widget's own name and description, as the picker shows them. Must name the widget in at least one language."
+        },
+        "module_source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The widget's browser-side module. Stored as an opaque string and executed only inside the sandbox; the platform never parses it. Capped in UTF-8 bytes, which this schema cannot express."
+        },
+        "sources": {
+          "type": "array",
+          "maxItems": 8,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          },
+          "description": "Data source ids this manifest also declares."
+        },
+        "sample_data": {
+          "type": "object",
+          "description": "Rows keyed by declared source id, so a preview renders with no network call. Keys naming an undeclared source are dropped."
+        },
+        "requires": {
+          "$ref": "#/$defs/requires"
+        }
+      }
+    },
+    "embed": {
+      "type": "object",
+      "required": [
+        "id",
+        "path",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "name": {
+          "$ref": "#/$defs/localizedText"
+        },
+        "scopes": {
+          "type": "array",
+          "maxItems": 2,
+          "items": {
+            "enum": [
+              "guild",
+              "initiative"
+            ]
+          },
+          "default": [
+            "guild"
+          ],
+          "description": "Where the surface renders. Declaring both gives it a guild-wide entry and an entry inside each initiative."
+        },
+        "visibility": {
+          "enum": [
+            "guild_admin",
+            "initiative_manager",
+            "member"
+          ],
+          "description": "The floor an audience clears. 'initiative_manager' is only namable by a surface that also renders in an initiative \u2014 a rule the platform enforces, not this schema."
+        },
+        "capabilities": {
+          "type": "array",
+          "maxItems": 8,
+          "items": {
+            "enum": [
+              "camera",
+              "clipboard-read",
+              "clipboard-write",
+              "display-capture",
+              "fullscreen",
+              "geolocation",
+              "microphone"
+            ]
+          },
+          "description": "Browser features the frame is granted. A surface that names nothing is framed with all of them denied."
+        },
+        "requires": {
+          "$ref": "#/$defs/requires"
+        }
+      }
+    }
+  }
+}

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -9,7 +9,6 @@
     "service",
     "features"
   ],
-  "additionalProperties": false,
   "properties": {
     "app_kind": {
       "const": "service",
@@ -20,7 +19,6 @@
       "required": [
         "public_id"
       ],
-      "additionalProperties": false,
       "properties": {
         "public_id": {
           "type": "string",
@@ -113,17 +111,15 @@
     },
     "localizedText": {
       "type": "object",
-      "description": "Localized text, keyed by language tag. At least one entry; the platform falls back to the reader's language, then to any entry.",
+      "description": "Localized text, keyed by language tag. At least one usable entry; the platform falls back to the reader's language, then to any entry. Text longer than 120 characters is truncated, and entries past the locale cap are ignored.",
       "minProperties": 1,
       "additionalProperties": {
-        "type": "string",
-        "maxLength": 120
+        "type": "string"
       }
     },
     "requires": {
       "type": "object",
       "description": "Connection ids that must hold a value before this is offered. Exactly one of 'all_of' or 'any_of'; each id must name a connection this manifest declares. Absent means always available.",
-      "additionalProperties": false,
       "minProperties": 1,
       "maxProperties": 1,
       "properties": {
@@ -148,7 +144,6 @@
     "accessHint": {
       "type": "object",
       "description": "What the credential will be used for. Display-only: it is shown beside the form so an admin can mint a minimal credential, and no other system's permissions are enforced from it.",
-      "additionalProperties": false,
       "properties": {
         "api": {
           "type": "string",
@@ -171,7 +166,6 @@
         "type",
         "label"
       ],
-      "additionalProperties": false,
       "properties": {
         "key": {
           "type": "string",
@@ -233,7 +227,6 @@
         "type",
         "label"
       ],
-      "additionalProperties": false,
       "properties": {
         "key": {
           "type": "string",
@@ -290,7 +283,6 @@
         "label",
         "fields"
       ],
-      "additionalProperties": false,
       "properties": {
         "id": {
           "$ref": "#/$defs/identifier"
@@ -327,7 +319,6 @@
         "id",
         "path"
       ],
-      "additionalProperties": false,
       "properties": {
         "id": {
           "$ref": "#/$defs/identifier"
@@ -344,10 +335,8 @@
         },
         "cache_ttl_seconds": {
           "type": "integer",
-          "minimum": 0,
-          "maximum": 86400,
           "default": 0,
-          "description": "Clamped into range rather than refused."
+          "description": "How long a response may be reused. Clamped into 0..86400 rather than refused, so a value outside that range is accepted and takes effect at the bound \u2014 which is why no range is asserted here."
         },
         "params_schema": {
           "type": "array",
@@ -368,7 +357,6 @@
         "meta",
         "module_source"
       ],
-      "additionalProperties": false,
       "properties": {
         "id": {
           "$ref": "#/$defs/identifier"
@@ -406,7 +394,6 @@
         "path",
         "name"
       ],
-      "additionalProperties": false,
       "properties": {
         "id": {
           "$ref": "#/$defs/identifier"

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -111,11 +111,8 @@
     },
     "localizedText": {
       "type": "object",
-      "description": "Localized text, keyed by language tag. At least one usable entry; the platform falls back to the reader's language, then to any entry. Text longer than 120 characters is truncated, and entries past the locale cap are ignored.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "type": "string"
-      }
+      "description": "Localized text, keyed by language tag. At least one usable entry; the platform falls back to the reader's language, then to any entry. Values should be strings: text longer than 120 characters is truncated, and an entry that is not a string, is not a language tag, or falls past the first 40 is ignored rather than refused.",
+      "minProperties": 1
     },
     "requires": {
       "type": "object",

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -120,8 +120,6 @@
     "requires": {
       "type": "object",
       "description": "Connection ids that must hold a value before this is offered. Exactly one of 'all_of' or 'any_of'; each id must name a connection this manifest declares. Absent means always available.",
-      "minProperties": 1,
-      "maxProperties": 1,
       "properties": {
         "all_of": {
           "type": "array",
@@ -139,7 +137,19 @@
             "$ref": "#/$defs/identifier"
           }
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "all_of"
+          ]
+        },
+        {
+          "required": [
+            "any_of"
+          ]
+        }
+      ]
     },
     "accessHint": {
       "type": "object",

--- a/backend/scripts/export_manifest_schema.py
+++ b/backend/scripts/export_manifest_schema.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Write the app manifest JSON Schema to a file.
+
+The schema is generated from the validator's own vocabulary
+(:mod:`app.services.marketplace.manifest_schema`), and the generated file is
+committed so an app author can read it without running this build — the same
+arrangement the frontend's generated API types use.
+
+Run it after changing anything the manifest validator accepts:
+
+    python scripts/export_manifest_schema.py
+
+CI regenerates and diffs, so a vocabulary change with no regenerated schema
+fails there rather than shipping a schema that describes the old rules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Importable when run as a script from anywhere in the backend tree.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.marketplace.manifest_schema import (  # noqa: E402
+    build_manifest_schema,
+)
+
+#: Beside the other things this build publishes for people writing against it.
+DEFAULT_OUTPUT = (
+    Path(__file__).resolve().parent.parent / "schemas" / "app-manifest.json"
+)
+
+
+def render() -> str:
+    """The schema as it is written to disk: stable key order, trailing newline."""
+    return json.dumps(build_manifest_schema(), indent=2, sort_keys=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"where to write (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if the file on disk differs, writing nothing",
+    )
+    args = parser.parse_args()
+
+    rendered = render()
+    if args.check:
+        if not args.output.exists():
+            print(f"{args.output} does not exist; run this script", file=sys.stderr)
+            return 1
+        if args.output.read_text(encoding="utf-8") != rendered:
+            print(
+                f"{args.output} is out of date; run scripts/export_manifest_schema.py",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Phase 5 left the manifest JSON Schema unbuilt, and it is what the SDK is built
on: §13.1 has `initiative-app-kit` generating types from the manifest schemas and
shipping them as language-neutral conformance assets. Without it, the kit has to
hand-write its own copy of what a manifest may contain — a second definition of a
contract, in another repository, that nothing keeps in step. That is exactly the
drift §13 avoids by refusing to ship a template repo.

## Changes

- **[manifest_schema.py](backend/app/services/marketplace/manifest_schema.py)** —
  builds a JSON Schema 2020-12 document for a service-app manifest. Every enum,
  cap, length and character class reads from the constant `service_apps.py` and
  `manifest_values.py` already declare, so raising a cap in one place raises it
  here on the next export. Nothing is restated.
- **[export_manifest_schema.py](backend/scripts/export_manifest_schema.py)** —
  writes it, with `--check` for a diff-only run.
- **[schemas/app-manifest.json](backend/schemas/app-manifest.json)** — the
  generated file, committed so an author reads it without running this build,
  the same arrangement the frontend's generated types use.

### Schema-valid is necessary, not sufficient

Four classes of rule can't be expressed in JSON Schema, and the schema's own
`description` says so rather than leaving an implementer to assume otherwise:
cross-references (a widget's data sources, a `requires` term's connection, an
event's service prefix), the features/blocks cross-check in both directions,
UTF-8 byte-size caps, and the conditional rules for `connect_path` and
initiative visibility. Three of those have cases pinning them, so the boundary is
a fact about this build rather than a caveat in a docstring.

## Testing

`app/services/marketplace/manifest_schema_test.py`, 25 cases in three groups:

- **Derivation** — each vocabulary and cap equals the constant it came from, and
  every `$ref` resolves.
- **Agreement** — a corpus run through both. Whatever the platform accepts must
  satisfy the schema (an author whose manifest installs must never be told it is
  malformed), and whatever the schema rejects for an expressible reason must be
  refused by the platform too (the schema must not invent a rule).
- **The boundary** — three manifests the schema passes and the platform refuses.

The agreement group caught two real defects while being written: `requires` was
modelled as a flat array when the platform wants `{"all_of": [...]}` or
`{"any_of": [...]}`, and `public_id` allowed a value with no `.` in it. Both
would have shipped an SDK teaching the wrong shape.

Also fixed before landing: the `path` pattern used a lazy quantifier where an
optional one was meant, and did not express the `//` / `..` refusal `check_path`
makes.

- `pytest app/services/marketplace/` — 453 passing
- `ruff check app scripts` / `ruff format app scripts` — clean

No new CI job: `test_the_committed_file_matches_the_generator` regenerates and
compares inside the backend suite, so a vocabulary change with no re-export fails
beside the change that caused it.
