### PR TITLE
Declare public-schema FKs and indexes in models, gate public drift

### DIFF
--- a/backend/alembic/migrations_test.py
+++ b/backend/alembic/migrations_test.py
@@ -37,6 +37,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 from app.core.config import settings
+from conftest import connect_su_postgres
 from app.db.tenancy import GUILD_SCOPED_TABLES
 
 
@@ -200,6 +201,13 @@ def _ordered_revisions_base_to_head() -> list[str]:
 
 
 def _parse_admin_url() -> dict:
+    """Connection kwargs for the app's provisioning role (``DATABASE_URL``).
+
+    Everything these tests do *inside* the database runs as this role, exactly
+    as migrations do in production. Creating and dropping the database itself
+    does not: that is cluster-level, and the provisioning role is deliberately
+    ``NOCREATEDB``. ``connect_su_postgres`` covers those two statements.
+    """
     parsed = urlparse(settings.DATABASE_URL.replace("+asyncpg", ""))
     return {
         "user": parsed.username,
@@ -209,30 +217,56 @@ def _parse_admin_url() -> dict:
     }
 
 
+async def _drop_prefixed_roles(conn: asyncpg.Connection) -> None:
+    """Drop this worker's cluster-global roles.
+
+    Roles outlive the database that used them, so a crashed run leaves them
+    behind — and a CREATEROLE role holds ADMIN OPTION only on roles it created
+    itself, so the provisioning role cannot re-grant a leftover it did not
+    make. Clearing them alongside the database keeps each run creating its own.
+    Safe to run before the database exists; call it *after* dropping the
+    database so no privileges still depend on them.
+    """
+    rows = await conn.fetch(
+        "SELECT rolname FROM pg_roles WHERE rolname LIKE $1",
+        f"{_MIGRATIONS_ROLE_PREFIX}%",
+    )
+    if rows:
+        names = ", ".join(f'"{row["rolname"]}"' for row in rows)
+        await conn.execute(f"DROP ROLE IF EXISTS {names}")
+
+
 async def _drop_db() -> None:
-    """Drop the dedicated migrations test database if it exists.
+    """Drop the dedicated migrations test database and this worker's roles.
 
     ``DROP DATABASE`` requires no other sessions to be connected. We use
     ``WITH (FORCE)`` (PG 13+) to evict any leftover connections from a
     crashed prior run.
     """
-    conn = await asyncpg.connect(database="postgres", **_parse_admin_url())
+    conn = await connect_su_postgres()
     try:
         await conn.execute(
             f'DROP DATABASE IF EXISTS "{MIGRATIONS_DB_NAME}" WITH (FORCE)'
         )
+        await _drop_prefixed_roles(conn)
     finally:
         await conn.close()
 
 
 async def _drop_and_create_db() -> None:
-    """Drop+recreate the dedicated migrations test database."""
-    conn = await asyncpg.connect(database="postgres", **_parse_admin_url())
+    """Drop+recreate the dedicated migrations test database.
+
+    Owned by the provisioning role so the migration chain runs against objects
+    it owns, the way a real deployment does.
+    """
+    owner = _parse_admin_url()["user"]
+    conn = await connect_su_postgres()
     try:
         await conn.execute(
             f'DROP DATABASE IF EXISTS "{MIGRATIONS_DB_NAME}" WITH (FORCE)'
         )
-        await conn.execute(f'CREATE DATABASE "{MIGRATIONS_DB_NAME}"')
+        await _drop_prefixed_roles(conn)
+        await conn.execute(f'CREATE DATABASE "{MIGRATIONS_DB_NAME}" OWNER "{owner}"')
     finally:
         await conn.close()
 

--- a/backend/app/db/migration_filters.py
+++ b/backend/app/db/migration_filters.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+from app.db.system_grants import NON_MODEL_SHARED_TABLES
 from app.db.tenancy import GUILD_SCOPED_TABLES
 
 IncludeObject = Callable[[object, str, str, bool, object], bool]
@@ -24,7 +25,10 @@ def make_include_object(guild_autogen: bool) -> IncludeObject:
     Default mode compares shared/public tables only: guild-content tables live
     in the per-guild schemas, so without the filter autogenerate would try to
     CREATE them in ``public`` (the model metadata still declares them for the
-    ORM).
+    ORM). ``NON_MODEL_SHARED_TABLES`` drops out of both modes — those tables
+    carry no SQLModel on purpose (``storage_backfill_state`` is created lazily
+    by its service), so every autogenerate run would otherwise want to DROP
+    them.
 
     Guild mode (``-x guild``) inverts the table filter (guild-content tables
     only, compared against ``guild_template``) and additionally scopes WHAT
@@ -46,6 +50,8 @@ def make_include_object(guild_autogen: bool) -> IncludeObject:
 
     def include_object(obj, name, type_, reflected, compare_to) -> bool:
         if type_ == "table":
+            if name in NON_MODEL_SHARED_TABLES:
+                return False
             return (name in GUILD_SCOPED_TABLES) == guild_autogen
 
         table = getattr(obj, "table", None)  # indexes/constraints/columns

--- a/backend/app/db/model_drift_test.py
+++ b/backend/app/db/model_drift_test.py
@@ -13,12 +13,10 @@ migrated test database through the exact ``include_object`` filter
 an empty diff — the database twin of the ``check-generated-types`` CI gate: if
 you changed a model, you must have generated the migration.
 
-Scope: guild mode only. The ``public`` schema carries known benign drift that
-predates this gate — FK ``ondelete`` behaviors that exist only in migrations,
-``ix_access_grants_user_guild`` undeclared in models — so a public-mode gate
-needs that cleanup first, tracked separately rather than baselined here as a
-tolerance list. (The index names left behind by the admin_api_keys →
-user_api_keys rename were part of that set; 20260811_0163 fixed them.)
+Both autogenerate modes are gated, and neither carries a tolerance list: the
+assertion is an empty diff. Anything the models genuinely don't own belongs in
+``include_object`` (where ``alembic revision --autogenerate`` honors it too),
+not in a per-diff exception here.
 """
 
 import pytest
@@ -62,4 +60,22 @@ async def test_models_match_guild_template(engine):
         "SQLModel models have drifted from guild_template — generate the guild "
         "migration with: cd backend && python scripts/gen_guild_migration.py "
         f'"desc". Autogenerate sees:\n{_render(diffs)}'
+    )
+
+
+@pytest.mark.database
+async def test_models_match_public_schema(engine):
+    """Shared/platform models == the migrated ``public`` schema. A diff means a
+    model changed without running ``alembic revision --autogenerate``.
+
+    Public mode compares more than guild mode does: FKs, indexes and unique
+    constraints are all model-declared here, so a model that leaves an
+    ``ondelete`` or a composite index to its migration reads as drift."""
+    async with engine.connect() as conn:
+        await conn.execute(text("SET LOCAL search_path TO public"))
+        diffs = await conn.run_sync(_model_diffs, False)
+    assert not diffs, (
+        "SQLModel models have drifted from the public schema — generate the "
+        'migration with: cd backend && alembic revision --autogenerate -m "desc". '
+        f"Autogenerate sees:\n{_render(diffs)}"
     )

--- a/backend/app/models/platform/access_grant.py
+++ b/backend/app/models/platform/access_grant.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from sqlalchemy import Column, DateTime, Integer, String, Text
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Index, SQLModel
 
 
 class AccessLevel(str, Enum):
@@ -64,12 +64,21 @@ class AccessGrant(SQLModel, table=True):
     """
 
     __tablename__ = "access_grants"
+    __table_args__ = (
+        # The live-grant lookup: "does this user hold a grant on this guild".
+        Index("ix_access_grants_user_guild", "user_id", "guild_id"),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
 
-    # The grantee and the guild they're being granted access to.
-    user_id: int = Field(foreign_key="users.id", nullable=False, index=True)
-    guild_id: int = Field(foreign_key="guilds.id", nullable=False, index=True)
+    # The grantee and the guild they're being granted access to. A grant is
+    # meaningless once either side is gone, so both cascade.
+    user_id: int = Field(
+        foreign_key="users.id", ondelete="CASCADE", nullable=False, index=True
+    )
+    guild_id: int = Field(
+        foreign_key="guilds.id", ondelete="CASCADE", nullable=False, index=True
+    )
 
     access_level: str = Field(
         sa_column=Column(
@@ -103,12 +112,16 @@ class AccessGrant(SQLModel, table=True):
     # Actors. ``requested_by_id`` equals ``user_id`` for self-service requests
     # but is kept distinct so an approver could later request on someone's
     # behalf without schema changes.
-    requested_by_id: int = Field(foreign_key="users.id", nullable=False)
+    # The requester goes with the grant; a decider does not — the audit row
+    # outlives the staff account that decided it, so those null out.
+    requested_by_id: int = Field(
+        foreign_key="users.id", ondelete="CASCADE", nullable=False
+    )
     approved_by_id: Optional[int] = Field(
-        default=None, foreign_key="users.id", nullable=True
+        default=None, foreign_key="users.id", ondelete="SET NULL", nullable=True
     )
     revoked_by_id: Optional[int] = Field(
-        default=None, foreign_key="users.id", nullable=True
+        default=None, foreign_key="users.id", ondelete="SET NULL", nullable=True
     )
 
     requested_at: datetime = Field(

--- a/backend/app/models/platform/api_key.py
+++ b/backend/app/models/platform/api_key.py
@@ -9,7 +9,9 @@ class UserApiKey(SQLModel, table=True):
     __tablename__ = "user_api_keys"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="users.id", nullable=False, index=True)
+    user_id: int = Field(
+        foreign_key="users.id", ondelete="CASCADE", nullable=False, index=True
+    )
     name: str = Field(nullable=False, max_length=100)
     token_prefix: str = Field(nullable=False, max_length=16, index=True)
     token_hash: str = Field(nullable=False, unique=True, max_length=128)

--- a/backend/app/models/platform/auth_provider.py
+++ b/backend/app/models/platform/auth_provider.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     Boolean,
     Column,
     DateTime,
+    ForeignKey,
     Integer,
     String,
     Text,
@@ -78,8 +79,11 @@ class AuthProvider(SQLModel, table=True):
     guild_id: Optional[int] = Field(
         default=None,
         sa_column=Column(
-            Integer, nullable=True, index=True
-        ),  # FK declared in the migration (ON DELETE CASCADE)
+            Integer,
+            ForeignKey("guilds.id", ondelete="CASCADE"),
+            nullable=True,
+            index=True,
+        ),
     )
 
     # OIDC / OAuth2 discovery + client identity (non-secret).

--- a/backend/app/models/platform/auth_provider_secret.py
+++ b/backend/app/models/platform/auth_provider_secret.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, Integer, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -13,7 +13,7 @@ class AuthProviderSecret(SQLModel, table=True):
     ``auth_providers``; only the secret lives here.
 
     1:1 with the provider — ``provider_id`` is the PK and an FK to
-    ``auth_providers.id`` (``ON DELETE CASCADE``, declared in the migration).
+    ``auth_providers.id`` (``ON DELETE CASCADE``).
     ``client_secret_encrypted`` is Fernet-encrypted at rest with
     ``SALT_OIDC_CLIENT_SECRET`` (registered in the secret-key rotation registry);
     it is ``NULL`` for public / PKCE-only providers with no secret.
@@ -21,8 +21,13 @@ class AuthProviderSecret(SQLModel, table=True):
 
     __tablename__ = "auth_provider_secrets"
 
-    # PK + FK to auth_providers (ON DELETE CASCADE declared in the migration).
-    provider_id: int = Field(sa_column=Column(Integer, primary_key=True))
+    provider_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("auth_providers.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
 
     client_secret_encrypted: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)

--- a/backend/app/models/platform/auth_session.py
+++ b/backend/app/models/platform/auth_session.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     DateTime,
+    ForeignKey,
     Integer,
     LargeBinary,
     Text,
@@ -60,8 +61,13 @@ class AuthSession(SQLModel, table=True):
             Uuid, primary_key=True, server_default=text("gen_random_uuid()")
         ),
     )
-    # FK declared in the migration (ON DELETE CASCADE).
-    user_id: int = Field(sa_column=Column(Integer, nullable=False))
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
 
     # SHA-256 of the raw refresh token — deterministic so a presented token maps
     # to one session by index lookup. The raw token is never stored.

--- a/backend/app/models/platform/auto_delegation_jti.py
+++ b/backend/app/models/platform/auto_delegation_jti.py
@@ -30,6 +30,7 @@ class AutoDelegationJti(SQLModel, table=True):
     redeemed_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
+    # Indexed for the sweep that drops expired entries.
     expires_at: datetime = Field(
-        sa_column=Column(DateTime(timezone=True), nullable=False),
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
     )

--- a/backend/app/models/platform/federated_identity.py
+++ b/backend/app/models/platform/federated_identity.py
@@ -1,7 +1,16 @@
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, Text, UniqueConstraint, text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Text,
+    UniqueConstraint,
+    text,
+)
 from sqlmodel import Field, SQLModel
 
 
@@ -29,9 +38,22 @@ class FederatedIdentity(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
 
-    # FKs declared in the migration (both ON DELETE CASCADE).
-    user_id: int = Field(sa_column=Column(Integer, nullable=False, index=True))
-    provider_id: int = Field(sa_column=Column(Integer, nullable=False, index=True))
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
+    provider_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("auth_providers.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
 
     # The IdP-asserted subject identifier — the stable join key.
     subject: str = Field(sa_column=Column(Text, nullable=False))

--- a/backend/app/models/platform/federated_identity_secret.py
+++ b/backend/app/models/platform/federated_identity_secret.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, Integer, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -13,16 +13,21 @@ class FederatedIdentitySecret(SQLModel, table=True):
     read and written only by the system engine.
 
     1:1 with the identity link — ``identity_id`` is the PK and an FK to
-    ``federated_identities.id`` (``ON DELETE CASCADE``, declared in the
-    migration). ``refresh_token_encrypted`` is Fernet-encrypted at rest and
+    ``federated_identities.id`` (``ON DELETE CASCADE``).
+    ``refresh_token_encrypted`` is Fernet-encrypted at rest and
     registered in the secret-key rotation registry; it is ``NULL`` when the IdP
     issued no refresh token or the token was revoked.
     """
 
     __tablename__ = "federated_identity_secrets"
 
-    # PK + FK to federated_identities (ON DELETE CASCADE declared in the migration).
-    identity_id: int = Field(sa_column=Column(Integer, primary_key=True))
+    identity_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("federated_identities.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
 
     refresh_token_encrypted: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)

--- a/backend/app/models/platform/guild.py
+++ b/backend/app/models/platform/guild.py
@@ -2,8 +2,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Optional, TYPE_CHECKING
 
-from sqlalchemy import Boolean, Column, DateTime, String, Integer
-from sqlmodel import Field, SQLModel, Enum as SQLEnum, Relationship
+from sqlalchemy import Boolean, Column, DateTime, String, Integer, Text
+from sqlmodel import Field, Index, SQLModel, Enum as SQLEnum, Relationship
 from pydantic import ConfigDict
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -41,9 +41,11 @@ class Guild(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(nullable=False)
-    description: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
     icon_base64: Optional[str] = Field(
-        default=None, sa_column=Column(String, nullable=True)
+        default=None, sa_column=Column(Text, nullable=True)
     )
     created_by_user_id: Optional[int] = Field(default=None, foreign_key="users.id")
     created_at: datetime = Field(
@@ -110,9 +112,14 @@ class GuildMembership(SQLModel, table=True):
     __tablename__ = "guild_memberships"
     __allow_unmapped__ = True
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    __table_args__ = (
+        # The primary key is (guild_id, user_id); this is the other direction,
+        # for "which guilds is this user in".
+        Index("idx_guild_memberships_user_guild", "user_id", "guild_id"),
+    )
 
-    guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
-    user_id: int = Field(foreign_key="users.id", primary_key=True)
+    guild_id: int = Field(foreign_key="guilds.id", ondelete="CASCADE", primary_key=True)
+    user_id: int = Field(foreign_key="users.id", ondelete="CASCADE", primary_key=True)
     role: GuildRole = Field(
         default=GuildRole.member,
         sa_column=Column(
@@ -145,8 +152,11 @@ class GuildInvite(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     code: str = Field(index=True, unique=True, nullable=False, max_length=64)
-    guild_id: int = Field(foreign_key="guilds.id", nullable=False)
-    created_by_user_id: Optional[int] = Field(foreign_key="users.id", nullable=True)
+    guild_id: int = Field(foreign_key="guilds.id", ondelete="CASCADE", nullable=False)
+    # The invite outlives the admin who issued it.
+    created_by_user_id: Optional[int] = Field(
+        foreign_key="users.id", ondelete="SET NULL", nullable=True
+    )
     expires_at: Optional[datetime] = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )

--- a/backend/app/models/platform/guild_auth_policy.py
+++ b/backend/app/models/platform/guild_auth_policy.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -22,17 +22,26 @@ class GuildAuthPolicy(SQLModel, table=True):
 
     __tablename__ = "guild_auth_policies"
 
-    # FK to guilds.id (ON DELETE CASCADE) declared in the migration.
-    guild_id: int = Field(sa_column=Column(Integer, primary_key=True))
+    guild_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("guilds.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
 
     # 'open' | 'required' ('managed' arrives with the broker phase).
     policy: str = Field(sa_column=Column(String(16), nullable=False))
 
-    # FK to auth_providers.id (ON DELETE RESTRICT — deleting a provider a
-    # guild requires must surface the conflict, never silently reopen the
-    # guild) declared in the migration.
+    # RESTRICT: deleting a provider a guild requires must surface the conflict,
+    # never silently reopen the guild.
     provider_id: Optional[int] = Field(
-        default=None, sa_column=Column(Integer, nullable=True)
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("auth_providers.id", ondelete="RESTRICT"),
+            nullable=True,
+        ),
     )
     provider_slug: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)

--- a/backend/app/models/platform/marketplace.py
+++ b/backend/app/models/platform/marketplace.py
@@ -21,7 +21,16 @@ from datetime import datetime, timezone
 from typing import Any, List, Optional, TYPE_CHECKING
 
 from pydantic import ConfigDict
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -133,6 +142,10 @@ class MarketplaceListingVersion(SQLModel, table=True):
     __tablename__ = "marketplace_listing_versions"
     __allow_unmapped__ = True
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    __table_args__ = (
+        # A listing publishes each version string once.
+        UniqueConstraint("listing_id", "version"),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     listing_id: int = Field(

--- a/backend/app/models/platform/notification.py
+++ b/backend/app/models/platform/notification.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Optional
 
 from sqlalchemy import Column, DateTime, JSON, String
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Index, SQLModel
 
 
 class NotificationType(str, Enum):
@@ -32,9 +32,15 @@ class NotificationType(str, Enum):
 
 class Notification(SQLModel, table=True):
     __tablename__ = "notifications"
+    __table_args__ = (
+        # The inbox query is always "my notifications, unread first", so the
+        # composite carries it; a bare ``user_id`` index would be a prefix of
+        # this one.
+        Index("ix_notifications_user_read", "user_id", "read_at"),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="users.id", nullable=False, index=True)
+    user_id: int = Field(foreign_key="users.id", ondelete="CASCADE", nullable=False)
     type: NotificationType = Field(
         sa_column=Column(String(64), nullable=False),
         default=NotificationType.task_assignment,

--- a/backend/app/models/platform/push_token.py
+++ b/backend/app/models/platform/push_token.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Index, SQLModel
 
 
 class PushToken(SQLModel, table=True):
@@ -13,13 +13,24 @@ class PushToken(SQLModel, table=True):
     """
 
     __tablename__ = "push_tokens"
+    __table_args__ = (
+        # One row per (device, token): re-registering the same token for a user
+        # updates the existing row rather than fanning out duplicate pushes.
+        Index("ix_push_tokens_user_device_token", "user_id", "push_token", unique=True),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="users.id", nullable=False, index=True)
+    user_id: int = Field(
+        foreign_key="users.id", ondelete="CASCADE", nullable=False, index=True
+    )
     # Links to device authentication token (nullable for cases where device token is deleted)
     device_token_id: Optional[int] = Field(
         default=None,
-        sa_column=Column(Integer, ForeignKey("user_tokens.id"), nullable=True),
+        sa_column=Column(
+            Integer,
+            ForeignKey("user_tokens.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
     )
     # FCM registration token (Android) or APNS device token (iOS)
     push_token: str = Field(

--- a/backend/app/models/platform/user_token.py
+++ b/backend/app/models/platform/user_token.py
@@ -16,7 +16,9 @@ class UserToken(SQLModel, table=True):
     __tablename__ = "user_tokens"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="users.id", nullable=False, index=True)
+    user_id: int = Field(
+        foreign_key="users.id", ondelete="CASCADE", nullable=False, index=True
+    )
     token: str = Field(
         sa_column=Column(String(128), nullable=False, unique=True, index=True),
     )

--- a/backend/app/models/platform/user_view_preference.py
+++ b/backend/app/models/platform/user_view_preference.py
@@ -31,7 +31,9 @@ class UserViewPreference(SQLModel, table=True):
     )
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="users.id", index=True, nullable=False)
+    user_id: int = Field(
+        foreign_key="users.id", ondelete="CASCADE", index=True, nullable=False
+    )
     scope_key: str = Field(max_length=MAX_SCOPE_KEY_LENGTH, nullable=False)
     value: Any = Field(sa_column=Column(JSON, nullable=False))
     updated_at: datetime = Field(

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -115,8 +115,13 @@ TEST_STATEMENT_TIMEOUT = "30s"
 BACKEND_DIR = Path(__file__).resolve().parent
 
 
-async def _connect_su_postgres() -> asyncpg.Connection:
-    """Test-infra superuser connection to the always-present ``postgres`` DB."""
+async def connect_su_postgres() -> asyncpg.Connection:
+    """Test-infra superuser connection to the always-present ``postgres`` DB.
+
+    Public because ``alembic/migrations_test.py`` creates its own database and
+    needs the same credentials — one definition of "the test-infra superuser",
+    not a second parse of ``DATABASE_URL`` that assumes the app's role is one.
+    """
     return await asyncpg.connect(
         user=_su_user,
         password=_su_password,
@@ -134,7 +139,7 @@ async def _ensure_test_database() -> None:
     being accessed"), so retry. ``CREATE DATABASE`` can't run inside a transaction,
     hence the autocommit asyncpg connection.
     """
-    conn = await _connect_su_postgres()
+    conn = await connect_su_postgres()
     try:
         for _attempt in range(12):
             exists = await conn.fetchval(
@@ -161,7 +166,7 @@ async def _ensure_test_database() -> None:
 async def _set_db_statement_timeout() -> None:
     """Apply a DB-level statement_timeout to the worker's test DB (catch-all net
     for cross-connection deadlocks). Affects connections opened afterward."""
-    conn = await _connect_su_postgres()
+    conn = await connect_su_postgres()
     try:
         await conn.execute(
             f'ALTER DATABASE "{TEST_DB_NAME}" SET statement_timeout = '
@@ -201,7 +206,7 @@ async def _migrate_under_lock() -> None:
     ``postgres`` DB for the whole migration; ``command.upgrade`` runs in a worker
     thread (where it can spin its own loop) while THIS loop keeps the lock
     connection — and thus the lock — alive."""
-    lock_conn = await _connect_su_postgres()
+    lock_conn = await connect_su_postgres()
     try:
         await lock_conn.execute("SELECT pg_advisory_lock($1)", _MIGRATION_LOCK_KEY)
         await _ensure_test_database()


### PR DESCRIPTION
## Problem

The model drift gate (`backend/app/db/model_drift_test.py`) asserts that SQLModel models match the Alembic-maintained schemas, but it only covered guild mode. Public mode could not be turned on because the shared models under-declare what the migrated `public` schema actually has, so the comparison was never empty.

Issue #811 listed three items; it was written in July and the set had grown since (auth providers, marketplace and storage landed in between). Running the comparison in public mode surfaced roughly 50 diffs.

None of it was a runtime bug — the database is correct. The cost is that every `alembic revision --autogenerate` on a public table emits spurious ops a human has to delete from the generated migration by hand.

## Changes

**No migration, and no deployed schema or grant changes.** The models catch up to the database, which is why the diff is model files only.

- **FK `ondelete` on 14 tables**, using SQLModel's `Field(ondelete=...)` so it stays a keyword rather than an `sa_column=Column(...)` rewrite. Six auth tables (`auth_providers`, `auth_provider_secrets`, `auth_sessions`, `federated_identities`, `federated_identity_secrets`, `guild_auth_policies`) declared a bare `Integer` column with a comment pointing at the migration; they now declare the FK, and the comments are gone.
- **Six undeclared indexes / constraints**: `ix_access_grants_user_guild`, `idx_guild_memberships_user_guild`, `ix_notifications_user_read`, `ix_push_tokens_user_device_token` (unique), `ix_auto_delegation_jti_blocklist_expires_at`, and the `(listing_id, version)` unique on `marketplace_listing_versions`. `notifications.user_id` drops its column-level `index=True`, which was a prefix of the composite the database actually has.
- **`guilds.description` / `icon_base64` are `TEXT`**, not `VARCHAR`.
- **`storage_backfill_state`** carries no SQLModel on purpose (its service creates it lazily), so autogenerate wanted to `DROP` it. It now drops out of both modes via the existing `NON_MODEL_SHARED_TABLES` registry — no second list, and because the filter is shared with `alembic/env.py`, real autogenerate runs get the same exclusion.

With that clean, `test_models_match_public_schema` joins the guild test. Empty-diff assertion, no tolerance list, as the issue asked: anything the models genuinely do not own belongs in `include_object`, where autogenerate honors it too.

## Also here: `migrations_test` fixture

Every test in `alembic/migrations_test.py` errored at fixture setup with `permission denied to create database`. It built its database URL from `DATABASE_URL` and assumed that role could `CREATE DATABASE`. CI's `DATABASE_URL` is the postgres image's bootstrap superuser, so it passed there and only broke where the role is the real least-privilege `app_provisioner`.

- Cluster-level statements (`CREATE`/`DROP DATABASE`) now use the test-infra superuser `conftest.py` already defines — `_connect_su_postgres` became public rather than a second parse of `DATABASE_URL`.
- The database is created `OWNER` the provisioning role, so the migration chain runs against objects it owns.
- The `migtest_*` roles are cluster-global and outlive the database. A CREATEROLE role holds ADMIN OPTION only on roles it created itself, so a leftover from an earlier run could not be re-granted. The fixture now clears its own role prefix alongside the database.

## Testing

```
cd backend
pytest app/db/model_drift_test.py     # 2 passed
pytest alembic/migrations_test.py     # 11 passed (all 11 errored before)
pytest app/db/ alembic/               # 361 passed
ruff check app && ruff format app && ty check app
```

The drift gate was verified against a dropped and rebuilt database, not the persisted test DB — 30 public tables migrated to head `20260814_0179`, both modes green.

The 11 `migrations_test` errors were confirmed pre-existing by stashing this branch and re-running.

Closes #811