### PR TITLE
Give push and email the same notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Android notifications now arrive on channels you can tune individually.** Comments, calendar events, event reminders, access requests, and the new overdue summary each get their own entry in the system notification settings, so you can silence one kind without silencing the rest — previously only five kinds were sorted this way and everything else arrived under a general heading. This part needs the updated app; the notifications themselves reach existing installs either way.
+
 ### Changed
 
 - **An app is told who you are without being told which account you are.** Apps now know each member by an identifier unique to that app's own installation, rather than by an account id shared across everything. Two apps cannot compare notes and work out they are dealing with the same person, and an app installed in two guilds cannot link those guilds to one of your members.
+- **The task-assignment digest now waits for the flurry to end.** It used to send on the first assignment and then go quiet for an hour, so a single task got an instant email while a batch of twelve arrived as one message plus a long silence — the opposite of what a digest is for. It now sends once nothing new has arrived for five minutes, or after thirty minutes if assignments keep trickling in. A lone assignment still reaches you promptly; a burst arrives as one summary.
+- **Assignment email and push are the same message on the same schedule.** Push fired once per task, so twelve assignments meant twelve buzzes while your inbox got one summary. Both channels now ship together from the digest, and a summary covering one task still opens straight to it. The in-app bell is unchanged and still lists each assignment as it happens.
+- Turning off the assignment email no longer stops push as well — the two toggles are now independent, as the settings page always implied.
+
+### Fixed
+
+- **Overdue tasks now reach your phone, not just your inbox.** The daily overdue digest was email-only despite the push toggle sitting beside it in notification settings, so anyone relying on the app for reminders never heard about overdue work. It now sends on whichever channels you have on, and turning the email off no longer silences the push. Tapping it opens My Tasks, since the digest spans every guild you are in.
+- Push notifications sent by the app's own background work — the overdue and assignment digests, and access-request notices — reached the device and then failed while recording the delivery, which could leave a stale device registration in place after the phone had been handed on.
+- **Un-assigning someone before the digest goes out now withdraws the announcement.** Previously the email still told them they had been assigned a task they no longer held.
+- Sent digest entries are now cleared a week after the fact. Nothing had ever deleted them, so every task assignment ever made left a permanent row behind.
 
 ## [0.62.5] - 2026-08-14
 

--- a/backend/alembic/versions/20260814_0181_push_tokens_system_update.py
+++ b/backend/alembic/versions/20260814_0181_push_tokens_system_update.py
@@ -1,0 +1,36 @@
+"""Let the system engine stamp push token delivery.
+
+``app_admin`` held SELECT/INSERT/DELETE on ``public.push_tokens`` but not
+UPDATE, while ``send_push_to_user`` writes ``last_used_at`` after every
+successful delivery. Every push the system engine sends — the background
+overdue/assignment digests, the PAM access-grant notices — therefore reached
+FCM and then faulted on the bookkeeping write.
+
+The request-path roles (``app_guild_base`` / ``platform_base``) already carry
+UPDATE for exactly this call; this brings the system engine in line. The bare
+login role still holds nothing on the table.
+
+Revision ID: 20260814_0181
+Revises: 20260814_0180
+Create Date: 2026-08-14
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20260814_0181"
+down_revision = "20260814_0180"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.get_bind().execute(text("GRANT UPDATE ON TABLE public.push_tokens TO app_admin"))
+
+
+def downgrade() -> None:
+    op.get_bind().execute(
+        text("REVOKE UPDATE ON TABLE public.push_tokens FROM app_admin")
+    )

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -365,6 +365,27 @@ async def create_user(
     return user
 
 
+def _assignment_digest_turned_off(user: User, update_data: dict) -> bool:
+    """Whether this update leaves the user wanting no assignment digest at all.
+
+    Email and push share one queue, so it is discarded only on the transition
+    to both being off — never when just one channel is switched off.
+    """
+
+    def _next(field: str, current: bool) -> bool | None:
+        value = update_data.get(field)
+        return current if value is None else value
+
+    was_on = notifications_service.wants_assignment_digest(
+        user.email_task_assignment, user.push_task_assignment
+    )
+    now_on = notifications_service.wants_assignment_digest(
+        _next("email_task_assignment", user.email_task_assignment),
+        _next("push_task_assignment", user.push_task_assignment),
+    )
+    return was_on and not now_on
+
+
 @router.patch("/me", response_model=UserRead)
 async def update_users_me(
     request: Request,
@@ -385,16 +406,12 @@ async def update_users_me(
         payload.has_federated_identity = is_sso_account
         return payload
 
-    if (
-        update_data.get("email_task_assignment") is False
-        and current_user.email_task_assignment is not False
-    ):
+    if _assignment_digest_turned_off(current_user, update_data):
         # The digest queue is guild-scoped, so it must be cleared inside each
         # of the user's guild schemas — before any mutation below, because the
         # fan-out expunges the identity map (per-schema ids collide). Restore
         # the platform context and re-fetch the user afterwards; the deletes
-        # ride this request's transaction and commit with it. Skipped when the
-        # preference is already off (nothing can be queued).
+        # ride this request's transaction and commit with it.
         user_id = current_user.id
         await notifications_service.clear_task_assignment_queue_across_guilds(
             session, user_id
@@ -624,6 +641,14 @@ async def update_user(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=UserMessages.STATUS_WRONG_ENDPOINT,
         )
+    if _assignment_digest_turned_off(user, update_data):
+        # This session is routed into one guild, so only that guild's queue is
+        # reachable — a guild admin has no business writing to schemas they
+        # have no rights in. Items left in the user's other guilds age out via
+        # the digest GC sweep.
+        await notifications_service.clear_task_assignment_queue_for_user(
+            session, user.id
+        )
     if password := update_data.pop("password", None):
         await enforce_password_policy(password)
         user.hashed_password = get_password_hash(password)
@@ -661,10 +686,6 @@ async def update_user(
             if normalized_week_start is not None:
                 setattr(user, field, normalized_week_start)
             continue
-        if field == "email_task_assignment" and value is False:
-            await notifications_service.clear_task_assignment_queue_for_user(
-                session, user.id
-            )
         setattr(user, field, value)
     user.updated_at = datetime.now(timezone.utc)
 

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -15,13 +15,18 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.db.query import MAX_ID_FILTER_VALUES
+from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
 from app.models.platform.user import User, UserRole, UserStatus
+from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 
 from app.testing.factories import (
     create_federated_identity,
     create_guild,
     create_guild_membership,
+    create_initiative,
+    create_project,
+    create_task,
     create_user,
     get_auth_headers,
     get_auth_token,
@@ -94,6 +99,80 @@ async def test_update_current_user_notification_preferences(
     data = response.json()
     assert data["email_task_assignment"] is False
     assert data["email_overdue_tasks"] is False
+
+
+async def _queue_assignment_item(session: AsyncSession, user, guild) -> None:
+    """Put one pending digest item in ``guild``'s schema for ``user``."""
+    initiative = await create_initiative(session, guild, user, name="Queue")
+    project = await create_project(session, initiative, user, name="Queue Project")
+    task = await create_task(session, project, title="Queued")
+    await set_rls_context(session, user_id=user.id, guild_id=guild.id)
+    session.add(
+        TaskAssignmentDigestItem(
+            user_id=user.id,
+            task_id=task.id,
+            project_id=project.id,
+            task_title="Queued",
+            project_name=project.name,
+            assigned_by_name="Assigner",
+        )
+    )
+    await session.commit()
+
+
+async def _pending_assignment_items(session: AsyncSession, user, guild) -> int:
+    session.expunge_all()
+    await set_rls_context(session, user_id=user.id, guild_id=guild.id)
+    rows = (
+        await session.exec(
+            select(TaskAssignmentDigestItem).where(
+                TaskAssignmentDigestItem.processed_at.is_(None)
+            )
+        )
+    ).all()
+    return len(rows)
+
+
+@pytest.mark.integration
+async def test_disabling_assignment_email_keeps_the_push_queue(
+    client: AsyncClient, session: AsyncSession
+):
+    """One queue now backs both channels, so switching the email off must not
+    discard the items the push digest is still going to send."""
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    await _queue_assignment_item(session, user, guild)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(user),
+        json={"email_task_assignment": False},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["email_task_assignment"] is False
+    assert await _pending_assignment_items(session, user, guild) == 1
+
+
+@pytest.mark.integration
+async def test_disabling_both_assignment_channels_clears_the_queue(
+    client: AsyncClient, session: AsyncSession
+):
+    """With neither channel left on, nothing will ever send the items."""
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=guild)
+    await _queue_assignment_item(session, user, guild)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(user),
+        json={"email_task_assignment": False, "push_task_assignment": False},
+    )
+
+    assert response.status_code == 200
+    assert await _pending_assignment_items(session, user, guild) == 0
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -722,6 +722,18 @@ async def _set_task_assignees(
 ) -> None:
     unique_ids = list(dict.fromkeys(assignee_ids or []))
 
+    # Read the current set before replacing it, so anyone dropped can have
+    # their un-sent digest item withdrawn. An explicit query rather than
+    # ``task.assignees`` — on a freshly flushed task that relationship is not
+    # loaded yet, and touching it would fire a lazy load.
+    previous_ids = set(
+        (
+            await session.exec(
+                select(TaskAssignee.user_id).where(TaskAssignee.task_id == task.id)
+            )
+        ).all()
+    )
+
     stmt = select(User).where(User.id.in_(tuple(unique_ids))) if unique_ids else None
 
     if stmt is not None:
@@ -740,6 +752,10 @@ async def _set_task_assignees(
         session.add_all(
             [TaskAssignee(task_id=task.id, user_id=user_id) for user_id in unique_ids]
         )
+
+    await notifications_service.dequeue_task_assignment_events(
+        session, task_id=task.id, user_ids=sorted(previous_ids - set(unique_ids))
+    )
 
     await session.flush()
     await session.refresh(task, attribute_names=["assignees"])

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -19,7 +19,11 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from sqlmodel import select
+
+from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
+from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
@@ -493,6 +497,57 @@ async def test_assign_user_to_task(
     data = response.json()
     assignee_ids = {a["id"] for a in data["assignees"]}
     assert assignee.user.id in assignee_ids
+
+
+@pytest.mark.integration
+async def test_unassigning_withdraws_the_pending_digest_item(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """An assignment that is undone before the digest goes out should not be
+    announced — the queue row is withdrawn along with the assignment."""
+    user = await acting_user(guild_role=GuildRole.member, initiative=True, project=True)
+    assignee = await acting_user(
+        guild_role=GuildRole.member,
+        guild=user.guild,
+        initiative=user.initiative,
+        initiative_role="member",
+    )
+    task = await _create_task(session, user.project)
+
+    assign = await client.patch(
+        user.g(f"/tasks/{task.id}"),
+        headers=user.headers,
+        json={"assignee_ids": [assignee.user.id]},
+    )
+    assert assign.status_code == 200
+
+    await set_rls_context(session, user_id=user.user.id, guild_id=user.guild.id)
+    pending = (
+        await session.exec(
+            select(TaskAssignmentDigestItem).where(
+                TaskAssignmentDigestItem.user_id == assignee.user.id,
+                TaskAssignmentDigestItem.processed_at.is_(None),
+            )
+        )
+    ).all()
+    assert len(pending) == 1
+
+    unassign = await client.patch(
+        user.g(f"/tasks/{task.id}"), headers=user.headers, json={"assignee_ids": []}
+    )
+    assert unassign.status_code == 200
+
+    session.expunge_all()
+    await set_rls_context(session, user_id=user.user.id, guild_id=user.guild.id)
+    pending = (
+        await session.exec(
+            select(TaskAssignmentDigestItem).where(
+                TaskAssignmentDigestItem.user_id == assignee.user.id,
+                TaskAssignmentDigestItem.processed_at.is_(None),
+            )
+        )
+    ).all()
+    assert pending == []
 
 
 @pytest.mark.integration

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -141,7 +141,10 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     "user_view_preferences": None,
     "notifications": frozenset({"SELECT", "INSERT", "DELETE"}),
     "user_tokens": frozenset({"SELECT", "INSERT", "DELETE"}),
-    "push_tokens": frozenset({"SELECT", "INSERT", "DELETE"}),
+    # the system engine delivers push itself (background digests, PAM notices),
+    # and delivery bookkeeping is part of that: UPDATE stamps last_used_at,
+    # DELETE prunes tokens FCM reports as unregistered
+    "push_tokens": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # pre-auth credential store — validated by token_hash before the user is
     # known, so the lookup + create + deactivate all run on the system engine
     # (no request-path grant, no own-row policy), like auth_sessions

--- a/backend/app/locales/de/notifications.json
+++ b/backend/app/locales/de/notifications.json
@@ -2,7 +2,13 @@
   "task": {
     "assignment": {
       "title": "Neue Aufgabenzuweisung",
-      "body": "{{title}} in {{project}}"
+      "body_one": "{{title}} in {{project}}",
+      "body_other": "{{count}} Aufgaben wurden dir zugewiesen, darunter {{title}}"
+    },
+    "overdue": {
+      "title": "Überfällige Aufgaben",
+      "body_one": "{{count}} Aufgabe ist überfällig: {{title}}",
+      "body_other": "{{count}} Aufgaben sind überfällig, darunter {{title}}"
     }
   },
   "initiative": {

--- a/backend/app/locales/en/notifications.json
+++ b/backend/app/locales/en/notifications.json
@@ -2,7 +2,13 @@
   "task": {
     "assignment": {
       "title": "New Task Assignment",
-      "body": "{{title}} in {{project}}"
+      "body_one": "{{title}} in {{project}}",
+      "body_other": "{{count}} tasks assigned to you, including {{title}}"
+    },
+    "overdue": {
+      "title": "Overdue tasks",
+      "body_one": "{{count}} task is overdue: {{title}}",
+      "body_other": "{{count}} tasks are overdue, including {{title}}"
     }
   },
   "initiative": {

--- a/backend/app/locales/es/notifications.json
+++ b/backend/app/locales/es/notifications.json
@@ -2,7 +2,13 @@
   "task": {
     "assignment": {
       "title": "Nueva tarea asignada",
-      "body": "{{title}} en {{project}}"
+      "body_one": "{{title}} en {{project}}",
+      "body_other": "Se te asignaron {{count}} tareas, incluida {{title}}"
+    },
+    "overdue": {
+      "title": "Tareas vencidas",
+      "body_one": "{{count}} tarea está vencida: {{title}}",
+      "body_other": "{{count}} tareas están vencidas, incluida {{title}}"
     }
   },
   "initiative": {

--- a/backend/app/locales/fr/notifications.json
+++ b/backend/app/locales/fr/notifications.json
@@ -2,7 +2,13 @@
   "task": {
     "assignment": {
       "title": "Nouvelle tâche assignée",
-      "body": "{{title}} dans {{project}}"
+      "body_one": "{{title}} dans {{project}}",
+      "body_other": "{{count}} tâches vous ont été assignées, dont {{title}}"
+    },
+    "overdue": {
+      "title": "Tâches en retard",
+      "body_one": "{{count}} tâche est en retard : {{title}}",
+      "body_other": "{{count}} tâches sont en retard, dont {{title}}"
     }
   },
   "initiative": {

--- a/backend/app/models/platform/notification.py
+++ b/backend/app/models/platform/notification.py
@@ -8,6 +8,7 @@ from sqlmodel import Field, Index, SQLModel
 
 class NotificationType(str, Enum):
     task_assignment = "task_assignment"
+    overdue_tasks = "overdue_tasks"
     initiative_added = "initiative_added"
     project_added = "project_added"
     user_pending_approval = "user_pending_approval"

--- a/backend/app/services/background_tasks.py
+++ b/backend/app/services/background_tasks.py
@@ -22,9 +22,11 @@ async def _loop_worker(task_coro, interval: int, name: str) -> None:
 
 def start_background_tasks() -> list[asyncio.Task]:
     from app.services.notifications import (
+        process_assignment_digest_gc,
         process_task_assignment_digests,
         process_overdue_notifications,
         process_event_reminders,
+        ASSIGNMENT_GC_POLL_SECONDS,
         DIGEST_POLL_SECONDS,
         OVERDUE_POLL_SECONDS,
         EVENT_REMINDER_POLL_SECONDS,
@@ -68,6 +70,13 @@ def start_background_tasks() -> list[asyncio.Task]:
         asyncio.create_task(
             _loop_worker(
                 process_task_assignment_digests, DIGEST_POLL_SECONDS, "task-digest"
+            )
+        ),
+        asyncio.create_task(
+            _loop_worker(
+                process_assignment_digest_gc,
+                ASSIGNMENT_GC_POLL_SECONDS,
+                "task-digest-gc",
             )
         ),
         asyncio.create_task(

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from sqlalchemy import select, delete, update as sa_update
+from sqlalchemy import or_, select, delete, update as sa_update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.email_i18n import email_t, translate
@@ -22,6 +22,7 @@ from app.models.tenant.calendar_event import (
     RSVPStatus,
 )
 from app.models.tenant.event_reminder_dispatch import EventReminderDispatch
+from app.models.platform.guild import Guild, GuildStatus
 from app.models.platform.user import User
 from app.models.platform.notification import NotificationType
 from app.services import email as email_service
@@ -30,12 +31,27 @@ from app.services.platform import push_notifications
 
 logger = logging.getLogger(__name__)
 
-DIGEST_POLL_SECONDS = 120
+DIGEST_POLL_SECONDS = 60
 OVERDUE_POLL_SECONDS = 300
+# A task-assignment digest waits for the flurry to end rather than firing on
+# the first item: it ships once nothing new has arrived for QUIET_PERIOD, so a
+# lone assignment still lands promptly while a burst collapses into one
+# notification. MAX_WINDOW bounds how long a steady trickle can hold it back.
+ASSIGNMENT_QUIET_PERIOD = timedelta(minutes=5)
+ASSIGNMENT_MAX_WINDOW = timedelta(minutes=30)
+# How long a sent digest's items are kept before the GC sweep drops them. They
+# are only bookkeeping once delivered; the notification itself lives in the
+# bell. Unsent items are dropped at the same age — anything that old is either
+# orphaned or long past being worth sending.
+ASSIGNMENT_ITEM_RETENTION = timedelta(days=7)
+ASSIGNMENT_GC_POLL_SECONDS = 3600
 EVENT_REMINDER_POLL_SECONDS = 60
 # Events that started within this window are still eligible, so a 0-minute
 # ("at start") reminder fires on the next poll rather than being missed.
 EVENT_REMINDER_GRACE = timedelta(minutes=5)
+# My Tasks is the app root: the cross-guild list of everything assigned to you.
+# Cross-guild notifications point here instead of at one guild's copy.
+MY_TASKS_TARGET_PATH = "/"
 
 
 def _normalize_target_path(target_path: str) -> str:
@@ -122,8 +138,14 @@ async def enqueue_task_assignment_event(
             "smart_link": smart_link,
         },
     )
-    # Email: enqueue digest if email preference enabled
-    if assignee.email_task_assignment is not False:
+    # Email and push both ship from the digest worker on one schedule, so the
+    # item is queued when EITHER channel is on; the worker re-reads both
+    # preferences when it sends. Only the in-app notification above is
+    # immediate — the bell is a list, not an interruption.
+    if (
+        assignee.email_task_assignment is not False
+        or assignee.push_task_assignment is not False
+    ):
         event = TaskAssignmentDigestItem(
             user_id=assignee.id,
             task_id=task.id,
@@ -134,30 +156,36 @@ async def enqueue_task_assignment_event(
             assigned_by_id=assigned_by.id,
         )
         session.add(event)
-    # Push notification
-    if assignee.push_task_assignment is not False:
-        locale = _recipient_locale(assignee)
-        try:
-            await push_notifications.send_push_to_user(
-                session=session,
-                user_id=assignee.id,
-                notification_type=NotificationType.task_assignment,
-                title=_nt("task.assignment.title", locale),
-                body=_nt(
-                    "task.assignment.body",
-                    locale,
-                    title=task.title,
-                    project=project_name,
-                ),
-                data={
-                    "type": "task_assignment",
-                    "task_id": str(task.id),
-                    "guild_id": str(guild_id),
-                    "target_path": target_path,
-                },
-            )
-        except Exception as exc:
-            logger.error(f"Failed to send push notification: {exc}", exc_info=True)
+
+
+def wants_assignment_digest(email_pref: bool | None, push_pref: bool | None) -> bool:
+    """Whether a user still wants the assignment digest on either channel.
+
+    One queue backs both, so it may only be discarded once neither is on —
+    clearing it because the email was switched off would silently take the
+    push with it.
+    """
+    return email_pref is not False or push_pref is not False
+
+
+async def dequeue_task_assignment_events(
+    session: AsyncSession, *, task_id: int, user_ids: list[int]
+) -> None:
+    """Drop pending digest items for users just unassigned from ``task_id``.
+
+    A digest that has not gone out yet should not announce an assignment that
+    no longer holds. Operates on the CURRENTLY ROUTED guild schema, which is
+    the task's own. Already-sent items are left alone — that mail is gone.
+    """
+    if not user_ids:
+        return
+    await session.exec(
+        delete(TaskAssignmentDigestItem).where(
+            TaskAssignmentDigestItem.task_id == task_id,
+            TaskAssignmentDigestItem.user_id.in_(tuple(user_ids)),
+            TaskAssignmentDigestItem.processed_at.is_(None),
+        )
+    )
 
 
 async def clear_task_assignment_queue_for_user(
@@ -1142,6 +1170,63 @@ async def notify_event_reminder(
     )
 
 
+async def _send_assignment_push(
+    session: AsyncSession, user: User, assignments: list[dict]
+) -> tuple[bool, bool]:
+    """Push a task-assignment digest. Returns ``(delivered, retry_worth_it)``.
+
+    A digest of one names its task and deep-links to it; a larger one spans
+    guilds, so it points at My Tasks the way the overdue digest does.
+    """
+    locale = _recipient_locale(user)
+    first = assignments[0]
+    data: dict[str, str] = {
+        "type": NotificationType.task_assignment.value,
+        "count": str(len(assignments)),
+        "target_path": MY_TASKS_TARGET_PATH,
+    }
+    if len(assignments) == 1 and first.get("guild_id") is not None:
+        data["target_path"] = _task_target_path(
+            first.get("task_id"), first.get("project_id")
+        )
+        data["guild_id"] = str(first["guild_id"])
+    try:
+        sent = await push_notifications.send_push_to_user(
+            session=session,
+            user_id=user.id,
+            notification_type=NotificationType.task_assignment,
+            title=_nt("task.assignment.title", locale),
+            body=_nt(
+                "task.assignment.body",
+                locale,
+                count=len(assignments),
+                title=first.get("task_title") or "",
+                project=first.get("project_name") or "",
+            ),
+            data=data,
+        )
+    except Exception as exc:
+        logger.error("Failed to send assignment digest push: %s", exc, exc_info=True)
+        return False, True
+    return sent > 0, False
+
+
+def _digest_is_due(timestamps: list[datetime], *, now: datetime) -> bool:
+    """Whether a user's queued items have settled enough to send.
+
+    The digest ships once nothing new has arrived for ``ASSIGNMENT_QUIET_PERIOD``
+    — so a lone assignment goes out promptly and a burst arrives as one — or
+    once the oldest item hits ``ASSIGNMENT_MAX_WINDOW``, which stops a steady
+    trickle from deferring it indefinitely.
+    """
+    if not timestamps:
+        return False
+    return (
+        now - max(timestamps) >= ASSIGNMENT_QUIET_PERIOD
+        or now - min(timestamps) >= ASSIGNMENT_MAX_WINDOW
+    )
+
+
 async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -> None:
     """Send task-assignment digests to opted-in users as of ``now``.
 
@@ -1149,26 +1234,40 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
     the test session. Each user's pending digest items live in their own guild
     schemas, so they're gathered with the user's membership context (no
     the guild's role) and the items are marked processed back in each schema.
+
+    Email and push ship together from here, on the same trigger, so the two
+    channels tell the same story — see :func:`_digest_is_due` for the timing.
     """
     result = await session.exec(
-        select(User).where(User.email_task_assignment.is_not(False))
+        select(User).where(
+            or_(
+                User.email_task_assignment.is_not(False),
+                User.push_task_assignment.is_not(False),
+            )
+        )
     )
     users = result.scalars().all()
     if not users:
         logger.debug("task-digest: no opted-in users")
         return
     # Capture before routing — the gather expunges the identity map.
-    candidates = [(u.id, u.email, u.last_task_assignment_digest_at) for u in users]
-    for user_id, email, last_at in candidates:
-        if last_at and last_at + timedelta(hours=1) > now:
-            continue  # rate-limited to one digest per hour
+    candidates = [
+        (u.id, u.email, u.email_task_assignment, u.push_task_assignment) for u in users
+    ]
+    for user_id, email, wants_email, wants_push in candidates:
         per_guild_items: dict[int, list[int]] = {}
+        queued_at: list[datetime] = []
 
         # Capture user_id / per_guild_items as defaults so this closure doesn't
         # bind the loop variables by reference (B023) — safe even if the call
         # site is ever refactored to defer the closures.
         async def _fetch(
-            routed: AsyncSession, gid: int, *, _uid=user_id, _items=per_guild_items
+            routed: AsyncSession,
+            gid: int,
+            *,
+            _uid=user_id,
+            _items=per_guild_items,
+            _queued=queued_at,
         ) -> list[dict]:
             items = (
                 (
@@ -1185,6 +1284,7 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
                 .all()
             )
             _items[gid] = [item.id for item in items]
+            _queued.extend(item.created_at for item in items)
             return [
                 {
                     "task_title": item.task_title,
@@ -1194,6 +1294,12 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
                         target_path=_task_target_path(item.task_id, item.project_id),
                         guild_id=gid,  # the item's guild IS the routed schema
                     ),
+                    # The push carries one deep link rather than a list; these
+                    # let a digest of one point at its task. Ignored by the
+                    # email, which renders ``link`` per row.
+                    "task_id": item.task_id,
+                    "project_id": item.project_id,
+                    "guild_id": gid,
                 }
                 for item in items
             ]
@@ -1204,7 +1310,7 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
         assignments = await gather_across_guilds(
             session, user_id, guild_ids, _fetch, satisfied_providers=SYSTEM_SATISFIED
         )
-        if not assignments:
+        if not assignments or not _digest_is_due(queued_at, now=now):
             continue
         # Send: re-load the user (gather expunged it) in a shared-table context.
         session.expunge_all()
@@ -1216,18 +1322,34 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
             user is None
         ):  # deleted between the snapshot and now — skip, don't abort the pass
             continue
-        try:
-            await email_service.send_task_assignment_digest_email(
-                session, user, assignments
-            )
-            logger.info(
-                "task-digest: sent %d assignment(s) to user %s", len(assignments), email
-            )
-        except email_service.EmailNotConfiguredError:
-            logger.warning("SMTP not configured; skipping task digest for %s", email)
-            continue
-        except RuntimeError as exc:  # pragma: no cover
-            logger.error("Failed to send task digest: %s", exc)
+        delivered = False
+        # A channel that is merely unconfigured will never deliver these items,
+        # so holding the queue for it would re-send nothing every poll forever.
+        # Only a transient failure is worth another pass.
+        retry = False
+        if wants_email is not False:
+            try:
+                await email_service.send_task_assignment_digest_email(
+                    session, user, assignments
+                )
+                delivered = True
+                logger.info(
+                    "task-digest: sent %d assignment(s) to user %s",
+                    len(assignments),
+                    email,
+                )
+            except email_service.EmailNotConfiguredError:
+                logger.warning(
+                    "SMTP not configured; skipping task digest for %s", email
+                )
+            except RuntimeError as exc:  # pragma: no cover
+                logger.error("Failed to send task digest: %s", exc)
+                retry = True
+        if wants_push is not False:
+            pushed, push_retry = await _send_assignment_push(session, user, assignments)
+            delivered = delivered or pushed
+            retry = retry or push_retry
+        if retry and not delivered:
             continue
         # Mark the gathered items processed, back in each guild's schema.
         for gid, item_ids in per_guild_items.items():
@@ -1253,6 +1375,8 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
         ).scalar_one_or_none()
         if user is None:
             continue
+        # A record of when the last digest went out (it is serialized on the
+        # user), not a gate — the send window is derived from the queue itself.
         user.last_task_assignment_digest_at = now
         session.add(user)
         await session.commit()
@@ -1261,6 +1385,43 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
 async def process_task_assignment_digests() -> None:
     async with AdminSessionLocal() as session:
         await _run_assignment_digest_pass(session, now=datetime.now(timezone.utc))
+
+
+async def _run_assignment_gc_pass(session: AsyncSession, *, now: datetime) -> None:
+    """Drop digest items older than the retention window, guild by guild.
+
+    Sent items are bookkeeping once the mail is gone. Unsent items of the same
+    age are dropped too: they are either orphaned (the user turned the channel
+    off in a guild an admin could not reach) or so stale that announcing them
+    would be noise.
+    """
+    cutoff = now - ASSIGNMENT_ITEM_RETENTION
+    guild_ids = (
+        (
+            await session.exec(
+                select(Guild.id)
+                .where(Guild.status == GuildStatus.active.value)
+                .order_by(Guild.id.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for guild_id in guild_ids:
+        session.expunge_all()
+        await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+        await session.exec(
+            delete(TaskAssignmentDigestItem).where(
+                TaskAssignmentDigestItem.created_at < cutoff
+            )
+        )
+        await session.commit()
+
+
+async def process_assignment_digest_gc() -> None:
+    async with AdminSessionLocal() as session:
+        await set_rls_context(session)
+        await _run_assignment_gc_pass(session, now=datetime.now(timezone.utc))
 
 
 def _resolve_timezone(value: str | None) -> ZoneInfo:
@@ -1310,6 +1471,42 @@ async def _overdue_tasks_for_user(session: AsyncSession, user_id: int) -> list[d
     return tasks
 
 
+async def _send_overdue_push(
+    session: AsyncSession, user: User, tasks: list[dict]
+) -> bool:
+    """Push the overdue digest to the user's devices. Returns whether it landed.
+
+    The digest spans every guild the user belongs to, so the tap lands on My
+    Tasks — the cross-guild list — rather than on any one task. It carries no
+    ``guild_id`` for that reason; the mobile tap handler treats a bare
+    ``target_path`` as an app-level route.
+    """
+    locale = _recipient_locale(user)
+    data = {
+        "type": NotificationType.overdue_tasks.value,
+        "count": str(len(tasks)),
+        "target_path": MY_TASKS_TARGET_PATH,
+    }
+    try:
+        sent = await push_notifications.send_push_to_user(
+            session=session,
+            user_id=user.id,
+            notification_type=NotificationType.overdue_tasks,
+            title=_nt("task.overdue.title", locale),
+            body=_nt(
+                "task.overdue.body",
+                locale,
+                count=len(tasks),
+                title=tasks[0]["title"],
+            ),
+            data=data,
+        )
+    except Exception as exc:
+        logger.error("Failed to send overdue push: %s", exc, exc_info=True)
+        return False
+    return sent > 0
+
+
 async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
     """Send overdue-task digests to opted-in users as of ``now``.
 
@@ -1317,8 +1514,19 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
     the test session (the worker opens its own ``AdminSessionLocal``). Each
     user's overdue tasks are gathered from their own guild schemas with their
     membership context — no all-guild access.
+
+    Both channels ship from this one pass: the digest email and, for users with
+    ``push_overdue_tasks`` on, a push notification. A user opted into either
+    channel is a candidate, so turning email off doesn't silence push.
     """
-    result = await session.exec(select(User).where(User.email_overdue_tasks.is_(True)))
+    result = await session.exec(
+        select(User).where(
+            or_(
+                User.email_overdue_tasks.is_(True),
+                User.push_overdue_tasks.is_(True),
+            )
+        )
+    )
     users = result.scalars().all()
     if not users:
         logger.debug("overdue-digest: no users opted in")
@@ -1332,10 +1540,20 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
             u.timezone,
             u.overdue_notification_time,
             u.last_overdue_notification_at,
+            u.email_overdue_tasks,
+            u.push_overdue_tasks,
         )
         for u in users
     ]
-    for user_id, email, user_tz, notify_time, last_at in candidates:
+    for (
+        user_id,
+        email,
+        user_tz,
+        notify_time,
+        last_at,
+        wants_email,
+        wants_push,
+    ) in candidates:
         tz = _resolve_timezone(user_tz)
         now_local = now.astimezone(tz)
         try:
@@ -1374,16 +1592,28 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
             user is None
         ):  # deleted between the snapshot and now — skip, don't abort the pass
             continue
-        try:
-            await email_service.send_overdue_tasks_email(session, user, tasks)
-            logger.info(
-                "overdue-digest: sent %d overdue task(s) to user %s", len(tasks), email
-            )
-        except email_service.EmailNotConfiguredError:
-            logger.warning("SMTP not configured; skipping overdue digest for %s", email)
-            continue
-        except RuntimeError as exc:  # pragma: no cover
-            logger.error("Failed to send overdue digest: %s", exc)
+        # Only stamp once something actually went out, so a channel that is
+        # merely unconfigured (no SMTP, no FCM) re-tries on the next poll
+        # instead of burning the user's one digest for the day.
+        delivered = False
+        if wants_email:
+            try:
+                await email_service.send_overdue_tasks_email(session, user, tasks)
+                delivered = True
+                logger.info(
+                    "overdue-digest: sent %d overdue task(s) to user %s",
+                    len(tasks),
+                    email,
+                )
+            except email_service.EmailNotConfiguredError:
+                logger.warning(
+                    "SMTP not configured; skipping overdue digest for %s", email
+                )
+            except RuntimeError as exc:  # pragma: no cover
+                logger.error("Failed to send overdue digest: %s", exc)
+        if wants_push:
+            delivered = await _send_overdue_push(session, user, tasks) or delivered
+        if not delivered:
             continue
         user.last_overdue_notification_at = now
         session.add(user)

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1250,11 +1250,11 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
     if not users:
         logger.debug("task-digest: no opted-in users")
         return
-    # Capture before routing — the gather expunges the identity map.
-    candidates = [
-        (u.id, u.email, u.email_task_assignment, u.push_task_assignment) for u in users
-    ]
-    for user_id, email, wants_email, wants_push in candidates:
+    # Capture before routing — the gather expunges the identity map. The
+    # channel preferences are deliberately NOT snapshotted here; they are read
+    # off the freshly reloaded row at delivery time.
+    candidates = [(u.id, u.email) for u in users]
+    for user_id, email in candidates:
         per_guild_items: dict[int, list[int]] = {}
         queued_at: list[datetime] = []
 
@@ -1327,7 +1327,10 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
         # so holding the queue for it would re-send nothing every poll forever.
         # Only a transient failure is worth another pass.
         retry = False
-        if wants_email is not False:
+        # Re-read the preferences off the row just reloaded, not the snapshot
+        # taken before the cross-guild gather: a channel switched off while the
+        # gather was running must not still be delivered to.
+        if user.email_task_assignment is not False:
             try:
                 await email_service.send_task_assignment_digest_email(
                     session, user, assignments
@@ -1345,12 +1348,24 @@ async def _run_assignment_digest_pass(session: AsyncSession, *, now: datetime) -
             except RuntimeError as exc:  # pragma: no cover
                 logger.error("Failed to send task digest: %s", exc)
                 retry = True
-        if wants_push is not False:
+        if user.push_task_assignment is not False:
             pushed, push_retry = await _send_assignment_push(session, user, assignments)
             delivered = delivered or pushed
             retry = retry or push_retry
         if retry and not delivered:
             continue
+        if retry:  # pragma: no cover — one channel got through, the other did not
+            # The two channels share one queue with a single processed marker,
+            # so the batch is consumed either way. Consuming loses one channel's
+            # copy; retaining would re-send the channel that already succeeded,
+            # and a duplicate digest is the louder failure. Logged so the loss
+            # is visible rather than silent.
+            logger.warning(
+                "task-digest: a channel failed after another delivered; "
+                "%d assignment(s) not retried for user %s",
+                len(assignments),
+                email,
+            )
         # Mark the gathered items processed, back in each guild's schema.
         for gid, item_ids in per_guild_items.items():
             if not item_ids:
@@ -1532,7 +1547,9 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
         logger.debug("overdue-digest: no users opted in")
         return
     # Capture plain fields up front: gathering routes per guild and expunges the
-    # identity map, which would detach these ORM rows.
+    # identity map, which would detach these ORM rows. The channel preferences
+    # are deliberately NOT snapshotted here; they are read off the freshly
+    # reloaded row at delivery time.
     candidates = [
         (
             u.id,
@@ -1540,20 +1557,10 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
             u.timezone,
             u.overdue_notification_time,
             u.last_overdue_notification_at,
-            u.email_overdue_tasks,
-            u.push_overdue_tasks,
         )
         for u in users
     ]
-    for (
-        user_id,
-        email,
-        user_tz,
-        notify_time,
-        last_at,
-        wants_email,
-        wants_push,
-    ) in candidates:
+    for user_id, email, user_tz, notify_time, last_at in candidates:
         tz = _resolve_timezone(user_tz)
         now_local = now.astimezone(tz)
         try:
@@ -1594,9 +1601,11 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
             continue
         # Only stamp once something actually went out, so a channel that is
         # merely unconfigured (no SMTP, no FCM) re-tries on the next poll
-        # instead of burning the user's one digest for the day.
+        # instead of burning the user's one digest for the day. Preferences are
+        # re-read off the row just reloaded, not the snapshot taken before the
+        # cross-guild gather, so a channel switched off meanwhile stays quiet.
         delivered = False
-        if wants_email:
+        if user.email_overdue_tasks:
             try:
                 await email_service.send_overdue_tasks_email(session, user, tasks)
                 delivered = True
@@ -1611,7 +1620,7 @@ async def _run_overdue_pass(session: AsyncSession, *, now: datetime) -> None:
                 )
             except RuntimeError as exc:  # pragma: no cover
                 logger.error("Failed to send overdue digest: %s", exc)
-        if wants_push:
+        if user.push_overdue_tasks:
             delivered = await _send_overdue_push(session, user, tasks) or delivered
         if not delivered:
             continue

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -29,9 +29,14 @@ from app.models.tenant.task import (
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.models.platform.user import User
 from app.services import email as email_service
+from app.services.platform import push_notifications
 from app.services.notifications import (
+    ASSIGNMENT_ITEM_RETENTION,
+    ASSIGNMENT_MAX_WINDOW,
+    ASSIGNMENT_QUIET_PERIOD,
     _format_event_when,
     _run_assignment_digest_pass,
+    _run_assignment_gc_pass,
     _run_event_reminder_pass,
     _run_overdue_pass,
     notify_initiative_membership,
@@ -398,6 +403,133 @@ async def test_overdue_digest_gathers_tasks_across_user_guilds(
     assert captured.get("titles") == {"Alpha overdue", "Beta overdue"}
 
 
+def _capture_push(monkeypatch) -> list[dict]:
+    """Record every ``send_push_to_user`` call instead of hitting FCM."""
+    sent: list[dict] = []
+
+    async def _fake_push(
+        *, session, user_id, notification_type, title, body, data=None
+    ):
+        sent.append(
+            {
+                "user_id": user_id,
+                "type": notification_type,
+                "title": title,
+                "body": body,
+                "data": data or {},
+            }
+        )
+        return 1
+
+    monkeypatch.setattr(push_notifications, "send_push_to_user", _fake_push)
+    return sent
+
+
+@pytest.mark.integration
+async def test_overdue_digest_pushes_alongside_email(
+    session: AsyncSession, monkeypatch
+):
+    """Push and email are the same digest on two channels: a user opted into
+    both must get both, and the push must carry a tappable deep link."""
+    user = await create_user(
+        session,
+        email="overdue-both@example.com",
+        email_overdue_tasks=True,
+        push_overdue_tasks=True,
+        overdue_notification_time="00:00",
+        timezone="UTC",
+    )
+    await _overdue_task_in_new_guild(session, user, label="Alpha")
+
+    emails: list[int] = []
+
+    async def _capture_email(sess, recipient, tasks):
+        emails.append(recipient.id)
+
+    monkeypatch.setattr(email_service, "send_overdue_tasks_email", _capture_email)
+    pushes = _capture_push(monkeypatch)
+
+    await set_rls_context(session)
+    await _run_overdue_pass(session, now=datetime.now(timezone.utc))
+
+    assert emails == [user.id]
+    assert len(pushes) == 1
+    push = pushes[0]
+    assert push["user_id"] == user.id
+    assert push["type"] == NotificationType.overdue_tasks
+    assert "Alpha overdue" in push["body"]
+    # The digest spans guilds, so the tap lands on the cross-guild My Tasks
+    # list — no guild_id, which is what tells the app not to switch guilds.
+    assert push["data"]["target_path"] == "/"
+    assert "guild_id" not in push["data"]
+
+
+@pytest.mark.integration
+async def test_overdue_digest_pushes_when_email_opted_out(
+    session: AsyncSession, monkeypatch
+):
+    """Turning the email off must not silence the push — the two toggles are
+    independent, and the day's send is still stamped so it fires once."""
+    user = await create_user(
+        session,
+        email="overdue-push-only@example.com",
+        email_overdue_tasks=False,
+        push_overdue_tasks=True,
+        overdue_notification_time="00:00",
+        timezone="UTC",
+    )
+    await _overdue_task_in_new_guild(session, user, label="Alpha")
+
+    async def _fail_email(sess, recipient, tasks):  # pragma: no cover
+        raise AssertionError("email must not be sent to an opted-out user")
+
+    monkeypatch.setattr(email_service, "send_overdue_tasks_email", _fail_email)
+    pushes = _capture_push(monkeypatch)
+
+    now = datetime.now(timezone.utc)
+    await set_rls_context(session)
+    await _run_overdue_pass(session, now=now)
+    assert len(pushes) == 1
+
+    # Second pass the same day is a no-op (the stamp landed on the push alone).
+    session.expunge_all()
+    await set_rls_context(session)
+    await _run_overdue_pass(session, now=now + timedelta(minutes=5))
+    assert len(pushes) == 1
+
+    refreshed = (
+        await session.exec(select(User).where(User.id == user.id))
+    ).one_or_none()
+    assert refreshed.last_overdue_notification_at is not None
+
+
+@pytest.mark.integration
+async def test_overdue_digest_skips_push_when_opted_out(
+    session: AsyncSession, monkeypatch
+):
+    """A user who wants only the email gets only the email."""
+    user = await create_user(
+        session,
+        email="overdue-email-only@example.com",
+        email_overdue_tasks=True,
+        push_overdue_tasks=False,
+        overdue_notification_time="00:00",
+        timezone="UTC",
+    )
+    await _overdue_task_in_new_guild(session, user, label="Alpha")
+
+    async def _capture_email(sess, recipient, tasks):
+        return None
+
+    monkeypatch.setattr(email_service, "send_overdue_tasks_email", _capture_email)
+    pushes = _capture_push(monkeypatch)
+
+    await set_rls_context(session)
+    await _run_overdue_pass(session, now=datetime.now(timezone.utc))
+
+    assert pushes == []
+
+
 async def _assignment_item_in_new_guild(
     session: AsyncSession, user: User, *, label: str
 ):
@@ -470,7 +602,10 @@ async def test_assignment_digest_gathers_items_across_user_guilds(
     )
 
     await set_rls_context(session)
-    await _run_assignment_digest_pass(session, now=datetime.now(timezone.utc))
+    # Past the quiet period, so the items have settled and the digest is due.
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_QUIET_PERIOD
+    )
 
     assert captured.get("user_id") == user.id
     assert captured.get("titles") == {"Alpha task", "Beta task"}
@@ -486,6 +621,196 @@ async def test_assignment_digest_gathers_items_across_user_guilds(
             )
         ).all()
         assert pending == [], f"guild {guild_id} items not marked processed"
+
+
+@pytest.mark.integration
+async def test_assignment_digest_waits_for_the_flurry_to_end(
+    session: AsyncSession, monkeypatch
+):
+    """The whole point of a digest: it must not fire on the first item while
+    more are still landing. The old behaviour emailed immediately and then
+    locked out for an hour, so a burst arrived as one mail plus a long delay."""
+    user = await create_user(session, email="debounce@example.com")
+    await _assignment_item_in_new_guild(session, user, label="Alpha")
+
+    sent: list[int] = []
+
+    async def _capture_email(sess, recipient, assignments):
+        sent.append(len(assignments))
+
+    monkeypatch.setattr(
+        email_service, "send_task_assignment_digest_email", _capture_email
+    )
+    _capture_push(monkeypatch)
+
+    # Item just landed — still accumulating, nothing goes out.
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(session, now=datetime.now(timezone.utc))
+    assert sent == []
+
+    # A second item lands, and the quiet period restarts from it: the run at
+    # what would have been the first item's deadline must still hold.
+    await _assignment_item_in_new_guild(session, user, label="Beta")
+    session.expunge_all()
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_QUIET_PERIOD / 2
+    )
+    assert sent == []
+
+    # Once it has been quiet, both items ship together.
+    session.expunge_all()
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_QUIET_PERIOD
+    )
+    assert sent == [2]
+
+
+@pytest.mark.integration
+async def test_assignment_digest_caps_a_steady_trickle(
+    session: AsyncSession, monkeypatch
+):
+    """A trickle that never goes quiet must not defer the digest forever —
+    the max window is what stops the quiet period from being gamed."""
+    user = await create_user(session, email="trickle@example.com")
+    await _assignment_item_in_new_guild(session, user, label="Alpha")
+
+    sent: list[int] = []
+
+    async def _capture_email(sess, recipient, assignments):
+        sent.append(len(assignments))
+
+    monkeypatch.setattr(
+        email_service, "send_task_assignment_digest_email", _capture_email
+    )
+    _capture_push(monkeypatch)
+
+    # An item that landed a moment ago would normally hold the digest, but the
+    # window opened long enough ago that it ships regardless.
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_MAX_WINDOW
+    )
+    assert sent == [1]
+
+
+@pytest.mark.integration
+async def test_assignment_digest_sends_both_channels_together(
+    session: AsyncSession, monkeypatch
+):
+    """Email and push now ship from the same pass on the same trigger, so the
+    two channels can't tell different stories about the same assignments."""
+    user = await create_user(session, email="digest-both@example.com")
+    await _assignment_item_in_new_guild(session, user, label="Alpha")
+    await _assignment_item_in_new_guild(session, user, label="Beta")
+
+    emails: list[int] = []
+
+    async def _capture_email(sess, recipient, assignments):
+        emails.append(len(assignments))
+
+    monkeypatch.setattr(
+        email_service, "send_task_assignment_digest_email", _capture_email
+    )
+    pushes = _capture_push(monkeypatch)
+
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_QUIET_PERIOD
+    )
+
+    assert emails == [2]
+    assert len(pushes) == 1
+    # A multi-task digest spans guilds, so it lands on My Tasks.
+    assert pushes[0]["data"]["count"] == "2"
+    assert pushes[0]["data"]["target_path"] == "/"
+    assert "guild_id" not in pushes[0]["data"]
+
+
+@pytest.mark.integration
+async def test_assignment_digest_of_one_deep_links_to_the_task(
+    session: AsyncSession, monkeypatch
+):
+    """A digest of one has an unambiguous destination, so it keeps the deep
+    link the old per-task push had."""
+    user = await create_user(session, email="digest-one@example.com")
+    guild = await _assignment_item_in_new_guild(session, user, label="Alpha")
+
+    async def _capture_email(sess, recipient, assignments):
+        return None
+
+    monkeypatch.setattr(
+        email_service, "send_task_assignment_digest_email", _capture_email
+    )
+    pushes = _capture_push(monkeypatch)
+
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_QUIET_PERIOD
+    )
+
+    assert len(pushes) == 1
+    assert pushes[0]["data"]["guild_id"] == str(guild.id)
+    assert pushes[0]["data"]["target_path"].startswith("/tasks/")
+
+
+@pytest.mark.integration
+async def test_assignment_digest_pushes_when_email_opted_out(
+    session: AsyncSession, monkeypatch
+):
+    """Queueing is gated on either channel, so a push-only user still gets the
+    digest — previously the queue row was written only for email."""
+    user = await create_user(
+        session,
+        email="digest-push-only@example.com",
+        email_task_assignment=False,
+        push_task_assignment=True,
+    )
+    await _assignment_item_in_new_guild(session, user, label="Alpha")
+
+    async def _fail_email(sess, recipient, assignments):  # pragma: no cover
+        raise AssertionError("email must not be sent to an opted-out user")
+
+    monkeypatch.setattr(email_service, "send_task_assignment_digest_email", _fail_email)
+    pushes = _capture_push(monkeypatch)
+
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_QUIET_PERIOD
+    )
+
+    assert len(pushes) == 1
+
+
+@pytest.mark.integration
+async def test_assignment_gc_drops_items_past_retention(session: AsyncSession):
+    """Digest items accumulated forever — nothing ever deleted them. The sweep
+    clears anything past the retention window, sent or not, so an orphaned
+    queue can't grow without bound either."""
+    user = await create_user(session, email="digest-gc@example.com")
+    guild = await _assignment_item_in_new_guild(session, user, label="Alpha")
+
+    async def _row_count() -> int:
+        session.expunge_all()
+        await set_rls_context(session, user_id=user.id, guild_id=guild.id)
+        rows = (await session.exec(select(TaskAssignmentDigestItem))).all()
+        return len(rows)
+
+    assert await _row_count() == 1
+
+    # Well inside the window: nothing is touched.
+    session.expunge_all()
+    await set_rls_context(session)
+    await _run_assignment_gc_pass(session, now=datetime.now(timezone.utc))
+    assert await _row_count() == 1
+
+    session.expunge_all()
+    await set_rls_context(session)
+    await _run_assignment_gc_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_ITEM_RETENTION
+    )
+    assert await _row_count() == 0
 
 
 @pytest.mark.integration

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -784,6 +784,40 @@ async def test_assignment_digest_pushes_when_email_opted_out(
 
 
 @pytest.mark.integration
+async def test_assignment_digest_honours_a_preference_changed_mid_pass(
+    session: AsyncSession, monkeypatch
+):
+    """The pass snapshots its candidates, then spends time routing through each
+    guild. A channel switched off in that gap must not still be delivered to —
+    the send has to read the reloaded row, not the snapshot."""
+    user = await create_user(session, email="pref-race@example.com")
+    await _assignment_item_in_new_guild(session, user, label="Alpha")
+
+    async def _fail_email(sess, recipient, assignments):  # pragma: no cover
+        raise AssertionError("email must not be sent after opting out")
+
+    monkeypatch.setattr(email_service, "send_task_assignment_digest_email", _fail_email)
+    pushes = _capture_push(monkeypatch)
+
+    # Turn the email off after the items were queued — as a request handled
+    # while the worker is mid-gather would.
+    session.expunge_all()
+    await set_rls_context(session, user_id=user.id)
+    fresh = (await session.exec(select(User).where(User.id == user.id))).one()
+    fresh.email_task_assignment = False
+    session.add(fresh)
+    await session.commit()
+
+    session.expunge_all()
+    await set_rls_context(session)
+    await _run_assignment_digest_pass(
+        session, now=datetime.now(timezone.utc) + ASSIGNMENT_QUIET_PERIOD
+    )
+
+    assert len(pushes) == 1  # push is still on, and still delivers
+
+
+@pytest.mark.integration
 async def test_assignment_gc_drops_items_past_retention(session: AsyncSession):
     """Digest items accumulated forever — nothing ever deleted them. The sweep
     clears anything past the retention window, sent or not, so an orphaned

--- a/backend/app/services/platform/push_notifications.py
+++ b/backend/app/services/platform/push_notifications.py
@@ -19,6 +19,43 @@ FCM_API_URL = "https://fcm.googleapis.com/v1/projects/{project_id}/messages:send
 # OAuth2 scopes required for FCM
 FCM_SCOPES = ["https://www.googleapis.com/auth/firebase.messaging"]
 
+# Android notification channel a given notification type is delivered on. The
+# channel is what the user sees (and can mute) in the OS notification settings,
+# so related types share one rather than getting a row each.
+#
+# These ids must exist in the installed app — see NotificationChannelManager in
+# frontend/android, which registers exactly this set. A type absent here (the
+# in-app-only ones, which never push) falls back to the general channel; adding
+# a NEW channel id means a native release, so prefer an existing one.
+DEFAULT_CHANNEL = "default"
+PUSH_CHANNELS: dict[NotificationType, str] = {
+    NotificationType.task_assignment: "task_assignment",
+    NotificationType.overdue_tasks: "overdue_tasks",
+    NotificationType.initiative_added: "initiative_added",
+    NotificationType.project_added: "project_added",
+    NotificationType.user_pending_approval: "user_pending_approval",
+    NotificationType.mention: "mention",
+    NotificationType.comment_on_task: "comments",
+    NotificationType.comment_on_document: "comments",
+    NotificationType.comment_reply: "comments",
+    NotificationType.event_invitation: "calendar_events",
+    NotificationType.event_updated: "calendar_events",
+    NotificationType.event_cancelled: "calendar_events",
+    NotificationType.event_rsvp: "calendar_events",
+    NotificationType.event_reminder: "event_reminder",
+    NotificationType.access_grant_requested: "access_grants",
+    NotificationType.access_grant_approved: "access_grants",
+    NotificationType.access_grant_denied: "access_grants",
+    NotificationType.access_grant_revoked: "access_grants",
+}
+
+
+def channel_for(notification_type: Optional[NotificationType]) -> str:
+    """Android channel id for a notification type."""
+    if notification_type is None:
+        return DEFAULT_CHANNEL
+    return PUSH_CHANNELS.get(notification_type, DEFAULT_CHANNEL)
+
 
 def _get_fcm_access_token() -> Optional[str]:
     """Get OAuth2 access token from service account credentials.
@@ -52,7 +89,7 @@ async def _send_to_fcm(
     title: str,
     body: str,
     data: Optional[Dict[str, Any]] = None,
-    notification_type: Optional[str] = None,
+    channel_id: Optional[str] = None,
 ) -> tuple[bool, bool]:
     """Send a push notification via FCM HTTP v1 API.
 
@@ -61,7 +98,7 @@ async def _send_to_fcm(
         title: Notification title
         body: Notification body
         data: Optional data payload (must be string key-value pairs)
-        notification_type: Type of notification for Android channel routing
+        channel_id: Android notification channel to deliver on
 
     Returns:
         Tuple of (success, should_delete_token):
@@ -94,10 +131,10 @@ async def _send_to_fcm(
     message = {"message": fcm_message}
 
     # Add Android-specific configuration for notification channels
-    if notification_type:
+    if channel_id:
         fcm_message["android"] = {
             "notification": {
-                "channel_id": notification_type,  # Maps to Android channel ID
+                "channel_id": channel_id,
             }
         }
 
@@ -156,7 +193,7 @@ async def send_push_notification(
     body: str,
     data: Optional[Dict[str, Any]] = None,
     platform: str = "android",
-    notification_type: Optional[str] = None,
+    channel_id: Optional[str] = None,
 ) -> tuple[bool, bool]:
     """Send a push notification to a single device.
 
@@ -166,14 +203,14 @@ async def send_push_notification(
         body: Notification body
         data: Optional data payload
         platform: Platform identifier ('android' or 'ios')
-        notification_type: Type of notification for Android channel routing
+        channel_id: Android notification channel to deliver on
 
     Returns:
         Tuple of (success, should_delete_token):
         - success: True if notification was sent successfully
         - should_delete_token: True if token is invalid and should be deleted
     """
-    return await _send_to_fcm(push_token, title, body, data, notification_type)
+    return await _send_to_fcm(push_token, title, body, data, channel_id)
 
 
 async def send_push_to_user(
@@ -210,8 +247,7 @@ async def send_push_to_user(
     successful = 0
     tokens_to_delete = []
 
-    # Convert NotificationType enum to string for channel routing
-    notification_type_str = notification_type.value if notification_type else None
+    channel_id = channel_for(notification_type)
 
     for token_record in tokens:
         success, should_delete = await send_push_notification(
@@ -220,7 +256,7 @@ async def send_push_to_user(
             body=body,
             data=data,
             platform=token_record.platform,
-            notification_type=notification_type_str,
+            channel_id=channel_id,
         )
 
         if success:

--- a/backend/app/services/platform/push_notifications_test.py
+++ b/backend/app/services/platform/push_notifications_test.py
@@ -1,0 +1,80 @@
+"""Channel routing for push notifications.
+
+The Android channel a notification lands on is chosen here and sent to FCM in
+the payload; the app can only honour a channel it already created. Nothing at
+runtime reconciles the two, so these tests hold the backend map and the app's
+registered channels together.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.models.platform.notification import NotificationType
+from app.services.platform.push_notifications import (
+    DEFAULT_CHANNEL,
+    PUSH_CHANNELS,
+    channel_for,
+)
+
+_ANDROID_CHANNELS = (
+    Path(__file__).resolve().parents[3]
+    / ".."
+    / "frontend"
+    / "android"
+    / "app"
+    / "src"
+    / "main"
+    / "java"
+    / "com"
+    / "morelitea"
+    / "initiative"
+    / "NotificationChannelManager.java"
+)
+
+# Types that only ever become an in-app notification — no push is sent for
+# them, so they need no channel of their own.
+_IN_APP_ONLY = {
+    NotificationType.export_ready,
+    NotificationType.export_failed,
+    NotificationType.import_ready,
+    NotificationType.import_failed,
+}
+
+
+@pytest.mark.unit
+def test_every_pushed_notification_type_has_a_channel():
+    """A new notification type that pushes must pick a channel. Defaulting is
+    silent — the notification still arrives, just filed under "General" where
+    the user can't mute it separately from everything else."""
+    assert set(PUSH_CHANNELS) == set(NotificationType) - _IN_APP_ONLY
+
+
+@pytest.mark.unit
+def test_in_app_only_types_fall_back_to_the_general_channel():
+    for notification_type in _IN_APP_ONLY:
+        assert channel_for(notification_type) == DEFAULT_CHANNEL
+    assert channel_for(None) == DEFAULT_CHANNEL
+
+
+@pytest.mark.unit
+def test_channels_are_registered_by_the_android_app():
+    """Every channel the backend routes to must be one the app creates on
+    launch. A channel id the app never created is not an error anywhere — the
+    notification quietly lands in Firebase's own fallback channel instead."""
+    source = _ANDROID_CHANNELS.read_text(encoding="utf-8")
+    # Each channel is declared as `String CHANNEL_X = "<id>";`
+    registered = set(re.findall(r'String CHANNEL_\w+ = "([^"]+)"', source))
+    assert registered, "no channel constants found — did the Java file move?"
+
+    missing = (set(PUSH_CHANNELS.values()) | {DEFAULT_CHANNEL}) - registered
+    assert not missing, f"channels missing from the Android app: {sorted(missing)}"
+
+    # Each declared constant must also be passed to createChannel(), or it is
+    # a name the app never actually registers.
+    created = set(re.findall(r"CHANNEL_(\w+),", source))
+    declared = set(re.findall(r"String CHANNEL_(\w+) = ", source))
+    assert declared - created == set(), (
+        f"declared but never created: {sorted(declared - created)}"
+    )

--- a/docs/en/guides/notifications.md
+++ b/docs/en/guides/notifications.md
@@ -27,7 +27,7 @@ The categories are:
 | Category | You're notified when… |
 |---|---|
 | **Initiative invites** | You're added to a new initiative. |
-| **Task assignments** | Someone assigns you tasks (sent as an hourly summary, not one-by-one). |
+| **Task assignments** | Someone assigns you tasks (sent as one summary, not one-by-one). |
 | **Mentions** | Someone `@mentions` you or comments on your work. |
 | **New project in initiative** | A project is created in one of your initiatives. |
 | **Overdue tasks** | A daily reminder of what's past due, at a time you choose. |
@@ -44,6 +44,7 @@ The categories are:
 
 A couple of categories are about *when*, not just *whether*:
 
+- **Task assignments** arrive as one summary once the dust settles: Initiative waits until nothing new has been assigned to you for a few minutes, so a batch of tasks reaches you as a single message rather than a stream. If assignments keep arriving, the summary is sent anyway within half an hour. Email and mobile follow the same schedule, so you never get the same news twice at different times.
 - **Overdue tasks** arrive as one **daily digest** at a time you set, in your **timezone**. Set both on the same Notifications page.
 - **Event reminders** can be set per event — at the start, or a chosen number of minutes, hours, or days before.
 

--- a/frontend/android/app/src/main/java/com/morelitea/initiative/NotificationChannelManager.java
+++ b/frontend/android/app/src/main/java/com/morelitea/initiative/NotificationChannelManager.java
@@ -9,16 +9,32 @@ import android.util.Log;
 /**
  * Manages notification channels for different types of push notifications.
  * Android O (API 26) and above require notification channels for all notifications.
+ *
+ * A channel is what the user sees (and can mute) in the OS notification
+ * settings, so related notification types share one rather than getting a row
+ * each. The backend picks the channel per notification and sends its id in the
+ * FCM payload — see PUSH_CHANNELS in backend/app/services/platform/
+ * push_notifications.py, which must stay in sync with the ids created here.
+ * A notification naming a channel this app never created lands in Firebase's
+ * own fallback channel instead, so a new channel id needs a native release.
+ *
+ * Channel ids are permanent: renaming one orphans whatever the user configured
+ * on the old channel, so change the display name, not the id.
  */
 public class NotificationChannelManager {
     private static final String TAG = "NotificationChannels";
 
-    // Channel IDs - must match backend notification types exactly
+    // Channel IDs - must match the backend's PUSH_CHANNELS values exactly
     public static final String CHANNEL_TASK_ASSIGNMENT = "task_assignment";
+    public static final String CHANNEL_OVERDUE_TASKS = "overdue_tasks";
     public static final String CHANNEL_INITIATIVE_ADDED = "initiative_added";
     public static final String CHANNEL_PROJECT_ADDED = "project_added";
     public static final String CHANNEL_USER_PENDING_APPROVAL = "user_pending_approval";
     public static final String CHANNEL_MENTION = "mention";
+    public static final String CHANNEL_COMMENTS = "comments";
+    public static final String CHANNEL_CALENDAR_EVENTS = "calendar_events";
+    public static final String CHANNEL_EVENT_REMINDER = "event_reminder";
+    public static final String CHANNEL_ACCESS_GRANTS = "access_grants";
     public static final String CHANNEL_DEFAULT = "default";
 
     /**
@@ -42,99 +58,118 @@ public class NotificationChannelManager {
         }
 
         // 1. Task Assignment Channel
-        NotificationChannel taskChannel = new NotificationChannel(
+        createChannel(
+            notificationManager,
             CHANNEL_TASK_ASSIGNMENT,
             "Task Assignments",
+            "Notifications when you're assigned to a task",
             NotificationManager.IMPORTANCE_HIGH
         );
-        taskChannel.setDescription("Notifications when you're assigned to a task");
-        taskChannel.enableVibration(true);
-        taskChannel.setShowBadge(true);
-        notificationManager.createNotificationChannel(taskChannel);
 
-        // 2. Initiative Added Channel
-        NotificationChannel initiativeChannel = new NotificationChannel(
+        // 2. Overdue Tasks Channel
+        createChannel(
+            notificationManager,
+            CHANNEL_OVERDUE_TASKS,
+            "Overdue Tasks",
+            "Your daily summary of tasks past their due date",
+            NotificationManager.IMPORTANCE_DEFAULT
+        );
+
+        // 3. Initiative Added Channel
+        createChannel(
+            notificationManager,
             CHANNEL_INITIATIVE_ADDED,
             "Initiative Invites",
+            "Notifications when you're added to an initiative",
             NotificationManager.IMPORTANCE_DEFAULT
         );
-        initiativeChannel.setDescription("Notifications when you're added to an initiative");
-        initiativeChannel.enableVibration(true);
-        initiativeChannel.setShowBadge(true);
-        notificationManager.createNotificationChannel(initiativeChannel);
 
-        // 3. Project Added Channel
-        NotificationChannel projectChannel = new NotificationChannel(
+        // 4. Project Added Channel
+        createChannel(
+            notificationManager,
             CHANNEL_PROJECT_ADDED,
             "New Projects",
+            "Notifications when projects are created in your initiatives",
             NotificationManager.IMPORTANCE_DEFAULT
         );
-        projectChannel.setDescription("Notifications when projects are created in your initiatives");
-        projectChannel.enableVibration(true);
-        projectChannel.setShowBadge(true);
-        notificationManager.createNotificationChannel(projectChannel);
 
-        // 4. User Pending Approval Channel
-        NotificationChannel userApprovalChannel = new NotificationChannel(
+        // 5. User Pending Approval Channel
+        createChannel(
+            notificationManager,
             CHANNEL_USER_PENDING_APPROVAL,
             "User Approvals",
+            "Notifications when new users request access",
             NotificationManager.IMPORTANCE_DEFAULT
         );
-        userApprovalChannel.setDescription("Notifications when new users request access");
-        userApprovalChannel.enableVibration(true);
-        userApprovalChannel.setShowBadge(true);
-        notificationManager.createNotificationChannel(userApprovalChannel);
 
-        // 5. Mentions Channel
-        NotificationChannel mentionChannel = new NotificationChannel(
+        // 6. Mentions Channel
+        createChannel(
+            notificationManager,
             CHANNEL_MENTION,
             "Mentions",
+            "Notifications when someone mentions you",
             NotificationManager.IMPORTANCE_HIGH
         );
-        mentionChannel.setDescription("Notifications when someone mentions you in a document");
-        mentionChannel.enableVibration(true);
-        mentionChannel.setShowBadge(true);
-        notificationManager.createNotificationChannel(mentionChannel);
 
-        // 6. Default Channel (fallback)
-        NotificationChannel defaultChannel = new NotificationChannel(
-            CHANNEL_DEFAULT,
-            "General Notifications",
+        // 7. Comments Channel
+        createChannel(
+            notificationManager,
+            CHANNEL_COMMENTS,
+            "Comments",
+            "Notifications when someone comments on or replies to your work",
             NotificationManager.IMPORTANCE_DEFAULT
         );
-        defaultChannel.setDescription("General app notifications");
-        defaultChannel.enableVibration(true);
-        defaultChannel.setShowBadge(true);
-        notificationManager.createNotificationChannel(defaultChannel);
+
+        // 8. Calendar Events Channel
+        createChannel(
+            notificationManager,
+            CHANNEL_CALENDAR_EVENTS,
+            "Calendar Events",
+            "Invitations, updates, cancellations, and RSVPs for events",
+            NotificationManager.IMPORTANCE_DEFAULT
+        );
+
+        // 9. Event Reminders Channel
+        createChannel(
+            notificationManager,
+            CHANNEL_EVENT_REMINDER,
+            "Event Reminders",
+            "Reminders ahead of events you're attending",
+            NotificationManager.IMPORTANCE_HIGH
+        );
+
+        // 10. Access Grants Channel
+        createChannel(
+            notificationManager,
+            CHANNEL_ACCESS_GRANTS,
+            "Access Requests",
+            "Updates on requests for temporary access to a guild",
+            NotificationManager.IMPORTANCE_DEFAULT
+        );
+
+        // 11. Default Channel (fallback)
+        createChannel(
+            notificationManager,
+            CHANNEL_DEFAULT,
+            "General Notifications",
+            "General app notifications",
+            NotificationManager.IMPORTANCE_DEFAULT
+        );
 
         Log.i(TAG, "Notification channels created successfully");
     }
 
-    /**
-     * Get the channel ID for a notification type.
-     * Maps backend notification types to Android channel IDs.
-     *
-     * @param notificationType Backend notification type (e.g., "task_assignment")
-     * @return Android channel ID
-     */
-    public static String getChannelIdForType(String notificationType) {
-        if (notificationType == null) {
-            return CHANNEL_DEFAULT;
-        }
-
-        switch (notificationType) {
-            case "task_assignment":
-                return CHANNEL_TASK_ASSIGNMENT;
-            case "initiative_added":
-                return CHANNEL_INITIATIVE_ADDED;
-            case "project_added":
-                return CHANNEL_PROJECT_ADDED;
-            case "user_pending_approval":
-                return CHANNEL_USER_PENDING_APPROVAL;
-            case "mention":
-                return CHANNEL_MENTION;
-            default:
-                return CHANNEL_DEFAULT;
-        }
+    private static void createChannel(
+        NotificationManager notificationManager,
+        String id,
+        String name,
+        String description,
+        int importance
+    ) {
+        NotificationChannel channel = new NotificationChannel(id, name, importance);
+        channel.setDescription(description);
+        channel.enableVibration(true);
+        channel.setShowBadge(true);
+        notificationManager.createNotificationChannel(channel);
     }
 }

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2893,6 +2893,7 @@ export type NotificationType = (typeof NotificationType)[keyof typeof Notificati
 
 export const NotificationType = {
   task_assignment: "task_assignment",
+  overdue_tasks: "overdue_tasks",
   initiative_added: "initiative_added",
   project_added: "project_added",
   user_pending_approval: "user_pending_approval",

--- a/frontend/src/hooks/usePushNotifications.tsx
+++ b/frontend/src/hooks/usePushNotifications.tsx
@@ -107,13 +107,19 @@ export const usePushNotifications = (): UsePushNotificationsReturn => {
             // Handle notification tap (navigate to target)
             console.log("Push notification action performed:", notification);
             const data = notification.notification.data;
-            if (data.target_path && data.guild_id) {
+            if (data.target_path) {
               const targetPath = data.target_path as string;
-              const guildId = data.guild_id as string;
-              router.navigate({
-                to: "/navigate",
-                search: { guild_id: guildId, target: targetPath },
-              });
+              const guildId = data.guild_id as string | undefined;
+              if (guildId) {
+                router.navigate({
+                  to: "/navigate",
+                  search: { guild_id: guildId, target: targetPath },
+                });
+              } else {
+                // Cross-guild notifications (e.g. the overdue digest) name an
+                // app-level route with no guild to switch into.
+                router.navigate({ to: targetPath });
+              }
             }
           }
         );


### PR DESCRIPTION
## Problem

The mobile app and email did not tell the same story about the same events.

- **Overdue tasks never reached the phone.** The daily digest was email-only, even though `push_overdue_tasks` had existed all along in the model, the API, and the settings grid — nothing ever read it.
- **The assignment digest did not digest.** The hour was a lockout *after* sending, not a window to accumulate in, so the first assignment after a quiet hour was emailed alone within two minutes and everything for the next hour was held. Meanwhile push fired once per task. A burst of twelve meant twelve buzzes and one email.
- **Turning the assignment email off silenced push too**, because the queue row was only written when the email preference was on.

Two bugs fell out along the way: `app_admin` held SELECT/INSERT/DELETE on `push_tokens` but not UPDATE, while `send_push_to_user` stamps `last_used_at` after every successful delivery — so every push the system engine sent (background digests, PAM notices) reached FCM and then faulted on the bookkeeping write, which also meant tokens FCM reported as unregistered were never pruned. And nothing had ever deleted a digest item, so every task assignment ever made left a permanent row behind.

## Changes

### Timing
- [`_digest_is_due`](backend/app/services/notifications.py) replaces the hour lockout: the digest ships once nothing new has arrived for 5 minutes, or once the oldest queued item hits 30 minutes. A lone assignment still lands promptly, a burst arrives as one message, and a trickle cannot defer it forever. Poll interval dropped 120s → 60s so the quiet period is not padded by scheduling lag.
- `last_task_assignment_digest_at` is now only a record (it is serialized on the user); nothing schedules off it.

### Channel parity
- The instant per-task push is gone from `enqueue_task_assignment_event`; both channels ship from the digest pass on one trigger, and the queue row is written when **either** preference is on. The in-app bell is unchanged and still lists each assignment as it happens.
- `_run_overdue_pass` considers users opted into either channel and dispatches to both. Each pass stamps only once something actually went out, so an unconfigured channel retries rather than burning the day's digest.
- Push bodies are bounded regardless of batch size — one title plus a count (`"12 tasks assigned to you, including Fix the header"`). Only the email enumerates. A digest of one keeps a deep link to its task; anything larger opens My Tasks.
- [usePushNotifications.tsx](frontend/src/hooks/usePushNotifications.tsx) required both `target_path` and `guild_id` to navigate and silently did nothing otherwise; a bare `target_path` is now treated as an app-level route, which is what a cross-guild digest needs.

### Android notification channels
- The registered set covered 5 of the 16 types that push, so comments, calendar events, event reminders and access grants all landed in Firebase's unsorted fallback. The channel choice moves to the backend ([`PUSH_CHANNELS`](backend/app/services/platform/push_notifications.py)), related types share a channel, and [NotificationChannelManager.java](frontend/android/app/src/main/java/com/morelitea/initiative/NotificationChannelManager.java) registers exactly that set. Existing channel ids are unchanged so nobody's per-channel settings are orphaned; the dead `getChannelIdForType` is removed rather than kept as a second copy of the mapping.
- [push_notifications_test.py](backend/app/services/platform/push_notifications_test.py) parses the Java constants and fails if the two sides drift, or if a new notification type silently falls back to "General".

### Bug fixes
- `GRANT UPDATE ON push_tokens TO app_admin`, recorded in the [system_grants](backend/app/db/system_grants.py) registry and applied by migration `20260814_0181`.
- [`_set_task_assignees`](backend/app/api/v1/tenant_endpoints/tasks.py) reads the previous assignees before replacing them and withdraws the un-sent digest item for anyone dropped, so an assignment undone in the window is not announced.
- An hourly GC sweep clears digest items past a 7-day retention.
- Clearing the shared queue now only happens on the transition to *both* channels off — switching just the email off must not discard pending pushes.
- [notifications.md](docs/en/guides/notifications.md) documented the hourly summary, which is no longer true.

## Notes for review

`MIN_NATIVE_VERSION` will bump automatically at release: `promote.sh` detects the `frontend/android` change and CI will build an APK rather than shipping OTA-only. Devices that stay on the old APK get the new channel ids for comments, events and access grants, which land in the fallback channel — exactly where those notifications go today, so nothing regresses.

The migration is renumbered to `0181` because `0180` landed on `dev` (#1173) while this was in progress.

## Testing

- `cd backend && ruff check app` — clean
- `cd backend && pytest app/db/ app/services/notifications_test.py app/services/platform/push_notifications_test.py app/api/v1/tenant_endpoints/tasks_test.py app/api/v1/platform_endpoints/users_test.py` — 473 passed
- Full `app/services` + `app/api/v1` sweep before the base moved — 2525 passed; the one failure (`test_register_with_invite_blocked_when_guild_full`) is the known local `.env` captcha leak, issue #1048
- `cd frontend && pnpm typecheck` — clean; `pnpm biome check` on changed files — clean
- `cd frontend && ./scripts/test-changed.sh` — 1497 passed
- Verified the OpenAPI spec is byte-identical apart from the new `overdue_tasks` enum value, and committed the regenerated types