### PR TITLE
Frame apps from the registrations, not the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **An app is told who you are without being told which account you are.** Apps now know each member by an identifier unique to that app's own installation, rather than by an account id shared across everything. Two apps cannot compare notes and work out they are dealing with the same person, and an app installed in two guilds cannot link those guilds to one of your members.
 
+### Fixed
+
+- **An app's page opens wherever the app is, however you got there, however long you have been signed in.** An app placed in an initiative now loads its page instead of an empty frame. So does one reached by clicking through the sidebar rather than by opening its address directly, and one opened after a long-running tab has been sitting idle. The browser permission an embedded app needs is now settled by which app services the deployment has connected, so it no longer depends on which page a tab happened to load first or on how recently you signed in.
+
 ## [0.62.5] - 2026-08-14
 
 ### Added

--- a/backend/app/api/embed_csp.py
+++ b/backend/app/api/embed_csp.py
@@ -1,146 +1,60 @@
-"""The frame policy for the document that opens an app's embed.
+"""The frame policy carried by the documents this deployment serves.
 
 An embedded app runs in a cross-origin iframe, which the app-wide
-``Content-Security-Policy`` forbids by default. The permission is granted for
-**one** document: the response that serves the embed route names that one app's
-registered origins, and every other response names none.
+``Content-Security-Policy`` forbids by default. The permission comes from the
+deployment's own registrations: ``app_service_registrations`` is the operator's
+trusted-site list, and the live ones' origins are what ``frame-src`` names.
 
-Scoping it this way rather than listing every registered app is deliberate. A
-unioned header would grow with the size of the catalog — hundreds of origins on
-every response for a capability almost no page uses — and would advertise each
-app's origins to pages that have nothing to do with it. Per document, it is one
-or two entries whatever the deployment installed.
+An origin reaches that list one way — an operator wires up an app service, and
+that service's handshake confirms the manifest it serves. So the header
+describes what this deployment runs. It names no guild, no install and no
+reader, and it is the same header on every document, which is what makes it
+answerable without a session and stable for as long as the operator's
+configuration is.
 
-Who is asking matters too. The origins are resolved only for a member of the
-guild in the path, so the header describes an app to the people who already see
-that app in their sidebar, and to nobody else. Anything unresolvable — a
-malformed path, no session, not a member, no such install, an app service this
-deployment never wired up — yields the ordinary policy, which frames nothing.
+The kill switch reaches it too: a registration that is stopped, or whose last
+verification found a different manifest behind it, is not live, and its origins
+leave the header within the registration cache's TTL.
+
+``connect-src`` is untouched — an app's data reaches the browser same-origin
+through the proxy.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Optional
-
-from fastapi import Request
-from sqlmodel import select
+from functools import lru_cache
 
 from app.core.config import settings
-from app.db import session as db_session
-from app.models.platform.guild import GuildMembership
-from app.models.tenant.guild_app import GuildApp
 from app.services.marketplace import registration_lookup
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["embed_document_csp", "parse_embed_path", "resolve_frame_origins"]
+__all__ = ["app_frame_policy"]
 
 
-def parse_embed_path(path: str) -> Optional[tuple[int, int]]:
-    """``g/{guild_id}/apps/{app_id}`` → the two ids, or ``None``.
-
-    Read explicitly rather than by pattern so the only thing that can come out
-    of it is a pair of positive integers — the ids then address a real row or
-    nothing at all.
-    """
-    parts = [part for part in path.strip("/").split("/") if part]
-    if len(parts) != 4 or parts[0] != "g" or parts[2] != "apps":
-        return None
-    if not parts[1].isdigit() or not parts[3].isdigit():
-        return None
-    guild_id, app_id = int(parts[1]), int(parts[3])
-    if guild_id <= 0 or app_id <= 0:
-        return None
-    return guild_id, app_id
-
-
-async def resolve_frame_origins(
-    *, guild_id: int, app_id: int, user_id: int
-) -> tuple[str, ...]:
-    """The origins the named install may be framed from, for this member.
-
-    Reads on the system engine, routed into the guild as an admin: the install
-    row lives in that guild's schema, and the caller's membership has already
-    been checked against the same guild. Only non-secret registration fields
-    leave this function.
-    """
-    async with db_session.AdminSessionLocal() as session:
-        membership = (
-            await session.exec(
-                # Composite primary key (guild_id, user_id) — there is no id
-                # column to select here.
-                select(GuildMembership.user_id).where(
-                    GuildMembership.guild_id == guild_id,
-                    GuildMembership.user_id == user_id,
-                )
-            )
-        ).first()
-        if membership is None:
-            return ()
-
-        await db_session.set_rls_context(session, guild_id=guild_id, guild_role="admin")
-        app = (
-            await session.exec(
-                select(GuildApp).where(
-                    GuildApp.id == app_id, GuildApp.guild_id == guild_id
-                )
-            )
-        ).first()
-        if app is None or not app.enabled:
-            return ()
-        definition = app.definition
-
-    registration = await registration_lookup.registration_for_definition(definition)
-    if registration is None or not registration.live:
-        return ()
-    return registration.allowed_origins
-
-
-async def embed_document_csp(request: Request, path: str) -> Optional[str]:
-    """The scoped policy for this document, or ``None`` for the ordinary one.
+async def app_frame_policy() -> str:
+    """The policy for a served document: the app-wide one, admitting the frame
+    origins this deployment's live registrations name.
 
     Deliberately fail-soft: a document is served either way, and the fallback is
     the stricter policy. Nothing here is allowed to cost a page load, so an
     unexpected failure is logged and the caller carries on.
     """
-    parsed = parse_embed_path(path)
-    if parsed is None:
-        return None
-    guild_id, app_id = parsed
-
     try:
-        user = await _current_user(request)
-        if user is None:
-            return None
-        origins = await resolve_frame_origins(
-            guild_id=guild_id, app_id=app_id, user_id=user.id
-        )
+        origins = await registration_lookup.frame_origins()
     except Exception:
-        logger.warning("embed CSP: could not resolve %s", path, exc_info=True)
-        return None
-
-    if not origins:
-        return None
-    return settings.content_security_policy_with_frames(origins)
+        logger.warning("embed CSP: could not read the frame origins", exc_info=True)
+        return settings.content_security_policy
+    return _policy_for(origins)
 
 
-async def _current_user(request: Request):
-    """Whoever is asking, or ``None``.
+@lru_cache(maxsize=8)
+def _policy_for(origins: tuple[str, ...]) -> str:
+    """The assembled header for one set of origins.
 
-    The SPA shell is served to anonymous visitors too, so this resolves a
-    session when there is one and answers ``None`` otherwise. It runs only for
-    the embed route — the catch-all also serves every static asset, and opening
-    a database session for those would be a per-request cost for nothing.
+    Built once per distinct set rather than once per document: the set changes
+    only when an operator changes a registration, and the string is the same
+    every time until they do.
     """
-    from app.api.deps import get_current_user_optional
-    from app.core.security import SESSION_COOKIE_NAME
-
-    header = request.headers.get("Authorization", "")
-    bearer = header[7:] if header[:7].lower() == "bearer " else None
-    cookie = request.cookies.get(SESSION_COOKIE_NAME)
-    if not bearer and not cookie:
-        return None
-
-    async with db_session.AsyncSessionLocal() as session:
-        return await get_current_user_optional(request, session, bearer, cookie)
+    return settings.content_security_policy_with_frames(origins)

--- a/backend/app/api/embed_csp_test.py
+++ b/backend/app/api/embed_csp_test.py
@@ -1,167 +1,74 @@
-"""Which document may frame which app.
+"""Which origins a served document may frame.
 
-The property under test is narrowness. A page that opens one app's embed is
-allowed to frame **that app's** origins; every other page, and every other app,
-gets nothing. A policy that listed every registered app would work just as well
-for the app being opened — and would also hand every page in the product the
-address of every integration the deployment has ever approved, growing with the
-catalog forever. So the assertions are as much about what is *absent* from the
-header as about what is present.
-
-The other half is who is asking. Only a member of the guild in the path gets the
-permission, so the header describes an app to people who already see it in their
-sidebar.
+The property under test is that the answer is a property of the **deployment**:
+the origins of the app services an operator has wired up and whose handshake
+confirmed the manifest behind them. So the same header goes to every document,
+it names no guild, install or reader, and an operator's kill switch is the
+thing that takes an origin back out of it.
 """
 
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.api.embed_csp import parse_embed_path, resolve_frame_origins
+from app.api.embed_csp import app_frame_policy
 from app.core.config import settings
 from app.models.platform.app_service_registration import AppServiceStatus
-from app.models.platform.guild import GuildRole
-from app.services.marketplace.registration_lookup import invalidate_registrations
-from app.testing import (
-    create_app_service_registration,
-    create_guild,
-    create_guild_app,
-    create_guild_membership,
-    create_user,
-    marketplace_uid,
+from app.services.marketplace import registration_lookup
+from app.services.marketplace.registration_lookup import (
+    frame_origins,
+    invalidate_registrations,
 )
+from app.testing import create_app_service_registration
 
 pytestmark = pytest.mark.asyncio
 
-APP_ID = "tests.framed"
-OTHER_ID = "tests.other"
+FRAMED = "https://framed.example.test"
+SECOND = "https://second.example.test"
 
 
-def _definition(public_id: str = APP_ID) -> dict:
-    return {
-        "app_kind": "service",
-        "service": {"public_id": public_id, "protocol": 1},
-        "features": ["embeds"],
-        "embeds": [
-            {
-                "id": "board",
-                "path": "/embed/board",
-                "visibility": "member",
-                "name": {"en": "Board"},
-            }
-        ],
-    }
+class TestTheRegisteredOrigins:
+    async def test_a_live_registration_is_named(self, session: AsyncSession):
+        await create_app_service_registration(
+            session,
+            public_id="tests.framed",
+            base_url=FRAMED,
+            allowed_origins=[FRAMED],
+        )
 
+        assert FRAMED in await frame_origins()
 
-class TestParsingTheRoute:
-    @pytest.mark.unit
-    def test_it_reads_the_embed_route(self):
-        assert parse_embed_path("/g/7/apps/12") == (7, 12)
-        assert parse_embed_path("g/7/apps/12") == (7, 12)
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "path",
-        [
-            "",
-            "/",
-            "/g/7/apps",
-            "/g/7/apps/12/extra",
-            "/g/seven/apps/12",
-            "/g/7/projects/12",
-            "/g/0/apps/12",
-            "/g/-1/apps/12",
-            "/api/v1/g/7/apps/12",
-        ],
-    )
-    def test_everything_else_is_not_an_embed_document(self, path: str):
-        assert parse_embed_path(path) is None
-
-
-class TestResolvingOrigins:
-    async def test_a_member_gets_the_opened_app_and_nothing_else(
+    async def test_every_live_registration_is_named_once_and_in_order(
         self, session: AsyncSession
     ):
-        user = await create_user(session, email="framed@example.com")
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(
-            session, user=user, guild=guild, role=GuildRole.admin
-        )
-        app = await create_guild_app(
+        """Two apps served from one origin put it on the list once. The order
+        is the sorted one, so the header is the same string until a
+        registration changes rather than varying with row order."""
+        await create_app_service_registration(
             session,
-            guild,
-            user,
-            definition=_definition(),
-            listing_uid=marketplace_uid("framed"),
+            public_id="tests.first",
+            base_url=FRAMED,
+            allowed_origins=[FRAMED, SECOND],
         )
         await create_app_service_registration(
             session,
-            public_id=APP_ID,
-            base_url="https://framed.example.test",
-            allowed_origins=["https://framed.example.test"],
-        )
-        # A second registered app the guild is not opening. Its origins must not
-        # appear anywhere near this document.
-        await create_app_service_registration(
-            session,
-            public_id=OTHER_ID,
-            base_url="https://other.example.test",
-            allowed_origins=["https://other.example.test"],
+            public_id="tests.second",
+            base_url=SECOND,
+            allowed_origins=[SECOND],
         )
 
-        origins = await resolve_frame_origins(
-            guild_id=guild.id, app_id=app.id, user_id=user.id
-        )
-        assert origins == ("https://framed.example.test",)
+        origins = await frame_origins()
+        assert FRAMED in origins
+        assert origins.count(SECOND) == 1
+        assert list(origins) == sorted(origins)
 
-        policy = settings.content_security_policy_with_frames(origins)
-        frame_src = _directive(policy, "frame-src")
-        assert "https://framed.example.test" in frame_src
-        assert "https://other.example.test" not in policy
-
-    async def test_a_non_member_gets_nothing(self, session: AsyncSession):
-        owner = await create_user(session, email="owner@example.com")
-        guild = await create_guild(session, creator=owner)
-        await create_guild_membership(
-            session, user=owner, guild=guild, role=GuildRole.admin
-        )
-        app = await create_guild_app(
-            session,
-            guild,
-            owner,
-            definition=_definition(),
-            listing_uid=marketplace_uid("framed"),
-        )
-        await create_app_service_registration(
-            session, public_id=APP_ID, base_url="https://framed.example.test"
-        )
-        outsider = await create_user(session, email="outsider@example.com")
-
-        assert (
-            await resolve_frame_origins(
-                guild_id=guild.id, app_id=app.id, user_id=outsider.id
-            )
-            == ()
-        )
-
-    async def test_a_deactivated_registration_frames_nothing(
-        self, session: AsyncSession
-    ):
-        """The kill switch reaches the header too: a stopped app is not framed
+    async def test_a_stopped_registration_is_not_named(self, session: AsyncSession):
+        """The kill switch reaches the header: a stopped app is not framed
         while it is stopped."""
-        user = await create_user(session, email="stopped@example.com")
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(
-            session, user=user, guild=guild, role=GuildRole.admin
-        )
-        app = await create_guild_app(
-            session,
-            guild,
-            user,
-            definition=_definition(),
-            listing_uid=marketplace_uid("framed"),
-        )
         registration = await create_app_service_registration(
-            session, public_id=APP_ID, base_url="https://framed.example.test"
+            session,
+            public_id="tests.stopped",
+            base_url=FRAMED,
+            allowed_origins=[FRAMED],
         )
 
         registration.enabled = False
@@ -169,32 +76,16 @@ class TestResolvingOrigins:
         await session.commit()
         invalidate_registrations()
 
-        assert (
-            await resolve_frame_origins(
-                guild_id=guild.id, app_id=app.id, user_id=user.id
-            )
-            == ()
-        )
+        assert FRAMED not in await frame_origins()
 
-    async def test_an_unverified_registration_frames_nothing(
-        self, session: AsyncSession
-    ):
-        """The origins named here come from a manifest, so the header waits on
-        the verification that says which manifest this service serves."""
-        user = await create_user(session, email="drifted@example.com")
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(
-            session, user=user, guild=guild, role=GuildRole.admin
-        )
-        app = await create_guild_app(
-            session,
-            guild,
-            user,
-            definition=_definition(),
-            listing_uid=marketplace_uid("drifted"),
-        )
+    async def test_an_unverified_registration_is_not_named(self, session: AsyncSession):
+        """The origins come from a manifest, so the header waits on the
+        verification that says which manifest this service serves."""
         registration = await create_app_service_registration(
-            session, public_id=APP_ID, base_url="https://drifted.example.test"
+            session,
+            public_id="tests.drifted",
+            base_url=FRAMED,
+            allowed_origins=[FRAMED],
         )
 
         registration.status = AppServiceStatus.MANIFEST_MISMATCH
@@ -202,43 +93,57 @@ class TestResolvingOrigins:
         await session.commit()
         invalidate_registrations()
 
-        assert (
-            await resolve_frame_origins(
-                guild_id=guild.id, app_id=app.id, user_id=user.id
-            )
-            == ()
-        )
+        assert FRAMED not in await frame_origins()
 
-    async def test_an_app_with_no_service_frames_nothing(self, session: AsyncSession):
-        """A tool instance mounts one of this build's own tools; there is no
-        third-party frame in it to permit."""
-        user = await create_user(session, email="tool@example.com")
-        guild = await create_guild(session, creator=user)
-        await create_guild_membership(
-            session, user=user, guild=guild, role=GuildRole.admin
-        )
-        app = await create_guild_app(
+
+class TestThePolicy:
+    async def test_a_document_may_frame_a_registered_app(self, session: AsyncSession):
+        await create_app_service_registration(
             session,
-            guild,
-            user,
-            definition={"app_kind": "tool_instance", "tool": "calendar"},
-            listing_uid=marketplace_uid("calendarapp"),
+            public_id="tests.framed",
+            base_url=FRAMED,
+            allowed_origins=[FRAMED],
         )
 
-        assert (
-            await resolve_frame_origins(
-                guild_id=guild.id, app_id=app.id, user_id=user.id
-            )
-            == ()
+        assert FRAMED in _directive(await app_frame_policy(), "frame-src")
+
+    async def test_a_deployment_with_nothing_live_frames_nothing(
+        self, session: AsyncSession
+    ):
+        """Nothing live, nothing named: the document carries the same policy
+        the middleware puts on everything else."""
+        registration = await create_app_service_registration(
+            session,
+            public_id="tests.stopped",
+            base_url=FRAMED,
+            allowed_origins=[FRAMED],
         )
+        registration.enabled = False
+        session.add(registration)
+        await session.commit()
+        invalidate_registrations()
+
+        assert await app_frame_policy() == settings.content_security_policy
+
+    async def test_an_unreadable_list_leaves_the_ordinary_policy(self, monkeypatch):
+        """Answered, not raised: this runs on the route that serves every
+        document, so the fallback is the stricter policy and the page still
+        loads."""
+
+        async def boom() -> tuple[str, ...]:
+            raise RuntimeError("no")
+
+        monkeypatch.setattr(registration_lookup, "frame_origins", boom)
+
+        assert await app_frame_policy() == settings.content_security_policy
 
 
 @pytest.mark.unit
 def test_the_ordinary_policy_frames_no_app():
-    """Every document that is not opening an embed carries this one."""
-    policy = settings.content_security_policy
-    frame_src = _directive(policy, "frame-src")
-    assert "example.test" not in frame_src
+    """What the middleware puts on every response that is not a document."""
+    assert "example.test" not in _directive(
+        settings.content_security_policy, "frame-src"
+    )
 
 
 def _directive(policy: str, name: str) -> str:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -291,7 +291,7 @@ class Settings(BaseSettings):
     def content_security_policy_with_frames(
         self, app_frame_origins: Sequence[str]
     ) -> str:
-        """The app-wide CSP, optionally admitting one app's frame origins.
+        """The app-wide CSP, optionally admitting the registered frame origins.
 
         Locks down the high-value vectors (``object-src``/``base-uri``/
         ``frame-ancestors``/``form-action``) and confines scripts to
@@ -304,13 +304,12 @@ class Settings(BaseSettings):
         ``https:``.
 
         ``app_frame_origins`` is how a marketplace app's embedded surface gets
-        framed, and it is deliberately **per document**: the response that opens
-        one app's embed names that app's registered origins, and every other
-        response names none. Listing every registered app instead would make
-        this header grow with the size of the catalog, on every response, for a
-        capability almost no page uses — and would advertise each app's origins
-        to pages that have nothing to do with it. ``connect-src`` is untouched:
-        an app's data reaches the browser same-origin through the proxy.
+        framed. It holds the origins of the app services this deployment has
+        registered — the operator's trusted-site list, passed in by
+        ``app.api.embed_csp`` on the documents where ``frame-src`` applies, and
+        empty here so the app-wide default names none. ``connect-src`` is
+        untouched: an app's data reaches the browser same-origin through the
+        proxy.
         """
         ws = "wss:" if self.APP_URL.startswith("https") else "ws:"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import get_upload_user
-from app.api.embed_csp import embed_document_csp
+from app.api.embed_csp import app_frame_policy
 from app.core.body_limit import BodySizeLimitMiddleware
 from app.api.v1.api import api_router
 from app.core.messages import GuildMessages
@@ -690,7 +690,7 @@ def _resolve_static_file(path: str) -> Path | None:
 
 
 @app.get("/{full_path:path}", include_in_schema=False)
-async def serve_spa(request: Request, full_path: str) -> FileResponse:
+async def serve_spa(full_path: str) -> FileResponse:
     if _is_reserved_path(full_path):
         raise HTTPException(status_code=404)
     static_file = _resolve_static_file(full_path) if full_path else None
@@ -707,13 +707,13 @@ async def serve_spa(request: Request, full_path: str) -> FileResponse:
             headers={"Cache-Control": "public, max-age=3600"},
         )
     if static_index_path.is_file():
-        headers = {"Cache-Control": "no-cache"}
-        # The document that opens one app's embed carries the frame permission
-        # for that app's registered origins; every other document carries none
-        # (see app.api.embed_csp). The middleware sets the app-wide policy with
-        # setdefault, so this scoped one wins where it applies.
-        scoped_csp = await embed_document_csp(request, full_path)
-        if scoped_csp is not None:
-            headers["Content-Security-Policy"] = scoped_csp
+        # A document is where `frame-src` means anything, so the registered app
+        # origins are named here rather than on every response (see
+        # app.api.embed_csp). The middleware sets the app-wide policy with
+        # setdefault, so this one wins.
+        headers = {
+            "Cache-Control": "no-cache",
+            "Content-Security-Policy": await app_frame_policy(),
+        }
         return FileResponse(static_index_path, headers=headers)
     raise HTTPException(status_code=404, detail="SPA bundle not found")

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -9,10 +9,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from fastapi.exceptions import RequestValidationError
 from httpx import ASGITransport, AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 import app.main as main_module
 from app.core.config import API_V1_STR, Settings, settings
 from app.main import SecurityHeadersMiddleware, validation_exception_handler
+from app.testing import create_app_service_registration
 
 
 @pytest.mark.unit
@@ -105,6 +107,50 @@ async def test_only_the_widget_sandbox_asset_carries_its_policy(
     other_csp = other_resp.headers.get("content-security-policy", "")
     assert "'wasm-unsafe-eval'" not in other_csp
     assert "script-src 'self'" in other_csp
+
+
+# --- The registered app frame origins (named on documents, and only there) ---
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "route",
+    ["/g/7/apps/12", "/g/7/initiatives/3/apps/12", "/"],
+)
+async def test_every_document_frames_the_registered_apps(
+    client: AsyncClient, session: AsyncSession, route: str
+) -> None:
+    """One header, whatever the route. An app opens the same way from a guild
+    page, from inside an initiative, and from a tab the SPA navigated to after
+    loading somewhere else — so the permission cannot be a property of which
+    document the browser happened to ask for."""
+    await create_app_service_registration(
+        session,
+        public_id="tests.framed",
+        base_url="https://framed.example.test",
+        allowed_origins=["https://framed.example.test"],
+    )
+    index = main_module.static_index_path
+    # A real build leaves one here; only a run without one writes and removes it.
+    written = not index.is_file()
+    if written:
+        index.parent.mkdir(parents=True, exist_ok=True)
+        index.write_text("<!doctype html>\n")
+    try:
+        document = await client.get(route)
+        api = await client.get("/api/v1/config")
+    finally:
+        if written:
+            index.unlink(missing_ok=True)
+
+    assert document.status_code == 200
+    assert "https://framed.example.test" in document.headers.get(
+        "content-security-policy", ""
+    )
+    # Only a document frames anything, so every other response is unchanged.
+    assert "https://framed.example.test" not in api.headers.get(
+        "content-security-policy", ""
+    )
 
 
 @pytest.mark.integration

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -49,6 +49,7 @@ __all__ = [
     "delegation_allowed",
     "resolve_delegated_member",
     "delegation_keys_for",
+    "frame_origins",
     "install_state",
     "invalidate_registrations",
     "load_registrations",
@@ -174,6 +175,31 @@ async def load_registrations(*, force: bool = False) -> dict[str, RegistrationSn
     _cache = snapshots
     _loaded_at = time.monotonic()
     return snapshots
+
+
+async def frame_origins() -> tuple[str, ...]:
+    """Every origin an app surface may be framed from, deduped and ordered.
+
+    This deployment's registrations are its trusted-site list. An origin gets
+    on it by an operator wiring up an app service and that service's handshake
+    confirming the manifest it serves — so what comes back describes the
+    services this deployment runs, and says nothing about any guild or reader.
+
+    Only live registrations count, which is how the operator's kill switch and
+    a failed re-verification reach the frame policy: within the cache TTL, a
+    stopped or drifted app's origins are gone from it.
+    """
+    snapshots = await load_registrations()
+    return tuple(
+        sorted(
+            {
+                origin
+                for snapshot in snapshots.values()
+                if snapshot.live
+                for origin in snapshot.allowed_origins
+            }
+        )
+    )
 
 
 def service_public_id(definition: dict[str, Any] | None) -> Optional[str]:


### PR DESCRIPTION
## Problem

`frame-src` named one app's origins on one document: the response serving `g/{guild_id}/apps/{app_id}`, resolved from the session cookie on that request. Binding the permission to the SPA shell document produced three failures.

- **An app opened inside an initiative was never framed.** `/g/{guild_id}/initiatives/{initiative_id}/apps/{app_id}` is six segments; the parser accepted four, so it resolved to nothing and the document got the ordinary policy.
- **Reaching an app by clicking through kept the wrong policy.** A document's CSP holds for that document's life and does not change on `history.pushState`, so a sidebar click — a client-side navigation — carried whatever policy the tab first loaded. The permission existed only when the tab was hard-loaded at the embed URL.
- **It lapsed with the session.** The `session_token` cookie's max-age is the access token's lifetime (15 min on the new model, 60 on the legacy one) and the SPA only renews on a 401, so a reload after an idle spell resolved no reader and fell back to the ordinary policy. Reported as "the CSP times out after about an hour."

## Change

The origins are the deployment's own. `app_service_registrations` is its trusted-site list — an origin gets on it by an operator wiring up a service and that service's handshake confirming the manifest it serves — and every served document names the live ones.

This is the shape [Salesforce CSP Trusted Sites](https://help.salesforce.com/s/articleView?id=csp_trusted_sites.htm&language=en_US&type=5) (an org-level list an admin ticks `frame-src` on) and [Atlassian Forge](https://developer.atlassian.com/platform/forge/add-content-security-and-egress-controls/) (`permissions.external.frames`, static per app version) both ship: static configuration, not a per-request answer, so there is nothing to go stale mid-session and nothing that varies by which document a tab happened to load.

The catalog-growth objection the old design rested on conflated two sets — the marketplace **catalog** (listings, unbounded) and this deployment's **registrations** (services an operator wired up and holds a shared secret for, a handful). Only the second reaches the header.

Net effect on what the header discloses: it no longer asserts which guild has which app installed. It names the app services the deployment runs, and nothing about a reader.

## Notable

- `registration_lookup.frame_origins()` — the live registrations' origins, deduped and sorted, off the existing 60s snapshot cache with its existing `invalidate_registrations()` write hook. The operator's kill switch and a failed re-verification both reach the header through `live`.
- `embed_csp.app_frame_policy()` — assembled once per distinct origin set, fail-soft to the ordinary policy.
- Named on the SPA document only, not in the middleware: `frame-src` means nothing on an API or asset response, and this keeps the registration read off that path entirely.
- **Removed with it:** `parse_embed_path`, the membership lookup that opened its own admin session and `SET ROLE`d into the guild, and the hand-rolled bearer/cookie extraction that ran on the static-file catch-all. `serve_spa` no longer takes a `Request`. Net −106 lines.
- No frontend change. `GuildAppPage` is untouched — the handoff mint, the origin-checked `postMessage` exchange, and the sandbox/`allow` attributes are all as they were.

## Testing

```
pytest app/api/embed_csp_test.py app/main_test.py \
       app/services/marketplace/registrations_test.py app/core/config_test.py
# 130 passed
ruff check app && ruff format app
ty check   # clean on changed files
```

New coverage: the origin list (live, deduped, ordered; a stopped one leaves; a drifted one leaves), the policy (a live registration is framed; nothing live is the ordinary policy; an unreadable list is answered rather than raised), and end-to-end through the SPA route that `/g/7/apps/12`, `/g/7/initiatives/3/apps/12` and `/` all carry the same header while `/api/v1/config` carries none of it.