### PR TITLE
Say which half of the document the schema describes

### DIFF
--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -413,11 +413,14 @@ def build_manifest_schema() -> dict[str, Any]:
     return {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": SCHEMA_ID,
-        "title": "Initiative app manifest",
+        "title": "Initiative app manifest (the 'definition' body)",
         "description": (
-            "What a service app may declare at "
-            "/.well-known/initiative-app.json. Generated from the platform's "
-            f"own validator vocabulary. {_AUTHORITY_NOTE}"
+            "What a service app declares it can do. This is the 'definition' "
+            "field of the document served at /.well-known/initiative-app.json, "
+            "NOT that whole document: a registrar also requires "
+            "protocol_version, public_id and kind alongside it, and refuses a "
+            "definition served bare. Generated from the platform's own "
+            f"validator vocabulary. {_AUTHORITY_NOTE}"
         ),
         "type": "object",
         "required": ["app_kind", "service", "features"],

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://initiative.morels.me/schemas/app-manifest-v1.json",
-  "title": "Initiative app manifest",
-  "description": "What a service app may declare at /.well-known/initiative-app.json. Generated from the platform's own validator vocabulary. A manifest that satisfies this schema is well-formed, not necessarily acceptable. Cross-references (a widget's data sources, a requires term's connection, an event's service prefix), the features/blocks cross-check in both directions, UTF-8 byte-size caps, and the conditional rules for connect_path and initiative visibility are enforced by the platform on publish and are not expressible here.",
+  "title": "Initiative app manifest (the 'definition' body)",
+  "description": "What a service app declares it can do. This is the 'definition' field of the document served at /.well-known/initiative-app.json, NOT that whole document: a registrar also requires protocol_version, public_id and kind alongside it, and refuses a definition served bare. Generated from the platform's own validator vocabulary. A manifest that satisfies this schema is well-formed, not necessarily acceptable. Cross-references (a widget's data sources, a requires term's connection, an event's service prefix), the features/blocks cross-check in both directions, UTF-8 byte-size caps, and the conditional rules for connect_path and initiative visibility are enforced by the platform on publish and are not expressible here.",
   "type": "object",
   "required": [
     "app_kind",


### PR DESCRIPTION
## Problem

`build_manifest_schema` generates from `normalize_service_app_definition`, so what it describes is the **`definition` body** — `app_kind`, `service`, `features` and the blocks behind them. Its title and description called it something else:

> "What a service app may declare at /.well-known/initiative-app.json"

That is the whole served document, which `perform_handshake` also requires `protocol_version`, `public_id` and `kind` on. An author who reads the schema as the served shape builds something refused on a field the schema never mentions.

That is not hypothetical. `initiative-app-kit` typed its `Manifest` from this schema and told apps to serve it bare; `initiative-github` — the public reference app — did exactly that, and is unregisterable today:

```
REFUSED: APP_SERVICE_INVALID_MANIFEST | protocol_version must be an integer
```

The SDK and the reference app are being fixed (Morelitea/initiative-app-kit#1, Morelitea/initiative-github#1). This is the label they both read.

## Change

Retitles to `Initiative app manifest (the 'definition' body)` and says in the description that it is the `definition` field of the served document rather than the document, naming what a registrar additionally requires.

Doc-only. Every property keeps its shape, the vocabulary is unchanged, and `$id` is untouched so a pinned consumer still resolves it. `_AUTHORITY_NOTE` is unchanged too — the kit asserts a phrase from it.

## Testing

`uv run pytest app/services/marketplace/manifest_schema_test.py` — 35 passed, including the on-disk-matches-generator check, so the regenerated `schemas/app-manifest.json` is committed alongside.

## Note for consumers

The exported file's bytes change, so anything pinning it wants a bump afterwards — Morelitea/initiative_auto#75 pins this by commit and will need its `SCHEMA_REF` moved.

## Worth considering separately

`_read_manifest_document` accepts both a wrapper and a flat document "because both shapes appear in the wild". Given the confusion above, some of that wild is arguably this label rather than genuine divergence — but narrowing it is a compatibility decision, not a doc fix, so it is left alone here.