### PR TITLE
Let an app ship dashboards with itself

### DIFF
--- a/backend/alembic/versions/20260815_0182_bundled_dashboard_listings.py
+++ b/backend/alembic/versions/20260815_0182_bundled_dashboard_listings.py
@@ -1,0 +1,55 @@
+"""Mark a dashboard listing an app ships with itself.
+
+An app that declares widgets otherwise leaves every guild to arrange them. A
+publisher can now ship ready-made arrangements in the manifest, and publishing
+the app derives one ordinary ``dashboard`` listing per entry.
+
+They are ordinary in every respect a guild can see — same kind, same uid rules,
+installed by the same call — because a dashboard published to share and one that
+arrives with an app are the same thing to whoever installs it. This column
+carries the two ways they differ: such a listing is offered only to guilds that
+have the app installed, and it is published and withdrawn with the app rather
+than on its own.
+
+Nullable with no backfill: every existing listing was published on its own,
+which is exactly what NULL means.
+
+Revision ID: 20260815_0182
+Revises: 20260814_0181
+Create Date: 2026-08-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260815_0182"
+down_revision = "20260814_0181"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "marketplace_listings",
+        sa.Column("bundled_with_uid", sa.String(length=14), nullable=True),
+        schema="public",
+    )
+    # The read this exists for runs on every catalog browse inside a guild:
+    # "which of these are bundled, and with what".
+    op.create_index(
+        "ix_marketplace_listings_bundled_with_uid",
+        "marketplace_listings",
+        ["bundled_with_uid"],
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_marketplace_listings_bundled_with_uid",
+        table_name="marketplace_listings",
+        schema="public",
+    )
+    op.drop_column("marketplace_listings", "bundled_with_uid", schema="public")

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -472,6 +472,10 @@ class MarketplaceMessages:
     #: by its publisher, or its only versions need a newer app.
     LISTING_UNAVAILABLE = "MARKETPLACE_LISTING_UNAVAILABLE"
     LISTING_VERSION_INCOMPATIBLE = "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE"
+    #: A dashboard that ships with an app, asked for by a guild that does not
+    #: have that app installed. Its tiles draw that app's widgets, so there
+    #: would be nothing behind any of them.
+    LISTING_NEEDS_APP = "MARKETPLACE_LISTING_NEEDS_APP"
     #: An upgrade was asked for on a dashboard that was authored here, not
     #: installed — there is no listing to re-pin it to.
     NOT_INSTALLED_FROM_LISTING = "MARKETPLACE_NOT_INSTALLED_FROM_LISTING"

--- a/backend/app/models/platform/marketplace.py
+++ b/backend/app/models/platform/marketplace.py
@@ -105,6 +105,23 @@ class MarketplaceListing(SQLModel, table=True):
     installs_count: int = Field(
         default=0, sa_column=Column(Integer, nullable=False, server_default="0")
     )
+    # Set on a dashboard listing an app ships with itself; NULL on anything
+    # published on its own.
+    #
+    # A bundled dashboard is an ordinary listing in every other respect — same
+    # kind, same uid rules, installed by the same call — because a dashboard
+    # somebody publishes to share and a dashboard that arrives with an app are
+    # the same thing to the guild installing it. This column carries the two
+    # ways they differ: it is offered only to guilds that have that app, and it
+    # is published and withdrawn with the app rather than on its own.
+    #
+    # The uid rather than a foreign key. Both rows come from one manifest, and a
+    # referential cascade here would be a second mechanism for a lifecycle the
+    # publish already owns.
+    bundled_with_uid: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(UID_LENGTH), nullable=True, index=True),
+    )
     # False once a registry withdraws a listing. Never deleted: installed
     # instances keep working and keep their provenance.
     available: bool = Field(

--- a/backend/app/services/marketplace/bundled_dashboards_test.py
+++ b/backend/app/services/marketplace/bundled_dashboards_test.py
@@ -186,6 +186,104 @@ class TestPublishing:
             )
 
 
+class TestItCannotTakeOverSomebodyElsesListing:
+    """Both identities matching is what an *update* looks like, so this is the
+    one path where a publish reaches an existing row rather than being refused
+    by the uniqueness rules. Ownership has to be checked on its own."""
+
+    async def _standalone(
+        self, session, uid=DASH_UID, public_id="tests.tracker-overview"
+    ):
+        # Deliberately a *different* version from the app's. Publishing at the
+        # same one would collide on version immutability and refuse for a reason
+        # that has nothing to do with ownership — which is how this case hid.
+        await service.upsert_listing(
+            session,
+            {
+                **_app_manifest(version="0.9.0"),
+                "uid": uid,
+                "public_id": public_id,
+                "kind": "dashboard",
+                "name": "Somebody else's board",
+                "definition": {"widgets": []},
+            },
+            source="operator",
+        )
+        await session.commit()
+
+    async def test_it_cannot_adopt_a_standalone_dashboard(self, session):
+        await self._standalone(session)
+
+        with pytest.raises(CatalogError):
+            await service.upsert_listing(
+                session, _app_manifest([_dashboard()]), source="operator"
+            )
+
+    async def test_the_standalone_listing_is_left_alone(self, session):
+        await self._standalone(session)
+
+        with pytest.raises(CatalogError):
+            await service.upsert_listing(
+                session, _app_manifest([_dashboard()]), source="operator"
+            )
+        await session.rollback()
+
+        untouched = await _by_uid(session, DASH_UID)
+        assert untouched.name == "Somebody else's board"
+        assert untouched.bundled_with_uid is None
+
+    async def test_it_cannot_adopt_another_app_s_dashboard(self, session):
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        # A different version too, so version immutability cannot be what
+        # refuses it — ownership has to be.
+        other = _app_manifest([_dashboard()], version="2.0.0")
+        other["uid"] = "P3R9WT5HZ2NM6D"
+        other["public_id"] = "tests.other-app"
+        other["definition"]["service"]["public_id"] = "tests.other-app"
+
+        with pytest.raises(CatalogError):
+            await service.upsert_listing(session, other, source="operator")
+
+    async def test_a_standalone_publish_cannot_adopt_a_bundled_one(self, session):
+        """The mirror. An operator dropping a file with a uid an app already
+        bundles must not edit that row, or take it out of the app's lifecycle."""
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        with pytest.raises(CatalogError):
+            await service.upsert_listing(
+                session,
+                {
+                    **_app_manifest(version="3.0.0"),
+                    "uid": DASH_UID,
+                    "public_id": "tests.tracker-overview",
+                    "kind": "dashboard",
+                    "name": "Mine now",
+                    "definition": {"widgets": []},
+                },
+                source="operator",
+            )
+
+    async def test_republishing_the_same_app_is_not_a_takeover(self, session):
+        """The case all of this has to stay out of the way of."""
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()], version="1.0.0"), source="operator"
+        )
+        await session.commit()
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()], version="2.0.0"), source="operator"
+        )
+        await session.commit()
+
+        assert (await _by_uid(session, DASH_UID)).bundled_with_uid == APP_UID
+
+
 class TestLifecycle:
     async def test_they_version_with_the_app(self, session):
         await service.upsert_listing(

--- a/backend/app/services/marketplace/bundled_dashboards_test.py
+++ b/backend/app/services/marketplace/bundled_dashboards_test.py
@@ -1,0 +1,382 @@
+"""Dashboards an app ships with itself.
+
+A publisher who declares widgets otherwise leaves every guild to arrange them.
+The point of bundling is that the operator adds one file and the arrangements
+come with it — so what these check is mostly about *identity and lifecycle*: the
+derived listing is an ordinary one, it is the publisher's own uid rather than
+anything invented here, and it lives and dies with the app that supplied it.
+
+The one case worth reading first is the last: a bundled dashboard is offered
+only where its app is installed, and that has to be decided at install and not
+only in the browse response, because a uid seen in one guild is otherwise just
+as installable in the next.
+"""
+
+import pytest
+from sqlmodel import select
+
+from app.models.platform.marketplace import MarketplaceListing
+from app.services.marketplace import catalog as service
+from app.services.marketplace.catalog import CatalogError
+from app.services.marketplace.installs import (
+    ListingInstallError,
+    resolve_listing_install,
+)
+from app.testing import create_guild, create_guild_app, create_user
+from app.testing.schema_harness import route_session_to_guild
+
+pytestmark = pytest.mark.asyncio
+
+APP_UID = "TYG4VVZKAWRMBZ"
+DASH_UID = "J9H7S9T7GP7FAG"
+OTHER_DASH_UID = "P3R9WT5HZ2NM6D"
+
+
+def _dashboard(uid=DASH_UID, public_id="tests.tracker-overview", **overrides):
+    entry = {
+        "uid": uid,
+        "public_id": public_id,
+        "name": "Tracker overview",
+        "description": "At a glance.",
+        "layout": {"columns": 12},
+        "widgets": [
+            {
+                "type": "open-items",
+                "title": "Open",
+                "grid": {"x": 0, "y": 0, "w": 4, "h": 3},
+                "binding": {"source_id": "open-items"},
+            }
+        ],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _app_manifest(dashboards=None, version="1.0.0"):
+    definition = {
+        "app_kind": "service",
+        "service": {"public_id": "tests.tracker", "protocol": 1},
+        "features": ["data", "widgets"],
+        "data_sources": [{"id": "open-items", "path": "/data/open-items"}],
+        "widgets": [
+            {
+                "id": "open-items",
+                "meta": {"name": {"en": "Open items"}},
+                "module_source": "export default () => ({});",
+                "sources": ["open-items"],
+            }
+        ],
+    }
+    if dashboards is not None:
+        definition["features"] = [*definition["features"], "dashboards"]
+        definition["dashboards"] = dashboards
+    return {
+        "uid": APP_UID,
+        "public_id": "tests.tracker",
+        "kind": "app",
+        "name": "Tracker",
+        "publisher": "Tests",
+        "description": "Track the things.",
+        "avatar_url": "/marketplace/tracker.svg",
+        "version": version,
+        "definition": definition,
+    }
+
+
+async def _by_uid(session, uid):
+    return (
+        await session.exec(
+            select(MarketplaceListing).where(MarketplaceListing.uid == uid)
+        )
+    ).first()
+
+
+class TestPublishing:
+    async def test_publishing_the_app_publishes_its_dashboards(self, session):
+        """One file for the operator. That is the whole point of the block."""
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        dashboard = await _by_uid(session, DASH_UID)
+        assert dashboard is not None
+        assert dashboard.kind == "dashboard"
+        assert dashboard.bundled_with_uid == APP_UID
+        # Inherited, because it *is* the app's publish.
+        assert dashboard.publisher == "Tests"
+        assert dashboard.source == "operator"
+
+    async def test_the_derived_row_is_an_ordinary_listing(self, session):
+        """Nothing downstream should be able to tell it was derived: a guild
+        installs it with the same call it installs any other dashboard with."""
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        dashboard = await _by_uid(session, DASH_UID)
+        version = await service.get_listing_version(
+            session, dashboard.latest_version_id
+        )
+        definition = version.definition
+
+        assert definition["kind"] == "dashboard"
+        assert definition["schema_version"] == 1
+        assert definition["layout"] == {"columns": 12}
+        widget = definition["widgets"][0]
+        # Resolved to the namespaced form here, from the app's own uid — a
+        # publisher writes a bare widget id and never a uid, so the two cannot
+        # disagree.
+        assert widget["type"] == f"app:{APP_UID}:open-items"
+        assert widget["binding"] == {
+            "source": "app",
+            "app_uid": APP_UID,
+            "source_id": "open-items",
+        }
+
+    async def test_it_carries_no_artwork_of_its_own(self, session):
+        """A dashboard previews by rendering its widgets against their sample
+        data, which cannot go stale against the app the way a picture would."""
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        dashboard = await _by_uid(session, DASH_UID)
+        assert dashboard.avatar_url == service.DEFAULT_AVATAR_URL
+        assert dashboard.images == []
+
+    async def test_an_app_with_no_dashboards_publishes_one_row(self, session):
+        await service.upsert_listing(session, _app_manifest(), source="operator")
+        await session.commit()
+
+        assert await _by_uid(session, DASH_UID) is None
+        assert await _by_uid(session, APP_UID) is not None
+
+    async def test_two_dashboards_sharing_a_uid_are_refused(self, session):
+        with pytest.raises(CatalogError):
+            await service.upsert_listing(
+                session,
+                _app_manifest(
+                    [_dashboard(), _dashboard(public_id="tests.tracker-second")]
+                ),
+                source="operator",
+            )
+
+    async def test_a_uid_another_listing_holds_is_refused(self, session):
+        """The catalog's own rule, and it has to hold for a derived row too —
+        a uid names one listing everywhere or it names nothing."""
+        await service.upsert_listing(
+            session,
+            {
+                **_app_manifest(),
+                "uid": DASH_UID,
+                "public_id": "tests.something-else",
+                "kind": "dashboard",
+                "definition": {"widgets": []},
+            },
+            source="operator",
+        )
+        await session.commit()
+
+        with pytest.raises(CatalogError):
+            await service.upsert_listing(
+                session, _app_manifest([_dashboard()]), source="operator"
+            )
+
+
+class TestLifecycle:
+    async def test_they_version_with_the_app(self, session):
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()], version="1.0.0"), source="operator"
+        )
+        await session.commit()
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()], version="2.0.0"), source="operator"
+        )
+        await session.commit()
+
+        dashboard = await _by_uid(session, DASH_UID)
+        version = await service.get_listing_version(
+            session, dashboard.latest_version_id
+        )
+        assert version.version == "2.0.0"
+
+    async def test_dropping_one_from_the_manifest_withdraws_it(self, session):
+        """Withdrawn, not deleted: a guild that installed it keeps what it has."""
+        await service.upsert_listing(
+            session,
+            _app_manifest([_dashboard(), _dashboard(OTHER_DASH_UID, "tests.second")]),
+            source="operator",
+        )
+        await session.commit()
+
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()], version="2.0.0"), source="operator"
+        )
+        await session.commit()
+
+        assert (await _by_uid(session, DASH_UID)).available is True
+        dropped = await _by_uid(session, OTHER_DASH_UID)
+        assert dropped is not None and dropped.available is False
+
+    async def test_withdrawing_the_app_withdraws_them(self, session):
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        assert await service.withdraw_listing(session, APP_UID) is True
+        await session.commit()
+
+        assert (await _by_uid(session, DASH_UID)).available is False
+
+    async def test_withdrawing_a_standalone_dashboard_touches_nothing_else(
+        self, session
+    ):
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        assert await service.withdraw_listing(session, DASH_UID) is True
+        await session.commit()
+
+        assert (await _by_uid(session, APP_UID)).available is True
+
+
+class TestWhoIsOfferedOne:
+    async def test_it_is_not_offered_to_a_caller_with_no_guild(self, session):
+        """The platform-addressed browse has no guild to decide for, so it
+        offers nothing bundled rather than offering it to everybody."""
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        listings, _ = await service.list_listings(session, kind="dashboard")
+        assert DASH_UID not in {listing.uid for listing in listings}
+
+    async def test_it_is_offered_where_the_app_is_installed(self, session):
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+
+        listings, _ = await service.list_listings(
+            session, kind="dashboard", bundled_with=[APP_UID]
+        )
+        assert DASH_UID in {listing.uid for listing in listings}
+
+    async def test_a_standalone_dashboard_is_offered_either_way(self, session):
+        await service.upsert_listing(
+            session,
+            {
+                **_app_manifest(),
+                "uid": OTHER_DASH_UID,
+                "public_id": "tests.shared-board",
+                "kind": "dashboard",
+                "definition": {"widgets": []},
+            },
+            source="operator",
+        )
+        await session.commit()
+
+        for bundled_with in (None, [APP_UID]):
+            listings, _ = await service.list_listings(
+                session, kind="dashboard", bundled_with=bundled_with
+            )
+            assert OTHER_DASH_UID in {listing.uid for listing in listings}
+
+
+class TestWhoMayInstallOne:
+    async def test_a_guild_with_the_app_may_install_it(self, session):
+        user = await create_user(session)
+        guild = await create_guild(session, creator=user)
+        await create_guild_app(
+            session,
+            guild,
+            user,
+            definition={
+                "app_kind": "service",
+                "service": {"public_id": "tests.tracker"},
+            },
+            listing_uid=APP_UID,
+        )
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+        await route_session_to_guild(session, guild.id)
+
+        listing, version = await resolve_listing_install(
+            session, DASH_UID, kind="dashboard"
+        )
+        assert listing.uid == DASH_UID
+        assert version.definition["widgets"][0]["binding"]["app_uid"] == APP_UID
+
+    async def test_a_guild_without_the_app_may_not(self, session):
+        """The case the browse filter cannot cover on its own. A uid read in a
+        guild that has the app is otherwise just as installable here."""
+        user = await create_user(session)
+        guild = await create_guild(session, creator=user)
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+        await route_session_to_guild(session, guild.id)
+
+        with pytest.raises(ListingInstallError) as caught:
+            await resolve_listing_install(session, DASH_UID, kind="dashboard")
+        assert caught.value.code == "MARKETPLACE_LISTING_NEEDS_APP"
+        assert caught.value.not_found is False
+
+    async def test_a_guild_that_switched_the_app_off_may_not(self, session):
+        user = await create_user(session)
+        guild = await create_guild(session, creator=user)
+        app = await create_guild_app(
+            session,
+            guild,
+            user,
+            definition={
+                "app_kind": "service",
+                "service": {"public_id": "tests.tracker"},
+            },
+            listing_uid=APP_UID,
+        )
+        app.enabled = False
+        session.add(app)
+        await service.upsert_listing(
+            session, _app_manifest([_dashboard()]), source="operator"
+        )
+        await session.commit()
+        await route_session_to_guild(session, guild.id)
+
+        with pytest.raises(ListingInstallError) as caught:
+            await resolve_listing_install(session, DASH_UID, kind="dashboard")
+        assert caught.value.code == "MARKETPLACE_LISTING_NEEDS_APP"
+
+    async def test_a_standalone_dashboard_needs_no_app(self, session):
+        """The other route, unchanged: somebody publishes a dashboard to share
+        and any guild installs it."""
+        user = await create_user(session)
+        guild = await create_guild(session, creator=user)
+        await service.upsert_listing(
+            session,
+            {
+                **_app_manifest(),
+                "uid": OTHER_DASH_UID,
+                "public_id": "tests.shared-board",
+                "kind": "dashboard",
+                "definition": {"widgets": []},
+            },
+            source="operator",
+        )
+        await session.commit()
+        await route_session_to_guild(session, guild.id)
+
+        listing, _ = await resolve_listing_install(
+            session, OTHER_DASH_UID, kind="dashboard"
+        )
+        assert listing.bundled_with_uid is None

--- a/backend/app/services/marketplace/catalog.py
+++ b/backend/app/services/marketplace/catalog.py
@@ -285,6 +285,7 @@ async def upsert_listing(
     manifest: dict[str, Any],
     *,
     source: str,
+    bundled_with: Optional[str] = None,
 ) -> MarketplaceListing:
     """Create or update one listing and the version its manifest describes.
 
@@ -293,6 +294,13 @@ async def upsert_listing(
     reassignable — a uid already held by a different ``public_id`` is refused,
     and vice versa, so a uid keeps meaning the listing it was first published
     for.
+
+    ``bundled_with`` names the app this listing is published as part of, and is
+    a third thing that cannot be reassigned. It is set only by
+    :func:`_publish_bundled_dashboards`, which is the app's own publish; every
+    other caller leaves it ``None`` and is publishing something that stands on
+    its own. A publish whose ownership disagrees with the stored row is refused
+    rather than applied, in either direction.
     """
     if source not in LISTING_SOURCES:
         raise CatalogError(f"unknown listing source {source!r}")
@@ -346,6 +354,21 @@ async def upsert_listing(
         raise CatalogError(
             f"uid {uid} is already held by {existing.public_id}; refusing to reassign"
         )
+    elif existing.bundled_with_uid != bundled_with:
+        # Both identities matching is what an *update* looks like, so this is
+        # the one path that reaches an existing row rather than being refused
+        # above — and who owns a listing is not something a later publish may
+        # change. An app bundling a uid somebody else published would otherwise
+        # rewrite that listing and attach its withdrawal to a different app.
+        held = (
+            f"as part of {existing.bundled_with_uid}"
+            if existing.bundled_with_uid
+            else "on its own"
+        )
+        wants = f"as part of {bundled_with}" if bundled_with else "on its own"
+        raise CatalogError(
+            f"{public_id} is already published {held}; refusing to republish {wants}"
+        )
 
     now = datetime.now(timezone.utc)
     # Everything a publish sets, whether the row is new or being updated. Built
@@ -360,6 +383,7 @@ async def upsert_listing(
         "long_description": manifest.get("long_description"),
         "avatar_url": avatar_url,
         "images": list(images),
+        "bundled_with_uid": bundled_with,
         "available": True,
         "updated_at": now,
     }
@@ -491,9 +515,10 @@ async def _publish_bundled_dashboards(
                 "widgets": widgets,
             },
         }
-        derived = await upsert_listing(session, manifest, source=source)
-        derived.bundled_with_uid = app.uid
-        session.add(derived)
+        # Ownership goes in as part of the publish rather than being stamped on
+        # afterwards, so the same call that refuses to reassign a uid refuses to
+        # take a listing away from whoever already published it.
+        await upsert_listing(session, manifest, source=source, bundled_with=app.uid)
         published.add(entry["uid"])
 
     # A dashboard dropped from the manifest is withdrawn rather than left

--- a/backend/app/services/marketplace/catalog.py
+++ b/backend/app/services/marketplace/catalog.py
@@ -38,6 +38,7 @@ from app.services.marketplace.definitions import (
     LISTING_KINDS,
     LISTING_SOURCES,
     ListingDefinitionError,
+    app_widget_type,
     normalize_publisher,
     normalize_listing_definition,
     reserved_prefix_problem,
@@ -163,10 +164,19 @@ async def list_listings(
     kind: Optional[str] = None,
     query: Optional[str] = None,
     include_unavailable: bool = False,
+    bundled_with: Optional[Sequence[str]] = None,
     offset: int = 0,
     limit: int = 50,
 ) -> tuple[Sequence[MarketplaceListing], int]:
-    """A page of listings, newest first, with the total that matched."""
+    """A page of listings, newest first, with the total that matched.
+
+    ``bundled_with`` names the app uids the caller is entitled to see bundled
+    dashboards for — the apps a guild has installed. Left unset, a dashboard
+    that ships with an app is not offered at all, which is the right answer for
+    a caller that has no guild to answer it for: such a dashboard draws that
+    app's widgets, so offering it where the app cannot be is offering a canvas
+    of tiles with nothing behind them.
+    """
     statement = select(MarketplaceListing)
     count_statement = select(func.count()).select_from(MarketplaceListing)
 
@@ -175,6 +185,15 @@ async def list_listings(
         filters.append(MarketplaceListing.available.is_(True))
     if kind:
         filters.append(MarketplaceListing.kind == kind)
+    if bundled_with:
+        filters.append(
+            or_(
+                MarketplaceListing.bundled_with_uid.is_(None),
+                MarketplaceListing.bundled_with_uid.in_(list(bundled_with)),
+            )
+        )
+    else:
+        filters.append(MarketplaceListing.bundled_with_uid.is_(None))
     if query:
         # Case-insensitive across the three fields someone would actually type.
         needle = f"%{query.strip()}%"
@@ -399,7 +418,107 @@ async def upsert_listing(
     listing.latest_version_id = version.id
     session.add(listing)
     await session.flush()
+
+    if kind == "app":
+        await _publish_bundled_dashboards(
+            session,
+            app=listing,
+            definition=definition,
+            version=version_str,
+            source=source,
+        )
+
     return listing
+
+
+async def _publish_bundled_dashboards(
+    session: AsyncSession,
+    *,
+    app: MarketplaceListing,
+    definition: dict[str, Any],
+    version: str,
+    source: str,
+) -> None:
+    """Publish one dashboard listing per entry in an app's ``dashboards`` block.
+
+    This is the whole reason a publisher declares these inside the manifest
+    rather than beside it: the operator adds one file, and the dashboards that
+    ship with the app are published, versioned and withdrawn with it.
+
+    Each one is an ordinary listing. It carries the publisher's own uid — which
+    is what makes it a real catalog identity rather than something invented here
+    — and inherits the app's publisher, source and version, because it *is* the
+    app's publish. ``bundled_with_uid`` is what marks it, and is how the browse
+    path knows to offer it only where the app is installed.
+
+    Widget types are resolved to their namespaced form here. A manifest carries
+    no uid inside it, so a publisher writes the bare widget id and this stamps
+    the app's own uid on — the same value :func:`app_widget_type` puts on the
+    palette. What gets stored is therefore the shape the dashboard tool already
+    renders, and nothing downstream needs to know the row was derived.
+    """
+    published: set[str] = set()
+
+    for entry in definition.get("dashboards") or []:
+        widgets = [
+            {
+                "id": widget["id"],
+                "type": app_widget_type(app.uid, widget["type"]),
+                **({"title": widget["title"]} if "title" in widget else {}),
+                **({"grid": widget["grid"]} if "grid" in widget else {}),
+                "binding": {"source": "app", "app_uid": app.uid, **widget["binding"]},
+            }
+            for widget in entry["widgets"]
+        ]
+        manifest: dict[str, Any] = {
+            "uid": entry["uid"],
+            "public_id": entry["public_id"],
+            "kind": "dashboard",
+            "name": entry["name"],
+            "publisher": app.publisher,
+            "description": entry.get("description") or app.description,
+            "version": version,
+            # No artwork of its own, deliberately: a dashboard previews by
+            # rendering its actual widgets against the sample data those widgets
+            # declare, which cannot go stale against the app the way a picture
+            # would.
+            "avatar_url": DEFAULT_AVATAR_URL,
+            "images": [],
+            "definition": {
+                "schema_version": 1,
+                "kind": "dashboard",
+                **({"layout": entry["layout"]} if "layout" in entry else {}),
+                "widgets": widgets,
+            },
+        }
+        derived = await upsert_listing(session, manifest, source=source)
+        derived.bundled_with_uid = app.uid
+        session.add(derived)
+        published.add(entry["uid"])
+
+    # A dashboard dropped from the manifest is withdrawn rather than left
+    # offered: the app that supplied its widgets no longer ships it. Withdrawn,
+    # not deleted — a guild that already installed it keeps what it has.
+    for stale in await _bundled_dashboards_of(session, app.uid):
+        if stale.uid not in published and stale.available:
+            stale.available = False
+            stale.updated_at = datetime.now(timezone.utc)
+            session.add(stale)
+
+    await session.flush()
+
+
+async def _bundled_dashboards_of(
+    session: AsyncSession, app_uid: str
+) -> Sequence[MarketplaceListing]:
+    """Every dashboard listing published as part of one app."""
+    return (
+        await session.exec(
+            select(MarketplaceListing).where(
+                MarketplaceListing.bundled_with_uid == app_uid
+            )
+        )
+    ).all()
 
 
 async def withdraw_listing(session: AsyncSession, uid: str) -> bool:
@@ -411,13 +530,27 @@ async def withdraw_listing(session: AsyncSession, uid: str) -> bool:
     cannot be installed again. Used when a deployment stops being able to serve
     something it previously seeded — an operator removing the configuration an
     app depends on — and later by the registry for a listing its publisher pulls.
+
+    Withdrawing an app withdraws the dashboards it bundles. They were published
+    by its manifest and have no existence apart from it, so leaving them offered
+    would mean offering an arrangement of widgets a guild can no longer install
+    the app for.
     """
     listing = await get_listing_by_uid(session, uid)
     if listing is None or not listing.available:
         return False
+    now = datetime.now(timezone.utc)
     listing.available = False
-    listing.updated_at = datetime.now(timezone.utc)
+    listing.updated_at = now
     session.add(listing)
+
+    if listing.kind == "app":
+        for bundled in await _bundled_dashboards_of(session, listing.uid):
+            if bundled.available:
+                bundled.available = False
+                bundled.updated_at = now
+                session.add(bundled)
+
     await session.flush()
     return True
 

--- a/backend/app/services/marketplace/installs.py
+++ b/backend/app/services/marketplace/installs.py
@@ -14,6 +14,7 @@ response.
 
 from __future__ import annotations
 
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.messages import MarketplaceMessages
@@ -21,6 +22,7 @@ from app.models.platform.marketplace import (
     MarketplaceListing,
     MarketplaceListingVersion,
 )
+from app.models.tenant.guild_app import GuildApp
 from app.services.marketplace import catalog as catalog_service
 
 __all__ = ["ListingInstallError", "resolve_listing_install"]
@@ -51,13 +53,22 @@ async def resolve_listing_install(
     catalog to someone guessing at it.
 
     The lookup runs on the session the request already has, which holds read
-    access to the catalog.
+    access to the catalog. For a dashboard an app ships with itself, that
+    session is also routed into the guild, which is what lets the check below
+    ask whether the guild has the app.
     """
     listing = await catalog_service.get_listing_by_uid(session, listing_uid)
     if listing is None or listing.kind != kind:
         raise ListingInstallError(MarketplaceMessages.LISTING_NOT_FOUND, not_found=True)
     if not listing.available:
         raise ListingInstallError(MarketplaceMessages.LISTING_UNAVAILABLE)
+    if listing.bundled_with_uid is not None and not await _app_is_installed(
+        session, listing.bundled_with_uid
+    ):
+        # Browse only offers this where the app is installed. Deciding it again
+        # here is the point at which it means anything: a uid read in one guild
+        # is otherwise just as installable in the next.
+        raise ListingInstallError(MarketplaceMessages.LISTING_NEEDS_APP)
     version = await catalog_service.resolve_installable_version(session, listing)
     if version is None:
         # Either it has published nothing, or its current version needs a newer
@@ -65,3 +76,19 @@ async def resolve_listing_install(
         # get something other than what the listing page showed them.
         raise ListingInstallError(MarketplaceMessages.LISTING_VERSION_INCOMPATIBLE)
     return listing, version
+
+
+async def _app_is_installed(session: AsyncSession, app_uid: str) -> bool:
+    """Whether the guild this session is routed to has that app, switched on.
+
+    Reads the guild's own install row, so the schema boundary is what answers —
+    there is no guild id to pass and no chance of asking about the wrong one.
+    """
+    return (
+        await session.exec(
+            select(GuildApp.id).where(
+                GuildApp.listing_uid == app_uid,
+                GuildApp.enabled.is_(True),
+            )
+        )
+    ).first() is not None

--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.models.platform.marketplace import UID_ALPHABET, UID_LENGTH
 from app.services.marketplace.manifest_values import (
     IDENTIFIER_CHARS,
     MAX_HINT_LENGTH,
@@ -75,14 +76,20 @@ from app.services.marketplace.service_apps import (
     FIELD_TYPES,
     GUILD_WIDE_VISIBILITIES,
     MAX_ACCESS_HINT_SCOPES,
+    MAX_BUNDLED_DASHBOARDS,
     MAX_CACHE_TTL_SECONDS,
     MAX_CONNECTIONS,
+    MAX_DASHBOARD_BINDING_PARAMS,
+    MAX_DASHBOARD_GRID_COLUMNS,
+    MAX_DASHBOARD_WIDGETS,
     MAX_DATA_SOURCES,
+    MAX_DESCRIPTION_LENGTH,
     MAX_EMBED_CAPABILITIES,
     MAX_EMBEDS,
     MAX_EVENT_TYPE_LENGTH,
     MAX_EVENTS,
     MAX_FIELDS_PER_CONNECTION,
+    MAX_PARAM_VALUE_LENGTH,
     MAX_PARAMS_PER_SOURCE,
     MAX_REQUIRES_TERMS,
     MAX_SELECT_OPTIONS,
@@ -368,6 +375,108 @@ def _widget() -> dict[str, Any]:
     }
 
 
+def _bundled_dashboard() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["uid", "public_id", "name", "widgets"],
+        "properties": {
+            "uid": {
+                "type": "string",
+                "minLength": UID_LENGTH,
+                "maxLength": UID_LENGTH,
+                "pattern": _pattern(frozenset(UID_ALPHABET)),
+                "description": (
+                    "This dashboard's own catalog id — publisher-assigned, "
+                    "immutable, never reused. It becomes a listing of its own, "
+                    "so this is a real catalog identity and not the app's."
+                ),
+            },
+            "public_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": MAX_PUBLIC_ID_LENGTH,
+                "pattern": _pattern(PUBLIC_ID_CHARS),
+                "description": (
+                    "'<publisher>.<slug>', and not the app's own — a bundled "
+                    "dashboard is a separate listing."
+                ),
+            },
+            "name": {"type": "string", "minLength": 1, "maxLength": MAX_NAME_LENGTH},
+            "description": {"type": "string", "maxLength": MAX_DESCRIPTION_LENGTH},
+            "layout": {
+                "type": "object",
+                "properties": {
+                    "columns": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_DASHBOARD_GRID_COLUMNS,
+                    }
+                },
+            },
+            "widgets": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": MAX_DASHBOARD_WIDGETS,
+                "items": {"$ref": "#/$defs/bundledDashboardWidget"},
+            },
+        },
+    }
+
+
+def _bundled_dashboard_widget() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["type", "binding"],
+        "properties": {
+            "id": {"$ref": "#/$defs/identifier"},
+            "type": {
+                "$ref": "#/$defs/identifier",
+                "description": (
+                    "One of this manifest's own widget ids — bare, with no uid. "
+                    "The platform stamps the app's uid on when it publishes, so "
+                    "the two can never disagree."
+                ),
+            },
+            "title": {"type": "string", "maxLength": MAX_NAME_LENGTH},
+            "grid": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": MAX_DASHBOARD_GRID_COLUMNS,
+                    },
+                    "y": {"type": "integer", "minimum": 0},
+                    "w": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_DASHBOARD_GRID_COLUMNS,
+                    },
+                    "h": {"type": "integer", "minimum": 1},
+                },
+            },
+            "binding": {
+                "type": "object",
+                "required": ["source_id"],
+                "properties": {
+                    "source_id": {
+                        "$ref": "#/$defs/identifier",
+                        "description": "One of this manifest's own data source ids.",
+                    },
+                    "params": {
+                        "type": "object",
+                        "maxProperties": MAX_DASHBOARD_BINDING_PARAMS,
+                        "additionalProperties": {
+                            "type": ["string", "integer", "boolean"],
+                            "maxLength": MAX_PARAM_VALUE_LENGTH,
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+
 def _embed() -> dict[str, Any]:
     return {
         "type": "object",
@@ -507,6 +616,16 @@ def build_manifest_schema() -> dict[str, Any]:
                     "by no vocabulary here."
                 ),
             },
+            "dashboards": {
+                "type": "array",
+                "maxItems": MAX_BUNDLED_DASHBOARDS,
+                "items": {"$ref": "#/$defs/bundledDashboard"},
+                "description": (
+                    "Ready-made arrangements of this app's own widgets. "
+                    "Publishing the app publishes one ordinary dashboard listing "
+                    "per entry, offered to guilds that install the app."
+                ),
+            },
         },
         "$defs": {
             "identifier": {
@@ -535,5 +654,7 @@ def build_manifest_schema() -> dict[str, Any]:
             "dataSource": _data_source(),
             "widget": _widget(),
             "embed": _embed(),
+            "bundledDashboard": _bundled_dashboard(),
+            "bundledDashboardWidget": _bundled_dashboard_widget(),
         },
     }

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -311,6 +311,69 @@ ACCEPTED = [
         ),
         id="requires-alongside-an-unknown-key",
     ),
+    pytest.param(
+        _manifest(
+            features=["data", "widgets", "dashboards"],
+            data_sources=[{"id": "s", "path": "/d"}],
+            widgets=[
+                {
+                    "id": "w",
+                    "meta": {"name": {"en": "W"}},
+                    "module_source": "export default () => ({});",
+                    "sources": ["s"],
+                }
+            ],
+            dashboards=[
+                {
+                    "uid": "J9H7S9T7GP7FAG",
+                    "public_id": "acme.tracker-overview",
+                    "name": "Overview",
+                    "description": "At a glance.",
+                    "layout": {"columns": 12},
+                    "widgets": [
+                        {
+                            "id": "one",
+                            # Bare, with no uid: the platform stamps the app's
+                            # own on when it publishes.
+                            "type": "w",
+                            "title": "One",
+                            "grid": {"x": 0, "y": 0, "w": 4, "h": 3},
+                            "binding": {
+                                "source_id": "s",
+                                "params": {"label": "bug", "limit": 5, "open": True},
+                            },
+                        }
+                    ],
+                }
+            ],
+        ),
+        id="a-dashboard-the-app-ships-with-itself",
+    ),
+    pytest.param(
+        _manifest(
+            features=["data", "widgets", "dashboards"],
+            data_sources=[{"id": "s", "path": "/d"}],
+            widgets=[
+                {
+                    "id": "w",
+                    "meta": {"name": {"en": "W"}},
+                    "module_source": "export default () => ({});",
+                    "sources": ["s"],
+                }
+            ],
+            dashboards=[
+                {
+                    "uid": "J9H7S9T7GP7FAG",
+                    "public_id": "acme.tracker-overview",
+                    "name": "Overview",
+                    # No description, layout, widget id or grid: a publisher who
+                    # wants one tile per widget writes almost nothing.
+                    "widgets": [{"type": "w", "binding": {"source_id": "s"}}],
+                }
+            ],
+        ),
+        id="a-bundled-dashboard-with-only-what-is-required",
+    ),
 ]
 
 

--- a/backend/app/services/marketplace/manifest_values.py
+++ b/backend/app/services/marketplace/manifest_values.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import json
 from typing import Any, NoReturn
 
+from app.models.platform.marketplace import UID_ALPHABET, UID_LENGTH
+
 __all__ = [
     "ListingDefinitionError",
     "IDENTIFIER_CHARS",
@@ -41,6 +43,7 @@ __all__ = [
     "check_path",
     "check_public_id",
     "check_single_line",
+    "check_uid",
     "check_url",
     "clean_text",
     "fail",
@@ -183,6 +186,23 @@ def check_public_id(value: Any, *, what: str) -> str:
             fail(f"{what} contains {character!r}, which is not allowed")
     if "." not in value:
         fail(f"{what} must be '<publisher>.<slug>'")
+    return value
+
+
+def check_uid(value: Any, *, what: str) -> str:
+    """A catalog uid: publisher-assigned, immutable, never reused.
+
+    One rule for the shape of a uid wherever it appears — the catalog's own
+    ingestion check and a manifest declaring one for a dashboard it bundles both
+    come here, so a value either accepts is a value the other does.
+    """
+    if not isinstance(value, str) or not value:
+        fail(f"{what} is required")
+    if len(value) != UID_LENGTH:
+        fail(f"{what} must be {UID_LENGTH} characters, got {len(value)}")
+    for character in value:
+        if character not in UID_ALPHABET:
+            fail(f"{what} contains {character!r}, which is not in the alphabet")
     return value
 
 

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -29,7 +29,7 @@ foothold in a guild is a legitimate install with nothing to render.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from app.services.marketplace.manifest_values import (
     MAX_HINT_LENGTH,
@@ -39,6 +39,7 @@ from app.services.marketplace.manifest_values import (
     check_json_size,
     check_path,
     check_public_id,
+    check_uid,
     clean_text,
     fail,
     require_list,
@@ -71,21 +72,25 @@ __all__ = [
 
 # --- vocabulary -------------------------------------------------------------
 
-#: Capability classes an app can contribute. Closed: a manifest naming anything
-#: else is refused rather than stored as a claim nothing can act on.
-FEATURES: frozenset[str] = frozenset(
-    {"data", "widgets", "embeds", "events", "automations"}
-)
-
 #: Which block backs each feature. The single source for the cross-check that
-#: keeps a declaration and a manifest body from disagreeing.
+#: keeps a declaration and a manifest body from disagreeing — and, below, for
+#: the vocabulary itself.
 FEATURE_BLOCKS: dict[str, str] = {
     "data": "data_sources",
     "widgets": "widgets",
     "embeds": "embeds",
     "events": "events",
     "automations": "automation",
+    "dashboards": "dashboards",
 }
+
+#: Capability classes an app can contribute. Closed: a manifest naming anything
+#: else is refused rather than stored as a claim nothing can act on.
+#:
+#: Derived rather than restated. A feature with no block behind it is exactly
+#: what :func:`_check_features` refuses, so a second list could only ever be
+#: wrong — and was, until a feature was added to one of them.
+FEATURES: frozenset[str] = frozenset(FEATURE_BLOCKS)
 
 #: Who supplies a connection's credential, which decides its scope.
 #:
@@ -197,6 +202,21 @@ MAX_WIDGET_SOURCES = 8
 MAX_DATA_SOURCES = 24
 MAX_PARAMS_PER_SOURCE = 12
 MAX_EMBEDS = 12
+#: An app ships a handful of arrangements of its own widgets, not a library of
+#: them. Each becomes a catalog row, so this is also how many listings a single
+#: publish can create.
+MAX_BUNDLED_DASHBOARDS = 8
+#: The dashboard tool's own limits, restated rather than imported: this is the
+#: manifest vocabulary, and the tool validates the derived definition again on
+#: its own terms when an instance is created from it.
+MAX_DASHBOARD_WIDGETS = 50
+MAX_DASHBOARD_GRID_COLUMNS = 12
+MAX_DASHBOARD_BINDING_PARAMS = 12
+#: One line under a bundled dashboard's name. Matches the catalog column it
+#: becomes, so a description that publishes here fits the row it derives.
+MAX_DESCRIPTION_LENGTH = 500
+#: A fixed parameter value on a tile's binding.
+MAX_PARAM_VALUE_LENGTH = 2_000
 MAX_EVENTS = 50
 MAX_EVENT_TYPE_LENGTH = 200
 #: A day. A source that wants a longer memory than that is asking for a stale
@@ -523,6 +543,182 @@ def _widget(
     return cleaned
 
 
+def _bundled_dashboard(
+    raw: Any, *, widget_ids: set[str], source_ids: set[str]
+) -> dict[str, Any]:
+    """One dashboard an app ships with itself.
+
+    A publisher who declares widgets otherwise leaves every guild to arrange
+    them. This is a ready-made arrangement of *this app's own* widgets, which
+    becomes an ordinary ``dashboard`` catalog listing when the app is published —
+    so a guild installs it the same way it installs any other dashboard, and
+    what it gets afterwards is an ordinary dashboard of its own.
+
+    Two things make it different from a dashboard published on its own, and both
+    are why it can be checked here at all:
+
+    * **It names widgets by bare id.** A manifest has no uid inside it — the uid
+      lives in the document envelope — so widget types are resolved to
+      ``app:<uid>:<widget id>`` at publish, exactly as
+      :func:`app_widget_type` already does for the palette. The publisher never
+      writes a uid into a widget type, so the two cannot disagree.
+    * **It can only reference this manifest.** Every widget and every bound
+      source is checked against what the same document declares, so a bundled
+      dashboard cannot name a widget the app does not have — the failure a
+      separately published dashboard can only hit at install, and silently.
+
+    The ``uid`` and ``public_id`` are the publisher's own, and are what make the
+    derived row a real catalog identity rather than something invented here.
+    """
+    entry = require_mapping(raw, "bundled dashboard")
+    uid = check_uid(entry.get("uid"), what="bundled dashboard uid")
+    public_id = check_public_id(
+        entry.get("public_id"), what=f"bundled dashboard {uid} public_id"
+    )
+    what = f"bundled dashboard {public_id!r}"
+
+    name = clean_text(entry.get("name"), what=f"{what} name", limit=MAX_NAME_LENGTH)
+    if not name:
+        fail(f"{what}: name is required")
+    description = clean_text(
+        entry.get("description"),
+        what=f"{what} description",
+        limit=MAX_DESCRIPTION_LENGTH,
+        required=False,
+    )
+
+    widgets = [
+        _bundled_dashboard_widget(
+            widget, widget_ids=widget_ids, source_ids=source_ids, what=what
+        )
+        for widget in require_list(
+            entry.get("widgets"), f"{what} widgets", MAX_DASHBOARD_WIDGETS
+        )
+    ]
+    if not widgets:
+        fail(f"{what}: a dashboard with no widgets shows nothing")
+
+    seen: set[str] = set()
+    for widget in widgets:
+        if widget["id"] in seen:
+            fail(f"{what}: two widgets share the id {widget['id']!r}")
+        seen.add(widget["id"])
+
+    cleaned: dict[str, Any] = {
+        "uid": uid,
+        "public_id": public_id,
+        "name": name,
+        "widgets": widgets,
+    }
+    if description is not None:
+        cleaned["description"] = description
+
+    columns = _grid_int(
+        (entry.get("layout") or {}).get("columns")
+        if isinstance(entry.get("layout"), dict)
+        else None,
+        low=1,
+        high=MAX_DASHBOARD_GRID_COLUMNS,
+        what=f"{what} layout.columns",
+    )
+    if columns is not None:
+        cleaned["layout"] = {"columns": columns}
+    return cleaned
+
+
+def _bundled_dashboard_widget(
+    raw: Any, *, widget_ids: set[str], source_ids: set[str], what: str
+) -> dict[str, Any]:
+    """One tile, naming one of this app's widgets and one of its sources."""
+    widget = require_mapping(raw, f"{what} widget")
+    widget_type = check_identifier(widget.get("type"), what=f"{what} widget type")
+    if widget_type not in widget_ids:
+        fail(f"{what}: names unknown widget {widget_type!r}")
+
+    binding = require_mapping(widget.get("binding"), f"{what} widget binding")
+    source_id = check_identifier(
+        binding.get("source_id"), what=f"{what} widget binding source_id"
+    )
+    if source_id not in source_ids:
+        fail(f"{what}: binds unknown data source {source_id!r}")
+
+    bound: dict[str, Any] = {"source_id": source_id}
+    params = binding.get("params")
+    if params is not None:
+        bound["params"] = _bundled_binding_params(params, what=what)
+
+    cleaned: dict[str, Any] = {
+        # Defaulted from the widget it draws, so a publisher who ships one tile
+        # per widget writes no ids at all.
+        "id": check_identifier(
+            widget.get("id") or widget_type, what=f"{what} widget id"
+        ),
+        "type": widget_type,
+        "binding": bound,
+    }
+
+    title = clean_text(
+        widget.get("title"),
+        what=f"{what} widget title",
+        limit=MAX_NAME_LENGTH,
+        required=False,
+    )
+    if title is not None:
+        cleaned["title"] = title
+
+    grid = widget.get("grid")
+    if isinstance(grid, dict):
+        placed = {
+            key: _grid_int(
+                grid.get(key),
+                low=0 if key in ("x", "y") else 1,
+                high=MAX_DASHBOARD_GRID_COLUMNS if key in ("x", "w") else None,
+                what=f"{what} widget grid.{key}",
+            )
+            for key in ("x", "y", "w", "h")
+        }
+        kept = {key: value for key, value in placed.items() if value is not None}
+        if kept:
+            cleaned["grid"] = kept
+    return cleaned
+
+
+def _bundled_binding_params(raw: Any, *, what: str) -> dict[str, Any]:
+    """Fixed parameter values for a tile's source. Scalars, kept as they are.
+
+    Deliberately not coerced: the source's ``params_schema`` declares the type,
+    and turning a ``true`` into a ``1`` here would satisfy a check the fetch path
+    is meant to make.
+    """
+    params = require_mapping(raw, f"{what} widget binding params")
+    if len(params) > MAX_DASHBOARD_BINDING_PARAMS:
+        fail(f"{what}: a binding carries at most {MAX_DASHBOARD_BINDING_PARAMS} params")
+    cleaned: dict[str, Any] = {}
+    for key, value in params.items():
+        name = check_identifier(key, what=f"{what} binding param")
+        if isinstance(value, bool) or isinstance(value, int):
+            cleaned[name] = value
+        elif isinstance(value, str):
+            cleaned[name] = clean_text(
+                value, what=f"{what} binding param {name}", limit=MAX_PARAM_VALUE_LENGTH
+            )
+        else:
+            fail(f"{what}: binding param {name!r} must be a string, integer or boolean")
+    return cleaned
+
+
+def _grid_int(raw: Any, *, low: int, high: Optional[int], what: str) -> Optional[int]:
+    """A grid coordinate, or ``None`` when the publisher left it to the canvas."""
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        fail(f"{what} must be a whole number")
+    if raw < low or (high is not None and raw > high):
+        bound = f"{low}..{high}" if high is not None else f"at least {low}"
+        fail(f"{what} must be {bound}")
+    return raw
+
+
 def _sample_data(raw: Any, *, sources: list[str], what: str) -> dict[str, Any]:
     """Rows that let a preview render with no network call at all.
 
@@ -789,6 +985,38 @@ def normalize_service_app_definition(definition: Any) -> dict[str, Any]:
         cleaned["widgets"] = widgets
     if embeds:
         cleaned["embeds"] = embeds
+
+    # After the widgets and sources it can name, because every tile is checked
+    # against them — the whole point of bundling rather than publishing
+    # separately is that this cross-check is possible at all.
+    dashboards = [
+        _bundled_dashboard(entry, widget_ids=widget_ids, source_ids=source_ids)
+        for entry in require_list(
+            body.get("dashboards"), "service app: dashboards", MAX_BUNDLED_DASHBOARDS
+        )
+    ]
+    if dashboards:
+        seen_uids: set[str] = set()
+        seen_public_ids: set[str] = set()
+        for dashboard in dashboards:
+            # Checked here as well as by the catalog: these become listing rows
+            # whose identities are unique, and a manifest that collides with
+            # itself would fail halfway through a publish.
+            if dashboard["uid"] in seen_uids:
+                fail(f"service app: two dashboards share the uid {dashboard['uid']}")
+            if dashboard["public_id"] in seen_public_ids:
+                fail(
+                    "service app: two dashboards share the public_id "
+                    f"{dashboard['public_id']!r}"
+                )
+            if dashboard["public_id"] == service["public_id"]:
+                fail(
+                    f"service app: dashboard {dashboard['uid']} uses the app's own "
+                    "public_id; a bundled dashboard is its own listing"
+                )
+            seen_uids.add(dashboard["uid"])
+            seen_public_ids.add(dashboard["public_id"])
+        cleaned["dashboards"] = dashboards
 
     events = _events(body.get("events"), service_public_id=service["public_id"])
     if events:

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -36,10 +36,11 @@
     },
     "features": {
       "type": "array",
-      "maxItems": 5,
+      "maxItems": 6,
       "items": {
         "enum": [
           "automations",
+          "dashboards",
           "data",
           "embeds",
           "events",
@@ -93,6 +94,14 @@
     "automation": {
       "type": "object",
       "description": "The automation service's own block. Opaque to the platform: checked for shape and size, stored verbatim, and described by no vocabulary here."
+    },
+    "dashboards": {
+      "type": "array",
+      "maxItems": 8,
+      "items": {
+        "$ref": "#/$defs/bundledDashboard"
+      },
+      "description": "Ready-made arrangements of this app's own widgets. Publishing the app publishes one ordinary dashboard listing per entry, offered to guilds that install the app."
     }
   },
   "$defs": {
@@ -451,6 +460,125 @@
         },
         "requires": {
           "$ref": "#/$defs/requires"
+        }
+      }
+    },
+    "bundledDashboard": {
+      "type": "object",
+      "required": [
+        "uid",
+        "public_id",
+        "name",
+        "widgets"
+      ],
+      "properties": {
+        "uid": {
+          "type": "string",
+          "minLength": 14,
+          "maxLength": 14,
+          "pattern": "^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]+$",
+          "description": "This dashboard's own catalog id \u2014 publisher-assigned, immutable, never reused. It becomes a listing of its own, so this is a real catalog identity and not the app's."
+        },
+        "public_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120,
+          "pattern": "^[\\-.0123456789_abcdefghijklmnopqrstuvwxyz]+$",
+          "description": "'<publisher>.<slug>', and not the app's own \u2014 a bundled dashboard is a separate listing."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 500
+        },
+        "layout": {
+          "type": "object",
+          "properties": {
+            "columns": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            }
+          }
+        },
+        "widgets": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/$defs/bundledDashboardWidget"
+          }
+        }
+      }
+    },
+    "bundledDashboardWidget": {
+      "type": "object",
+      "required": [
+        "type",
+        "binding"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "type": {
+          "$ref": "#/$defs/identifier",
+          "description": "One of this manifest's own widget ids \u2014 bare, with no uid. The platform stamps the app's uid on when it publishes, so the two can never disagree."
+        },
+        "title": {
+          "type": "string",
+          "maxLength": 255
+        },
+        "grid": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 12
+            },
+            "y": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "w": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "h": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "binding": {
+          "type": "object",
+          "required": [
+            "source_id"
+          ],
+          "properties": {
+            "source_id": {
+              "$ref": "#/$defs/identifier",
+              "description": "One of this manifest's own data source ids."
+            },
+            "params": {
+              "type": "object",
+              "maxProperties": 12,
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "integer",
+                  "boolean"
+                ],
+                "maxLength": 2000
+              }
+            }
+          }
         }
       }
     }

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -365,6 +365,7 @@
   "BILLING_PORTAL_SIGNING_NOT_CONFIGURED": "Das Abrechnungsportal ist noch nicht vollständig konfiguriert. Wende dich an deine Administration.",
   "BILLING_PORTAL_GRANT_UNAVAILABLE": "Zugriff auf die Abrechnung dieser Gilde nicht möglich. Prüfe, ob dafür noch eine Zugriffsanfrage offen ist.",
   "MARKETPLACE_LISTING_NOT_FOUND": "Diesen Marktplatz-Eintrag gibt es nicht mehr.",
+  "MARKETPLACE_LISTING_NEEDS_APP": "Dieses Dashboard gehört zu einer App, die deine Gilde nicht installiert hat. Installiere zuerst die App und füge dann das Dashboard hinzu.",
   "MARKETPLACE_LISTING_UNAVAILABLE": "Dieser Eintrag wurde zurückgezogen und kann nicht mehr installiert werden.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "Dieser Eintrag benötigt eine neuere Version der App. Bitte eine Administratorin oder einen Administrator um ein Update und versuche es dann erneut.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "Das wurde hier erstellt und nicht installiert – es gibt also keinen Eintrag, von dem aus aktualisiert werden könnte.",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -365,6 +365,7 @@
   "BILLING_PORTAL_SIGNING_NOT_CONFIGURED": "The billing portal is not fully configured yet. Contact your administrator.",
   "BILLING_PORTAL_GRANT_UNAVAILABLE": "Could not obtain access to this guild's billing. Check whether you have an access request still pending for it.",
   "MARKETPLACE_LISTING_NOT_FOUND": "That marketplace listing no longer exists.",
+  "MARKETPLACE_LISTING_NEEDS_APP": "This dashboard comes with an app your guild has not installed. Install the app first, then add the dashboard.",
   "MARKETPLACE_LISTING_UNAVAILABLE": "This listing has been withdrawn and can no longer be installed.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "This listing needs a newer version of the app. Ask an administrator to update, then try again.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "This was built here rather than installed, so there is no listing to update it from.",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -365,6 +365,7 @@
   "BILLING_PORTAL_SIGNING_NOT_CONFIGURED": "El portal de facturación aún no está configurado por completo. Contacta con tu administración.",
   "BILLING_PORTAL_GRANT_UNAVAILABLE": "No se pudo obtener acceso a la facturación de este gremio. Comprueba si tienes una solicitud de acceso pendiente.",
   "MARKETPLACE_LISTING_NOT_FOUND": "Ese elemento del mercado ya no existe.",
+  "MARKETPLACE_LISTING_NEEDS_APP": "Este panel viene con una aplicación que tu gremio no tiene instalada. Instala primero la aplicación y después añade el panel.",
   "MARKETPLACE_LISTING_UNAVAILABLE": "Este elemento se ha retirado y ya no se puede instalar.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "Este elemento necesita una versión más reciente de la aplicación. Pide a un administrador que la actualice y vuelve a intentarlo.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "Esto se creó aquí en lugar de instalarse, así que no hay ningún elemento desde el que actualizarlo.",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -365,6 +365,7 @@
   "BILLING_PORTAL_SIGNING_NOT_CONFIGURED": "Le portail de facturation n'est pas encore entièrement configuré. Contacte ton administration.",
   "BILLING_PORTAL_GRANT_UNAVAILABLE": "Impossible d'obtenir l'accès à la facturation de cette guilde. Vérifie si une demande d'accès est encore en attente.",
   "MARKETPLACE_LISTING_NOT_FOUND": "Cette fiche du catalogue n'existe plus.",
+  "MARKETPLACE_LISTING_NEEDS_APP": "Ce tableau de bord accompagne une application que votre guilde n'a pas installée. Installez d'abord l'application, puis ajoutez le tableau de bord.",
   "MARKETPLACE_LISTING_UNAVAILABLE": "Cette fiche a été retirée et ne peut plus être installée.",
   "MARKETPLACE_LISTING_VERSION_INCOMPATIBLE": "Cette fiche nécessite une version plus récente de l'application. Demandez à une administratrice ou un administrateur de la mettre à jour, puis réessayez.",
   "MARKETPLACE_NOT_INSTALLED_FROM_LISTING": "Ceci a été créé ici plutôt qu'installé : il n'y a donc aucune fiche depuis laquelle le mettre à jour.",


### PR DESCRIPTION
## Problem

An app that declares widgets leaves every guild to arrange them. A publisher who
wanted to ship an arrangement had to publish a **second listing** beside the app:
two uids, two versions to keep in step, two files for an operator to place and
withdraw — and the dashboard was offered to every guild in the catalog, including
the ones with no app installed to draw its tiles.

## Changes

A manifest can carry them. Publishing the app publishes one ordinary `dashboard`
listing per entry.

- **`dashboards` block** — [`service_apps.py`](backend/app/services/marketplace/service_apps.py).
  Each entry carries the publisher's **own uid and public_id**, so the derived
  row is a real catalog identity rather than something invented at publish. Every
  tile is checked against the widgets and data sources the *same document*
  declares, which is the check a separately published dashboard can only fail at
  install, silently.
- **Bare widget ids.** A manifest has no uid inside it, so a tile names
  `open-items` and the platform stamps `app:<uid>:open-items` on at publish —
  the same call `app_data.py` already makes for the palette. A publisher never
  writes a uid into a widget type, so the two cannot disagree.
- **`MarketplaceListing.bundled_with_uid`** — NULL for a listing published on its
  own; set for one that ships with an app. That single column carries the two
  ways they differ: offered only where the app is installed, and published and
  withdrawn with it.
- **Both routes stay identical otherwise.** Same kind, same uid rules, installed
  by the same `POST /dashboards/` with `listing_uid`, same provenance columns. A
  dashboard somebody publishes to share and one that arrives with an app are the
  same thing to the guild installing it, so nothing downstream branches.

### Lifecycle

Dropping a dashboard from the manifest withdraws it; withdrawing the app
withdraws the dashboards it bundles. Withdrawn, never deleted — a guild that
already installed one keeps what it has.

### Gating

`resolve_listing_install` refuses a bundled dashboard to a guild without the app
(`MARKETPLACE_LISTING_NEEDS_APP`, localized in all four locales). Doing it at
install rather than only in the browse response is the point at which it means
anything: a uid read in one guild is otherwise just as installable in the next.

`list_listings` gains `bundled_with`. Unset — the platform-addressed browse,
which has no guild to answer for — bundled dashboards are not offered at all.

## Not in this PR

The guild-addressed browse route (`/g/{guild_id}/marketplace/listings`) that
passes `bundled_with` from a guild's installs, and the frontend pointing at it.
Until then a bundled dashboard is published and installable-if-you-have-the-app
but offered nowhere, which is the safe half-state to be in.

## Testing

- `app/services/marketplace/bundled_dashboards_test.py` — 17 cases: derivation,
  the derived row being ordinary, no artwork, uid collisions refused, versions
  moving with the app, both withdrawal directions, who is offered one, and who
  may install one.
- `manifest_schema_test.py` — two cases added to the agreement set, so the
  exported schema accepts what the platform accepts for the new block.
- `pytest app/services/marketplace app/services/tenant/dashboard_definition_test.py
  app/api/v1/tenant_endpoints/dashboards_test.py app/api/v1/platform_endpoints/marketplace_test.py`
  — 578 passing; plus `guild_apps_platform_test.py`, `guild_apps_test.py`,
  `tenancy_test.py` at 80.
- Migration applied and round-tripped (`upgrade head`, `downgrade -1`, `upgrade head`).
- `ruff check` / `ruff format` / `uv run ty check app` — clean.

## Note

`FEATURES` was a hand-maintained frozenset duplicating `FEATURE_BLOCKS`' keys.
It now derives from it — a feature with no block is exactly what `_check_features`
refuses, so the second list could only ever be wrong.
