### PR TITLE
Add change-capture outbox foundation

### DIFF
--- a/backend/alembic/versions/20260815_0182_add_event_outbox.py
+++ b/backend/alembic/versions/20260815_0182_add_event_outbox.py
@@ -1,0 +1,102 @@
+"""Add the change-capture outbox and per-subscription cursor
+
+Guild-content migration. ``event_outbox`` is the append-only log the capture
+trigger writes one row to per changed content row: identifiers, the action, and
+the names of the columns that changed — never a value. Consumers read current
+state back through the REST API, where the six gates apply to the read.
+
+``initiative_id`` is NOT NULL: the trigger resolves it from the same
+``INITIATIVE_PATHS`` declaration that renders each table's RLS policies, and
+skips emitting when it cannot (an orphaned child row during a parent cascade —
+whose parent already emitted its own ``deleted``). RLS for this table comes from
+that registry at provisioning time, not from this migration.
+
+``webhook_subscriptions.cursor_event_id`` is each subscription's position in the
+log. Delivery state lives there rather than in per-(event, subscription) rows,
+so one log row serves any number of subscribers and retention is an age sweep.
+
+Revision ID: 20260815_0182
+Revises: 20260814_0181
+Create Date: 2026-08-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.db.guild_migrations import run_for_each_guild_schema
+
+revision = "20260815_0182"
+down_revision = "20260814_0181"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_upgrade)
+
+
+def _apply_upgrade() -> None:
+    op.create_table(
+        "event_outbox",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("txn_id", sa.BigInteger(), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("actor_user_id", sa.Integer(), nullable=True),
+        sa.Column("initiative_id", sa.Integer(), nullable=False),
+        sa.Column("resource_type", sa.String(length=63), nullable=False),
+        sa.Column("resource_id", sa.Integer(), nullable=False),
+        sa.Column("action", sa.String(length=16), nullable=False),
+        sa.Column(
+            "changed",
+            postgresql.ARRAY(sa.String(length=63)),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["initiative_id"], ["initiatives.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "action IN ('created', 'updated', 'deleted')",
+            name="ck_event_outbox_action",
+        ),
+    )
+    with op.batch_alter_table("event_outbox", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_event_outbox_txn_id"), ["txn_id"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_event_outbox_occurred_at"), ["occurred_at"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_event_outbox_initiative_id"),
+            ["initiative_id"],
+            unique=False,
+        )
+
+    op.add_column(
+        "webhook_subscriptions",
+        sa.Column(
+            "cursor_event_id",
+            sa.BigInteger(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_downgrade)
+
+
+def _apply_downgrade() -> None:
+    op.drop_column("webhook_subscriptions", "cursor_event_id")
+    with op.batch_alter_table("event_outbox", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_event_outbox_initiative_id"))
+        batch_op.drop_index(batch_op.f("ix_event_outbox_occurred_at"))
+        batch_op.drop_index(batch_op.f("ix_event_outbox_txn_id"))
+    op.drop_table("event_outbox")

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -44,6 +44,7 @@ from app.models.tenant.calendar_event import (
     CalendarEventTag,
     CalendarEventDocument,
 )
+from app.models.tenant.event_outbox import EventOutbox
 from app.models.tenant.event_reminder_dispatch import EventReminderDispatch
 from app.models.tenant.dashboard import Dashboard, DashboardTag
 from app.models.tenant.counter import (
@@ -132,6 +133,7 @@ __all__ = [
     "CalendarEventAttendee",
     "CalendarEventTag",
     "CalendarEventDocument",
+    "EventOutbox",
     "EventReminderDispatch",
     "Dashboard",
     "DashboardTag",

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -33,7 +33,7 @@ from sqlalchemy.schema import CheckConstraint, CreateTable
 from app.db.initiative_rls import (
     INITIATIVE_PATHS,
     INITIATIVE_SCOPED_TABLES,
-    PathBuilder,
+    InitiativePath,
 )
 from app.db.soft_delete_filter import SOFT_DELETE_TABLES
 from app.db.tenancy import GUILD_SCOPED_TABLES, OWN_ROW_TABLES
@@ -144,13 +144,13 @@ _COMMANDS = (
 )
 
 
-def _table_block(table: str, build: PathBuilder) -> str:
+def _table_block(table: str, path: InitiativePath) -> str:
     lines = [
         f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;",
         f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY;",
     ]
     for suffix, command, clause, write in _COMMANDS:
-        pred = build(table, write)
+        pred = path.predicate(table, write)
         name = f"initiative_member_{suffix}"
         lines.append(f"DROP POLICY IF EXISTS {name} ON {table};")
         lines.append(f"CREATE POLICY {name} ON {table} AS PERMISSIVE FOR {command}")

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -243,6 +243,9 @@ INITIATIVE_PATHS: dict[str, InitiativePath] = {
     "dashboards": direct(),
     "property_definitions": direct(),
     "resource_grants": direct(),
+    # The change log itself. Scoped like the rows it describes, which is what
+    # lets the poller read it AS the subscriber (see EVENTED_TABLES below).
+    "event_outbox": direct(),
     # One hop -> projects
     "tasks": via("projects", "project_id"),
     "task_statuses": via("projects", "project_id"),
@@ -301,3 +304,30 @@ INITIATIVE_PATHS: dict[str, InitiativePath] = {
 
 # Derived — the classification follows the registry, never duplicates it.
 INITIATIVE_SCOPED_TABLES: frozenset[str] = frozenset(INITIATIVE_PATHS)
+
+
+# Tables that get NO change-capture trigger, and why. Stated as an EXCLUSION so
+# the default is "a new content table is evented": a new entry in
+# INITIATIVE_PATHS starts emitting with no second edit, and anything that should
+# stay silent has to say so here deliberately. An inclusion list would instead
+# let a new table ship emitting nothing, which is the failure this whole
+# mechanism exists to remove.
+NON_EVENTED_TABLES: frozenset[str] = frozenset(
+    {
+        # The log cannot log itself.
+        "event_outbox",
+        # Per-user viewing/ordering state and internal dispatch bookkeeping.
+        # These record what one member did with their own UI, not a change to
+        # the initiative's content, so emitting them is pure noise on every
+        # subscription.
+        "recent_views",
+        "project_orders",
+        "project_favorites",
+        "task_assignment_digest_items",
+        "event_reminder_dispatches",
+    }
+)
+
+# The tables the capture trigger is installed on. Derived, so it follows
+# INITIATIVE_PATHS automatically.
+EVENTED_TABLES: frozenset[str] = INITIATIVE_SCOPED_TABLES - NON_EVENTED_TABLES

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -20,6 +20,7 @@ be imported by ``tenancy`` and by the build-time generator alike.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable
 
 from app.core.tools import RECENTABLE_TOOLS
@@ -33,54 +34,102 @@ _UID = "(NULLIF(current_setting('app.current_user_id'::text, true), ''::text))::
 # the four policies — read uses write=False, write commands use write=True.
 PathBuilder = Callable[[str, bool], str]
 
+# A row-locator takes a trigger row alias ("NEW"/"OLD") and returns a scalar SQL
+# expression yielding that row's initiative id (or NULL).
+RowLocator = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class InitiativePath:
+    """How one table's rows resolve an initiative, rendered two ways.
+
+    ``predicate`` builds the RLS policy body; ``initiative_expr`` builds the
+    scalar lookup the change-capture trigger stamps onto an outbox row. Both come
+    from the SAME declaration, so a table cannot be gated by one initiative and
+    have its events attributed to another. Adding a table still means one entry
+    in ``INITIATIVE_PATHS`` — the builders below produce both forms.
+    """
+
+    predicate: PathBuilder
+    initiative_expr: RowLocator
+
 
 def _access(initiative_expr: str, write: bool) -> str:
     return f"public.initiative_access({initiative_expr}, {_UID}, {'true' if write else 'false'})"
 
 
-def direct() -> PathBuilder:
+def direct() -> InitiativePath:
     """The table has its own ``initiative_id`` column."""
-    return lambda t, w: _access(f"{t}.initiative_id", w)
+    return InitiativePath(
+        predicate=lambda t, w: _access(f"{t}.initiative_id", w),
+        initiative_expr=lambda r: f"{r}.initiative_id",
+    )
 
 
-def via(parent: str, fk: str, *, parent_pk: str = "id") -> PathBuilder:
+def via(parent: str, fk: str, *, parent_pk: str = "id") -> InitiativePath:
     """One hop: ``table.<fk> -> parent.<parent_pk>``; parent has ``initiative_id``."""
-    return lambda t, w: (
-        f"EXISTS (SELECT 1 FROM {parent} "
-        f"WHERE {parent}.{parent_pk} = {t}.{fk} "
-        f"AND {_access(f'{parent}.initiative_id', w)})"
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"EXISTS (SELECT 1 FROM {parent} "
+            f"WHERE {parent}.{parent_pk} = {t}.{fk} "
+            f"AND {_access(f'{parent}.initiative_id', w)})"
+        ),
+        initiative_expr=lambda r: (
+            f"(SELECT {parent}.initiative_id FROM {parent} "  # noqa: S608
+            f"WHERE {parent}.{parent_pk} = {r}.{fk})"
+        ),
     )
 
 
-def via_task_project(fk: str = "task_id") -> PathBuilder:
+def via_task_project(fk: str = "task_id") -> InitiativePath:
     """Two hops: ``table.<fk> -> tasks -> projects.initiative_id``."""
-    return lambda t, w: (
-        f"EXISTS (SELECT 1 FROM tasks tk JOIN projects pr ON pr.id = tk.project_id "
-        f"WHERE tk.id = {t}.{fk} "
-        f"AND {_access('pr.initiative_id', w)})"
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"EXISTS (SELECT 1 FROM tasks tk JOIN projects pr ON pr.id = tk.project_id "
+            f"WHERE tk.id = {t}.{fk} "
+            f"AND {_access('pr.initiative_id', w)})"
+        ),
+        initiative_expr=lambda r: (
+            f"(SELECT pr.initiative_id FROM tasks tk "  # noqa: S608
+            f"JOIN projects pr ON pr.id = tk.project_id WHERE tk.id = {r}.{fk})"
+        ),
     )
 
 
-def via_queue_item(fk: str = "queue_item_id") -> PathBuilder:
+def via_queue_item(fk: str = "queue_item_id") -> InitiativePath:
     """Two hops: ``table.<fk> -> queue_items -> queues.initiative_id``."""
-    return lambda t, w: (
-        f"EXISTS (SELECT 1 FROM queue_items qi JOIN queues q ON q.id = qi.queue_id "
-        f"WHERE qi.id = {t}.{fk} "
-        f"AND {_access('q.initiative_id', w)})"
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"EXISTS (SELECT 1 FROM queue_items qi JOIN queues q ON q.id = qi.queue_id "
+            f"WHERE qi.id = {t}.{fk} "
+            f"AND {_access('q.initiative_id', w)})"
+        ),
+        initiative_expr=lambda r: (
+            f"(SELECT q.initiative_id FROM queue_items qi "  # noqa: S608
+            f"JOIN queues q ON q.id = qi.queue_id WHERE qi.id = {r}.{fk})"
+        ),
     )
 
 
-def via_event_calendar(fk: str = "calendar_event_id") -> PathBuilder:
+def via_event_calendar(fk: str = "calendar_event_id") -> InitiativePath:
     """Two hops: ``table.<fk> -> calendar_events -> calendars.initiative_id``."""
-    return lambda t, w: (
-        f"EXISTS (SELECT 1 FROM calendar_events ce "
-        f"JOIN calendars cal ON cal.id = ce.calendar_id "
-        f"WHERE ce.id = {t}.{fk} "
-        f"AND {_access('cal.initiative_id', w)})"
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"EXISTS (SELECT 1 FROM calendar_events ce "
+            f"JOIN calendars cal ON cal.id = ce.calendar_id "
+            f"WHERE ce.id = {t}.{fk} "
+            f"AND {_access('cal.initiative_id', w)})"
+        ),
+        initiative_expr=lambda r: (
+            f"(SELECT cal.initiative_id FROM calendar_events ce "  # noqa: S608
+            f"JOIN calendars cal ON cal.id = ce.calendar_id WHERE ce.id = {r}.{fk})"
+        ),
     )
 
 
-def via_property(entity_from: str, entity_pred: str, entity_init: str) -> PathBuilder:
+def via_property(
+    entity_from: str, entity_pred: str, entity_init: str
+) -> InitiativePath:
     """Property-value rows: join the entity and ``property_definitions`` and
     require both resolve to the SAME initiative, then check access on it.
 
@@ -92,23 +141,40 @@ def via_property(entity_from: str, entity_pred: str, entity_init: str) -> PathBu
     Every fragment interpolated here is a string literal from the
     INITIATIVE_PATHS registry in this module — policy DDL rendering, never
     user input."""
-    return lambda t, w: (
-        f"EXISTS (SELECT 1 FROM {entity_from} "  # noqa: S608
-        f"JOIN property_definitions pd ON pd.id = {t}.property_id "
-        f"WHERE {entity_pred.format(t=t)} AND {entity_init} = pd.initiative_id "
-        f"AND {_access('pd.initiative_id', w)})"
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"EXISTS (SELECT 1 FROM {entity_from} "  # noqa: S608
+            f"JOIN property_definitions pd ON pd.id = {t}.property_id "
+            f"WHERE {entity_pred.format(t=t)} AND {entity_init} = pd.initiative_id "
+            f"AND {_access('pd.initiative_id', w)})"
+        ),
+        # The policy already requires entity and definition to share an
+        # initiative, so either side names the same one; the definition is a
+        # single-table lookup.
+        initiative_expr=lambda r: (
+            f"(SELECT pd.initiative_id FROM property_definitions pd "  # noqa: S608
+            f"WHERE pd.id = {r}.property_id)"
+        ),
     )
 
 
-def comments_path() -> PathBuilder:
+def comments_path() -> InitiativePath:
     """Comments hang off EITHER a task or a document."""
-    return lambda t, w: (
-        f"(({t}.task_id IS NOT NULL AND EXISTS ("
-        f"SELECT 1 FROM tasks tk JOIN projects pr ON pr.id = tk.project_id "
-        f"WHERE tk.id = {t}.task_id AND {_access('pr.initiative_id', w)})) "
-        f"OR ({t}.document_id IS NOT NULL AND EXISTS ("
-        f"SELECT 1 FROM documents d WHERE d.id = {t}.document_id "
-        f"AND {_access('d.initiative_id', w)})))"
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"(({t}.task_id IS NOT NULL AND EXISTS ("
+            f"SELECT 1 FROM tasks tk JOIN projects pr ON pr.id = tk.project_id "
+            f"WHERE tk.id = {t}.task_id AND {_access('pr.initiative_id', w)})) "
+            f"OR ({t}.document_id IS NOT NULL AND EXISTS ("
+            f"SELECT 1 FROM documents d WHERE d.id = {t}.document_id "
+            f"AND {_access('d.initiative_id', w)})))"
+        ),
+        initiative_expr=lambda r: (
+            "COALESCE("
+            f"(SELECT pr.initiative_id FROM tasks tk "  # noqa: S608
+            f"JOIN projects pr ON pr.id = tk.project_id WHERE tk.id = {r}.task_id), "
+            f"(SELECT d.initiative_id FROM documents d WHERE d.id = {r}.document_id))"
+        ),
     )
 
 
@@ -119,7 +185,7 @@ def comments_path() -> PathBuilder:
 RECENT_ENTITY_TABLES: dict[str, str] = {t.value: t.plural for t in RECENTABLE_TOOLS}
 
 
-def recent_views_path() -> PathBuilder:
+def recent_views_path() -> InitiativePath:
     def build(t: str, w: bool) -> str:
         legs = [
             f"({t}.entity_type = '{etype}' AND EXISTS (SELECT 1 FROM {tbl} "
@@ -128,10 +194,18 @@ def recent_views_path() -> PathBuilder:
         ]
         return "(" + " OR ".join(legs) + ")"
 
-    return build
+    def locate(r: str) -> str:
+        arms = " ".join(
+            f"WHEN '{etype}' THEN "
+            f"(SELECT {tbl}.initiative_id FROM {tbl} WHERE {tbl}.id = {r}.entity_id)"  # noqa: S608
+            for etype, tbl in RECENT_ENTITY_TABLES.items()
+        )
+        return f"(CASE {r}.entity_type {arms} END)"
+
+    return InitiativePath(predicate=build, initiative_expr=locate)
 
 
-def document_links_path() -> PathBuilder:
+def document_links_path() -> InitiativePath:
     """A link must clear initiative access on BOTH endpoints. With only the
     source checked, a write-member of one initiative could point
     ``target_document_id`` at a document in an initiative they can't reach (and
@@ -143,15 +217,23 @@ def document_links_path() -> PathBuilder:
             f"AND {_access('documents.initiative_id', w)})"
         )
 
-    return lambda t, w: (
-        f"({_leg('source_document_id', t, w)} AND {_leg('target_document_id', t, w)})"
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"({_leg('source_document_id', t, w)} AND {_leg('target_document_id', t, w)})"
+        ),
+        # Both endpoints clear the same gate to exist, so the source names the
+        # initiative the link belongs to.
+        initiative_expr=lambda r: (
+            f"(SELECT documents.initiative_id FROM documents "  # noqa: S608
+            f"WHERE documents.id = {r}.source_document_id)"
+        ),
     )
 
 
 # table -> how its rows resolve an initiative for initiative_access(...). THE
 # source of truth: INITIATIVE_SCOPED_TABLES and the rendered RLS DDL (app.db.guild_ddl) both derive from
 # this dict, so a new initiative-scoped table is declared here exactly once.
-INITIATIVE_PATHS: dict[str, PathBuilder] = {
+INITIATIVE_PATHS: dict[str, InitiativePath] = {
     # Own initiative_id column
     "projects": direct(),
     "documents": direct(),

--- a/backend/app/models/tenant/event_outbox.py
+++ b/backend/app/models/tenant/event_outbox.py
@@ -1,0 +1,92 @@
+"""Append-only change log, written by the capture trigger.
+
+One row per changed content row, stamped by the generic capture trigger the
+provisioning pipeline installs on every evented guild-content table. The row
+carries **identifiers and changed column names only** — never a value. A
+consumer learns *that* something changed and reads the current state back
+through the REST API, where the six gates apply to the read.
+
+``initiative_id`` is NOT NULL and resolved by the trigger from the same
+``INITIATIVE_PATHS`` declaration that renders the table's RLS policies, so an
+event is scoped exactly like the row it describes. The outbox itself carries
+initiative-member RLS (``direct()``), which is what lets the poller read it *as
+the subscriber* and get back only the events that subscriber may see.
+
+Delivery state is not held here: this is a log, and each subscription tracks its
+own position in it (``webhook_subscriptions.cursor_event_id``). One row can
+therefore serve any number of subscribers, and retention is a plain age sweep.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+)
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlmodel import Field, SQLModel
+
+#: The three actions the trigger emits. A soft delete is reported as ``deleted``
+#: and a restore as ``created``, so a consumer never has to know our
+#: ``deleted_at`` convention to notice that a row came or went.
+ACTION_CREATED = "created"
+ACTION_UPDATED = "updated"
+ACTION_DELETED = "deleted"
+ACTIONS = (ACTION_CREATED, ACTION_UPDATED, ACTION_DELETED)
+
+
+class EventOutbox(SQLModel, table=True):
+    __tablename__ = "event_outbox"
+
+    id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(BigInteger, primary_key=True, autoincrement=True),
+    )
+
+    # ``txid_current()`` of the writing transaction. Every row a single
+    # transaction produced shares one value, which is what lets the poller
+    # deliver a transaction as one batched envelope instead of N envelopes.
+    txn_id: int = Field(sa_column=Column(BigInteger, nullable=False, index=True))
+
+    occurred_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
+    )
+
+    # The user whose request caused the change, from the request GUC. NULL for a
+    # system-attributed write (background jobs, migrations).
+    actor_user_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+        ),
+    )
+
+    initiative_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("initiatives.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
+
+    # The table the change happened to, and its primary key.
+    resource_type: str = Field(sa_column=Column(String(length=63), nullable=False))
+    resource_id: int = Field(sa_column=Column(Integer, nullable=False))
+
+    action: str = Field(sa_column=Column(String(length=16), nullable=False))
+
+    # Changed column NAMES. Empty on create and delete, where the whole row
+    # came or went and naming every column would say nothing.
+    changed: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(ARRAY(String(length=63)), nullable=False, server_default="{}"),
+    )

--- a/backend/app/models/tenant/webhook_subscription.py
+++ b/backend/app/models/tenant/webhook_subscription.py
@@ -12,7 +12,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+)
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlmodel import Field, SQLModel
 
@@ -64,6 +72,15 @@ class WebhookSubscription(SQLModel, table=True):
     active: bool = Field(
         default=True,
         sa_column=Column(Boolean, nullable=False, server_default="true"),
+    )
+
+    # This subscription's position in ``event_outbox``. The poller reads rows
+    # with a greater id, delivers them, and only then advances — so a delivery
+    # that fails is retried on the next cycle rather than lost. One log, one
+    # cursor per subscriber, no per-subscription delivery rows.
+    cursor_event_id: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False, server_default="0"),
     )
 
     # TZ-aware columns to match the migration.


### PR DESCRIPTION
## Problem

Guild content changes are announced to three unrelated places today: `realtime.broadcast_event` (30 call sites), `stream_authz.authority.emit` (30 more), and `webhook_dispatcher.dispatch_event` — which has exactly **one** first-party call site, `task.created`. Roughly 60 semantic events happen; an outbound subscriber can observe one of them.

Adding the missing 59 by hand would mean 59 more chances to forget, and a new model would still start at zero coverage. This PR lays the foundation for capturing changes at the database instead, so a table emits by existing rather than by remembering.

No behavior changes yet — nothing reads or writes the new table in this PR.

## Changes

**`InitiativePath` renders each registry entry two ways** (`app/db/initiative_rls.py`)

`INITIATIVE_PATHS` entries now return an `InitiativePath` carrying both the RLS policy predicate (unchanged) and a scalar expression that resolves a row's initiative id from a trigger row alias. Because the entries are function *calls*, all 44 registry lines are untouched — only the nine builder functions changed.

Both forms come from the same declaration, so a table cannot be gated by one initiative and have its events attributed to another.

**`event_outbox`** (`app/models/tenant/event_outbox.py`, migration `20260815_0182`)

An append-only log: one row per changed content row, carrying identifiers, the action, and the **names** of the columns that changed — never a value. Consumers read current state back through the REST API, so the six gates decide what they actually see.

- `initiative_id` is NOT NULL, resolved from the same `INITIATIVE_PATHS` declaration that renders the table's RLS. The trigger (next PR) skips emitting when it cannot resolve one — an orphaned child row during a parent cascade, whose parent emits its own `deleted` that a subscriber acts on instead.
- It's an ordinary registry entry, so it picks up the four `initiative_member_*` policies automatically. That's what lets the poller read the log *as the subscriber*.
- `webhook_subscriptions.cursor_event_id` holds each subscription's position in the log, so one row serves any number of subscribers and retention is a plain age sweep rather than per-delivery rows.

**`EVENTED_TABLES`** derives as `INITIATIVE_SCOPED_TABLES - NON_EVENTED_TABLES`. Stated as an exclusion so a new content table starts emitting with no second edit; the exclusions are the log itself plus per-user view/order state and internal dispatch bookkeeping, which record what one member did with their own UI rather than a change to content.

## Schema

Guild-content migration `20260815_0182` — creates `event_outbox` in `guild_template` and every `guild_<id>`, and adds `webhook_subscriptions.cursor_event_id` (server default `0`, so existing rows start at the head of an empty log). RLS comes from the registry at provisioning time, not from the migration. Clean downgrade provided.

## Testing

```
ruff check app && ruff format app
ty check app/db/initiative_rls.py app/models/tenant/event_outbox.py
pytest app/db/tenancy_test.py app/core/tools_test.py          # 21 passed
pytest app/db/tenancy_test.py app/db/guild_rls_test.py        # 12 passed
```

The refactor was verified non-behavioral by rendering `render_guild_rls_ddl()` before and after and diffing: **byte-identical**. All 44 generated initiative expressions were rendered and reviewed individually, including the polymorphic ones (`comments` resolves via COALESCE over task/document; `recent_views` via CASE over `entity_type`).

## Follow-ups

Next PR builds on this branch: the generic capture trigger rendered per evented table and wired into provisioning + the boot backfill, then the poller that drains the log.
