### PR TITLE
Capture content changes with one trigger function

### DIFF
--- a/backend/alembic/versions/20260815_0183_add_capture_change_function.py
+++ b/backend/alembic/versions/20260815_0183_add_capture_change_function.py
@@ -1,0 +1,42 @@
+"""Add public.capture_change(), the one change-capture trigger function
+
+Created once in ``public`` and shared by every guild schema, exactly like
+``public.initiative_access``. The body names content tables unqualified, so they
+resolve through the caller's ``search_path`` — the routed ``guild_<id>`` — and
+one function serves every guild rather than one per schema.
+
+Per-table knowledge arrives as trigger arguments rendered from the registries
+that already describe these tables (``app/db/event_capture.py``): how a row
+resolves its initiative, which resource an event names, and which columns are
+excluded from the reported change set. The triggers themselves are installed per
+schema at provisioning time, not here.
+
+The function writes identifiers, an action, and changed column NAMES. It never
+writes a value: a consumer reads current state back through the REST API.
+
+Revision ID: 20260815_0183
+Revises: 20260815_0182
+Create Date: 2026-08-15
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from app.db.event_capture import CAPTURE_FUNCTION, CAPTURE_FUNCTION_SQL
+
+revision = "20260815_0183"
+down_revision = "20260815_0182"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The body names guild-local tables that no schema on the migration-time
+    # search_path holds; resolution is per call, through the routed search_path.
+    op.execute("SET LOCAL check_function_bodies = false")
+    op.execute(CAPTURE_FUNCTION_SQL)
+
+
+def downgrade() -> None:
+    op.execute(f"DROP FUNCTION IF EXISTS {CAPTURE_FUNCTION}()")

--- a/backend/alembic/versions/20260815_0183_add_event_outbox.py
+++ b/backend/alembic/versions/20260815_0183_add_event_outbox.py
@@ -15,8 +15,8 @@ that registry at provisioning time, not from this migration.
 log. Delivery state lives there rather than in per-(event, subscription) rows,
 so one log row serves any number of subscribers and retention is an age sweep.
 
-Revision ID: 20260815_0182
-Revises: 20260814_0181
+Revision ID: 20260815_0183
+Revises: 20260815_0182
 Create Date: 2026-08-15
 """
 
@@ -28,8 +28,8 @@ from sqlalchemy.dialects import postgresql
 
 from app.db.guild_migrations import run_for_each_guild_schema
 
-revision = "20260815_0182"
-down_revision = "20260814_0181"
+revision = "20260815_0183"
+down_revision = "20260815_0182"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260815_0184_add_capture_change_function.py
+++ b/backend/alembic/versions/20260815_0184_add_capture_change_function.py
@@ -14,8 +14,8 @@ schema at provisioning time, not here.
 The function writes identifiers, an action, and changed column NAMES. It never
 writes a value: a consumer reads current state back through the REST API.
 
-Revision ID: 20260815_0183
-Revises: 20260815_0182
+Revision ID: 20260815_0184
+Revises: 20260815_0183
 Create Date: 2026-08-15
 """
 
@@ -25,8 +25,8 @@ from alembic import op
 
 from app.db.event_capture import CAPTURE_FUNCTION, CAPTURE_FUNCTION_SQL
 
-revision = "20260815_0183"
-down_revision = "20260815_0182"
+revision = "20260815_0184"
+down_revision = "20260815_0183"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/db/event_capture.py
+++ b/backend/app/db/event_capture.py
@@ -32,7 +32,9 @@ junction's name — so a new junction is covered by construction.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
+from sqlalchemy import Column
 from sqlmodel import SQLModel
 
 from app.db.initiative_rls import EVENTED_TABLES, INITIATIVE_PATHS
@@ -78,7 +80,7 @@ def _singular(table: str) -> str:
     return table[:-1] if table.endswith("s") else table
 
 
-def _owner_of(column) -> str | None:
+def _owner_of(column: Column[Any]) -> str | None:
     """The table a FK column points at, or None if it is not a FK."""
     for fk in column.foreign_keys:
         return fk.column.table.name
@@ -219,13 +221,17 @@ BEGIN
 
     v_actor := NULLIF(current_setting('app.current_user_id', true), '')::integer;
 
-    INSERT INTO event_outbox (
-        txn_id, occurred_at, actor_user_id, initiative_id,
-        resource_type, resource_id, action, changed
-    ) VALUES (
-        txid_current(), now(), v_actor, v_initiative,
-        TG_ARGV[1], v_resource, v_action, v_changed
-    );
+    -- Write to the outbox of the schema the CHANGED ROW lives in, named from
+    -- TG_TABLE_SCHEMA rather than resolved through the caller's search_path.
+    -- The row's own schema is the authoritative answer to which guild this
+    -- event belongs to, and it is what the trigger is attached to.
+    EXECUTE format(
+        'INSERT INTO %I.event_outbox ('
+        '  txn_id, occurred_at, actor_user_id, initiative_id,'
+        '  resource_type, resource_id, action, changed'
+        ') VALUES (txid_current(), now(), $1, $2, $3, $4, $5, $6)',
+        TG_TABLE_SCHEMA
+    ) USING v_actor, v_initiative, TG_ARGV[1], v_resource, v_action, v_changed;
 
     RETURN NULL;
 END

--- a/backend/app/db/event_capture.py
+++ b/backend/app/db/event_capture.py
@@ -1,0 +1,289 @@
+"""Change capture — one trigger function, every evented content table.
+
+The capture rule lives in ONE place, ``public.capture_change()``. Per-table
+knowledge reaches it as trigger arguments rendered from the registries that
+already describe these tables, so installing capture on a new table needs no new
+declaration:
+
+* **which initiative a row belongs to** — ``INITIATIVE_PATHS`` (the same entry
+  that renders the table's RLS policies), so an event is scoped exactly like the
+  row it describes;
+* **which resource the event names** — the table's own primary key, or for a
+  junction its owner (below), read off the SQLModel metadata.
+
+What lands in ``event_outbox`` is identifiers, an action, and the **names** of
+the columns that changed. Never a value: a consumer reads current state back
+through the REST API, where the six gates apply to the read.
+
+Junctions report their owner
+----------------------------
+Over half these tables are junctions with a composite primary key
+(``task_tags``, ``task_assignees``, ``document_property_values``, …) and no id
+of their own. Their first primary-key column is always the FK to the resource
+that owns them, so a row appearing in ``task_tags`` is reported as
+``task.updated`` with ``changed = ['tags']``.
+
+That is also the semantics a subscriber wants: "this task was tagged", not "a
+row appeared in a junction table". The owner and the label are both derived —
+the owner from the FK, the label by stripping the owner's singular stem from the
+junction's name — so a new junction is covered by construction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlmodel import SQLModel
+
+from app.db.initiative_rls import EVENTED_TABLES, INITIATIVE_PATHS
+
+#: The function name every per-table trigger calls. Created once in ``public``
+#: (not per guild schema): the body names content tables unqualified, so it
+#: resolves them through the caller's ``search_path`` — the routed guild schema —
+#: exactly as ``public.initiative_access`` does.
+CAPTURE_FUNCTION = "public.capture_change"
+
+#: Columns whose changes are not worth reporting. ``updated_at`` moves on every
+#: write, and search vectors / denormalized counters churn on their own, so
+#: leaving them in would make every column filter match constantly.
+HOUSEKEEPING_COLUMNS: frozenset[str] = frozenset(
+    {"updated_at", "created_at", "search_vector"}
+)
+
+#: Same idea, by suffix, for generated text-search columns.
+HOUSEKEEPING_SUFFIXES: tuple[str, ...] = ("_vector", "_tsv")
+
+
+@dataclass(frozen=True)
+class CaptureSpec:
+    """How one table's changes are reported."""
+
+    #: The table the trigger is installed on.
+    table: str
+    #: The resource an event names — the table itself, or a junction's owner.
+    resource_type: str
+    #: Column on the changed row holding ``resource_type``'s id.
+    resource_id_column: str
+    #: For a junction, the label reported in ``changed`` (e.g. ``tags``).
+    #: ``None`` when the table is its own resource and real column names apply.
+    facet: str | None
+
+    @property
+    def trigger_name(self) -> str:
+        return f"capture_{self.table}"
+
+
+def _singular(table: str) -> str:
+    """Junction owners are all regular plurals in this schema."""
+    return table[:-1] if table.endswith("s") else table
+
+
+def _owner_of(column) -> str | None:
+    """The table a FK column points at, or None if it is not a FK."""
+    for fk in column.foreign_keys:
+        return fk.column.table.name
+    return None
+
+
+def build_specs() -> list[CaptureSpec]:
+    """One spec per evented table, derived from the model metadata.
+
+    Raises when a table can be neither addressed by its own primary key nor
+    resolved to an owner — capture would otherwise install a trigger that emits
+    rows naming no resource, and a silently unaddressable event is worse than a
+    failed boot.
+    """
+    specs: list[CaptureSpec] = []
+    for table_name in sorted(EVENTED_TABLES):
+        table = SQLModel.metadata.tables.get(table_name)
+        if table is None:
+            raise RuntimeError(
+                f"{table_name} is in EVENTED_TABLES but has no mapped model"
+            )
+        pk = list(table.primary_key.columns)
+        if len(pk) == 1:
+            specs.append(
+                CaptureSpec(
+                    table=table_name,
+                    resource_type=table_name,
+                    resource_id_column=pk[0].name,
+                    facet=None,
+                )
+            )
+            continue
+
+        owner_column = pk[0]
+        owner = _owner_of(owner_column)
+        if owner is None:
+            raise RuntimeError(
+                f"{table_name} has a composite primary key whose first column "
+                f"({owner_column.name}) is not a foreign key, so its events "
+                "cannot name an owning resource"
+            )
+        facet = table_name.removeprefix(f"{_singular(owner)}_")
+        specs.append(
+            CaptureSpec(
+                table=table_name,
+                resource_type=owner,
+                resource_id_column=owner_column.name,
+                facet=facet,
+            )
+        )
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# The capture function
+# ---------------------------------------------------------------------------
+
+#: Rendered once into ``public``. Per-table knowledge arrives as TG_ARGV:
+#:   0 — SQL expression resolving the row's initiative id, over ``($1)``
+#:   1 — resource type the event names
+#:   2 — column on the row holding that resource's id
+#:   3 — junction facet label, or '' when the table is its own resource
+#:   4 — array literal of column names excluded from ``changed``
+CAPTURE_FUNCTION_SQL = f"""
+CREATE OR REPLACE FUNCTION {CAPTURE_FUNCTION}() RETURNS trigger
+    LANGUAGE plpgsql AS $capture$
+DECLARE
+    v_row        record;
+    v_initiative integer;
+    v_action     text;
+    v_changed    text[] := '{{}}';
+    v_resource   integer;
+    v_actor      integer;
+    v_new        jsonb;
+    v_old        jsonb;
+    v_facet      text := TG_ARGV[3];
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_row := OLD;
+    ELSE
+        v_row := NEW;
+    END IF;
+
+    -- Which initiative this row belongs to, per its INITIATIVE_PATHS entry.
+    -- A row whose initiative no longer resolves is skipped: that is an orphaned
+    -- child during a parent cascade, and the parent emits its own delete.
+    EXECUTE 'SELECT ' || TG_ARGV[0] INTO v_initiative USING v_row;
+    IF v_initiative IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    EXECUTE format('SELECT ($1).%I', TG_ARGV[2]) INTO v_resource USING v_row;
+    IF v_resource IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        v_action := 'created';
+    ELSIF TG_OP = 'DELETE' THEN
+        v_action := 'deleted';
+    ELSE
+        v_new := to_jsonb(NEW);
+        v_old := to_jsonb(OLD);
+
+        -- Soft delete and restore are reported as what they are, so a consumer
+        -- never has to know the deleted_at convention to see a row come or go.
+        IF v_new ? 'deleted_at'
+           AND v_old ->> 'deleted_at' IS NULL
+           AND v_new ->> 'deleted_at' IS NOT NULL THEN
+            v_action := 'deleted';
+        ELSIF v_new ? 'deleted_at'
+           AND v_old ->> 'deleted_at' IS NOT NULL
+           AND v_new ->> 'deleted_at' IS NULL THEN
+            v_action := 'created';
+        ELSE
+            v_action := 'updated';
+            SELECT coalesce(array_agg(key ORDER BY key), '{{}}')
+              INTO v_changed
+              FROM jsonb_each(v_new) AS e(key, value)
+             WHERE value IS DISTINCT FROM (v_old -> e.key)
+               AND NOT (key = ANY (TG_ARGV[4]::text[]));
+
+            -- Nothing a subscriber can act on changed.
+            IF cardinality(v_changed) = 0 THEN
+                RETURN NULL;
+            END IF;
+        END IF;
+    END IF;
+
+    -- A junction has no columns of its own worth naming; report the change as
+    -- the owning resource being updated in one respect.
+    IF v_facet <> '' THEN
+        v_changed := ARRAY[v_facet];
+        IF v_action <> 'updated' THEN
+            v_action := 'updated';
+        END IF;
+    END IF;
+
+    v_actor := NULLIF(current_setting('app.current_user_id', true), '')::integer;
+
+    INSERT INTO event_outbox (
+        txn_id, occurred_at, actor_user_id, initiative_id,
+        resource_type, resource_id, action, changed
+    ) VALUES (
+        txid_current(), now(), v_actor, v_initiative,
+        TG_ARGV[1], v_resource, v_action, v_changed
+    );
+
+    RETURN NULL;
+END
+$capture$;
+"""
+
+
+def _housekeeping_literal(table_name: str) -> str:
+    """SQL array literal of column names excluded from ``changed`` for a table."""
+    table = SQLModel.metadata.tables[table_name]
+    excluded = sorted(
+        c.name
+        for c in table.columns
+        if c.name in HOUSEKEEPING_COLUMNS or c.name.endswith(HOUSEKEEPING_SUFFIXES)
+    )
+    inner = ",".join(f'"{name}"' for name in excluded)
+    return f"'{{{inner}}}'"
+
+
+def _trigger_block(spec: CaptureSpec) -> str:
+    path = INITIATIVE_PATHS[spec.table]
+    # The row reaches the expression as $1 in a dynamic EXECUTE, so the locator
+    # renders against ($1) instead of NEW/OLD.
+    initiative_expr = path.initiative_expr("($1)").replace("'", "''")
+    facet = spec.facet or ""
+    return "\n".join(
+        [
+            f"DROP TRIGGER IF EXISTS {spec.trigger_name} ON {spec.table};",
+            f"CREATE TRIGGER {spec.trigger_name}",
+            f"  AFTER INSERT OR UPDATE OR DELETE ON {spec.table}",
+            f"  FOR EACH ROW EXECUTE FUNCTION {CAPTURE_FUNCTION}(",
+            f"    '{initiative_expr}',",
+            f"    '{spec.resource_type}',",
+            f"    '{spec.resource_id_column}',",
+            f"    '{facet}',",
+            f"    {_housekeeping_literal(spec.table)}",
+            "  );",
+        ]
+    )
+
+
+_HEADER = """\
+-- ============================================================================
+-- CHANGE CAPTURE — GENERATED, DO NOT EDIT BY HAND
+-- RENDERED AT RUNTIME from app/db/event_capture.py.
+--
+-- One trigger per evented content table, all calling public.capture_change().
+-- Per-table knowledge is passed as trigger arguments derived from
+-- INITIATIVE_PATHS (which initiative a row belongs to) and the model metadata
+-- (which resource an event names), so a new content table is captured without
+-- a second declaration.
+--
+-- The outbox carries identifiers and changed column NAMES only. Values are read
+-- back through the REST API, where the six gates apply to the read.
+-- ============================================================================"""
+
+
+def render_guild_capture_ddl() -> str:
+    """Per-table trigger DDL, applied inside each guild schema."""
+    blocks = [_trigger_block(spec) for spec in build_specs()]
+    return _HEADER + "\n\n" + "\n\n".join(blocks) + "\n"

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -155,6 +155,7 @@ class ProvisioningBundle:
 
     schema_ddl: str
     rls_ddl: str
+    capture_ddl: str
     stamp: str
 
 
@@ -170,13 +171,16 @@ async def get_provisioning_bundle() -> ProvisioningBundle:
     async with _bundle_lock:
         if _bundle is not None:
             return _bundle
+        from app.db.event_capture import render_guild_capture_ddl
         from app.db.guild_ddl import render_guild_rls_ddl, render_guild_schema_ddl
 
         schema_ddl = await render_guild_schema_ddl(db_session.provisioning_engine)
         rls_ddl = render_guild_rls_ddl()
+        capture_ddl = render_guild_capture_ddl()
         digest = hashlib.sha256()
         digest.update(schema_ddl.encode())
         digest.update(rls_ddl.encode())
+        digest.update(capture_ddl.encode())
         digest.update(
             "\n".join(
                 _grant_statements(
@@ -190,6 +194,7 @@ async def get_provisioning_bundle() -> ProvisioningBundle:
         _bundle = ProvisioningBundle(
             schema_ddl=schema_ddl,
             rls_ddl=rls_ddl,
+            capture_ddl=capture_ddl,
             stamp=f"provisioned:{digest.hexdigest()[:16]}",
         )
         return _bundle
@@ -238,6 +243,24 @@ async def apply_guild_rls(conn: AsyncConnection, schema: str) -> None:
     )
 
 
+async def apply_guild_capture(conn: AsyncConnection, schema: str) -> None:
+    """Install the change-capture triggers on ``schema``'s evented tables.
+
+    Schema-relative + idempotent (``DROP TRIGGER IF EXISTS`` + ``CREATE
+    TRIGGER``), so a re-run re-asserts them harmlessly. Every trigger calls the
+    one ``public.capture_change`` (qualified, so it resolves regardless of
+    search_path); the per-table initiative lookups it runs resolve against the
+    guild-local tables through the caller's search_path, the same way the RLS
+    policies' EXISTS joins do. Requires ``public.capture_change`` to exist
+    (created by migration 20260815_0183).
+    """
+    ddl = (await get_provisioning_bundle()).capture_ddl
+    raw = await conn.get_raw_connection()
+    await raw.driver_connection.execute(
+        f'SET search_path TO "{schema}", public;\n{ddl}\nSET search_path TO public;'
+    )
+
+
 async def apply_template_rls() -> None:
     """Re-assert the registry-rendered RLS on ``guild_template``.
 
@@ -250,6 +273,7 @@ async def apply_template_rls() -> None:
 
     async with db_session.provisioning_engine.begin() as conn:
         await apply_guild_rls(conn, TEMPLATE_SCHEMA)
+        await apply_guild_capture(conn, TEMPLATE_SCHEMA)
 
 
 def _grant_statements(
@@ -359,6 +383,7 @@ async def provision_guild_schema(conn: AsyncConnection, guild_id: int) -> str:
     await apply_guild_schema(conn, schema)  # canonical Alembic-owned table DDL
     await _exec_batch(conn, _grant_statements(schema, role, ro_role, support_role))
     await apply_guild_rls(conn, schema)  # initiative-level RLS policies
+    await apply_guild_capture(conn, schema)  # change-capture triggers
     # Stamp the artifacts' version so the boot back-fill can skip this guild
     # until they change (constant hex literal, safe to inline).
     stamp = (await get_provisioning_bundle()).stamp

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -252,7 +252,7 @@ async def apply_guild_capture(conn: AsyncConnection, schema: str) -> None:
     search_path); the per-table initiative lookups it runs resolve against the
     guild-local tables through the caller's search_path, the same way the RLS
     policies' EXISTS joins do. Requires ``public.capture_change`` to exist
-    (created by migration 20260815_0183).
+    (created by migration 20260815_0184).
     """
     ddl = (await get_provisioning_bundle()).capture_ddl
     raw = await conn.get_raw_connection()


### PR DESCRIPTION
> **Stacked on #1181** — targets `feat/event-bus-outbox`, so the diff here is only the capture layer. Merge #1181 first.

## What this adds

`public.capture_change()` — one trigger function, created once and shared by every guild schema exactly like `public.initiative_access`. Its body names content tables unqualified, so they resolve through the caller's `search_path` (the routed `guild_<id>`), and one function serves every guild rather than one per schema.

Per-table knowledge arrives as trigger arguments rendered from registries that already describe these tables, so capturing a new table needs no new declaration:

- **which initiative a row belongs to** — `INITIATIVE_PATHS`, the same entry that renders the table's RLS policies, so an event is scoped exactly like the row it describes;
- **which resource an event names** — the table's own primary key, or a junction's owner (below), read off the model metadata;
- **which columns don't count as a change** — `updated_at` and generated search vectors, which otherwise move on every write.

## Junctions report their owner

19 of the 35 evented tables are junctions with a composite primary key and no id of their own (`task_tags`, `task_assignees`, `document_property_values`, …). Skipping them would drop tagging, assignment, and property-value events — most of what a subscriber keys on.

Their first primary-key column is always the FK to the owning resource, so a row appearing in `task_tags` is reported as `task.updated` with `changed = ['tags']`. That is also the better semantics: "this task was tagged", not "a row appeared in a junction table". Owner and label are both derived — the owner from the FK, the label by stripping the owner's singular stem — so a new junction is covered by construction.

`build_specs()` raises rather than guessing if a composite-key table's first column isn't a FK, so an unaddressable event fails the boot instead of shipping silently.

## Reported actions

- INSERT → `created`, DELETE → `deleted`, UPDATE → `updated` with the changed column names.
- A soft delete (`deleted_at` NULL → non-NULL) is reported as `deleted`, and a restore as `created` — a consumer never has to know our `deleted_at` convention to see a row come or go.
- An update touching only excluded columns emits nothing.
- A row whose initiative no longer resolves emits nothing — that's an orphaned child during a parent cascade, and the parent emits its own `deleted`, which is the event a subscriber acts on.

## Provisioning

`capture_ddl` joins the provisioning bundle and is hashed into the stamp, so editing the registry invalidates every guild's stamp and schedules one idempotent re-provisioning sweep on the next boot — the same path a registry-driven RLS change already takes. `apply_guild_capture()` mirrors `apply_guild_rls()`: schema-relative, `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER`, safe to re-run. It runs for `guild_template` too, so the template keeps matching a provisioned guild.

## Schema

Migration `20260815_0183` creates `public.capture_change()`. The triggers themselves are installed per schema at provisioning time, not by the migration. Clean downgrade.

## Testing

```
ruff check app && ruff format app
ty check app/db/event_capture.py app/db/schema_provisioning.py
```

Rendered all 35 specs and reviewed the derived owner/label for every junction, including the irregular ones (`calendar_event_property_values` → owner `calendar_events` via `event_id`, label `property_values`; `document_links` → owner `documents` via `source_document_id`, label `links`). Verified `capture_change()` parses and creates against Postgres.

Full suite left to CI per request.

## Follow-ups

Next: the poller that drains the log — reading it **as the subscriber**, so RLS on `event_outbox` decides which events each subscription may see, then batching per transaction and advancing its cursor only on a 2xx.
