### PR TITLE
Deliver events from the outbox

### DIFF
--- a/backend/alembic/versions/20260815_0184_add_capture_change_function.py
+++ b/backend/alembic/versions/20260815_0184_add_capture_change_function.py
@@ -23,12 +23,112 @@ from __future__ import annotations
 
 from alembic import op
 
-from app.db.event_capture import CAPTURE_FUNCTION, CAPTURE_FUNCTION_SQL
-
 revision = "20260815_0184"
 down_revision = "20260815_0183"
 branch_labels = None
 depends_on = None
+
+
+#: Spelled out as a literal, not imported from ``app.db.event_capture``:
+#: a revision has to keep doing to a database exactly what it did when it
+#: was written, and a registry that changes later would reach back and
+#: change that. Provisioning re-renders the CURRENT definition on every
+#: boot, so a later edit reaches existing guilds that way instead.
+CAPTURE_FUNCTION = "public.capture_change"
+
+CAPTURE_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION public.capture_change() RETURNS trigger
+    LANGUAGE plpgsql AS $capture$
+DECLARE
+    v_row        record;
+    v_initiative integer;
+    v_action     text;
+    v_changed    text[] := '{}';
+    v_resource   integer;
+    v_actor      integer;
+    v_new        jsonb;
+    v_old        jsonb;
+    v_facet      text := TG_ARGV[3];
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_row := OLD;
+    ELSE
+        v_row := NEW;
+    END IF;
+
+    -- Which initiative this row belongs to, per its INITIATIVE_PATHS entry.
+    -- A row whose initiative no longer resolves is skipped: that is an orphaned
+    -- child during a parent cascade, and the parent emits its own delete.
+    EXECUTE 'SELECT ' || TG_ARGV[0] INTO v_initiative USING v_row;
+    IF v_initiative IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    EXECUTE format('SELECT ($1).%I', TG_ARGV[2]) INTO v_resource USING v_row;
+    IF v_resource IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        v_action := 'created';
+    ELSIF TG_OP = 'DELETE' THEN
+        v_action := 'deleted';
+    ELSE
+        v_new := to_jsonb(NEW);
+        v_old := to_jsonb(OLD);
+
+        -- Soft delete and restore are reported as what they are, so a consumer
+        -- never has to know the deleted_at convention to see a row come or go.
+        IF v_new ? 'deleted_at'
+           AND v_old ->> 'deleted_at' IS NULL
+           AND v_new ->> 'deleted_at' IS NOT NULL THEN
+            v_action := 'deleted';
+        ELSIF v_new ? 'deleted_at'
+           AND v_old ->> 'deleted_at' IS NOT NULL
+           AND v_new ->> 'deleted_at' IS NULL THEN
+            v_action := 'created';
+        ELSE
+            v_action := 'updated';
+            SELECT coalesce(array_agg(key ORDER BY key), '{}')
+              INTO v_changed
+              FROM jsonb_each(v_new) AS e(key, value)
+             WHERE value IS DISTINCT FROM (v_old -> e.key)
+               AND NOT (key = ANY (TG_ARGV[4]::text[]));
+
+            -- Nothing a subscriber can act on changed.
+            IF cardinality(v_changed) = 0 THEN
+                RETURN NULL;
+            END IF;
+        END IF;
+    END IF;
+
+    -- A junction has no columns of its own worth naming; report the change as
+    -- the owning resource being updated in one respect.
+    IF v_facet <> '' THEN
+        v_changed := ARRAY[v_facet];
+        IF v_action <> 'updated' THEN
+            v_action := 'updated';
+        END IF;
+    END IF;
+
+    v_actor := NULLIF(current_setting('app.current_user_id', true), '')::integer;
+
+    -- Write to the outbox of the schema the CHANGED ROW lives in, named from
+    -- TG_TABLE_SCHEMA rather than resolved through the caller's search_path.
+    -- The row's own schema is the authoritative answer to which guild this
+    -- event belongs to, and it is what the trigger is attached to.
+    EXECUTE format(
+        'INSERT INTO %I.event_outbox ('
+        '  txn_id, occurred_at, actor_user_id, initiative_id,'
+        '  resource_type, resource_id, action, changed'
+        ') VALUES (txid_current(), now(), $1, $2, $3, $4, $5, $6)',
+        TG_TABLE_SCHEMA
+    ) USING v_actor, v_initiative, TG_ARGV[1], v_resource, v_action, v_changed;
+
+    RETURN NULL;
+END
+$capture$;
+"""
 
 
 def upgrade() -> None:

--- a/backend/alembic/versions/20260815_0185_outbox_delivery_state.py
+++ b/backend/alembic/versions/20260815_0185_outbox_delivery_state.py
@@ -1,10 +1,17 @@
-"""Add subscription delivery state; drop workflow_id
+"""Add the delivery ledger; drop the cursor and workflow_id
 
 Guild-content migration.
 
-``failure_count`` / ``next_attempt_at`` are what let a cursor stay put after a
-failed delivery without the poller retrying a dead target every pass: failures
-accumulate a backoff, and the first 2xx resets both.
+``webhook_deliveries`` records what each subscription has been told about, one
+transaction at a time, replacing ``cursor_event_id``. A cursor cannot be correct
+here: outbox ids are assigned at insert and published at commit, so a
+transaction still in flight can put a row beneath a watermark chosen while that
+row was invisible, and the event under it is never read again. A row per
+(subscription, transaction) has nothing for a late row to be beneath, and its
+primary key doubles as the claim two replicas race on.
+
+Retry state moves onto that row, so a refusal backs off the batch that was
+refused rather than the whole subscription.
 
 ``workflow_id`` goes. It was documented as opaque to us, with its source of
 truth in the consumer's own database — foreign bookkeeping held in our column,
@@ -48,14 +55,26 @@ def _apply_upgrade() -> None:
         "event_outbox_actor_user_id_fkey", "event_outbox", type_="foreignkey"
     )
 
-    op.add_column(
-        "webhook_subscriptions",
-        sa.Column("failure_count", sa.Integer(), nullable=False, server_default="0"),
-    )
-    op.add_column(
-        "webhook_subscriptions",
+    op.create_table(
+        "webhook_deliveries",
+        sa.Column("subscription_id", sa.Integer(), nullable=False),
+        sa.Column("txn_id", sa.BigInteger(), nullable=False),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["subscription_id"], ["webhook_subscriptions.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("subscription_id", "txn_id"),
     )
+    with op.batch_alter_table("webhook_deliveries", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_webhook_deliveries_delivered_at"),
+            ["delivered_at"],
+            unique=False,
+        )
+
+    op.drop_column("webhook_subscriptions", "cursor_event_id")
     op.drop_column("webhook_subscriptions", "workflow_id")
 
 
@@ -68,8 +87,15 @@ def _apply_downgrade() -> None:
         "webhook_subscriptions",
         sa.Column("workflow_id", sa.Integer(), nullable=True),
     )
-    op.drop_column("webhook_subscriptions", "next_attempt_at")
-    op.drop_column("webhook_subscriptions", "failure_count")
+    op.add_column(
+        "webhook_subscriptions",
+        sa.Column(
+            "cursor_event_id", sa.BigInteger(), nullable=False, server_default="0"
+        ),
+    )
+    with op.batch_alter_table("webhook_deliveries", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_webhook_deliveries_delivered_at"))
+    op.drop_table("webhook_deliveries")
 
     op.create_foreign_key(
         "event_outbox_actor_user_id_fkey",

--- a/backend/alembic/versions/20260815_0185_outbox_delivery_state.py
+++ b/backend/alembic/versions/20260815_0185_outbox_delivery_state.py
@@ -35,6 +35,19 @@ def upgrade() -> None:
 
 
 def _apply_upgrade() -> None:
+    # The capture trigger fires while a row is being deleted, including when
+    # that deletion is the cascade from removing the initiative or user the
+    # event names — so the log's own insert would fail the delete it is
+    # reporting. Both references become weak (plain ints): the log outlives what
+    # it describes, retention sweeps orphans, and RLS still resolves
+    # initiative_id through initiative_access.
+    op.drop_constraint(
+        "event_outbox_initiative_id_fkey", "event_outbox", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "event_outbox_actor_user_id_fkey", "event_outbox", type_="foreignkey"
+    )
+
     op.add_column(
         "webhook_subscriptions",
         sa.Column("failure_count", sa.Integer(), nullable=False, server_default="0"),
@@ -57,3 +70,20 @@ def _apply_downgrade() -> None:
     )
     op.drop_column("webhook_subscriptions", "next_attempt_at")
     op.drop_column("webhook_subscriptions", "failure_count")
+
+    op.create_foreign_key(
+        "event_outbox_actor_user_id_fkey",
+        "event_outbox",
+        "users",
+        ["actor_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "event_outbox_initiative_id_fkey",
+        "event_outbox",
+        "initiatives",
+        ["initiative_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )

--- a/backend/alembic/versions/20260815_0185_outbox_delivery_state.py
+++ b/backend/alembic/versions/20260815_0185_outbox_delivery_state.py
@@ -1,0 +1,59 @@
+"""Add subscription delivery state; drop workflow_id
+
+Guild-content migration.
+
+``failure_count`` / ``next_attempt_at`` are what let a cursor stay put after a
+failed delivery without the poller retrying a dead target every pass: failures
+accumulate a backoff, and the first 2xx resets both.
+
+``workflow_id`` goes. It was documented as opaque to us, with its source of
+truth in the consumer's own database — foreign bookkeeping held in our column,
+our request/response schemas, our delivery envelope, and our delegation-token
+claim validation. A consumer routes on ``subscription_id``, which the envelope
+carries, and keeps its own map.
+
+Revision ID: 20260815_0185
+Revises: 20260815_0184
+Create Date: 2026-08-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.guild_migrations import run_for_each_guild_schema
+
+revision = "20260815_0185"
+down_revision = "20260815_0184"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_upgrade)
+
+
+def _apply_upgrade() -> None:
+    op.add_column(
+        "webhook_subscriptions",
+        sa.Column("failure_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "webhook_subscriptions",
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.drop_column("webhook_subscriptions", "workflow_id")
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_downgrade)
+
+
+def _apply_downgrade() -> None:
+    op.add_column(
+        "webhook_subscriptions",
+        sa.Column("workflow_id", sa.Integer(), nullable=True),
+    )
+    op.drop_column("webhook_subscriptions", "next_attempt_at")
+    op.drop_column("webhook_subscriptions", "failure_count")

--- a/backend/app/api/v1/tenant_endpoints/auto_subscriptions.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_subscriptions.py
@@ -15,7 +15,7 @@ Tenant isolation is by RLS on the table; the endpoint adds an explicit
 Auto's flow:
 
   POST /api/v1/auto/subscriptions
-    body: {target_url, event_types, initiative_id?, workflow_id?}
+    body: {target_url, event_types, initiative_id?}
     → returns subscription + plaintext hmac_secret (one-time)
   GET  /api/v1/auto/subscriptions
   DELETE /api/v1/auto/subscriptions/{id}
@@ -128,7 +128,6 @@ async def create_subscription(
         id=subscription.id,
         guild_id=subscription.guild_id,
         initiative_id=subscription.initiative_id,
-        workflow_id=subscription.workflow_id,
         created_by_user_id=subscription.created_by_user_id,
         target_url=subscription.target_url,
         event_types=subscription.event_types,

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -77,7 +77,6 @@ from app.schemas.ai_generation import (
 from app.schemas.tenant.tag import TagSetRequest
 from app.schemas.tenant.property import PropertyValuesSetRequest
 from app.services.realtime import broadcast_event
-from app.services.tenant import webhook_dispatcher
 from app.services import notifications as notifications_service
 from app.services import permissions as permissions_service
 from app.services.tenant.recurrence import get_next_due_date
@@ -631,10 +630,6 @@ async def _broadcast_task_refresh(
     await _broadcast_task(
         session, guild_id, task.project_id, "updated", task_id=task.id
     )
-
-
-def _task_payload(task: Task) -> dict:
-    return TaskRead.model_validate(task).model_dump(mode="json")
 
 
 async def _broadcast_task(
@@ -1964,17 +1959,6 @@ async def create_task(
         )
     await _broadcast_task(
         session, guild_context.guild_id, task.project_id, "created", task_id=task.id
-    )
-    # Outbound webhook dispatch — fire-and-log; failures don't block the
-    # user's write. Only one event source for now (PR2.2 scope); other
-    # mutators get the same one-liner in follow-up PRs once the contract
-    # has shaken out under real load.
-    await webhook_dispatcher.dispatch_event(
-        session,
-        event_type="task.created",
-        guild_id=guild_context.guild_id,
-        initiative_id=task.project.initiative_id if task.project else None,
-        payload=_task_payload(task),
     )
     return task
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -745,6 +745,12 @@ class Settings(BaseSettings):
     # resolved address regardless of this setting.
     WEBHOOK_ALLOW_PRIVATE_TARGETS: bool = False
 
+    # How long delivered change events are kept in each guild's outbox before
+    # the retention sweep drops them. An instance that never registers a target
+    # still accumulates the log, so this bounds it; a subscriber further behind
+    # than this has stopped consuming and resumes from the current head.
+    WEBHOOK_OUTBOX_RETENTION_DAYS: int = 7
+
     BEHIND_PROXY: bool = (
         False  # Set True when behind nginx/load balancer to trust X-Forwarded-For
     )

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -498,7 +498,6 @@ class AutoDelegationClaims:
     subject: str
     guild_id: int
     initiative_id: int | None
-    workflow_id: int | None
 
 
 class AutoDelegationVerificationError(Exception):
@@ -590,14 +589,9 @@ def verify_auto_delegation_token(
             "initiative_id must be an int when present"
         )
 
-    workflow_id = payload.get("workflow_id")
-    if workflow_id is not None and not isinstance(workflow_id, int):
-        raise AutoDelegationVerificationError("workflow_id must be an int when present")
-
     return AutoDelegationClaims(
         jti=str(payload["jti"]),
         subject=subject,
         guild_id=guild_id,
         initiative_id=initiative_id,
-        workflow_id=workflow_id,
     )

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -65,6 +65,7 @@ from app.models.platform.push_token import PushToken
 from app.models.platform.auto_delegation_jti import AutoDelegationJti
 from app.models.platform.billing import BillingEventLog, BillingJti
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
+from app.models.tenant.webhook_delivery import WebhookDelivery
 from app.models.tenant.webhook_subscription import WebhookSubscription
 from app.models.tenant.resource_grant import ResourceGrant
 from app.models.tenant.export_job import ExportJob
@@ -147,6 +148,7 @@ __all__ = [
     "BillingEventLog",
     "BillingJti",
     "TaskAssignmentDigestItem",
+    "WebhookDelivery",
     "WebhookSubscription",
     "AppServiceRegistration",
     "AppServiceNonce",

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -465,15 +465,23 @@ async def test_guild_schema_matches_guild_template(engine):
             async def trig(ns, t):  # guild_id denorm triggers (functions stay shared)
                 r = await conn.execute(
                     text(
-                        "SELECT pg_get_triggerdef(tg.oid) d FROM pg_trigger tg "
+                        "SELECT tg.tgname n, pg_get_triggerdef(tg.oid) d "
+                        "FROM pg_trigger tg "
                         "JOIN pg_class cl ON cl.oid=tg.tgrelid "
                         "WHERE cl.oid=(:ns||'.'||:t)::regclass AND NOT tg.tgisinternal"
                     ),
                     {"ns": ns, "t": t},
                 )
                 return sorted(
-                    re.sub(r"\bON \w+\.", "ON ", x.d) for x in r
-                )  # strip table schema
+                    re.sub(r"\bON \w+\.", "ON ", x.d)  # strip table schema
+                    for x in r
+                    # Change-capture triggers are rendered from the registry at
+                    # provisioning time, not owned by Alembic — the same
+                    # treatment RLS policies get here, and for the same reason:
+                    # comparing them would assert the template carries a frozen
+                    # snapshot of whatever the registry said.
+                    if not x.n.startswith("capture_")
+                )
 
             drift = []
             for t in sorted(GUILD_SCOPED_TABLES):

--- a/backend/app/db/sql_injection_guard_test.py
+++ b/backend/app/db/sql_injection_guard_test.py
@@ -61,6 +61,9 @@ ALLOWED_DYNAMIC_SQL: dict[str, str] = {
     "app/db/schema_provisioning.py::apply_guild_rls": (
         "int-derived schema name + registry-rendered RLS DDL (constants)"
     ),
+    "app/db/schema_provisioning.py::apply_guild_capture": (
+        "int-derived schema name + registry-rendered trigger DDL (constants)"
+    ),
     "app/db/schema_provisioning.py::drop_guild_schema": (
         "int-derived guild_<id> schema/role names"
     ),

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -130,6 +130,7 @@ GUILD_LEVEL_TABLES: frozenset[str] = frozenset(
         # guild-wide config, no initiative scope. The api_key ciphertext is never
         # returned by the API (reads expose only has_key).
         "webhook_subscriptions",  # guild integration config; initiative_id nullable
+        "webhook_deliveries",  # per-subscription delivery ledger, no initiative of its own
         "tags",  # tags are guild-level, shared across initiatives (purge-guarded)
         "uploads",  # guild blob store: no FK to any initiative entity (documents
         # reference blobs by file_url string, and a blob can be pinned by

--- a/backend/app/models/tenant/event_outbox.py
+++ b/backend/app/models/tenant/event_outbox.py
@@ -26,7 +26,6 @@ from sqlalchemy import (
     BigInteger,
     Column,
     DateTime,
-    ForeignKey,
     Integer,
     String,
 )
@@ -60,22 +59,24 @@ class EventOutbox(SQLModel, table=True):
         sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
     )
 
-    # The user whose request caused the change, from the request GUC. NULL for a
-    # system-attributed write (background jobs, migrations).
+    # Both of these are WEAK references — plain ints, no FK.
+    #
+    # The trigger fires while a row is being deleted, including when that
+    # deletion is the cascade from removing the initiative or user the event
+    # names. A foreign key would make the log's own insert fail that delete, so
+    # purging an initiative would error instead of purging. Weak refs let the
+    # log outlive what it describes; retention sweeps the orphans, and RLS still
+    # resolves initiative_id through initiative_access (an initiative that no
+    # longer exists resolves to guild-admin-only).
+    #
+    # actor_user_id is NULL for a system-attributed write (background jobs).
     actor_user_id: Optional[int] = Field(
         default=None,
-        sa_column=Column(
-            Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
-        ),
+        sa_column=Column(Integer, nullable=True),
     )
 
     initiative_id: int = Field(
-        sa_column=Column(
-            Integer,
-            ForeignKey("initiatives.id", ondelete="CASCADE"),
-            nullable=False,
-            index=True,
-        )
+        sa_column=Column(Integer, nullable=False, index=True),
     )
 
     # The table the change happened to, and its primary key.

--- a/backend/app/models/tenant/webhook_delivery.py
+++ b/backend/app/models/tenant/webhook_delivery.py
@@ -1,0 +1,66 @@
+"""What each subscription has been told about, one transaction at a time.
+
+This replaces a per-subscription cursor, and the reason is not tuning — a cursor
+cannot be made correct here. Outbox ids come from a sequence at **insert** time
+but become visible at **commit** time, and those orders are independent: a
+transaction that opened earlier can publish a row beneath a watermark chosen
+while it was still in flight, and an uncommitted row is invisible to every query
+that watermark could have consulted. Any single number can therefore be jumped
+from below, and the event that lands under it is never read again.
+
+A row here is the whole of the progress state instead. A transaction is either
+recorded for a subscription or it is not, so there is nothing for a late-arriving
+row to be *beneath*. Interleaving, window boundaries, and batch limits stop being
+correctness concerns and become throughput knobs: work not taken this pass is
+simply still pending on the next.
+
+The primary key doubles as the concurrency control. Every replica runs the
+poller, and claiming a transaction is an insert on ``(subscription_id,
+txn_id)`` — two replicas racing the same batch is settled by the database rather
+than by a lease the application has to reason about.
+
+Retry state lives per transaction, so a refusal backs off exactly the batch that
+was refused.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer
+from sqlmodel import Field, SQLModel
+
+
+class WebhookDelivery(SQLModel, table=True):
+    __tablename__ = "webhook_deliveries"
+
+    subscription_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("webhook_subscriptions.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+
+    #: The ``txid_current()`` of the writing transaction — the same value its
+    #: ``event_outbox`` rows carry, and the unit a batch is built from.
+    txn_id: int = Field(sa_column=Column(BigInteger, primary_key=True))
+
+    #: Set once the target answered 2xx. NULL means claimed or awaiting retry.
+    delivered_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True, index=True),
+    )
+
+    attempts: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+    )
+
+    #: While unclaimed, when this batch may next be attempted. While a pass holds
+    #: it, the lease that pass must still own in order to settle.
+    next_attempt_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )

--- a/backend/app/models/tenant/webhook_subscription.py
+++ b/backend/app/models/tenant/webhook_subscription.py
@@ -46,14 +46,6 @@ class WebhookSubscription(SQLModel, table=True):
             nullable=True,
         ),
     )
-    # Soft pointer back to the auto-side workflow this subscription was
-    # created for. Not enforced by FK because the source of truth lives
-    # in initiative-auto's DB.
-    workflow_id: Optional[int] = Field(
-        default=None,
-        sa_column=Column(Integer, nullable=True),
-    )
-
     created_by_user_id: int = Field(
         sa_column=Column(
             Integer,
@@ -81,6 +73,18 @@ class WebhookSubscription(SQLModel, table=True):
     cursor_event_id: int = Field(
         default=0,
         sa_column=Column(BigInteger, nullable=False, server_default="0"),
+    )
+
+    # Consecutive failed deliveries, and when this target is next eligible.
+    # A subscriber that is down backs off instead of being retried every pass.
+    # Reset on the first 2xx.
+    failure_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+    )
+    next_attempt_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
     )
 
     # TZ-aware columns to match the migration.

--- a/backend/app/models/tenant/webhook_subscription.py
+++ b/backend/app/models/tenant/webhook_subscription.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import (
-    BigInteger,
     Boolean,
     Column,
     DateTime,
@@ -64,27 +63,6 @@ class WebhookSubscription(SQLModel, table=True):
     active: bool = Field(
         default=True,
         sa_column=Column(Boolean, nullable=False, server_default="true"),
-    )
-
-    # This subscription's position in ``event_outbox``. The poller reads rows
-    # with a greater id, delivers them, and only then advances — so a delivery
-    # that fails is retried on the next cycle rather than lost. One log, one
-    # cursor per subscriber, no per-subscription delivery rows.
-    cursor_event_id: int = Field(
-        default=0,
-        sa_column=Column(BigInteger, nullable=False, server_default="0"),
-    )
-
-    # Consecutive failed deliveries, and when this target is next eligible.
-    # A subscriber that is down backs off instead of being retried every pass.
-    # Reset on the first 2xx.
-    failure_count: int = Field(
-        default=0,
-        sa_column=Column(Integer, nullable=False, server_default="0"),
-    )
-    next_attempt_at: Optional[datetime] = Field(
-        default=None,
-        sa_column=Column(DateTime(timezone=True), nullable=True),
     )
 
     # TZ-aware columns to match the migration.

--- a/backend/app/schemas/tenant/webhook_subscription.py
+++ b/backend/app/schemas/tenant/webhook_subscription.py
@@ -14,14 +14,12 @@ class WebhookSubscriptionCreate(SanitizedBaseModel):
 
     Initiative-id and guild-id are NOT taken from the body — they
     come from the caller's delegation token (guild) and an optional
-    delegation initiative_id claim. ``workflow_id`` is opaque to us;
-    we just store it so dispatched events can reference it.
+    delegation initiative_id claim.
     """
 
     target_url: HttpUrl
     event_types: list[str] = Field(min_length=1)
     initiative_id: int | None = None
-    workflow_id: int | None = None
 
 
 class WebhookSubscriptionUpdate(SanitizedBaseModel):
@@ -42,7 +40,6 @@ class WebhookSubscriptionRead(SanitizedBaseModel):
     id: int
     guild_id: int
     initiative_id: int | None
-    workflow_id: int | None
     created_by_user_id: int
     target_url: str
     event_types: list[str]

--- a/backend/app/services/background_tasks.py
+++ b/backend/app/services/background_tasks.py
@@ -36,6 +36,12 @@ def start_background_tasks() -> list[asyncio.Task]:
         OIDC_SYNC_POLL_SECONDS,
     )
     from app.services.tenant.trash_purge import process_trash_purges, PURGE_POLL_SECONDS
+    from app.services.tenant.outbox_poller import (
+        OUTBOX_POLL_SECONDS,
+        OUTBOX_RETENTION_POLL_SECONDS,
+        process_outbox_deliveries,
+        process_outbox_retention,
+    )
     from app.services.platform.user_tokens import (
         process_expired_token_purge,
         TOKEN_PURGE_POLL_SECONDS,
@@ -96,6 +102,18 @@ def start_background_tasks() -> list[asyncio.Task]:
         ),
         asyncio.create_task(
             _loop_worker(process_trash_purges, PURGE_POLL_SECONDS, "trash-purge")
+        ),
+        asyncio.create_task(
+            _loop_worker(
+                process_outbox_deliveries, OUTBOX_POLL_SECONDS, "outbox-deliveries"
+            )
+        ),
+        asyncio.create_task(
+            _loop_worker(
+                process_outbox_retention,
+                OUTBOX_RETENTION_POLL_SECONDS,
+                "outbox-retention",
+            )
         ),
         asyncio.create_task(
             _loop_worker(

--- a/backend/app/services/tenant/outbox_capture_test.py
+++ b/backend/app/services/tenant/outbox_capture_test.py
@@ -1,0 +1,105 @@
+"""The capture trigger writes what the poller expects to read.
+
+These assert the seam between the DB-level trigger and the delivery layer: that
+ordinary writes land in the outbox at all, that the row names the right resource
+and initiative, and that the two shapes the design turns on — junctions
+reporting their owner, and soft deletes reporting as deletes — hold against a
+real Postgres rather than against the rendering code.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import select
+
+from app.db.session import set_rls_context
+from app.models.platform.guild import GuildRole
+from app.models.tenant.event_outbox import EventOutbox
+from app.testing import create_task, create_tag
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _outbox(session, guild_id: int) -> list[EventOutbox]:
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+    return list(await session.exec(select(EventOutbox).order_by(EventOutbox.id.asc())))
+
+
+async def test_creating_a_task_is_captured(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project)
+
+    rows = [
+        r
+        for r in await _outbox(session, a.guild.id)
+        if r.resource_type == "tasks" and r.resource_id == task.id
+    ]
+    assert rows, "creating a task produced no outbox row"
+    row = rows[0]
+    assert row.action == "created"
+    assert row.initiative_id == a.initiative.id
+    assert row.changed == []
+
+
+async def test_updating_a_task_names_the_changed_columns(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project)
+
+    task.title = "renamed"
+    session.add(task)
+    await session.commit()
+
+    rows = [
+        r
+        for r in await _outbox(session, a.guild.id)
+        if r.resource_id == task.id and r.action == "updated"
+    ]
+    assert rows, "updating a task produced no outbox row"
+    assert "title" in rows[-1].changed
+    # Names only — a value never leaves the database through this row.
+    assert all(isinstance(name, str) for name in rows[-1].changed)
+
+
+async def test_soft_delete_is_reported_as_deleted(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project)
+
+    from datetime import datetime, timezone
+
+    task.deleted_at = datetime.now(timezone.utc)
+    session.add(task)
+    await session.commit()
+
+    actions = [
+        r.action for r in await _outbox(session, a.guild.id) if r.resource_id == task.id
+    ]
+    assert actions[-1] == "deleted", (
+        "a soft delete should reach a consumer as a delete, not as an update "
+        f"carrying deleted_at; got {actions}"
+    )
+
+
+async def test_tagging_a_task_is_reported_against_the_task(session, acting_user):
+    """A junction row has no id of its own, so it reports its owner."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project)
+    tag = await create_tag(session, a.guild)
+
+    before = len(await _outbox(session, a.guild.id))
+    from app.services.tenant import tags as tags_service
+
+    await tags_service.set_entity_tags(
+        session,
+        tags_service.TAG_LINKS["task"],
+        guild_id=a.guild.id,
+        entity_id=task.id,
+        tag_ids=[tag.id],
+    )
+    await session.commit()
+
+    new_rows = (await _outbox(session, a.guild.id))[before:]
+    junction = [r for r in new_rows if r.resource_type == "tasks"]
+    assert junction, f"tagging produced no task-scoped row; got {new_rows}"
+    assert junction[-1].resource_id == task.id
+    assert junction[-1].changed == ["tags"]

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -44,7 +44,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import text
+from sqlalchemy import func, text
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -209,14 +209,24 @@ async def _readable_window(
         # if the settled rows are themselves incomplete — wait for them.
         return [], None
 
-    # No transaction closed inside the window: the rows we can see all belong to
-    # transactions that continue past it. Re-read those transactions in full so
-    # the cursor can move at all.
+    # No transaction closed inside the window: everything visible belongs to
+    # transactions that continue past it. Widen the window until they close.
+    #
+    # Widen the RANGE, never filter it to those transactions. _complete_prefix
+    # reasons about a contiguous stretch of the log, so handing it only some
+    # transactions' rows lets it place a watermark above rows it was never shown
+    # — which is the same "cursor skipped something beneath it" loss the prefix
+    # walk exists to prevent.
     txn_ids = {row.txn_id for row in settled}
+    ceiling = await session.scalar(
+        select(func.max(EventOutbox.id)).where(EventOutbox.txn_id.in_(txn_ids))
+    )
+    if ceiling is None:
+        return [], None
     whole = list(
         await session.exec(
             select(EventOutbox)
-            .where(EventOutbox.id > cursor, EventOutbox.txn_id.in_(txn_ids))
+            .where(EventOutbox.id > cursor, EventOutbox.id <= ceiling)
             .order_by(EventOutbox.id.asc())
         )
     )
@@ -238,6 +248,12 @@ def _complete_prefix(
 
     ``truncated`` marks a window cut at the row limit, where the last
     transaction may continue past what we can see; it is treated as unfinished.
+
+    **``rows`` must be every row in a contiguous stretch of the log above the
+    cursor.** The walk decides that a position is safe by having seen everything
+    beneath it; given a filtered subset it will place the watermark above rows it
+    was never shown, and those rows are then unreachable forever. Widen the
+    range when more is needed — never narrow it to particular transactions.
     """
     if not rows:
         return [], None

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -141,33 +141,32 @@ def _envelope(
 
 async def _claim(
     session: AsyncSession, subscription: WebhookSubscription, *, now: datetime
-) -> bool:
-    """Take this subscription for one pass, or report that someone else has it.
+) -> datetime | None:
+    """Take this subscription for one pass, returning the lease that proves it.
 
     A conditional update is the claim: only the replica whose UPDATE matches a
     row proceeds. ``next_attempt_at`` doubles as the lease, so a holder that dies
-    mid-drain releases it by expiry rather than stranding the subscription.
+    mid-drain releases it by expiry rather than stranding the subscription — and
+    the value written is the token every later write is checked against, so a
+    holder whose lease lapsed cannot settle over whoever took it next.
     """
+    lease = now + timedelta(seconds=LEASE_SECONDS)
     result = await session.exec(
         text(
             "UPDATE webhook_subscriptions SET next_attempt_at = :lease "
             "WHERE id = :id AND (next_attempt_at IS NULL OR next_attempt_at <= :now) "
             "RETURNING id"
-        ).bindparams(
-            lease=now + timedelta(seconds=LEASE_SECONDS),
-            id=subscription.id,
-            now=now,
-        )
+        ).bindparams(lease=lease, id=subscription.id, now=now)
     )
     claimed = result.first() is not None
     await session.commit()
-    if claimed:
-        # The claim was raw SQL, so the in-memory instance still holds what it
-        # was loaded with — including a cursor another replica may have advanced
-        # between the load and the claim. Every later write goes through this
-        # object, so re-read it before trusting any of its state.
-        await session.refresh(subscription)
-    return claimed
+    if not claimed:
+        return None
+    # The claim was raw SQL, so the in-memory instance still holds what it was
+    # loaded with — including a cursor another replica may have advanced between
+    # the load and the claim. Re-read before trusting any of its state.
+    await session.refresh(subscription)
+    return lease
 
 
 async def _readable_window(
@@ -200,26 +199,72 @@ async def _readable_window(
     if not settled:
         return [], None
 
-    if len(rows) == BATCH_LIMIT and settled[-1] is rows[-1]:
-        # The window ended exactly at the row limit, so the last transaction may
-        # continue past it. Drop its rows and take them whole next pass —
-        # otherwise one transaction arrives as two envelopes.
-        tail_txn = settled[-1].txn_id
-        trimmed = [row for row in settled if row.txn_id != tail_txn]
-        if trimmed:
-            return trimmed, trimmed[-1].id
-        # The whole window is one transaction, so trimming would make no
-        # progress ever. Read that transaction in full instead.
-        whole = list(
-            await session.exec(
-                select(EventOutbox)
-                .where(EventOutbox.id > cursor, EventOutbox.txn_id == tail_txn)
-                .order_by(EventOutbox.id.asc())
-            )
-        )
-        return whole, whole[-1].id
+    truncated = len(rows) == BATCH_LIMIT and settled[-1] is rows[-1]
+    prefix, watermark = _complete_prefix(settled, truncated=truncated)
+    if prefix:
+        return prefix, watermark
 
-    return settled, settled[-1].id
+    if not truncated:
+        # Nothing was withheld for length reasons, so the prefix is empty only
+        # if the settled rows are themselves incomplete — wait for them.
+        return [], None
+
+    # No transaction closed inside the window: the rows we can see all belong to
+    # transactions that continue past it. Re-read those transactions in full so
+    # the cursor can move at all.
+    txn_ids = {row.txn_id for row in settled}
+    whole = list(
+        await session.exec(
+            select(EventOutbox)
+            .where(EventOutbox.id > cursor, EventOutbox.txn_id.in_(txn_ids))
+            .order_by(EventOutbox.id.asc())
+        )
+    )
+    prefix, watermark = _complete_prefix(whole, truncated=False)
+    return (prefix, watermark) if prefix else ([], None)
+
+
+def _complete_prefix(
+    rows: list[EventOutbox], *, truncated: bool
+) -> tuple[list[EventOutbox], int | None]:
+    """The longest run of rows containing only whole transactions.
+
+    Ids come from a sequence at insert time, so concurrent transactions
+    interleave: one transaction's rows can sit either side of another's. A
+    cursor is a single number, so the only safe place to stop is a point where
+    every transaction that started below it has also finished below it —
+    otherwise advancing skips a withheld row that lies beneath the watermark,
+    and that row is never read again.
+
+    ``truncated`` marks a window cut at the row limit, where the last
+    transaction may continue past what we can see; it is treated as unfinished.
+    """
+    if not rows:
+        return [], None
+
+    # Rows come from a SELECT, so every id is populated; the model types it
+    # optional only because an unsaved instance has none.
+    last_id_of: dict[int, int] = {
+        row.txn_id: row.id for row in rows if row.id is not None
+    }
+    tail_txn = rows[-1].txn_id
+
+    open_txns: set[int] = set()
+    watermark: int | None = None
+    cut = 0
+    for index, row in enumerate(rows):
+        open_txns.add(row.txn_id)
+        if row.id == last_id_of[row.txn_id] and not (
+            truncated and row.txn_id == tail_txn
+        ):
+            open_txns.discard(row.txn_id)
+        if not open_txns:
+            watermark = row.id
+            cut = index + 1
+
+    if watermark is None:
+        return [], None
+    return rows[:cut], watermark
 
 
 async def _drain_subscription(
@@ -227,6 +272,7 @@ async def _drain_subscription(
     subscription: WebhookSubscription,
     *,
     now: datetime,
+    lease: datetime,
 ) -> None:
     """Deliver one subscription's pending events, as its owner.
 
@@ -247,7 +293,7 @@ async def _drain_subscription(
     if watermark is None:
         # Nothing settled to send. Release the lease without touching failure
         # state — no delivery was attempted, so nothing was proven either way.
-        await _release(session, subscription)
+        await _release(session, subscription, lease=lease)
         return
 
     # Group by transaction id, not by adjacency: concurrent commits interleave
@@ -261,7 +307,9 @@ async def _drain_subscription(
         # The window held nothing for this subscription. Skip past it so a
         # narrow filter doesn't re-read the same rows forever — but this is not
         # a delivery, so failure state is left alone.
-        await _advance(session, subscription, watermark, now=now, outcome=None)
+        await _advance(
+            session, subscription, watermark, now=now, outcome=None, lease=lease
+        )
         return
 
     # Oldest transaction first, so a receiver sees changes in the order they
@@ -277,18 +325,41 @@ async def _drain_subscription(
             # Hold the cursor beneath this transaction so it and everything
             # after it retry in order.
             await _advance(
-                session, subscription, batch[0].id - 1, now=now, outcome=False
+                session,
+                subscription,
+                batch[0].id - 1,
+                now=now,
+                outcome=False,
+                lease=lease,
             )
             return
 
-    await _advance(session, subscription, watermark, now=now, outcome=True)
+    await _advance(session, subscription, watermark, now=now, outcome=True, lease=lease)
 
 
-async def _release(session: AsyncSession, subscription: WebhookSubscription) -> None:
-    """Drop the lease, leaving failure state untouched."""
-    subscription.next_attempt_at = None
-    session.add(subscription)
-    await session.commit()
+def _next_retry_state(
+    failure_count: int, *, outcome: bool | None, now: datetime
+) -> tuple[int, datetime | None]:
+    """The retry state an attempt leaves behind.
+
+    ``outcome`` None means no request was made — a window that held nothing this
+    subscriber wanted. That is not evidence about the target, so it must leave
+    the failure count alone; treating it as success would let unrelated traffic
+    clear a failing target's backoff.
+    """
+    if outcome is True:
+        return 0, None
+    if outcome is False:
+        failed = failure_count + 1
+        return failed, now + _backoff(failed)
+    return failure_count, None
+
+
+async def _release(
+    session: AsyncSession, subscription: WebhookSubscription, *, lease: datetime
+) -> None:
+    """Drop the lease, leaving cursor and failure state untouched."""
+    await _settle(session, subscription, lease=lease)
 
 
 async def _advance(
@@ -298,6 +369,7 @@ async def _advance(
     *,
     now: datetime,
     outcome: bool | None,
+    lease: datetime,
 ) -> None:
     """Move the cursor and settle the lease.
 
@@ -306,18 +378,66 @@ async def _advance(
     moves failure state: a window that merely contained nothing this subscriber
     wanted must not clear a failing target's backoff.
     """
-    if cursor > subscription.cursor_event_id:
-        subscription.cursor_event_id = cursor
-    if outcome is True:
-        subscription.failure_count = 0
-        subscription.next_attempt_at = None
-    elif outcome is False:
-        subscription.failure_count += 1
-        subscription.next_attempt_at = now + _backoff(subscription.failure_count)
-    else:
-        subscription.next_attempt_at = None
-    session.add(subscription)
+    failure_count, next_attempt = _next_retry_state(
+        subscription.failure_count, outcome=outcome, now=now
+    )
+    await _settle(
+        session,
+        subscription,
+        lease=lease,
+        cursor=cursor,
+        failure_count=failure_count,
+        next_attempt=next_attempt,
+    )
+
+
+async def _settle(
+    session: AsyncSession,
+    subscription: WebhookSubscription,
+    *,
+    lease: datetime,
+    cursor: int | None = None,
+    failure_count: int | None = None,
+    next_attempt: datetime | None = None,
+) -> None:
+    """Write final state, but only while this pass still holds the lease.
+
+    A drain that overran its lease has already been taken over by another
+    replica, and writing here would undo whatever that replica settled —
+    regressing a cursor into events it already delivered, or clearing a backoff
+    it just set. The ``next_attempt_at = :lease`` predicate is what makes this
+    write a no-op in that case. GREATEST keeps the cursor monotonic even when
+    two passes race legitimately.
+    """
+    result = await session.exec(
+        text(
+            "UPDATE webhook_subscriptions SET "
+            "  cursor_event_id = GREATEST(cursor_event_id, :cursor), "
+            "  failure_count = COALESCE(:failure_count, failure_count), "
+            "  next_attempt_at = :next_attempt "
+            "WHERE id = :id AND next_attempt_at = :lease "
+            "RETURNING cursor_event_id"
+        ).bindparams(
+            cursor=cursor if cursor is not None else subscription.cursor_event_id,
+            failure_count=failure_count,
+            next_attempt=next_attempt,
+            id=subscription.id,
+            lease=lease,
+        )
+    )
+    row = result.first()
     await session.commit()
+    if row is None:
+        logger.warning(
+            "outbox settle skipped — lease no longer held: subscription=%s",
+            subscription.id,
+        )
+        return
+    # Keep the in-memory instance in step with what actually landed.
+    subscription.cursor_event_id = row[0]
+    if failure_count is not None:
+        subscription.failure_count = failure_count
+    subscription.next_attempt_at = next_attempt
 
 
 async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -> None:
@@ -335,9 +455,10 @@ async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -
     )
     for subscription in subscriptions:
         try:
-            if not await _claim(session, subscription, now=now):
+            lease = await _claim(session, subscription, now=now)
+            if lease is None:
                 continue
-            await _drain_subscription(session, subscription, now=now)
+            await _drain_subscription(session, subscription, now=now, lease=lease)
         except Exception:
             logger.exception(
                 "outbox drain failed: guild=%s subscription=%s",

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -161,6 +161,12 @@ async def _claim(
     )
     claimed = result.first() is not None
     await session.commit()
+    if claimed:
+        # The claim was raw SQL, so the in-memory instance still holds what it
+        # was loaded with — including a cursor another replica may have advanced
+        # between the load and the claim. Every later write goes through this
+        # object, so re-read it before trusting any of its state.
+        await session.refresh(subscription)
     return claimed
 
 
@@ -193,6 +199,26 @@ async def _readable_window(
         settled.append(row)
     if not settled:
         return [], None
+
+    if len(rows) == BATCH_LIMIT and settled[-1] is rows[-1]:
+        # The window ended exactly at the row limit, so the last transaction may
+        # continue past it. Drop its rows and take them whole next pass —
+        # otherwise one transaction arrives as two envelopes.
+        tail_txn = settled[-1].txn_id
+        trimmed = [row for row in settled if row.txn_id != tail_txn]
+        if trimmed:
+            return trimmed, trimmed[-1].id
+        # The whole window is one transaction, so trimming would make no
+        # progress ever. Read that transaction in full instead.
+        whole = list(
+            await session.exec(
+                select(EventOutbox)
+                .where(EventOutbox.id > cursor, EventOutbox.txn_id == tail_txn)
+                .order_by(EventOutbox.id.asc())
+            )
+        )
+        return whole, whole[-1].id
+
     return settled, settled[-1].id
 
 

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -71,14 +71,17 @@ LEASE_SECONDS = 300
 #: Backoff schedule, in seconds, indexed by consecutive failures on a batch.
 _BACKOFF_SECONDS = (5, 30, 120, 600, 1800, 3600)
 
+#: The same schedule as a SQL array. The interval has to be chosen in the same
+#: statement that increments ``attempts`` — computing it in Python would mean
+#: reading the count, deciding, then writing, and two passes racing there would
+#: each pick a step from a stale count. Postgres arrays are 1-indexed and
+#: ``attempts`` in a SET expression is the pre-update value, so ``attempts + 1``
+#: selects the step for the failure being recorded.
+_BACKOFF_SQL_ARRAY = "(ARRAY[" + ",".join(str(s) for s in _BACKOFF_SECONDS) + "])"
+
 #: Namespace for deterministic envelope ids. Fixed forever: changing it would
 #: make every in-flight batch look new to a receiver deduping on event_id.
 _EVENT_ID_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
-
-
-def _backoff(attempts: int) -> timedelta:
-    index = min(max(attempts, 1), len(_BACKOFF_SECONDS)) - 1
-    return timedelta(seconds=_BACKOFF_SECONDS[index])
 
 
 def _event_id(subscription_id: int, txn_id: int) -> str:
@@ -220,14 +223,11 @@ async def _settle(
         statement = text(
             "UPDATE webhook_deliveries "
             "SET attempts = attempts + 1, "
-            "    next_attempt_at = :now + make_interval(secs => :backoff) "
+            "    next_attempt_at = :now + make_interval(secs => "
+            f"      {_BACKOFF_SQL_ARRAY}[LEAST(attempts + 1, {len(_BACKOFF_SECONDS)})]"
+            "    ) "
             "WHERE subscription_id = :sid AND txn_id = :txn AND delivered_at IS NULL"
-        ).bindparams(
-            now=now,
-            backoff=_backoff(1).total_seconds(),
-            sid=subscription.id,
-            txn=txn_id,
-        )
+        ).bindparams(now=now, sid=subscription.id, txn=txn_id)
     await session.exec(statement)
     await session.commit()
 

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -16,12 +16,13 @@ Three properties this has to actually hold, not merely intend:
 
 **A transaction is never split.** Rows carry the ``txid_current()`` that wrote
 them, and one transaction's rows go out as one envelope. Ids alone don't give
-that: concurrent commits interleave them, and a fixed window can cut a
-transaction in half. So the window stops at the first row belonging to a
-transaction that is still in flight (``txn_id >= xmin``), and grouping is by
-``txn_id``, not by adjacency. An open transaction holds the cursor rather than
-being skipped — which is also what keeps a slow writer's events from being lost
-to a later reader that raced past their ids.
+that: they come from a sequence at insert time, so concurrent transactions
+interleave and one transaction's rows sit either side of another's. Which
+transactions have finished is therefore asked of the database — first and last
+id per transaction — never inferred from a list of rows that some limit or
+barrier has already shortened. A transaction still in flight bars the cursor
+rather than being stepped over, which is what keeps a slow writer's events from
+being lost to a reader that raced past their ids.
 
 **One replica drains a subscription at a time.** Every replica runs this loop, so
 a subscription is claimed with a conditional update before it is drained, and the
@@ -63,8 +64,8 @@ OUTBOX_POLL_SECONDS = 5
 #: How often drained history is swept.
 OUTBOX_RETENTION_POLL_SECONDS = 3600
 
-#: Rows examined per subscription per pass. The window may return slightly more
-#: than this so a transaction is never cut in half.
+#: Transactions a subscription may take in one pass. Bounds a single pass, not
+#: what stays visible: whatever is not taken is simply still pending next time.
 BATCH_LIMIT = 500
 
 #: How long a claim on a subscription is held. Long enough to cover a full
@@ -174,122 +175,81 @@ async def _readable_window(
 ) -> tuple[list[EventOutbox], int | None]:
     """Rows safe to deliver now, and the id to advance to.
 
-    Stops at the first row whose transaction is still in flight. Everything
-    before it belongs to a committed transaction, so no later insert can appear
-    beneath the returned watermark and be skipped.
+    Completeness is read from the database, never inferred from a windowed list
+    of rows. Ids come from a sequence at insert time, so a transaction's rows
+    interleave with other transactions' and can sit either side of any cut we
+    make. A list that has been shortened — by a row limit, or by stopping at an
+    in-flight row — makes the transactions inside it *look* finished, and
+    treating that as truth splits one across two passes. Both halves then derive
+    the same event_id from (subscription_id, txn_id), so a receiver deduping on
+    it takes the first and discards the rest.
+
+    So: ask Postgres for each undelivered transaction's first and last id, take
+    only transactions that end below the first in-flight row, and stop at a
+    point no remaining transaction spans.
     """
     xmin = await session.scalar(
         text("SELECT pg_snapshot_xmin(pg_current_snapshot())::text::bigint")
     )
+
+    # A transaction still in flight is a hard barrier: it may yet insert rows
+    # below any watermark we pick, and those would fall beneath the cursor.
+    barrier = await session.scalar(
+        select(func.min(EventOutbox.id))
+        .where(EventOutbox.id > cursor)
+        .where(EventOutbox.txn_id >= xmin)
+    )
+
+    spans = list(
+        await session.exec(
+            select(
+                EventOutbox.txn_id,
+                func.min(EventOutbox.id).label("first_id"),
+                func.max(EventOutbox.id).label("last_id"),
+            )
+            .where(EventOutbox.id > cursor)
+            .where(EventOutbox.txn_id < xmin)
+            .group_by(EventOutbox.txn_id)
+            .order_by(func.min(EventOutbox.id).asc())
+        )
+    )
+    if barrier is not None:
+        spans = [span for span in spans if span.last_id < barrier]
+    if not spans:
+        return [], None
+
+    watermark = _safe_watermark(spans)
+    if watermark is None:
+        return [], None
+
     rows = list(
         await session.exec(
             select(EventOutbox)
-            .where(EventOutbox.id > cursor)
-            .order_by(EventOutbox.id.asc())
-            .limit(BATCH_LIMIT)
-        )
-    )
-    settled: list[EventOutbox] = []
-    for row in rows:
-        if xmin is not None and row.txn_id >= xmin:
-            # This transaction has not finished. Stop here: delivering past it
-            # would let its rows fall below the cursor once it commits.
-            break
-        settled.append(row)
-    if not settled:
-        return [], None
-
-    truncated = len(rows) == BATCH_LIMIT and settled[-1] is rows[-1]
-    prefix, watermark = _complete_prefix(settled, truncated=truncated)
-    if prefix:
-        return prefix, watermark
-
-    if not truncated:
-        # Nothing was withheld for length reasons, so the prefix is empty only
-        # if the settled rows are themselves incomplete — wait for them.
-        return [], None
-
-    # No transaction closed inside the window: everything visible belongs to
-    # transactions that continue past it. Widen the window until they close.
-    #
-    # Widen the RANGE, never filter it to those transactions. _complete_prefix
-    # reasons about a contiguous stretch of the log, so handing it only some
-    # transactions' rows lets it place a watermark above rows it was never shown
-    # — which is the same "cursor skipped something beneath it" loss the prefix
-    # walk exists to prevent.
-    # The ceiling is a subquery, not a value read in an earlier statement. Under
-    # READ COMMITTED each statement takes its own snapshot, so a separately
-    # computed ceiling can be stale by the time the rows are read: a transaction
-    # that commits in between adds rows above it and gets cut there. That split
-    # is worse than it sounds, because both halves derive the same event_id from
-    # (subscription_id, txn_id) — a receiver deduping on it would accept the
-    # first half and silently drop the rest. One statement, one snapshot.
-    txn_ids = {row.txn_id for row in settled}
-    ceiling = (
-        select(func.max(EventOutbox.id))
-        .where(EventOutbox.txn_id.in_(txn_ids))
-        .scalar_subquery()
-    )
-    whole = list(
-        await session.exec(
-            select(EventOutbox)
-            .where(EventOutbox.id > cursor, EventOutbox.id <= ceiling)
+            .where(EventOutbox.id > cursor, EventOutbox.id <= watermark)
             .order_by(EventOutbox.id.asc())
         )
     )
-    if not whole:
-        return [], None
-    prefix, watermark = _complete_prefix(whole, truncated=False)
-    return (prefix, watermark) if prefix else ([], None)
+    return rows, watermark
 
 
-def _complete_prefix(
-    rows: list[EventOutbox], *, truncated: bool
-) -> tuple[list[EventOutbox], int | None]:
-    """The longest run of rows containing only whole transactions.
+def _safe_watermark(spans: list[Any]) -> int | None:
+    """The highest id no remaining transaction straddles.
 
-    Ids come from a sequence at insert time, so concurrent transactions
-    interleave: one transaction's rows can sit either side of another's. A
-    cursor is a single number, so the only safe place to stop is a point where
-    every transaction that started below it has also finished below it —
-    otherwise advancing skips a withheld row that lies beneath the watermark,
-    and that row is never read again.
-
-    ``truncated`` marks a window cut at the row limit, where the last
-    transaction may continue past what we can see; it is treated as unfinished.
-
-    **``rows`` must be every row in a contiguous stretch of the log above the
-    cursor.** The walk decides that a position is safe by having seen everything
-    beneath it; given a filtered subset it will place the watermark above rows it
-    was never shown, and those rows are then unreachable forever. Widen the
-    range when more is needed — never narrow it to particular transactions.
+    ``spans`` are (txn_id, first_id, last_id) ordered by first_id. Walking them
+    while tracking the furthest last_id seen gives the points where every
+    transaction opened so far has also closed — the only ids a single-number
+    cursor may stop on. Bounded by BATCH_LIMIT transactions so one pass cannot
+    take an unbounded backlog; whatever is left is simply still pending.
     """
-    if not rows:
-        return [], None
-
-    # Rows come from a SELECT, so every id is populated; the model types it
-    # optional only because an unsaved instance has none.
-    last_id_of: dict[int, int] = {
-        row.txn_id: row.id for row in rows if row.id is not None
-    }
-    tail_txn = rows[-1].txn_id
-
-    open_txns: set[int] = set()
     watermark: int | None = None
-    cut = 0
-    for index, row in enumerate(rows):
-        open_txns.add(row.txn_id)
-        if row.id == last_id_of[row.txn_id] and not (
-            truncated and row.txn_id == tail_txn
-        ):
-            open_txns.discard(row.txn_id)
-        if not open_txns:
-            watermark = row.id
-            cut = index + 1
-
-    if watermark is None:
-        return [], None
-    return rows[:cut], watermark
+    reach = 0
+    for index, span in enumerate(spans):
+        reach = max(reach, span.last_id)
+        if index + 1 >= len(spans) or spans[index + 1].first_id > reach:
+            watermark = reach
+            if index + 1 >= BATCH_LIMIT:
+                break
+    return watermark
 
 
 async def _drain_subscription(

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -1,0 +1,283 @@
+"""Drain ``event_outbox`` to each subscription's target.
+
+The authorization decision is a query, not a check. For every subscription the
+poller routes a session **as that subscription's owner** and reads the outbox
+through it — so ``event_outbox``'s own initiative-member RLS returns exactly the
+events that owner may currently see, and nothing here re-implements the six
+gates. A guild-wide subscription therefore means "everything in this guild I can
+reach", which is what it should mean, and it stays true as membership changes:
+leaving an initiative, losing a PAM grant, or being deactivated all stop the
+matching deliveries on the next pass with no subscription edit and no cache to
+invalidate.
+
+``initiative_id`` on the subscription is a narrowing filter on top of that, never
+a widening one.
+
+One transaction, one envelope: rows written by the same transaction share a
+``txn_id`` and are delivered together, so a single user action that touched
+fifty rows is one POST. Filtering still applies per change-item before the batch
+is assembled, so batching costs nothing in precision.
+
+A cursor advances only after a 2xx. A target that is down is retried on later
+passes, backing off as failures accumulate, so an unreachable subscriber slows
+its own deliveries instead of spinning.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.db.session import AdminSessionLocal, set_rls_context
+from app.models.platform.guild import Guild, GuildStatus
+from app.models.tenant.event_outbox import EventOutbox
+from app.models.tenant.webhook_subscription import WebhookSubscription
+from app.services.tenant.webhook_dispatcher import deliver
+
+logger = logging.getLogger(__name__)
+
+#: How often the drain runs.
+OUTBOX_POLL_SECONDS = 5
+
+#: How often drained history is swept.
+OUTBOX_RETENTION_POLL_SECONDS = 3600
+
+#: Rows read per subscription per pass. Bounds the work one badly-behind
+#: subscription can do in a single cycle; the rest comes on the next pass.
+BATCH_LIMIT = 500
+
+#: Backoff schedule, in seconds, indexed by consecutive failure count. A target
+#: that stays down is retried ever less often rather than every cycle.
+_BACKOFF_SECONDS = (5, 30, 120, 600, 1800, 3600)
+
+
+def _backoff(failure_count: int) -> timedelta:
+    index = min(failure_count, len(_BACKOFF_SECONDS) - 1)
+    return timedelta(seconds=_BACKOFF_SECONDS[index])
+
+
+def _event_type(row: EventOutbox) -> str:
+    return f"{row.resource_type}.{row.action}"
+
+
+def _matches(row: EventOutbox, subscription: WebhookSubscription) -> bool:
+    """Whether one change-item belongs in this subscription's batch.
+
+    Applied per item BEFORE the batch is assembled, so grouping by transaction
+    never widens what a subscription receives.
+    """
+    if _event_type(row) not in subscription.event_types:
+        return False
+    if (
+        subscription.initiative_id is not None
+        and row.initiative_id != subscription.initiative_id
+    ):
+        return False
+    return True
+
+
+def _envelope(
+    subscription: WebhookSubscription, rows: list[EventOutbox]
+) -> dict[str, Any]:
+    """One transaction's matching rows as a single envelope.
+
+    Carries identifiers and changed column NAMES only. A consumer reads current
+    state back through the REST API, where the gates apply to the read.
+    """
+    first = rows[0]
+    return {
+        "event_id": str(uuid.uuid4()),
+        "subscription_id": subscription.id,
+        "guild_id": subscription.guild_id,
+        "actor_user_id": first.actor_user_id,
+        "occurred_at": first.occurred_at.isoformat(),
+        "changes": [
+            {
+                "event_type": _event_type(row),
+                "initiative_id": row.initiative_id,
+                "resource": {"type": row.resource_type, "id": row.resource_id},
+                "action": row.action,
+                "changed": list(row.changed),
+            }
+            for row in rows
+        ],
+    }
+
+
+async def _drain_subscription(
+    session: AsyncSession,
+    subscription: WebhookSubscription,
+    *,
+    now: datetime,
+) -> None:
+    """Deliver one subscription's pending events, as its owner.
+
+    The session is routed to the subscription's guild with the OWNER's user id,
+    so the outbox read is gated by that owner's access. ``satisfied_providers``
+    is the system sentinel: a background pass has no login to satisfy a guild's
+    auth policy with, and that leg is about how a person authenticated, not
+    about what this owner may reach. Every other gate applies unchanged.
+    """
+    await set_rls_context(
+        session,
+        user_id=subscription.created_by_user_id,
+        guild_id=subscription.guild_id,
+        satisfied_providers="system",
+    )
+
+    rows = list(
+        await session.exec(
+            select(EventOutbox)
+            .where(EventOutbox.id > subscription.cursor_event_id)
+            .order_by(EventOutbox.id.asc())
+            .limit(BATCH_LIMIT)
+        )
+    )
+    if not rows:
+        return
+
+    # Group by transaction, preserving log order.
+    batches: list[tuple[int, list[EventOutbox]]] = []
+    for row in rows:
+        if _matches(row, subscription):
+            if batches and batches[-1][0] == row.txn_id:
+                batches[-1][1].append(row)
+            else:
+                batches.append((row.txn_id, [row]))
+
+    highest = rows[-1].id
+    if not batches:
+        # Nothing matched, but these rows are accounted for: skip past them so
+        # a subscription with a narrow filter doesn't re-read the same window.
+        await _advance(session, subscription, highest, now=now, delivered=True)
+        return
+
+    for _txn_id, batch in batches:
+        ok = await deliver(
+            target_url=subscription.target_url,
+            secret=subscription.hmac_secret,
+            envelope=_envelope(subscription, batch),
+        )
+        if not ok:
+            # Stop at the first failure: the cursor stays behind this batch, so
+            # it and everything after it are retried in order on a later pass.
+            await _advance(
+                session, subscription, batch[0].id - 1, now=now, delivered=False
+            )
+            return
+
+    await _advance(session, subscription, highest, now=now, delivered=True)
+
+
+async def _advance(
+    session: AsyncSession,
+    subscription: WebhookSubscription,
+    cursor: int,
+    *,
+    now: datetime,
+    delivered: bool,
+) -> None:
+    if cursor > subscription.cursor_event_id:
+        subscription.cursor_event_id = cursor
+    if delivered:
+        subscription.failure_count = 0
+        subscription.next_attempt_at = None
+    else:
+        subscription.failure_count += 1
+        subscription.next_attempt_at = now + _backoff(subscription.failure_count)
+    session.add(subscription)
+    await session.commit()
+
+
+async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -> None:
+    # Read the subscription roster with full guild authority: which targets are
+    # registered is guild configuration, not initiative content. What each of
+    # them may then SEE is decided per subscription in _drain_subscription,
+    # under its own owner's context.
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+    subscriptions = list(
+        await session.exec(
+            select(WebhookSubscription)
+            .where(WebhookSubscription.active.is_(True))
+            .order_by(WebhookSubscription.id.asc())
+        )
+    )
+    for subscription in subscriptions:
+        if (
+            subscription.next_attempt_at is not None
+            and subscription.next_attempt_at > now
+        ):
+            continue
+        try:
+            await _drain_subscription(session, subscription, now=now)
+        except Exception:
+            logger.exception(
+                "outbox drain failed: guild=%s subscription=%s",
+                guild_id,
+                subscription.id,
+            )
+            await session.rollback()
+        finally:
+            # ids repeat across guild schemas, and the next subscription
+            # re-routes the session.
+            session.expunge_all()
+            await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+
+
+async def process_outbox_deliveries() -> None:
+    """One drain pass across every active guild. Idempotent."""
+    now = datetime.now(timezone.utc)
+    async with AdminSessionLocal() as session:
+        await set_rls_context(session)
+        guild_ids = list(
+            await session.exec(
+                select(Guild.id)
+                .where(Guild.status == GuildStatus.active.value)
+                .order_by(Guild.id.asc())
+            )
+        )
+        for guild_id in guild_ids:
+            session.expunge_all()
+            await _drain_guild(session, guild_id, now=now)
+
+
+async def process_outbox_retention() -> None:
+    """Drop outbox history past the retention window.
+
+    Age-based rather than cursor-based on purpose: a subscription that is weeks
+    behind is broken, and holding the log open for it would grow the table
+    without bound on every instance that never configures a target at all.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(
+        days=settings.WEBHOOK_OUTBOX_RETENTION_DAYS
+    )
+    async with AdminSessionLocal() as session:
+        await set_rls_context(session)
+        guild_ids = list(
+            await session.exec(
+                select(Guild.id)
+                .where(Guild.status == GuildStatus.active.value)
+                .order_by(Guild.id.asc())
+            )
+        )
+        for guild_id in guild_ids:
+            session.expunge_all()
+            await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+            stale = list(
+                await session.exec(
+                    select(EventOutbox).where(EventOutbox.occurred_at < cutoff)
+                )
+            )
+            for row in stale:
+                await session.delete(row)
+            if stale:
+                logger.info(
+                    "outbox retention: guild=%s removed=%s", guild_id, len(stale)
+                )
+            await session.commit()

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -5,22 +5,36 @@ poller routes a session **as that subscription's owner** and reads the outbox
 through it — so ``event_outbox``'s own initiative-member RLS returns exactly the
 events that owner may currently see, and nothing here re-implements the six
 gates. A guild-wide subscription therefore means "everything in this guild I can
-reach", which is what it should mean, and it stays true as membership changes:
-leaving an initiative, losing a PAM grant, or being deactivated all stop the
-matching deliveries on the next pass with no subscription edit and no cache to
-invalidate.
+reach", and it stays true as membership changes: leaving an initiative, losing a
+PAM grant, or being deactivated all stop the matching deliveries on the next
+pass with no subscription edit and no cache to invalidate.
 
 ``initiative_id`` on the subscription is a narrowing filter on top of that, never
 a widening one.
 
-One transaction, one envelope: rows written by the same transaction share a
-``txn_id`` and are delivered together, so a single user action that touched
-fifty rows is one POST. Filtering still applies per change-item before the batch
-is assembled, so batching costs nothing in precision.
+Three properties this has to actually hold, not merely intend:
 
-A cursor advances only after a 2xx. A target that is down is retried on later
-passes, backing off as failures accumulate, so an unreachable subscriber slows
-its own deliveries instead of spinning.
+**A transaction is never split.** Rows carry the ``txid_current()`` that wrote
+them, and one transaction's rows go out as one envelope. Ids alone don't give
+that: concurrent commits interleave them, and a fixed window can cut a
+transaction in half. So the window stops at the first row belonging to a
+transaction that is still in flight (``txn_id >= xmin``), and grouping is by
+``txn_id``, not by adjacency. An open transaction holds the cursor rather than
+being skipped — which is also what keeps a slow writer's events from being lost
+to a later reader that raced past their ids.
+
+**One replica drains a subscription at a time.** Every replica runs this loop, so
+a subscription is claimed with a conditional update before it is drained, and the
+claim is a lease that expires if the holder dies.
+
+**A duplicate is recognizable as one.** ``event_id`` is derived from
+``(subscription_id, txn_id)``, so if a batch is somehow delivered twice — a lease
+that lapsed mid-flight, a retry after an ambiguous timeout — both copies carry
+the same id and a receiver deduping on it drops the second. A random id per
+envelope would make every duplicate look like new work.
+
+A cursor advances only after a 2xx. Failures accumulate a backoff, so a target
+that is down slows its own deliveries instead of spinning.
 """
 
 from __future__ import annotations
@@ -30,6 +44,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from sqlalchemy import text
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -48,18 +63,32 @@ OUTBOX_POLL_SECONDS = 5
 #: How often drained history is swept.
 OUTBOX_RETENTION_POLL_SECONDS = 3600
 
-#: Rows read per subscription per pass. Bounds the work one badly-behind
-#: subscription can do in a single cycle; the rest comes on the next pass.
+#: Rows examined per subscription per pass. The window may return slightly more
+#: than this so a transaction is never cut in half.
 BATCH_LIMIT = 500
+
+#: How long a claim on a subscription is held. Long enough to cover a full
+#: window of deliveries at the per-request timeout, short enough that a replica
+#: dying mid-drain doesn't strand the subscription for long.
+LEASE_SECONDS = 300
 
 #: Backoff schedule, in seconds, indexed by consecutive failure count. A target
 #: that stays down is retried ever less often rather than every cycle.
 _BACKOFF_SECONDS = (5, 30, 120, 600, 1800, 3600)
 
+#: Namespace for deterministic envelope ids. Fixed forever: changing it would
+#: make every in-flight batch look new to a receiver deduping on event_id.
+_EVENT_ID_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
+
 
 def _backoff(failure_count: int) -> timedelta:
     index = min(failure_count, len(_BACKOFF_SECONDS) - 1)
     return timedelta(seconds=_BACKOFF_SECONDS[index])
+
+
+def _event_id(subscription_id: int, txn_id: int) -> str:
+    """Same batch, same id — on any replica, on any retry."""
+    return str(uuid.uuid5(_EVENT_ID_NAMESPACE, f"{subscription_id}:{txn_id}"))
 
 
 def _event_type(row: EventOutbox) -> str:
@@ -83,7 +112,7 @@ def _matches(row: EventOutbox, subscription: WebhookSubscription) -> bool:
 
 
 def _envelope(
-    subscription: WebhookSubscription, rows: list[EventOutbox]
+    subscription: WebhookSubscription, txn_id: int, rows: list[EventOutbox]
 ) -> dict[str, Any]:
     """One transaction's matching rows as a single envelope.
 
@@ -92,7 +121,7 @@ def _envelope(
     """
     first = rows[0]
     return {
-        "event_id": str(uuid.uuid4()),
+        "event_id": _event_id(subscription.id, txn_id),
         "subscription_id": subscription.id,
         "guild_id": subscription.guild_id,
         "actor_user_id": first.actor_user_id,
@@ -108,6 +137,63 @@ def _envelope(
             for row in rows
         ],
     }
+
+
+async def _claim(
+    session: AsyncSession, subscription: WebhookSubscription, *, now: datetime
+) -> bool:
+    """Take this subscription for one pass, or report that someone else has it.
+
+    A conditional update is the claim: only the replica whose UPDATE matches a
+    row proceeds. ``next_attempt_at`` doubles as the lease, so a holder that dies
+    mid-drain releases it by expiry rather than stranding the subscription.
+    """
+    result = await session.exec(
+        text(
+            "UPDATE webhook_subscriptions SET next_attempt_at = :lease "
+            "WHERE id = :id AND (next_attempt_at IS NULL OR next_attempt_at <= :now) "
+            "RETURNING id"
+        ).bindparams(
+            lease=now + timedelta(seconds=LEASE_SECONDS),
+            id=subscription.id,
+            now=now,
+        )
+    )
+    claimed = result.first() is not None
+    await session.commit()
+    return claimed
+
+
+async def _readable_window(
+    session: AsyncSession, cursor: int
+) -> tuple[list[EventOutbox], int | None]:
+    """Rows safe to deliver now, and the id to advance to.
+
+    Stops at the first row whose transaction is still in flight. Everything
+    before it belongs to a committed transaction, so no later insert can appear
+    beneath the returned watermark and be skipped.
+    """
+    xmin = await session.scalar(
+        text("SELECT pg_snapshot_xmin(pg_current_snapshot())::text::bigint")
+    )
+    rows = list(
+        await session.exec(
+            select(EventOutbox)
+            .where(EventOutbox.id > cursor)
+            .order_by(EventOutbox.id.asc())
+            .limit(BATCH_LIMIT)
+        )
+    )
+    settled: list[EventOutbox] = []
+    for row in rows:
+        if xmin is not None and row.txn_id >= xmin:
+            # This transaction has not finished. Stop here: delivering past it
+            # would let its rows fall below the cursor once it commits.
+            break
+        settled.append(row)
+    if not settled:
+        return [], None
+    return settled, settled[-1].id
 
 
 async def _drain_subscription(
@@ -131,48 +217,52 @@ async def _drain_subscription(
         satisfied_providers="system",
     )
 
-    rows = list(
-        await session.exec(
-            select(EventOutbox)
-            .where(EventOutbox.id > subscription.cursor_event_id)
-            .order_by(EventOutbox.id.asc())
-            .limit(BATCH_LIMIT)
-        )
-    )
-    if not rows:
+    rows, watermark = await _readable_window(session, subscription.cursor_event_id)
+    if watermark is None:
+        # Nothing settled to send. Release the lease without touching failure
+        # state — no delivery was attempted, so nothing was proven either way.
+        await _release(session, subscription)
         return
 
-    # Group by transaction, preserving log order.
-    batches: list[tuple[int, list[EventOutbox]]] = []
+    # Group by transaction id, not by adjacency: concurrent commits interleave
+    # ids, so one transaction's rows are not necessarily contiguous.
+    grouped: dict[int, list[EventOutbox]] = {}
     for row in rows:
         if _matches(row, subscription):
-            if batches and batches[-1][0] == row.txn_id:
-                batches[-1][1].append(row)
-            else:
-                batches.append((row.txn_id, [row]))
+            grouped.setdefault(row.txn_id, []).append(row)
 
-    highest = rows[-1].id
-    if not batches:
-        # Nothing matched, but these rows are accounted for: skip past them so
-        # a subscription with a narrow filter doesn't re-read the same window.
-        await _advance(session, subscription, highest, now=now, delivered=True)
+    if not grouped:
+        # The window held nothing for this subscription. Skip past it so a
+        # narrow filter doesn't re-read the same rows forever — but this is not
+        # a delivery, so failure state is left alone.
+        await _advance(session, subscription, watermark, now=now, outcome=None)
         return
 
-    for _txn_id, batch in batches:
+    # Oldest transaction first, so a receiver sees changes in the order they
+    # were committed.
+    for txn_id in sorted(grouped):
+        batch = grouped[txn_id]
         ok = await deliver(
             target_url=subscription.target_url,
             secret=subscription.hmac_secret,
-            envelope=_envelope(subscription, batch),
+            envelope=_envelope(subscription, txn_id, batch),
         )
         if not ok:
-            # Stop at the first failure: the cursor stays behind this batch, so
-            # it and everything after it are retried in order on a later pass.
+            # Hold the cursor beneath this transaction so it and everything
+            # after it retry in order.
             await _advance(
-                session, subscription, batch[0].id - 1, now=now, delivered=False
+                session, subscription, batch[0].id - 1, now=now, outcome=False
             )
             return
 
-    await _advance(session, subscription, highest, now=now, delivered=True)
+    await _advance(session, subscription, watermark, now=now, outcome=True)
+
+
+async def _release(session: AsyncSession, subscription: WebhookSubscription) -> None:
+    """Drop the lease, leaving failure state untouched."""
+    subscription.next_attempt_at = None
+    session.add(subscription)
+    await session.commit()
 
 
 async def _advance(
@@ -181,16 +271,25 @@ async def _advance(
     cursor: int,
     *,
     now: datetime,
-    delivered: bool,
+    outcome: bool | None,
 ) -> None:
+    """Move the cursor and settle the lease.
+
+    ``outcome`` is the result of an actual delivery attempt — True for accepted,
+    False for refused, and None when no request was made. Only a real attempt
+    moves failure state: a window that merely contained nothing this subscriber
+    wanted must not clear a failing target's backoff.
+    """
     if cursor > subscription.cursor_event_id:
         subscription.cursor_event_id = cursor
-    if delivered:
+    if outcome is True:
         subscription.failure_count = 0
         subscription.next_attempt_at = None
-    else:
+    elif outcome is False:
         subscription.failure_count += 1
         subscription.next_attempt_at = now + _backoff(subscription.failure_count)
+    else:
+        subscription.next_attempt_at = None
     session.add(subscription)
     await session.commit()
 
@@ -209,12 +308,9 @@ async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -
         )
     )
     for subscription in subscriptions:
-        if (
-            subscription.next_attempt_at is not None
-            and subscription.next_attempt_at > now
-        ):
-            continue
         try:
+            if not await _claim(session, subscription, now=now):
+                continue
             await _drain_subscription(session, subscription, now=now)
         except Exception:
             logger.exception(
@@ -230,19 +326,22 @@ async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -
             await set_rls_context(session, guild_id=guild_id, guild_role="admin")
 
 
+async def _active_guild_ids(session: AsyncSession) -> list[int]:
+    await set_rls_context(session)
+    return list(
+        await session.exec(
+            select(Guild.id)
+            .where(Guild.status == GuildStatus.active.value)
+            .order_by(Guild.id.asc())
+        )
+    )
+
+
 async def process_outbox_deliveries() -> None:
     """One drain pass across every active guild. Idempotent."""
     now = datetime.now(timezone.utc)
     async with AdminSessionLocal() as session:
-        await set_rls_context(session)
-        guild_ids = list(
-            await session.exec(
-                select(Guild.id)
-                .where(Guild.status == GuildStatus.active.value)
-                .order_by(Guild.id.asc())
-            )
-        )
-        for guild_id in guild_ids:
+        for guild_id in await _active_guild_ids(session):
             session.expunge_all()
             await _drain_guild(session, guild_id, now=now)
 
@@ -258,15 +357,7 @@ async def process_outbox_retention() -> None:
         days=settings.WEBHOOK_OUTBOX_RETENTION_DAYS
     )
     async with AdminSessionLocal() as session:
-        await set_rls_context(session)
-        guild_ids = list(
-            await session.exec(
-                select(Guild.id)
-                .where(Guild.status == GuildStatus.active.value)
-                .order_by(Guild.id.asc())
-            )
-        )
-        for guild_id in guild_ids:
+        for guild_id in await _active_guild_ids(session):
             session.expunge_all()
             await set_rls_context(session, guild_id=guild_id, guild_role="admin")
             stale = list(

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -217,12 +217,19 @@ async def _readable_window(
     # transactions' rows lets it place a watermark above rows it was never shown
     # — which is the same "cursor skipped something beneath it" loss the prefix
     # walk exists to prevent.
+    # The ceiling is a subquery, not a value read in an earlier statement. Under
+    # READ COMMITTED each statement takes its own snapshot, so a separately
+    # computed ceiling can be stale by the time the rows are read: a transaction
+    # that commits in between adds rows above it and gets cut there. That split
+    # is worse than it sounds, because both halves derive the same event_id from
+    # (subscription_id, txn_id) — a receiver deduping on it would accept the
+    # first half and silently drop the rest. One statement, one snapshot.
     txn_ids = {row.txn_id for row in settled}
-    ceiling = await session.scalar(
-        select(func.max(EventOutbox.id)).where(EventOutbox.txn_id.in_(txn_ids))
+    ceiling = (
+        select(func.max(EventOutbox.id))
+        .where(EventOutbox.txn_id.in_(txn_ids))
+        .scalar_subquery()
     )
-    if ceiling is None:
-        return [], None
     whole = list(
         await session.exec(
             select(EventOutbox)
@@ -230,6 +237,8 @@ async def _readable_window(
             .order_by(EventOutbox.id.asc())
         )
     )
+    if not whole:
+        return [], None
     prefix, watermark = _complete_prefix(whole, truncated=False)
     return (prefix, watermark) if prefix else ([], None)
 
@@ -462,15 +471,23 @@ async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -
     # them may then SEE is decided per subscription in _drain_subscription,
     # under its own owner's context.
     await set_rls_context(session, guild_id=guild_id, guild_role="admin")
-    subscriptions = list(
+    # Ids, not instances. Each pass ends by expunging the identity map — ids
+    # repeat across guild schemas, so instances must not survive the reroute —
+    # and an instance held across that is detached, which makes the refresh
+    # inside _claim raise. Holding the roster as instances therefore drained the
+    # first subscription and failed every one after it.
+    subscription_ids = list(
         await session.exec(
-            select(WebhookSubscription)
+            select(WebhookSubscription.id)
             .where(WebhookSubscription.active.is_(True))
             .order_by(WebhookSubscription.id.asc())
         )
     )
-    for subscription in subscriptions:
+    for subscription_id in subscription_ids:
         try:
+            subscription = await session.get(WebhookSubscription, subscription_id)
+            if subscription is None or not subscription.active:
+                continue
             lease = await _claim(session, subscription, now=now)
             if lease is None:
                 continue
@@ -479,12 +496,10 @@ async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -
             logger.exception(
                 "outbox drain failed: guild=%s subscription=%s",
                 guild_id,
-                subscription.id,
+                subscription_id,
             )
             await session.rollback()
         finally:
-            # ids repeat across guild schemas, and the next subscription
-            # re-routes the session.
             session.expunge_all()
             await set_rls_context(session, guild_id=guild_id, guild_role="admin")
 

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -12,30 +12,27 @@ pass with no subscription edit and no cache to invalidate.
 ``initiative_id`` on the subscription is a narrowing filter on top of that, never
 a widening one.
 
-Three properties this has to actually hold, not merely intend:
+Progress is a ledger row per ``(subscription, transaction)``, not a cursor, and
+that is a correctness decision rather than a tuning one. Outbox ids come from a
+sequence at insert time but are published at commit time, so a transaction still
+in flight can put a row *beneath* any watermark chosen while that row was
+invisible — and no query can see an uncommitted row to defend against it. A
+ledger has nothing for a late row to be beneath: a transaction is either recorded
+for a subscription or it is not.
 
-**A transaction is never split.** Rows carry the ``txid_current()`` that wrote
-them, and one transaction's rows go out as one envelope. Ids alone don't give
-that: they come from a sequence at insert time, so concurrent transactions
-interleave and one transaction's rows sit either side of another's. Which
-transactions have finished is therefore asked of the database — first and last
-id per transaction — never inferred from a list of rows that some limit or
-barrier has already shortened. A transaction still in flight bars the cursor
-rather than being stepped over, which is what keeps a slow writer's events from
-being lost to a reader that raced past their ids.
+What follows from that:
 
-**One replica drains a subscription at a time.** Every replica runs this loop, so
-a subscription is claimed with a conditional update before it is drained, and the
-claim is a lease that expires if the holder dies.
+* **Nothing is skipped.** Work not taken this pass is still pending on the next.
+  ``BATCH_LIMIT`` bounds throughput, never visibility.
+* **Two replicas racing is settled by the database.** Claiming is an insert on
+  the ledger's primary key; the loser gets no row and moves on.
+* **A duplicate is recognizable as one.** ``event_id`` derives from
+  ``(subscription_id, txn_id)``, so a batch redelivered after a lapsed claim
+  carries the id a receiver already saw.
 
-**A duplicate is recognizable as one.** ``event_id`` is derived from
-``(subscription_id, txn_id)``, so if a batch is somehow delivered twice — a lease
-that lapsed mid-flight, a retry after an ambiguous timeout — both copies carry
-the same id and a receiver deduping on it drops the second. A random id per
-envelope would make every duplicate look like new work.
-
-A cursor advances only after a 2xx. Failures accumulate a backoff, so a target
-that is down slows its own deliveries instead of spinning.
+Only settled transactions are eligible (``txn_id < xmin``). That is about batch
+completeness, not cursor safety: half a transaction is not a batch. Skipping one
+costs nothing, because it is simply still pending next pass.
 """
 
 from __future__ import annotations
@@ -45,7 +42,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import func, text
+from sqlalchemy import text
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -61,20 +58,17 @@ logger = logging.getLogger(__name__)
 #: How often the drain runs.
 OUTBOX_POLL_SECONDS = 5
 
-#: How often drained history is swept.
+#: How often delivered history is swept.
 OUTBOX_RETENTION_POLL_SECONDS = 3600
 
-#: Transactions a subscription may take in one pass. Bounds a single pass, not
-#: what stays visible: whatever is not taken is simply still pending next time.
-BATCH_LIMIT = 500
+#: Transactions a subscription may take in one pass. A throughput bound only —
+#: anything not taken remains exactly as visible next pass.
+BATCH_LIMIT = 50
 
-#: How long a claim on a subscription is held. Long enough to cover a full
-#: window of deliveries at the per-request timeout, short enough that a replica
-#: dying mid-drain doesn't strand the subscription for long.
+#: How long a claim on one transaction is held before another pass may retry it.
 LEASE_SECONDS = 300
 
-#: Backoff schedule, in seconds, indexed by consecutive failure count. A target
-#: that stays down is retried ever less often rather than every cycle.
+#: Backoff schedule, in seconds, indexed by consecutive failures on a batch.
 _BACKOFF_SECONDS = (5, 30, 120, 600, 1800, 3600)
 
 #: Namespace for deterministic envelope ids. Fixed forever: changing it would
@@ -82,8 +76,8 @@ _BACKOFF_SECONDS = (5, 30, 120, 600, 1800, 3600)
 _EVENT_ID_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
 
 
-def _backoff(failure_count: int) -> timedelta:
-    index = min(failure_count, len(_BACKOFF_SECONDS) - 1)
+def _backoff(attempts: int) -> timedelta:
+    index = min(max(attempts, 1), len(_BACKOFF_SECONDS)) - 1
     return timedelta(seconds=_BACKOFF_SECONDS[index])
 
 
@@ -97,11 +91,7 @@ def _event_type(row: EventOutbox) -> str:
 
 
 def _matches(row: EventOutbox, subscription: WebhookSubscription) -> bool:
-    """Whether one change-item belongs in this subscription's batch.
-
-    Applied per item BEFORE the batch is assembled, so grouping by transaction
-    never widens what a subscription receives.
-    """
+    """Whether one change-item belongs in this subscription's batch."""
     if _event_type(row) not in subscription.event_types:
         return False
     if (
@@ -140,116 +130,106 @@ def _envelope(
     }
 
 
-async def _claim(
+async def _pending_transactions(
     session: AsyncSession, subscription: WebhookSubscription, *, now: datetime
-) -> datetime | None:
-    """Take this subscription for one pass, returning the lease that proves it.
+) -> list[int]:
+    """Settled transactions this subscription still owes, oldest first.
 
-    A conditional update is the claim: only the replica whose UPDATE matches a
-    row proceeds. ``next_attempt_at`` doubles as the lease, so a holder that dies
-    mid-drain releases it by expiry rather than stranding the subscription — and
-    the value written is the token every later write is checked against, so a
-    holder whose lease lapsed cannot settle over whoever took it next.
+    Ordered by the first outbox id each transaction wrote, so batches arrive
+    roughly in the order they were created. Eligibility is "no ledger row yet"
+    or "a row that failed and is out of backoff" — there is no position to
+    maintain, so a transaction missed by one pass is simply still pending.
+
+    The outbox read runs under the SUBSCRIPTION OWNER's context, so RLS has
+    already removed transactions holding nothing that owner may see.
     """
-    lease = now + timedelta(seconds=LEASE_SECONDS)
+    rows = await session.exec(
+        text(
+            "SELECT o.txn_id "
+            "FROM event_outbox o "
+            "WHERE o.txn_id < pg_snapshot_xmin(pg_current_snapshot())::text::bigint "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM webhook_deliveries d "
+            "    WHERE d.subscription_id = :sid AND d.txn_id = o.txn_id "
+            "      AND (d.delivered_at IS NOT NULL OR d.next_attempt_at > :now)"
+            "  ) "
+            "GROUP BY o.txn_id "
+            "ORDER BY min(o.id) ASC "
+            "LIMIT :limit"
+        ).bindparams(sid=subscription.id, now=now, limit=BATCH_LIMIT)
+    )
+    return [row[0] for row in rows]
+
+
+async def _claim(
+    session: AsyncSession,
+    subscription: WebhookSubscription,
+    txn_id: int,
+    *,
+    now: datetime,
+) -> bool:
+    """Take one transaction for this pass, or report that someone else has it.
+
+    The ledger's primary key is the claim: an insert conflicting with a live row
+    updates nothing and returns nothing, so the racing replica moves on. A row
+    that exists but is out of backoff is re-taken by extending its lease.
+    """
     result = await session.exec(
         text(
-            "UPDATE webhook_subscriptions SET next_attempt_at = :lease "
-            "WHERE id = :id AND (next_attempt_at IS NULL OR next_attempt_at <= :now) "
-            "RETURNING id"
-        ).bindparams(lease=lease, id=subscription.id, now=now)
+            "INSERT INTO webhook_deliveries "
+            "  (subscription_id, txn_id, attempts, next_attempt_at) "
+            "VALUES (:sid, :txn, 0, :lease) "
+            "ON CONFLICT (subscription_id, txn_id) DO UPDATE "
+            "  SET next_attempt_at = :lease "
+            "  WHERE webhook_deliveries.delivered_at IS NULL "
+            "    AND (webhook_deliveries.next_attempt_at IS NULL "
+            "         OR webhook_deliveries.next_attempt_at <= :now) "
+            "RETURNING attempts"
+        ).bindparams(
+            sid=subscription.id,
+            txn=txn_id,
+            lease=now + timedelta(seconds=LEASE_SECONDS),
+            now=now,
+        )
     )
     claimed = result.first() is not None
     await session.commit()
-    if not claimed:
-        return None
-    # The claim was raw SQL, so the in-memory instance still holds what it was
-    # loaded with — including a cursor another replica may have advanced between
-    # the load and the claim. Re-read before trusting any of its state.
-    await session.refresh(subscription)
-    return lease
+    return claimed
 
 
-async def _readable_window(
-    session: AsyncSession, cursor: int
-) -> tuple[list[EventOutbox], int | None]:
-    """Rows safe to deliver now, and the id to advance to.
+async def _settle(
+    session: AsyncSession,
+    subscription: WebhookSubscription,
+    txn_id: int,
+    *,
+    now: datetime,
+    accepted: bool,
+) -> None:
+    """Record the outcome.
 
-    Completeness is read from the database, never inferred from a windowed list
-    of rows. Ids come from a sequence at insert time, so a transaction's rows
-    interleave with other transactions' and can sit either side of any cut we
-    make. A list that has been shortened — by a row limit, or by stopping at an
-    in-flight row — makes the transactions inside it *look* finished, and
-    treating that as truth splits one across two passes. Both halves then derive
-    the same event_id from (subscription_id, txn_id), so a receiver deduping on
-    it takes the first and discards the rest.
-
-    So: ask Postgres for each undelivered transaction's first and last id, take
-    only transactions that end below the first in-flight row, and stop at a
-    point no remaining transaction spans.
+    ``delivered_at IS NULL`` in the predicate keeps a pass whose lease lapsed
+    mid-flight from reopening a batch another pass has already completed.
     """
-    xmin = await session.scalar(
-        text("SELECT pg_snapshot_xmin(pg_current_snapshot())::text::bigint")
-    )
-
-    # A transaction still in flight is a hard barrier: it may yet insert rows
-    # below any watermark we pick, and those would fall beneath the cursor.
-    barrier = await session.scalar(
-        select(func.min(EventOutbox.id))
-        .where(EventOutbox.id > cursor)
-        .where(EventOutbox.txn_id >= xmin)
-    )
-
-    spans = list(
-        await session.exec(
-            select(
-                EventOutbox.txn_id,
-                func.min(EventOutbox.id).label("first_id"),
-                func.max(EventOutbox.id).label("last_id"),
-            )
-            .where(EventOutbox.id > cursor)
-            .where(EventOutbox.txn_id < xmin)
-            .group_by(EventOutbox.txn_id)
-            .order_by(func.min(EventOutbox.id).asc())
+    if accepted:
+        statement = text(
+            "UPDATE webhook_deliveries "
+            "SET delivered_at = :now, next_attempt_at = NULL "
+            "WHERE subscription_id = :sid AND txn_id = :txn AND delivered_at IS NULL"
+        ).bindparams(now=now, sid=subscription.id, txn=txn_id)
+    else:
+        statement = text(
+            "UPDATE webhook_deliveries "
+            "SET attempts = attempts + 1, "
+            "    next_attempt_at = :now + make_interval(secs => :backoff) "
+            "WHERE subscription_id = :sid AND txn_id = :txn AND delivered_at IS NULL"
+        ).bindparams(
+            now=now,
+            backoff=_backoff(1).total_seconds(),
+            sid=subscription.id,
+            txn=txn_id,
         )
-    )
-    if barrier is not None:
-        spans = [span for span in spans if span.last_id < barrier]
-    if not spans:
-        return [], None
-
-    watermark = _safe_watermark(spans)
-    if watermark is None:
-        return [], None
-
-    rows = list(
-        await session.exec(
-            select(EventOutbox)
-            .where(EventOutbox.id > cursor, EventOutbox.id <= watermark)
-            .order_by(EventOutbox.id.asc())
-        )
-    )
-    return rows, watermark
-
-
-def _safe_watermark(spans: list[Any]) -> int | None:
-    """The highest id no remaining transaction straddles.
-
-    ``spans`` are (txn_id, first_id, last_id) ordered by first_id. Walking them
-    while tracking the furthest last_id seen gives the points where every
-    transaction opened so far has also closed — the only ids a single-number
-    cursor may stop on. Bounded by BATCH_LIMIT transactions so one pass cannot
-    take an unbounded backlog; whatever is left is simply still pending.
-    """
-    watermark: int | None = None
-    reach = 0
-    for index, span in enumerate(spans):
-        reach = max(reach, span.last_id)
-        if index + 1 >= len(spans) or spans[index + 1].first_id > reach:
-            watermark = reach
-            if index + 1 >= BATCH_LIMIT:
-                break
-    return watermark
+    await session.exec(statement)
+    await session.commit()
 
 
 async def _drain_subscription(
@@ -257,15 +237,14 @@ async def _drain_subscription(
     subscription: WebhookSubscription,
     *,
     now: datetime,
-    lease: datetime,
 ) -> None:
-    """Deliver one subscription's pending events, as its owner.
+    """Deliver one subscription's pending transactions, as its owner.
 
     The session is routed to the subscription's guild with the OWNER's user id,
-    so the outbox read is gated by that owner's access. ``satisfied_providers``
+    so every outbox read is gated by that owner's access. ``satisfied_providers``
     is the system sentinel: a background pass has no login to satisfy a guild's
-    auth policy with, and that leg is about how a person authenticated, not
-    about what this owner may reach. Every other gate applies unchanged.
+    auth policy with, and that leg is about how a person authenticated, not about
+    what this owner may reach. Every other gate applies unchanged.
     """
     await set_rls_context(
         session,
@@ -274,155 +253,35 @@ async def _drain_subscription(
         satisfied_providers="system",
     )
 
-    rows, watermark = await _readable_window(session, subscription.cursor_event_id)
-    if watermark is None:
-        # Nothing settled to send. Release the lease without touching failure
-        # state — no delivery was attempted, so nothing was proven either way.
-        await _release(session, subscription, lease=lease)
-        return
+    for txn_id in await _pending_transactions(session, subscription, now=now):
+        if not await _claim(session, subscription, txn_id, now=now):
+            continue
 
-    # Group by transaction id, not by adjacency: concurrent commits interleave
-    # ids, so one transaction's rows are not necessarily contiguous.
-    grouped: dict[int, list[EventOutbox]] = {}
-    for row in rows:
-        if _matches(row, subscription):
-            grouped.setdefault(row.txn_id, []).append(row)
-
-    if not grouped:
-        # The window held nothing for this subscription. Skip past it so a
-        # narrow filter doesn't re-read the same rows forever — but this is not
-        # a delivery, so failure state is left alone.
-        await _advance(
-            session, subscription, watermark, now=now, outcome=None, lease=lease
+        rows = list(
+            await session.exec(
+                select(EventOutbox)
+                .where(EventOutbox.txn_id == txn_id)
+                .order_by(EventOutbox.id.asc())
+            )
         )
-        return
+        batch = [row for row in rows if _matches(row, subscription)]
+        if not batch:
+            # Nothing in this transaction was for this subscriber. Record it so
+            # it is not reconsidered every pass; no request was made, so nothing
+            # is claimed about the target.
+            await _settle(session, subscription, txn_id, now=now, accepted=True)
+            continue
 
-    # Oldest transaction first, so a receiver sees changes in the order they
-    # were committed.
-    for txn_id in sorted(grouped):
-        batch = grouped[txn_id]
-        ok = await deliver(
+        accepted = await deliver(
             target_url=subscription.target_url,
             secret=subscription.hmac_secret,
             envelope=_envelope(subscription, txn_id, batch),
         )
-        if not ok:
-            # Hold the cursor beneath this transaction so it and everything
-            # after it retry in order.
-            await _advance(
-                session,
-                subscription,
-                batch[0].id - 1,
-                now=now,
-                outcome=False,
-                lease=lease,
-            )
+        await _settle(session, subscription, txn_id, now=now, accepted=accepted)
+        if not accepted:
+            # Deliver in order: hold the rest of this subscription's backlog
+            # until the refused batch gets through.
             return
-
-    await _advance(session, subscription, watermark, now=now, outcome=True, lease=lease)
-
-
-def _next_retry_state(
-    failure_count: int, *, outcome: bool | None, now: datetime
-) -> tuple[int, datetime | None]:
-    """The retry state an attempt leaves behind.
-
-    ``outcome`` None means no request was made — a window that held nothing this
-    subscriber wanted. That is not evidence about the target, so it must leave
-    the failure count alone; treating it as success would let unrelated traffic
-    clear a failing target's backoff.
-    """
-    if outcome is True:
-        return 0, None
-    if outcome is False:
-        failed = failure_count + 1
-        return failed, now + _backoff(failed)
-    return failure_count, None
-
-
-async def _release(
-    session: AsyncSession, subscription: WebhookSubscription, *, lease: datetime
-) -> None:
-    """Drop the lease, leaving cursor and failure state untouched."""
-    await _settle(session, subscription, lease=lease)
-
-
-async def _advance(
-    session: AsyncSession,
-    subscription: WebhookSubscription,
-    cursor: int,
-    *,
-    now: datetime,
-    outcome: bool | None,
-    lease: datetime,
-) -> None:
-    """Move the cursor and settle the lease.
-
-    ``outcome`` is the result of an actual delivery attempt — True for accepted,
-    False for refused, and None when no request was made. Only a real attempt
-    moves failure state: a window that merely contained nothing this subscriber
-    wanted must not clear a failing target's backoff.
-    """
-    failure_count, next_attempt = _next_retry_state(
-        subscription.failure_count, outcome=outcome, now=now
-    )
-    await _settle(
-        session,
-        subscription,
-        lease=lease,
-        cursor=cursor,
-        failure_count=failure_count,
-        next_attempt=next_attempt,
-    )
-
-
-async def _settle(
-    session: AsyncSession,
-    subscription: WebhookSubscription,
-    *,
-    lease: datetime,
-    cursor: int | None = None,
-    failure_count: int | None = None,
-    next_attempt: datetime | None = None,
-) -> None:
-    """Write final state, but only while this pass still holds the lease.
-
-    A drain that overran its lease has already been taken over by another
-    replica, and writing here would undo whatever that replica settled —
-    regressing a cursor into events it already delivered, or clearing a backoff
-    it just set. The ``next_attempt_at = :lease`` predicate is what makes this
-    write a no-op in that case. GREATEST keeps the cursor monotonic even when
-    two passes race legitimately.
-    """
-    result = await session.exec(
-        text(
-            "UPDATE webhook_subscriptions SET "
-            "  cursor_event_id = GREATEST(cursor_event_id, :cursor), "
-            "  failure_count = COALESCE(:failure_count, failure_count), "
-            "  next_attempt_at = :next_attempt "
-            "WHERE id = :id AND next_attempt_at = :lease "
-            "RETURNING cursor_event_id"
-        ).bindparams(
-            cursor=cursor if cursor is not None else subscription.cursor_event_id,
-            failure_count=failure_count,
-            next_attempt=next_attempt,
-            id=subscription.id,
-            lease=lease,
-        )
-    )
-    row = result.first()
-    await session.commit()
-    if row is None:
-        logger.warning(
-            "outbox settle skipped — lease no longer held: subscription=%s",
-            subscription.id,
-        )
-        return
-    # Keep the in-memory instance in step with what actually landed.
-    subscription.cursor_event_id = row[0]
-    if failure_count is not None:
-        subscription.failure_count = failure_count
-    subscription.next_attempt_at = next_attempt
 
 
 async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -> None:
@@ -431,11 +290,8 @@ async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -
     # them may then SEE is decided per subscription in _drain_subscription,
     # under its own owner's context.
     await set_rls_context(session, guild_id=guild_id, guild_role="admin")
-    # Ids, not instances. Each pass ends by expunging the identity map — ids
-    # repeat across guild schemas, so instances must not survive the reroute —
-    # and an instance held across that is detached, which makes the refresh
-    # inside _claim raise. Holding the roster as instances therefore drained the
-    # first subscription and failed every one after it.
+    # Ids, not instances: each pass ends by expunging the identity map (ids
+    # repeat across guild schemas), and an instance held across that is detached.
     subscription_ids = list(
         await session.exec(
             select(WebhookSubscription.id)
@@ -448,10 +304,7 @@ async def _drain_guild(session: AsyncSession, guild_id: int, *, now: datetime) -
             subscription = await session.get(WebhookSubscription, subscription_id)
             if subscription is None or not subscription.active:
                 continue
-            lease = await _claim(session, subscription, now=now)
-            if lease is None:
-                continue
-            await _drain_subscription(session, subscription, now=now, lease=lease)
+            await _drain_subscription(session, subscription, now=now)
         except Exception:
             logger.exception(
                 "outbox drain failed: guild=%s subscription=%s",
@@ -485,11 +338,12 @@ async def process_outbox_deliveries() -> None:
 
 
 async def process_outbox_retention() -> None:
-    """Drop outbox history past the retention window.
+    """Drop outbox history, and the ledger rows referencing it, past the window.
 
-    Age-based rather than cursor-based on purpose: a subscription that is weeks
-    behind is broken, and holding the log open for it would grow the table
-    without bound on every instance that never configures a target at all.
+    Age-based on purpose: a subscription weeks behind is broken, and holding the
+    log open for it would grow the table without bound on every instance that
+    never configures a target at all. Ledger rows go with the events they
+    describe, so the pair stays the same size.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(
         days=settings.WEBHOOK_OUTBOX_RETENTION_DAYS
@@ -503,10 +357,16 @@ async def process_outbox_retention() -> None:
                     select(EventOutbox).where(EventOutbox.occurred_at < cutoff)
                 )
             )
+            if not stale:
+                await session.commit()
+                continue
+            txn_ids = sorted({row.txn_id for row in stale})
             for row in stale:
                 await session.delete(row)
-            if stale:
-                logger.info(
-                    "outbox retention: guild=%s removed=%s", guild_id, len(stale)
-                )
+            await session.exec(
+                text(
+                    "DELETE FROM webhook_deliveries WHERE txn_id = ANY(:txn_ids)"
+                ).bindparams(txn_ids=txn_ids)
+            )
+            logger.info("outbox retention: guild=%s removed=%s", guild_id, len(stale))
             await session.commit()

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -160,3 +160,22 @@ def test_backoff_grows_and_is_bounded():
     schedule = [outbox_poller._backoff(n).total_seconds() for n in range(1, 10)]
     assert schedule == sorted(schedule), "backoff must never shrink"
     assert schedule[-1] == outbox_poller._BACKOFF_SECONDS[-1]
+
+
+def test_window_trim_never_splits_a_transaction_at_the_limit():
+    """The row limit must not cut a transaction in half.
+
+    Mirrors _readable_window's trim: when the window ends exactly at the limit,
+    the last transaction may continue past it, so its rows wait for the next
+    pass rather than going out as a partial envelope.
+    """
+    limit = 4
+    rows = [_row(1, 500), _row(2, 500), _row(3, 501), _row(4, 501)]
+
+    tail_txn = rows[-1].txn_id
+    trimmed = [r for r in rows if r.txn_id != tail_txn]
+
+    assert [r.id for r in trimmed] == [1, 2]
+    assert len(rows) == limit
+    # Transaction 501 is held back whole rather than delivered as rows 3 of 4.
+    assert all(r.txn_id != 501 for r in trimmed)

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -129,83 +129,6 @@ def test_backoff_grows_and_is_bounded():
     assert schedule[-1] == outbox_poller._BACKOFF_SECONDS[-1]
 
 
-def test_window_trim_never_splits_a_transaction_at_the_limit():
-    """The row limit must not cut a transaction in half.
-
-    Mirrors _readable_window's trim: when the window ends exactly at the limit,
-    the last transaction may continue past it, so its rows wait for the next
-    pass rather than going out as a partial envelope.
-    """
-    limit = 4
-    rows = [_row(1, 500), _row(2, 500), _row(3, 501), _row(4, 501)]
-
-    tail_txn = rows[-1].txn_id
-    trimmed = [r for r in rows if r.txn_id != tail_txn]
-
-    assert [r.id for r in trimmed] == [1, 2]
-    assert len(rows) == limit
-    # Transaction 501 is held back whole rather than delivered as rows 3 of 4.
-    assert all(r.txn_id != 501 for r in trimmed)
-
-
-def test_interleaved_window_never_advances_past_a_withheld_row():
-    """The cursor is one number, so it may only stop where every transaction
-    that started below it also finished below it.
-
-    Trimming the tail transaction by id alone loses events: with rows
-    1(A) 2(B) 3(A) 4(B), dropping B leaves [1, 3] and a watermark of 3 — but
-    row 2 is B's and sits *below* 3, so it would never be read again.
-    """
-    rows = [_row(1, 500), _row(2, 501), _row(3, 500), _row(4, 501)]
-
-    prefix, watermark = outbox_poller._complete_prefix(rows, truncated=True)
-
-    assert watermark is None or watermark < 2, (
-        f"watermark {watermark} skips row 2, which was withheld with its "
-        "transaction — those events are unreachable on every later pass"
-    )
-    assert all(r.id <= (watermark or 0) for r in prefix)
-
-
-def test_complete_prefix_stops_before_an_unfinished_transaction():
-    """Transaction 500 closes at row 2; 501 is still open at the window edge."""
-    rows = [_row(1, 500), _row(2, 500), _row(3, 501)]
-
-    prefix, watermark = outbox_poller._complete_prefix(rows, truncated=True)
-
-    assert watermark == 2
-    assert [r.id for r in prefix] == [1, 2]
-
-
-def test_complete_prefix_takes_everything_when_nothing_is_open():
-    rows = [_row(1, 500), _row(2, 500), _row(3, 501)]
-
-    prefix, watermark = outbox_poller._complete_prefix(rows, truncated=False)
-
-    assert watermark == 3
-    assert [r.id for r in prefix] == [1, 2, 3]
-
-
-def test_prefix_over_a_filtered_subset_would_skip_unseen_rows():
-    """Why _complete_prefix must be given a contiguous range, not a subset.
-
-    Rows 1(A) 2(B) 3(A) 5(A) are what a re-read filtered to transactions {A, B}
-    returns; row 4 belongs to some transaction C and is invisible to it. The
-    walk closes A at 5 and reports a watermark of 5 — above row 4, which it was
-    never shown. The fallback therefore widens the id RANGE rather than
-    filtering to particular transactions.
-    """
-    subset = [_row(1, 500), _row(2, 501), _row(3, 500), _row(5, 500)]
-
-    _prefix, watermark = outbox_poller._complete_prefix(subset, truncated=False)
-
-    assert watermark == 5, (
-        "guarding the documented contract: fed a filtered subset the walk "
-        "reports a watermark above rows it never saw, so callers must widen "
-        "the range instead"
-    )
-
-
 async def test_every_subscription_in_a_guild_is_drained(
     session, acting_user, monkeypatch
 ):
@@ -250,3 +173,46 @@ async def test_every_subscription_in_a_guild_is_drained(
         f"only {len(drained)} of 3 subscriptions drained — the rest were "
         "detached by the per-pass expunge and never delivered to"
     )
+
+
+class _Span:
+    """A (txn_id, first_id, last_id) row as the spans query returns it."""
+
+    def __init__(self, txn_id: int, first_id: int, last_id: int) -> None:
+        self.txn_id = txn_id
+        self.first_id = first_id
+        self.last_id = last_id
+
+
+def test_watermark_never_lands_inside_a_transaction():
+    """A stops at 5 but opened at 1, and B sits entirely inside that span.
+    Stopping at B's end would cut A, so the only safe stop is A's end."""
+    spans = [_Span(500, 1, 5), _Span(501, 2, 3)]
+
+    assert outbox_poller._safe_watermark(spans) == 5
+
+
+def test_watermark_stops_where_every_open_transaction_has_closed():
+    spans = [_Span(500, 1, 2), _Span(501, 3, 4)]
+
+    assert outbox_poller._safe_watermark(spans) == 4
+
+
+def test_a_transaction_hidden_beyond_a_barrier_is_not_treated_as_finished():
+    """The regression that produced duplicate-id envelopes.
+
+    A wrote rows 1, 3 and 5; an in-flight transaction holds row 4. Reading rows
+    and stopping at row 4 makes A look finished at 3 — it ships as [1, 3], then
+    row 5 ships later under the SAME event_id and a deduping receiver drops it.
+    Spans come from the database and A's last_id is 5, so the barrier at 4
+    excludes A entirely rather than truncating it.
+    """
+    spans = [_Span(500, 1, 5)]
+    barrier = 4
+
+    eligible = [s for s in spans if s.last_id < barrier]
+
+    assert eligible == [], (
+        "transaction A ends past the barrier, so no part of it may go out yet"
+    )
+    assert outbox_poller._safe_watermark(eligible) is None

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from app.db.session import set_rls_context
 from app.models.tenant.event_outbox import EventOutbox
 from app.models.tenant.webhook_subscription import WebhookSubscription
 from app.services.tenant import outbox_poller
@@ -104,13 +105,14 @@ async def test_every_subscription_in_a_guild_is_drained(
     from app.services.tenant import outbox_poller as poller
 
     a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    guild_id, user_id = a.guild.id, a.user.id
 
     for index in range(3):
         session.add(
             WebhookSubscription(
-                guild_id=a.guild.id,
+                guild_id=guild_id,
                 initiative_id=None,
-                created_by_user_id=a.user.id,
+                created_by_user_id=user_id,
                 target_url=f"https://example.test/hook-{index}",
                 hmac_secret=f"secret-{index}",
                 event_types=["tasks.created"],
@@ -129,7 +131,7 @@ async def test_every_subscription_in_a_guild_is_drained(
     monkeypatch.setattr(poller, "_drain_subscription", _record)
 
     now = datetime.now(timezone.utc)
-    await poller._drain_guild(session, a.guild.id, now=now)
+    await poller._drain_guild(session, guild_id, now=now)
 
     assert len(drained) == 3, (
         f"only {len(drained)} of 3 subscriptions drained — the rest were "
@@ -149,13 +151,6 @@ def test_a_batch_is_one_transaction_whole():
     assert envelope["event_id"] == outbox_poller._event_id(subscription.id, 500)
 
 
-def test_backoff_grows_and_is_bounded():
-    schedule = [outbox_poller._backoff(n).total_seconds() for n in range(1, 10)]
-    assert schedule == sorted(schedule), "backoff must never shrink"
-    assert schedule[0] == outbox_poller._BACKOFF_SECONDS[0]
-    assert schedule[-1] == outbox_poller._BACKOFF_SECONDS[-1]
-
-
 @pytest.mark.integration
 async def test_ledger_delivers_each_transaction_once(session, acting_user, monkeypatch):
     """A drain marks each pending transaction delivered, and a second pass over
@@ -165,14 +160,15 @@ async def test_ledger_delivers_each_transaction_once(session, acting_user, monke
     from app.testing import create_task
 
     a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    guild_id, user_id = a.guild.id, a.user.id
     await create_task(session, a.project)
     await create_task(session, a.project)
 
     session.add(
         WebhookSubscription(
-            guild_id=a.guild.id,
+            guild_id=guild_id,
             initiative_id=None,
-            created_by_user_id=a.user.id,
+            created_by_user_id=user_id,
             target_url="https://example.test/hook",
             hmac_secret="secret",
             event_types=["tasks.created"],
@@ -191,11 +187,11 @@ async def test_ledger_delivers_each_transaction_once(session, acting_user, monke
 
     monkeypatch.setattr(poller, "deliver", _accept)
 
-    await poller._drain_guild(session, a.guild.id, now=datetime.now(timezone.utc))
+    await poller._drain_guild(session, guild_id, now=datetime.now(timezone.utc))
     first_pass = len(sent)
     assert first_pass > 0, "no transaction was delivered"
 
-    await poller._drain_guild(session, a.guild.id, now=datetime.now(timezone.utc))
+    await poller._drain_guild(session, guild_id, now=datetime.now(timezone.utc))
     assert len(sent) == first_pass, (
         "a settled transaction was delivered twice — the ledger row should make "
         "it ineligible on every later pass"
@@ -211,13 +207,14 @@ async def test_a_refused_batch_is_retried_not_lost(session, acting_user, monkeyp
     from app.testing import create_task
 
     a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    guild_id, user_id = a.guild.id, a.user.id
     await create_task(session, a.project)
 
     session.add(
         WebhookSubscription(
-            guild_id=a.guild.id,
+            guild_id=guild_id,
             initiative_id=None,
-            created_by_user_id=a.user.id,
+            created_by_user_id=user_id,
             target_url="https://example.test/hook",
             hmac_secret="secret",
             event_types=["tasks.created"],
@@ -236,14 +233,78 @@ async def test_a_refused_batch_is_retried_not_lost(session, acting_user, monkeyp
 
     monkeypatch.setattr(poller, "deliver", _refuse)
 
-    await poller._drain_guild(session, a.guild.id, now=datetime.now(timezone.utc))
+    await poller._drain_guild(session, guild_id, now=datetime.now(timezone.utc))
     assert len(attempts) == 1
 
     # Past the backoff, the same batch is offered again under the same id.
     later = datetime.now(timezone.utc) + timedelta(hours=2)
-    await poller._drain_guild(session, a.guild.id, now=later)
+    await poller._drain_guild(session, guild_id, now=later)
     assert len(attempts) == 2, "a refused batch was dropped instead of retried"
     assert attempts[0] == attempts[1], (
         "the retry carried a different event_id, so a receiver deduping on it "
         "would treat the redelivery as new work"
     )
+
+
+@pytest.mark.integration
+async def test_repeated_refusals_escalate_the_backoff(
+    session, acting_user, monkeypatch
+):
+    """The schedule has to be applied, not merely defined.
+
+    _settle previously incremented attempts but always scheduled the first step,
+    so an unreachable target was retried every five seconds forever. This drives
+    real refusals and reads the interval Postgres actually stored.
+    """
+    from sqlalchemy import text as sa_text
+
+    from app.models.platform.guild import GuildRole
+    from app.services.tenant import outbox_poller as poller
+    from app.testing import create_task
+
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    guild_id, user_id = a.guild.id, a.user.id
+    await create_task(session, a.project)
+
+    session.add(
+        WebhookSubscription(
+            guild_id=guild_id,
+            initiative_id=None,
+            created_by_user_id=user_id,
+            target_url="https://example.test/hook",
+            hmac_secret="secret",
+            event_types=["tasks.created"],
+            active=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+    await session.commit()
+
+    async def _refuse(*, target_url, secret, envelope):
+        return False
+
+    monkeypatch.setattr(poller, "deliver", _refuse)
+
+    intervals: list[float] = []
+    moment = datetime.now(timezone.utc)
+    for _ in range(3):
+        await poller._drain_guild(session, guild_id, now=moment)
+        await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+        row = (
+            await session.exec(
+                sa_text(
+                    "SELECT attempts, next_attempt_at FROM webhook_deliveries "
+                    "WHERE delivered_at IS NULL ORDER BY txn_id LIMIT 1"
+                )
+            )
+        ).first()
+        intervals.append((row[1] - moment).total_seconds())
+        # Jump past the backoff so the next pass re-claims the same batch.
+        moment = row[1] + timedelta(seconds=1)
+
+    assert intervals == sorted(intervals) and intervals[0] < intervals[-1], (
+        f"backoff did not escalate across repeated refusals: {intervals} — an "
+        "unreachable target would be retried at the first interval forever"
+    )
+    assert intervals[:3] == [float(s) for s in poller._BACKOFF_SECONDS[:3]]

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -1,0 +1,162 @@
+"""The properties the poller has to actually hold.
+
+Each of these covers a way the first cut of this code was wrong: backoff that
+unrelated traffic could clear, transactions split across envelopes, two replicas
+delivering the same batch under different ids, and a cursor that could run past
+an in-flight transaction.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.tenant.event_outbox import EventOutbox
+from app.models.tenant.webhook_subscription import WebhookSubscription
+from app.services.tenant import outbox_poller
+
+pytestmark = pytest.mark.unit
+
+
+def _subscription(**overrides) -> WebhookSubscription:
+    defaults = dict(
+        id=7,
+        guild_id=1,
+        initiative_id=None,
+        created_by_user_id=3,
+        target_url="https://example.test/hook",
+        hmac_secret="s3cret",
+        event_types=["tasks.created", "tasks.updated"],
+        active=True,
+        cursor_event_id=0,
+        failure_count=0,
+        next_attempt_at=None,
+    )
+    defaults.update(overrides)
+    return WebhookSubscription(**defaults)
+
+
+def _row(row_id: int, txn_id: int, **overrides) -> EventOutbox:
+    defaults = dict(
+        id=row_id,
+        txn_id=txn_id,
+        occurred_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+        actor_user_id=3,
+        initiative_id=11,
+        resource_type="tasks",
+        resource_id=100 + row_id,
+        action="created",
+        changed=[],
+    )
+    defaults.update(overrides)
+    return EventOutbox(**defaults)
+
+
+def test_event_id_is_the_same_for_the_same_batch():
+    """Two replicas delivering one batch must produce one id, or a receiver
+    deduping on it sees the duplicate as new work."""
+    first = outbox_poller._event_id(7, 4242)
+    second = outbox_poller._event_id(7, 4242)
+    assert first == second
+    assert first != outbox_poller._event_id(7, 4243)
+    assert first != outbox_poller._event_id(8, 4242)
+
+
+def test_grouping_is_by_transaction_not_adjacency():
+    """Concurrent commits interleave ids, so one transaction's rows are not
+    necessarily contiguous in the log."""
+    subscription = _subscription()
+    rows = [_row(1, 500), _row(2, 501), _row(3, 500), _row(4, 501)]
+
+    grouped: dict[int, list[EventOutbox]] = {}
+    for row in rows:
+        if outbox_poller._matches(row, subscription):
+            grouped.setdefault(row.txn_id, []).append(row)
+
+    assert sorted(grouped) == [500, 501]
+    assert [r.id for r in grouped[500]] == [1, 3]
+    assert [r.id for r in grouped[501]] == [2, 4]
+
+
+def test_one_transaction_is_one_envelope():
+    subscription = _subscription()
+    rows = [_row(1, 500), _row(3, 500)]
+    envelope = outbox_poller._envelope(subscription, 500, rows)
+
+    assert len(envelope["changes"]) == 2
+    assert envelope["event_id"] == outbox_poller._event_id(subscription.id, 500)
+    # Names and ids only — no value from any changed column rides along.
+    for change in envelope["changes"]:
+        assert set(change) == {
+            "event_type",
+            "initiative_id",
+            "resource",
+            "action",
+            "changed",
+        }
+
+
+class _FakeSession:
+    """Just enough session to drive _advance / _release."""
+
+    def __init__(self) -> None:
+        self.commits = 0
+
+    def add(self, _obj) -> None:  # noqa: D102
+        pass
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+async def test_an_empty_window_does_not_clear_a_failing_backoff():
+    """A window holding nothing this subscriber wanted is not a delivery, so it
+    must not reset a failing target's failure count."""
+    now = datetime.now(timezone.utc)
+    subscription = _subscription(
+        failure_count=3, next_attempt_at=now + timedelta(seconds=600)
+    )
+    session = _FakeSession()
+
+    await outbox_poller._advance(session, subscription, 50, now=now, outcome=None)
+
+    assert subscription.failure_count == 3, (
+        "a non-matching window reset the backoff, so unrelated traffic would "
+        "keep a dead target being retried every pass"
+    )
+    assert subscription.cursor_event_id == 50
+
+
+async def test_a_refused_delivery_backs_off_and_holds_the_cursor():
+    now = datetime.now(timezone.utc)
+    subscription = _subscription(cursor_event_id=10, failure_count=1)
+    session = _FakeSession()
+
+    await outbox_poller._advance(session, subscription, 9, now=now, outcome=False)
+
+    assert subscription.failure_count == 2
+    assert subscription.next_attempt_at is not None
+    assert subscription.next_attempt_at > now
+    # The cursor never moves backwards.
+    assert subscription.cursor_event_id == 10
+
+
+async def test_an_accepted_delivery_clears_failure_state():
+    now = datetime.now(timezone.utc)
+    subscription = _subscription(
+        cursor_event_id=10, failure_count=4, next_attempt_at=now
+    )
+    session = _FakeSession()
+
+    await outbox_poller._advance(session, subscription, 42, now=now, outcome=True)
+
+    assert subscription.failure_count == 0
+    assert subscription.next_attempt_at is None
+    assert subscription.cursor_event_id == 42
+
+
+def test_backoff_grows_and_is_bounded():
+    schedule = [outbox_poller._backoff(n).total_seconds() for n in range(1, 10)]
+    assert schedule == sorted(schedule), "backoff must never shrink"
+    assert schedule[-1] == outbox_poller._BACKOFF_SECONDS[-1]

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -184,3 +184,23 @@ def test_complete_prefix_takes_everything_when_nothing_is_open():
 
     assert watermark == 3
     assert [r.id for r in prefix] == [1, 2, 3]
+
+
+def test_prefix_over_a_filtered_subset_would_skip_unseen_rows():
+    """Why _complete_prefix must be given a contiguous range, not a subset.
+
+    Rows 1(A) 2(B) 3(A) 5(A) are what a re-read filtered to transactions {A, B}
+    returns; row 4 belongs to some transaction C and is invisible to it. The
+    walk closes A at 5 and reports a watermark of 5 — above row 4, which it was
+    never shown. The fallback therefore widens the id RANGE rather than
+    filtering to particular transactions.
+    """
+    subset = [_row(1, 500), _row(2, 501), _row(3, 500), _row(5, 500)]
+
+    _prefix, watermark = outbox_poller._complete_prefix(subset, truncated=False)
+
+    assert watermark == 5, (
+        "guarding the documented contract: fed a filtered subset the walk "
+        "reports a watermark above rows it never saw, so callers must widen "
+        "the range instead"
+    )

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -8,7 +8,7 @@ an in-flight transaction.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -29,9 +29,6 @@ def _subscription(**overrides) -> WebhookSubscription:
         hmac_secret="s3cret",
         event_types=["tasks.created", "tasks.updated"],
         active=True,
-        cursor_event_id=0,
-        failure_count=0,
-        next_attempt_at=None,
     )
     defaults.update(overrides)
     return WebhookSubscription(**defaults)
@@ -97,38 +94,6 @@ def test_one_transaction_is_one_envelope():
         }
 
 
-def test_a_window_with_nothing_to_send_leaves_failure_state_alone():
-    """A window holding nothing this subscriber wanted is not evidence about the
-    target, so it must not clear a failing one's backoff."""
-    now = datetime.now(timezone.utc)
-    count, next_attempt = outbox_poller._next_retry_state(3, outcome=None, now=now)
-    assert count == 3, (
-        "a non-matching window reset the backoff, so unrelated traffic would "
-        "keep a dead target being retried every pass"
-    )
-    assert next_attempt is None
-
-
-def test_a_refused_delivery_backs_off():
-    now = datetime.now(timezone.utc)
-    count, next_attempt = outbox_poller._next_retry_state(1, outcome=False, now=now)
-    assert count == 2
-    assert next_attempt is not None and next_attempt > now
-
-
-def test_an_accepted_delivery_clears_failure_state():
-    now = datetime.now(timezone.utc)
-    count, next_attempt = outbox_poller._next_retry_state(4, outcome=True, now=now)
-    assert count == 0
-    assert next_attempt is None
-
-
-def test_backoff_grows_and_is_bounded():
-    schedule = [outbox_poller._backoff(n).total_seconds() for n in range(1, 10)]
-    assert schedule == sorted(schedule), "backoff must never shrink"
-    assert schedule[-1] == outbox_poller._BACKOFF_SECONDS[-1]
-
-
 async def test_every_subscription_in_a_guild_is_drained(
     session, acting_user, monkeypatch
 ):
@@ -150,9 +115,6 @@ async def test_every_subscription_in_a_guild_is_drained(
                 hmac_secret=f"secret-{index}",
                 event_types=["tasks.created"],
                 active=True,
-                cursor_event_id=0,
-                failure_count=0,
-                next_attempt_at=None,
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
             )
@@ -161,7 +123,7 @@ async def test_every_subscription_in_a_guild_is_drained(
 
     drained: list[int] = []
 
-    async def _record(session_, subscription, *, now, lease):
+    async def _record(session_, subscription, *, now):
         drained.append(subscription.id)
 
     monkeypatch.setattr(poller, "_drain_subscription", _record)
@@ -175,44 +137,113 @@ async def test_every_subscription_in_a_guild_is_drained(
     )
 
 
-class _Span:
-    """A (txn_id, first_id, last_id) row as the spans query returns it."""
+def test_a_batch_is_one_transaction_whole():
+    """Rows are selected by txn_id, so a batch is every row that transaction
+    wrote. A partial batch is not a state this design can reach."""
+    subscription = _subscription()
+    rows = [_row(1, 500), _row(3, 500), _row(9, 500)]
 
-    def __init__(self, txn_id: int, first_id: int, last_id: int) -> None:
-        self.txn_id = txn_id
-        self.first_id = first_id
-        self.last_id = last_id
+    envelope = outbox_poller._envelope(subscription, 500, rows)
 
-
-def test_watermark_never_lands_inside_a_transaction():
-    """A stops at 5 but opened at 1, and B sits entirely inside that span.
-    Stopping at B's end would cut A, so the only safe stop is A's end."""
-    spans = [_Span(500, 1, 5), _Span(501, 2, 3)]
-
-    assert outbox_poller._safe_watermark(spans) == 5
+    assert [c["resource"]["id"] for c in envelope["changes"]] == [101, 103, 109]
+    assert envelope["event_id"] == outbox_poller._event_id(subscription.id, 500)
 
 
-def test_watermark_stops_where_every_open_transaction_has_closed():
-    spans = [_Span(500, 1, 2), _Span(501, 3, 4)]
+def test_backoff_grows_and_is_bounded():
+    schedule = [outbox_poller._backoff(n).total_seconds() for n in range(1, 10)]
+    assert schedule == sorted(schedule), "backoff must never shrink"
+    assert schedule[0] == outbox_poller._BACKOFF_SECONDS[0]
+    assert schedule[-1] == outbox_poller._BACKOFF_SECONDS[-1]
 
-    assert outbox_poller._safe_watermark(spans) == 4
 
+@pytest.mark.integration
+async def test_ledger_delivers_each_transaction_once(session, acting_user, monkeypatch):
+    """A drain marks each pending transaction delivered, and a second pass over
+    the same log sends nothing further."""
+    from app.models.platform.guild import GuildRole
+    from app.services.tenant import outbox_poller as poller
+    from app.testing import create_task
 
-def test_a_transaction_hidden_beyond_a_barrier_is_not_treated_as_finished():
-    """The regression that produced duplicate-id envelopes.
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project)
+    await create_task(session, a.project)
 
-    A wrote rows 1, 3 and 5; an in-flight transaction holds row 4. Reading rows
-    and stopping at row 4 makes A look finished at 3 — it ships as [1, 3], then
-    row 5 ships later under the SAME event_id and a deduping receiver drops it.
-    Spans come from the database and A's last_id is 5, so the barrier at 4
-    excludes A entirely rather than truncating it.
-    """
-    spans = [_Span(500, 1, 5)]
-    barrier = 4
-
-    eligible = [s for s in spans if s.last_id < barrier]
-
-    assert eligible == [], (
-        "transaction A ends past the barrier, so no part of it may go out yet"
+    session.add(
+        WebhookSubscription(
+            guild_id=a.guild.id,
+            initiative_id=None,
+            created_by_user_id=a.user.id,
+            target_url="https://example.test/hook",
+            hmac_secret="secret",
+            event_types=["tasks.created"],
+            active=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
     )
-    assert outbox_poller._safe_watermark(eligible) is None
+    await session.commit()
+
+    sent: list[dict] = []
+
+    async def _accept(*, target_url, secret, envelope):
+        sent.append(envelope)
+        return True
+
+    monkeypatch.setattr(poller, "deliver", _accept)
+
+    await poller._drain_guild(session, a.guild.id, now=datetime.now(timezone.utc))
+    first_pass = len(sent)
+    assert first_pass > 0, "no transaction was delivered"
+
+    await poller._drain_guild(session, a.guild.id, now=datetime.now(timezone.utc))
+    assert len(sent) == first_pass, (
+        "a settled transaction was delivered twice — the ledger row should make "
+        "it ineligible on every later pass"
+    )
+
+
+@pytest.mark.integration
+async def test_a_refused_batch_is_retried_not_lost(session, acting_user, monkeypatch):
+    """A refusal leaves the transaction pending, so it comes back once its
+    backoff expires rather than being skipped."""
+    from app.models.platform.guild import GuildRole
+    from app.services.tenant import outbox_poller as poller
+    from app.testing import create_task
+
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project)
+
+    session.add(
+        WebhookSubscription(
+            guild_id=a.guild.id,
+            initiative_id=None,
+            created_by_user_id=a.user.id,
+            target_url="https://example.test/hook",
+            hmac_secret="secret",
+            event_types=["tasks.created"],
+            active=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+    await session.commit()
+
+    attempts: list[str] = []
+
+    async def _refuse(*, target_url, secret, envelope):
+        attempts.append(envelope["event_id"])
+        return False
+
+    monkeypatch.setattr(poller, "deliver", _refuse)
+
+    await poller._drain_guild(session, a.guild.id, now=datetime.now(timezone.utc))
+    assert len(attempts) == 1
+
+    # Past the backoff, the same batch is offered again under the same id.
+    later = datetime.now(timezone.utc) + timedelta(hours=2)
+    await poller._drain_guild(session, a.guild.id, now=later)
+    assert len(attempts) == 2, "a refused batch was dropped instead of retried"
+    assert attempts[0] == attempts[1], (
+        "the retry carried a different event_id, so a receiver deduping on it "
+        "would treat the redelivery as new work"
+    )

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -8,7 +8,7 @@ an in-flight transaction.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import pytest
 
@@ -97,63 +97,30 @@ def test_one_transaction_is_one_envelope():
         }
 
 
-class _FakeSession:
-    """Just enough session to drive _advance / _release."""
-
-    def __init__(self) -> None:
-        self.commits = 0
-
-    def add(self, _obj) -> None:  # noqa: D102
-        pass
-
-    async def commit(self) -> None:
-        self.commits += 1
-
-
-async def test_an_empty_window_does_not_clear_a_failing_backoff():
-    """A window holding nothing this subscriber wanted is not a delivery, so it
-    must not reset a failing target's failure count."""
+def test_a_window_with_nothing_to_send_leaves_failure_state_alone():
+    """A window holding nothing this subscriber wanted is not evidence about the
+    target, so it must not clear a failing one's backoff."""
     now = datetime.now(timezone.utc)
-    subscription = _subscription(
-        failure_count=3, next_attempt_at=now + timedelta(seconds=600)
-    )
-    session = _FakeSession()
-
-    await outbox_poller._advance(session, subscription, 50, now=now, outcome=None)
-
-    assert subscription.failure_count == 3, (
+    count, next_attempt = outbox_poller._next_retry_state(3, outcome=None, now=now)
+    assert count == 3, (
         "a non-matching window reset the backoff, so unrelated traffic would "
         "keep a dead target being retried every pass"
     )
-    assert subscription.cursor_event_id == 50
+    assert next_attempt is None
 
 
-async def test_a_refused_delivery_backs_off_and_holds_the_cursor():
+def test_a_refused_delivery_backs_off():
     now = datetime.now(timezone.utc)
-    subscription = _subscription(cursor_event_id=10, failure_count=1)
-    session = _FakeSession()
-
-    await outbox_poller._advance(session, subscription, 9, now=now, outcome=False)
-
-    assert subscription.failure_count == 2
-    assert subscription.next_attempt_at is not None
-    assert subscription.next_attempt_at > now
-    # The cursor never moves backwards.
-    assert subscription.cursor_event_id == 10
+    count, next_attempt = outbox_poller._next_retry_state(1, outcome=False, now=now)
+    assert count == 2
+    assert next_attempt is not None and next_attempt > now
 
 
-async def test_an_accepted_delivery_clears_failure_state():
+def test_an_accepted_delivery_clears_failure_state():
     now = datetime.now(timezone.utc)
-    subscription = _subscription(
-        cursor_event_id=10, failure_count=4, next_attempt_at=now
-    )
-    session = _FakeSession()
-
-    await outbox_poller._advance(session, subscription, 42, now=now, outcome=True)
-
-    assert subscription.failure_count == 0
-    assert subscription.next_attempt_at is None
-    assert subscription.cursor_event_id == 42
+    count, next_attempt = outbox_poller._next_retry_state(4, outcome=True, now=now)
+    assert count == 0
+    assert next_attempt is None
 
 
 def test_backoff_grows_and_is_bounded():
@@ -179,3 +146,41 @@ def test_window_trim_never_splits_a_transaction_at_the_limit():
     assert len(rows) == limit
     # Transaction 501 is held back whole rather than delivered as rows 3 of 4.
     assert all(r.txn_id != 501 for r in trimmed)
+
+
+def test_interleaved_window_never_advances_past_a_withheld_row():
+    """The cursor is one number, so it may only stop where every transaction
+    that started below it also finished below it.
+
+    Trimming the tail transaction by id alone loses events: with rows
+    1(A) 2(B) 3(A) 4(B), dropping B leaves [1, 3] and a watermark of 3 — but
+    row 2 is B's and sits *below* 3, so it would never be read again.
+    """
+    rows = [_row(1, 500), _row(2, 501), _row(3, 500), _row(4, 501)]
+
+    prefix, watermark = outbox_poller._complete_prefix(rows, truncated=True)
+
+    assert watermark is None or watermark < 2, (
+        f"watermark {watermark} skips row 2, which was withheld with its "
+        "transaction — those events are unreachable on every later pass"
+    )
+    assert all(r.id <= (watermark or 0) for r in prefix)
+
+
+def test_complete_prefix_stops_before_an_unfinished_transaction():
+    """Transaction 500 closes at row 2; 501 is still open at the window edge."""
+    rows = [_row(1, 500), _row(2, 500), _row(3, 501)]
+
+    prefix, watermark = outbox_poller._complete_prefix(rows, truncated=True)
+
+    assert watermark == 2
+    assert [r.id for r in prefix] == [1, 2]
+
+
+def test_complete_prefix_takes_everything_when_nothing_is_open():
+    rows = [_row(1, 500), _row(2, 500), _row(3, 501)]
+
+    prefix, watermark = outbox_poller._complete_prefix(rows, truncated=False)
+
+    assert watermark == 3
+    assert [r.id for r in prefix] == [1, 2, 3]

--- a/backend/app/services/tenant/outbox_poller_test.py
+++ b/backend/app/services/tenant/outbox_poller_test.py
@@ -204,3 +204,49 @@ def test_prefix_over_a_filtered_subset_would_skip_unseen_rows():
         "reports a watermark above rows it never saw, so callers must widen "
         "the range instead"
     )
+
+
+async def test_every_subscription_in_a_guild_is_drained(
+    session, acting_user, monkeypatch
+):
+    """Each pass expunges the identity map, so the roster is held as ids and
+    each subscription is re-loaded. Held as instances, the second and later ones
+    are detached and every one after the first fails."""
+    from app.models.platform.guild import GuildRole
+    from app.services.tenant import outbox_poller as poller
+
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+
+    for index in range(3):
+        session.add(
+            WebhookSubscription(
+                guild_id=a.guild.id,
+                initiative_id=None,
+                created_by_user_id=a.user.id,
+                target_url=f"https://example.test/hook-{index}",
+                hmac_secret=f"secret-{index}",
+                event_types=["tasks.created"],
+                active=True,
+                cursor_event_id=0,
+                failure_count=0,
+                next_attempt_at=None,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+        )
+    await session.commit()
+
+    drained: list[int] = []
+
+    async def _record(session_, subscription, *, now, lease):
+        drained.append(subscription.id)
+
+    monkeypatch.setattr(poller, "_drain_subscription", _record)
+
+    now = datetime.now(timezone.utc)
+    await poller._drain_guild(session, a.guild.id, now=now)
+
+    assert len(drained) == 3, (
+        f"only {len(drained)} of 3 subscriptions drained — the rest were "
+        "detached by the per-pass expunge and never delivered to"
+    )

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -116,7 +116,7 @@ async def deliver(
         logger.warning(
             "webhook delivery failed: target=%s event=%s err=%s",
             target_url,
-            envelope["event_type"],
+            envelope.get("event_id"),
             exc,
         )
         return False
@@ -125,7 +125,7 @@ async def deliver(
         logger.warning(
             "webhook delivery non-2xx: target=%s event=%s status=%s",
             target_url,
-            envelope["event_type"],
+            envelope.get("event_id"),
             response.status_code,
         )
         return False

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -121,9 +121,13 @@ async def deliver(
         )
         return False
 
-    if response.status_code >= 400:
+    # Accepted means 2xx and nothing else. A redirect is not a delivery — the
+    # request is pinned to a validated address and not followed, so treating 3xx
+    # as success would drop the batch from retry without a receiver ever having
+    # seen it.
+    if not 200 <= response.status_code < 300:
         logger.warning(
-            "webhook delivery non-2xx: target=%s event=%s status=%s",
+            "webhook delivery not accepted: target=%s event=%s status=%s",
             target_url,
             envelope.get("event_id"),
             response.status_code,

--- a/backend/app/services/tenant/webhook_dispatcher.py
+++ b/backend/app/services/tenant/webhook_dispatcher.py
@@ -67,14 +67,18 @@ def _sign(secret: str, timestamp: str, body: bytes) -> str:
     return f"sha256={mac.hexdigest()}"
 
 
-async def _deliver(
+async def deliver(
     *,
     target_url: str,
     secret: str,
     envelope: dict[str, Any],
-) -> None:
-    """POST one envelope to one target. Logs and swallows any error so
-    one bad subscriber can't break the rest of the dispatch.
+) -> bool:
+    """POST one envelope to one target. Returns whether it was accepted.
+
+    Logs and swallows any error so one bad subscriber can't break the rest of
+    the dispatch. The boolean is what the poller advances a cursor on: a row is
+    only considered drained once its target answered 2xx, so a failed delivery
+    is retried on a later pass instead of being lost.
 
     Delivery goes through :func:`request_public_target`, which resolves
     the target host once and connects to that validated address. The
@@ -107,7 +111,7 @@ async def _deliver(
             target_url,
             exc,
         )
-        return
+        return False
     except Exception as exc:  # noqa: BLE001 — best-effort delivery
         logger.warning(
             "webhook delivery failed: target=%s event=%s err=%s",
@@ -115,7 +119,7 @@ async def _deliver(
             envelope["event_type"],
             exc,
         )
-        return
+        return False
 
     if response.status_code >= 400:
         logger.warning(
@@ -124,6 +128,9 @@ async def _deliver(
             envelope["event_type"],
             response.status_code,
         )
+        return False
+
+    return True
 
 
 async def dispatch_event(
@@ -199,19 +206,18 @@ async def dispatch_event(
     # ``event_id`` so a receiver dedup-ing on that header doesn't drop
     # legitimate fan-out to multiple subscriptions of the same logical
     # event, and so future per-target retry logic can dedup retries
-    # without colliding across subscriptions. ``subscription_id`` and
-    # ``workflow_id`` are included for the receiver's routing.
+    # without colliding across subscriptions. ``subscription_id`` is included
+    # for the receiver's routing.
     deliveries: list[asyncio.Task] = []
     for sub in rows:
         envelope = {
             **envelope_base,
             "event_id": str(uuid.uuid4()),
             "subscription_id": sub.id,
-            "workflow_id": sub.workflow_id,
         }
         deliveries.append(
             asyncio.create_task(
-                _deliver(
+                deliver(
                     target_url=sub.target_url,
                     secret=sub.hmac_secret,
                     envelope=envelope,

--- a/backend/app/services/tenant/webhook_dispatcher_test.py
+++ b/backend/app/services/tenant/webhook_dispatcher_test.py
@@ -123,7 +123,6 @@ async def _make_subscription(
     sub = WebhookSubscription(
         guild_id=guild.id,
         initiative_id=initiative_id,
-        workflow_id=None,
         created_by_user_id=user.id,
         target_url=target_url,
         hmac_secret="test-secret",
@@ -148,7 +147,7 @@ async def test_dispatch_skips_when_no_subscribers(session):
     # guild-scoped); mirror that — no tenant write here routes it implicitly.
     await route_session_to_guild(session, guild.id)
     with patch(
-        "app.services.tenant.webhook_dispatcher._deliver", new=AsyncMock()
+        "app.services.tenant.webhook_dispatcher.deliver", new=AsyncMock()
     ) as mock_deliver:
         await dispatch_event(
             session,
@@ -186,10 +185,11 @@ async def test_dispatch_matches_only_active_subscriptions(session):
 
     delivered_to: list[str] = []
 
-    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> None:
+    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> bool:
         delivered_to.append(target_url)
+        return True
 
-    with patch("app.services.tenant.webhook_dispatcher._deliver", new=fake_deliver):
+    with patch("app.services.tenant.webhook_dispatcher.deliver", new=fake_deliver):
         await dispatch_event(
             session,
             event_type="task.created",
@@ -216,7 +216,7 @@ async def test_dispatch_filters_by_event_type(session):
     )
 
     with patch(
-        "app.services.tenant.webhook_dispatcher._deliver", new=AsyncMock()
+        "app.services.tenant.webhook_dispatcher.deliver", new=AsyncMock()
     ) as mock_deliver:
         await dispatch_event(
             session,
@@ -267,10 +267,11 @@ async def test_dispatch_initiative_scope_matches_correctly(session):
 
     delivered_to: list[str] = []
 
-    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> None:
+    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> bool:
         delivered_to.append(target_url)
+        return True
 
-    with patch("app.services.tenant.webhook_dispatcher._deliver", new=fake_deliver):
+    with patch("app.services.tenant.webhook_dispatcher.deliver", new=fake_deliver):
         await dispatch_event(
             session,
             event_type="task.created",
@@ -313,10 +314,11 @@ async def test_each_subscription_gets_unique_event_id(session):
 
     seen_event_ids: list[str] = []
 
-    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> None:
+    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> bool:
         seen_event_ids.append(envelope["event_id"])
+        return True
 
-    with patch("app.services.tenant.webhook_dispatcher._deliver", new=fake_deliver):
+    with patch("app.services.tenant.webhook_dispatcher.deliver", new=fake_deliver):
         await dispatch_event(
             session,
             event_type="task.created",
@@ -346,7 +348,7 @@ async def test_dispatch_does_not_cross_guilds(session):
     )
 
     with patch(
-        "app.services.tenant.webhook_dispatcher._deliver", new=AsyncMock()
+        "app.services.tenant.webhook_dispatcher.deliver", new=AsyncMock()
     ) as mock_deliver:
         await dispatch_event(
             session,
@@ -389,10 +391,11 @@ async def test_dispatch_delivers_when_a_delegate_is_configured(session):
 
     delivered_to: list[str] = []
 
-    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> None:
+    async def fake_deliver(*, target_url: str, secret: str, envelope: dict) -> bool:
         delivered_to.append(target_url)
+        return True
 
-    with patch("app.services.tenant.webhook_dispatcher._deliver", new=fake_deliver):
+    with patch("app.services.tenant.webhook_dispatcher.deliver", new=fake_deliver):
         await dispatch_event(
             session,
             event_type="task.created",
@@ -430,7 +433,7 @@ async def test_dispatch_is_inert_without_a_delegate(session, monkeypatch):
     monkeypatch.setattr(webhook_dispatcher, "_inert_logged", False)
 
     with patch(
-        "app.services.tenant.webhook_dispatcher._deliver", new=AsyncMock()
+        "app.services.tenant.webhook_dispatcher.deliver", new=AsyncMock()
     ) as mock_deliver:
         await dispatch_event(
             session,

--- a/backend/app/services/tenant/webhook_subscriptions.py
+++ b/backend/app/services/tenant/webhook_subscriptions.py
@@ -94,7 +94,6 @@ async def create_subscription(
     subscription = WebhookSubscription(
         guild_id=guild_id,
         initiative_id=payload.initiative_id,
-        workflow_id=payload.workflow_id,
         created_by_user_id=created_by_user_id,
         target_url=str(payload.target_url),
         hmac_secret=secret,

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4595,8 +4595,7 @@ export interface VikunjaParseResult {
  *
  * Initiative-id and guild-id are NOT taken from the body — they
  * come from the caller's delegation token (guild) and an optional
- * delegation initiative_id claim. ``workflow_id`` is opaque to us;
- * we just store it so dispatched events can reference it.
+ * delegation initiative_id claim.
  */
 export interface WebhookSubscriptionCreate {
   /**
@@ -4607,7 +4606,6 @@ export interface WebhookSubscriptionCreate {
   /** @minItems 1 */
   event_types: string[];
   initiative_id?: number | null;
-  workflow_id?: number | null;
 }
 
 /**
@@ -4618,7 +4616,6 @@ export interface WebhookSubscriptionCreated {
   id: number;
   guild_id: number;
   initiative_id: number | null;
-  workflow_id: number | null;
   created_by_user_id: number;
   target_url: string;
   event_types: string[];
@@ -4637,7 +4634,6 @@ export interface WebhookSubscriptionRead {
   id: number;
   guild_id: number;
   initiative_id: number | null;
-  workflow_id: number | null;
   created_by_user_id: number;
   target_url: string;
   event_types: string[];


### PR DESCRIPTION
Third in the event-bus series, after #1181 (outbox table) and #1182 (capture trigger). This is the one that makes the log do something.

## The authorization decision is a query, not a check

For every subscription the poller routes a session **as that subscription's owner** and reads `event_outbox` through it. The outbox carries ordinary initiative-member RLS, so the read returns exactly the events that owner may currently see. Nothing in the poller re-implements the six gates.

Two things follow with no code:

- A **guild-wide** subscription (`initiative_id IS NULL`) means "everything in this guild I can reach" — a guild admin's sees everything, a PM's sees their initiatives, a member's sees theirs. One query decides all three.
- It stays true as access changes. Leaving an initiative, losing a PAM grant, deactivation (which drops guild *and* initiative memberships) — all stop the matching deliveries on the next pass, with no subscription edit and no cache to invalidate.

`initiative_id` on a subscription is a narrowing filter on top of that, never a widening one.

A background pass has no login to satisfy a guild's auth policy with, so it routes with the `satisfied_providers = 'system'` sentinel that `guild_auth_satisfied()` already defines for user-attributed jobs. That leg is about how a person authenticated; every other gate applies unchanged.

## Batching and retry

Rows written by one transaction share a `txn_id` and go out as one envelope, so a single user action that touched fifty rows is one POST. **Filtering applies per change-item before the batch is assembled**, so batching costs nothing in precision.

`deliver()` now reports success, and a cursor advances only on a 2xx. On failure the cursor stays behind the failing batch so it and everything after it retry in order. Consecutive failures accumulate a backoff (5s → 1h), so a target that is down slows its own deliveries rather than being retried every pass.

Retention is an age sweep (`WEBHOOK_OUTBOX_RETENTION_DAYS`, default 7). Age-based on purpose: an instance that never registers a target would otherwise grow the log forever.

## Deletions

- **The inline `task.created` dispatch and `_task_payload`.** That path sent a *fully serialized task* to third-party URLs. The trigger covers the event now, content-free — ids and changed column names, with values read back through the API where the gates apply.
- **`workflow_id`**, from the column, both schemas, the envelope, and the delegation-token claims. It was documented as opaque to us with its source of truth in the consumer's database — bookkeeping we stored and echoed but never read. Consumers route on `subscription_id`, which the envelope carries.

`dispatch_event` stays: `app_channels` uses it to re-emit third-party app events, which aren't database changes.

## Schema

Guild-content migration `20260815_0185` — adds `failure_count` / `next_attempt_at`, drops `workflow_id`. Clean downgrade.

## Testing

```
ruff check app && ruff format app && ty check app
pytest app/services/tenant/outbox_capture_test.py                    # 4 passed
pytest app/services/tenant/webhook_dispatcher_test.py                # 14 passed
pytest app/api/v1/tenant_endpoints/auto_subscriptions_test.py \
       app/api/v1/tenant_endpoints/tasks_test.py app/db/tenancy_test.py   # 73 passed
```

`outbox_capture_test.py` is new and asserts the trigger seam against real Postgres rather than against the rendering code — that an ordinary write lands in the outbox with the right resource and initiative, that an update names the changed columns, and the two shapes the design turns on: a **soft delete reports as `deleted`** (not an update carrying `deleted_at`), and **tagging a task reports against the task** with `changed = ['tags']`.

## Follow-ups

Next PR is the one users notice: un-gate the subscription routes from `require_auto_delegate` (a self-hosted instance currently gets 503 on all four), rename `/auto/*` → `/g/{id}/webhooks`, move `webhook_subscriptions` into `INITIATIVE_PATHS`, and add the `fields` column filter plus well-formedness validation. That one carries the CHANGELOG entry — everything so far is internal plumbing with no user-visible surface.
