### PR TITLE
Skip template projects in overdue digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Webhooks are now available to every guild.** Register a URL under a guild's settings and Initiative will POST a signed message whenever content changes — pick the events you care about, and optionally narrow updates to particular fields, so "tell me when a task's status or due date moves" no longer means "tell me about every task edit". Initiatives and tags count too — an integration can react to one being created, to someone joining or leaving, or to a tag changing. Each message says what changed and which resource it happened to, and your integration reads the current state back through the API. A subscription never sees more than the person who created it: delivery is checked against their access every time, so it stops on its own if they leave an initiative.
 
+### Fixed
+
+- **The overdue digest no longer counts tasks in template projects.** Templates hold blueprint tasks whose due dates were never real deadlines, so anyone with a dated template project got emails and push notifications about work that did not exist. Only tasks in real projects are counted now.
+
 ## [0.62.6] - 2026-08-14
 
 ### Added

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1452,6 +1452,8 @@ async def _overdue_tasks_for_user(session: AsyncSession, user_id: int) -> list[d
 
     Run once per guild via ``gather_across_guilds`` (the session is routed into
     each of the user's guilds in turn), so it only ever sees one guild's rows.
+    Template projects are excluded: their tasks are blueprints, not work, so a
+    due date on one is never actually overdue.
     """
     stmt = (
         select(Task, Project.name, Project.id, Initiative.guild_id)
@@ -1461,6 +1463,7 @@ async def _overdue_tasks_for_user(session: AsyncSession, user_id: int) -> list[d
         .join(TaskStatus, Task.task_status_id == TaskStatus.id)
         .where(
             TaskAssignee.user_id == user_id,
+            Project.is_template.is_(False),
             Task.due_date.is_not(None),
             Task.due_date < datetime.now(timezone.utc),
             TaskStatus.category != TaskStatusCategory.done,

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -334,13 +334,17 @@ async def test_notify_initiative_membership_carries_guild_context(
     assert f"guild_id={guild.id}" in data["smart_link"]
 
 
-async def _overdue_task_in_new_guild(session: AsyncSession, user: User, *, label: str):
+async def _overdue_task_in_new_guild(
+    session: AsyncSession, user: User, *, label: str, is_template: bool = False
+):
     """Give ``user`` an overdue task assigned to them in a brand-new guild, so a
     user in several guilds has overdue work spread across guild schemas."""
     guild = await create_guild(session, creator=user)
     await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
     initiative = await create_initiative(session, guild, user, name=label)
-    project = await create_project(session, initiative, user, name=f"{label} Project")
+    project = await create_project(
+        session, initiative, user, name=f"{label} Project", is_template=is_template
+    )
     status = TaskStatus(
         guild_id=guild.id,
         project_id=project.id,
@@ -528,6 +532,39 @@ async def test_overdue_digest_skips_push_when_opted_out(
     await _run_overdue_pass(session, now=datetime.now(timezone.utc))
 
     assert pushes == []
+
+
+@pytest.mark.integration
+async def test_overdue_digest_skips_template_projects(
+    session: AsyncSession, monkeypatch
+):
+    """Tasks living in a template project are blueprints, not work — their due
+    dates must never reach the digest (email or push)."""
+    user = await create_user(
+        session,
+        email="template-overdue@example.com",
+        email_overdue_tasks=True,
+        push_overdue_tasks=True,
+        overdue_notification_time="00:00",
+        timezone="UTC",
+    )
+    await _overdue_task_in_new_guild(session, user, label="Real")
+    await _overdue_task_in_new_guild(session, user, label="Template", is_template=True)
+
+    captured: dict = {}
+
+    async def _capture_email(sess, recipient, tasks):
+        captured["titles"] = {t["title"] for t in tasks}
+
+    monkeypatch.setattr(email_service, "send_overdue_tasks_email", _capture_email)
+    pushes = _capture_push(monkeypatch)
+
+    await set_rls_context(session)
+    await _run_overdue_pass(session, now=datetime.now(timezone.utc))
+
+    assert captured.get("titles") == {"Real overdue"}
+    assert len(pushes) == 1
+    assert "Template overdue" not in pushes[0]["body"]
 
 
 async def _assignment_item_in_new_guild(


### PR DESCRIPTION
## Problem

The overdue digest gathered every assigned task with a past due date, including tasks living in **template** projects. A template's tasks are blueprints — their due dates are never real deadlines — so anyone with a dated template project received email and push notifications about work that does not exist.

## Changes

- [notifications.py](backend/app/services/notifications.py) — `_overdue_tasks_for_user` already joined `Project`, but only filtered on assignee, due date, and status category. Added `Project.is_template.is_(False)` to the `WHERE`. The email digest and the push both read from this one function via `gather_across_guilds`, so a single filter covers both channels. This matches how the cross-guild My Tasks query in `tasks.py` already treats templates.
- [notifications_test.py](backend/app/services/notifications_test.py) — new `test_overdue_digest_skips_template_projects`: a user with an overdue task in a real project and one in a template project gets only the real title in the email, and the push body excludes the template task. `_overdue_task_in_new_guild` gained an `is_template` kwarg.
- [CHANGELOG.md](CHANGELOG.md) — entry under `[Unreleased]` → Fixed.

## Testing

- `pytest app/services/notifications_test.py -k overdue` → 5 passed
- `ruff check app` → All checks passed
- Full local suite skipped; relying on CI for it.