### PR TITLE
Make tool breadcrumbs consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Webhooks are now available to every guild.** Register a URL under a guild's settings and Initiative will POST a signed message whenever content changes — pick the events you care about, and optionally narrow updates to particular fields, so "tell me when a task's status or due date moves" no longer means "tell me about every task edit". Initiatives and tags count too — an integration can react to one being created, to someone joining or leaving, or to a tag changing. Each message says what changed and which resource it happened to, and your integration reads the current state back through the API. A subscription never sees more than the person who created it: delivery is checked against their access every time, so it stops on its own if they leave an initiative.
 
+### Fixed
+
+- **Breadcrumbs are now consistent everywhere.** Every project, document, queue, counter group, calendar, and dashboard page — and each one's settings page — now shows the same trail back to its initiative. Settings pages had dropped the initiative from the trail, and a counter group's page had no breadcrumb at all; both now match the rest.
+
 ## [0.62.6] - 2026-08-14
 
 ### Added

--- a/frontend/src/components/tools/ToolBreadcrumb.tsx
+++ b/frontend/src/components/tools/ToolBreadcrumb.tsx
@@ -1,0 +1,91 @@
+/**
+ * THE breadcrumb trail for every tool surface: Initiative → tool list →
+ * whatever the page adds (the entity, a content item beneath it, "Settings").
+ * The initiative and tool-list crumbs are derived from the `Tool` enum via
+ * `src/lib/tools.ts`, so a new tool's pages get the right shape for free and
+ * every existing tool renders the same shape by construction rather than by
+ * each page hand-rolling its own.
+ */
+import { Link } from "@tanstack/react-router";
+import { Fragment, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { Tool } from "@/api/generated/initiativeAPI.schemas";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { useInitiativeName } from "@/hooks/useInitiatives";
+import { useGuildPath } from "@/lib/guildUrl";
+import { toolListRoute, toolNavLabelKey } from "@/lib/tools";
+
+export interface ToolBreadcrumbSegment {
+  label: ReactNode;
+  /** Guild-relative path (e.g. from `toolDetailRoute`). Omit on the last
+   *  segment — it renders as the current page instead of a link. */
+  to?: string;
+}
+
+export interface ToolBreadcrumbProps {
+  tool: Tool;
+  /** The initiative this entity lives in. Omit (or null) for a guild-level
+   *  entity (e.g. a calendar with no initiative) — that crumb is dropped. */
+  initiativeId?: number | null;
+  /** Segments after the tool-list crumb, in order: the entity, a content item
+   *  beneath it, "Settings" — whichever apply on this page. The last one
+   *  renders as the current page; every earlier one needs a `to`. Leave empty
+   *  when the tool-list page itself is the current page. */
+  trail?: ToolBreadcrumbSegment[];
+}
+
+export const ToolBreadcrumb = ({ tool, initiativeId, trail = [] }: ToolBreadcrumbProps) => {
+  const { t } = useTranslation("nav");
+  const gp = useGuildPath();
+  const initiativeName = useInitiativeName(initiativeId);
+  const toolListIsCurrentPage = trail.length === 0;
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {initiativeName && (
+          <>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to={gp(`/initiatives/${initiativeId}`)}>{initiativeName}</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+          </>
+        )}
+        <BreadcrumbItem>
+          {toolListIsCurrentPage ? (
+            <BreadcrumbPage>{t(toolNavLabelKey(tool))}</BreadcrumbPage>
+          ) : (
+            <BreadcrumbLink asChild>
+              <Link to={gp(toolListRoute(tool))}>{t(toolNavLabelKey(tool))}</Link>
+            </BreadcrumbLink>
+          )}
+        </BreadcrumbItem>
+        {trail.map((segment, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: trail is a fixed, caller-provided sequence — position is the identity
+          <Fragment key={index}>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              {segment.to ? (
+                <BreadcrumbLink asChild>
+                  <Link to={gp(segment.to)}>{segment.label}</Link>
+                </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{segment.label}</BreadcrumbPage>
+              )}
+            </BreadcrumbItem>
+          </Fragment>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+};

--- a/frontend/src/components/tools/settings/ToolSettingsPage.tsx
+++ b/frontend/src/components/tools/settings/ToolSettingsPage.tsx
@@ -12,7 +12,7 @@
  * for every tool.
  */
 
-import { Link, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { Loader2, Trash2 } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,14 +20,7 @@ import { useTranslation } from "react-i18next";
 import type { ResourceGrantSchema, TagSummary, Tool } from "@/api/generated/initiativeAPI.schemas";
 import { ShareControl } from "@/components/access/ShareControl";
 import { TagPicker } from "@/components/tags";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -39,7 +32,7 @@ import { useSetToolTags } from "@/hooks/useToolTags";
 import { toast } from "@/lib/chesterToast";
 import { useGuildPath } from "@/lib/guildUrl";
 import { hasWriteAccess } from "@/lib/permissions";
-import { toolDetailRoute, toolListRoute, toolNavLabelKey } from "@/lib/tools";
+import { toolDetailRoute, toolListRoute } from "@/lib/tools";
 
 /**
  * The slice of a tool's read schema this page needs. Queues, counter groups,
@@ -156,25 +149,14 @@ export const ToolSettingsPage = ({
 
   return (
     <div className="space-y-6">
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to={gp(toolListRoute(tool))}>{t(toolNavLabelKey(tool), { ns: "nav" })}</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to={gp(toolDetailRoute(tool, entity.id))}>{entity.name}</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>{t("common:toolSettings.title")}</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+      <ToolBreadcrumb
+        tool={tool}
+        initiativeId={entity.initiative_id}
+        trail={[
+          { label: entity.name, to: toolDetailRoute(tool, entity.id) },
+          { label: t("common:toolSettings.title") },
+        ]}
+      />
 
       <div className="space-y-1">
         <h1 className="font-semibold text-3xl tracking-tight">{t("common:toolSettings.title")}</h1>

--- a/frontend/src/hooks/useInitiatives.ts
+++ b/frontend/src/hooks/useInitiatives.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { InitiativeCreate, InitiativeRead } from "@/api/generated/initiativeAPI.schemas";
@@ -68,6 +69,21 @@ export const useInitiative = (initiativeId: number | null, options?: QueryOpts<I
     enabled: initiativeId !== null && Number.isFinite(initiativeId) && userEnabled,
     ...rest,
   });
+};
+
+/**
+ * An initiative's display name, resolved from the cached initiatives list —
+ * the one lookup every tool breadcrumb uses, since most tool read schemas
+ * carry only `initiative_id`, not a nested initiative object. Returns
+ * undefined until the id is set and the list has loaded (or for a guild-level
+ * entity with no initiative_id, forever — callers treat that as "no crumb").
+ */
+export const useInitiativeName = (initiativeId: number | null | undefined): string | undefined => {
+  const initiativesQuery = useInitiatives({ enabled: initiativeId != null });
+  return useMemo(
+    () => initiativesQuery.data?.find((initiative) => initiative.id === initiativeId)?.name,
+    [initiativesQuery.data, initiativeId]
+  );
 };
 
 // ── Mutations ───────────────────────────────────────────────────────────────

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -88,15 +88,8 @@ import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import type { SmartLinkContent } from "@/components/documents/SmartLinkDocumentViewer";
 import type { SpreadsheetContent } from "@/components/documents/SpreadsheetDocumentEditor";
 import type { WhiteboardScene } from "@/components/documents/WhiteboardDocumentEditor";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Badge } from "@/components/ui/badge";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -1044,25 +1037,11 @@ export const DocumentDetailPage = () => {
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <Breadcrumb>
-          <BreadcrumbList>
-            {document.initiative && (
-              <>
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <Link to={gp(`/initiatives/${document.initiative.id}`)}>
-                      {document.initiative.name}
-                    </Link>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-              </>
-            )}
-            <BreadcrumbItem>
-              <BreadcrumbPage>{document.title}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+        <ToolBreadcrumb
+          tool={Tool.document}
+          initiativeId={document.initiative_id}
+          trail={[{ label: document.title }]}
+        />
         <div className="flex items-center gap-2">
           <DocumentExportMenu
             documentId={document.id}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -15,14 +15,7 @@ import { ProjectOverviewCard } from "@/components/projects/ProjectOverviewCard";
 import { ProjectTasksSection } from "@/components/projects/ProjectTasksSection";
 import { StatusMessage } from "@/components/StatusMessage";
 import { clearLastUsedProject } from "@/components/tasks/CreateTaskWizard";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Button } from "@/components/ui/button";
 import { useInitiativeAccess } from "@/hooks/useInitiativeAccess";
 import { useProject, useProjectTaskStatuses } from "@/hooks/useProjects";
@@ -180,25 +173,11 @@ export const ProjectDetailPage = () => {
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <Breadcrumb>
-            <BreadcrumbList>
-              {project.initiative && (
-                <>
-                  <BreadcrumbItem>
-                    <BreadcrumbLink asChild>
-                      <Link to={gp(`/initiatives/${project.initiative.id}`)}>
-                        {project.initiative.name}
-                      </Link>
-                    </BreadcrumbLink>
-                  </BreadcrumbItem>
-                  <BreadcrumbSeparator />
-                </>
-              )}
-              <BreadcrumbItem>
-                <BreadcrumbPage>{project.name}</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
+          <ToolBreadcrumb
+            tool={Tool.project}
+            initiativeId={project.initiative_id}
+            trail={[{ label: project.name }]}
+          />
           {canManageSettings ? (
             <Button
               asChild

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useBlocker, useParams, useRouter } from "@tanstack/react-router";
+import { useBlocker, useParams, useRouter } from "@tanstack/react-router";
 import { format } from "date-fns";
 import {
   AlertCircle,
@@ -27,6 +27,7 @@ import type {
   TaskRead,
   TaskRecurrenceOutput,
 } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { getReadTaskApiV1GGuildIdTasksTaskIdGetQueryKey } from "@/api/generated/tasks/tasks";
 import { invalidateProject, invalidateProjectTaskStatuses } from "@/api/query-keys";
 import { CommentSection } from "@/components/comments/CommentSection";
@@ -36,16 +37,9 @@ import { StatusMessage } from "@/components/StatusMessage";
 import { MoveTaskDialog } from "@/components/tasks/MoveTaskDialog";
 import { TaskChecklist } from "@/components/tasks/TaskChecklist";
 import { serializeTaskFormValue, TaskForm, type TaskFormValue } from "@/components/tasks/TaskForm";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -686,35 +680,14 @@ export const TaskEditPage = () => {
 
   return (
     <div className="space-y-6">
-      <Breadcrumb>
-        <BreadcrumbList>
-          {project?.initiative && (
-            <>
-              <BreadcrumbItem>
-                <BreadcrumbLink asChild>
-                  <Link to={gp(`/initiatives/${project.initiative.id}`)}>
-                    {project.initiative.name}
-                  </Link>
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-            </>
-          )}
-          {project && (
-            <>
-              <BreadcrumbItem>
-                <BreadcrumbLink asChild>
-                  <Link to={gp(`/projects/${project.id}`)}>{project.name}</Link>
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-            </>
-          )}
-          <BreadcrumbItem>
-            <BreadcrumbPage>{title || task?.title}</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+      <ToolBreadcrumb
+        tool={Tool.project}
+        initiativeId={project?.initiative_id}
+        trail={[
+          ...(project ? [{ label: project.name, to: `/projects/${project.id}` }] : []),
+          { label: title || task?.title },
+        ]}
+      />
       <div className="space-y-3">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="font-semibold text-3xl tracking-tight">{title || task?.title}</h1>

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupDetailPage.tsx
@@ -33,6 +33,7 @@ import { TOOL_EXPORT_FORMATS } from "@/components/exports/formats";
 import { CounterFormDialog } from "@/components/initiativeTools/counters/CounterFormDialog";
 import { type CounterLayout, CounterRow } from "@/components/initiativeTools/counters/CounterRow";
 import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -192,14 +193,14 @@ export function CounterGroupDetailPage() {
 
   return (
     <div className="space-y-6">
+      <ToolBreadcrumb
+        tool={Tool.counter_group}
+        initiativeId={group.initiative_id}
+        trail={[{ label: group.name }]}
+      />
+
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <Button variant="ghost" size="sm" asChild className="mb-2 -ml-3">
-            <Link to={gp("/counter-groups")}>
-              <ArrowLeft className="h-4 w-4" />
-              {t("backToGroups")}
-            </Link>
-          </Button>
           <h1 className="font-semibold text-3xl tracking-tight">{group.name}</h1>
           {group.description && (
             <p className="mt-1 max-w-2xl text-muted-foreground text-sm">{group.description}</p>

--- a/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/DashboardDetailPage.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from "@tanstack/react-router";
 import { SearchX, Settings, ShieldAlert } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
@@ -9,19 +9,11 @@ import { DashboardUpdateBadge } from "@/components/initiativeTools/dashboards/Da
 import { WidgetConfigDialog } from "@/components/initiativeTools/dashboards/WidgetConfigDialog";
 import { WidgetPicker } from "@/components/initiativeTools/dashboards/WidgetPicker";
 import { StatusMessage } from "@/components/StatusMessage";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDashboardEditor } from "@/hooks/useDashboardEditor";
 import { useDashboard, useWidgetCatalog } from "@/hooks/useDashboards";
-import { useInitiatives } from "@/hooks/useInitiatives";
 import { useRecordRecentView } from "@/hooks/useRecents";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
@@ -57,15 +49,6 @@ export function DashboardDetailPage() {
   const [configuringId, setConfiguringId] = useState<string | null>(null);
   const configuring =
     editor.definition.widgets.find((widget) => widget.id === configuringId) ?? null;
-
-  const initiativesQuery = useInitiatives();
-  const initiativeName = useMemo(
-    () =>
-      dashboard
-        ? (initiativesQuery.data?.find((init) => init.id === dashboard.initiative_id)?.name ?? null)
-        : null,
-    [dashboard, initiativesQuery.data]
-  );
 
   if (!Number.isFinite(parsedId)) {
     return <p className="text-destructive">{t("notFound")}</p>;
@@ -104,33 +87,11 @@ export function DashboardDetailPage() {
   // is what made an ordinary load look like a reload.
   return (
     <div className="space-y-6">
-      <Breadcrumb>
-        <BreadcrumbList>
-          {initiativeName && dashboard && (
-            <>
-              <BreadcrumbItem>
-                <BreadcrumbLink asChild>
-                  <Link to={gp(`/initiatives/${dashboard.initiative_id}`)}>{initiativeName}</Link>
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-            </>
-          )}
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to={gp("/dashboards")}>{t("title")}</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            {dashboard ? (
-              <BreadcrumbPage>{dashboard.name}</BreadcrumbPage>
-            ) : (
-              <Skeleton className="h-4 w-32" />
-            )}
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+      <ToolBreadcrumb
+        tool={Tool.dashboard}
+        initiativeId={dashboard?.initiative_id}
+        trail={[{ label: dashboard ? dashboard.name : <Skeleton className="h-4 w-32" /> }]}
+      />
 
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 space-y-1">

--- a/frontend/src/pages/initiativeTools/events/EventDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventDetailPage.tsx
@@ -12,19 +12,12 @@ import {
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { RSVPStatus } from "@/api/generated/initiativeAPI.schemas";
+import { type RSVPStatus, Tool } from "@/api/generated/initiativeAPI.schemas";
 import { PropertyValueCell } from "@/components/properties/PropertyValueCell";
 import { iconForPropertyType } from "@/components/properties/propertyTypeIcons";
 import { StatusMessage } from "@/components/StatusMessage";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Badge } from "@/components/ui/badge";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -41,7 +34,6 @@ import {
   useDeleteCalendarEvent,
   useUpdateEventRSVP,
 } from "@/hooks/useCalendarEvents";
-import { useInitiatives } from "@/hooks/useInitiatives";
 import { toast } from "@/lib/chesterToast";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
@@ -151,14 +143,6 @@ export function EventDetailPage() {
   const eventQuery = useCalendarEvent(Number.isFinite(parsedId) ? parsedId : null);
   const event = eventQuery.data;
 
-  // Get initiative name for breadcrumb
-  const initiativesQuery = useInitiatives();
-  const initiativeName = useMemo(() => {
-    if (!event) return null;
-    const initiative = initiativesQuery.data?.find((i) => i.id === event.initiative_id);
-    return initiative?.name ?? null;
-  }, [event, initiativesQuery.data]);
-
   // Delete event
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const deleteEvent = useDeleteCalendarEvent({
@@ -230,29 +214,11 @@ export function EventDetailPage() {
     <div className="space-y-6">
       {/* Breadcrumb header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <Breadcrumb>
-          <BreadcrumbList>
-            {initiativeName && (
-              <>
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <Link to={gp(`/initiatives/${event.initiative_id}`)}>{initiativeName}</Link>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-              </>
-            )}
-            <BreadcrumbItem>
-              <BreadcrumbLink asChild>
-                <Link to={gp("/calendars")}>{t("title")}</Link>
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{event.title}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+        <ToolBreadcrumb
+          tool={Tool.calendar}
+          initiativeId={event.initiative_id}
+          trail={[{ label: event.title }]}
+        />
 
         <div className="flex items-center gap-2">
           {event.all_day && <Badge variant="secondary">{t("allDay")}</Badge>}

--- a/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
+++ b/frontend/src/pages/initiativeTools/events/EventSettingsPage.tsx
@@ -8,6 +8,7 @@ import type {
   PropertySummary,
   TagSummary,
 } from "@/api/generated/initiativeAPI.schemas";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import {
   datesAreValid,
   endTimeOptionsFor,
@@ -21,14 +22,7 @@ import {
 import { MemberMultiSelect } from "@/components/members/MemberSearchSelect";
 import { AddPropertyButton, PropertyList } from "@/components/properties";
 import { TagPicker } from "@/components/tags";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -253,25 +247,14 @@ export function EventSettingsPage() {
 
   return (
     <div className="space-y-6">
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to={gp("/calendars")}>{t("title")}</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to={gp(`/calendar-events/${eventId}`)}>{event.title}</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>{t("settings")}</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+      <ToolBreadcrumb
+        tool={Tool.calendar}
+        initiativeId={event.initiative_id}
+        trail={[
+          { label: event.title, to: `/calendar-events/${eventId}` },
+          { label: t("common:toolSettings.title") },
+        ]}
+      />
 
       {/* Details */}
       <Card>

--- a/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueueDetailPage.tsx
@@ -16,19 +16,11 @@ import { QueueTimeline } from "@/components/initiativeTools/queues/QueueTimeline
 import { QueueViewToggle } from "@/components/initiativeTools/queues/QueueViewToggle";
 import { useRegisterPrimaryCreateAction } from "@/components/navigation/CreateActionContext";
 import { StatusMessage } from "@/components/StatusMessage";
+import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Badge } from "@/components/ui/badge";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { useInitiatives } from "@/hooks/useInitiatives";
 import {
   useAdvanceTurn,
   useHoldCurrent,
@@ -80,14 +72,6 @@ export function QueueDetailPage() {
 
   // Connect WebSocket for live updates
   useQueueRealtime(Number.isFinite(parsedId) ? parsedId : null);
-
-  // Get initiative name for breadcrumb
-  const initiativesQuery = useInitiatives();
-  const initiativeName = useMemo(() => {
-    if (!queue) return null;
-    const initiative = initiativesQuery.data?.find((i) => i.id === queue.initiative_id);
-    return initiative?.name ?? null;
-  }, [queue, initiativesQuery.data]);
 
   // Queue name editing
   const [editingName, setEditingName] = useState(false);
@@ -202,29 +186,11 @@ export function QueueDetailPage() {
     <div className="space-y-6">
       {/* Breadcrumb header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <Breadcrumb>
-          <BreadcrumbList>
-            {initiativeName && (
-              <>
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <Link to={gp(`/initiatives/${queue.initiative_id}`)}>{initiativeName}</Link>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-              </>
-            )}
-            <BreadcrumbItem>
-              <BreadcrumbLink asChild>
-                <Link to={gp("/queues")}>{t("title")}</Link>
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{queue.name}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+        <ToolBreadcrumb
+          tool={Tool.queue}
+          initiativeId={queue.initiative_id}
+          trail={[{ label: queue.name }]}
+        />
 
         <div className="flex items-center gap-2">
           <Badge variant={queue.is_active ? "default" : "secondary"}>


### PR DESCRIPTION
## Problem
Breadcrumbs across tool surfaces had no consistent shape and no single source of truth:
- Every tool's settings page (Project, Document, Queue, Counter Group, Calendar, Dashboard — all routed through the shared `ToolSettingsPage`) was missing the initiative crumb.
- `ProjectDetailPage` and `DocumentDetailPage` skipped the tool-list crumb, jumping straight from Initiative to the entity.
- `CounterGroupDetailPage` had no breadcrumb at all — just a "← Back to groups" button, a different navigation pattern from every other tool.
- `EventSettingsPage` (calendar content) was also missing its initiative crumb.
- Initiative-name lookup logic was copy-pasted with slight variations across Queue, Event, and Dashboard detail pages.

## Changes
- Add [`ToolBreadcrumb`](frontend/src/components/tools/ToolBreadcrumb.tsx), a shared breadcrumb component that renders Initiative → tool list → entity/content → Settings. The tool-list crumb's route and label are derived from the `Tool` enum via the existing `toolListRoute`/`toolNavLabelKey` helpers, so a new tool gets correct breadcrumbs on every surface by construction.
- Add `useInitiativeName` to [`useInitiatives.ts`](frontend/src/hooks/useInitiatives.ts), replacing three duplicated initiative-lookup implementations.
- Wire `ToolBreadcrumb` into `ToolSettingsPage`, `ProjectDetailPage`, `DocumentDetailPage`, `TaskEditPage`, `DashboardDetailPage`, `QueueDetailPage`, `EventDetailPage`, `EventSettingsPage`, and `CounterGroupDetailPage`, fixing the gaps above.
- Net effect: ~180 fewer lines of hand-rolled breadcrumb JSX across the codebase.

## Testing
- `pnpm typecheck` — clean
- `pnpm check` (biome) — clean, no new warnings (8 pre-existing warnings unrelated to these files, unchanged from `dev`)
- `pnpm test:run` — full suite, 1497 tests passed