### PR TITLE
Skip archived work in overdue digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document reads accept `?include_content=false` to return everything except the body. A document's body is by far the largest thing the API returns and usually isn't what changed, so a subscription reacting to an edit no longer has to fetch it.
 - **Gantt widgets are now a proper project timeline.** The chart draws a line on today's date, so you can see at a glance what is behind and what is still ahead. Rows fold: bind one to Projects and each project is a single bar you can open to reveal its tasks, and a bar's fill is how much of the work under it is finished — a project that is halfway through its tasks is a half-filled bar, with the count beside its name. Bound to Tasks, you can group rows by project, status, priority, or assignee instead, and a total row across the top sums up everything shown.
 
+### Fixed
+
+- **The overdue digest no longer counts tasks you have set aside.** It swept up tasks in archived projects, and tasks you had archived yourself, so people were chased about work they had already cleared off their plate. The daily email and push now count only live tasks in live projects, matching what My Tasks has always shown.
+
 ## [0.62.7] - 2026-08-18
 
 ### Added

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1453,7 +1453,11 @@ async def _overdue_tasks_for_user(session: AsyncSession, user_id: int) -> list[d
     Run once per guild via ``gather_across_guilds`` (the session is routed into
     each of the user's guilds in turn), so it only ever sees one guild's rows.
     Template projects are excluded: their tasks are blueprints, not work, so a
-    due date on one is never actually overdue.
+    due date on one is never actually overdue. Archived projects and archived
+    tasks are excluded for the same reason — archiving is how a user says the
+    work is off their plate, so a past due date on one is not a deadline the
+    digest should still be chasing. This matches the filters the cross-guild My
+    Tasks list already applies.
     """
     stmt = (
         select(Task, Project.name, Project.id, Initiative.guild_id)
@@ -1464,6 +1468,8 @@ async def _overdue_tasks_for_user(session: AsyncSession, user_id: int) -> list[d
         .where(
             TaskAssignee.user_id == user_id,
             Project.is_template.is_(False),
+            Project.is_archived.is_(False),
+            Task.is_archived.is_(False),
             Task.due_date.is_not(None),
             Task.due_date < datetime.now(timezone.utc),
             TaskStatus.category != TaskStatusCategory.done,

--- a/backend/app/services/notifications_test.py
+++ b/backend/app/services/notifications_test.py
@@ -335,7 +335,13 @@ async def test_notify_initiative_membership_carries_guild_context(
 
 
 async def _overdue_task_in_new_guild(
-    session: AsyncSession, user: User, *, label: str, is_template: bool = False
+    session: AsyncSession,
+    user: User,
+    *,
+    label: str,
+    is_template: bool = False,
+    project_archived: bool = False,
+    task_archived: bool = False,
 ):
     """Give ``user`` an overdue task assigned to them in a brand-new guild, so a
     user in several guilds has overdue work spread across guild schemas."""
@@ -343,7 +349,12 @@ async def _overdue_task_in_new_guild(
     await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
     initiative = await create_initiative(session, guild, user, name=label)
     project = await create_project(
-        session, initiative, user, name=f"{label} Project", is_template=is_template
+        session,
+        initiative,
+        user,
+        name=f"{label} Project",
+        is_template=is_template,
+        is_archived=project_archived,
     )
     status = TaskStatus(
         guild_id=guild.id,
@@ -363,6 +374,7 @@ async def _overdue_task_in_new_guild(
         title=f"{label} overdue",
         priority=TaskPriority.medium,
         due_date=datetime.now(timezone.utc) - timedelta(days=1),
+        is_archived=task_archived,
     )
     session.add(task)
     await session.commit()
@@ -565,6 +577,46 @@ async def test_overdue_digest_skips_template_projects(
     assert captured.get("titles") == {"Real overdue"}
     assert len(pushes) == 1
     assert "Template overdue" not in pushes[0]["body"]
+
+
+@pytest.mark.integration
+async def test_overdue_digest_skips_archived_projects_and_tasks(
+    session: AsyncSession, monkeypatch
+):
+    """Archiving is how a user says work is off their plate — an archived
+    project, or an archived task in a live project, is not a deadline the
+    digest should still be chasing."""
+    user = await create_user(
+        session,
+        email="archived-overdue@example.com",
+        email_overdue_tasks=True,
+        push_overdue_tasks=True,
+        overdue_notification_time="00:00",
+        timezone="UTC",
+    )
+    await _overdue_task_in_new_guild(session, user, label="Live")
+    await _overdue_task_in_new_guild(
+        session, user, label="ArchivedProject", project_archived=True
+    )
+    await _overdue_task_in_new_guild(
+        session, user, label="ArchivedTask", task_archived=True
+    )
+
+    captured: dict = {}
+
+    async def _capture_email(sess, recipient, tasks):
+        captured["titles"] = {t["title"] for t in tasks}
+
+    monkeypatch.setattr(email_service, "send_overdue_tasks_email", _capture_email)
+    pushes = _capture_push(monkeypatch)
+
+    await set_rls_context(session)
+    await _run_overdue_pass(session, now=datetime.now(timezone.utc))
+
+    assert captured.get("titles") == {"Live overdue"}
+    assert len(pushes) == 1
+    assert "ArchivedProject overdue" not in pushes[0]["body"]
+    assert "ArchivedTask overdue" not in pushes[0]["body"]
 
 
 async def _assignment_item_in_new_guild(


### PR DESCRIPTION
## Problem

Follow-up to #1192. That PR filtered template projects out of the overdue digest; the same gather query had no filter on `is_archived` either. Tasks in an **archived project**, and tasks a user had **archived individually**, still produced overdue email and push notifications.

Archiving is how a user says the work is off their plate, so a past due date on one is not a deadline the digest should still be chasing.

## Changes

- [notifications.py](backend/app/services/notifications.py) — added `Project.is_archived.is_(False)` and `Task.is_archived.is_(False)` to `_overdue_tasks_for_user`. Both columns are non-nullable bools. As with the template filter, email and push both read from this one function, so it covers both channels. The cross-guild My Tasks query already applies exactly these filters.
- [notifications_test.py](backend/app/services/notifications_test.py) — new `test_overdue_digest_skips_archived_projects_and_tasks` covering three guilds: a live task, one in an archived project, one archived itself. Asserts only the live title reaches the email and that neither archived title appears in the push body. `_overdue_task_in_new_guild` gained `project_archived` / `task_archived` kwargs.
- [CHANGELOG.md](CHANGELOG.md) — entry under `[Unreleased]` → Fixed. (The template entry from #1192 was stamped into the released 0.62.7 section, so it is left untouched.)

## Testing

- `pytest app/services/notifications_test.py -k overdue` → 6 passed
- Reverted the two new predicates and re-ran: the new test fails with all three tasks in the digest ("3 tasks are overdue"), confirming it is not vacuous. Restored, re-ran, green.
- `ruff check` on both changed files → All checks passed

## Note

`dev` currently has three pre-existing failures in `outbox_poller_test.py` unrelated to this change; they were red on #1192 too.