### PR TITLE
Let the log record a member's own exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Leaving a guild works again.** If you belonged to any of the guild's initiatives, leaving it failed outright with a permission error, and so did stepping out of an initiative you managed. Both go through now, and the change is still reported to any webhook watching.
 - **The overdue digest no longer counts tasks you have set aside.** It swept up tasks in archived projects, and tasks you had archived yourself, so people were chased about work they had already cleared off their plate. The daily email and push now count only live tasks in live projects, matching what My Tasks has always shown.
 
 ## [0.62.7] - 2026-08-18

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -150,13 +150,11 @@ _COMMANDS = (
 # Tables written only by a trigger, never by hand: their INSERT policy admits the
 # capture trigger instead of re-deciding the writer's access.
 #
-# ``event_outbox`` is the one. A row lands there because a content write already
-# cleared that table's own gate, so re-asking the same question at insert time
-# adds nothing — and gets the wrong answer for the change that ENDS the writer's
-# access: removing an initiative_members row (leaving a guild, or a manager
-# removing themselves) deletes the very membership the check reads, so the event
-# recording it would be refused. Who may READ the log is still the initiative
-# gate; the other three policies are unchanged.
+# ``event_outbox`` is the one. A row lands there as a consequence of a content
+# write that already cleared its own table's gate, so the log RECORDS what
+# happened rather than deciding it a second time — including a change that ends
+# the writer's own access, which it must still be able to record. Who may READ
+# the log is unchanged: the initiative gate, via the other three policies.
 _TRIGGER_WRITTEN_INSERT: dict[str, str] = {"event_outbox": "pg_trigger_depth() > 0"}
 
 

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -92,6 +92,10 @@ _HEADER = """\
 -- rendered policies automatically (the provisioning stamp includes this
 -- rendering, so a registry change triggers the one-time sweep).
 --
+-- One table deviates on INSERT: the change log (event_outbox) is written by the
+-- capture trigger and by nothing else, so its insert policy admits the trigger
+-- rather than re-deciding the writer's access — see _TRIGGER_WRITTEN_INSERT.
+--
 -- Soft-delete tables additionally carry a RESTRICTIVE FOR DELETE policy
 -- (soft_delete_admin_purge): hard delete = purge, and only a routed guild admin
 -- may. It is RESTRICTIVE, so it AND-combines with the PERMISSIVE delete policy
@@ -143,6 +147,18 @@ _COMMANDS = (
     ("delete", "DELETE", "USING", True),
 )
 
+# Tables written only by a trigger, never by hand: their INSERT policy admits the
+# capture trigger instead of re-deciding the writer's access.
+#
+# ``event_outbox`` is the one. A row lands there because a content write already
+# cleared that table's own gate, so re-asking the same question at insert time
+# adds nothing — and gets the wrong answer for the change that ENDS the writer's
+# access: removing an initiative_members row (leaving a guild, or a manager
+# removing themselves) deletes the very membership the check reads, so the event
+# recording it would be refused. Who may READ the log is still the initiative
+# gate; the other three policies are unchanged.
+_TRIGGER_WRITTEN_INSERT: dict[str, str] = {"event_outbox": "pg_trigger_depth() > 0"}
+
 
 def _table_block(table: str, path: InitiativePath) -> str:
     lines = [
@@ -151,6 +167,8 @@ def _table_block(table: str, path: InitiativePath) -> str:
     ]
     for suffix, command, clause, write in _COMMANDS:
         pred = path.predicate(table, write)
+        if command == "INSERT" and table in _TRIGGER_WRITTEN_INSERT:
+            pred = _TRIGGER_WRITTEN_INSERT[table]
         name = f"initiative_member_{suffix}"
         lines.append(f"DROP POLICY IF EXISTS {name} ON {table};")
         lines.append(f"CREATE POLICY {name} ON {table} AS PERMISSIVE FOR {command}")

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -276,6 +276,8 @@ INITIATIVE_PATHS: dict[str, InitiativePath] = {
     "resource_grants": direct(),
     # The change log itself. Scoped like the rows it describes, which is what
     # lets the poller read it AS the subscriber (see EVENT_SOURCES below).
+    # Reading is the question this path answers; writing is the capture
+    # trigger's alone (app.db.guild_ddl._TRIGGER_WRITTEN_INSERT).
     "event_outbox": direct(),
     # Integration config, reached by whoever can reach what it watches.
     "webhook_subscriptions": webhook_subscription_path(),

--- a/backend/app/services/tenant/outbox_capture_test.py
+++ b/backend/app/services/tenant/outbox_capture_test.py
@@ -343,10 +343,9 @@ async def test_a_member_removing_themselves_is_captured(
 ):
     """The log records the change that ends the writer's own access.
 
-    Leaving a guild — or a manager stepping out of an initiative — deletes the
-    membership row that ``initiative_access`` reads. Run as the real request
-    role, so the outbox write is the one the leaver's own session performs
-    rather than a superuser's.
+    Leaving a guild, or a manager stepping out of an initiative, is still an
+    event a subscriber acts on. Run as the real request role, so the outbox
+    write is the one the leaver's own session performs, not a superuser's.
     """
     from sqlalchemy import text
 

--- a/backend/app/services/tenant/outbox_capture_test.py
+++ b/backend/app/services/tenant/outbox_capture_test.py
@@ -336,3 +336,70 @@ async def test_a_trash_row_removed_outright_is_still_silent(session, acting_user
     assert not [r for r in new_rows if r.action == "deleted"], (
         f"a hard delete on a trash-lifecycle table surfaced; got {new_rows}"
     )
+
+
+async def test_a_member_removing_themselves_is_captured(
+    session, acting_user, role_session
+):
+    """The log records the change that ends the writer's own access.
+
+    Leaving a guild — or a manager stepping out of an initiative — deletes the
+    membership row that ``initiative_access`` reads. Run as the real request
+    role, so the outbox write is the one the leaver's own session performs
+    rather than a superuser's.
+    """
+    from sqlalchemy import text
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    before = len(await _outbox(session, a.guild.id))
+
+    s = await role_session("app_user")
+    await set_rls_context(
+        s,
+        user_id=a.user.id,
+        guild_id=a.guild.id,
+        guild_role=GuildRole.member.value,
+    )
+    await s.exec(
+        text(
+            "DELETE FROM initiative_members WHERE initiative_id = :i AND user_id = :u"
+        ),
+        params={"i": a.initiative.id, "u": a.user.id},
+    )
+    await s.commit()
+
+    new_rows = (await _outbox(session, a.guild.id))[before:]
+    assert [
+        r
+        for r in new_rows
+        if r.resource_type == "initiatives" and r.resource_id == a.initiative.id
+    ], f"a member removing themselves produced no event; got {new_rows}"
+
+
+async def test_the_log_is_written_only_by_the_trigger(
+    session, acting_user, role_session
+):
+    """A member may read their initiative's events, never author one: the
+    outbox insert policy admits the capture trigger and nothing else."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import ProgrammingError
+
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+
+    s = await role_session("app_user")
+    await set_rls_context(
+        s,
+        user_id=a.user.id,
+        guild_id=a.guild.id,
+        guild_role=GuildRole.member.value,
+    )
+    with pytest.raises(ProgrammingError, match="row-level security"):
+        await s.exec(
+            text(
+                "INSERT INTO event_outbox "
+                "(txn_id, occurred_at, actor_user_id, initiative_id, "
+                " resource_type, resource_id, action, changed) "
+                "VALUES (txid_current(), now(), :u, :i, 'tasks', 1, 'created', '{}')"
+            ),
+            params={"i": a.initiative.id, "u": a.user.id},
+        )


### PR DESCRIPTION
## Problem

Leaving a guild failed with **403** for anyone who belonged to one of its initiatives, and a manager removing themselves from an initiative hit the same wall:

```
insufficient_privilege mapped to 403: DELETE /api/v1/guilds/1/leave
new row violates row-level security policy for table "event_outbox"
```

The change-capture trigger writes an `event_outbox` row for every content change, and `event_outbox` gets the uniform four `initiative_member_*` policies from `INITIATIVE_PATHS` — so its INSERT re-asked `initiative_access(initiative_id, current_user, write)` at insert time. That is the wrong question for the one change that *ends* the writer's access: leaving deletes the leaver's `initiative_members` row, the trigger then tries to log that delete, the policy re-reads the membership that no longer exists, and Postgres refuses the row.

Shipped in v0.62.7 (the capture triggers landed before that tag), so leaving a guild is broken on that release.

Only the two succeed-path leave tests caught it — the others block earlier with 400, and an *admin* removing a member passes the `guild_role='admin'` leg.

## Changes

- [guild_ddl.py](backend/app/db/guild_ddl.py) — `event_outbox`'s INSERT policy admits the capture trigger (`pg_trigger_depth() > 0`) instead of re-deciding the writer's access. The row is already authorized by the gate on the table that changed. SELECT/UPDATE/DELETE stay initiative-scoped, so who may *read* the log is unchanged, and the policy names are the same so `guild_rls_test`'s four-policy invariant still holds. This is strictly tighter than before — a routed member could previously hand-insert forged events into their own initiative; now nothing outside the trigger can write the log.
- [initiative_rls.py](backend/app/db/initiative_rls.py) — note at the registry entry pointing at the deviation.
- [outbox_capture_test.py](backend/app/services/tenant/outbox_capture_test.py) — two regressions, both run as the real `app_user` request role: a member removing their own membership succeeds *and* the event lands; a hand-written outbox INSERT is refused.
- `CHANGELOG.md` — `[Unreleased] → Fixed`.

**No migration.** RLS is rendered at runtime and the provisioning stamp covers `render_guild_rls_ddl()`, so existing guilds pick up the corrected policy on the next boot sweep.

## Testing

- `pytest app/api/v1/platform_endpoints/guilds_test.py -k leave` — 7 passed (both originally failing tests now pass)
- `pytest app/services/tenant/outbox_capture_test.py` — 15 passed; both new tests verified to **fail** against the pre-fix renderer (the forged-row one by the insert being accepted)
- `pytest -n 4` (full backend suite) — 3395 passed, with `auth_test.py::test_register_with_invite_blocked_when_guild_full` deselected: it fails locally on `dev` too (the local `.env` captcha leak, #1048) and is green in CI
- `ruff check app` — clean; `ruff format` applied
