### PR TITLE
Pin name resolution and drop the unused TEMPORARY grant

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/events.py
+++ b/backend/app/api/v1/tenant_endpoints/events.py
@@ -10,7 +10,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import establish_guild_access, GuildAccessError
 from app.core.security import SESSION_COOKIE_NAME
-from app.db.session import AsyncSessionLocal
+from app.db.session import CONNECTION_RESET_SQL, AsyncSessionLocal
 from app.models.tenant.initiative import Initiative
 from app.models.platform.user import User
 from app.services.membership import initiative_scope_clause
@@ -109,11 +109,7 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
         # Reset any stale GUCs the pooled connection may carry (e.g. a SET ROLE to
         # a since-dropped guild role would make every query error) before the auth
         # query — AsyncSessionLocal doesn't run get_session's per-request reset.
-        await session.exec(
-            text(
-                "SELECT set_config('role', 'none', false), set_config('search_path', 'public', false)"
-            )
-        )
+        await session.exec(text(CONNECTION_RESET_SQL))
         user = await _user_from_token(token, session)
         if user is None:
             logger.warning("Events WebSocket: Auth failed")

--- a/backend/app/db/database_grants_test.py
+++ b/backend/app/db/database_grants_test.py
@@ -1,0 +1,45 @@
+"""The database-level TEMPORARY grant is revoked where roles are created.
+
+The app creates no temporary objects, so it does not need the TEMPORARY grant
+PUBLIC carries by default on a new database. Only a database's owner can change
+its ACL, so this is applied where ``app_provisioner`` itself is created — the
+compose ``initdb`` config for fresh installs, and
+``scripts/create-provisioner.sql`` for deployments that predate it — never by a
+migration, which runs as the provisioning role and cannot change a database ACL.
+
+Only ``docker-compose.example.yml`` is tracked; an operator's own
+``docker-compose.yml`` is gitignored and free to diverge.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COMPOSE_EXAMPLE = _REPO_ROOT / "docker-compose.example.yml"
+_PROVISIONER_SQL = _REPO_ROOT / "backend" / "scripts" / "create-provisioner.sql"
+
+_REVOKE = "REVOKE TEMPORARY ON DATABASE"
+
+
+def test_fresh_installs_revoke_it_at_database_init():
+    assert _COMPOSE_EXAMPLE.exists(), f"not found: {_COMPOSE_EXAMPLE}"
+    _, _, initdb = _COMPOSE_EXAMPLE.read_text().partition("initdb-provisioner:")
+    assert _REVOKE in initdb, (
+        "the compose initdb config no longer revokes TEMPORARY, so a fresh "
+        "install would be provisioned with a grant the app does not use"
+    )
+
+
+def test_existing_installs_have_the_same_revoke():
+    assert _REVOKE in _PROVISIONER_SQL.read_text()
+
+
+def test_the_revoke_is_verified_rather_than_assumed():
+    """A REVOKE issued by a non-owner reports success and changes nothing, so
+    the script confirms the grant is gone instead of trusting the exit code."""
+    body = _PROVISIONER_SQL.read_text()
+    assert "aclexplode" in body
+    assert "RAISE EXCEPTION" in body

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -913,12 +913,14 @@ async def verify_engine_identities() -> None:
     so residual pool state can never skew the answer.
     """
     async with db_session.engine.connect() as conn:
-        app_login, app_db, app_bypasses = (
+        app_login, app_db, app_bypasses, app_temp = (
             await conn.execute(
                 text(
                     "SELECT session_user, current_database(), "
                     "(SELECT rolsuper OR rolbypassrls FROM pg_roles "
-                    " WHERE rolname = session_user)"
+                    " WHERE rolname = session_user), "
+                    "has_database_privilege("
+                    "  session_user, current_database(), 'TEMP')"
                 )
             )
         ).one()
@@ -967,6 +969,25 @@ async def verify_engine_identities() -> None:
             "%s",
             bar,
             app_login,
+            bar,
+        )
+
+    if app_temp:
+        logger.warning(
+            "\n%s\n"
+            "PRIVILEGE DRIFT: the request login %r holds TEMPORARY on database\n"
+            "%r. The app creates no temporary objects, so this grant is unused;\n"
+            "fresh installs revoke it from PUBLIC at database init. Deployments\n"
+            "created before that still carry it. To align, run as the database\n"
+            "owner:\n"
+            "  REVOKE TEMPORARY ON DATABASE %s FROM PUBLIC;\n"
+            "or re-run backend/scripts/create-provisioner.sql, which does this\n"
+            "and verifies it took effect.\n"
+            "%s",
+            bar,
+            app_login,
+            app_db,
+            app_db,
             bar,
         )
 

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -1077,6 +1077,19 @@ async def test_engine_identities_warn_on_privileged_app_login(
         await swapped_app.dispose()
 
 
+async def test_engine_identities_flag_an_unused_temporary_grant(caplog):
+    """The request login needs no TEMPORARY on the database. Only the database
+    owner can revoke it, so the app reports the drift and names the command
+    rather than trying to change it."""
+    with caplog.at_level("WARNING", logger="app.db.schema_provisioning"):
+        await schema_provisioning.verify_engine_identities()
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    # The test database keeps the default grant, so the notice is expected here.
+    assert "PRIVILEGE DRIFT" in joined
+    assert "REVOKE TEMPORARY ON DATABASE" in joined
+    assert "create-provisioner.sql" in joined
+
+
 async def test_effective_grants_pass_for_privileged_logins(engine, monkeypatch):
     import app.db.session as db_session
 

--- a/backend/app/db/search_path_pinning_test.py
+++ b/backend/app/db/search_path_pinning_test.py
@@ -1,0 +1,158 @@
+"""Name resolution for the shared functions is a property of the route.
+
+``public.initiative_access`` and ``public.capture_change`` name guild tables
+unqualified — that is exactly what lets one definition in ``public`` serve every
+``guild_<id>`` schema, rather than one copy per guild. The routed
+``search_path`` is therefore what binds those names, so it names every schema
+they may resolve in, in priority order, ending at ``pg_temp``
+(``app.db.session._search_path``).
+
+These run under the real ``app_user`` login with a routed context rather than
+the superuser-backed ``session`` fixture, because the binding under test is a
+property of the routed session.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.db.session import set_rls_context
+from app.models.platform.guild import GuildRole
+from app.testing import (
+    create_guild,
+    create_initiative,
+    create_project,
+    create_task,
+    create_user,
+)
+
+pytestmark = pytest.mark.database
+
+
+@pytest.fixture
+async def workspace(session):
+    """One guild, two initiatives, and a task in the first."""
+    owner = await create_user(session)
+    guild = await create_guild(session, creator=owner)
+    first = await create_initiative(session, guild=guild, creator=owner, name="First")
+    second = await create_initiative(session, guild=guild, creator=owner, name="Second")
+    project = await create_project(session, initiative=first, owner=owner)
+    task = await create_task(session, project=project, title="a task")
+    return owner, guild, first, second, project, task
+
+
+@pytest.fixture
+async def routed(role_session, workspace):
+    """An ``app_user`` session routed into the guild as a member.
+
+    Rolled back on teardown: these tests create session-local tables, and the
+    open transaction would hold locks against the schema cleanup that follows.
+    """
+    owner, guild, *_ = workspace
+    s = await role_session("app_user")
+    await set_rls_context(
+        s, user_id=owner.id, guild_id=guild.id, guild_role=GuildRole.member.value
+    )
+    yield s
+    await s.rollback()
+
+
+class TestRoutedPath:
+    async def test_it_names_the_guild_schema_public_and_pg_temp(
+        self, routed, workspace
+    ):
+        _, guild, *_ = workspace
+        path = (
+            await routed.exec(text("SELECT current_setting('search_path')"))
+        ).scalar()
+        assert path.split(", ") == [f"guild_{guild.id}", "public", "pg_temp"]
+
+
+class TestInitiativeAccessBindsTheRoutedSchema:
+    async def test_membership_resolves_in_the_guild_schema(self, routed, workspace):
+        """``initiative_members`` is the guild's table, whatever else the
+        session holds under that name."""
+        owner, guild, first, *_ = workspace
+        await routed.exec(
+            text(
+                "CREATE TEMP TABLE initiative_members (initiative_id int, user_id int)"
+            )
+        )
+        bound = (
+            await routed.exec(
+                text(
+                    "SELECT n.nspname FROM pg_class c"
+                    " JOIN pg_namespace n ON n.oid = c.relnamespace"
+                    " WHERE c.oid = 'initiative_members'::regclass"
+                )
+            )
+        ).scalar()
+        assert bound == f"guild_{guild.id}"
+
+        granted = (
+            await routed.exec(
+                text("SELECT public.initiative_access(:i, :u, false)").bindparams(
+                    i=first.id, u=owner.id
+                )
+            )
+        ).scalar()
+        assert granted is True
+
+    async def test_a_non_member_stays_a_non_member(
+        self, session, role_session, workspace
+    ):
+        """The gate answers from the guild's own membership rows."""
+        _, guild, first, *_ = workspace
+        outsider = await create_user(session)
+        s = await role_session("app_user")
+        await set_rls_context(
+            s, user_id=outsider.id, guild_id=guild.id, guild_role=GuildRole.member.value
+        )
+        await s.exec(
+            text(
+                "CREATE TEMP TABLE initiative_members (initiative_id int, user_id int)"
+            )
+        )
+        await s.exec(
+            text("INSERT INTO pg_temp.initiative_members VALUES (:i, :u)").bindparams(
+                i=first.id, u=outsider.id
+            )
+        )
+        granted = (
+            await s.exec(
+                text("SELECT public.initiative_access(:i, :u, false)").bindparams(
+                    i=first.id, u=outsider.id
+                )
+            )
+        ).scalar()
+        assert granted is False
+        assert (await s.exec(text("SELECT count(*) FROM tasks"))).scalar() == 0
+        await s.rollback()
+
+
+class TestCaptureChangeBindsTheRoutedSchema:
+    async def test_an_event_carries_the_initiative_the_row_belongs_to(
+        self, routed, workspace
+    ):
+        """``capture_change`` resolves a task's initiative through the guild's
+        own ``projects``, so the event is scoped like the row it describes."""
+        _, guild, first, second, project, task = workspace
+        await routed.exec(
+            text(
+                f"CREATE TEMP TABLE projects AS "  # noqa: S608
+                f"SELECT {project.id}::int AS id, {second.id}::int AS initiative_id"
+            )
+        )
+        await routed.exec(
+            text("UPDATE tasks SET title = 'renamed' WHERE id = :t").bindparams(
+                t=task.id
+            )
+        )
+        row = (
+            await routed.exec(
+                text(
+                    "SELECT initiative_id, resource_type, action FROM event_outbox"
+                    " ORDER BY id DESC LIMIT 1"
+                )
+            )
+        ).first()
+        assert tuple(row) == (first.id, "tasks", "updated")

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -118,6 +118,28 @@ class StaleAuthorizationContext(RuntimeError):
 
 _ROLE_RESET_SQL = "SELECT set_config('role', 'none', true)"
 
+
+def _search_path(*schemas: str) -> str:
+    """The schemas a request resolves unqualified names against, in priority order.
+
+    ``pg_temp`` is named explicitly, and last. Postgres searches it FIRST for
+    relation names when it is left off the path, and the shared functions in
+    ``public`` (``initiative_access``, ``capture_change``) resolve guild tables
+    through whatever path their caller carries — that is what lets one
+    definition serve every guild schema. Naming every schema here keeps their
+    resolution a property of the route rather than of the connection.
+    """
+    return ", ".join((*schemas, "pg_temp"))
+
+
+#: Clears the role and path a pooled connection may still carry. For entry
+#: points that build their own session (websockets, background re-auth) instead
+#: of going through ``get_session``, which resets per request.
+CONNECTION_RESET_SQL = (
+    "SELECT set_config('role', 'none', false), "
+    f"set_config('search_path', '{_search_path('public')}', false)"
+)
+
 _CONTEXT_SQL = (
     "SELECT set_config('app.current_user_id', :uid, true), "
     "set_config('app.current_guild_id', :gid, true), "
@@ -163,7 +185,7 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
             "pw": "false",
             "satp": "",
             "bgid": str(int(billing_guild_id)),
-            "sp": "public",
+            "sp": _search_path("public"),
             "role": billing_role_name(),
         }
 
@@ -190,12 +212,12 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
         # Public/platform path: assume the caller's platform-tier role when
         # one is supplied so the request is role-scoped (fail-closed);
         # 'none' (the login role) only for unauthenticated/unrouted contexts.
-        sp = "public"
+        sp = _search_path("public")
         role_target = (
             platform_role_name(platform_role) if platform_role is not None else "none"
         )
     else:
-        sp = f"{guild_schema_name(route_guild)}, public"
+        sp = _search_path(guild_schema_name(route_guild), "public")
         # Pick the guild role by how access was granted:
         # - read grant, or a read_only-status member (guild_id set + read_only):
         #   the SELECT-only guild_<id>_ro role — writes denied at the role level.

--- a/backend/app/db/session_routing_test.py
+++ b/backend/app/db/session_routing_test.py
@@ -9,10 +9,11 @@ import pytest
 
 from app.db.schema_provisioning import (
     guild_readonly_role_name,
+    guild_schema_name,
     guild_role_name,
     guild_support_role_name,
 )
-from app.db.session import _render_context_bind_params
+from app.db.session import CONNECTION_RESET_SQL, _render_context_bind_params
 
 pytestmark = pytest.mark.unit
 
@@ -84,3 +85,58 @@ def test_member_and_break_glass_keep_full_role():
         _params(guild_id=3, guild_role="admin", pam_guild_id=3, pam_write=True)
     )
     assert bg["role"] == guild_role_name(3)
+
+
+class TestSearchPathNamesEverySchema:
+    """The routed path names every schema it resolves against, in priority
+    order, ending at ``pg_temp`` (see ``_search_path``). Guild content resolves
+    in the guild schema first; the platform and billing routes resolve in
+    ``public``."""
+
+    def test_guild_route_names_guild_schema_then_public(self):
+        out = _render_context_bind_params(_params(guild_id=3, guild_role="member"))
+        assert out["sp"] == f"{guild_schema_name(3)}, public, pg_temp"
+
+    def test_platform_route_names_public(self):
+        out = _render_context_bind_params(_params(platform_role="member"))
+        assert out["sp"] == "public, pg_temp"
+
+    def test_billing_route_names_public(self):
+        out = _render_context_bind_params(_params(billing_guild_id=5))
+        assert out["sp"] == "public, pg_temp"
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"guild_id": 3, "guild_role": "member"},
+            {"guild_id": 3, "guild_role": "admin", "read_only": True},
+            {"pam_guild_id": 4, "pam_read": True},
+            {"pam_guild_id": 4, "pam_write": True},
+            {"platform_role": "owner"},
+            {"billing_guild_id": 5},
+            {},
+        ],
+        ids=[
+            "member",
+            "read-only-admin",
+            "pam-read",
+            "pam-write",
+            "platform",
+            "billing",
+            "unrouted",
+        ],
+    )
+    def test_every_route_ends_at_pg_temp(self, overrides):
+        """One helper renders them all, so no route can drift off the pattern."""
+        out = _render_context_bind_params(_params(**overrides))
+        assert out["sp"].endswith(", pg_temp")
+
+
+class TestConnectionReset:
+    def test_reset_clears_role_and_names_the_same_path(self):
+        """Entry points that build their own session share one reset with the
+        routed platform path, rather than spelling it out again."""
+        assert "set_config('role', 'none', false)" in CONNECTION_RESET_SQL
+        assert "set_config('search_path', 'public, pg_temp', false)" in (
+            CONNECTION_RESET_SQL
+        )

--- a/backend/app/services/stream_authz.py
+++ b/backend/app/services/stream_authz.py
@@ -34,7 +34,11 @@ from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.deps import GuildAccessError, establish_guild_access
-from app.db.session import RLS_CONTEXT_MAX_AGE_SECONDS, AsyncSessionLocal
+from app.db.session import (
+    CONNECTION_RESET_SQL,
+    RLS_CONTEXT_MAX_AGE_SECONDS,
+    AsyncSessionLocal,
+)
 from app.models.platform.user import User
 
 logger = logging.getLogger(__name__)
@@ -193,12 +197,7 @@ class StreamAuthority:
             async with AsyncSessionLocal() as session:
                 # AsyncSessionLocal skips get_session's per-request reset; clear
                 # any stale pooled-connection GUCs before establishing context.
-                await session.exec(
-                    text(
-                        "SELECT set_config('role', 'none', false), "
-                        "set_config('search_path', 'public', false)"
-                    )
-                )
+                await session.exec(text(CONNECTION_RESET_SQL))
                 try:
                     await establish_guild_access(
                         session,

--- a/backend/scripts/create-provisioner.sql
+++ b/backend/scripts/create-provisioner.sql
@@ -125,4 +125,36 @@ ALTER DEFAULT PRIVILEGES FOR ROLE app_provisioner IN SCHEMA public
     GRANT SELECT, USAGE ON SEQUENCES
     TO app_user, app_guild_base, platform_base;
 
+-- 6. Least privilege on the database itself: the app creates no temporary
+--    objects, so it does not need the TEMPORARY grant PUBLIC carries by
+--    default on a new database. Fresh docker-compose installs do this at
+--    database init; this brings an existing deployment in line.
+SELECT format('REVOKE TEMPORARY ON DATABASE %I FROM PUBLIC', current_database())
+\gexec
+
+-- Only a database's owner can change its ACL. A REVOKE issued by any other
+-- role reports success with a WARNING and changes nothing, so confirm the
+-- grant is actually gone rather than trusting the command's exit.
+DO $verify$
+DECLARE
+    db_owner text;
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_database d,
+             aclexplode(coalesce(d.datacl, acldefault('d', d.datdba))) a
+        WHERE d.datname = current_database()
+          AND a.grantee = 0                       -- 0 is PUBLIC
+          AND a.privilege_type = 'TEMPORARY'
+    ) THEN
+        SELECT pg_get_userbyid(datdba) INTO db_owner
+          FROM pg_database WHERE datname = current_database();
+        RAISE EXCEPTION
+            'REVOKE TEMPORARY did not take effect on database %. Re-run this '
+            'script connected as its owner (%).',
+            current_database(), db_owner;
+    END IF;
+END
+$verify$;
+
 \echo 'app_provisioner ready — point DATABASE_URL at it and restart the app.'

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -84,6 +84,11 @@ configs:
       CREATE ROLE app_provisioner WITH LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS
         PASSWORD '${PROVISIONER_PASSWORD:-provisioner_password}';
       GRANT CREATE, CONNECT ON DATABASE "${POSTGRES_DB:-initiative}" TO app_provisioner;
+      -- Least privilege on the database itself: the app creates no temporary
+      -- objects, so it does not need the TEMPORARY grant PUBLIC carries by
+      -- default on a new database. Existing deployments apply this by
+      -- re-running backend/scripts/create-provisioner.sql.
+      REVOKE TEMPORARY ON DATABASE "${POSTGRES_DB:-initiative}" FROM PUBLIC;
       -- Postgres 15+ made CREATE on the public schema owner-only, and the
       -- baseline migration (running as app_provisioner) builds the shared
       -- schema there — including COMMENT ON SCHEMA, which needs ownership.

--- a/docs/en/admin/installation.md
+++ b/docs/en/admin/installation.md
@@ -53,7 +53,7 @@ Initiative connects to PostgreSQL with **three** connection strings, and it won'
 | `DATABASE_URL_APP` | `app_user` | The everyday, security-enforced connection for normal requests. |
 | `DATABASE_URL_ADMIN` | `app_admin` | Migrations and background jobs. |
 
-The provisioning URL bootstraps the roles; the password you put in each `APP`/`ADMIN` URL becomes that role's password. (Upgrading an existing install? Run `backend/scripts/create-provisioner.sql` once to create `app_provisioner`, or keep your current superuser URL — the app logs a reminder at startup.) The example compose file wires all three together with matching credentials, so the default path just works. If you write your own compose file or use `docker run`, you must set all three.
+The provisioning URL bootstraps the roles; the password you put in each `APP`/`ADMIN` URL becomes that role's password. (Upgrading an existing install? Run `backend/scripts/create-provisioner.sql` once to create `app_provisioner`, or keep your current superuser URL — the app logs a reminder at startup. Re-running it later is safe: it also brings database-level grants in line with what a fresh install gets, and tells you if it could not, so connect as the database owner.) The example compose file wires all three together with matching credentials, so the default path just works. If you write your own compose file or use `docker run`, you must set all three.
 
 ## Running as a specific user (PUID / PGID)
 


### PR DESCRIPTION
## Problem

Two shared functions in `public` — `initiative_access` and `capture_change` — name guild tables unqualified. That is deliberate and load-bearing: it is what lets one definition serve every `guild_<id>` schema instead of one copy per guild. It also means the routed `search_path` is what binds those names, and the path did not name every schema it could resolve in.

Separately, the app has never created a temporary object, but it still carried the database-level `TEMPORARY` grant that `PUBLIC` gets by default on a new database.

## Changes

**Name resolution (`backend/app/db/session.py`)**

- One `_search_path()` helper renders every routed path, so the guild, platform and billing routes name their schemas in one place instead of three literals.
- Two websocket entry points (`stream_authz.py`, `events.py`) each carried their own copy of the connection-reset SQL; they now share a `CONNECTION_RESET_SQL` constant built from the same helper.

**Database privileges**

- `REVOKE TEMPORARY ON DATABASE … FROM PUBLIC` in the compose `initdb` config (fresh installs) and in `backend/scripts/create-provisioner.sql` (existing installs).
- Not a migration: only a database's owner can change its ACL, and `app_provisioner` is not the owner. A `REVOKE` from any other role reports success with a `WARNING` and changes nothing, so the script re-reads the ACL afterwards and raises if the grant is still present.
- Because existing installs cannot be reached by an upgrade at all, `verify_engine_identities()` reports the drift at boot and names the exact command.

## Notes for review

- The two changes are independent and deliberately overlapping. The first ships in the image and applies to every install on deploy; the second is stronger where it lands but only reaches fresh installs automatically, since the app never holds owner or superuser credentials.
- Only `docker-compose.example.yml` is tracked — an operator's `docker-compose.yml` is gitignored — so the guard test asserts against the example file.
- The test database deliberately keeps the `TEMPORARY` grant, so the resolution guards in `search_path_pinning_test.py` exercise the real path.

## Testing

```
cd backend && pytest app/db/                    # 372 passed
pytest app/services/stream_authz_test.py \
       app/api/v1/tenant_endpoints/ws_token_version_test.py \
       app/services/realtime_test.py            # 23 passed
ruff format app && ruff check app               # clean
ty check                                        # 16 pre-existing alembic warnings, unchanged
```

Also verified by hand against Postgres 17: the `create-provisioner.sql` section succeeds as the database owner and fails with an actionable error as a non-owner.