### PR TITLE
Let entities name the initiative they live in

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/comments.py
+++ b/backend/app/api/v1/tenant_endpoints/comments.py
@@ -216,6 +216,15 @@ async def recent_comments(
                 document_title=document.title if document else None,
                 project_id=project.id if project else None,
                 project_name=project.name if project else None,
+                # A comment hangs off a task XOR a document, so whichever
+                # parent loaded is the one that names the initiative.
+                initiative_id=(
+                    document.initiative_id
+                    if document
+                    else project.initiative_id
+                    if project
+                    else None
+                ),
             )
         )
     return entries

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1459,6 +1459,7 @@ async def get_backlinks(
             id=doc.id,
             title=doc.title,
             updated_at=doc.updated_at,
+            initiative_id=doc.initiative_id,
         )
         for doc in backlinks
     ]

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -512,16 +512,20 @@ def _visible_project_conditions(
     archived: Optional[bool],
     template: Optional[bool],
     search: Optional[str] = None,
+    initiative_id: Optional[int] = None,
 ) -> list:
     """WHERE clauses for the guild's DAC-visible projects.
 
-    ``archived``/``template``/``search`` are pushed into SQL (mirroring the old
-    ``_matches_filters``: ``None`` means "exclude" for the boolean flags). DAC
-    scoping is preserved exactly — a guild admin or a live PAM grant sees every
-    project in the guild; otherwise the set is narrowed to the user's
-    explicit/role-granted projects via ``visible_project_ids_subquery``.
+    ``archived``/``template``/``search``/``initiative_id`` are pushed into SQL
+    (mirroring the old ``_matches_filters``: ``None`` means "exclude" for the
+    boolean flags, and "every initiative" for the initiative). DAC scoping is
+    preserved exactly — a guild admin or a live PAM grant sees every project in
+    the guild; otherwise the set is narrowed to the user's explicit/role-granted
+    projects via ``visible_project_ids_subquery``.
     """
     conditions = [Initiative.guild_id == guild_id]
+    if initiative_id is not None:
+        conditions.append(Project.initiative_id == initiative_id)
     if not has_active_grant(
         guild_id
     ) and not permissions_service.is_request_guild_admin(guild_id):
@@ -994,6 +998,13 @@ async def list_projects(
     search: Optional[str] = Query(
         default=None, description="Case-insensitive substring match on name."
     ),
+    initiative_id: Optional[int] = Query(
+        default=None,
+        description=(
+            "Only projects in this initiative. Omit for every initiative the "
+            "caller can see."
+        ),
+    ),
     slim: bool = Query(
         default=False,
         description=(
@@ -1007,7 +1018,7 @@ async def list_projects(
 ) -> ProjectListResponse:
     # Filtering, ordering, and pagination all happen in SQL: the DAC scope
     # (guild admin / PAM see all, else visible-project-ids) plus archived/
-    # template/search go into the WHERE, and the per-user manual order
+    # template/search/initiative go into the WHERE, and the per-user manual order
     # (project_orders, NULLS last) drives ORDER BY so LIMIT/OFFSET can page the
     # rows instead of loading the whole visible graph.
     conditions = _visible_project_conditions(
@@ -1016,6 +1027,7 @@ async def list_projects(
         archived=archived,
         template=template,
         search=search,
+        initiative_id=initiative_id,
     )
 
     count_stmt = (

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -255,6 +255,52 @@ async def test_list_projects_with_archived_filter(
 
 
 @pytest.mark.integration
+async def test_list_projects_filters_by_initiative(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A project list is scoped to one initiative in SQL.
+
+    Every tool page is addressed inside its initiative now, so the list it
+    renders must come back already narrowed rather than filtered client-side.
+    """
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    other_initiative = await create_initiative(session, admin.guild, admin.user)
+    mine = await create_project(session, admin.initiative, admin.user, name="Mine")
+    theirs = await create_project(session, other_initiative, admin.user, name="Theirs")
+
+    response = await client.get(
+        admin.g(f"/projects/?initiative_id={admin.initiative.id}"),
+        headers=admin.headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    project_ids = {p["id"] for p in body["items"]}
+    assert mine.id in project_ids
+    assert theirs.id not in project_ids
+    # The count is narrowed too, or the pager would offer empty pages.
+    assert body["total_count"] == 1
+
+
+@pytest.mark.integration
+async def test_list_projects_without_initiative_spans_them_all(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """Omitting the filter keeps the cross-initiative behaviour the guild home
+    and the sidebar's project tree depend on."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    other_initiative = await create_initiative(session, admin.guild, admin.user)
+    mine = await create_project(session, admin.initiative, admin.user, name="Mine")
+    theirs = await create_project(session, other_initiative, admin.user, name="Theirs")
+
+    response = await client.get(admin.g("/projects/"), headers=admin.headers)
+
+    assert response.status_code == 200
+    project_ids = {p["id"] for p in response.json()["items"]}
+    assert {mine.id, theirs.id} <= project_ids
+
+
+@pytest.mark.integration
 async def test_list_projects_search_filters_by_name(
     client: AsyncClient, session: AsyncSession, acting_user
 ):

--- a/backend/app/api/v1/tenant_endpoints/recents.py
+++ b/backend/app/api/v1/tenant_endpoints/recents.py
@@ -170,6 +170,7 @@ async def _enrich_recent_rows(
                 entity_type=tool.value,
                 entity_id=entity.id,
                 guild_id=entity.guild_id,
+                initiative_id=getattr(entity, "initiative_id", None),
                 name=getattr(entity, spec.name_attr),
                 last_viewed_at=row.last_viewed_at,
                 **(spec.extra(entity) if spec.extra else {}),

--- a/backend/app/api/v1/tenant_endpoints/recents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/recents_test.py
@@ -40,6 +40,9 @@ async def test_record_and_list_recent_project(
     assert items[0]["entity_type"] == "project"
     assert items[0]["entity_id"] == project.id
     assert items[0]["name"] == "P1"
+    # The tabs bar builds /g/{guild}/i/{initiative}/projects/{id} from this —
+    # without the initiative it can't address the entity at all.
+    assert items[0]["initiative_id"] == a.initiative.id
 
 
 @pytest.mark.integration
@@ -250,3 +253,27 @@ async def test_record_and_list_recent_calendar(
     assert r.status_code == 204
     r = await client.get("/api/v1/recents/", headers=a.headers)
     assert all(i["entity_type"] != "calendar" for i in r.json())
+
+
+@pytest.mark.integration
+async def test_recent_guild_level_calendar_has_no_initiative(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A guild-level calendar reports ``initiative_id: None`` — the tabs bar
+    reads that as "address me at the guild route", not as missing data."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    a.initiative.calendars_enabled = True
+    session.add(a.initiative)
+    await session.commit()
+    calendar = await create_calendar(session, a.initiative, a.user, name="GuildCal")
+    calendar.initiative_id = None
+    session.add(calendar)
+    await session.commit()
+
+    r = await client.post(a.g(f"/calendars/{calendar.id}/view"), headers=a.headers)
+    assert r.status_code == 200, r.text
+
+    r = await client.get("/api/v1/recents/", headers=a.headers)
+    assert r.status_code == 200
+    row = next(i for i in r.json() if i["entity_id"] == calendar.id)
+    assert row["initiative_id"] is None

--- a/backend/app/schemas/tenant/comment.py
+++ b/backend/app/schemas/tenant/comment.py
@@ -85,6 +85,9 @@ class RecentActivityEntry(SanitizedBaseModel):
     document_title: Optional[str] = None
     project_id: Optional[int] = None
     project_name: Optional[str] = None
+    # The initiative the commented-on entity lives in, so the row can link at
+    # its real address. None when the parent is gone or unreadable.
+    initiative_id: Optional[int] = None
 
 
 class MentionSuggestion(SanitizedBaseModel):

--- a/backend/app/schemas/tenant/document.py
+++ b/backend/app/schemas/tenant/document.py
@@ -28,6 +28,9 @@ class DocumentProjectLink(SanitizedBaseModel):
     project_id: int
     project_name: Optional[str] = None
     project_icon: Optional[str] = None
+    # The initiative the project lives in — its URL addresses it, so the link
+    # resolves without a second fetch. None when the project isn't loaded.
+    project_initiative_id: Optional[int] = None
     attached_at: datetime
 
 
@@ -85,6 +88,9 @@ class DocumentBacklink(SanitizedBaseModel):
     id: int
     title: str
     updated_at: datetime
+    # The initiative the document lives in — its URL addresses it, so a
+    # backlink can link straight there instead of resolving the id first.
+    initiative_id: int
 
 
 class DocumentSummary(DocumentBase):
@@ -183,6 +189,7 @@ def _serialize_project_links(document: "Document") -> List[DocumentProjectLink]:
                 project_id=link.project_id,
                 project_name=getattr(project, "name", None),
                 project_icon=getattr(project, "icon", None),
+                project_initiative_id=getattr(project, "initiative_id", None),
                 attached_at=link.attached_at,
             )
         )

--- a/backend/app/schemas/tenant/recent_view.py
+++ b/backend/app/schemas/tenant/recent_view.py
@@ -41,6 +41,9 @@ class RecentItemRead(SanitizedBaseModel):
     entity_type: RecentEntityType
     entity_id: int
     guild_id: int
+    # The initiative the entity lives in, which its URL addresses. NULL for a
+    # guild-level entity — only calendars have any — which keeps a guild route.
+    initiative_id: Optional[int] = None
     name: str
     last_viewed_at: datetime
     # Projects: emoji string stored on the project itself.

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1605,6 +1605,7 @@ export interface DocumentBacklink {
   id: number;
   title: string;
   updated_at: string;
+  initiative_id: number;
 }
 
 export interface DocumentCopyRequest {
@@ -1709,6 +1710,7 @@ export interface DocumentProjectLink {
   project_id: number;
   project_name?: string | null;
   project_icon?: string | null;
+  project_initiative_id?: number | null;
   attached_at: string;
 }
 
@@ -3527,6 +3529,7 @@ export interface RecentActivityEntry {
   document_title?: string | null;
   project_id?: number | null;
   project_name?: string | null;
+  initiative_id?: number | null;
 }
 
 export type RecentEntityType = (typeof RecentEntityType)[keyof typeof RecentEntityType];
@@ -3550,6 +3553,7 @@ export interface RecentItemRead {
   entity_type: RecentEntityType;
   entity_id: number;
   guild_id: number;
+  initiative_id: number | null;
   name: string;
   last_viewed_at: string;
   icon: string | null;
@@ -4912,6 +4916,10 @@ export type ListProjectsApiV1GGuildIdProjectsGetParams = {
    * Case-insensitive substring match on name.
    */
   search?: string | null;
+  /**
+   * Only projects in this initiative. Omit for every initiative the caller can see.
+   */
+  initiative_id?: number | null;
   /**
    * Return a lightweight projection (id, name, icon, initiative_id, my_permission_level) without documents, grants, tags, or the nested initiative. For project pickers and other list-only callers.
    */


### PR DESCRIPTION
**Stack 1/3** — base for [`feat/initiative-scoped-urls`](../../tree/feat/initiative-scoped-urls).

## Problem

Tool entities are about to be addressed inside their initiative
(`/g/1/i/5/projects/7`), which means a link needs the whole parent chain rather
than just an id. Four payloads carried an id alone, so nothing rendering them
could build the new address:

- `RecentItemRead` — the recents tab bar builds every tab's link from it
- `DocumentBacklink` and `RecentActivityEntry` — both rendered as links
- `DocumentProjectLink` — a document's attached projects

Separately, `list_projects` was the only one of the six tool list endpoints with
no `initiative_id` filter, which is why the projects page fetched the guild's
whole visible set and narrowed it in the browser.

## Changes

- Each of the four payloads now reports its initiative — [`recent_view.py`](backend/app/schemas/tenant/recent_view.py), [`document.py`](backend/app/schemas/tenant/document.py), [`comment.py`](backend/app/schemas/tenant/comment.py). Nullable only where the model genuinely allows it: an app-installed calendar belongs to no initiative, and a comment whose parent is gone names none.
- `list_projects` gains an `initiative_id` query param, threaded into `_visible_project_conditions` so the count and the page narrow together — [`projects.py`](backend/app/api/v1/tenant_endpoints/projects.py).
- Regenerated Orval output.

Purely additive: no existing field or behaviour changes, so the frontend is
untouched apart from the generated types.

## Testing

- `pytest app/api/v1/tenant_endpoints/{projects,recents,comments,documents}_test.py` — 134 passed, including new cases for the `initiative_id` filter (narrowing *and* the unfiltered cross-initiative path the sidebar depends on) and for a guild-level calendar reporting `initiative_id: null`.
- `ruff check app` — clean.
- `cd frontend && pnpm typecheck` — clean.