### PR TITLE
Resolve tool visibility through one clause

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/comments.py
+++ b/backend/app/api/v1/tenant_endpoints/comments.py
@@ -12,7 +12,7 @@ from app.api.deps import (
     get_current_active_user,
     get_guild_membership,
 )
-from app.core.pam_context import has_active_grant
+from app.core.tools import Tool
 from app.models.tenant.comment import Comment
 from app.models.tenant.document import Document
 from app.models.tenant.initiative import Initiative, InitiativeMember
@@ -20,8 +20,7 @@ from app.models.tenant.project import Project
 from app.models.tenant.task import Task
 from app.models.platform.user import User, UserStatus
 from app.services.permissions import (
-    visible_document_ids_subquery,
-    visible_project_ids_subquery,
+    dac_scope_clause,
 )
 from app.schemas.tenant.comment import (
     CommentAuthor,
@@ -136,25 +135,24 @@ async def recent_comments(
         Comment.parent_comment_id.is_(None),
         Comment.guild_id == guild_context.guild_id,
     ]
-    # A PAM grantee can read all of the guild's content (RLS already scopes the
-    # joined tables to the granted guild), so skip the per-DAC visibility
-    # narrowing that a non-member would otherwise fail. Members still see only
-    # the tasks/documents they have permission for.
-    if not has_active_grant(guild_context.guild_id):
-        visible_projects = visible_project_ids_subquery(user_id).subquery()
-        visible_documents = visible_document_ids_subquery(user_id).subquery()
-        conditions.append(
-            or_(
-                and_(
-                    Project.id.isnot(None),
-                    Project.id.in_(select(visible_projects)),
+    # A comment is reached through its task's project or through its document, so
+    # the sharing gate is applied per kind. Each clause is a no-op for a request
+    # that reaches the whole guild, leaving only "attached to one or the other".
+    guild_id = guild_context.guild_id
+    conditions.append(
+        or_(
+            and_(
+                Project.id.isnot(None),
+                dac_scope_clause(Tool.project, Project.id, user_id, guild_id=guild_id),
+            ),
+            and_(
+                Document.id.isnot(None),
+                dac_scope_clause(
+                    Tool.document, Document.id, user_id, guild_id=guild_id
                 ),
-                and_(
-                    Document.id.isnot(None),
-                    Document.id.in_(select(visible_documents)),
-                ),
-            )
+            ),
         )
+    )
 
     stmt = (
         select(Comment)

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -40,7 +40,6 @@ from app.core.messages import (
     InitiativeMessages,
     QueryMessages,
 )
-from app.core.pam_context import has_active_grant
 from app.core.rate_limit import limiter
 from app.db.session import get_admin_session
 from app.services.cross_guild import gather_across_guilds, member_guild_ids
@@ -342,18 +341,17 @@ def _build_visible_docs_filters(
     is_template: Optional[bool] = None,
     document_type: Optional[DocumentType] = None,
 ):
-    """Build common WHERE conditions for visible-document queries."""
-    # A guild admin (full access to all guild data) or a live PAM grant sees all
-    # of the guild's documents in one bulk, guild-scoped query; otherwise narrow
-    # to documents the user has explicit/role permission for. Guild scope + RLS
-    # apply either way.
-    conditions = [Initiative.guild_id == guild_id]
-    if not has_active_grant(
-        guild_id
-    ) and not permissions_service.is_request_guild_admin(guild_id):
-        conditions.append(
-            Document.id.in_(permissions_service.visible_document_ids_subquery(user_id))
-        )
+    """Build common WHERE conditions for visible-document queries.
+
+    Guild scope + RLS apply either way; ``dac_scope_clause`` adds the sharing
+    gate, resolving to a no-op for a request that reaches the whole guild.
+    """
+    conditions = [
+        Initiative.guild_id == guild_id,
+        permissions_service.dac_scope_clause(
+            Tool.document, Document.id, user_id, guild_id=guild_id
+        ),
+    ]
 
     if initiative_id is not None:
         conditions.append(Document.initiative_id == initiative_id)

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -64,7 +64,6 @@ from app.db.query import (
     page_has_next,
     paginate_sequence,
 )
-from app.core.pam_context import has_active_grant
 from app.services.realtime import broadcast_event
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.schemas.tenant.project import (
@@ -521,20 +520,18 @@ def _visible_project_conditions(
 
     ``archived``/``template``/``search``/``initiative_id`` are pushed into SQL
     (mirroring the old ``_matches_filters``: ``None`` means "exclude" for the
-    boolean flags, and "every initiative" for the initiative). DAC scoping is
-    preserved exactly — a guild admin or a live PAM grant sees every project in
-    the guild; otherwise the set is narrowed to the user's explicit/role-granted
-    projects via ``visible_project_ids_subquery``.
+    boolean flags, and "every initiative" for the initiative). ``dac_scope_clause``
+    supplies the sharing gate — it resolves to a no-op for a request that reaches
+    the whole guild, so there is nothing to branch on here.
     """
-    conditions = [Initiative.guild_id == guild_id]
+    conditions = [
+        Initiative.guild_id == guild_id,
+        permissions_service.dac_scope_clause(
+            Tool.project, Project.id, user_id, guild_id=guild_id
+        ),
+    ]
     if initiative_id is not None:
         conditions.append(Project.initiative_id == initiative_id)
-    if not has_active_grant(
-        guild_id
-    ) and not permissions_service.is_request_guild_admin(guild_id):
-        conditions.append(
-            Project.id.in_(permissions_service.visible_project_ids_subquery(user_id))
-        )
 
     if template is None:
         conditions.append(Project.is_template.is_(False))
@@ -950,31 +947,35 @@ async def _list_global_projects(
     """List projects across every guild the user belongs to.
 
     Visits each guild's schema in turn (per-schema ids mean a single cross-guild
-    query isn't possible) and merges, filtering through the DAC
-    visible-project-ids subquery for permission checks. Membership is implied by
-    only iterating the user's own guilds.
+    query isn't possible) and merges. Membership is implied by only iterating the
+    user's own guilds.
+
+    The sharing gate is resolved per guild, inside ``_fetch``: the answer depends
+    on the caller's role in that guild, which ``gather_across_guilds`` establishes
+    for each one in turn.
     """
     target_guilds = await member_guild_ids(
         session, current_user.id, restrict_to=guild_ids
     )
 
-    has_permission_subq = permissions_service.visible_project_ids_subquery(
-        current_user.id
-    )
     conditions = [
         Project.is_archived.is_(False),
         Project.is_template.is_(False),
-        Project.id.in_(has_permission_subq),
     ]
     if search:
         conditions.append(
             func.lower(Project.name).contains(search.strip().lower(), autoescape=True)
         )
 
-    async def _fetch(guild_session: AsyncSession, _guild_id: int) -> list[ProjectRead]:
+    async def _fetch(guild_session: AsyncSession, guild_id: int) -> list[ProjectRead]:
         statement = (
             select(Project)
-            .where(*conditions)
+            .where(
+                *conditions,
+                permissions_service.dac_scope_clause(
+                    Tool.project, Project.id, current_user.id, guild_id=guild_id
+                ),
+            )
             .options(
                 selectinload(Project.grants).options(
                     selectinload(ResourceGrant.role), selectinload(ResourceGrant.user)
@@ -1143,15 +1144,13 @@ async def get_project_counts_by_initiative(
         Initiative.guild_id == guild_context.guild_id,
         Project.is_archived.is_(False),
         Project.is_template.is_(False),
+        permissions_service.dac_scope_clause(
+            Tool.project,
+            Project.id,
+            current_user.id,
+            guild_id=guild_context.guild_id,
+        ),
     ]
-    if not has_active_grant(
-        guild_context.guild_id
-    ) and not permissions_service.is_request_guild_admin(guild_context.guild_id):
-        conditions.append(
-            Project.id.in_(
-                permissions_service.visible_project_ids_subquery(current_user.id)
-            )
-        )
 
     statement = (
         select(Project.initiative_id, func.count(Project.id))

--- a/backend/app/api/v1/tenant_endpoints/property_definitions.py
+++ b/backend/app/api/v1/tenant_endpoints/property_definitions.py
@@ -18,6 +18,7 @@ from app.api.deps import (
     get_guild_membership,
 )
 from app.core.messages import PropertyMessages
+from app.core.tools import Tool
 from app.models.tenant.calendar import Calendar
 from app.models.tenant.calendar_event import CalendarEvent
 from app.models.tenant.document import Document
@@ -328,6 +329,7 @@ async def get_property_entities(
     definition_id: int,
     session: RLSSessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
 ) -> PropertyEntitiesResult:
     """List all documents and tasks with a value for this property.
 
@@ -335,17 +337,25 @@ async def get_property_entities(
     """
     defn = await _get_definition_or_404(session, definition_id)
 
-    project_access_subq = permissions_service.visible_project_ids_subquery(
-        current_user.id
+    task_project_scope = permissions_service.dac_scope_clause(
+        Tool.project,
+        Task.project_id,
+        current_user.id,
+        guild_id=guild_context.guild_id,
     )
-    doc_access_subq = permissions_service.visible_document_ids_subquery(current_user.id)
+    doc_scope = permissions_service.dac_scope_clause(
+        Tool.document,
+        Document.id,
+        current_user.id,
+        guild_id=guild_context.guild_id,
+    )
 
     tasks_stmt = (
         select(Task)
         .join(TaskPropertyValue, TaskPropertyValue.task_id == Task.id)
         .where(
             TaskPropertyValue.property_id == defn.id,
-            Task.project_id.in_(project_access_subq),
+            task_project_scope,
         )
         .options(selectinload(Task.project))
     )
@@ -366,7 +376,7 @@ async def get_property_entities(
         .join(DocumentPropertyValue, DocumentPropertyValue.document_id == Document.id)
         .where(
             DocumentPropertyValue.property_id == defn.id,
-            Document.id.in_(doc_access_subq),
+            doc_scope,
         )
         .options(selectinload(Document.initiative))
     )

--- a/backend/app/api/v1/tenant_endpoints/tags.py
+++ b/backend/app/api/v1/tenant_endpoints/tags.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Annotated, List, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import func, update as sa_update
+from sqlalchemy import ColumnElement, func, update as sa_update
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
@@ -308,7 +308,7 @@ async def get_tag_entities(
     # Sharing gate on the project (a no-op for a request that reaches the whole
     # guild). Two columns name a project here — a task's FK and the project's own
     # id — so the clause is built against each.
-    def _project_scope(col):
+    def _project_scope(col: ColumnElement[int]) -> ColumnElement[bool]:
         return permissions_service.dac_scope_clause(
             Tool.project, col, current_user.id, guild_id=guild_context.guild_id
         )

--- a/backend/app/api/v1/tenant_endpoints/tags.py
+++ b/backend/app/api/v1/tenant_endpoints/tags.py
@@ -305,10 +305,13 @@ async def get_tag_entities(
     """
     tag = await _get_tag_or_404(session, tag_id, guild_context.guild_id)
 
-    # Build project access subquery (user + role)
-    project_access_subq = permissions_service.visible_project_ids_subquery(
-        current_user.id
-    )
+    # Sharing gate on the project (a no-op for a request that reaches the whole
+    # guild). Two columns name a project here — a task's FK and the project's own
+    # id — so the clause is built against each.
+    def _project_scope(col):
+        return permissions_service.dac_scope_clause(
+            Tool.project, col, current_user.id, guild_id=guild_context.guild_id
+        )
 
     # Get tasks with this tag that user can access
     tasks_stmt = (
@@ -316,7 +319,7 @@ async def get_tag_entities(
         .join(TaskTag, TaskTag.task_id == Task.id)
         .where(
             TaskTag.tag_id == tag.id,
-            Task.project_id.in_(project_access_subq),
+            _project_scope(Task.project_id),
         )
         .options(selectinload(Task.project))
     )
@@ -338,7 +341,7 @@ async def get_tag_entities(
         .join(ProjectTag, ProjectTag.project_id == Project.id)
         .where(
             ProjectTag.tag_id == tag.id,
-            Project.id.in_(project_access_subq),
+            _project_scope(Project.id),
         )
         .options(selectinload(Project.initiative))
     )
@@ -354,8 +357,12 @@ async def get_tag_entities(
         for project in projects
     ]
 
-    # Build document access subquery (user + role)
-    doc_access_subq = permissions_service.visible_document_ids_subquery(current_user.id)
+    doc_scope = permissions_service.dac_scope_clause(
+        Tool.document,
+        Document.id,
+        current_user.id,
+        guild_id=guild_context.guild_id,
+    )
 
     # Get documents with this tag that user can access
     documents_stmt = (
@@ -363,7 +370,7 @@ async def get_tag_entities(
         .join(DocumentTag, DocumentTag.document_id == Document.id)
         .where(
             DocumentTag.tag_id == tag.id,
-            Document.id.in_(doc_access_subq),
+            doc_scope,
         )
         .options(selectinload(Document.initiative))
     )

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -980,11 +980,10 @@ async def _allowed_project_ids(
     """
     # A guild admin (full guild access) or a live PAM grant sees tasks in every
     # project of the guild — like a member of every initiative — regardless of
-    # any explicit DAC permission row. (The projects list grants the same via
-    # ``visible_project_ids_subquery``'s guild-admin branch; without this leg an
-    # admin who holds no permission row on a project sees "no results" for it.)
-    # Return all of the guild's project ids so the task query stays explicitly
-    # guild-scoped; RLS also scopes to the guild / grant guild.
+    # any explicit DAC permission row. Same decision the project list makes
+    # through ``permissions.dac_scope_clause``; here it returns all of the
+    # guild's project ids so the task query stays explicitly guild-scoped (RLS
+    # also scopes to the guild / grant guild).
     if permissions_service.is_request_guild_admin(guild_id) or has_active_grant(
         guild_id
     ):

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import Any, TypeVar
 
 from fastapi import HTTPException, status
-from sqlalchemy import and_, or_, true
+from sqlalchemy import ColumnElement, and_, or_, true
 from sqlmodel import select
 
 from app.core.pam_context import active_grant_level, grant_satisfies, has_active_grant
@@ -223,11 +223,11 @@ def request_bypasses_dac(
 
 def dac_scope_clause(
     tool: Tool,
-    id_col: Any,
+    id_col: ColumnElement[int],
     user_id: int,
     *,
     guild_id: int | None,
-) -> Any:
+) -> ColumnElement[bool]:
     """The WHERE leg narrowing ``id_col`` to the ``tool`` rows this request may see.
 
     The query-shaped counterpart of :func:`request_bypasses_dac`: that one asks

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import Any, TypeVar
 
 from fastapi import HTTPException, status
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, true
 from sqlmodel import select
 
 from app.core.pam_context import active_grant_level, grant_satisfies, has_active_grant
@@ -29,7 +29,6 @@ from app.core.role_context import (
     request_overrides_sharing,
 )
 from app.core.tools import Tool
-from app.services.membership import guild_member_clause
 
 from app.models.platform.guild import GuildMembership, GuildRole
 from app.models.tenant.project import (
@@ -166,22 +165,6 @@ def visible_resource_ids_subquery(resource_type: str, user_id: int):
     )
 
 
-def visible_project_ids_subquery(user_id: int):
-    """Project IDs the user can access: granted ∪ (all projects if guild admin)."""
-    guild_admin_subq = select(Project.id).where(
-        guild_member_clause(user_id, Project.guild_id, role=GuildRole.admin)
-    )
-    return visible_resource_ids_subquery("project", user_id).union(guild_admin_subq)
-
-
-def visible_document_ids_subquery(user_id: int):
-    """Document IDs the user can access: granted ∪ (all documents if guild admin)."""
-    guild_admin_subq = select(Document.id).where(
-        guild_member_clause(user_id, Document.guild_id, role=GuildRole.admin)
-    )
-    return visible_resource_ids_subquery("document", user_id).union(guild_admin_subq)
-
-
 # ── Initiative-scope gate (loaded-data variant) ──────────────────
 
 
@@ -236,6 +219,35 @@ def request_bypasses_dac(
     if is_request_guild_admin(guild_id, guild_role=guild_role):
         return True
     return request_overrides_sharing(initiative_id)
+
+
+def dac_scope_clause(
+    tool: Tool,
+    id_col: Any,
+    user_id: int,
+    *,
+    guild_id: int | None,
+) -> Any:
+    """The WHERE leg narrowing ``id_col`` to the ``tool`` rows this request may see.
+
+    The query-shaped counterpart of :func:`request_bypasses_dac`: that one asks
+    about a loaded row, this one asks once for a whole statement, and both read
+    the same request context. Returns ``true()`` when the request reaches the
+    guild regardless of grants, so a caller appends it unconditionally rather
+    than branching around the narrowing.
+
+    ``id_col`` is whichever column names the resource — its own id, or a foreign
+    key to it (``Task.project_id``).
+
+    The initiative "Full access" override is deliberately not folded in: it is
+    per-initiative, so it cannot collapse to one guild-wide answer, and no
+    listing path applies it today.
+    """
+    if guild_id is not None and (
+        has_active_grant(guild_id) or is_request_guild_admin(guild_id)
+    ):
+        return true()
+    return id_col.in_(visible_resource_ids_subquery(tool, user_id))
 
 
 #: Distinguishes "this row has no initiative_id column" from "its initiative_id

--- a/backend/app/services/permissions_test.py
+++ b/backend/app/services/permissions_test.py
@@ -17,6 +17,8 @@ from app.core.messages import DocumentMessages, ProjectMessages
 from app.models.tenant.document import DocumentPermissionLevel
 from app.models.tenant.project import ProjectPermissionLevel
 from app.models.platform.user import UserRole
+from sqlalchemy import ColumnElement
+
 from app.core.pam_context import set_active_grant
 from app.core.role_context import set_active_role, set_override_sharing_initiatives
 from app.core.tools import Tool
@@ -612,7 +614,7 @@ def test_membership_without_permission_row_still_denied():
 # ── dac_scope_clause: the query-shaped half of the DAC decision ──────────────
 
 
-def _compiled(clause) -> str:
+def _compiled(clause: ColumnElement[bool]) -> str:
     return str(clause.compile(compile_kwargs={"literal_binds": True}))
 
 

--- a/backend/app/services/permissions_test.py
+++ b/backend/app/services/permissions_test.py
@@ -17,8 +17,16 @@ from app.core.messages import DocumentMessages, ProjectMessages
 from app.models.tenant.document import DocumentPermissionLevel
 from app.models.tenant.project import ProjectPermissionLevel
 from app.models.platform.user import UserRole
+from app.core.pam_context import set_active_grant
+from app.core.role_context import set_active_role, set_override_sharing_initiatives
+from app.core.tools import Tool
+from app.models.platform.guild import GuildRole
+from app.models.tenant.document import Document
+from app.models.tenant.project import Project
+from app.models.tenant.queue import Queue
 from app.services.permissions import (
     PROJECT_LEVEL_ORDER,
+    dac_scope_clause,
     compute_document_permission,
     compute_project_permission,
     effective_permission_level,
@@ -599,3 +607,79 @@ def test_membership_without_permission_row_still_denied():
     with pytest.raises(HTTPException) as exc_info:
         require_document_access(doc, user, access="read")
     assert exc_info.value.status_code == 403
+
+
+# ── dac_scope_clause: the query-shaped half of the DAC decision ──────────────
+
+
+def _compiled(clause) -> str:
+    return str(clause.compile(compile_kwargs={"literal_binds": True}))
+
+
+def test_dac_scope_clause_is_a_no_op_for_a_guild_wide_request():
+    """A guild admin, or a live PAM grant, reaches the whole guild — so the
+    clause adds nothing and the caller needs no branch around it."""
+    set_active_grant(None, None)
+    set_override_sharing_initiatives(None)
+    try:
+        set_active_role(7, GuildRole.admin.value)
+        assert _compiled(dac_scope_clause(Tool.project, Project.id, 1, guild_id=7)) == (
+            "true"
+        )
+
+        set_active_role(None, None)
+        set_active_grant(7, "read")
+        assert (
+            _compiled(dac_scope_clause(Tool.document, Document.id, 1, guild_id=7))
+            == "true"
+        )
+    finally:
+        set_active_role(None, None)
+        set_active_grant(None, None)
+
+
+def test_dac_scope_clause_narrows_an_ordinary_member():
+    """A member is scoped to the resources granted to them, and the clause names
+    the tool it was asked about."""
+    set_active_grant(None, None)
+    set_override_sharing_initiatives(None)
+    set_active_role(7, GuildRole.member.value)
+    try:
+        sql = _compiled(dac_scope_clause(Tool.queue, Queue.id, 1, guild_id=7))
+        assert "resource_grants" in sql
+        assert "queue" in sql
+        assert sql != "true"
+    finally:
+        set_active_role(None, None)
+
+
+def test_dac_scope_clause_narrows_when_the_role_is_for_another_guild():
+    """Role context is keyed by guild, so being an admin of guild 8 grants
+    nothing in guild 7."""
+    set_active_grant(None, None)
+    set_override_sharing_initiatives(None)
+    set_active_role(8, GuildRole.admin.value)
+    try:
+        assert (
+            _compiled(dac_scope_clause(Tool.project, Project.id, 1, guild_id=7))
+            != "true"
+        )
+        # ...and no guild at all narrows too, rather than opening up.
+        assert (
+            _compiled(dac_scope_clause(Tool.project, Project.id, 1, guild_id=None))
+            != "true"
+        )
+    finally:
+        set_active_role(None, None)
+
+
+@pytest.mark.parametrize("tool", list(Tool))
+def test_every_tool_can_be_scoped(tool):
+    """Every tool in the registry answers the sharing gate. A new tool that adds
+    a listing endpoint cannot quietly skip it."""
+    set_active_role(None, None)
+    set_active_grant(None, None)
+    set_override_sharing_initiatives(None)
+    sql = _compiled(dac_scope_clause(tool, Project.id, 1, guild_id=7))
+    assert "resource_grants" in sql
+    assert tool.value in sql


### PR DESCRIPTION
## Problem

"Which rows may this request see?" was answered two different ways for projects and documents, over two different sources of truth.

At the call site, a request-context check: `is_request_guild_admin(guild_id)` plus `has_active_grant(guild_id)`, short-circuiting the DAC narrowing entirely.

Inside `visible_project_ids_subquery` / `visible_document_ids_subquery`, a second one: a UNION of every row in the guild, gated on an EXISTS against `public.guild_memberships` in SQL.

The two covered different call sites. `projects.py`, `projects.py` (counts) and `documents.py` short-circuited before the subquery ever ran, so the UNION was dead there. `tags.py` (×2), `property_definitions.py` (×2), `comments.py` and `/me/projects` applied the subquery unconditionally, and for those the UNION was the only guild-admin branch. Nothing in either spelling marked which case it was in, so adding or removing a short-circuit silently changed visibility.

`/me/projects` is why the SQL version existed at all: it builds its predicate once, outside the per-guild loop, so it had no guild id to ask a context-based predicate about.

## Changes

`permissions.dac_scope_clause(tool, id_col, user_id, *, guild_id)` is now the one answer — the query-shaped counterpart of `request_bypasses_dac`, reading the same request context. It returns `true()` when the request reaches the whole guild, so callers append it unconditionally rather than branching around the narrowing, and it accepts any column that names the resource (a row's own id, or a task's `project_id`).

- Both UNION subqueries removed.
- All nine call sites moved onto the clause.
- `/me/projects` resolves it inside `_fetch`, where `gather_across_guilds` has already established that guild's role.
- `get_property_entities` gains `GuildContextDep` — it had no guild in scope.

Behaviour is unchanged. The clause is a lazy SQLAlchemy expression executed once per guild inside the routed session, and no tenant model hardcodes a schema, so unqualified names resolved through each guild's `search_path` either way; the `Project.guild_id` correlation matched the routed guild. The two spellings agreed — there was just nothing making them agree.

The initiative "Full access" override is deliberately not folded in: it is per-initiative, so it cannot collapse to one guild-wide answer, and no listing path applies it today. Noted in the docstring.

## Tests

`permissions_test.py` gains coverage for the clause: no-op for a guild admin and for a live PAM grant, narrowing for an ordinary member, narrowing when the role context belongs to a different guild or no guild at all, and a parametrized pass over `Tool` so a tool that gains a listing endpoint has to answer the gate.

```
pytest app/services/permissions_test.py                       48 passed
pytest app/api/v1/tenant_endpoints/{projects,documents,tasks}_test.py    144 passed
pytest app/api/v1/tenant_endpoints/{tags,property_definitions,comments,me_projects,me_documents,initiative_share_override}_test.py    89 passed
ruff check app && ruff format app && ty check                 clean (ty: same 16 pre-existing warnings as dev)
```

## Notes

Internal refactor, no user-facing change, so no changelog entry.

This is the first slice of a larger unification — the same decision is still spelled several other ways across the queue, counter, calendar and dashboard listing paths and the export enumerators. Those move separately.
