### PR TITLE
Fix mobile tag browser overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The tag browser on a phone spilled over the documents behind it.** Opening "Browse by tag" on a narrow screen drew the whole tag tree past the bottom of its panel and on top of the document cards. The panel now keeps its tags inside it and scrolls, and its chevron turns over when it opens.
+
 ## [0.63.0] - 2026-08-21
 
 ### Added

--- a/frontend/src/components/documents/DocumentsTagsView.tsx
+++ b/frontend/src/components/documents/DocumentsTagsView.tsx
@@ -57,7 +57,7 @@ export const DocumentsTagsView = ({
         <CollapsibleTrigger asChild>
           <button
             type="button"
-            className="flex w-full items-center justify-between px-3 py-2 font-medium text-sm"
+            className="group flex w-full items-center justify-between px-3 py-2 font-medium text-sm"
           >
             <span className="flex items-center gap-2">
               <Tags className="h-4 w-4" />
@@ -68,11 +68,11 @@ export const DocumentsTagsView = ({
                 </Badge>
               )}
             </span>
-            <ChevronDown className="h-4 w-4" />
+            <ChevronDown className="h-4 w-4 transition-transform group-data-[state=open]:rotate-180" />
           </button>
         </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="max-h-64">
+        <CollapsibleContent className="overflow-hidden">
+          <div className="max-h-64 overflow-y-auto overscroll-contain">
             <TagTreeView
               tags={allTags}
               tagCounts={tagCounts}


### PR DESCRIPTION
## Problem

On a phone, opening **Browse by tag** in the documents tag view drew the whole tag tree past the bottom of its panel and on top of the document cards behind it.

The collapsible's content wrapper was `max-h-64` with no overflow handling — `max-height` caps the box, not the content, so the list simply spilled out. `TagTreeView`'s Radix `ScrollArea` didn't save it either: it asks for `h-full`, and a percentage height against an auto-height parent resolves to auto, so it never bounded itself. Radix's ScrollArea needs a *definite* height to scroll, which the mobile panel can't hand it without forcing 16rem even for two tags — so the fix puts native scrolling on the wrapper instead.

Desktop was never affected: there the flex row gives the ScrollArea a real height.

## Changes

- [DocumentsTagsView.tsx](frontend/src/components/documents/DocumentsTagsView.tsx) — mobile panel content is now `max-h-64 overflow-y-auto overscroll-contain` (bounded, scrolls on touch, no scroll chaining to the page), and `CollapsibleContent` gets `overflow-hidden` so nothing escapes mid-transition.
- Same file — the trigger chevron now rotates on open (`group` + `group-data-[state=open]:rotate-180`); it was static before.
- [CHANGELOG.md](CHANGELOG.md) — entry under `[Unreleased] → Fixed`.

Checked the rest of the codebase for the same `CollapsibleContent` + `max-h-*` pattern; this was the only instance.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm lint` — clean (one pre-existing array-index-key warning in the heatmap component, untouched here)
- `cd frontend && ./scripts/test-changed.sh` — 132 files / 1710 tests passed

CSS containment fix verified by reading the layout, not by screenshot.