### PR TITLE
Rename author keys only where they exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Updating to 0.63.0 could stop partway with a database error.** The migration that gave every kind of content one `created_by` field also renamed the foreign keys named after the old field — but a guild created recently never had those keys to begin with, so the update failed on `constraint "calendars_created_by_id_fkey" for table "calendars" does not exist` and the app would not start. The rename now skips what a guild's schema does not have. An install stopped by this can simply update again; nothing was left half-applied.
 - **The tag browser on a phone spilled over the documents behind it.** Opening "Browse by tag" on a narrow screen drew the whole tag tree past the bottom of its panel and on top of the document cards. The panel now keeps its tags inside it and scrolls, and its chevron turns over when it opens.
 
 ## [0.63.0] - 2026-08-21

--- a/backend/alembic/migrations_test.py
+++ b/backend/alembic/migrations_test.py
@@ -68,6 +68,23 @@ INTENTIONALLY_IRREVERSIBLE = frozenset(
     }
 )
 
+# 20260820_0188 (one author column across the guild schema) and the revision it
+# starts from. Named here because the regression test below replays that one
+# revision over a hand-made database state.
+AUTHOR_RENAME_REVISION = "20260820_0188"
+PRE_AUTHOR_RENAME_REVISION = "20260815_0187"
+
+# The guild-content tables whose foreign key into ``public.users`` is named after
+# the author column 0188 renames — (table, pre-0188 column name).
+AUTHOR_FOREIGN_KEY_TABLES = (
+    ("calendars", "created_by_id"),
+    ("dashboards", "created_by_id"),
+    ("export_jobs", "created_by_id"),
+    ("guild_ai_connections", "created_by_user_id"),
+    ("guild_apps", "installed_by_id"),
+    ("import_jobs", "created_by_id"),
+)
+
 # Per-worker so parallel xdist workers don't drop/recreate the same DB. xdist's
 # worker id is used verbatim ("gw0"/… distributed, "master" standalone).
 _WORKER = os.environ.get("PYTEST_XDIST_WORKER", "master")
@@ -371,6 +388,28 @@ def _constraint_exists(table: str, name: str, schema: str = "public") -> bool:
     return asyncio.run(_constraint_exists_async(table, name, schema))
 
 
+async def _column_exists_async(table: str, column: str, schema: str) -> bool:
+    conn = await _connect_test_db()
+    try:
+        return bool(
+            await conn.fetchval(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM information_schema.columns "
+                "  WHERE table_schema = $1 AND table_name = $2 AND column_name = $3"
+                ")",
+                schema,
+                table,
+                column,
+            )
+        )
+    finally:
+        await conn.close()
+
+
+def _column_exists(table: str, column: str, schema: str = "public") -> bool:
+    return asyncio.run(_column_exists_async(table, column, schema))
+
+
 async def _execute_sql_async(sql: str) -> None:
     conn = await _connect_test_db()
     try:
@@ -536,6 +575,51 @@ class TestMigrationsAgainstDatabase:
         assert _sequence_exists("user_api_keys_id_seq"), (
             "the shared user_api_keys id sequence must survive the drop"
         )
+
+    def test_author_rename_skips_foreign_keys_a_guild_schema_lacks(
+        self, fresh_migrations_db: str
+    ) -> None:
+        """20260820_0188 renames the foreign keys named after the author column,
+        and a guild schema built by the app's provisioner has none of them.
+
+        ``app.db.guild_ddl`` renders intra-schema references only — a reference
+        to ``public.users`` is left soft, because the schema is the tenant
+        boundary — so a guild created that way carries the author column without
+        the key, while ``guild_template`` and the guilds provisioned before that
+        renderer carry both. Both shapes are live in the field, so the rename has
+        to ask rather than assume: it stopped every upgrade that had one of the
+        first kind (issue #1218).
+
+        A fresh database has only ``guild_template``, which does carry the keys,
+        so the other shape is fabricated here — drop them, then replay the
+        revision over it, in both directions.
+        """
+        _run_alembic("upgrade", "head")
+        _run_alembic("downgrade", PRE_AUTHOR_RENAME_REVISION)
+
+        for table, column in AUTHOR_FOREIGN_KEY_TABLES:
+            name = f"{table}_{column}_fkey"
+            assert _constraint_exists(table, name, schema="guild_template"), (
+                f"expected {name!r} before the fabrication — the shape this test "
+                "removes must be the one the migration chain produces"
+            )
+            _execute_sql(f"ALTER TABLE guild_template.{table} DROP CONSTRAINT {name}")
+
+        _run_alembic("upgrade", "head")
+
+        for table, _column in AUTHOR_FOREIGN_KEY_TABLES:
+            assert _column_exists(table, "created_by", schema="guild_template"), (
+                f"{table}.created_by must be renamed whether or not a foreign "
+                "key carries the old name"
+            )
+            assert not _constraint_exists(
+                table, f"{table}_created_by_fkey", schema="guild_template"
+            ), "a key that wasn't there must not be conjured by the rename"
+
+        # The reverse has the same two shapes to survive.
+        _run_alembic("downgrade", PRE_AUTHOR_RENAME_REVISION)
+        for table, column in AUTHOR_FOREIGN_KEY_TABLES:
+            assert _column_exists(table, column, schema="guild_template")
 
     def test_step_by_step_upgrade_from_base_to_head(
         self, fresh_migrations_db: str

--- a/backend/alembic/versions/20260820_0188_guild_created_by_column.py
+++ b/backend/alembic/versions/20260820_0188_guild_created_by_column.py
@@ -75,20 +75,48 @@ _RENAMES: tuple[tuple[str, str], ...] = (
 #: who changed a document, with the transaction and the columns involved.
 _DROPPED_UPDATED_BY = ("documents", "updated_by_id")
 
+
+def _rename_constraint(table: str, old_name: str, new_name: str) -> str:
+    """Rename a constraint where the schema has one.
+
+    Guild schemas do not all carry the same foreign keys. A schema built by the
+    app's provisioner has only intra-schema ones — a reference to
+    ``public.users`` is left soft, because the schema is the tenant boundary
+    (``app.db.guild_ddl``) — while ``guild_template`` and the guilds provisioned
+    before that renderer existed do have them. Both shapes are live in the
+    field, so this asks before renaming instead of assuming; a schema without
+    the constraint simply has nothing to bring along.
+
+    ``to_regclass`` resolves through the ``search_path`` the per-schema loop
+    sets, so it names the table in the schema currently being migrated.
+    """
+    return (
+        f"DO $rename$ BEGIN "
+        f"IF EXISTS (SELECT 1 FROM pg_constraint "
+        f"WHERE conrelid = to_regclass('{table}') AND conname = '{old_name}') THEN "
+        f"ALTER TABLE {table} RENAME CONSTRAINT {old_name} TO {new_name}; "
+        f"END IF; END $rename$"
+    )
+
+
 #: Constraints and indexes named after a renamed column. Postgres rewrites what
 #: they reference on RENAME COLUMN but keeps their own name, so the name is
-#: brought along by hand — as (forward, reverse) statement pairs.
+#: brought along by hand — as (forward, reverse) statement pairs. Each one is
+#: conditional: which of these objects a given guild schema holds depends on how
+#: it was built (see :func:`_rename_constraint`).
 _RENAMED_OBJECTS: tuple[tuple[str, str], ...] = (
     (
-        "ALTER INDEX ix_comments_author_id RENAME TO ix_comments_created_by",
-        "ALTER INDEX ix_comments_created_by RENAME TO ix_comments_author_id",
+        "ALTER INDEX IF EXISTS ix_comments_author_id RENAME TO ix_comments_created_by",
+        "ALTER INDEX IF EXISTS ix_comments_created_by RENAME TO ix_comments_author_id",
     ),
     *(
         (
-            f"ALTER TABLE {table} RENAME CONSTRAINT "
-            f"{table}_{old}_fkey TO {table}_created_by_fkey",
-            f"ALTER TABLE {table} RENAME CONSTRAINT "
-            f"{table}_created_by_fkey TO {table}_{old}_fkey",
+            _rename_constraint(
+                table, f"{table}_{old}_fkey", f"{table}_created_by_fkey"
+            ),
+            _rename_constraint(
+                table, f"{table}_created_by_fkey", f"{table}_{old}_fkey"
+            ),
         )
         for table, old in (
             ("calendars", "created_by_id"),


### PR DESCRIPTION
## Problem

Updating to 0.63.0 stops with the app refusing to start:

```
sqlalchemy.exc.ProgrammingError: constraint "calendars_created_by_id_fkey" for table "calendars" does not exist
[SQL: ALTER TABLE calendars RENAME CONSTRAINT calendars_created_by_id_fkey TO calendars_created_by_fkey]
```

`20260820_0188` renames six foreign keys by their literal name while giving guild content one `created_by` column. All six are references into `public.users`, and **whether a guild schema has them depends on how that schema was built**:

- `guild_template`, and any guild schema provisioned before the reflect-and-render provisioner, carries them — the tables were created by `op.create_table` with an unqualified `["users.id"]` FK (`calendars` in 0157, `dashboards` in 0162, `guild_apps` in 0167, …).
- A guild schema created by the app's provisioner does **not** — [guild_ddl.py](backend/app/db/guild_ddl.py) renders intra-schema references only (`elif r.contype == "f" and r.tgt in GUILD_SCOPED_TABLES`), deliberately, because the schema is the tenant boundary.

`run_for_each_guild_schema` visits `guild_1, guild_2, …, guild_template`, so the first recently-created guild raises before the template — which would have succeeded — is reached. `transaction_per_migration=True` means the revision rolled back cleanly every time; nothing was half-applied, the app just would not boot.

## Changes

- [20260820_0188_guild_created_by_column.py](backend/alembic/versions/20260820_0188_guild_created_by_column.py) — the six renames go through a new `_rename_constraint()`, which emits a guarded `DO … IF EXISTS (SELECT 1 FROM pg_constraint …)` block, forward and reverse. `to_regclass` resolves through the `search_path` the per-schema loop sets, so it names the table in the schema being migrated. The `ix_comments_author_id` index rename takes `IF EXISTS` for the same reason. Where the constraint is present the result is byte-for-byte what it was, so databases that already applied 0188 are unaffected.
- [migrations_test.py](backend/alembic/migrations_test.py) — `test_author_rename_skips_foreign_keys_a_guild_schema_lacks` builds head, rewinds to `20260815_0187`, drops the six keys to fabricate the provisioner's shape, and replays the revision over it in both directions. Adds a `_column_exists` helper alongside the existing `_constraint_exists`.
- `CHANGELOG.md` — entry under `[Unreleased] / Fixed`.

Neighbouring revisions were swept for the same hazard: `0185` drops two cross-schema FKs on `event_outbox` unconditionally, but `0183`–`0187` all shipped together in v0.62.7, so no deployment can have provisioned a guild inside that window; `0192`'s `drop_constraint` targets a CHECK, which the provisioner does render. `0188` is the only break.

## Testing

- Copied a dev database in the reporter's exact shape (three provisioned guild schemas, none carrying the six keys; `guild_template` carrying all six) and ran the real chain against the copy: `alembic upgrade head` ✅ → `alembic downgrade 20260815_0187` ✅ → `alembic upgrade head` ✅. Verified afterwards that `guild_template` holds `calendars_created_by_fkey` etc., that no key was conjured in the guild schemas, and that `ix_comments_created_by` landed in all four schemas.
- `pytest alembic/migrations_test.py` — 12 passed. The new test fails with the original `UndefinedObjectError` when the fix is stashed, and passes with it.
- `pytest app/db/migration_imports_test.py app/db/model_drift_test.py` — 3 passed.
- `ruff check app` — clean; `ruff format --check` on both touched files — clean.

Fixes #1218