### PR TITLE
Add document filters and table memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Task and document tables remember how you left them.** The column you sorted by, the grouping you chose, and the columns you showed or hid now come back on your next visit — on a project's task list (kept per project, so one project's arrangement doesn't follow you into the next), My Tasks and Created Tasks, a tag's task list, and the documents list. My Tasks also stops claiming it is sorted by date window when your saved sort says otherwise. Settings and admin tables are unchanged: they are places you pass through, not arrange.
+- **Documents and templates are listed separately, and the list filters by type.** An initiative's Documents tab now opens on a Documents / Templates toggle carrying each state's total, the way the projects list splits its own templates out; the templates view is linkable and answers the back button, and a tag's document browse lists documents only. The filter panel gains a document-type filter, so a list can be narrowed to text documents, files, whiteboards, spreadsheets or smart links; it counts toward the filter button's badge and Clear all.
+
 ## [0.63.1] - 2026-08-23
 
 ### Fixed

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -517,11 +517,18 @@ async def get_document_counts(
     guild_context: GuildContextDep,
     initiative_id: Optional[int] = Query(default=None),
     search: Optional[str] = Query(default=None),
+    is_template: Optional[bool] = Query(
+        default=None, description="Filter to template (or non-template) documents"
+    ),
+    document_type: Optional[DocumentType] = Query(
+        default=None, description="Filter by document type"
+    ),
 ) -> DocumentCountsResponse:
     """Get per-tag document counts for visible documents.
 
     Lightweight endpoint for the tag tree sidebar. Does NOT accept tag_ids
-    because counts should reflect all tags.
+    because counts should reflect all tags. The remaining filters mirror the
+    list endpoint so the sidebar counts match the list beside it.
     """
     if initiative_id is not None:
         await _get_initiative_or_404(
@@ -533,6 +540,8 @@ async def get_document_counts(
         current_user.id,
         initiative_id=initiative_id,
         search=search,
+        is_template=is_template,
+        document_type=document_type,
     )
 
     # Subquery: IDs of visible documents

--- a/backend/app/api/v1/tenant_endpoints/documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_test.py
@@ -945,6 +945,53 @@ async def test_list_documents_filters_by_template_and_type(
 
 
 @pytest.mark.integration
+async def test_document_counts_filter_by_template_and_type(
+    client: AsyncClient, session, acting_user
+):
+    """The tag-sidebar counts honor the same template/type narrowing as the
+    list, so the two never disagree."""
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+
+    await create_document(session, actor.initiative, actor.user, is_template=True)
+    await create_document(
+        session,
+        actor.initiative,
+        actor.user,
+        is_template=True,
+        document_type=DocumentType.whiteboard,
+    )
+    await create_document(session, actor.initiative, actor.user)
+
+    response = await client.get(actor.g("/documents/counts"), headers=actor.headers)
+    assert response.status_code == 200
+    assert response.json()["total_count"] == 3
+
+    response = await client.get(
+        actor.g("/documents/counts"),
+        headers=actor.headers,
+        params={"is_template": True},
+    )
+    assert response.status_code == 200
+    assert response.json()["total_count"] == 2
+
+    response = await client.get(
+        actor.g("/documents/counts"),
+        headers=actor.headers,
+        params={"is_template": True, "document_type": "whiteboard"},
+    )
+    assert response.status_code == 200
+    assert response.json()["total_count"] == 1
+
+    response = await client.get(
+        actor.g("/documents/counts"),
+        headers=actor.headers,
+        params={"document_type": "native"},
+    )
+    assert response.status_code == 200
+    assert response.json()["total_count"] == 2
+
+
+@pytest.mark.integration
 async def test_list_documents_rejects_too_many_ids(client: AsyncClient, acting_user):
     actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
 

--- a/frontend/public/locales/de/documents.json
+++ b/frontend/public/locales/de/documents.json
@@ -28,6 +28,13 @@
     "searchPlaceholder": "Dokumente suchen",
     "filterByTag": "Nach Tag filtern",
     "allTags": "Alle Tags",
+    "filterByType": "Nach Typ filtern",
+    "allTypes": "Alle Typen",
+    "typeNative": "Textdokument",
+    "typeFile": "Datei",
+    "typeWhiteboard": "Whiteboard",
+    "typeSpreadsheet": "Tabelle",
+    "typeSmartLink": "Smart-Link",
     "accessRestrictedTitle": "Zugriff eingeschränkt",
     "accessRestrictedDescription": "Du hast keine Berechtigung, Dokumente in dieser Initiative anzusehen. Wende dich an einen Administrator, wenn du glaubst, dass dies ein Fehler ist.",
     "loading": "Dokumente werden geladen…",
@@ -36,6 +43,8 @@
     "browseByTag": "Nach Tag durchsuchen",
     "noDocumentsTitle": "Noch keine Dokumente",
     "noDocumentsDescription": "Erstelle dein erstes Initiative-Dokument, um Briefings, Entscheidungen oder Anleitungen zu teilen.",
+    "noTemplatesTitle": "Noch keine Vorlagen",
+    "noTemplatesDescription": "Markiere ein beliebiges Dokument in seinen Einstellungen als Vorlage, um es später wiederzuverwenden.",
     "startWriting": "Mit dem Schreiben beginnen",
     "filterPlaceholder": "Nach Titel filtern…",
     "perPage": "Pro Seite:",
@@ -56,6 +65,11 @@
   "type": {
     "template": "Vorlage",
     "document": "Dokument"
+  },
+  "status": {
+    "label": "Anzeigen",
+    "documents": "Dokumente",
+    "templates": "Vorlagen"
   },
   "bulk": {
     "delete": "Löschen",

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -28,6 +28,13 @@
     "searchPlaceholder": "Search documents",
     "filterByTag": "Filter by tag",
     "allTags": "All tags",
+    "filterByType": "Filter by type",
+    "allTypes": "All types",
+    "typeNative": "Text document",
+    "typeFile": "File",
+    "typeWhiteboard": "Whiteboard",
+    "typeSpreadsheet": "Spreadsheet",
+    "typeSmartLink": "Smart link",
     "accessRestrictedTitle": "Access Restricted",
     "accessRestrictedDescription": "You don’t have permission to view documents in this initiative. Contact an administrator if you believe this is an error.",
     "loading": "Loading documents…",
@@ -36,6 +43,8 @@
     "browseByTag": "Browse by tag",
     "noDocumentsTitle": "No documents yet",
     "noDocumentsDescription": "Create your first initiative document to share briefs, decisions, or guides.",
+    "noTemplatesTitle": "No templates yet",
+    "noTemplatesDescription": "Mark any document as a template in its settings to reuse it later.",
     "startWriting": "Start writing",
     "filterPlaceholder": "Filter by title…",
     "perPage": "Per page:",
@@ -56,6 +65,11 @@
   "type": {
     "template": "Template",
     "document": "Document"
+  },
+  "status": {
+    "label": "Show",
+    "documents": "Documents",
+    "templates": "Templates"
   },
   "bulk": {
     "delete": "Delete",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -28,6 +28,13 @@
     "searchPlaceholder": "Buscar documentos",
     "filterByTag": "Filtrar por etiqueta",
     "allTags": "Todas las etiquetas",
+    "filterByType": "Filtrar por tipo",
+    "allTypes": "Todos los tipos",
+    "typeNative": "Documento de texto",
+    "typeFile": "Archivo",
+    "typeWhiteboard": "Pizarra",
+    "typeSpreadsheet": "Hoja de cálculo",
+    "typeSmartLink": "Enlace inteligente",
     "accessRestrictedTitle": "Acceso restringido",
     "accessRestrictedDescription": "No tienes permiso para ver documentos en esta iniciativa. Contacta a un administrador si crees que esto es un error.",
     "loading": "Cargando documentos…",
@@ -36,6 +43,8 @@
     "browseByTag": "Explorar por etiqueta",
     "noDocumentsTitle": "Aún no hay documentos",
     "noDocumentsDescription": "Crea tu primer documento de iniciativa para compartir resúmenes, decisiones o guías.",
+    "noTemplatesTitle": "Aún no hay plantillas",
+    "noTemplatesDescription": "Marca cualquier documento como plantilla en su configuración para reutilizarlo más adelante.",
     "startWriting": "Comenzar a escribir",
     "filterPlaceholder": "Filtrar por título…",
     "perPage": "Por página:",
@@ -56,6 +65,11 @@
   "type": {
     "template": "Plantilla",
     "document": "Documento"
+  },
+  "status": {
+    "label": "Mostrar",
+    "documents": "Documentos",
+    "templates": "Plantillas"
   },
   "bulk": {
     "delete": "Eliminar",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -28,6 +28,13 @@
     "searchPlaceholder": "Rechercher des documents",
     "filterByTag": "Filtrer par étiquette",
     "allTags": "Toutes les étiquettes",
+    "filterByType": "Filtrer par type",
+    "allTypes": "Tous les types",
+    "typeNative": "Document texte",
+    "typeFile": "Fichier",
+    "typeWhiteboard": "Tableau blanc",
+    "typeSpreadsheet": "Feuille de calcul",
+    "typeSmartLink": "Lien intelligent",
     "accessRestrictedTitle": "Accès restreint",
     "accessRestrictedDescription": "Vous n'avez pas la permission de voir les documents dans cette initiative. Contactez un administrateur si vous pensez qu'il s'agit d'une erreur.",
     "loading": "Chargement des documents…",
@@ -36,6 +43,8 @@
     "browseByTag": "Parcourir par étiquette",
     "noDocumentsTitle": "Aucun document pour l'instant",
     "noDocumentsDescription": "Créez votre premier document d'initiative pour partager des briefs, des décisions ou des guides.",
+    "noTemplatesTitle": "Aucun modèle pour l'instant",
+    "noTemplatesDescription": "Marquez un document comme modèle dans ses paramètres pour le réutiliser plus tard.",
     "startWriting": "Commencer à écrire",
     "filterPlaceholder": "Filtrer par titre…",
     "perPage": "Par page :",
@@ -56,6 +65,11 @@
   "type": {
     "template": "Modèle",
     "document": "Document"
+  },
+  "status": {
+    "label": "Afficher",
+    "documents": "Documents",
+    "templates": "Modèles"
   },
   "bulk": {
     "delete": "Supprimer",

--- a/frontend/src/api/generated/documents/documents.ts
+++ b/frontend/src/api/generated/documents/documents.ts
@@ -71,7 +71,8 @@ const withQueryKey = <T extends object, K>(query: T, queryKey: K): T & { queryKe
  * Get per-tag document counts for visible documents.
  *
  * Lightweight endpoint for the tag tree sidebar. Does NOT accept tag_ids
- * because counts should reflect all tags.
+ * because counts should reflect all tags. The remaining filters mirror the
+ * list endpoint so the sidebar counts match the list beside it.
  * @summary Get Document Counts
  */
 export const getDocumentCountsApiV1GGuildIdDocumentsCountsGet = (

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -5019,6 +5019,14 @@ export type SearchInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembersSe
 export type GetDocumentCountsApiV1GGuildIdDocumentsCountsGetParams = {
   initiative_id?: number | null;
   search?: string | null;
+  /**
+   * Filter to template (or non-template) documents
+   */
+  is_template?: boolean | null;
+  /**
+   * Filter by document type
+   */
+  document_type?: DocumentType | null;
 };
 
 export type ListDocumentsApiV1GGuildIdDocumentsGetParams = {

--- a/frontend/src/components/documents/DocumentsFilterBar.tsx
+++ b/frontend/src/components/documents/DocumentsFilterBar.tsx
@@ -1,12 +1,33 @@
 import { useTranslation } from "react-i18next";
 
 import type { TagSummary } from "@/api/generated/initiativeAPI.schemas";
+import { DocumentType } from "@/api/generated/initiativeAPI.schemas";
 import { ToolFilterPanel } from "@/components/initiativeTools/shared/ToolFilterPanel";
 import type { PropertyFilterCondition } from "@/components/properties/PropertyFilter";
 import { PropertyFilter } from "@/components/properties/PropertyFilter";
 import { TagPicker } from "@/components/tags/TagPicker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/** "All" is a sentinel: the underlying filters are absent, not a value. */
+export const ALL_DOCUMENT_TYPES = "all" as const;
+export type DocumentTypeFilter = DocumentType | typeof ALL_DOCUMENT_TYPES;
+
+/** Order the types are offered in — native first, since it's the common case. */
+const DOCUMENT_TYPE_OPTIONS = [
+  { value: DocumentType.native, labelKey: "page.typeNative" },
+  { value: DocumentType.file, labelKey: "page.typeFile" },
+  { value: DocumentType.whiteboard, labelKey: "page.typeWhiteboard" },
+  { value: DocumentType.spreadsheet, labelKey: "page.typeSpreadsheet" },
+  { value: DocumentType.smart_link, labelKey: "page.typeSmartLink" },
+] as const;
 
 export interface DocumentsFilterBarProps {
   searchQuery: string;
@@ -17,12 +38,15 @@ export interface DocumentsFilterBarProps {
   tagFilters: TagSummary[];
   onTagFiltersChange: (tags: TagSummary[]) => void;
   fixedTagIds?: number[];
+  documentTypeFilter: DocumentTypeFilter;
+  onDocumentTypeFilterChange: (value: DocumentTypeFilter) => void;
   propertyFilters: PropertyFilterCondition[];
   onPropertyFiltersChange: (next: PropertyFilterCondition[]) => void;
   /** How many filters are currently set — tells "Clear all" whether it has
    *  anything to do. */
   activeCount?: number;
-  /** Resets search, tags, and property conditions — offered in the sheet. */
+  /** Resets search, tags, type, and property conditions — offered in the
+   *  sheet. */
   onClear?: () => void;
 }
 
@@ -35,6 +59,8 @@ export const DocumentsFilterBar = ({
   tagFilters,
   onTagFiltersChange,
   fixedTagIds,
+  documentTypeFilter,
+  onDocumentTypeFilterChange,
   propertyFilters,
   onPropertyFiltersChange,
   onClear,
@@ -82,6 +108,30 @@ export const DocumentsFilterBar = ({
             />
           </div>
         )}
+        <div className="w-full space-y-2 sm:w-48">
+          <Label
+            htmlFor="document-type-filter"
+            className="block font-medium text-muted-foreground text-xs"
+          >
+            {t("page.filterByType")}
+          </Label>
+          <Select
+            value={documentTypeFilter}
+            onValueChange={(value) => onDocumentTypeFilterChange(value as DocumentTypeFilter)}
+          >
+            <SelectTrigger id="document-type-filter">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_DOCUMENT_TYPES}>{t("page.allTypes")}</SelectItem>
+              {DOCUMENT_TYPE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {t(option.labelKey)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
       <PropertyFilter value={propertyFilters} onChange={onPropertyFiltersChange} />
     </ToolFilterPanel>

--- a/frontend/src/components/documents/DocumentsListView.tsx
+++ b/frontend/src/components/documents/DocumentsListView.tsx
@@ -73,6 +73,9 @@ export interface DocumentsListViewProps {
   onPageChange: (updater: number | ((prev: number) => number)) => void;
   onPrefetchPage: (page: number) => void;
   onSortingChange: (sorting: SortingState) => void;
+  /** The sort the page restored, so the header agrees with the rows the
+   *  server already sorted. */
+  initialSorting?: SortingState;
 }
 
 export const DocumentsListView = ({
@@ -96,6 +99,7 @@ export const DocumentsListView = ({
   onPageChange,
   onPrefetchPage,
   onSortingChange,
+  initialSorting,
 }: DocumentsListViewProps) => {
   const { t } = useTranslation(["documents", "common"]);
 
@@ -273,6 +277,7 @@ export const DocumentsListView = ({
         }}
         onPrefetchPage={(pageIndex: number) => onPrefetchPage(pageIndex + 1)}
         manualSorting
+        initialSorting={initialSorting}
         onSortingChange={onSortingChange}
         enableResetSorting
         enableRowSelection

--- a/frontend/src/components/documents/DocumentsStatusFilter.tsx
+++ b/frontend/src/components/documents/DocumentsStatusFilter.tsx
@@ -1,0 +1,70 @@
+import { LayoutTemplate } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { TOOL_ICONS } from "@/lib/tools";
+
+export const DOCUMENT_STATUSES = ["documents", "templates"] as const;
+
+export type DocumentStatus = (typeof DOCUMENT_STATUSES)[number];
+
+export const isDocumentStatus = (value: unknown): value is DocumentStatus =>
+  typeof value === "string" && (DOCUMENT_STATUSES as readonly string[]).includes(value);
+
+const STATUS_ICONS = {
+  documents: TOOL_ICONS[Tool.document],
+  templates: LayoutTemplate,
+} as const;
+
+type DocumentsStatusFilterProps = {
+  value: DocumentStatus;
+  onChange: (value: DocumentStatus) => void;
+  /** Per-state totals; a state whose count hasn't loaded just shows no badge. */
+  counts?: Partial<Record<DocumentStatus, number | undefined>>;
+};
+
+/**
+ * Which documents the list is showing. Templates are a state of the same list
+ * rather than a separate destination — same cards, filters, and bulk actions —
+ * so this sits beside the list the way the projects list splits its own
+ * templates out, with both totals visible instead of hidden behind a menu.
+ */
+export const DocumentsStatusFilter = ({ value, onChange, counts }: DocumentsStatusFilterProps) => {
+  const { t } = useTranslation("documents");
+
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      // Radix clears a single-select group when the active item is clicked
+      // again; a list must always be showing one of the two states.
+      onValueChange={(next) => next && onChange(next as DocumentStatus)}
+      variant="outline"
+      aria-label={t("status.label")}
+      className="h-9 shrink-0 justify-start"
+    >
+      {DOCUMENT_STATUSES.map((status) => {
+        const Icon = STATUS_ICONS[status];
+        const count = counts?.[status];
+        return (
+          <ToggleGroupItem
+            key={status}
+            value={status}
+            // Below `sm` the label drops and the icon carries the meaning — the
+            // states plus their totals share the row with the filter, view, and
+            // overflow controls.
+            aria-label={t(`status.${status}` as const)}
+            className="h-9 shrink-0 gap-1.5 px-2.5 sm:gap-2 sm:px-3"
+          >
+            <Icon className="h-4 w-4" />
+            <span className="hidden sm:inline">{t(`status.${status}` as const)}</span>
+            {typeof count === "number" ? (
+              <span className="text-muted-foreground text-xs tabular-nums">{count}</span>
+            ) : null}
+          </ToggleGroupItem>
+        );
+      })}
+    </ToggleGroup>
+  );
+};

--- a/frontend/src/components/initiativeTools/shared/ToolListToolbar.test.tsx
+++ b/frontend/src/components/initiativeTools/shared/ToolListToolbar.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ToolListToolbar } from "./ToolListToolbar";
+
+describe("ToolListToolbar heading", () => {
+  it("keeps the heading on the control row, in a container that still wraps", () => {
+    render(
+      <ToolListToolbar
+        heading={<h2>Project tasks</h2>}
+        filters={{ open: false, onOpenChange: () => {}, activeCount: 0 }}
+      />
+    );
+
+    const heading = screen.getByRole("heading", { name: "Project tasks" });
+    const filterButton = screen.getByRole("button", { name: /filters/i });
+
+    // Same flex row: the heading's wrapper and the controls' group are siblings
+    // inside the toolbar, rather than the heading sitting on a line above it.
+    const row = heading.parentElement?.parentElement;
+    expect(row).toBe(filterButton.parentElement?.parentElement);
+    // Wrapping is what lets the controls drop to a second line when the row
+    // runs out of room instead of squeezing against the heading.
+    expect(row).toHaveClass("flex-wrap");
+  });
+
+  it("renders no heading container when the list has no heading", () => {
+    render(<ToolListToolbar filters={{ open: false, onOpenChange: () => {} }} />);
+
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/initiativeTools/shared/ToolListToolbar.tsx
+++ b/frontend/src/components/initiativeTools/shared/ToolListToolbar.tsx
@@ -20,6 +20,10 @@ export type ToolViewOption<V extends string> = {
 };
 
 type ToolListToolbarProps<V extends string> = {
+  /** The list's own heading, kept on the control row instead of a line of its
+   *  own above it. It shares the row's wrapping: when the two no longer fit,
+   *  the controls drop to a second line rather than squeezing against it. */
+  heading?: ReactNode;
   /** Leading control — the scope or status the list is showing. */
   leading?: ReactNode;
   /** Filter disclosure state, shared with the page's {@link ToolFilterPanel}.
@@ -58,6 +62,7 @@ type ToolListToolbarProps<V extends string> = {
  * keeps the row reachable forty cards into a scroll.
  */
 export const ToolListToolbar = <V extends string>({
+  heading,
   leading,
   filters,
   view,
@@ -75,6 +80,9 @@ export const ToolListToolbar = <V extends string>({
       className="sticky z-30 -mx-4 flex flex-wrap items-center gap-2 bg-background/90 px-4 py-2 backdrop-blur supports-backdrop-filter:bg-background/70 max-sm:border-b sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:backdrop-blur-none"
       style={{ top: "var(--safe-area-inset-top)" }}
     >
+      {/* Shrinkable and truncating, so a long title gives way to the controls
+          rather than pushing them off the row. */}
+      {heading ? <div className="min-w-0 shrink truncate">{heading}</div> : null}
       {/* Two different ways to run out of room. Below `sm` the controls are
           icon-only and the leading group claims no width of its own (basis-0),
           so it scrolls sideways and the row stays one line. From `sm` up the

--- a/frontend/src/components/projects/ProjectTasksSection.tsx
+++ b/frontend/src/components/projects/ProjectTasksSection.tsx
@@ -887,9 +887,8 @@ export const ProjectTasksSection = ({
   return (
     <div className="space-y-4">
       <Tabs value={viewMode} onValueChange={handleViewModeChange} className="space-y-4">
-        <h2 className="font-semibold text-xl">{t("tasks.projectTasks")}</h2>
-
         <ToolListToolbar
+          heading={<h2 className="truncate font-semibold text-xl">{t("tasks.projectTasks")}</h2>}
           filters={{
             open: filtersOpen,
             onOpenChange: setFiltersOpen,

--- a/frontend/src/components/projects/ProjectTasksTableView.tsx
+++ b/frontend/src/components/projects/ProjectTasksTableView.tsx
@@ -11,7 +11,7 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, MessageSquare } from "lucide-react";
 import type React from "react";
-import { createContext, memo, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, memo, useCallback, useContext, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import type { TaskListRead, TaskStatusRead } from "@/api/generated/initiativeAPI.schemas";
@@ -44,6 +44,7 @@ import {
 } from "@/components/ui/select";
 import { TableRow } from "@/components/ui/table";
 import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
+import { usePersistedTableState } from "@/hooks/usePersistedTableState";
 import { useProperties } from "@/hooks/useProperties";
 import { useGuildPath } from "@/lib/guildUrl";
 import { summarizeRecurrence } from "@/lib/recurrence";
@@ -530,11 +531,15 @@ const ProjectTasksTableViewComponent = ({
 
   const sortableItems = useMemo(() => tasks.map((task) => task.id.toString()), [tasks]);
 
-  // Track sorting/grouping state to know when DnD is possible.
-  // When either is active, we skip useSortable hooks entirely for performance.
-  const [hasSorting, setHasSorting] = useState(false);
-  const [grouping, setGrouping] = useState<string[]>([]);
-  const dndEnabled = canReorderTasks && !hasSorting && grouping.length === 0;
+  // How the reader left the table last time: which column it's grouped and
+  // sorted by, kept beside the column-visibility map above so the whole "how
+  // this list is shown" answer survives a reload together.
+  const tableStorageKey = `initiative-project-${projectId}-task-table`;
+  const [tableState, { setGrouping, setSorting }] = usePersistedTableState(tableStorageKey);
+  const { grouping, sorting } = tableState;
+  // Grouping and sorting each disable drag-to-reorder: a manual order can only
+  // be expressed by the table's own row order.
+  const dndEnabled = canReorderTasks && sorting.length === 0 && grouping.length === 0;
 
   // Grouping by tag means one row per (task, tag) pair — a task with three tags
   // belongs under all three, not under whichever one happens to come first.
@@ -543,12 +548,6 @@ const ProjectTasksTableViewComponent = ({
     () => (isTagGrouped ? fanOutTasksByTag(tasks, untaggedLabel) : tasks),
     [isTagGrouped, tasks, untaggedLabel]
   );
-
-  const handleSortingChange = useCallback(
-    (sorting: { id: string; desc: boolean }[]) => setHasSorting(sorting.length > 0),
-    []
-  );
-  const handleGroupingChange = useCallback((next: string[]) => setGrouping(next), []);
 
   // Selection reports rows; a tag-grouped task holds one row per tag, so
   // collapse them back to the tasks themselves.
@@ -582,6 +581,10 @@ const ProjectTasksTableViewComponent = ({
         strategy={verticalListSortingStrategy}
       >
         <DataTable
+          // The table seeds its grouping and sorting once, at mount. Moving
+          // between projects swaps which saved answer applies, so it has to be
+          // a fresh table rather than the previous project's.
+          key={tableStorageKey}
           columns={columnsWithProperties}
           data={rows}
           enableVirtualization
@@ -590,8 +593,8 @@ const ProjectTasksTableViewComponent = ({
           groupingOptions={groupingOptions}
           columnVisibility={effectiveColumnVisibility}
           onColumnVisibilityChange={setColumnVisibility}
-          onSortingChange={handleSortingChange}
-          onGroupingChange={handleGroupingChange}
+          onSortingChange={setSorting}
+          onGroupingChange={setGrouping}
           helpText={(table) => {
             const sorting = table.atoms.sorting?.get() ?? [];
             const grouping = table.atoms.grouping?.get() ?? [];
@@ -617,8 +620,9 @@ const ProjectTasksTableViewComponent = ({
               </div>
             ) : null;
           }}
+          initialSorting={sorting}
           initialState={{
-            // grouping: ["date group"],
+            grouping,
             expanded: true,
           }}
           rowWrapper={rowWrapper}

--- a/frontend/src/components/tasks/TagTasksTable.test.tsx
+++ b/frontend/src/components/tasks/TagTasksTable.test.tsx
@@ -1,0 +1,59 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { buildTask } from "@/__tests__/factories";
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { createTestQueryClient, renderPage } from "@/__tests__/helpers/render";
+
+import { TagTasksTable } from "./TagTasksTable";
+
+const TAG_ID = 7;
+
+/** Capture every tasks request so the sort the table asked for is visible. */
+function stubTasks() {
+  const requests: URLSearchParams[] = [];
+  server.use(
+    guildHttp.get("/tasks/", ({ request }) => {
+      requests.push(new URL(request.url).searchParams);
+      return HttpResponse.json({
+        items: [buildTask({ title: "Water the plants" })],
+        total_count: 1,
+        page: 1,
+        page_size: 20,
+        has_next: false,
+      });
+    })
+  );
+  return requests;
+}
+
+const renderTagTasks = () =>
+  renderPage(() => <TagTasksTable tagId={TAG_ID} />, { queryClient: createTestQueryClient() });
+
+const latest = (requests: URLSearchParams[]) => requests[requests.length - 1];
+const sortOf = (requests: URLSearchParams[]) => JSON.parse(latest(requests).get("sorting") ?? "[]");
+
+describe("TagTasksTable remembered sort", () => {
+  it("opens sorted by due date and remembers a different sort for the next visit", async () => {
+    const user = userEvent.setup();
+    const requests = stubTasks();
+    const first = renderTagTasks();
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(sortOf(requests)).toEqual([{ field: "due_date", dir: "asc" }]);
+
+    // The priority column header, not the "All priorities" filter beside it.
+    const priorityHeader = await screen.findByRole("columnheader", { name: /priority/i });
+    await user.click(within(priorityHeader).getByRole("button"));
+    await waitFor(() => expect(sortOf(requests)).toEqual([{ field: "priority", dir: "asc" }]));
+
+    first.unmount();
+    requests.length = 0;
+    renderTagTasks();
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(sortOf(requests)).toEqual([{ field: "priority", dir: "asc" }]);
+  });
+});

--- a/frontend/src/components/tasks/TagTasksTable.tsx
+++ b/frontend/src/components/tasks/TagTasksTable.tsx
@@ -30,6 +30,8 @@ import { DataTable } from "@/components/ui/data-table";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { useGuilds } from "@/hooks/useGuilds";
+import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
+import { usePersistedTableState } from "@/hooks/usePersistedTableState";
 import { usePrefetchTasks, useTasks, useUpdateTask } from "@/hooks/useTasks";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
@@ -64,6 +66,22 @@ const SORT_FIELD_MAP: Record<string, string> = {
   priority: "priority",
 };
 
+/** Table arrangement is per tag list, not per tag — every tag's task list is
+ *  the same list of the same columns. */
+const TABLE_STATE_KEY = "initiative-tag-tasks-table";
+const COLUMNS_KEY = "initiative-tag-tasks-columns";
+const DEFAULT_SORTING: SortingState = [{ id: "due date", desc: false }];
+
+/** The backend fields behind the table's own column sorting. */
+const toSortFields = (tableSorting: SortingState): SortField[] =>
+  tableSorting
+    .map((col) => {
+      const field = SORT_FIELD_MAP[col.id];
+      if (!field) return null;
+      return { field, dir: col.desc ? "desc" : "asc" } as SortField;
+    })
+    .filter((f): f is SortField => f !== null);
+
 export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
   const { t } = useTranslation("tasks");
   const { activeGuildId } = useGuilds();
@@ -85,7 +103,13 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
 
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
   const [pageSize, setPageSize] = useState(TAG_TASKS_PAGE_SIZE);
-  const [sorting, setSorting] = useState<SortField[]>([{ field: "due_date", dir: "asc" }]);
+  // How the reader left the table: which column it is sorted by, and which
+  // columns are showing. Both come back on the next visit.
+  const [tableState, { setSorting: persistSorting }] = usePersistedTableState(TABLE_STATE_KEY, {
+    sorting: DEFAULT_SORTING,
+  });
+  const [columnVisibility, setColumnVisibility] = usePersistedColumnVisibility(COLUMNS_KEY, []);
+  const sorting = useMemo(() => toSortFields(tableState.sorting), [tableState.sorting]);
 
   const statusOptions = useMemo(
     () => [
@@ -117,21 +141,10 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
 
   const handleSortingChange = useCallback(
     (tableSorting: SortingState) => {
-      if (tableSorting.length > 0) {
-        const fields: SortField[] = tableSorting
-          .map((col) => {
-            const field = SORT_FIELD_MAP[col.id];
-            if (!field) return null;
-            return { field, dir: col.desc ? "desc" : "asc" } as SortField;
-          })
-          .filter((f): f is SortField => f !== null);
-        setSorting(fields);
-      } else {
-        setSorting([]);
-      }
+      persistSorting(tableSorting);
       setPage(1);
     },
-    [setPage]
+    [persistSorting, setPage]
   );
 
   // Reset to page 1 when filters change
@@ -542,7 +555,9 @@ export const TagTasksTable = ({ tagId }: TagTasksTableProps) => {
           <DataTable
             columns={columns}
             data={tasks}
-            initialSorting={[{ id: "due date", desc: false }]}
+            initialSorting={tableState.sorting}
+            columnVisibility={columnVisibility}
+            onColumnVisibilityChange={setColumnVisibility}
             enableFilterInput
             filterInputColumnKey="title"
             filterInputPlaceholder={t("filters.filterPlaceholder")}

--- a/frontend/src/hooks/useGlobalTasksTable.ts
+++ b/frontend/src/hooks/useGlobalTasksTable.ts
@@ -87,6 +87,13 @@ const SORT_FIELD_MAP: Record<string, string> = {
   priority: "priority",
 };
 
+/** The same map read the other way, to seed the table's headers from the sort
+ *  the preferences restored — otherwise the rows come back sorted but the
+ *  header claims something else. */
+const SORT_COLUMN_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(SORT_FIELD_MAP).map(([columnId, field]) => [field, columnId])
+);
+
 export type MyTasksView = "assigned" | "created";
 
 interface UseGlobalTasksTableOptions {
@@ -185,6 +192,20 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
       });
     },
     [router]
+  );
+
+  // The table captures its seed at mount, so this is the sort as it stood when
+  // the preferences first resolved; every later change flows through
+  // handleSortingChange below.
+  const initialSorting = useMemo<SortingState>(
+    () =>
+      sorting
+        .map((entry) => {
+          const columnId = SORT_COLUMN_MAP[entry.field];
+          return columnId ? { id: columnId, desc: entry.dir === "desc" } : null;
+        })
+        .filter((entry): entry is SortingState[number] => entry !== null),
+    [sorting]
   );
 
   const handleSortingChange = useCallback(
@@ -441,6 +462,7 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
     totalCount,
 
     // Sorting
+    initialSorting,
     handleSortingChange,
 
     // Prefetching

--- a/frontend/src/hooks/useGlobalTasksTable.ts
+++ b/frontend/src/hooks/useGlobalTasksTable.ts
@@ -285,6 +285,11 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
     queryKey: getMyTasksQueryKey(tasksParams),
     queryFn: () => listMyTasks(tasksParams),
     placeholderData: keepPreviousData,
+    // Nothing is worth asking for until the saved filters and sort are in
+    // hand: a request built on the defaults would be thrown away the moment
+    // they arrive, and its rows would sit under the saved sort's headers in
+    // the meantime.
+    enabled: preferencesLoaded,
   });
 
   const prefetchPage = useCallback(

--- a/frontend/src/hooks/useGlobalTasksTable.ts
+++ b/frontend/src/hooks/useGlobalTasksTable.ts
@@ -125,10 +125,8 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
   );
 
   // --- Server-persisted filter + sort preferences ---
-  const [storedPrefsRaw, setStoredPrefs] = useViewPreference<StoredPrefs>(
-    storageKey,
-    FILTER_DEFAULTS
-  );
+  const [storedPrefsRaw, setStoredPrefs, { isLoaded: preferencesLoaded }] =
+    useViewPreference<StoredPrefs>(storageKey, FILTER_DEFAULTS);
   const storedPrefs = useMemo(() => sanitizeStoredPrefs(storedPrefsRaw), [storedPrefsRaw]);
   const { statusFilters, priorityFilters, guildFilters, propertyFilters, sorting } = storedPrefs;
 
@@ -194,9 +192,9 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
     [router]
   );
 
-  // The table captures its seed at mount, so this is the sort as it stood when
-  // the preferences first resolved; every later change flows through
-  // handleSortingChange below.
+  // The table captures its seed at mount, which is why the caller holds the
+  // table back until `preferencesLoaded` — mounting first would freeze the
+  // headers on the default sort while the rows came back in the saved one.
   const initialSorting = useMemo<SortingState>(
     () =>
       sorting
@@ -464,6 +462,9 @@ export function useGlobalTasksTable({ view, storageKeyPrefix }: UseGlobalTasksTa
     // Sorting
     initialSorting,
     handleSortingChange,
+
+    // False until the saved filters and sort have resolved.
+    preferencesLoaded,
 
     // Prefetching
     prefetchPage,

--- a/frontend/src/hooks/usePersistedTableState.test.tsx
+++ b/frontend/src/hooks/usePersistedTableState.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { DataTable } from "@/components/ui/data-table";
+import { usePersistedTableState } from "@/hooks/usePersistedTableState";
+import { getItem, setItem } from "@/lib/storage";
+
+const KEY = "test-table";
+
+type Row = { id: number; name: string; team: string };
+
+const data: Row[] = [
+  { id: 1, name: "b", team: "red" },
+  { id: 2, name: "a", team: "blue" },
+];
+
+const columns = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: ({ column }) => (
+      <button type="button" onClick={() => column.toggleSorting(false)}>
+        Name
+      </button>
+    ),
+    cell: ({ row }) => row.original.name,
+    enableSorting: true,
+  },
+  { id: "team", accessorKey: "team", header: "Team", cell: ({ row }) => row.original.team },
+] as never;
+
+/** Wired exactly the way a list wires it: stored state seeds, changes write. */
+function Harness({ storageKey = KEY }: { storageKey?: string }) {
+  const [tableState, { setGrouping, setSorting }] = usePersistedTableState(storageKey);
+  return (
+    <DataTable
+      key={storageKey}
+      columns={columns}
+      data={data}
+      enableFilterInput
+      groupingOptions={[{ id: "team", label: "Team" }]}
+      initialSorting={tableState.sorting}
+      initialState={{ grouping: tableState.grouping }}
+      onGroupingChange={setGrouping}
+      onSortingChange={setSorting}
+    />
+  );
+}
+
+const stored = () => JSON.parse(getItem(KEY) ?? "null");
+
+describe("usePersistedTableState", () => {
+  it("remembers a grouping choice across a remount", async () => {
+    const user = userEvent.setup();
+    const first = render(<Harness />);
+
+    await user.click(screen.getByRole("combobox", { name: /group by/i }));
+    await user.click(screen.getByRole("option", { name: "Team" }));
+    expect(stored().grouping).toEqual(["team"]);
+
+    first.unmount();
+    render(<Harness />);
+    expect(screen.getByRole("combobox", { name: /group by/i })).toHaveTextContent("Team");
+  });
+
+  it("remembers a sort choice across a remount", async () => {
+    const user = userEvent.setup();
+    const first = render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "Name" }));
+    expect(stored().sorting).toEqual([{ id: "name", desc: false }]);
+
+    first.unmount();
+    render(<Harness />);
+    // Ascending by name puts "a" first; unsorted, the source order leads with "b".
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("a");
+  });
+
+  it("clearing a choice clears what was stored", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("combobox", { name: /group by/i }));
+    await user.click(screen.getByRole("option", { name: "Team" }));
+    await user.click(screen.getByRole("combobox", { name: /group by/i }));
+    await user.click(screen.getByRole("option", { name: "None" }));
+
+    expect(stored().grouping).toEqual([]);
+  });
+
+  it("swaps to the new key's answer when the list changes what it is showing", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<Harness storageKey="table-a" />);
+
+    await user.click(screen.getByRole("combobox", { name: /group by/i }));
+    await user.click(screen.getByRole("option", { name: "Team" }));
+
+    // A sibling list with nothing saved must not inherit this one's grouping.
+    rerender(<Harness storageKey="table-b" />);
+    expect(screen.getByRole("combobox", { name: /group by/i })).toHaveTextContent("None");
+
+    rerender(<Harness storageKey="table-a" />);
+    expect(screen.getByRole("combobox", { name: /group by/i })).toHaveTextContent("Team");
+  });
+
+  it("falls back to no grouping or sorting when the stored blob is unusable", () => {
+    setItem(KEY, "{ not json");
+    render(<Harness />);
+
+    expect(screen.getByRole("combobox", { name: /group by/i })).toHaveTextContent("None");
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("b");
+  });
+});

--- a/frontend/src/hooks/usePersistedTableState.ts
+++ b/frontend/src/hooks/usePersistedTableState.ts
@@ -1,0 +1,123 @@
+import type { GroupingState, SortingState } from "@tanstack/react-table";
+import { useCallback, useRef, useState } from "react";
+
+import { getItem, setItem } from "@/lib/storage";
+
+/**
+ * The parts of a DataTable's state that are the reader's own choices about how
+ * a list is shown, rather than what it holds. Column visibility is the third
+ * such choice and has its own hook ({@link usePersistedColumnVisibility}),
+ * which predates this one and keeps its own storage key.
+ */
+export type PersistedTableState = {
+  grouping: GroupingState;
+  sorting: SortingState;
+};
+
+const EMPTY: PersistedTableState = { grouping: [], sorting: [] };
+
+/**
+ * DataTable ``grouping`` and ``sorting`` persisted to our @/lib/storage wrapper
+ * (localStorage on web, Capacitor Preferences on native, always synchronous —
+ * which is what lets the stored value seed the table on its very first render,
+ * where DataTable captures `initialSorting`/`initialState.grouping`).
+ *
+ * Feed the returned state back as those two seeds and write to it from
+ * ``onGroupingChange``/``onSortingChange``:
+ *
+ * ```tsx
+ * const [tableState, { setGrouping, setSorting }] = usePersistedTableState(key);
+ * <DataTable
+ *   initialSorting={tableState.sorting}
+ *   initialState={{ grouping: tableState.grouping }}
+ *   onGroupingChange={setGrouping}
+ *   onSortingChange={setSorting}
+ * />
+ * ```
+ *
+ * ``defaults`` cover the first visit only — once anything is stored, that blob
+ * is the whole answer, so a reader who deliberately cleared the sorting gets an
+ * unsorted table back rather than the default returning behind them.
+ *
+ * A table whose sorting is owned elsewhere (a server-persisted preference, say)
+ * can use the grouping half alone and leave ``onSortingChange`` to that owner.
+ *
+ * Ids are stored as written. An id that no longer matches a column is simply
+ * ignored by TanStack, and starts applying again if that column comes back —
+ * so a column that loads late (a property definition, say) keeps its sort.
+ */
+export function usePersistedTableState(
+  storageKey: string,
+  defaults?: Partial<PersistedTableState>
+): [
+  PersistedTableState,
+  { setGrouping: (next: GroupingState) => void; setSorting: (next: SortingState) => void },
+] {
+  // Captured once: a caller that rebuilds the object every render must not
+  // reset a table that has since been stored.
+  const defaultsRef = useRef(defaults);
+  const [state, setState] = useState<PersistedTableState>(() =>
+    readStored(storageKey, defaultsRef.current)
+  );
+  // A list that swaps which thing it is showing (one project to the next)
+  // swaps storage keys without remounting, and must not carry the previous
+  // one's answer over. Re-read during render rather than in an effect, so the
+  // first render under the new key already has the right seed.
+  const [activeKey, setActiveKey] = useState(storageKey);
+  if (activeKey !== storageKey) {
+    setActiveKey(storageKey);
+    setState(readStored(storageKey, defaultsRef.current));
+  }
+
+  const write = useCallback(
+    (patch: Partial<PersistedTableState>) => {
+      setState((prev) => {
+        const next = { ...prev, ...patch };
+        try {
+          setItem(storageKey, JSON.stringify(next));
+        } catch {
+          // Quota errors, malformed storage — persistence is best-effort.
+        }
+        return next;
+      });
+    },
+    [storageKey]
+  );
+
+  const setGrouping = useCallback((next: GroupingState) => write({ grouping: next }), [write]);
+  const setSorting = useCallback((next: SortingState) => write({ sorting: next }), [write]);
+
+  return [state, { setGrouping, setSorting }];
+}
+
+const readStored = (
+  storageKey: string,
+  defaults?: Partial<PersistedTableState>
+): PersistedTableState => {
+  const fallback: PersistedTableState = { ...EMPTY, ...defaults };
+  const raw = getItem(storageKey);
+  if (!raw) return fallback;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return fallback;
+    const { grouping, sorting } = parsed as Partial<PersistedTableState>;
+    return {
+      // A missing half (a table that only ever writes one) keeps its default;
+      // an explicitly empty one is a real answer and stays empty.
+      grouping: Array.isArray(grouping)
+        ? grouping.filter((id) => typeof id === "string")
+        : fallback.grouping,
+      sorting: Array.isArray(sorting)
+        ? sorting.filter(
+            (entry): entry is SortingState[number] =>
+              entry !== null &&
+              typeof entry === "object" &&
+              typeof (entry as SortingState[number]).id === "string" &&
+              typeof (entry as SortingState[number]).desc === "boolean"
+          )
+        : fallback.sorting,
+    };
+  } catch {
+    return fallback;
+  }
+};

--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -1,0 +1,152 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { buildDocumentSummary } from "@/__tests__/factories";
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { createTestQueryClient, renderPage } from "@/__tests__/helpers/render";
+import type { DocumentSummary } from "@/api/generated/initiativeAPI.schemas";
+import { VIEW_PREFERENCES_QUERY_KEY } from "@/hooks/useViewPreference";
+
+import { DocumentsView } from "./DocumentsPage";
+
+const INITIATIVE_ID = 1;
+
+/**
+ * Render in list view: the tags view routes its tag filtering through the tree
+ * sidebar, and the type select plus the documents/templates toggle are what
+ * these tests drive.
+ */
+function renderDocuments() {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(VIEW_PREFERENCES_QUERY_KEY, {
+    items: { "documents:view-mode": "list" },
+  });
+  const Page = () => <DocumentsView fixedInitiativeId={INITIATIVE_ID} canCreate={false} />;
+  return renderPage(Page, { queryClient });
+}
+
+/** Capture every documents list request and serve `items` back. */
+function stubDocuments(items: DocumentSummary[] = []) {
+  const requests: URLSearchParams[] = [];
+  server.use(
+    guildHttp.get("/documents/", ({ request }) => {
+      requests.push(new URL(request.url).searchParams);
+      return HttpResponse.json({
+        items,
+        total_count: items.length,
+        page: 1,
+        page_size: 20,
+        has_next: false,
+        sort_by: null,
+        sort_dir: null,
+      });
+    }),
+    guildHttp.get("/documents/counts", ({ request }) => {
+      const params = new URL(request.url).searchParams;
+      return HttpResponse.json({
+        // Distinct totals so the toggle's two badges are told apart.
+        total_count: params.get("is_template") === "true" ? 2 : 7,
+        untagged_count: 0,
+        tag_counts: {},
+      });
+    })
+  );
+  return requests;
+}
+
+const latest = (requests: URLSearchParams[]) => requests[requests.length - 1];
+
+describe("DocumentsView document type filter", () => {
+  it("omits the type filter until one is chosen", async () => {
+    const requests = stubDocuments();
+    renderDocuments();
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(latest(requests).get("document_type")).toBeNull();
+  });
+
+  it("narrows the query by document type", async () => {
+    const user = userEvent.setup();
+    const requests = stubDocuments();
+    renderDocuments();
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+
+    await user.click(await screen.findByRole("button", { name: /filters/i }));
+    await user.click(screen.getByRole("combobox", { name: /filter by type/i }));
+    await user.click(screen.getByRole("option", { name: "Whiteboard" }));
+
+    await waitFor(() => expect(latest(requests).get("document_type")).toBe("whiteboard"));
+    // The type filter narrows within the state being shown, not across it.
+    expect(latest(requests).get("is_template")).toBe("false");
+    expect(
+      await screen.findByRole("button", { name: /filters \(1 active\)/i })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }));
+    await waitFor(() => expect(latest(requests).get("document_type")).toBeNull());
+  });
+});
+
+describe("DocumentsView remembered sort", () => {
+  it("opens newest-first and remembers a different sort for the next visit", async () => {
+    const user = userEvent.setup();
+    // The table only renders once the list has something in it.
+    const requests = stubDocuments([buildDocumentSummary({ initiative_id: INITIATIVE_ID })]);
+    const first = renderDocuments();
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(latest(requests).get("sort_by")).toBe("updated_at");
+    expect(latest(requests).get("sort_dir")).toBe("desc");
+
+    await user.click(await screen.findByRole("button", { name: /title/i }));
+    await waitFor(() => expect(latest(requests).get("sort_by")).toBe("name"));
+    expect(latest(requests).get("sort_dir")).toBe("asc");
+
+    // The next visit asks the server for the same order it was left in.
+    first.unmount();
+    requests.length = 0;
+    renderDocuments();
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(latest(requests).get("sort_by")).toBe("name");
+    expect(latest(requests).get("sort_dir")).toBe("asc");
+  });
+});
+
+describe("DocumentsView documents/templates states", () => {
+  it("lists documents by default and templates when toggled", async () => {
+    const user = userEvent.setup();
+    const requests = stubDocuments();
+    renderDocuments();
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(latest(requests).get("is_template")).toBe("false");
+
+    await user.click(await screen.findByRole("radio", { name: "Templates" }));
+    await waitFor(() => expect(latest(requests).get("is_template")).toBe("true"));
+
+    await user.click(screen.getByRole("radio", { name: "Documents" }));
+    await waitFor(() => expect(latest(requests).get("is_template")).toBe("false"));
+  });
+
+  it("badges each state with its own total", async () => {
+    stubDocuments();
+    renderDocuments();
+
+    expect(await screen.findByRole("radio", { name: "Documents" })).toHaveTextContent("7");
+    expect(await screen.findByRole("radio", { name: "Templates" })).toHaveTextContent("2");
+  });
+
+  it("offers no create action in the empty templates state", async () => {
+    const user = userEvent.setup();
+    stubDocuments();
+    renderDocuments();
+
+    await user.click(await screen.findByRole("radio", { name: "Templates" }));
+
+    expect(await screen.findByText("No templates yet")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Start writing" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -224,6 +224,14 @@ export const DocumentsView = ({
     [router]
   );
 
+  // The cursor lives in the URL as well as in state, so a history move (Back
+  // out of the templates view, say) has to carry the list with it — otherwise
+  // the address names one page while the list shows another.
+  useEffect(() => {
+    const urlPage = searchParams.page ?? 1;
+    setPageState((prev) => (prev === urlPage ? prev : urlPage));
+  }, [searchParams.page]);
+
   const handlePageSizeChange = useCallback(
     (size: number) => {
       setPageSizeState(size);

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -207,6 +207,9 @@ export const DocumentsView = ({
 
   const setStatus = useCallback(
     (next: DocumentStatus) => {
+      // Pushed, not replaced: switching between documents and templates is a
+      // move the reader made, so Back has to take them out of it. (Paging
+      // replaces, because a cursor is not somewhere you went.)
       void router.navigate({
         to: ".",
         search: {
@@ -215,7 +218,6 @@ export const DocumentsView = ({
           // The other state's cursor means nothing in this one.
           page: undefined,
         },
-        replace: true,
       });
       setPageState(1);
     },

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -18,8 +18,17 @@ import { BulkEditTagsDialog } from "@/components/documents/BulkEditTagsDialog";
 import { CreateDocumentDialog } from "@/components/documents/CreateDocumentDialog";
 import { DocumentCard } from "@/components/documents/DocumentCard";
 import { DocumentsBulkBar } from "@/components/documents/DocumentsBulkBar";
-import { DocumentsFilterBar } from "@/components/documents/DocumentsFilterBar";
+import {
+  ALL_DOCUMENT_TYPES,
+  DocumentsFilterBar,
+  type DocumentTypeFilter,
+} from "@/components/documents/DocumentsFilterBar";
 import { DocumentsListView } from "@/components/documents/DocumentsListView";
+import {
+  type DocumentStatus,
+  DocumentsStatusFilter,
+  isDocumentStatus,
+} from "@/components/documents/DocumentsStatusFilter";
 import { DocumentsTagsView } from "@/components/documents/DocumentsTagsView";
 import { PaginationBar } from "@/components/documents/PaginationBar";
 import { ToolImportAction, useToolImportAction } from "@/components/imports/ToolImportAction";
@@ -43,6 +52,7 @@ import {
 } from "@/hooks/useDocuments";
 import { useInitiativeAccess, useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
+import { usePersistedTableState } from "@/hooks/usePersistedTableState";
 import { useTags } from "@/hooks/useTags";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { useGuildPath } from "@/lib/guildUrl";
@@ -58,6 +68,11 @@ const SORT_FIELD_MAP: Record<string, string> = {
   "last updated": "updated_at",
 };
 const DOCUMENT_TAG_FILTERS_KEY = "documents:tag-filters";
+/** Table arrangement (which column the list is sorted by) — one answer for the
+ *  documents list, alongside the column-visibility map the table already keeps. */
+const DOCUMENT_TABLE_STATE_KEY = "initiative-documents-table";
+/** Newest first, the way the list has always opened. */
+const DEFAULT_SORTING: SortingState = [{ id: "last updated", desc: true }];
 
 type DocumentsViewProps = {
   fixedInitiativeId?: number;
@@ -81,6 +96,7 @@ export const DocumentsView = ({
   const searchParams = useSearch({ strict: false }) as {
     create?: string;
     page?: number;
+    status?: string;
   };
   // The initiative comes from the path. It is absent only on the tag browse,
   // which is deliberately cross-initiative.
@@ -139,10 +155,37 @@ export const DocumentsView = ({
 
   const [propertyFilters, setPropertyFilters] = useState<PropertyFilterCondition[]>([]);
 
+  // Session-scoped like the property conditions above: a persisted type filter
+  // would hide most of the list on the next visit with no obvious cause.
+  const [documentTypeFilter, setDocumentTypeFilter] =
+    useState<DocumentTypeFilter>(ALL_DOCUMENT_TYPES);
+  const queryDocumentType =
+    documentTypeFilter === ALL_DOCUMENT_TYPES ? undefined : documentTypeFilter;
+
+  // Documents and templates are two states of one list, the way the projects
+  // list splits its own templates out. It lives in the URL so a templates view
+  // is linkable and answers the back button; the cross-initiative tag browse
+  // only ever reads documents, so it pins the value and hides the control.
+  const status: DocumentStatus =
+    !fixedTagIds && isDocumentStatus(searchParams.status) ? searchParams.status : "documents";
+  const isTemplateView = status === "templates";
+
   const [page, setPageState] = useState(() => searchParams.page ?? 1);
   const [pageSize, setPageSizeState] = useState(20);
-  const [sortBy, setSortBy] = useState<string | undefined>("updated_at");
-  const [sortDir, setSortDir] = useState<string | undefined>("desc");
+
+  // The sort is the reader's, so it outlives the visit. Held in the table's own
+  // column vocabulary and mapped to backend fields for the query, so the header
+  // and the rows can't disagree after a reload.
+  const [tableState, { setSorting: persistSorting }] = usePersistedTableState(
+    DOCUMENT_TABLE_STATE_KEY,
+    { sorting: DEFAULT_SORTING }
+  );
+  const [sortBy, sortDir] = useMemo(() => {
+    const first = tableState.sorting[0];
+    const field = first ? SORT_FIELD_MAP[first.id] : undefined;
+    if (!first || !field) return [undefined, undefined] as const;
+    return [field, first.desc ? "desc" : "asc"] as const;
+  }, [tableState.sorting]);
 
   const setPage = useCallback(
     (updater: number | ((prev: number) => number)) => {
@@ -162,6 +205,23 @@ export const DocumentsView = ({
     [router]
   );
 
+  const setStatus = useCallback(
+    (next: DocumentStatus) => {
+      void router.navigate({
+        to: ".",
+        search: {
+          ...searchParamsRef.current,
+          status: next === "documents" ? undefined : next,
+          // The other state's cursor means nothing in this one.
+          page: undefined,
+        },
+        replace: true,
+      });
+      setPageState(1);
+    },
+    [router]
+  );
+
   const handlePageSizeChange = useCallback(
     (size: number) => {
       setPageSizeState(size);
@@ -172,23 +232,10 @@ export const DocumentsView = ({
 
   const handleSortingChange = useCallback(
     (sorting: SortingState) => {
-      if (sorting.length > 0) {
-        const col = sorting[0];
-        const field = SORT_FIELD_MAP[col.id];
-        if (field) {
-          setSortBy(field);
-          setSortDir(col.desc ? "desc" : "asc");
-        } else {
-          setSortBy(undefined);
-          setSortDir(undefined);
-        }
-      } else {
-        setSortBy(undefined);
-        setSortDir(undefined);
-      }
+      persistSorting(sorting);
       setPage(1);
     },
-    [setPage]
+    [persistSorting, setPage]
   );
 
   const { data: allTags = [] } = useTags();
@@ -262,12 +309,21 @@ export const DocumentsView = ({
   // In tags view: use tree-derived tag IDs; in other views: use filter bar tag IDs
   const queryTagIds = viewMode === "tags" ? treeTagIds : effectiveTagFilters;
 
-  // Reset to page 1 when filters or view mode change
-  const _queryTagIdsKey = JSON.stringify(queryTagIds);
+  // Reset to page 1 when filters or view mode change — a narrower list can
+  // have fewer pages than the one currently shown.
+  const queryTagIdsKey = JSON.stringify(queryTagIds);
   const propertyFiltersKey = JSON.stringify(propertyFilters);
   useEffect(() => {
     setPage(1);
-  }, [setPage]);
+  }, [
+    setPage,
+    searchQuery,
+    queryTagIdsKey,
+    propertyFiltersKey,
+    treeWantsUntagged,
+    documentTypeFilter,
+    viewMode,
+  ]);
 
   // Serialize property filters for the backend query string. The backend
   // expects a JSON-encoded array on ``property_filters`` and we pre-encode
@@ -281,6 +337,8 @@ export const DocumentsView = ({
     ...(queryTagIds.length > 0 ? { tag_ids: queryTagIds } : {}),
     ...(treeWantsUntagged ? { untagged: true } : {}),
     ...(encodedPropertyFilters ? { property_filters: encodedPropertyFilters } : {}),
+    ...(queryDocumentType ? { document_type: queryDocumentType } : {}),
+    is_template: isTemplateView,
     page,
     page_size: pageSize,
     ...(sortBy ? { sort_by: sortBy } : {}),
@@ -293,9 +351,29 @@ export const DocumentsView = ({
   const countsQueryParams = {
     ...(lockedInitiativeId ? { initiative_id: lockedInitiativeId } : {}),
     ...(searchQuery.trim() ? { search: searchQuery.trim() } : {}),
+    ...(queryDocumentType ? { document_type: queryDocumentType } : {}),
+    is_template: isTemplateView,
   };
 
   const countsQuery = useDocumentCounts(countsQueryParams, { enabled: viewMode === "tags" });
+
+  // Totals behind each state, so the toggle says how much sits in the other one
+  // before it is opened. Scoped to the initiative only — like the projects
+  // list's status counts, these answer "how many exist", not "how many survive
+  // the current filters". The tag browse hides the toggle, so it skips them.
+  const statusCountsBase = lockedInitiativeId ? { initiative_id: lockedInitiativeId } : {};
+  const documentsCountQuery = useDocumentCounts(
+    { ...statusCountsBase, is_template: false },
+    { enabled: !fixedTagIds }
+  );
+  const templatesCountQuery = useDocumentCounts(
+    { ...statusCountsBase, is_template: true },
+    { enabled: !fixedTagIds }
+  );
+  const statusCounts = {
+    documents: documentsCountQuery.data?.total_count,
+    templates: templatesCountQuery.data?.total_count,
+  };
 
   // Prefetch adjacent page on hover
   const prefetchPage = useCallback(
@@ -307,6 +385,8 @@ export const DocumentsView = ({
         ...(queryTagIds.length > 0 ? { tag_ids: queryTagIds } : {}),
         ...(treeWantsUntagged ? { untagged: true } : {}),
         ...(encodedPropertyFilters ? { property_filters: encodedPropertyFilters } : {}),
+        ...(queryDocumentType ? { document_type: queryDocumentType } : {}),
+        is_template: isTemplateView,
         page: targetPage,
         page_size: pageSize,
         ...(sortBy ? { sort_by: sortBy } : {}),
@@ -320,6 +400,8 @@ export const DocumentsView = ({
       queryTagIds,
       treeWantsUntagged,
       encodedPropertyFilters,
+      queryDocumentType,
+      isTemplateView,
       pageSize,
       sortBy,
       sortDir,
@@ -365,12 +447,13 @@ export const DocumentsView = ({
     setCardSelectionActive(false);
     setSelectedDocuments([]);
   }, []);
-  // Switching views must not strand a hidden selection behind another view's
-  // bulk actions — every view change starts unselected.
+  // Switching views (or between documents and templates) must not strand a
+  // hidden selection behind another view's bulk actions — every change starts
+  // unselected.
   useEffect(() => {
     setCardSelectionActive(false);
     setSelectedDocuments([]);
-  }, [viewMode]);
+  }, [viewMode, status]);
 
   // Check if user owns all selected documents (required for delete)
   const canDeleteSelectedDocuments = useMemo(() => {
@@ -438,12 +521,14 @@ export const DocumentsView = ({
   const activeFilterCount =
     (searchQuery.trim() ? 1 : 0) +
     (fixedTagIds || viewMode === "tags" ? 0 : tagFilters.length) +
+    (queryDocumentType ? 1 : 0) +
     propertyFilters.length;
 
   const clearFilters = useCallback(() => {
     setSearchQuery("");
     setTagFilters([]);
     setPropertyFilters([]);
+    setDocumentTypeFilter(ALL_DOCUMENT_TYPES);
   }, [setTagFilters]);
 
   // Drive the app-wide bottom-nav add button for this route.
@@ -521,6 +606,13 @@ export const DocumentsView = ({
       )}
 
       <ToolListToolbar
+        leading={
+          // The tag browse reads documents across initiatives and has no
+          // templates state to offer.
+          fixedTagIds ? undefined : (
+            <DocumentsStatusFilter value={status} onChange={setStatus} counts={statusCounts} />
+          )
+        }
         filters={{
           open: filtersOpen,
           onOpenChange: setFiltersOpen,
@@ -569,6 +661,8 @@ export const DocumentsView = ({
         tagFilters={selectedTagsForFilter}
         onTagFiltersChange={handleTagFiltersChange}
         fixedTagIds={fixedTagIds}
+        documentTypeFilter={documentTypeFilter}
+        onDocumentTypeFilterChange={setDocumentTypeFilter}
         propertyFilters={propertyFilters}
         onPropertyFiltersChange={setPropertyFilters}
         onClear={clearFilters}
@@ -702,8 +796,18 @@ export const DocumentsView = ({
             onPageChange={setPage}
             onPrefetchPage={prefetchPage}
             onSortingChange={handleSortingChange}
+            initialSorting={tableState.sorting}
           />
         )
+      ) : isTemplateView ? (
+        // A template is made by marking an existing document as one, so this
+        // state has no create action of its own to offer.
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("page.noTemplatesTitle")}</CardTitle>
+            <CardDescription>{t("page.noTemplatesDescription")}</CardDescription>
+          </CardHeader>
+        </Card>
       ) : (
         <Card>
           <CardHeader>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -74,7 +74,6 @@ export const ProjectsView = ({ fixedInitiativeId, fixedTagIds, canCreate }: Proj
       void router.navigate({
         to: ".",
         search: { ...search, status: next === "active" ? undefined : next },
-        replace: true,
       });
     },
     [router, search]

--- a/frontend/src/pages/user/GlobalTasksPage.tsx
+++ b/frontend/src/pages/user/GlobalTasksPage.tsx
@@ -248,7 +248,11 @@ export const GlobalTasksPage = ({
                   </div>
                 </div>
               ) : null}
-              {table.isInitialLoad ? (
+              {/* The saved sort has to be in hand before the table mounts: it
+                  seeds its headers once, so a table built on the defaults would
+                  keep claiming them while the rows came back in the saved
+                  order. The filters resolve from the same request. */}
+              {table.isInitialLoad || !table.preferencesLoaded ? (
                 <div className="flex items-center justify-center py-12">
                   <Loader2 className="h-8 w-8 animate-spin" />
                 </div>

--- a/frontend/src/pages/user/GlobalTasksPage.tsx
+++ b/frontend/src/pages/user/GlobalTasksPage.tsx
@@ -27,6 +27,7 @@ import { useFocusSummary } from "@/hooks/useFocusSummary";
 import { type MyTasksView, useGlobalTasksTable } from "@/hooks/useGlobalTasksTable";
 import { useGuilds } from "@/hooks/useGuilds";
 import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
+import { usePersistedTableState } from "@/hooks/usePersistedTableState";
 import { useProperties } from "@/hooks/useProperties";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { guildPath, useGuildPath } from "@/lib/guildUrl";
@@ -95,6 +96,13 @@ export const GlobalTasksPage = ({
   const [columnVisibility, setColumnVisibility] = usePersistedColumnVisibility(
     columnsStorageKey,
     propertyHiddenIds
+  );
+  // Grouping is the reader's own arrangement, so it outlives the visit. Sorting
+  // rides along with this list's other preferences (see useGlobalTasksTable),
+  // which is why only the grouping half is kept here.
+  const [tableState, { setGrouping }] = usePersistedTableState(
+    `initiative-${storageKeyPrefix}-table`,
+    { grouping: ["date group"] }
   );
   // Seed the two existing hidden-by-default columns from this page only on
   // first-ever render; after that, persisted state governs everything.
@@ -255,14 +263,12 @@ export const GlobalTasksPage = ({
                   groupingOptions={groupingOptions}
                   columnVisibility={effectiveColumnVisibility}
                   onColumnVisibilityChange={setColumnVisibility}
+                  onGroupingChange={setGrouping}
                   initialState={{
-                    grouping: ["date group"],
+                    grouping: tableState.grouping,
                     expanded: true,
                   }}
-                  initialSorting={[
-                    { id: "date group", desc: false },
-                    { id: "due date", desc: false },
-                  ]}
+                  initialSorting={table.initialSorting}
                   enableFilterInput
                   filterInputColumnKey="title"
                   filterInputPlaceholder={t("filters.filterPlaceholder")}

--- a/frontend/src/pages/user/MyTasksPage.test.tsx
+++ b/frontend/src/pages/user/MyTasksPage.test.tsx
@@ -12,17 +12,20 @@ import { MyTasksPage } from "./MyTasksPage";
 
 /** Serve one page of assigned tasks; the list has to be non-empty to render. */
 function stubTasks() {
+  const requests: URLSearchParams[] = [];
   server.use(
-    http.get("/api/v1/me/tasks", () =>
-      HttpResponse.json({
+    http.get("/api/v1/me/tasks", ({ request }) => {
+      requests.push(new URL(request.url).searchParams);
+      return HttpResponse.json({
         items: [buildTask({ title: "Write the thing" })],
         total_count: 1,
         page: 1,
         page_size: 20,
         has_next: false,
-      })
-    )
+      });
+    })
   );
+  return requests;
 }
 
 function renderMyTasks() {
@@ -44,16 +47,23 @@ function stubPreferences(prefs: unknown, { delayMs = 0 } = {}) {
 
 const groupSelect = () => screen.getByRole("combobox", { name: /group by/i });
 
+/** The table's own requests. The focus summary reads the same endpoint with a
+ *  page size of its own, and asks for its own "due soonest" order. */
+const tableRequests = (requests: URLSearchParams[]) =>
+  requests.filter((params) => params.get("page_size") === "20");
+
 describe("MyTasksPage saved sort", () => {
-  it("waits for the saved sort before mounting the table", async () => {
-    stubTasks();
+  it("waits for the saved sort before asking for rows or mounting the table", async () => {
+    const requests = stubTasks();
     // Preferences land after the tasks request, which is the case that used to
     // freeze the headers on the default sort.
     stubPreferences({ sorting: [{ field: "priority", dir: "desc" }] }, { delayMs: 50 });
     renderPage(MyTasksPage, { queryClient: createTestQueryClient() });
 
-    // Nothing is drawn on the defaults in the meantime.
+    // Nothing is drawn on the defaults in the meantime, and nothing is asked
+    // for in them either.
     expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
+    expect(tableRequests(requests)).toHaveLength(0);
 
     // Once the saved sort is in hand the table mounts seeded with it — the
     // header carries a direction arrow rather than the unsorted glyph, so it
@@ -61,6 +71,13 @@ describe("MyTasksPage saved sort", () => {
     const priorityHeader = await screen.findByRole("columnheader", { name: /priority/i });
     const icon = within(priorityHeader).getByRole("button").querySelector("svg");
     expect(icon).toHaveClass("lucide-arrow-down");
+
+    // And the rows under them were fetched in that order — one request, in the
+    // saved sort, rather than the default sort followed by a throwaway refetch.
+    expect(tableRequests(requests)).toHaveLength(1);
+    expect(JSON.parse(tableRequests(requests)[0].get("sorting") ?? "[]")).toEqual([
+      { field: "priority", dir: "desc" },
+    ]);
   });
 });
 

--- a/frontend/src/pages/user/MyTasksPage.test.tsx
+++ b/frontend/src/pages/user/MyTasksPage.test.tsx
@@ -1,6 +1,6 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { HttpResponse, http } from "msw";
+import { delay, HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { buildTask } from "@/__tests__/factories";
@@ -32,7 +32,37 @@ function renderMyTasks() {
   return renderPage(MyTasksPage, { queryClient });
 }
 
+/** Serve saved preferences, optionally after the tasks request has resolved. */
+function stubPreferences(prefs: unknown, { delayMs = 0 } = {}) {
+  server.use(
+    http.get("/api/v1/user-view-preferences", async () => {
+      if (delayMs > 0) await delay(delayMs);
+      return HttpResponse.json({ items: { "initiative-my-tasks-filters": prefs } });
+    })
+  );
+}
+
 const groupSelect = () => screen.getByRole("combobox", { name: /group by/i });
+
+describe("MyTasksPage saved sort", () => {
+  it("waits for the saved sort before mounting the table", async () => {
+    stubTasks();
+    // Preferences land after the tasks request, which is the case that used to
+    // freeze the headers on the default sort.
+    stubPreferences({ sorting: [{ field: "priority", dir: "desc" }] }, { delayMs: 50 });
+    renderPage(MyTasksPage, { queryClient: createTestQueryClient() });
+
+    // Nothing is drawn on the defaults in the meantime.
+    expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
+
+    // Once the saved sort is in hand the table mounts seeded with it — the
+    // header carries a direction arrow rather than the unsorted glyph, so it
+    // agrees with the order the rows came back in.
+    const priorityHeader = await screen.findByRole("columnheader", { name: /priority/i });
+    const icon = within(priorityHeader).getByRole("button").querySelector("svg");
+    expect(icon).toHaveClass("lucide-arrow-down");
+  });
+});
 
 describe("MyTasksPage grouping", () => {
   it("remembers the grouping choice for the next visit", async () => {

--- a/frontend/src/pages/user/MyTasksPage.test.tsx
+++ b/frontend/src/pages/user/MyTasksPage.test.tsx
@@ -1,0 +1,54 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { buildTask } from "@/__tests__/factories";
+import { server } from "@/__tests__/helpers/msw-server";
+import { createTestQueryClient, renderPage } from "@/__tests__/helpers/render";
+import { VIEW_PREFERENCES_QUERY_KEY } from "@/hooks/useViewPreference";
+
+import { MyTasksPage } from "./MyTasksPage";
+
+/** Serve one page of assigned tasks; the list has to be non-empty to render. */
+function stubTasks() {
+  server.use(
+    http.get("/api/v1/me/tasks", () =>
+      HttpResponse.json({
+        items: [buildTask({ title: "Write the thing" })],
+        total_count: 1,
+        page: 1,
+        page_size: 20,
+        has_next: false,
+      })
+    )
+  );
+}
+
+function renderMyTasks() {
+  const queryClient = createTestQueryClient();
+  // Skip the preferences fetch so the table mounts with its defaults.
+  queryClient.setQueryData(VIEW_PREFERENCES_QUERY_KEY, { items: {} });
+  return renderPage(MyTasksPage, { queryClient });
+}
+
+const groupSelect = () => screen.getByRole("combobox", { name: /group by/i });
+
+describe("MyTasksPage grouping", () => {
+  it("remembers the grouping choice for the next visit", async () => {
+    const user = userEvent.setup();
+    stubTasks();
+    const first = renderMyTasks();
+
+    // Opens grouped by date window, as it always has.
+    await waitFor(() => expect(groupSelect()).toHaveTextContent(/date/i));
+
+    await user.click(groupSelect());
+    await user.click(screen.getByRole("option", { name: "None" }));
+    await waitFor(() => expect(groupSelect()).toHaveTextContent(/none/i));
+
+    first.unmount();
+    renderMyTasks();
+    await waitFor(() => expect(groupSelect()).toHaveTextContent(/none/i));
+  });
+});


### PR DESCRIPTION
## Problem

Three things on one theme — lists that don't tell you enough, and tables that forget what you told them:

1. The documents list mixed templates in with ordinary documents and offered no way to narrow by document type, even though the backend list endpoint already supported both filters.
2. Task and document tables remembered which columns you had shown or hidden, but forgot your grouping and sorting on every reload. My Tasks was the worst case: it reset to "group by date window" every visit, and its headers were seeded from a hardcoded sort, so a restored sort ordered the rows while the header claimed something else.
3. A project's "Project tasks" heading took a row of its own directly above the control row.

## Changes

**Documents list**
- [DocumentsStatusFilter.tsx](frontend/src/components/documents/DocumentsStatusFilter.tsx) — a Documents / Templates toggle badged with each state's total, mirroring [ProjectStatusFilter.tsx](frontend/src/components/projects/ProjectStatusFilter.tsx). State lives in the URL (`?status=templates`, already accepted by `validateInitiativeToolSearch`), so it is linkable and answers the back button. Switching states clears the page cursor and any bulk selection. The tag browse pins "documents" and hides the toggle, as the projects tag browse pins "active".
- [DocumentsFilterBar.tsx](frontend/src/components/documents/DocumentsFilterBar.tsx) — a document-type filter (text document, file, whiteboard, spreadsheet, smart link) that counts toward the filter button's badge and Clear all.
- [documents.py](backend/app/api/v1/tenant_endpoints/documents.py) — `/documents/counts` gained `is_template` and `document_type` so the tag sidebar's counts follow the state being shown, and the toggle's badges come from that cheap endpoint rather than the heavy list query. The list endpoint already supported both. Types regenerated with Orval.
- An empty templates state explains how a template is made rather than offering a create button.

**Table memory** — new [usePersistedTableState.ts](frontend/src/hooks/usePersistedTableState.ts) holds `grouping` + `sorting` in `@/lib/storage` (synchronous, so the stored value is there on the table's first render, which is when `DataTable` captures its seeds). Defaults apply on the first visit only, so a deliberately cleared sort doesn't have the default creep back in.

| Table | Sorting | Grouping | Columns |
|---|---|---|---|
| Project tasks | new | new | already did |
| My / Created Tasks | already did (server prefs) — now shown correctly | new | already did |
| Tag's task list | new | n/a | new |
| Documents list | new | n/a | already did |

- [ProjectTasksTableView.tsx](frontend/src/components/projects/ProjectTasksTableView.tsx) — persisted per project, and the table remounts when that key changes so one project's arrangement doesn't follow you into the next. Replaces the separate `hasSorting`/`grouping` state that drove drag-and-drop, so there is one source of truth.
- [TagTasksTable.tsx](frontend/src/components/tasks/TagTasksTable.tsx) and [DocumentsPage.tsx](frontend/src/pages/DocumentsPage.tsx) — sorting is held in the table's own column vocabulary and the backend sort fields derive from it, so the restored sort drives the query *and* the header. [DocumentsListView.tsx](frontend/src/components/documents/DocumentsListView.tsx) gained an `initialSorting` prop for that.
- [useGlobalTasksTable.ts](frontend/src/hooks/useGlobalTasksTable.ts) — inverts its `SORT_FIELD_MAP` and exposes `initialSorting` derived from stored prefs, fixing the header/rows mismatch. Sorting stays in the existing server preference rather than being duplicated.
- Settings and admin tables are deliberately untouched: they are places you pass through, not arrange.

**Layout**
- [ToolListToolbar.tsx](frontend/src/components/initiativeTools/shared/ToolListToolbar.tsx) — a `heading` slot rendering as the first item of the existing `flex-wrap` row, so the heading shares the row and the controls still drop to a second line when space runs out. [ProjectTasksSection.tsx](frontend/src/components/projects/ProjectTasksSection.tsx) passes its `<h2>` through it.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check src` — clean (1 pre-existing warning elsewhere)
- `cd frontend && ./scripts/test-changed.sh` — 137 files, 1725 tests passed, including 5 new files:
  - `usePersistedTableState.test.tsx` — grouping/sort survive a remount, clearing clears, a corrupt blob falls back, a key swap doesn't inherit the previous list's answer
  - `DocumentsPage.test.tsx` — the type filter and status toggle reach the query params; the restored sort reaches the server query on the next visit
  - `MyTasksPage.test.tsx` — grouping survives a remount
  - `TagTasksTable.test.tsx` — the restored sort reaches the server query
  - `ToolListToolbar.test.tsx` — heading and controls share one wrapping row
- `cd backend && ruff check app` — clean
- `cd backend && ./scripts/test-changed.sh` — 43 passed, including a new `/documents/counts` filter test
- Generated types verified in sync with the backend schema (`export_openapi.py` diff)

Not verified in a browser: no Playwright/chromium driver is installed in this environment.