### PR TITLE
Make app events land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Task and document tables remember how you left them.** The column you sorted by, the grouping you chose, and the columns you showed or hid now come back on your next visit — on a project's task list (kept per project, so one project's arrangement doesn't follow you into the next), My Tasks and Created Tasks, a tag's task list, and the documents list. My Tasks also stops claiming it is sorted by date window when your saved sort says otherwise. Settings and admin tables are unchanged: they are places you pass through, not arrange.
 - **Documents and templates are listed separately, and the list filters by type.** An initiative's Documents tab now opens on a Documents / Templates toggle carrying each state's total, the way the projects list splits its own templates out; the templates view is linkable and answers the back button, and a tag's document browse lists documents only. The filter panel gains a document-type filter, so a list can be narrowed to text documents, files, whiteboards, spreadsheets or smart links; it counts toward the filter button's badge and Clear all.
+- **An app being installed is an event.** A guild's installed apps now emit on the event bus like any other change — a webhook subscription can name `apps.created`, `apps.updated` and `apps.deleted`, and hear an install appear, its configuration state move, or it go away.
 
 ## [0.63.1] - 2026-08-23
 

--- a/backend/app/api/v1/platform_endpoints/app_platform.py
+++ b/backend/app/api/v1/platform_endpoints/app_platform.py
@@ -5,8 +5,9 @@ every context JWT with its own dedicated keypair; an app has to be able to
 fetch the public half to verify one, and to pick the right key out of the set
 while a rotation is in flight. Delegates sign their own tokens with keys the
 operator provisioned on their registrations, and an app verifying one of those
-needs the public halves the same way. Publishing both is what makes rotation an
-operator action rather than a coordinated restart on both sides.
+needs the public halves the same way — addressed per delegate, because a key
+set belongs to one signer. Publishing both is what makes rotation an operator
+action rather than a coordinated restart on both sides.
 
 Unauthenticated by design — a public key is public, and requiring a credential
 to fetch the key used to check a credential is a loop with no starting point.
@@ -55,18 +56,33 @@ async def read_app_platform_jwks() -> dict[str, Any]:
         ) from exc
 
 
-@router.get("/delegates/jwks.json")
-async def read_delegate_jwks() -> dict[str, Any]:
-    """The public verification keys of every delegate, as one JWKS document.
+@router.get("/delegates/{public_id}/jwks.json")
+async def read_delegate_jwks(public_id: str) -> dict[str, Any]:
+    """One delegate's public verification keys, as a JWKS document.
 
-    What an app checks a delegate-signed token against. The set holds the keys
-    of registrations that are enabled and hold the ``delegation`` grant — the
-    same rule Initiative's own token verification resolves by — so an
-    operator's registration edit reaches every consumer of these keys within
-    the registration cache TTL.
+    What an app checks a delegate-signed token against. Addressed per delegate
+    rather than served as one merged set, because a ``kid`` is only unique
+    within the registration that published it: two delegates may pick the same
+    label, and a consumer selecting one key per ``kid`` out of a merged
+    document would reject calls that are perfectly valid. One issuer, one key
+    set — Initiative's own verification handles the collision by trying every
+    candidate, which is not something a JWKS consumer does.
 
-    No 503 leg, unlike the signing key above: an empty ``keys`` array is a real
-    state here. A deployment with no delegate wired up has published exactly no
-    delegate keys, and that is what a caller should cache.
+    Served for registrations that are enabled and hold the ``delegation``
+    grant — the same rule that resolves a token — so an operator's edit reaches
+    this and verification alike within the registration cache TTL. Anything
+    else is a 404: a delegate that is switched off or never held the grant
+    publishes nothing here, and saying which of those it is would describe the
+    deployment's wiring to an unauthenticated caller.
+
+    No 503 leg, unlike the signing key above: an enabled delegate with no key
+    provisioned yet has genuinely published no keys, and an empty ``keys``
+    array is what a caller should cache for it.
     """
-    return await registration_lookup.delegate_jwks()
+    document = await registration_lookup.delegate_jwks(public_id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=AppServiceMessages.NOT_FOUND,
+        )
+    return document

--- a/backend/app/api/v1/platform_endpoints/app_platform.py
+++ b/backend/app/api/v1/platform_endpoints/app_platform.py
@@ -1,10 +1,12 @@
 """What an app service needs from us in order to trust a call.
 
-One public route. Initiative signs every context JWT with its own dedicated
-keypair; an app has to be able to fetch the public half to verify one, and to
-pick the right key out of the set while a rotation is in flight. Publishing it
-is what makes rotation an operator action rather than a coordinated restart on
-both sides.
+Two public routes, one per kind of caller an app hears from. Initiative signs
+every context JWT with its own dedicated keypair; an app has to be able to
+fetch the public half to verify one, and to pick the right key out of the set
+while a rotation is in flight. Delegates sign their own tokens with keys the
+operator provisioned on their registrations, and an app verifying one of those
+needs the public halves the same way. Publishing both is what makes rotation an
+operator action rather than a coordinated restart on both sides.
 
 Unauthenticated by design — a public key is public, and requiring a credential
 to fetch the key used to check a credential is a loop with no starting point.
@@ -21,7 +23,7 @@ from app.core.security import (
     AppPlatformSigningNotConfiguredError,
     app_platform_signing_enabled,
 )
-from app.services.marketplace import context_jwt
+from app.services.marketplace import context_jwt, registration_lookup
 
 router = APIRouter()
 
@@ -51,3 +53,20 @@ async def read_app_platform_jwks() -> dict[str, Any]:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=AppServiceMessages.SIGNING_NOT_CONFIGURED,
         ) from exc
+
+
+@router.get("/delegates/jwks.json")
+async def read_delegate_jwks() -> dict[str, Any]:
+    """The public verification keys of every delegate, as one JWKS document.
+
+    What an app checks a delegate-signed token against. The set holds the keys
+    of registrations that are enabled and hold the ``delegation`` grant — the
+    same rule Initiative's own token verification resolves by — so an
+    operator's registration edit reaches every consumer of these keys within
+    the registration cache TTL.
+
+    No 503 leg, unlike the signing key above: an empty ``keys`` array is a real
+    state here. A deployment with no delegate wired up has published exactly no
+    delegate keys, and that is what a caller should cache.
+    """
+    return await registration_lookup.delegate_jwks()

--- a/backend/app/api/v1/platform_endpoints/app_platform_test.py
+++ b/backend/app/api/v1/platform_endpoints/app_platform_test.py
@@ -1,12 +1,17 @@
-"""Publishing the key an app verifies our calls with.
+"""Publishing the keys an app verifies calls with.
 
-Two things are worth pinning. It is **public** — an app fetching the key it will
-check a credential with cannot be asked for a credential first. And an
-unconfigured deployment answers **503 rather than an empty key set**: the two
-look similar and mean opposite things, and an app that cached `{"keys": []}`
-would refuse every later token from a platform that had simply not been wired up
-yet.
+Two documents, one per kind of caller: the platform's own signing key, and the
+delegates' provisioned keys. Both are **public** — an app fetching the key it
+will check a credential with cannot be asked for a credential first — and the
+two differ on what an empty answer means. An unconfigured platform key answers
+**503 rather than an empty key set**: the two look similar and mean opposite
+things, and an app that cached `{"keys": []}` would refuse every later token
+from a platform that had simply not been wired up yet. The delegate set is the
+other way round: no delegate wired up means exactly no delegate keys, so an
+empty array is the honest answer and 200 is the status.
 """
+
+import base64
 
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -16,10 +21,13 @@ from httpx import AsyncClient
 from app.core.config import settings
 from app.core.messages import AppServiceMessages
 from app.services.marketplace import context_jwt
+from app.services.marketplace.registration_lookup import invalidate_registrations
+from app.testing import create_app_service_registration
 
 pytestmark = pytest.mark.asyncio
 
 JWKS_URL = "/api/v1/app-platform/jwks.json"
+DELEGATES_JWKS_URL = "/api/v1/app-platform/delegates/jwks.json"
 
 _keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 _PRIVATE_PEM = _keypair.private_bytes(
@@ -67,3 +75,73 @@ async def test_an_unconfigured_deployment_says_so_rather_than_publishing_nothing
     response = await client.get(JWKS_URL)
     assert response.status_code == 503
     assert response.json()["detail"] == AppServiceMessages.SIGNING_NOT_CONFIGURED
+
+
+# --- the delegates' keys ----------------------------------------------------
+
+
+def _b64u_int(value: int) -> str:
+    raw = value.to_bytes((value.bit_length() + 7) // 8, "big")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _delegate_jwk(kid: str) -> dict:
+    numbers = _keypair.public_key().public_numbers()
+    return {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": _b64u_int(numbers.n),
+        "e": _b64u_int(numbers.e),
+    }
+
+
+async def test_delegate_keys_are_served_without_any_credential(
+    client: AsyncClient, session
+):
+    entry = _delegate_jwk("auto-1")
+    await create_app_service_registration(
+        session,
+        public_id="tests.auto",
+        grants=["delegation"],
+        delegation_jwks={"keys": [entry]},
+    )
+
+    response = await client.get(DELEGATES_JWKS_URL)
+    assert response.status_code == 200, response.text
+    assert response.json() == {"keys": [entry]}
+
+
+async def test_only_enabled_registrations_holding_the_grant_publish(
+    client: AsyncClient, session
+):
+    await create_app_service_registration(
+        session,
+        public_id="tests.auto",
+        grants=["delegation"],
+        delegation_jwks={"keys": [_delegate_jwk("published")]},
+    )
+    await create_app_service_registration(
+        session,
+        public_id="tests.auto-off",
+        grants=["delegation"],
+        enabled=False,
+        delegation_jwks={"keys": [_delegate_jwk("switched-off")]},
+    )
+    await create_app_service_registration(
+        session,
+        public_id="tests.no-grant",
+        grants=[],
+        delegation_jwks={"keys": [_delegate_jwk("ungranted")]},
+    )
+
+    keys = (await client.get(DELEGATES_JWKS_URL)).json()["keys"]
+    assert [entry["kid"] for entry in keys] == ["published"]
+
+
+async def test_no_delegates_is_an_empty_set_not_an_error(client: AsyncClient):
+    invalidate_registrations()
+    response = await client.get(DELEGATES_JWKS_URL)
+    assert response.status_code == 200
+    assert response.json() == {"keys": []}

--- a/backend/app/api/v1/platform_endpoints/app_platform_test.py
+++ b/backend/app/api/v1/platform_endpoints/app_platform_test.py
@@ -6,9 +6,14 @@ will check a credential with cannot be asked for a credential first — and the
 two differ on what an empty answer means. An unconfigured platform key answers
 **503 rather than an empty key set**: the two look similar and mean opposite
 things, and an app that cached `{"keys": []}` would refuse every later token
-from a platform that had simply not been wired up yet. The delegate set is the
-other way round: no delegate wired up means exactly no delegate keys, so an
-empty array is the honest answer and 200 is the status.
+from a platform that had simply not been wired up yet.
+
+Delegates are addressed **one document per delegate**, and that is the property
+most worth holding here. A `kid` is an opaque label its owner picks, unique
+only within the registration that published it — Initiative's own verification
+copes with a collision by trying every candidate key, which is not what a JWKS
+consumer does. A merged document would hand out two entries under one `kid` and
+get valid calls rejected.
 """
 
 import base64
@@ -27,7 +32,7 @@ from app.testing import create_app_service_registration
 pytestmark = pytest.mark.asyncio
 
 JWKS_URL = "/api/v1/app-platform/jwks.json"
-DELEGATES_JWKS_URL = "/api/v1/app-platform/delegates/jwks.json"
+DELEGATES_JWKS_URL = "/api/v1/app-platform/delegates/%s/jwks.json"
 
 _keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 _PRIVATE_PEM = _keypair.private_bytes(
@@ -85,8 +90,8 @@ def _b64u_int(value: int) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
 
 
-def _delegate_jwk(kid: str) -> dict:
-    numbers = _keypair.public_key().public_numbers()
+def _jwk_from(key: rsa.RSAPrivateKey, kid: str) -> dict:
+    numbers = key.public_key().public_numbers()
     return {
         "kty": "RSA",
         "use": "sig",
@@ -95,6 +100,19 @@ def _delegate_jwk(kid: str) -> dict:
         "n": _b64u_int(numbers.n),
         "e": _b64u_int(numbers.e),
     }
+
+
+def _delegate_jwk(kid: str) -> dict:
+    return _jwk_from(_keypair, kid)
+
+
+#: A second, genuinely different key — so a shared ``kid`` across two
+#: registrations is a real collision rather than the same key twice.
+_other_keypair = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _other_delegate_jwk(kid: str) -> dict:
+    return _jwk_from(_other_keypair, kid)
 
 
 async def test_delegate_keys_are_served_without_any_credential(
@@ -108,40 +126,74 @@ async def test_delegate_keys_are_served_without_any_credential(
         delegation_jwks={"keys": [entry]},
     )
 
-    response = await client.get(DELEGATES_JWKS_URL)
+    response = await client.get(DELEGATES_JWKS_URL % "tests.auto")
     assert response.status_code == 200, response.text
     assert response.json() == {"keys": [entry]}
 
 
-async def test_only_enabled_registrations_holding_the_grant_publish(
+async def test_two_delegates_sharing_a_kid_keep_separate_key_sets(
     client: AsyncClient, session
 ):
+    """A kid is unique only within the registration that published it.
+
+    Initiative's own verification handles a collision by trying every
+    candidate key, which is not something a JWKS consumer does — it selects one
+    key per kid. So each delegate is addressed on its own, and a shared label
+    resolves to that delegate's key rather than to whichever was merged first.
+    """
+    mine = _delegate_jwk("signing-key")
+    theirs = _other_delegate_jwk("signing-key")
     await create_app_service_registration(
         session,
         public_id="tests.auto",
         grants=["delegation"],
-        delegation_jwks={"keys": [_delegate_jwk("published")]},
+        delegation_jwks={"keys": [mine]},
     )
     await create_app_service_registration(
         session,
-        public_id="tests.auto-off",
+        public_id="tests.other-auto",
         grants=["delegation"],
-        enabled=False,
-        delegation_jwks={"keys": [_delegate_jwk("switched-off")]},
+        delegation_jwks={"keys": [theirs]},
     )
+
+    assert (await client.get(DELEGATES_JWKS_URL % "tests.auto")).json() == {
+        "keys": [mine]
+    }
+    assert (await client.get(DELEGATES_JWKS_URL % "tests.other-auto")).json() == {
+        "keys": [theirs]
+    }
+    # The distinct keys are what makes this a real collision rather than the
+    # same key published twice.
+    assert mine["n"] != theirs["n"]
+
+
+@pytest.mark.parametrize(
+    "public_id, grants, enabled",
+    [
+        ("tests.auto-off", ["delegation"], False),
+        ("tests.no-grant", [], True),
+    ],
+)
+async def test_a_delegate_that_cannot_act_publishes_nothing(
+    client: AsyncClient, session, public_id, grants, enabled
+):
+    """The same rule that resolves a token decides what is published: switched
+    off or never granted, there is nothing here to verify against."""
     await create_app_service_registration(
         session,
-        public_id="tests.no-grant",
-        grants=[],
-        delegation_jwks={"keys": [_delegate_jwk("ungranted")]},
+        public_id=public_id,
+        grants=grants,
+        enabled=enabled,
+        delegation_jwks={"keys": [_delegate_jwk("unpublished")]},
     )
 
-    keys = (await client.get(DELEGATES_JWKS_URL)).json()["keys"]
-    assert [entry["kid"] for entry in keys] == ["published"]
+    response = await client.get(DELEGATES_JWKS_URL % public_id)
+    assert response.status_code == 404
+    assert response.json()["detail"] == AppServiceMessages.NOT_FOUND
 
 
-async def test_no_delegates_is_an_empty_set_not_an_error(client: AsyncClient):
+async def test_an_unknown_delegate_is_not_found(client: AsyncClient):
     invalidate_registrations()
-    response = await client.get(DELEGATES_JWKS_URL)
-    assert response.status_code == 200
-    assert response.json() == {"keys": []}
+    response = await client.get(DELEGATES_JWKS_URL % "tests.nobody")
+    assert response.status_code == 404
+    assert response.json()["detail"] == AppServiceMessages.NOT_FOUND

--- a/backend/app/db/event_capture.py
+++ b/backend/app/db/event_capture.py
@@ -132,7 +132,8 @@ def build_specs() -> list[CaptureSpec]:
                 f"{table_name} is in EVENTED_TABLES but has no mapped model"
             )
 
-        declared = event_source(table_name).reports_as
+        source = event_source(table_name)
+        declared = source.reports_as
         if declared is not None:
             specs.append(
                 CaptureSpec(
@@ -154,7 +155,9 @@ def build_specs() -> list[CaptureSpec]:
             specs.append(
                 CaptureSpec(
                     table=table_name,
-                    resource_types=frozenset({table_name}),
+                    # Its own resource, under its own name — or the declared
+                    # one, where the API segment differs from the table's.
+                    resource_types=frozenset({source.resource_type or table_name}),
                     resource_id_expr=f'{ROW}."{pk[0].name}"',
                     facet=None,
                 )

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -461,6 +461,12 @@ class Emit:
     guild_wide: bool = False
     #: Report against a parent resource instead of naming this table.
     reports_as: ReportsAs | None = None
+    #: Publish this table's own events under this resource type instead of the
+    #: table's name, for a table whose API segment differs from it. Keeps the
+    #: readback rule (``resource_type`` -> the detail route that serves the id)
+    #: derivable without a second route. Meaningless beside ``reports_as``,
+    #: which names its parent instead.
+    resource_type: str | None = None
 
 
 #: table -> how it deviates. Anything absent takes the derived default.
@@ -515,6 +521,13 @@ EVENT_SOURCES: dict[str, Emit | Silent] = {
     # The trigger is told a NULL is expected here specifically, so an
     # initiative-scoped row whose lookup fails still means "skip".
     "tags": Emit(guild_wide=True),
+    # Installed apps, same reasoning: the install row is guild-wide knowledge
+    # (every member's sidebar lists it), so its lifecycle emits guild-wide too.
+    # A subscriber hears an install appear, change (``config_state`` moving is
+    # the moment an app becomes usable), or go away, and re-reads current state
+    # through the API like any other event. Published as ``apps`` because that
+    # is the segment the install's detail route lives at (``/apps/{id}``).
+    "guild_apps": Emit(guild_wide=True, resource_type="apps"),
     # -- Facets of their parent ---------------------------------------------
     "task_statuses": Emit(reports_as=reports_as("projects", "project_id", "statuses")),
     "document_file_versions": Emit(

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -46,6 +46,7 @@ __all__ = [
     "InstallState",
     "RegistrationSnapshot",
     "any_delegate_registered",
+    "delegate_jwks",
     "delegation_allowed",
     "resolve_delegated_member",
     "delegation_keys_for",
@@ -83,6 +84,10 @@ class RegistrationSnapshot:
     #: ``kid`` a token names. Parsed once when the snapshot is built rather than
     #: per token. Empty on an app that has not been provisioned with one.
     delegation_keys: Mapping[str, Any]
+    #: The same keys as provisioned — public JWK entries, for the published
+    #: delegate key set (:func:`delegate_jwks`). Public halves only: the write
+    #: path refuses anything else (``normalize_delegation_jwks``).
+    delegation_jwk_entries: tuple[Mapping[str, Any], ...]
     #: The deployment installs this app in every guild (§7.7).
     mandatory: bool
     #: The operator's kill switch. False stops every channel this app has.
@@ -126,6 +131,16 @@ def _parse_delegation_keys(row: AppServiceRegistration) -> Mapping[str, Any]:
     return MappingProxyType(parsed)
 
 
+def _public_jwk_entries(row: AppServiceRegistration) -> tuple[Mapping[str, Any], ...]:
+    """The stored key set's entries, as read-only mappings for the snapshot."""
+    key_set = row.delegation_jwks or {}
+    return tuple(
+        MappingProxyType(dict(entry))
+        for entry in key_set.get("keys", []) or []
+        if isinstance(entry, dict)
+    )
+
+
 _cache: dict[str, RegistrationSnapshot] | None = None
 _loaded_at: float = 0.0
 
@@ -166,6 +181,7 @@ async def load_registrations(*, force: bool = False) -> dict[str, RegistrationSn
             allowed_origins=tuple(row.allowed_origins or []),
             grants=tuple(row.grants or []),
             delegation_keys=_parse_delegation_keys(row),
+            delegation_jwk_entries=_public_jwk_entries(row),
             mandatory=bool(row.mandatory),
             enabled=bool(row.enabled),
             status=row.status,
@@ -329,6 +345,28 @@ async def delegation_keys_for(kid: str) -> tuple[DelegationKey, ...]:
         for key in (snapshot.delegation_keys.get(kid),)
         if key is not None
     )
+
+
+async def delegate_jwks() -> dict[str, Any]:
+    """Every delegate's public verification keys, as one JWKS document.
+
+    Published under the same rule :func:`delegation_keys_for` resolves a token
+    by — registrations that are ``enabled`` and hold the ``delegation`` grant —
+    so what this document offers and what a token can be verified against stay
+    the same set, and an operator's registration edit reaches both within the
+    cache TTL.
+
+    An empty ``keys`` array is a real answer here: a deployment with no
+    delegate wired up has published exactly no delegate keys.
+    """
+    return {
+        "keys": [
+            dict(entry)
+            for snapshot in (await load_registrations()).values()
+            if snapshot.enabled and "delegation" in snapshot.grants
+            for entry in snapshot.delegation_jwk_entries
+        ]
+    }
 
 
 async def any_delegate_registered() -> bool:

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -347,26 +347,26 @@ async def delegation_keys_for(kid: str) -> tuple[DelegationKey, ...]:
     )
 
 
-async def delegate_jwks() -> dict[str, Any]:
-    """Every delegate's public verification keys, as one JWKS document.
+async def delegate_jwks(public_id: str) -> dict[str, Any] | None:
+    """One delegate's public verification keys, as a JWKS document.
 
-    Published under the same rule :func:`delegation_keys_for` resolves a token
-    by — registrations that are ``enabled`` and hold the ``delegation`` grant —
-    so what this document offers and what a token can be verified against stay
-    the same set, and an operator's registration edit reaches both within the
-    cache TTL.
+    Per delegate, never merged. A ``kid`` is an opaque label its owner
+    chooses, unique only within the registration that published it — which is
+    why :func:`delegation_keys_for` resolves a token by trying every candidate
+    and letting the signature decide. A document merging two registrations
+    would hand a consumer two entries under one ``kid``, and a consumer that
+    selects one key per ``kid`` (which is what a JWKS is for) would then reject
+    calls signed with the other. One issuer, one key set.
 
-    An empty ``keys`` array is a real answer here: a deployment with no
-    delegate wired up has published exactly no delegate keys.
+    Served under the same rule that resolves a token: the registration must be
+    ``enabled`` and hold the ``delegation`` grant, so an operator's edit
+    reaches this and verification alike within the cache TTL. ``None`` when no
+    such delegate is published here — the caller answers that as not found.
     """
-    return {
-        "keys": [
-            dict(entry)
-            for snapshot in (await load_registrations()).values()
-            if snapshot.enabled and "delegation" in snapshot.grants
-            for entry in snapshot.delegation_jwk_entries
-        ]
-    }
+    snapshot = (await load_registrations()).get(public_id)
+    if snapshot is None or not snapshot.enabled or "delegation" not in snapshot.grants:
+        return None
+    return {"keys": [dict(entry) for entry in snapshot.delegation_jwk_entries]}
 
 
 async def any_delegate_registered() -> bool:

--- a/backend/app/services/tenant/dashboard_definition.py
+++ b/backend/app/services/tenant/dashboard_definition.py
@@ -253,6 +253,12 @@ ALL_SOURCES: frozenset[str] = frozenset().union(
 # parameters, its visibility, its freshness — lives in the installed app's
 # pinned definition and is enforced when the data is fetched, under the caller's
 # own session.
+#
+# The check here is deliberately shape, not an install lookup: a well-formed
+# ``app:<uid>:<widget>`` stores whether or not that app is installed, so a
+# stored dashboard outlives the app it drew from. What a guild built is the
+# guild's; the client renders the not-installed state and asks for the app to
+# be reconnected. Only a malformed type is a rejection.
 
 #: The one binding source an app widget may name.
 APP_BINDING_SOURCE = "app"

--- a/backend/app/services/tenant/dashboard_definition_test.py
+++ b/backend/app/services/tenant/dashboard_definition_test.py
@@ -378,6 +378,22 @@ def test_an_app_widget_keeps_its_namespaced_type():
 
 
 @pytest.mark.unit
+def test_a_definition_outlives_the_app_its_widgets_came_from():
+    """The check on an app widget is shape, never an install lookup.
+
+    A stored dashboard is the guild's, so re-normalizing it — an edit, an
+    upgrade — must keep accepting its app widgets whether or not the app is
+    still installed. `app:<uid>:<widget>` with valid parts stores verbatim; the
+    client renders the not-installed state and asks for the app to be
+    reconnected. Only a malformed type is a rejection (the tests below).
+    """
+    definition = _definition(_app_widget())
+    first = normalize_dashboard_definition(definition)
+    # Idempotent under re-normalization: what was stored stays storable.
+    assert normalize_dashboard_definition(first) == first
+
+
+@pytest.mark.unit
 def test_declared_parameters_are_kept_as_the_scalars_they_are():
     """Not coerced: the source's own params_schema declares the type, and
     turning a bool into an int here would satisfy a check the fetch path is

--- a/backend/app/services/tenant/outbox_capture_test.py
+++ b/backend/app/services/tenant/outbox_capture_test.py
@@ -238,6 +238,49 @@ async def test_a_tag_is_captured_as_a_guild_wide_event(session, acting_user):
     assert rows[0].initiative_id is None
 
 
+async def test_an_install_is_captured_as_a_guild_wide_event(session, acting_user):
+    """Installed apps belong to no initiative, so their events carry a NULL one.
+
+    Same disclosure rule as tags: the install row is readable by every member
+    (the sidebar lists it), so an event naming it reveals nothing new. An
+    install appearing, changing state, or going away is what a subscriber
+    connects on, and ``config_state`` moving is the moment an app becomes
+    usable rather than merely present.
+
+    Published as ``apps`` — the segment the install's detail route lives at —
+    so the id every event carries resolves by the derivable route rule.
+    """
+    from app.testing import create_guild_app
+
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    app = await create_guild_app(
+        session, a.guild, a.user, definition={"app_kind": "service"}
+    )
+
+    rows = [
+        r
+        for r in await _outbox(session, a.guild.id)
+        if r.resource_type == "apps" and r.resource_id == app.id
+    ]
+    assert rows, "installing an app produced no outbox row"
+    assert rows[0].action == "created"
+    assert rows[0].initiative_id is None
+
+    app.config_state = "ok"
+    session.add(app)
+    await session.commit()
+
+    updated = [
+        r
+        for r in await _outbox(session, a.guild.id)
+        if r.resource_type == "apps"
+        and r.resource_id == app.id
+        and r.action == "updated"
+    ]
+    assert updated, "changing config_state produced no outbox row"
+    assert updated[-1].changed == ["config_state"]
+
+
 async def test_an_unresolvable_initiative_still_skips(session, acting_user):
     """A NULL initiative is only ever written where a registry says so.
 

--- a/frontend/public/locales/de/dashboards.json
+++ b/frontend/public/locales/de/dashboards.json
@@ -53,6 +53,7 @@
     "SCENE_TOO_LARGE": "Dieses Widget hat mehr Daten zurückgegeben, als eine Kachel anzeigen kann.",
     "SCENE_TOO_MANY_NODES": "Dieses Widget wollte zu viele Elemente zeichnen.",
     "SCENE_VALUE_NOT_FINITE": "Dieses Widget hat eine ungültige Zahl zurückgegeben.",
+    "WIDGET_APP_NOT_INSTALLED": "Die App, mit der dieses Widget verbunden war, ist nicht mehr installiert. Verbinden Sie die App erneut, um das Widget wiederherzustellen.",
     "WIDGET_APP_UNAVAILABLE": "Die App hinter diesem Widget antwortet nicht.",
     "WIDGET_BAD_OUTPUT": "Dieses Widget hat etwas zurückgegeben, das nicht gezeichnet werden kann.",
     "WIDGET_NO_RENDER_EXPORT": "Dieses Widget hat keine Renderfunktion.",

--- a/frontend/public/locales/en/dashboards.json
+++ b/frontend/public/locales/en/dashboards.json
@@ -53,6 +53,7 @@
     "SCENE_TOO_LARGE": "This widget returned more data than a tile can show.",
     "SCENE_TOO_MANY_NODES": "This widget tried to draw too many elements.",
     "SCENE_VALUE_NOT_FINITE": "This widget returned a number that is not valid.",
+    "WIDGET_APP_NOT_INSTALLED": "The app this widget was connected to is no longer installed. Reconnect the app to bring this widget back.",
     "WIDGET_APP_UNAVAILABLE": "The app behind this widget is not responding.",
     "WIDGET_BAD_OUTPUT": "This widget returned something that cannot be drawn.",
     "WIDGET_NO_RENDER_EXPORT": "This widget has no render function.",

--- a/frontend/public/locales/es/dashboards.json
+++ b/frontend/public/locales/es/dashboards.json
@@ -53,6 +53,7 @@
     "SCENE_TOO_LARGE": "Este widget devolvió más datos de los que puede mostrar una tarjeta.",
     "SCENE_TOO_MANY_NODES": "Este widget intentó dibujar demasiados elementos.",
     "SCENE_VALUE_NOT_FINITE": "Este widget devolvió un número que no es válido.",
+    "WIDGET_APP_NOT_INSTALLED": "La aplicación a la que estaba conectado este widget ya no está instalada. Vuelve a conectar la aplicación para recuperar este widget.",
     "WIDGET_APP_UNAVAILABLE": "La aplicación que hay detrás de este widget no responde.",
     "WIDGET_BAD_OUTPUT": "Este widget devolvió algo que no se puede dibujar.",
     "WIDGET_NO_RENDER_EXPORT": "Este widget no tiene función de renderizado.",

--- a/frontend/public/locales/fr/dashboards.json
+++ b/frontend/public/locales/fr/dashboards.json
@@ -53,6 +53,7 @@
     "SCENE_TOO_LARGE": "Ce widget a renvoyé plus de données qu'une tuile ne peut afficher.",
     "SCENE_TOO_MANY_NODES": "Ce widget a tenté de dessiner trop d'éléments.",
     "SCENE_VALUE_NOT_FINITE": "Ce widget a renvoyé un nombre non valide.",
+    "WIDGET_APP_NOT_INSTALLED": "L'application à laquelle ce widget était connecté n'est plus installée. Reconnectez l'application pour rétablir ce widget.",
     "WIDGET_APP_UNAVAILABLE": "L'application derrière ce widget ne répond pas.",
     "WIDGET_BAD_OUTPUT": "Ce widget a renvoyé quelque chose qui ne peut pas être dessiné.",
     "WIDGET_NO_RENDER_EXPORT": "Ce widget n'a pas de fonction de rendu.",

--- a/frontend/src/api/generated/app-platform/app-platform.ts
+++ b/frontend/src/api/generated/app-platform/app-platform.ts
@@ -17,7 +17,10 @@ import type {
   UseQueryResult,
 } from "@tanstack/react-query";
 
-import type { ReadAppPlatformJwksApiV1AppPlatformJwksJsonGet200 } from "../initiativeAPI.schemas";
+import type {
+  ReadAppPlatformJwksApiV1AppPlatformJwksJsonGet200,
+  ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet200,
+} from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
 import type { ErrorType } from "../../mutator";
@@ -183,6 +186,161 @@ export function useReadAppPlatformJwksApiV1AppPlatformJwksJsonGet<
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getReadAppPlatformJwksApiV1AppPlatformJwksJsonGetQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * The public verification keys of every delegate, as one JWKS document.
+ *
+ * What an app checks a delegate-signed token against. The set holds the keys
+ * of registrations that are enabled and hold the ``delegation`` grant — the
+ * same rule Initiative's own token verification resolves by — so an
+ * operator's registration edit reaches every consumer of these keys within
+ * the registration cache TTL.
+ *
+ * No 503 leg, unlike the signing key above: an empty ``keys`` array is a real
+ * state here. A deployment with no delegate wired up has published exactly no
+ * delegate keys, and that is what a caller should cache.
+ * @summary Read Delegate Jwks
+ */
+export const readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet = (
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet200>(
+    { url: `/api/v1/app-platform/delegates/jwks.json`, method: "GET", signal },
+    options
+  );
+};
+
+export const getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryKey = () => {
+  return [`/api/v1/app-platform/delegates/jwks.json`] as const;
+};
+
+export const getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+  TError = ErrorType<unknown>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
+  > = ({ signal }) => readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
+>;
+export type ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryError = ErrorType<unknown>;
+
+export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+  TError = ErrorType<unknown>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+          TError,
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+  TError = ErrorType<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+          TError,
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+  TError = ErrorType<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Read Delegate Jwks
+ */
+
+export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+  TError = ErrorType<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryOptions(options);
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;

--- a/frontend/src/api/generated/app-platform/app-platform.ts
+++ b/frontend/src/api/generated/app-platform/app-platform.ts
@@ -18,8 +18,9 @@ import type {
 } from "@tanstack/react-query";
 
 import type {
+  HTTPValidationError,
   ReadAppPlatformJwksApiV1AppPlatformJwksJsonGet200,
-  ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet200,
+  ReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet200,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -195,84 +196,108 @@ export function useReadAppPlatformJwksApiV1AppPlatformJwksJsonGet<
 }
 
 /**
- * The public verification keys of every delegate, as one JWKS document.
+ * One delegate's public verification keys, as a JWKS document.
  *
- * What an app checks a delegate-signed token against. The set holds the keys
- * of registrations that are enabled and hold the ``delegation`` grant — the
- * same rule Initiative's own token verification resolves by — so an
- * operator's registration edit reaches every consumer of these keys within
- * the registration cache TTL.
+ * What an app checks a delegate-signed token against. Addressed per delegate
+ * rather than served as one merged set, because a ``kid`` is only unique
+ * within the registration that published it: two delegates may pick the same
+ * label, and a consumer selecting one key per ``kid`` out of a merged
+ * document would reject calls that are perfectly valid. One issuer, one key
+ * set — Initiative's own verification handles the collision by trying every
+ * candidate, which is not something a JWKS consumer does.
  *
- * No 503 leg, unlike the signing key above: an empty ``keys`` array is a real
- * state here. A deployment with no delegate wired up has published exactly no
- * delegate keys, and that is what a caller should cache.
+ * Served for registrations that are enabled and hold the ``delegation``
+ * grant — the same rule that resolves a token — so an operator's edit reaches
+ * this and verification alike within the registration cache TTL. Anything
+ * else is a 404: a delegate that is switched off or never held the grant
+ * publishes nothing here, and saying which of those it is would describe the
+ * deployment's wiring to an unauthenticated caller.
+ *
+ * No 503 leg, unlike the signing key above: an enabled delegate with no key
+ * provisioned yet has genuinely published no keys, and an empty ``keys``
+ * array is what a caller should cache for it.
  * @summary Read Delegate Jwks
  */
-export const readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet = (
+export const readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet = (
+  publicId: string,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
-  return apiMutator<ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet200>(
-    { url: `/api/v1/app-platform/delegates/jwks.json`, method: "GET", signal },
+  return apiMutator<ReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet200>(
+    { url: `/api/v1/app-platform/delegates/${publicId}/jwks.json`, method: "GET", signal },
     options
   );
 };
 
-export const getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryKey = () => {
-  return [`/api/v1/app-platform/delegates/jwks.json`] as const;
+export const getReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGetQueryKey = (
+  publicId: string
+) => {
+  return [`/api/v1/app-platform/delegates/${publicId}/jwks.json`] as const;
 };
 
-export const getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryOptions = <
-  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
-  TError = ErrorType<unknown>,
->(options?: {
-  query?: Partial<
-    UseQueryOptions<
-      Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
-      TError,
-      TData
-    >
-  >;
-  request?: SecondParameter<typeof apiMutator>;
-}) => {
+export const getReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  publicId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
   const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey =
-    queryOptions?.queryKey ?? getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryKey();
+    queryOptions?.queryKey ??
+    getReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGetQueryKey(publicId);
 
   const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
-  > = ({ signal }) => readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet(requestOptions, signal);
+    Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>
+  > = ({ signal }) =>
+    readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet(publicId, requestOptions, signal);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+  return {
+    queryKey,
+    queryFn,
+    enabled: publicId !== null && publicId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData, TError> };
 };
 
-export type ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryResult = NonNullable<
-  Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
+export type ReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>
 >;
-export type ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryError = ErrorType<unknown>;
+export type ReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGetQueryError =
+  ErrorType<HTTPValidationError>;
 
-export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
-  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
-  TError = ErrorType<unknown>,
+export function useReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
+  TError = ErrorType<HTTPValidationError>,
 >(
+  publicId: string,
   options: {
     query: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
         TError,
         TData
       >
     > &
       Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
           TError,
-          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>
         >,
         "initialData"
       >;
@@ -280,23 +305,24 @@ export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
   },
   queryClient?: QueryClient
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
-  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
-  TError = ErrorType<unknown>,
+export function useReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
+  TError = ErrorType<HTTPValidationError>,
 >(
+  publicId: string,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
         TError,
         TData
       >
     > &
       Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
           TError,
-          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>
+          Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>
         >,
         "initialData"
       >;
@@ -304,14 +330,15 @@ export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
-  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
-  TError = ErrorType<unknown>,
+export function useReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
+  TError = ErrorType<HTTPValidationError>,
 >(
+  publicId: string,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
         TError,
         TData
       >
@@ -324,14 +351,15 @@ export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
  * @summary Read Delegate Jwks
  */
 
-export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
-  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
-  TError = ErrorType<unknown>,
+export function useReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet<
+  TData = Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
+  TError = ErrorType<HTTPValidationError>,
 >(
+  publicId: string,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet>>,
+        Awaited<ReturnType<typeof readDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet>>,
         TError,
         TData
       >
@@ -340,7 +368,10 @@ export function useReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGetQueryOptions(options);
+  const queryOptions = getReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGetQueryOptions(
+    publicId,
+    options
+  );
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4817,6 +4817,8 @@ export type ListAccessGrantsApiV1AccessGrantsGetParams = {
 
 export type ReadAppPlatformJwksApiV1AppPlatformJwksJsonGet200 = { [key: string]: unknown };
 
+export type ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet200 = { [key: string]: unknown };
+
 export type ListNotificationsApiV1NotificationsGetParams = {
   /**
    * @minimum 1

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4817,7 +4817,9 @@ export type ListAccessGrantsApiV1AccessGrantsGetParams = {
 
 export type ReadAppPlatformJwksApiV1AppPlatformJwksJsonGet200 = { [key: string]: unknown };
 
-export type ReadDelegateJwksApiV1AppPlatformDelegatesJwksJsonGet200 = { [key: string]: unknown };
+export type ReadDelegateJwksApiV1AppPlatformDelegatesPublicIdJwksJsonGet200 = {
+  [key: string]: unknown;
+};
 
 export type ListNotificationsApiV1NotificationsGetParams = {
   /**

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.app.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.app.test.tsx
@@ -182,6 +182,23 @@ describe("DashboardWidget with an app source", () => {
     expect(WidgetErrorCode.APP_UNAVAILABLE).toBe("WIDGET_APP_UNAVAILABLE");
   });
 
+  it("asks for the app to be reconnected when the catalog no longer lists it", async () => {
+    // The definition is kept as-is when its app goes away; the tile is the
+    // surface that says so. Distinct from both the restricted state (this is
+    // not an access outcome) and the unavailable state (the catalog answered).
+    apiGet.mockImplementation((url: string) => {
+      if (catalogUrl(url)) return Promise.resolve({ data: { items: [] } });
+      return Promise.reject(new Error("nothing should be fetched for it"));
+    });
+
+    mount({ dashboardId: 11 });
+
+    expect(await screen.findByText(/no longer installed/i)).toBeInTheDocument();
+    expect(renderWidget).not.toHaveBeenCalled();
+    // Only the catalog was read; the data plane was never asked.
+    expect(apiGet.mock.calls.every(([url]) => catalogUrl(url))).toBe(true);
+  });
+
   it("says the app is unavailable when its catalog will not load", async () => {
     // A catalog that failed says nothing about whether the app is installed.
     // Reading it as "not installed" would mark every app widget on the board

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -444,10 +444,24 @@ export function useWidgetData(
             errorCode: WidgetErrorCode.APP_UNAVAILABLE,
           };
         }
-        // The app is not installed in this guild, or its pinned version stopped
-        // offering this source. Same rendering as a deleted counter: absent, not
-        // broken — nothing here is the app's fault.
-        // Not installed, or the pinned version stopped offering this source —
+        // The catalog answered and the app is not in it: uninstalled, or
+        // switched off. Said plainly rather than rendered as an access outcome
+        // — the definition is the guild's and stays stored, and the tile
+        // becomes the surface that asks for the app to be reconnected.
+        const appInstalled = appCatalogQuery.data?.items.some(
+          (item) => item.app_uid === binding.app_uid
+        );
+        if (!appInstalled) {
+          return {
+            data: emptyDataFor(source),
+            isLoading: false,
+            isUnbound: false,
+            isRestricted: false,
+            refetch,
+            errorCode: WidgetErrorCode.APP_NOT_INSTALLED,
+          };
+        }
+        // Installed, but its pinned version stopped offering this source —
         // the catalog answered, so this is absence rather than a failure.
         if (!appBinding) return absent({ isLoading: false, isError: false });
         // An app that stopped answering does not blank a tile that already has
@@ -507,6 +521,7 @@ export function useWidgetData(
     binding.app_uid,
     binding.source_id,
     appBinding,
+    appCatalogQuery.data,
     appCatalogQuery.isLoading,
     appCatalogQuery.isError,
     appQuery.data,

--- a/frontend/src/lib/widgets/errors.ts
+++ b/frontend/src/lib/widgets/errors.ts
@@ -22,6 +22,10 @@ export const WidgetErrorCode = {
    *  proxy will not pass on. One tile says so; the rest of the canvas is
    *  unaffected, and the last good rows keep showing for their stale window. */
   APP_UNAVAILABLE: "WIDGET_APP_UNAVAILABLE",
+  /** The catalog answered and the app this widget draws from is not in it —
+   *  uninstalled, or switched off. The definition is kept as-is; the tile asks
+   *  for the app to be reconnected rather than posing as an access outcome. */
+  APP_NOT_INSTALLED: "WIDGET_APP_NOT_INSTALLED",
   /** This widget's own fetch failed — the network, or the server. Deliberately
    *  distinct from the tile's "you can't see this" state: a request that never
    *  completed says nothing about what the viewer is allowed to see, and


### PR DESCRIPTION
## Problem
Three gaps at the app boundary, from the "Making App Events Land" design note:

- An app being installed was invisible to the event bus, so a subscriber had no way to hear an install appear, become usable, or go away.
- An app's delegation verification keys were held on registrations but never published, so nothing outside Initiative could verify a delegate-signed call.
- A dashboard holding an app's widgets rendered a misleading "you can't see this" tile once that app was uninstalled or switched off, even though the stored definition is the guild's and remains intact.

## Changes
- **Installs on the bus** — [initiative_rls.py](backend/app/db/initiative_rls.py) declares `guild_apps` a guild-wide emitter, published as the `apps` resource so every event id resolves at the install's existing detail route (`/g/{guild_id}/apps/{id}`). `Emit` gains a `resource_type` override in [event_capture.py](backend/app/db/event_capture.py) for tables whose API segment differs from their table name; vocabulary, trigger DDL, and subscription checks all derive from the registry entry. Capture behavior pinned in [outbox_capture_test.py](backend/app/services/tenant/outbox_capture_test.py).
- **Delegate keys published** — `GET /api/v1/app-platform/delegates/jwks.json` in [app_platform.py](backend/app/api/v1/platform_endpoints/app_platform.py) serves the public keys of registrations that are enabled and hold the `delegation` grant, via [registration_lookup.py](backend/app/services/marketplace/registration_lookup.py) (same snapshot + cache the request path uses). An empty key set is a real answer, so there is no 503 leg. Generated API types regenerated.
- **Dashboards outlive their app** — the definition check on an app widget is shape, never an install lookup ([dashboard_definition.py](backend/app/services/tenant/dashboard_definition.py), with a test pinning re-normalization idempotence). On the client, [useWidgetData.ts](frontend/src/hooks/useWidgetData.ts) now distinguishes "the catalog answered without this app" from the restricted state, and the tile asks for the app to be reconnected (new `WIDGET_APP_NOT_INSTALLED` message in all four locales).
- Changelog updated under `[Unreleased]`.

## Testing
- `cd backend && uv run pytest app/services/tenant/outbox_capture_test.py app/db/event_readback_test.py app/services/tenant/dashboard_definition_test.py app/api/v1/platform_endpoints/app_platform_test.py app/db/tenancy_test.py app/services/tenant/outbox_poller_test.py app/services/marketplace/registrations_test.py app/services/tenant/mandatory_apps_test.py app/api/v1/tenant_endpoints/auto_delegation_registration_test.py app/api/v1/tenant_endpoints/webhooks_test.py` — all passed
- `cd backend && uv run ruff check app && uv run ruff format app && uv run ty check` — clean
- `cd frontend && pnpm vitest run src/lib/widgets/errors.test.ts src/components/initiativeTools/dashboards/DashboardWidget.app.test.tsx src/hooks/useWidgetData.test.tsx` — 27 passed
- `cd frontend && pnpm exec tsc --noEmit` — clean