### PR TITLE
Tell a delegate where an app answers

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
@@ -2,13 +2,15 @@
 
 An automation service acts on apps as well as on Initiative — it asks one to
 open a GitHub issue the way it asks us to create a task — and to do that it has
-to know where the app is. Only the registration says, and the registration is
-operator wiring: an internal Service address on a cluster.
+to know where the app is. Only the registration says, and that is operator
+wiring rather than anything the install describes.
 
-So this route hands it over on one condition and hides it from everybody else.
-What is pinned here is that condition, both halves of it: the caller must have
-arrived as a live delegate, and every way of not being one answers the same 404
-as an app that does not exist.
+So this route hands it over on two conditions and answers everybody else the
+same 404 as an app that does not exist. Both are pinned here: the caller
+arrived as a live delegate, **and** the operator conferred ``app_directory`` on
+it. The second is what separates an automation service from an app that merely
+acts for its own members — the test below holds that line, because a delegate
+is the shape most apps have and the address is not theirs to read.
 """
 
 from __future__ import annotations
@@ -34,7 +36,7 @@ from app.testing.schema_harness import route_session_to_guild
 #: the whole point is one app learning where a *different* one lives.
 TARGET_PUBLIC_ID = "morelitea.github"
 TARGET_LISTING_UID = "TESTGITHUB0001"
-TARGET_BASE_URL = "http://initiative-github.svc.cluster.local:8080"
+TARGET_BASE_URL = "http://initiative-github.internal:8080"
 
 
 @pytest.fixture(autouse=True)
@@ -45,7 +47,9 @@ async def _enable_delegation(session: AsyncSession):
             "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
             "-----BEGIN PRIVATE KEY-----",
         )
-        await register_delegate(session)
+        # Both grants: acting for a member is what authenticates the call, and
+        # ``app_directory`` is what this route additionally asks for.
+        await register_delegate(session, grants=("delegation", "app_directory"))
         yield
     invalidate_registrations()
 
@@ -254,6 +258,49 @@ async def test_a_delegate_that_may_not_act_is_refused(
     )
 
     assert response.status_code == 401
+    assert TARGET_BASE_URL not in response.text
+
+
+@pytest.mark.integration
+async def test_a_delegate_without_the_directory_grant_is_refused(
+    client: AsyncClient, session: AsyncSession, scene
+):
+    """The line between acting for a member and reading the wiring.
+
+    This caller is a perfectly good delegate: enabled, holding ``delegation``,
+    its token verifying — so it reaches the route rather than being stopped a
+    floor down, which is what makes this a different assertion from the one
+    above. It is refused here because acting for its own members is all the
+    operator conferred, and where another app answers is not part of that.
+
+    The shape most apps have, and the reason the grant is separate: an app that
+    works one vendor should not learn the deployment's wiring for the rest.
+    """
+    actor, subject = scene
+    guild, installer = actor.guild, actor.user
+    await _register_target(session)
+    app = await _install_target(session, guild, installer)
+    headers = _headers(subject, guild.id, "svc-no-directory")
+
+    from sqlmodel import delete
+
+    from app.models.platform.app_service_registration import AppServiceRegistration
+    from app.testing.delegation import DELEGATE_PUBLIC_ID
+
+    await session.exec(
+        delete(AppServiceRegistration).where(
+            AppServiceRegistration.public_id == DELEGATE_PUBLIC_ID
+        )
+    )
+    await session.commit()
+    await register_delegate(session, grants=("delegation",))
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service", headers=headers
+    )
+
+    # The route's own gate, not the auth layer's: this token authenticated.
+    assert response.status_code == 404, response.text
     assert TARGET_BASE_URL not in response.text
 
 

--- a/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
@@ -2,15 +2,12 @@
 
 An automation service acts on apps as well as on Initiative — it asks one to
 open a GitHub issue the way it asks us to create a task — and to do that it has
-to know where the app is. Only the registration says, and that is operator
-wiring rather than anything the install describes.
+to know where the app is. Only the registration carries an address.
 
-So this route hands it over on two conditions and answers everybody else the
-same 404 as an app that does not exist. Both are pinned here: the caller
-arrived as a live delegate, **and** the operator conferred ``app_directory`` on
-it. The second is what separates an automation service from an app that merely
-acts for its own members — the test below holds that line, because a delegate
-is the shape most apps have and the address is not theirs to read.
+The route serves one to a caller holding both ``delegation`` and
+``app_directory``, and answers everybody else the same 404 as an app that does
+not exist. Both grants are pinned here, the second because it is what separates
+an automation service from an app that only acts for its own members.
 """
 
 from __future__ import annotations
@@ -218,18 +215,11 @@ async def test_a_first_party_session_is_refused(
 async def test_a_delegate_that_may_not_act_is_refused(
     client: AsyncClient, session: AsyncSession, scene, grants, enabled, case
 ):
-    """An operator's edit ends the call, and it ends it before the route.
+    """An operator's edit ends the call.
 
-    The same rule decides which keys verify a delegate's tokens, so withdrawing
-    the grant or switching the registration off leaves the token resolving to
-    no key at all — it is not authenticated as a delegation, and the answer is
-    the bare **401** that every refused delegation gets, not this route's 404.
-
-    Asserted rather than assumed, because it is the difference between two
-    kinds of protection. The route's own ``live_delegate`` check is defence in
-    depth for exactly this case; what stops it here is the auth layer, one
-    floor down, and a change that moved the address behind a different auth
-    path would need to keep this property on purpose.
+    Withdrawing the grant or switching the registration off leaves the caller
+    unauthenticated as a delegate, so the answer is the 401 every refused
+    delegation gets rather than this route's 404.
     """
     actor, subject = scene
     guild, installer = actor.guild, actor.user
@@ -265,16 +255,10 @@ async def test_a_delegate_that_may_not_act_is_refused(
 async def test_a_delegate_without_the_directory_grant_is_refused(
     client: AsyncClient, session: AsyncSession, scene
 ):
-    """The line between acting for a member and reading the wiring.
+    """A delegate conferred only ``delegation`` is not told an address.
 
-    This caller is a perfectly good delegate: enabled, holding ``delegation``,
-    its token verifying — so it reaches the route rather than being stopped a
-    floor down, which is what makes this a different assertion from the one
-    above. It is refused here because acting for its own members is all the
-    operator conferred, and where another app answers is not part of that.
-
-    The shape most apps have, and the reason the grant is separate: an app that
-    works one vendor should not learn the deployment's wiring for the rest.
+    The shape most apps have: enabled, acting for its own members, and with no
+    call to read where a different app answers.
     """
     actor, subject = scene
     guild, installer = actor.guild, actor.user

--- a/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
@@ -1,0 +1,301 @@
+"""Where an installed app's service answers, served to a delegate.
+
+An automation service acts on apps as well as on Initiative — it asks one to
+open a GitHub issue the way it asks us to create a task — and to do that it has
+to know where the app is. Only the registration says, and the registration is
+operator wiring: an internal Service address on a cluster.
+
+So this route hands it over on one condition and hides it from everybody else.
+What is pinned here is that condition, both halves of it: the caller must have
+arrived as a live delegate, and every way of not being one answers the same 404
+as an app that does not exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core import config as config_module
+from app.models.platform.guild import GuildRole
+from app.services.marketplace.registration_lookup import invalidate_registrations
+from app.testing.delegation import (
+    authorize_delegate,
+    delegate_subject,
+    install_delegate,
+    mint_delegation_token,
+    register_delegate,
+)
+from app.testing.factories import create_guild_app
+from app.testing.schema_harness import route_session_to_guild
+
+#: The app being asked about — not the delegate. Two registrations, because
+#: the whole point is one app learning where a *different* one lives.
+TARGET_PUBLIC_ID = "morelitea.github"
+TARGET_LISTING_UID = "TESTGITHUB0001"
+TARGET_BASE_URL = "http://initiative-github.svc.cluster.local:8080"
+
+
+@pytest.fixture(autouse=True)
+async def _enable_delegation(session: AsyncSession):
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            config_module.settings,
+            "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
+            "-----BEGIN PRIVATE KEY-----",
+        )
+        await register_delegate(session)
+        yield
+    invalidate_registrations()
+
+
+async def _register_target(session: AsyncSession, *, enabled: bool = True) -> None:
+    """The app whose address is being asked for."""
+    from app.models.platform.app_service_registration import (
+        AppServiceRegistration,
+        AppServiceStatus,
+    )
+
+    session.add(
+        AppServiceRegistration(
+            public_id=TARGET_PUBLIC_ID,
+            listing_uid=TARGET_LISTING_UID,
+            base_url=TARGET_BASE_URL,
+            allowed_origins=[TARGET_BASE_URL],
+            secret_encrypted=None,
+            grants=[],
+            delegation_jwks=None,
+            enabled=enabled,
+            status=AppServiceStatus.OK,
+        )
+    )
+    await session.commit()
+    invalidate_registrations()
+
+
+async def _install_target(session: AsyncSession, guild, installer, **overrides):
+    await route_session_to_guild(session, guild.id)
+    return await create_guild_app(
+        session,
+        guild,
+        installer,
+        definition={
+            "app_kind": "service",
+            "service": {"public_id": TARGET_PUBLIC_ID},
+        },
+        listing_uid=TARGET_LISTING_UID,
+        name="GitHub",
+        **overrides,
+    )
+
+
+@pytest.fixture
+async def scene(session: AsyncSession, acting_user):
+    """A guild with the delegate installed and a member who authorized it.
+
+    Built through ``acting_user`` so the member is a real one — membership and
+    a first-party session included. Both are load-bearing here: a delegated
+    call runs under the named member's own authorization, and one of these
+    tests needs that member's browser session to be refused where their
+    delegate's token is not.
+    """
+    actor = await acting_user(guild_role=GuildRole.admin)
+    await install_delegate(session, actor.guild, creator=actor.user)
+    await authorize_delegate(session, actor.guild, actor.user)
+    subject = await delegate_subject(session, actor.guild, actor.user)
+    return actor, subject
+
+
+def _headers(subject: str, guild_id: int, jti: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {mint_delegation_token(subject=subject, guild_id=guild_id, jti=jti)}"
+    }
+
+
+@pytest.mark.integration
+async def test_a_live_delegate_is_told_where_the_app_answers(
+    client: AsyncClient, session: AsyncSession, scene
+):
+    actor, subject = scene
+    guild, installer = actor.guild, actor.user
+    await _register_target(session)
+    app = await _install_target(session, guild, installer)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service",
+        headers=_headers(subject, guild.id, "svc-ok-001"),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "public_id": TARGET_PUBLIC_ID,
+        "base_url": TARGET_BASE_URL,
+        "available": True,
+    }
+
+
+@pytest.mark.integration
+async def test_the_answer_says_nothing_about_the_person(
+    client: AsyncClient, session: AsyncSession, scene
+):
+    """The caller learns an address and the app's own id. Not who asked, not
+    who installed it, and nothing that correlates a member across apps."""
+    actor, subject = scene
+    guild, installer = actor.guild, actor.user
+    await _register_target(session)
+    app = await _install_target(session, guild, installer)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service",
+        headers=_headers(subject, guild.id, "svc-shape-001"),
+    )
+
+    assert set(response.json()) == {"public_id", "base_url", "available"}
+    assert subject not in response.text
+    assert installer.email not in response.text
+
+
+@pytest.mark.integration
+async def test_a_switched_off_install_still_answers_and_says_so(
+    client: AsyncClient, session: AsyncSession, scene
+):
+    """``available`` is a real answer rather than a 404.
+
+    A caller that knows the app is switched off can park a run and say why. An
+    address it cannot tell from a missing app leaves it guessing.
+    """
+    actor, subject = scene
+    guild, installer = actor.guild, actor.user
+    await _register_target(session)
+    app = await _install_target(session, guild, installer, enabled=False)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service",
+        headers=_headers(subject, guild.id, "svc-disabled-001"),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["available"] is False
+    assert response.json()["base_url"] == TARGET_BASE_URL
+
+
+@pytest.mark.integration
+async def test_a_first_party_session_is_refused(
+    client: AsyncClient, session: AsyncSession, scene
+):
+    """The address is not a member's to read.
+
+    A signed-in guild admin can see the install in every other way; this one
+    field is the operator's wiring, and a browser has no use for it.
+    """
+    actor, _subject = scene
+    guild, installer = actor.guild, actor.user
+    await _register_target(session)
+    app = await _install_target(session, guild, installer)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service", headers=actor.headers
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "grants, enabled, case",
+    [
+        pytest.param((), True, "grant-withdrawn", id="delegate-without-the-grant"),
+        pytest.param(
+            ("delegation",), False, "switched-off", id="delegate-switched-off"
+        ),
+    ],
+)
+async def test_a_delegate_that_may_not_act_is_refused(
+    client: AsyncClient, session: AsyncSession, scene, grants, enabled, case
+):
+    """An operator's edit ends the call, and it ends it before the route.
+
+    The same rule decides which keys verify a delegate's tokens, so withdrawing
+    the grant or switching the registration off leaves the token resolving to
+    no key at all — it is not authenticated as a delegation, and the answer is
+    the bare **401** that every refused delegation gets, not this route's 404.
+
+    Asserted rather than assumed, because it is the difference between two
+    kinds of protection. The route's own ``live_delegate`` check is defence in
+    depth for exactly this case; what stops it here is the auth layer, one
+    floor down, and a change that moved the address behind a different auth
+    path would need to keep this property on purpose.
+    """
+    actor, subject = scene
+    guild, installer = actor.guild, actor.user
+    await _register_target(session)
+    app = await _install_target(session, guild, installer)
+    headers = _headers(subject, guild.id, f"svc-{case}")
+
+    # Re-register the delegate with the operator's edit applied. Done after the
+    # token is minted, because what is being tested is the check at use rather
+    # than at issue.
+    from sqlmodel import delete
+
+    from app.models.platform.app_service_registration import AppServiceRegistration
+    from app.testing.delegation import DELEGATE_PUBLIC_ID
+
+    await session.exec(
+        delete(AppServiceRegistration).where(
+            AppServiceRegistration.public_id == DELEGATE_PUBLIC_ID
+        )
+    )
+    await session.commit()
+    await register_delegate(session, grants=grants, enabled=enabled)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service", headers=headers
+    )
+
+    assert response.status_code == 401
+    assert TARGET_BASE_URL not in response.text
+
+
+@pytest.mark.integration
+async def test_an_app_with_no_service_behind_it_has_no_address(
+    client: AsyncClient, session: AsyncSession, scene
+):
+    """A tool instance or an embed is installed but has no container, so there
+    is no address for one to be given."""
+    actor, subject = scene
+    guild, installer = actor.guild, actor.user
+    await route_session_to_guild(session, guild.id)
+    app = await create_guild_app(
+        session,
+        guild,
+        installer,
+        definition={"app_kind": "tool", "tool": "projects"},
+        listing_uid="TESTTOOL000001",
+        name="A tool",
+    )
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service",
+        headers=_headers(subject, guild.id, "svc-no-service-001"),
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.integration
+async def test_a_service_this_deployment_never_wired_up_has_no_address(
+    client: AsyncClient, session: AsyncSession, scene
+):
+    """Installed here, but with no registration — so nothing it offers can be
+    reached and there is no address to hand over."""
+    actor, subject = scene
+    guild, installer = actor.guild, actor.user
+    app = await _install_target(session, guild, installer)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/apps/{app.id}/service",
+        headers=_headers(subject, guild.id, "svc-unregistered-001"),
+    )
+
+    assert response.status_code == 404

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -902,7 +902,14 @@ async def _require_delegating_app(app: GuildApp) -> None:
         )
 
 
-@router.get("/{app_id}/service", response_model=GuildAppServiceRead)
+# Off the schema, like every other route only a machine calls
+# (``app_service_endpoints`` excludes its whole router the same way). No browser
+# reaches this one, so publishing it would put a delegate-only address in the
+# SPA's generated client and this route's reasoning in a file the frontend
+# ships.
+@router.get(
+    "/{app_id}/service", response_model=GuildAppServiceRead, include_in_schema=False
+)
 async def read_app_service_address(
     app_id: int,
     request: Request,
@@ -917,15 +924,18 @@ async def read_app_service_address(
     the operator's wiring, held here and deliberately absent from
     :class:`GuildAppRead` so it never travels to a browser.
 
-    **Delegates only, and every miss is the same 404.** The caller must have
+    **Two grants, and every miss is the same 404.** The caller must have
     arrived on a delegation token (``request.state.delegating_app``) whose
-    registration is enabled and holds the ``delegation`` grant — the identical
-    rule that decides which keys verify its tokens, read through
-    :func:`registration_lookup.live_delegate` so an operator's edit reaches
-    this and the key set together. A first-party session reaching this route
-    gets the same 404 as an unknown app: the address is not a member's to read,
-    and answering the two apart would describe the deployment's wiring to a
-    caller with no standing to ask about it.
+    registration is enabled, holds ``delegation``, and holds ``app_directory``
+    — read through :func:`registration_lookup.directory_reader` so an
+    operator's edit to either reaches this and the key set together.
+
+    The second grant is the point of this route's gate. Acting for a member and
+    learning where another app answers are different powers, so an app that
+    works its own vendor holds at most the first and gets nothing here; an
+    automation service, whose whole job is acting on one app's behalf at
+    another, is conferred both. A first-party session gets the same 404: the
+    address is operator wiring rather than a member's to read.
 
     What is *not* flattened into the 404 is ``available``. Once the caller is
     established as a live delegate, "installed but switched off" is an answer it
@@ -933,7 +943,7 @@ async def read_app_service_address(
     from a missing app leaves it guessing.
     """
     delegate = getattr(request.state, "delegating_app", None)
-    if not delegate or await registration_lookup.live_delegate(delegate) is None:
+    if not delegate or await registration_lookup.directory_reader(delegate) is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=GuildAppMessages.NOT_FOUND,

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -903,10 +903,7 @@ async def _require_delegating_app(app: GuildApp) -> None:
 
 
 # Off the schema, like every other route only a machine calls
-# (``app_service_endpoints`` excludes its whole router the same way). No browser
-# reaches this one, so publishing it would put a delegate-only address in the
-# SPA's generated client and this route's reasoning in a file the frontend
-# ships.
+# (``app_service_endpoints`` excludes its whole router the same way).
 @router.get(
     "/{app_id}/service", response_model=GuildAppServiceRead, include_in_schema=False
 )
@@ -916,31 +913,19 @@ async def read_app_service_address(
     session: RLSSessionDep,
     guild_context: GuildContextDep,
 ) -> GuildAppServiceRead:
-    """Where this install's service answers — for a delegate about to call it.
+    """Where this install's service answers.
 
     An automation service acts on apps as well as on Initiative: it asks one to
-    open a GitHub issue the same way it asks us to create a task. To do that it
-    has to know where the app *is*, and only the registration says — which is
-    the operator's wiring, held here and deliberately absent from
-    :class:`GuildAppRead` so it never travels to a browser.
+    open a GitHub issue the same way it asks us to create a task, and to do
+    that it needs the app's address. Only the registration carries one, so it is
+    served here rather than on :class:`GuildAppRead`.
 
-    **Two grants, and every miss is the same 404.** The caller must have
-    arrived on a delegation token (``request.state.delegating_app``) whose
-    registration is enabled, holds ``delegation``, and holds ``app_directory``
-    — read through :func:`registration_lookup.directory_reader` so an
-    operator's edit to either reaches this and the key set together.
+    Requires a delegation token from a registration holding both ``delegation``
+    and ``app_directory``. Anything else answers 404, as does an install with no
+    service behind it.
 
-    The second grant is the point of this route's gate. Acting for a member and
-    learning where another app answers are different powers, so an app that
-    works its own vendor holds at most the first and gets nothing here; an
-    automation service, whose whole job is acting on one app's behalf at
-    another, is conferred both. A first-party session gets the same 404: the
-    address is operator wiring rather than a member's to read.
-
-    What is *not* flattened into the 404 is ``available``. Once the caller is
-    established as a live delegate, "installed but switched off" is an answer it
-    can act on — it can park a run and say why — where an address it cannot tell
-    from a missing app leaves it guessing.
+    ``available`` is reported rather than folded into the 404: a caller told an
+    app is switched off can park its work and say why.
     """
     delegate = getattr(request.state, "delegating_app", None)
     if not delegate or await registration_lookup.directory_reader(delegate) is None:

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -31,7 +31,7 @@ from datetime import datetime, timezone
 from typing import Annotated, Any, Optional
 from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -54,6 +54,7 @@ from app.models.platform.user import User
 from app.models.tenant.guild_app import GuildApp
 from app.models.tenant.initiative import Initiative
 from app.schemas.tenant.guild_app import (
+    GuildAppServiceRead,
     GuildAppConfigUpdate,
     GuildAppConnectionSummary,
     GuildAppConnectStart,
@@ -899,6 +900,70 @@ async def _require_delegating_app(app: GuildApp) -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=GuildAppMessages.DELEGATION_NOT_OFFERED,
         )
+
+
+@router.get("/{app_id}/service", response_model=GuildAppServiceRead)
+async def read_app_service_address(
+    app_id: int,
+    request: Request,
+    session: RLSSessionDep,
+    guild_context: GuildContextDep,
+) -> GuildAppServiceRead:
+    """Where this install's service answers — for a delegate about to call it.
+
+    An automation service acts on apps as well as on Initiative: it asks one to
+    open a GitHub issue the same way it asks us to create a task. To do that it
+    has to know where the app *is*, and only the registration says — which is
+    the operator's wiring, held here and deliberately absent from
+    :class:`GuildAppRead` so it never travels to a browser.
+
+    **Delegates only, and every miss is the same 404.** The caller must have
+    arrived on a delegation token (``request.state.delegating_app``) whose
+    registration is enabled and holds the ``delegation`` grant — the identical
+    rule that decides which keys verify its tokens, read through
+    :func:`registration_lookup.live_delegate` so an operator's edit reaches
+    this and the key set together. A first-party session reaching this route
+    gets the same 404 as an unknown app: the address is not a member's to read,
+    and answering the two apart would describe the deployment's wiring to a
+    caller with no standing to ask about it.
+
+    What is *not* flattened into the 404 is ``available``. Once the caller is
+    established as a live delegate, "installed but switched off" is an answer it
+    can act on — it can park a run and say why — where an address it cannot tell
+    from a missing app leaves it guessing.
+    """
+    delegate = getattr(request.state, "delegating_app", None)
+    if not delegate or await registration_lookup.live_delegate(delegate) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=GuildAppMessages.NOT_FOUND,
+        )
+
+    app = await _load(session, app_id)
+    public_id = registration_lookup.service_public_id(app.definition)
+    if public_id is None:
+        # A tool instance or an embed: installed, but with no container behind
+        # it, so there is no address for one to be given.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=GuildAppMessages.NOT_FOUND,
+        )
+
+    snapshot = (await registration_lookup.load_registrations()).get(public_id)
+    if snapshot is None:
+        # Installed here, but this deployment never wired the service up (or no
+        # longer does). Nothing it offers can be reached, and there is no
+        # address to hand over.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=GuildAppMessages.NOT_FOUND,
+        )
+
+    return GuildAppServiceRead(
+        public_id=public_id,
+        base_url=snapshot.base_url,
+        available=bool(app.enabled) and snapshot.live,
+    )
 
 
 @router.get("/{app_id}/delegation", response_model=GuildAppDelegationRead)

--- a/backend/app/models/platform/app_service_registration.py
+++ b/backend/app/models/platform/app_service_registration.py
@@ -16,10 +16,10 @@ Two columns exist only because of that split:
   * ``delegation`` — the holder may call Initiative's API as a real user, under
     that user's own gates.
   * ``app_directory`` — the holder may ask where *another* installed app's
-    service answers. Separate from ``delegation`` because they are different
-    powers: an app that acts for its own members has no call to learn the
-    deployment's wiring for anybody else's app. An automation service holds
-    both, because acting on one app's behalf at another is what it is for.
+    service answers. Separate from ``delegation`` because the two confer
+    different things: an app that acts for its own members has no call to read
+    another app's address. An automation service holds both, because acting on
+    one app's behalf at another is what it is for.
 * ``mandatory`` — the deployment asserts this app is part of what it *is*, so
   every guild has it and guild admins cannot remove it. The operator's kill
   switch (``enabled``) still outranks it.

--- a/backend/app/models/platform/app_service_registration.py
+++ b/backend/app/models/platform/app_service_registration.py
@@ -9,10 +9,17 @@ what this deployment does with it.
 
 Two columns exist only because of that split:
 
-* ``grants`` — powers beyond what any app gets by default. Today the closed
-  vocabulary holds one value, ``delegation``: the holder may call Initiative's
-  API as a real user, under that user's own gates. Conferring it is an operator
-  edit; revoking it is the same edit in reverse.
+* ``grants`` — powers beyond what any app gets by default, from a closed
+  vocabulary. Conferring one is an operator edit; revoking it is the same edit
+  in reverse.
+
+  * ``delegation`` — the holder may call Initiative's API as a real user, under
+    that user's own gates.
+  * ``app_directory`` — the holder may ask where *another* installed app's
+    service answers. Separate from ``delegation`` because they are different
+    powers: an app that acts for its own members has no call to learn the
+    deployment's wiring for anybody else's app. An automation service holds
+    both, because acting on one app's behalf at another is what it is for.
 * ``mandatory`` — the deployment asserts this app is part of what it *is*, so
   every guild has it and guild admins cannot remove it. The operator's kill
   switch (``enabled``) still outranks it.
@@ -76,7 +83,7 @@ APP_SERVICE_STATUSES: frozenset[str] = frozenset(
 #: The closed vocabulary of operator-conferred powers. A value outside this set
 #: is refused on write rather than stored as something no code resolves — the
 #: same "declare it or it does not exist" rule the listing validator applies.
-APP_SERVICE_GRANTS: frozenset[str] = frozenset({"delegation"})
+APP_SERVICE_GRANTS: frozenset[str] = frozenset({"delegation", "app_directory"})
 
 
 class AppServiceRegistration(SQLModel, table=True):

--- a/backend/app/schemas/tenant/guild_app.py
+++ b/backend/app/schemas/tenant/guild_app.py
@@ -486,24 +486,18 @@ def serialize_delegation(row: Any) -> GuildAppDelegationRead:
 
 
 class GuildAppServiceRead(SanitizedBaseModel):
-    """Where one installed app's service answers, for a delegate to call it.
+    """Where one installed app's service answers.
 
-    Served only to a caller the operator conferred ``app_directory`` on (see
-    the route), and deliberately not part of :class:`GuildAppRead`:
-    ``base_url`` is where Initiative's *server* reaches the app, which is the
-    operator's own wiring rather than anything an install describes. It has no
-    business travelling to a browser alongside the rest of an install — a
-    member reading the sidebar has no use for it.
+    Not part of :class:`GuildAppRead`: ``base_url`` is operator wiring rather
+    than anything an install describes, and nothing in the UI draws it.
     """
 
     #: The app's registered service id, echoed so a caller can check it got the
     #: app it meant rather than matching on the install id alone.
     public_id: str
     base_url: str
-    #: Whether anything may flow through this app right now — the guild's own
-    #: switch and the operator's kill switch, together. False is a real answer
-    #: rather than a 404: a caller that knows the app is switched off can say
-    #: so, where a missing address is indistinguishable from a missing app.
+    #: Whether anything may flow through this app right now: the guild's own
+    #: switch and the operator's, together.
     available: bool
 
 

--- a/backend/app/schemas/tenant/guild_app.py
+++ b/backend/app/schemas/tenant/guild_app.py
@@ -485,6 +485,28 @@ def serialize_delegation(row: Any) -> GuildAppDelegationRead:
     )
 
 
+class GuildAppServiceRead(SanitizedBaseModel):
+    """Where one installed app's service answers, for a delegate to call it.
+
+    Served only to a delegate (see the route), and deliberately not part of
+    :class:`GuildAppRead`: ``base_url`` is where Initiative's *server* reaches
+    the app, which on a cluster is an internal address. It is operator wiring,
+    so it has no business travelling to a browser alongside the rest of an
+    install — a member reading the sidebar has no use for it and every reason
+    not to be told.
+    """
+
+    #: The app's registered service id, echoed so a caller can check it got the
+    #: app it meant rather than matching on the install id alone.
+    public_id: str
+    base_url: str
+    #: Whether anything may flow through this app right now — the guild's own
+    #: switch and the operator's kill switch, together. False is a real answer
+    #: rather than a 404: a caller that knows the app is switched off can say
+    #: so, where a missing address is indistinguishable from a missing app.
+    available: bool
+
+
 def serialize_member_delegation(row: Any) -> GuildAppMemberDelegation:
     return GuildAppMemberDelegation(
         user_id=row.user_id,

--- a/backend/app/schemas/tenant/guild_app.py
+++ b/backend/app/schemas/tenant/guild_app.py
@@ -488,12 +488,12 @@ def serialize_delegation(row: Any) -> GuildAppDelegationRead:
 class GuildAppServiceRead(SanitizedBaseModel):
     """Where one installed app's service answers, for a delegate to call it.
 
-    Served only to a delegate (see the route), and deliberately not part of
-    :class:`GuildAppRead`: ``base_url`` is where Initiative's *server* reaches
-    the app, which on a cluster is an internal address. It is operator wiring,
-    so it has no business travelling to a browser alongside the rest of an
-    install — a member reading the sidebar has no use for it and every reason
-    not to be told.
+    Served only to a caller the operator conferred ``app_directory`` on (see
+    the route), and deliberately not part of :class:`GuildAppRead`:
+    ``base_url`` is where Initiative's *server* reaches the app, which is the
+    operator's own wiring rather than anything an install describes. It has no
+    business travelling to a browser alongside the rest of an install — a
+    member reading the sidebar has no use for it.
     """
 
     #: The app's registered service id, echoed so a caller can check it got the

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -367,6 +367,25 @@ async def live_delegate(public_id: str) -> Optional[RegistrationSnapshot]:
     return snapshot
 
 
+async def directory_reader(public_id: str) -> Optional[RegistrationSnapshot]:
+    """The registration behind a caller allowed to ask where other apps answer.
+
+    A live delegate that *also* holds ``app_directory``. Two grants rather than
+    one because they are two powers: acting for a member is what most delegates
+    are for, and learning the deployment's wiring for somebody else's app is
+    not part of it. An automation service is conferred both; an app that only
+    ever works its own vendor holds at most the first, and asking gets it the
+    same nothing as an app the operator never registered.
+
+    Reads through the same snapshot :func:`live_delegate` does, so revoking
+    either grant lands on both within the cache TTL.
+    """
+    snapshot = await live_delegate(public_id)
+    if snapshot is None or "app_directory" not in snapshot.grants:
+        return None
+    return snapshot
+
+
 async def delegate_jwks(public_id: str) -> dict[str, Any] | None:
     """One delegate's public verification keys, as a JWKS document.
 

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -368,17 +368,13 @@ async def live_delegate(public_id: str) -> Optional[RegistrationSnapshot]:
 
 
 async def directory_reader(public_id: str) -> Optional[RegistrationSnapshot]:
-    """The registration behind a caller allowed to ask where other apps answer.
+    """The registration behind a caller that may ask where other apps answer.
 
-    A live delegate that *also* holds ``app_directory``. Two grants rather than
-    one because they are two powers: acting for a member is what most delegates
-    are for, and learning the deployment's wiring for somebody else's app is
-    not part of it. An automation service is conferred both; an app that only
-    ever works its own vendor holds at most the first, and asking gets it the
-    same nothing as an app the operator never registered.
-
-    Reads through the same snapshot :func:`live_delegate` does, so revoking
-    either grant lands on both within the cache TTL.
+    A live delegate that also holds ``app_directory``. Two grants rather than
+    one because they confer different things: acting for a member is what most
+    delegates are for, and reading another app's address is not part of it. An
+    automation service is conferred both; an app that works its own vendor is
+    conferred at most the first.
     """
     snapshot = await live_delegate(public_id)
     if snapshot is None or "app_directory" not in snapshot.grants:

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -33,7 +33,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useAuth } from "@/hooks/useAuth";
 import { useCreateCalendarEvent } from "@/hooks/useCalendarEvents";
-import { useCalendarsList } from "@/hooks/useCalendars";
+import { useCalendar, useCalendarsList } from "@/hooks/useCalendars";
 import { getItem, setItem } from "@/lib/storage";
 import type { DialogProps } from "@/types/dialog";
 
@@ -97,22 +97,28 @@ export const CreateEventDialog = ({
   );
 
   // Calendars the current user may author events in (write on the calendar).
+  // Locked to one calendar the picker is hidden, so there is no list to fill:
+  // that calendar is read on its own instead. A guild calendar's surface shows
+  // guild-level content only, and this is the one read on it that would
+  // otherwise span the guild's initiatives.
   const calendarsQuery = useCalendarsList(
     { page_size: 200, ...(initiativeId ? { initiative_id: initiativeId } : {}) },
-    { enabled: open }
+    { enabled: open && calendarId === undefined }
   );
   const writableCalendars = useMemo(
     () => (calendarsQuery.data?.items ?? []).filter(isWritableCalendar),
     [calendarsQuery.data]
   );
+  const lockedCalendarQuery = useCalendar(calendarId ?? null, { enabled: open });
 
   const effectiveCalendarId =
     calendarId ?? (selectedCalendarId ? Number(selectedCalendarId) : null);
   const effectiveCalendar = useMemo(
     () =>
+      lockedCalendarQuery.data ??
       (calendarsQuery.data?.items ?? []).find((calendar) => calendar.id === effectiveCalendarId) ??
       null,
-    [calendarsQuery.data, effectiveCalendarId]
+    [lockedCalendarQuery.data, calendarsQuery.data, effectiveCalendarId]
   );
 
   // Default the picker: explicit default > last-used (per guild) > the only

--- a/frontend/src/pages/initiativeTools/events/CalendarsPage.test.tsx
+++ b/frontend/src/pages/initiativeTools/events/CalendarsPage.test.tsx
@@ -159,3 +159,72 @@ describe("CalendarsView calendar-entries query", () => {
     await waitFor(() => expect(screen.queryByText("Apollo task")).toBeNull());
   });
 });
+
+describe("CalendarsView on a guild calendar", () => {
+  /** The calendar the app mounts: guild-level, so it belongs to no initiative. */
+  const guildCalendar = {
+    id: 42,
+    name: "Guild calendar",
+    description: null,
+    color: "#6366f1",
+    initiative_id: null,
+    guild_id: 1,
+    created_by: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    my_permission_level: "write",
+    tags: [],
+    grants: [],
+  };
+
+  it("asks for its own events only, and reads nothing initiative-shaped", async () => {
+    const entries: URLSearchParams[] = [];
+    const calendarList: string[] = [];
+    const projectList: string[] = [];
+    server.use(
+      guildHttp.get("/calendar-entries/", ({ request }) => {
+        entries.push(new URL(request.url).searchParams);
+        return HttpResponse.json({ events: [], tasks: [] });
+      }),
+      guildHttp.get("/calendars/", ({ request }) => {
+        calendarList.push(request.url);
+        return HttpResponse.json({
+          items: [],
+          total_count: 0,
+          page: 1,
+          page_size: 100,
+          has_next: false,
+        });
+      }),
+      guildHttp.get("/projects/", ({ request }) => {
+        projectList.push(request.url);
+        return HttpResponse.json({
+          items: [],
+          total_count: 0,
+          page: 1,
+          page_size: 0,
+          has_next: false,
+        });
+      })
+    );
+
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(VIEW_PREFERENCES_QUERY_KEY, {
+      items: { [CALENDAR_VIEW_MODE_KEY]: "list" },
+    });
+    const Page = () => <CalendarsView soloCalendar={guildCalendar} />;
+    renderPage(Page, { queryClient });
+
+    await waitFor(() => expect(entries.length).toBeGreaterThan(0));
+
+    // Exactly this calendar, no task leg, and no initiative to narrow to.
+    expect(entries[0].getAll("calendar_ids")).toEqual([String(guildCalendar.id)]);
+    expect(entries[0].get("include_tasks")).toBe("false");
+    expect(entries[0].get("initiative_id")).toBeNull();
+
+    // The panel, the task-calendar rows and the filter bar are all initiative-
+    // shaped, so the surface never lists the guild's calendars or projects.
+    expect(calendarList).toEqual([]);
+    expect(projectList).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

An automation service acts on apps as well as on Initiative — it asks one to open a GitHub issue the way it asks us to create a task. To dispatch that call it has to know **where the app is**, and only the registration says. That address is operator wiring (an internal Service name on a cluster), so `GuildAppRead` deliberately does not carry it and there was no other way to ask.

## Changes

**1. The route** — `GET /api/v1/g/{guild_id}/apps/{app_id}/service`

Answers `{public_id, base_url, available}`, and only to a delegate. The caller must have arrived on a delegation token (`request.state.delegating_app`) whose registration is `enabled` and holds the `delegation` grant — read through `registration_lookup.live_delegate`, so an operator's edit reaches this route and the published key set together rather than one of them a minute later.

A first-party session gets the same `404` as an unknown app. The address is not a member's to read: they can see the install every other way, and a browser has no use for the cluster-internal address.

**2. What is deliberately not flattened into that 404**

`available` — the guild's own switch and the operator's kill switch together. Once the caller is established as a live delegate, "installed but switched off" is an answer it can act on (park a run and say why), where an address it cannot tell from a missing app leaves it guessing. Every *other* miss is one 404: not a service app, no registration on this deployment, no such install.

**3. A property worth knowing about, asserted rather than assumed**

A delegate that lost its grant, or whose registration was switched off, is refused one floor lower than this route — its token resolves to no key, so it is not authenticated as a delegation at all and gets the bare `401` every refused delegation gets. The route's own `live_delegate` check is defence in depth for exactly that case. The test pins the 401 so a change that moved this behind a different auth path would have to keep the property on purpose.

## Schema / env

No migration, no env. One new response schema (`GuildAppServiceRead`); the route is on the normal `/g/{guild_id}/apps` router, so generated frontend types pick it up.

## Testing

```
.venv/bin/python -m pytest app/api/v1/tenant_endpoints/guild_app_service_test.py \
  app/api/v1/tenant_endpoints/guild_apps_test.py \
  app/api/v1/tenant_endpoints/guild_app_delegations_test.py \
  app/api/v1/tenant_endpoints/auto_delegation_test.py   # 59 passed
ruff check app && ty check app                          # clean
```

8 new tests: the happy path, that the answer names nobody (no subject, no email), a switched-off install answering `available: false`, a first-party session refused, both delegate-may-not-act legs, a tool instance with no service behind it, and a service this deployment never wired up.

## Note on the second commit

`Read the locked calendar on its own` is an unrelated calendar-dialog fix that was already in the working tree; carried along here rather than stranded.