### PR TITLE
Send the guild with the connect handle

### DIFF
--- a/backend/app/api/v1/app_service_endpoints/installs_test.py
+++ b/backend/app/api/v1/app_service_endpoints/installs_test.py
@@ -860,6 +860,41 @@ class TestConnectionWriteBack:
             "access_token": "gho_freshly_minted"
         }
 
+    async def test_a_ref_only_resolves_in_the_guild_it_was_minted_for(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """The guild in a write selects an install; the ref is what has to match.
+
+        A member is handed ``?connection_ref=…&guild_id=…`` in their own browser
+        and can change either before the app ever sees them, so the pairing is
+        checked rather than trusted: the ref is looked up inside the install the
+        named guild holds, and one minted elsewhere is not in it. Both guilds
+        below have the app installed, which is the case where a guild id on its
+        own would otherwise name something real.
+        """
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, user, app = await _install(session)
+        row = await _member_connection(
+            session, guild=guild, app=app, user=user, with_secret=False
+        )
+        other_guild, _other_user, _other_app = await _install(session)
+
+        written = await _put(
+            client,
+            f"{BASE}/installs/{other_guild.id}/connections/{row.connection_ref}",
+            {"values": {"access_token": "gho_written_to_the_wrong_guild"}},
+        )
+
+        assert written.status_code == 404, written.text
+        # Named, so this pins the ref lookup refusing rather than the install
+        # one — the other guild really does have the app, and the write got as
+        # far as looking the handle up in it.
+        assert written.json()["detail"] == AppChannelMessages.CONNECTION_NOT_FOUND
+
+        # And the row it named is untouched where that ref actually lives.
+        config = await _get(client, f"{BASE}/installs/{guild.id}/config")
+        assert config.json()["member_connections"][0]["values"] == {}
+
     async def test_a_refresh_replaces_the_stored_value(
         self, client: AsyncClient, session: AsyncSession
     ):

--- a/backend/app/api/v1/app_service_endpoints/installs_test.py
+++ b/backend/app/api/v1/app_service_endpoints/installs_test.py
@@ -863,14 +863,11 @@ class TestConnectionWriteBack:
     async def test_a_ref_only_resolves_in_the_guild_it_was_minted_for(
         self, client: AsyncClient, session: AsyncSession
     ):
-        """The guild in a write selects an install; the ref is what has to match.
+        """A write names a guild, and the handle is looked up inside it.
 
-        A member is handed ``?connection_ref=…&guild_id=…`` in their own browser
-        and can change either before the app ever sees them, so the pairing is
-        checked rather than trusted: the ref is looked up inside the install the
-        named guild holds, and one minted elsewhere is not in it. Both guilds
-        below have the app installed, which is the case where a guild id on its
-        own would otherwise name something real.
+        Both guilds below have the app installed, so the install resolves and
+        the lookup is the thing being exercised rather than short-circuited by
+        a guild with nothing in it.
         """
         await register_app_service(session, listing_uid=SHOP_UID)
         guild, user, app = await _install(session)
@@ -886,12 +883,11 @@ class TestConnectionWriteBack:
         )
 
         assert written.status_code == 404, written.text
-        # Named, so this pins the ref lookup refusing rather than the install
-        # one — the other guild really does have the app, and the write got as
-        # far as looking the handle up in it.
+        # Named rather than taken as any 404: the handle is what did not
+        # resolve, the install having been found.
         assert written.json()["detail"] == AppChannelMessages.CONNECTION_NOT_FOUND
 
-        # And the row it named is untouched where that ref actually lives.
+        # And the row it named is unchanged where that handle does live.
         config = await _get(client, f"{BASE}/installs/{guild.id}/config")
         assert config.json()["member_connections"][0]["values"] == {}
 

--- a/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
@@ -372,10 +372,13 @@ class TestConnect:
         assert body["status"] == "pending"
         assert body["connection_ref"]
         # Where to actually send them: the operator's address, the manifest's
-        # path, and the handle the app will store its result against.
+        # path, the handle the app will store its result against, and the guild
+        # to write it back under — the app addresses every install by guild and
+        # cannot derive one from the ref.
         assert body["connect_url"] == (
             "https://shop.example.test/connect/github"
             f"?connection_ref={body['connection_ref']}"
+            f"&guild_id={a.guild.id}"
         )
 
     async def test_the_handle_is_opaque_and_carries_nothing_about_the_person(

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -812,8 +812,19 @@ async def connect_guild_app(
         connect_url=(
             # The member's browser is what follows this, so it is built from
             # the address a browser can resolve.
+            #
+            # The guild travels with the ref because the app's return leg has
+            # no other way to learn it: the channel addresses every install by
+            # guild, and a ref on its own names nothing the app can look up.
+            # Without it each app would sweep its installs guild by guild
+            # looking for the ref — the same sweep, rewritten per app.
+            #
+            # It is a routing hint rather than an authority. Every write still
+            # resolves the ref inside the install the *signature* selected, so
+            # a guild that does not hold this ref simply does not find it.
             f"{registration.browser_base}{connect_path}"
             f"?connection_ref={quote(row.connection_ref, safe='')}"
+            f"&guild_id={app.guild_id}"
         ),
         status=row.status,
     )

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -813,15 +813,10 @@ async def connect_guild_app(
             # The member's browser is what follows this, so it is built from
             # the address a browser can resolve.
             #
-            # The guild travels with the ref because the app's return leg has
-            # no other way to learn it: the channel addresses every install by
-            # guild, and a ref on its own names nothing the app can look up.
-            # Without it each app would sweep its installs guild by guild
-            # looking for the ref — the same sweep, rewritten per app.
-            #
-            # It is a routing hint rather than an authority. Every write still
-            # resolves the ref inside the install the *signature* selected, so
-            # a guild that does not hold this ref simply does not find it.
+            # The guild travels with the ref because the channel addresses
+            # every install by guild: the app writes its result back to
+            # ``/installs/{guild_id}/connections/{ref}``, and a ref on its own
+            # names nothing it can look up.
             f"{registration.browser_base}{connect_path}"
             f"?connection_ref={quote(row.connection_ref, safe='')}"
             f"&guild_id={app.guild_id}"

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -876,6 +876,7 @@ class TestConnectLaunch:
         assert body["connect_url"] == (
             "https://widgetco.example.test/connect/github"
             f"?connection_ref={body['connection_ref']}"
+            f"&guild_id={a.guild.id}"
         )
 
     async def test_the_url_uses_the_browser_address(
@@ -905,9 +906,9 @@ class TestConnectLaunch:
     async def test_no_token_travels_in_the_url(
         self, client: AsyncClient, acting_user, session: AsyncSession, registration
     ):
-        """The only thing in the query string is the opaque handle. It
-        authorizes nothing: the app writes its result back over its own
-        authenticated channel."""
+        """The query string carries the opaque handle and the guild to write
+        back under, and no credential of any kind: the app writes its result
+        over its own authenticated channel."""
         a = await acting_user(guild_role=GuildRole.admin)
         app = await self._install(session, a)
 
@@ -917,7 +918,10 @@ class TestConnectLaunch:
             )
         ).json()
         query = body["connect_url"].split("?", 1)[1]
-        assert query == f"connection_ref={body['connection_ref']}"
+        # Pinned exactly, so anything added to this URL is added deliberately.
+        assert query == (
+            f"connection_ref={body['connection_ref']}&guild_id={a.guild.id}"
+        )
         for smell in ("token", "jwt", "secret", "Bearer", "eyJ"):
             assert smell not in query
 


### PR DESCRIPTION
## Problem

`POST /apps/{id}/connections/{connection}/connect` hands the member's browser a
URL built from the operator's browser-facing address, the manifest's path, and
the connection handle — and nothing else. But the app's return leg writes its
result back to `/app-service/installs/{guild_id}/connections/{ref}`, which is
addressed **by guild**, and a handle on its own names nothing an app can look
up.

So an app finishing a vendor flow had to sweep: for each guild it is installed
in, list connections and look for the handle. Every app that runs a vendor flow
needs that same answer, so a sweep in one of them is a sweep each future app
rewrites.

## Changes

[guild_apps.py](backend/app/api/v1/tenant_endpoints/guild_apps.py) appends
`&guild_id={app.guild_id}` to `connect_url`. One expression; the response schema
is unchanged, so no generated types move.

A write names a guild and the handle is looked up inside that guild's install,
which is what
[installs_test.py](backend/app/api/v1/app_service_endpoints/installs_test.py)
now pins — with the app installed in both guilds, so the install resolves and
the lookup is the thing exercised.

Three existing assertions pinned the old single-parameter URL and are updated:
two in
[guild_apps_platform_test.py](backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py)
and one in
[guild_app_connections_test.py](backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py).
The query string stays pinned exactly, so anything added to this URL later is
added deliberately, and it still carries no credential of any kind.

## Testing

- `pytest app/api/v1/tenant_endpoints/guild_apps_platform_test.py app/api/v1/tenant_endpoints/guild_app_connections_test.py app/api/v1/app_service_endpoints/ app/api/v1/tenant_endpoints/guild_apps_test.py`
- `ruff check app`, `ruff format`, `ty check app` — clean
- `scripts/export_openapi.py` — no schema drift, `frontend/src/api/generated/`
  untouched

## Coordination

The GitHub app's half depends on this shipping first: it captures `guild_id` at
`/connect/github` and persists it beside the handle and the PKCE verifier rather
than reading it at the callback, since the vendor echoes only `state`.
