### PR TITLE
Give an app one endpoint vocabulary instead of three surfaces

### DIFF
--- a/backend/app/api/v1/app_service_endpoints/events_test.py
+++ b/backend/app/api/v1/app_service_endpoints/events_test.py
@@ -37,11 +37,12 @@ ORDER_CREATED = "app.tests.shop.order_created"
 
 
 def _definition(public_id: str = "tests.shop", events: list[str] | None = None) -> dict:
+    declared = [ORDER_CREATED] if events is None else events
     return {
         "app_kind": "service",
         "service": {"public_id": public_id, "protocol": 1},
-        "features": ["events"],
-        "events": [ORDER_CREATED] if events is None else events,
+        "features": ["endpoints"],
+        "endpoints": [{"id": event, "direction": "emit"} for event in declared],
     }
 
 
@@ -177,6 +178,33 @@ async def test_another_apps_namespace_is_refused(
             "event_type": "app.tests.other.order_created",
             "payload": {},
         },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == AppChannelMessages.UNKNOWN_EVENT_TYPE
+    assert dispatched == []
+
+
+async def test_an_endpoint_that_is_not_an_emit_is_refused(
+    client: AsyncClient, session: AsyncSession, dispatched
+):
+    """Reads, writes and emissions share one id space, so being declared is not
+    enough — an app announcing under a read's id would be emitting something no
+    subscriber could have asked for, because only emissions are subscribable."""
+    await register_app_service(session, listing_uid=SHOP_UID)
+    guild, _ = await _install(
+        session,
+        definition={
+            "app_kind": "service",
+            "service": {"public_id": "tests.shop", "protocol": 1},
+            "features": ["endpoints"],
+            "endpoints": [{"id": ORDER_CREATED, "direction": "read"}],
+        },
+    )
+
+    response = await _emit(
+        client,
+        {"guild_id": guild.id, "event_type": ORDER_CREATED, "payload": {}},
     )
 
     assert response.status_code == 400

--- a/backend/app/api/v1/tenant_endpoints/app_data.py
+++ b/backend/app/api/v1/tenant_endpoints/app_data.py
@@ -7,8 +7,8 @@ widgets, what each widget draws, and the module the browser will run in its
 sandbox. It comes from each install's **pinned** definition, so a canvas is
 authored against the version the guild chose.
 
-``/apps/{app_id}/data/{source_id}`` is the proxy. A widget never names an
-endpoint — it names a source on an installed app, and this route turns that into
+``/apps/{app_id}/data/{endpoint_id}`` is the proxy. A widget never names an
+endpoint — it names a endpoint on an installed app, and this route turns that into
 one bounded call to the app's own service. The request carries the dashboard the
 widget sits on, and that is what makes the gates run **before** anything else:
 
@@ -17,9 +17,9 @@ widget sits on, and that is what makes the gates run **before** anything else:
 * the dashboard is loaded through the ordinary resource path, so a member of the
   guild who is not in the dashboard's initiative gets the same answer they would
   get for the dashboard itself — nothing;
-* the dashboard has to actually bind this source, so holding one dashboard is
-  not a key to every source an app offers;
-* the source's own ``visibility`` is then checked against the caller's real
+* the dashboard has to actually bind this endpoint, so holding one dashboard is
+  not a key to every endpoint an app offers;
+* the endpoint's own ``visibility`` is then checked against the caller's real
   guild role.
 
 Only after all of that does the service layer look at the response cache, which
@@ -64,9 +64,9 @@ def _binds_source(
     config: dict[str, Any] | None,
     *,
     app_uid: str,
-    source_id: str,
+    endpoint_id: str,
 ) -> bool:
-    """Whether a dashboard actually displays this source.
+    """Whether a dashboard actually displays this endpoint.
 
     The instance config layers over the definition's binding exactly as the
     canvas resolves it, so a slot a listing left open and the guild filled in
@@ -88,7 +88,7 @@ def _binds_source(
         if (
             effective.get("source") == "app"
             and effective.get("app_uid") == app_uid
-            and effective.get("source_id") == source_id
+            and effective.get("endpoint_id") == endpoint_id
         ):
             return True
     return False
@@ -105,8 +105,8 @@ async def read_app_widget_catalog(
     """Which widgets this guild's installed apps contribute.
 
     Every member may read it: an app's existence is guild-wide knowledge and the
-    palette carries no guild data — declarations, module source, and sample
-    rows, all from the pinned definition. A source declared for guild admins is
+    palette carries no guild data — declarations, module endpoint, and sample
+    rows, all from the pinned definition. A endpoint declared for guild admins is
     still listed, and still refused at fetch time to anyone else.
 
     Disabled installs are left out entirely: their widgets have nothing to draw,
@@ -132,15 +132,15 @@ async def read_app_widget_catalog(
         if not widgets:
             continue
 
-        sources = [
+        endpoints = [
             AppDataSourceRead(
-                id=source["id"],
-                visibility=source.get("visibility") or "member",
-                cache_ttl_seconds=source.get("cache_ttl_seconds") or 0,
-                params_schema=source.get("params_schema") or [],
+                id=endpoint["id"],
+                visibility=endpoint.get("visibility") or "member",
+                cache_ttl_seconds=endpoint.get("cache_ttl_seconds") or 0,
+                params_schema=endpoint.get("params") or [],
             )
-            for source in definition.get("data_sources") or []
-            if isinstance(source, dict) and isinstance(source.get("id"), str)
+            for endpoint in definition.get("endpoints") or []
+            if isinstance(endpoint, dict) and isinstance(endpoint.get("id"), str)
         ]
         items.append(
             AppWidgetCatalogEntry(
@@ -154,21 +154,21 @@ async def read_app_widget_catalog(
                         id=widget["id"],
                         meta=widget.get("meta") or {},
                         module_source=widget.get("module_source") or "",
-                        sources=widget.get("sources") or [],
+                        endpoints=widget.get("endpoints") or [],
                         sample_data=widget.get("sample_data") or {},
                     )
                     for widget in widgets
                 ],
-                data_sources=sources,
+                data_sources=endpoints,
             )
         )
     return AppWidgetCatalogResponse(items=items)
 
 
-@router.get("/{app_id}/data/{source_id}", response_model=AppDataResponse)
+@router.get("/{app_id}/data/{endpoint_id}", response_model=AppDataResponse)
 async def read_app_data(
     app_id: int,
-    source_id: str,
+    endpoint_id: str,
     session: RLSSessionDep,
     current_user: CurrentUser,
     guild_context: GuildContextDep,
@@ -186,7 +186,7 @@ async def read_app_data(
         Query(description="The binding's parameters, as a JSON object."),
     ] = None,
 ) -> AppDataResponse:
-    """One app data source, resolved for this viewer.
+    """One app data endpoint, resolved for this viewer.
 
     Returns the app's rows verbatim with the time they were obtained. An app
     that is unreachable, slow, oversized, or answering in a shape this build
@@ -210,7 +210,7 @@ async def read_app_data(
         dashboard.definition,
         dashboard.config,
         app_uid=app.listing_uid,
-        source_id=source_id,
+        endpoint_id=endpoint_id,
     ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -221,7 +221,7 @@ async def read_app_data(
         result = await app_data_service.fetch_app_source(
             session,
             app=app,
-            source_id=source_id,
+            endpoint_id=endpoint_id,
             raw_params=params,
             user_id=current_user.id,
             is_guild_admin=rls_service.is_guild_admin(guild_context.role),

--- a/backend/app/api/v1/tenant_endpoints/app_data.py
+++ b/backend/app/api/v1/tenant_endpoints/app_data.py
@@ -44,7 +44,7 @@ from app.models.platform.user import User
 from app.models.tenant.guild_app import GuildApp
 from app.schemas.tenant.app_data import (
     AppDataResponse,
-    AppDataSourceRead,
+    AppEndpointRead,
     AppWidgetCatalogEntry,
     AppWidgetCatalogResponse,
     AppWidgetRead,
@@ -132,15 +132,19 @@ async def read_app_widget_catalog(
         if not widgets:
             continue
 
+        # Reads only. A picker offering a write would offer a tile that makes
+        # the app act every time somebody looks at a dashboard.
         endpoints = [
-            AppDataSourceRead(
+            AppEndpointRead(
                 id=endpoint["id"],
                 visibility=endpoint.get("visibility") or "member",
                 cache_ttl_seconds=endpoint.get("cache_ttl_seconds") or 0,
-                params_schema=endpoint.get("params") or [],
+                params=endpoint.get("params") or [],
             )
             for endpoint in definition.get("endpoints") or []
-            if isinstance(endpoint, dict) and isinstance(endpoint.get("id"), str)
+            if isinstance(endpoint, dict)
+            and isinstance(endpoint.get("id"), str)
+            and endpoint.get("direction") == "read"
         ]
         items.append(
             AppWidgetCatalogEntry(
@@ -159,7 +163,7 @@ async def read_app_widget_catalog(
                     )
                     for widget in widgets
                 ],
-                data_sources=endpoints,
+                endpoints=endpoints,
             )
         )
     return AppWidgetCatalogResponse(items=items)

--- a/backend/app/api/v1/tenant_endpoints/app_data.py
+++ b/backend/app/api/v1/tenant_endpoints/app_data.py
@@ -7,9 +7,9 @@ widgets, what each widget draws, and the module the browser will run in its
 sandbox. It comes from each install's **pinned** definition, so a canvas is
 authored against the version the guild chose.
 
-``/apps/{app_id}/data/{endpoint_id}`` is the proxy. A widget never names an
-endpoint — it names a endpoint on an installed app, and this route turns that into
-one bounded call to the app's own service. The request carries the dashboard the
+``/apps/{app_id}/endpoints/{endpoint_id}`` is the proxy. A widget never names
+an address — it names a read endpoint on an installed app, and this route turns
+that into one bounded call to the app's own service. The request carries the dashboard the
 widget sits on, and that is what makes the gates run **before** anything else:
 
 * the URL is ``/g/{guild_id}/…`` under a session that assumes the guild's own
@@ -59,7 +59,7 @@ CurrentUser = Annotated[User, Depends(get_current_active_user)]
 GuildContextDep = Annotated[GuildContext, Depends(get_guild_membership)]
 
 
-def _binds_source(
+def _binds_endpoint(
     definition: dict[str, Any] | None,
     config: dict[str, Any] | None,
     *,
@@ -105,9 +105,9 @@ async def read_app_widget_catalog(
     """Which widgets this guild's installed apps contribute.
 
     Every member may read it: an app's existence is guild-wide knowledge and the
-    palette carries no guild data — declarations, module endpoint, and sample
-    rows, all from the pinned definition. A endpoint declared for guild admins is
-    still listed, and still refused at fetch time to anyone else.
+    palette carries no guild data — declarations, module source, and sample
+    rows, all from the pinned definition. An endpoint declared for guild admins
+    is still listed, and still refused at fetch time to anyone else.
 
     Disabled installs are left out entirely: their widgets have nothing to draw,
     so offering them would be offering a binding that cannot resolve.
@@ -169,7 +169,7 @@ async def read_app_widget_catalog(
     return AppWidgetCatalogResponse(items=items)
 
 
-@router.get("/{app_id}/data/{endpoint_id}", response_model=AppDataResponse)
+@router.get("/{app_id}/endpoints/{endpoint_id}", response_model=AppDataResponse)
 async def read_app_data(
     app_id: int,
     endpoint_id: str,
@@ -190,7 +190,7 @@ async def read_app_data(
         Query(description="The binding's parameters, as a JSON object."),
     ] = None,
 ) -> AppDataResponse:
-    """One app data endpoint, resolved for this viewer.
+    """One of an app's read endpoints, resolved for this viewer.
 
     Returns the app's rows verbatim with the time they were obtained. An app
     that is unreachable, slow, oversized, or answering in a shape this build
@@ -208,9 +208,9 @@ async def read_app_data(
     if app is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=AppDataMessages.SOURCE_NOT_FOUND,
+            detail=AppDataMessages.ENDPOINT_NOT_FOUND,
         )
-    if not _binds_source(
+    if not _binds_endpoint(
         dashboard.definition,
         dashboard.config,
         app_uid=app.listing_uid,
@@ -218,7 +218,7 @@ async def read_app_data(
     ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=AppDataMessages.SOURCE_NOT_FOUND,
+            detail=AppDataMessages.ENDPOINT_NOT_FOUND,
         )
 
     try:

--- a/backend/app/api/v1/tenant_endpoints/app_data_test.py
+++ b/backend/app/api/v1/tenant_endpoints/app_data_test.py
@@ -32,6 +32,7 @@ for real.
 
 from datetime import datetime, timezone
 
+import json
 import httpx
 import jwt
 import pytest
@@ -56,6 +57,13 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
 APP_UID = "SHPAPP00000001"
 PUBLIC_ID = "acme.shop"
+
+#: What the fixture app declares. Namespaced under its own service id, which is
+#: what every endpoint id has to be.
+ORDERS_SUMMARY = f"app.{PUBLIC_ID}.orders-summary"
+REVENUE = f"app.{PUBLIC_ID}.revenue"
+MY_PRS = f"app.{PUBLIC_ID}.my-prs"
+REFUND = f"app.{PUBLIC_ID}.refund"
 BASE_URL = "http://127.0.0.1:9100"
 
 #: A widget module with the characters a plain-text sanitizer would mangle.
@@ -90,32 +98,34 @@ def _definition() -> dict:
     return {
         "app_kind": "service",
         "service": {"public_id": PUBLIC_ID, "protocol": 1},
-        "features": ["data", "widgets"],
+        "features": ["endpoints", "widgets"],
         "connections": [ADMIN_CONNECTION, GITHUB_CONNECTION],
-        "data_sources": [
+        "endpoints": [
             {
-                "id": "orders_summary",
-                "path": "/v1/data/orders_summary",
+                "id": ORDERS_SUMMARY,
+                "direction": "read",
                 "visibility": "member",
                 "cache_ttl_seconds": 60,
-                "params_schema": [
+                "params": [
                     _field("range", "select", options=["7d", "30d"]),
                     _field("limit", "int"),
                 ],
             },
             {
-                "id": "revenue",
-                "path": "/v1/data/revenue",
+                "id": REVENUE,
+                "direction": "read",
                 "visibility": "guild_admin",
                 "cache_ttl_seconds": 0,
             },
             {
-                "id": "my_prs",
-                "path": "/v1/data/my_prs",
+                "id": MY_PRS,
+                "direction": "read",
                 "visibility": "member",
                 "cache_ttl_seconds": 60,
                 "requires": {"all_of": ["github"]},
             },
+            # A write, so a case can prove a tile cannot reach one.
+            {"id": REFUND, "direction": "write", "actors": ["member"]},
         ],
         "widgets": [
             {
@@ -125,14 +135,14 @@ def _definition() -> dict:
                 # JavaScript, and a plain-text sanitizer on the way out would
                 # rewrite these into something that no longer parses.
                 "module_source": MODULE_SOURCE,
-                "sources": ["orders_summary"],
-                "sample_data": {"orders_summary": [{"day": "mon", "total": 4}]},
+                "endpoints": [ORDERS_SUMMARY],
+                "sample_data": {ORDERS_SUMMARY: [{"day": "mon", "total": 4}]},
             }
         ],
     }
 
 
-def _dashboard_definition(*source_ids: str) -> dict:
+def _dashboard_definition(*endpoint_ids: str) -> dict:
     return normalize_dashboard_definition(
         {
             "widgets": [
@@ -142,10 +152,10 @@ def _dashboard_definition(*source_ids: str) -> dict:
                     "binding": {
                         "source": "app",
                         "app_uid": APP_UID,
-                        "source_id": source_id,
+                        "endpoint_id": endpoint_id,
                     },
                 }
-                for index, source_id in enumerate(source_ids)
+                for index, endpoint_id in enumerate(endpoint_ids)
             ]
         }
     )
@@ -252,7 +262,7 @@ async def _workspace(session: AsyncSession, acting_user, *sources: str):
         session,
         a.initiative,
         a.user,
-        definition=_dashboard_definition(*(sources or ("orders_summary",))),
+        definition=_dashboard_definition(*(sources or (ORDERS_SUMMARY,))),
     )
     return a, app, dashboard
 
@@ -276,7 +286,7 @@ class TestGates:
         a, app, dashboard = await _workspace(session, acting_user)
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 200, response.text
         body = response.json()
@@ -295,7 +305,7 @@ class TestGates:
         outsider = await acting_user(guild_role=GuildRole.member, guild=a.guild)
 
         response = await client.get(
-            _url(outsider, app, "orders_summary", dashboard), headers=outsider.headers
+            _url(outsider, app, ORDERS_SUMMARY, dashboard), headers=outsider.headers
         )
         assert response.status_code == 404
         assert upstream.count == 0
@@ -305,11 +315,9 @@ class TestGates:
     ):
         """The dashboard names which sources it displays; anything else is not
         reachable through it, even though the same app offers it."""
-        a, app, dashboard = await _workspace(session, acting_user, "orders_summary")
+        a, app, dashboard = await _workspace(session, acting_user, ORDERS_SUMMARY)
 
-        response = await client.get(
-            _url(a, app, "revenue", dashboard), headers=a.headers
-        )
+        response = await client.get(_url(a, app, REVENUE, dashboard), headers=a.headers)
         assert response.status_code == 404
         assert response.json()["detail"] == AppDataMessages.SOURCE_NOT_FOUND
         assert upstream.count == 0
@@ -331,11 +339,9 @@ class TestVisibility:
     async def test_a_guild_admin_source_is_open_to_an_admin(
         self, client, acting_user, session, upstream
     ):
-        a, app, dashboard = await _workspace(session, acting_user, "revenue")
+        a, app, dashboard = await _workspace(session, acting_user, REVENUE)
 
-        response = await client.get(
-            _url(a, app, "revenue", dashboard), headers=a.headers
-        )
+        response = await client.get(_url(a, app, REVENUE, dashboard), headers=a.headers)
         assert response.status_code == 200, response.text
 
     async def test_a_guild_admin_source_is_refused_to_a_member(
@@ -343,7 +349,7 @@ class TestVisibility:
     ):
         """Checked against the caller's real guild role, on the pinned
         definition — not against anything the request supplied."""
-        a, app, dashboard = await _workspace(session, acting_user, "revenue")
+        a, app, dashboard = await _workspace(session, acting_user, REVENUE)
         member = await acting_user(
             guild_role=GuildRole.member,
             guild=a.guild,
@@ -352,7 +358,7 @@ class TestVisibility:
         )
 
         response = await client.get(
-            _url(member, app, "revenue", dashboard), headers=member.headers
+            _url(member, app, REVENUE, dashboard), headers=member.headers
         )
         assert response.status_code == 403
         assert response.json()["detail"] == AppDataMessages.ADMIN_ONLY
@@ -370,7 +376,7 @@ class TestKillSwitches:
         await session.commit()
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 409
         assert response.json()["detail"] == AppDataMessages.APP_DISABLED
@@ -386,7 +392,7 @@ class TestKillSwitches:
         await session.commit()
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 409
         assert response.json()["detail"] == AppDataMessages.SERVICE_DISABLED
@@ -399,7 +405,7 @@ class TestKillSwitches:
         moment earlier is not served after the switch flips."""
         a, app, dashboard = await _workspace(session, acting_user)
         first = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert first.status_code == 200
 
@@ -409,7 +415,7 @@ class TestKillSwitches:
         await session.commit()
 
         second = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert second.status_code == 409
 
@@ -425,11 +431,11 @@ class TestKillSwitches:
             session,
             a.initiative,
             a.user,
-            definition=_dashboard_definition("orders_summary"),
+            definition=_dashboard_definition(ORDERS_SUMMARY),
         )
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 404
         assert response.json()["detail"] == AppDataMessages.SERVICE_NOT_REGISTERED
@@ -442,11 +448,15 @@ class TestParams:
         a, app, dashboard = await _workspace(session, acting_user)
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard, params='{"range":"30d"}'),
+            _url(a, app, ORDERS_SUMMARY, dashboard, params='{"range":"30d"}'),
             headers=a.headers,
         )
         assert response.status_code == 200, response.text
-        assert upstream.calls[0].url.params["range"] == "30d"
+        # In the body now, not the query string: one path serves every endpoint,
+        # so which one is being called travels with the parameters.
+        body = json.loads(upstream.calls[0].content)
+        assert body["endpoint"] == ORDERS_SUMMARY
+        assert body["params"]["range"] == "30d"
 
     @pytest.mark.parametrize(
         "params",
@@ -465,7 +475,7 @@ class TestParams:
         a, app, dashboard = await _workspace(session, acting_user)
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard, params=params),
+            _url(a, app, ORDERS_SUMMARY, dashboard, params=params),
             headers=a.headers,
         )
         assert response.status_code == 400
@@ -478,7 +488,7 @@ class TestContextToken:
         self, client, acting_user, session, upstream
     ):
         a, app, dashboard = await _workspace(session, acting_user)
-        await client.get(_url(a, app, "orders_summary", dashboard), headers=a.headers)
+        await client.get(_url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers)
 
         header = upstream.calls[0].headers["Authorization"]
         assert header.startswith("Bearer ")
@@ -489,8 +499,8 @@ class TestContextToken:
         )
         assert claims["guild_id"] == a.guild.id
         assert claims["app_install_id"] == app.id
-        assert claims["scope"] == "data"
-        assert claims["source_id"] == "orders_summary"
+        assert claims["scope"] == "endpoint"
+        assert claims["endpoint_id"] == ORDERS_SUMMARY
         assert claims["aud"] == f"initiative-app:{PUBLIC_ID}"
         assert claims["exp"] - claims["iat"] == 60
         assert "sub" not in claims
@@ -525,11 +535,9 @@ class TestConnections:
     async def test_a_member_who_has_not_connected_is_told_to(
         self, client, acting_user, session, upstream
     ):
-        a, app, dashboard = await _workspace(session, acting_user, "my_prs")
+        a, app, dashboard = await _workspace(session, acting_user, MY_PRS)
 
-        response = await client.get(
-            _url(a, app, "my_prs", dashboard), headers=a.headers
-        )
+        response = await client.get(_url(a, app, MY_PRS, dashboard), headers=a.headers)
         assert response.status_code == 409
         assert response.json()["detail"] == AppDataMessages.CONNECTION_REQUIRED
         assert upstream.count == 0
@@ -537,7 +545,7 @@ class TestConnections:
     async def test_a_blocked_member_is_refused_by_name(
         self, client, acting_user, session, upstream
     ):
-        a, app, dashboard = await _workspace(session, acting_user, "my_prs")
+        a, app, dashboard = await _workspace(session, acting_user, MY_PRS)
         await route_session_to_guild(session, a.guild.id)
         session.add(
             GuildAppUserConnection(
@@ -552,9 +560,7 @@ class TestConnections:
         )
         await session.commit()
 
-        response = await client.get(
-            _url(a, app, "my_prs", dashboard), headers=a.headers
-        )
+        response = await client.get(_url(a, app, MY_PRS, dashboard), headers=a.headers)
         assert response.status_code == 403
         assert response.json()["detail"] == GuildAppMessages.CONNECTION_BLOCKED
         assert upstream.count == 0
@@ -562,12 +568,10 @@ class TestConnections:
     async def test_the_token_carries_the_opaque_handle_not_the_person(
         self, client, acting_user, session, upstream
     ):
-        a, app, dashboard = await _workspace(session, acting_user, "my_prs")
+        a, app, dashboard = await _workspace(session, acting_user, MY_PRS)
         await _connect(session, app=app, user_id=a.user.id, ref="cr_alice")
 
-        response = await client.get(
-            _url(a, app, "my_prs", dashboard), headers=a.headers
-        )
+        response = await client.get(_url(a, app, MY_PRS, dashboard), headers=a.headers)
         assert response.status_code == 200, response.text
 
         claims = jwt.decode(
@@ -585,7 +589,7 @@ class TestConnections:
         """A source needing the guild's own credential says so rather than
         calling an app that would fail."""
         definition = _definition()
-        definition["data_sources"][0]["requires"] = {"all_of": ["admin"]}
+        definition["endpoints"][0]["requires"] = {"all_of": ["admin"]}
 
         a = await acting_user(guild_role=GuildRole.admin, initiative=True)
         a.initiative.dashboards_enabled = True
@@ -599,11 +603,11 @@ class TestConnections:
             session,
             a.initiative,
             a.user,
-            definition=_dashboard_definition("orders_summary"),
+            definition=_dashboard_definition(ORDERS_SUMMARY),
         )
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 409
         assert response.json()["detail"] == AppDataMessages.NEEDS_CONFIGURATION
@@ -625,10 +629,10 @@ class TestCache:
         )
 
         first = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         second = await client.get(
-            _url(member, app, "orders_summary", dashboard), headers=member.headers
+            _url(member, app, ORDERS_SUMMARY, dashboard), headers=member.headers
         )
 
         assert first.status_code == 200
@@ -643,11 +647,11 @@ class TestCache:
         a, app, dashboard = await _workspace(session, acting_user)
 
         await client.get(
-            _url(a, app, "orders_summary", dashboard, params='{"range":"7d"}'),
+            _url(a, app, ORDERS_SUMMARY, dashboard, params='{"range":"7d"}'),
             headers=a.headers,
         )
         await client.get(
-            _url(a, app, "orders_summary", dashboard, params='{"range":"30d"}'),
+            _url(a, app, ORDERS_SUMMARY, dashboard, params='{"range":"30d"}'),
             headers=a.headers,
         )
         assert upstream.count == 2
@@ -661,7 +665,7 @@ class TestCache:
         dashboard. Their vendor accounts differ, so their rows differ, and a
         shared entry would show one person the other's data.
         """
-        a, app, dashboard = await _workspace(session, acting_user, "my_prs")
+        a, app, dashboard = await _workspace(session, acting_user, MY_PRS)
         b = await acting_user(
             guild_role=GuildRole.member,
             guild=a.guild,
@@ -672,9 +676,9 @@ class TestCache:
         await _connect(session, app=app, user_id=b.user.id, ref="cr_bob")
 
         upstream.rows = [{"pr": "alice"}]
-        alice = await client.get(_url(a, app, "my_prs", dashboard), headers=a.headers)
+        alice = await client.get(_url(a, app, MY_PRS, dashboard), headers=a.headers)
         upstream.rows = [{"pr": "bob"}]
-        bob = await client.get(_url(b, app, "my_prs", dashboard), headers=b.headers)
+        bob = await client.get(_url(b, app, MY_PRS, dashboard), headers=b.headers)
 
         assert alice.status_code == 200, alice.text
         assert bob.status_code == 200, bob.text
@@ -687,11 +691,11 @@ class TestCache:
     async def test_one_members_repeated_reads_still_collapse(
         self, client, acting_user, session, upstream
     ):
-        a, app, dashboard = await _workspace(session, acting_user, "my_prs")
+        a, app, dashboard = await _workspace(session, acting_user, MY_PRS)
         await _connect(session, app=app, user_id=a.user.id, ref="cr_alice")
 
-        await client.get(_url(a, app, "my_prs", dashboard), headers=a.headers)
-        again = await client.get(_url(a, app, "my_prs", dashboard), headers=a.headers)
+        await client.get(_url(a, app, MY_PRS, dashboard), headers=a.headers)
+        again = await client.get(_url(a, app, MY_PRS, dashboard), headers=a.headers)
 
         assert again.json()["cached"] is True
         assert upstream.count == 1
@@ -700,7 +704,7 @@ class TestCache:
         self, client, acting_user, session, upstream
     ):
         a, app, dashboard = await _workspace(session, acting_user)
-        await client.get(_url(a, app, "orders_summary", dashboard), headers=a.headers)
+        await client.get(_url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers)
         assert upstream.count == 1
 
         await route_session_to_guild(session, a.guild.id)
@@ -709,7 +713,7 @@ class TestCache:
         await session.commit()
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.json()["cached"] is False
         assert upstream.count == 2
@@ -717,10 +721,10 @@ class TestCache:
     async def test_a_source_asking_for_no_cache_is_not_cached(
         self, client, acting_user, session, upstream
     ):
-        a, app, dashboard = await _workspace(session, acting_user, "revenue")
+        a, app, dashboard = await _workspace(session, acting_user, REVENUE)
 
-        await client.get(_url(a, app, "revenue", dashboard), headers=a.headers)
-        await client.get(_url(a, app, "revenue", dashboard), headers=a.headers)
+        await client.get(_url(a, app, REVENUE, dashboard), headers=a.headers)
+        await client.get(_url(a, app, REVENUE, dashboard), headers=a.headers)
         assert upstream.count == 2
 
 
@@ -734,7 +738,7 @@ class TestFailureIsOneTile:
         )
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 502
         assert response.json()["detail"] == AppDataMessages.SERVICE_UNAVAILABLE
@@ -746,12 +750,12 @@ class TestFailureIsOneTile:
         upstream.error = app_data_service.AppDataError(
             AppDataMessages.SERVICE_UNAVAILABLE, 502, "down"
         )
-        await client.get(_url(a, app, "orders_summary", dashboard), headers=a.headers)
+        await client.get(_url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers)
 
         upstream.error = None
         upstream.rows = [{"id": 2}]
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 200
         assert response.json()["rows"] == [{"id": 2}]
@@ -769,7 +773,7 @@ class TestFailureIsOneTile:
         )
 
         response = await client.get(
-            _url(a, app, "orders_summary", dashboard), headers=a.headers
+            _url(a, app, ORDERS_SUMMARY, dashboard), headers=a.headers
         )
         assert response.status_code == 503
         assert response.json()["detail"] == AppDataMessages.BUSY
@@ -794,11 +798,11 @@ class TestWidgetCatalog:
         # Byte-for-byte: the module is JavaScript, and anything that rewrote a
         # ``<`` or an ``&`` on the way out would ship a module that cannot parse.
         assert widget["module_source"] == MODULE_SOURCE
-        assert widget["sample_data"] == {"orders_summary": [{"day": "mon", "total": 4}]}
+        assert widget["sample_data"] == {ORDERS_SUMMARY: [{"day": "mon", "total": 4}]}
 
-        sources = {source["id"]: source for source in entry["data_sources"]}
-        assert sources["revenue"]["visibility"] == "guild_admin"
-        assert sources["orders_summary"]["cache_ttl_seconds"] == 60
+        sources = {source["id"]: source for source in entry["endpoints"]}
+        assert sources[REVENUE]["visibility"] == "guild_admin"
+        assert sources[ORDERS_SUMMARY]["cache_ttl_seconds"] == 60
 
     async def test_a_disabled_install_offers_no_widgets(
         self, client, acting_user, session

--- a/backend/app/api/v1/tenant_endpoints/app_data_test.py
+++ b/backend/app/api/v1/tenant_endpoints/app_data_test.py
@@ -267,11 +267,11 @@ async def _workspace(session: AsyncSession, acting_user, *sources: str):
     return a, app, dashboard
 
 
-def _url(actor, app, source_id: str, dashboard, **params) -> str:
+def _url(actor, app, endpoint_id: str, dashboard, **params) -> str:
     query = f"dashboard_id={dashboard.id}"
     for key, value in params.items():
         query = f"{query}&{key}={value}"
-    return actor.g(f"/apps/{app.id}/data/{source_id}?{query}")
+    return actor.g(f"/apps/{app.id}/endpoints/{endpoint_id}?{query}")
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +319,7 @@ class TestGates:
 
         response = await client.get(_url(a, app, REVENUE, dashboard), headers=a.headers)
         assert response.status_code == 404
-        assert response.json()["detail"] == AppDataMessages.SOURCE_NOT_FOUND
+        assert response.json()["detail"] == AppDataMessages.ENDPOINT_NOT_FOUND
         assert upstream.count == 0
 
     async def test_a_source_the_app_does_not_declare_is_refused(
@@ -331,7 +331,7 @@ class TestGates:
             _url(a, app, "made_up", dashboard), headers=a.headers
         )
         assert response.status_code == 404
-        assert response.json()["detail"] == AppDataMessages.SOURCE_NOT_FOUND
+        assert response.json()["detail"] == AppDataMessages.ENDPOINT_NOT_FOUND
         assert upstream.count == 0
 
 

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -701,7 +701,7 @@ class AppDataMessages:
 
     #: The install names no such data source, or the pinned definition is not a
     #: service app's at all.
-    SOURCE_NOT_FOUND = "APP_DATA_SOURCE_NOT_FOUND"
+    ENDPOINT_NOT_FOUND = "APP_DATA_ENDPOINT_NOT_FOUND"
     #: The source is declared for guild admins and the caller is a member.
     ADMIN_ONLY = "APP_DATA_ADMIN_ONLY"
     #: The install is turned off in this guild.

--- a/backend/app/schemas/tenant/app_data.py
+++ b/backend/app/schemas/tenant/app_data.py
@@ -37,7 +37,7 @@ class AppDataResponse(SanitizedBaseModel):
 
 
 class AppDataParam(SanitizedBaseModel):
-    """One parameter a source accepts, from its ``params_schema``."""
+    """One parameter an endpoint accepts, from its ``params``."""
 
     key: str
     type: str
@@ -46,8 +46,12 @@ class AppDataParam(SanitizedBaseModel):
     options: Optional[List[str]] = None
 
 
-class AppDataSourceRead(SanitizedBaseModel):
-    """A source a widget may bind to."""
+class AppEndpointRead(SanitizedBaseModel):
+    """A read endpoint a widget may bind to.
+
+    Reads only. A write and an emission are both real endpoints and neither
+    fills a tile, so neither belongs in a widget picker.
+    """
 
     id: str
     #: ``member`` or ``guild_admin`` — enforced again on every fetch under the
@@ -57,7 +61,7 @@ class AppDataSourceRead(SanitizedBaseModel):
     #: What the manifest asks for, already clamped at publish time. The proxy
     #: applies the deployment's own ceiling on top.
     cache_ttl_seconds: int = 0
-    params_schema: List[AppDataParam] = []
+    params: List[AppDataParam] = []
 
 
 class AppWidgetRead(SanitizedBaseModel):
@@ -75,9 +79,9 @@ class AppWidgetRead(SanitizedBaseModel):
     #: something that no longer parses. Nothing on this side reads, compiles, or
     #: evaluates it — the browser's sandbox is the only thing that runs it.
     module_source: RawTextStr
-    #: Which of the app's sources this widget draws.
-    sources: List[str] = []
-    #: Rows for a preview that issues no request at all, keyed by source.
+    #: Which of the app's read endpoints this widget draws.
+    endpoints: List[str] = []
+    #: Rows for a preview that issues no request at all, keyed by endpoint id.
     sample_data: Dict[str, Any] = {}
 
 
@@ -89,7 +93,7 @@ class AppWidgetCatalogEntry(SanitizedBaseModel):
     name: str
     enabled: bool = True
     widgets: List[AppWidgetRead] = []
-    data_sources: List[AppDataSourceRead] = []
+    endpoints: List[AppEndpointRead] = []
 
 
 class AppWidgetCatalogResponse(SanitizedBaseModel):

--- a/backend/app/services/marketplace/app_data.py
+++ b/backend/app/services/marketplace/app_data.py
@@ -1,6 +1,6 @@
 """External data reaching a widget: the proxy behind the ``app`` binding.
 
-A widget never names an endpoint. It names a *source* on an installed app, and
+A widget never names an endpoint. It names a *endpoint* on an installed app, and
 this module turns that into one bounded call to the app's own service and hands
 back rows. Everything the call needs — where the app lives, which credentials it
 may use, how long an answer is good for — comes from state the guild and the
@@ -10,8 +10,8 @@ operator already own, never from the request.
 under the caller's own guild session, so the install row is reachable only from
 inside that guild and a guild admin's wider reach is inherited rather than
 re-implemented. What is left here is the app-shaped part of the decision: the
-source's declared visibility, the two kill switches (the guild's install and the
-operator's registration), and whether the credentials the source declared it
+endpoint's declared visibility, the two kill switches (the guild's install and the
+operator's registration), and whether the credentials the endpoint declared it
 needs are actually present.
 
 **The cache key contains every credential the response depended on.** That is
@@ -19,7 +19,7 @@ the whole rule, and it is what makes a stored body safe to replay:
 
 * the guild, the install, and the pinned listing version — an entry is
   unreachable from a session that is not already inside that guild;
-* the source and its parameters;
+* the endpoint and its parameters;
 * a fingerprint of the install's stored configuration, so rotating a credential
   retires the answers it produced;
 * the opaque handles of every per-member connection the call used, so two
@@ -84,7 +84,7 @@ __all__ = [
     "AppDataResult",
     "clear_app_data_cache",
     "fetch_app_source",
-    "find_data_source",
+    "find_read_endpoint",
     "service_public_id",
     "validate_params",
 ]
@@ -93,7 +93,7 @@ __all__ = [
 # --- bounds -----------------------------------------------------------------
 #
 # All per worker, all deliberately small. A dashboard is a display surface: a
-# source that cannot answer in five seconds inside a megabyte is not going to
+# endpoint that cannot answer in five seconds inside a megabyte is not going to
 # render usefully, and letting it try costs everyone sharing the process.
 
 #: Wall-clock budget for one upstream call. Connect and read are capped
@@ -130,7 +130,7 @@ class AppDataError(Exception):
 
 @dataclass(frozen=True)
 class AppDataResult:
-    """One source's answer, and when it was actually obtained upstream."""
+    """One endpoint's answer, and when it was actually obtained upstream."""
 
     rows: list[Any]
     fetched_at: datetime
@@ -153,25 +153,29 @@ def service_public_id(definition: Mapping[str, Any] | None) -> Optional[str]:
     return public_id if isinstance(public_id, str) and public_id else None
 
 
-def _data_sources(definition: Mapping[str, Any] | None) -> list[dict[str, Any]]:
-    declared = (definition or {}).get("data_sources")
+def _endpoints(definition: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    declared = (definition or {}).get("endpoints")
     if not isinstance(declared, list):
         return []
     return [entry for entry in declared if isinstance(entry, dict)]
 
 
-def find_data_source(
-    definition: Mapping[str, Any] | None, source_id: str
+def find_read_endpoint(
+    definition: Mapping[str, Any] | None, endpoint_id: str
 ) -> Optional[dict[str, Any]]:
-    """One source from the *pinned* definition, or None.
+    """One readable endpoint from the *pinned* definition, or None.
 
     Pinned rather than current on purpose: what an install offers is the version
     its guild chose, so publishing a new one never silently widens what an
-    existing install will fetch.
+    existing install will answer.
+
+    Readable rather than declared, because this is the fetch path. A write and
+    an emission are both real endpoints and neither is reachable from here — a
+    dashboard rendering a tile must not be a way to make an app act.
     """
-    for source in _data_sources(definition):
-        if source.get("id") == source_id:
-            return source
+    for endpoint in _endpoints(definition):
+        if endpoint.get("id") == endpoint_id and endpoint.get("direction") == "read":
+            return endpoint
     return None
 
 
@@ -221,12 +225,12 @@ def _coerce_param(field_spec: Mapping[str, Any], value: Any) -> str:
 
 
 def validate_params(
-    source: Mapping[str, Any], raw: str | None
+    endpoint: Mapping[str, Any], raw: str | None
 ) -> tuple[dict[str, str], str]:
-    """Check a request's ``params`` against the source's ``params_schema``.
+    """Check a request's ``params`` against the endpoint's ``params_schema``.
 
     Returns the values to send upstream and their canonical form for the cache
-    key. A parameter the source does not declare is refused rather than
+    key. A parameter the endpoint does not declare is refused rather than
     forwarded: the schema is the whole of what a widget may vary, and anything
     else would be a caller shaping the app's request directly.
     """
@@ -242,7 +246,7 @@ def validate_params(
         if not isinstance(supplied, dict):
             raise AppDataError(AppDataMessages.INVALID_PARAMS, 400)
 
-    declared_raw = source.get("params_schema")
+    declared_raw = endpoint.get("params")
     declared = {
         entry["key"]: entry
         for entry in (declared_raw if isinstance(declared_raw, list) else [])
@@ -264,16 +268,16 @@ def validate_params(
     return values, canonical
 
 
-# --- which credentials this source runs on ----------------------------------
+# --- which credentials this endpoint runs on ----------------------------------
 
 
-def _required_connection_ids(source: Mapping[str, Any]) -> tuple[list[str], bool]:
-    """The connections a source names, and whether all of them are needed.
+def _required_connection_ids(endpoint: Mapping[str, Any]) -> tuple[list[str], bool]:
+    """The connections a endpoint names, and whether all of them are needed.
 
-    ``requires`` is one level with one operator (§7.4). Absent means the source
+    ``requires`` is one level with one operator (§7.4). Absent means the endpoint
     needs no credential at all.
     """
-    requires = source.get("requires")
+    requires = endpoint.get("requires")
     if not isinstance(requires, dict):
         return [], True
     for key, needs_all in (("all_of", True), ("any_of", False)):
@@ -287,10 +291,10 @@ async def _resolve_connections(
     session: AsyncSession,
     *,
     app: GuildApp,
-    source: Mapping[str, Any],
+    endpoint: Mapping[str, Any],
     user_id: int,
 ) -> dict[str, str]:
-    """Decide whether this source can run, and collect the handles it runs with.
+    """Decide whether this endpoint can run, and collect the handles it runs with.
 
     Satisfaction is presence alone — which fields hold a value. This build never
     inspects a credential, calls a vendor, or learns a scope; whether a stored
@@ -301,7 +305,7 @@ async def _resolve_connections(
     someone who has not is told to connect rather than being served the other
     person's view.
     """
-    required, needs_all = _required_connection_ids(source)
+    required, needs_all = _required_connection_ids(endpoint)
     if not required:
         return {}
 
@@ -316,7 +320,7 @@ async def _resolve_connections(
         connection = app_config_service.connection_by_id(app.definition, connection_id)
         if connection is None:
             # The pinned definition names a connection it does not declare —
-            # nothing can satisfy it, so the source cannot run.
+            # nothing can satisfy it, so the endpoint cannot run.
             refusal = refusal or AppDataError(AppDataMessages.NEEDS_CONFIGURATION, 409)
             continue
 
@@ -443,7 +447,7 @@ def clear_app_data_cache(
 def _cache_key(
     *,
     app: GuildApp,
-    source_id: str,
+    endpoint_id: str,
     canonical_params: str,
     refs: Mapping[str, str],
 ) -> str:
@@ -452,7 +456,7 @@ def _cache_key(
     Guild and install lead so an entry is scoped to the same boundary the
     request was, and a prefix drop can retire one install's answers. The
     fingerprint covers the stored configuration as a whole rather than only the
-    connections this source named: rotating a credential is rare next to reading
+    connections this endpoint named: rotating a credential is rare next to reading
     a widget, and narrowing it would trade a cheap hash for the chance of
     serving a body a withdrawn credential produced.
     """
@@ -469,7 +473,7 @@ def _cache_key(
             default=str,
         ).encode("utf-8")
     ).hexdigest()
-    return f"{app.guild_id}:{app.id}:{source_id}:{canonical_params}:{fingerprint}"
+    return f"{app.guild_id}:{app.id}:{endpoint_id}:{canonical_params}:{fingerprint}"
 
 
 def _cache_get(key: str) -> Optional[AppDataResult]:
@@ -497,8 +501,8 @@ def _cache_put(key: str, result: AppDataResult, ttl: int) -> None:
     _cache[key] = _CacheEntry(result=result, expires_at=time.monotonic() + ttl)
 
 
-def _effective_ttl(source: Mapping[str, Any]) -> int:
-    declared = source.get("cache_ttl_seconds")
+def _effective_ttl(endpoint: Mapping[str, Any]) -> int:
+    declared = endpoint.get("cache_ttl_seconds")
     if isinstance(declared, bool) or not isinstance(declared, int):
         return 0
     return max(0, min(declared, MAX_CACHE_TTL_SECONDS))
@@ -507,13 +511,16 @@ def _effective_ttl(source: Mapping[str, Any]) -> int:
 # --- the upstream call ------------------------------------------------------
 
 
-def _source_url(registration: AppServiceRegistration, source: Mapping[str, Any]) -> str:
-    """Where the source lives: the operator's base URL joined to the manifest's
-    path. A manifest states which route; only a registration states where."""
-    path = source.get("path")
-    if not isinstance(path, str) or not path.startswith("/"):
-        raise AppDataError(AppDataMessages.SOURCE_NOT_FOUND, 404)
-    return f"{registration.base_url.rstrip('/')}{path}"
+#: Every app answers every endpoint here. Fixed by the protocol rather than
+#: chosen per app, so a caller that knows an id needs nothing else.
+ENDPOINTS_PATH = "/v1/endpoints"
+
+
+def _endpoints_url(registration: AppServiceRegistration) -> str:
+    """Where this app answers: the operator's base URL joined to the one path
+    every app serves. A manifest names an endpoint; only a registration says
+    where the app is."""
+    return f"{registration.base_url.rstrip('/')}{ENDPOINTS_PATH}"
 
 
 async def _read_rows(
@@ -565,7 +572,13 @@ async def _read_rows(
             AppDataMessages.SERVICE_UNAVAILABLE, 502, "app did not answer with JSON"
         ) from exc
 
-    rows = body.get("rows") if isinstance(body, dict) else None
+    # The app answers with what it did — the endpoint it ran, whose credential
+    # ran it, and the result — so the rows are one level in. Reported as the app
+    # being unavailable rather than as a bad request: from a dashboard's side
+    # "this app is not answering" is true whether the service is down or talking
+    # a shape this build does not accept.
+    result = body.get("result") if isinstance(body, dict) else None
+    rows = result.get("rows") if isinstance(result, dict) else None
     if not isinstance(rows, list):
         raise AppDataError(
             AppDataMessages.SERVICE_UNAVAILABLE, 502, "app answered without rows"
@@ -577,8 +590,8 @@ async def _call_app(
     *,
     registration: AppServiceRegistration,
     app: GuildApp,
-    source: Mapping[str, Any],
-    source_id: str,
+    endpoint: Mapping[str, Any],
+    endpoint_id: str,
     params: Mapping[str, str],
     refs: Mapping[str, str],
     transport: httpx.AsyncBaseTransport | None,
@@ -602,24 +615,32 @@ async def _call_app(
                 public_id=public_id,
                 guild_id=app.guild_id,
                 app_install_id=app.id,
-                scope="data",
-                source_id=source_id,
+                scope="endpoint",
+                endpoint_id=endpoint_id,
                 connection_refs=refs,
             )
         except AppPlatformSigningNotConfiguredError as exc:
             raise AppDataError(AppServiceMessages.SIGNING_NOT_CONFIGURED, 503) from exc
 
-        url = _source_url(registration, source)
-        if params:
-            url = f"{url}?{httpx.QueryParams(dict(params))}"
+        # POST rather than GET, and a body rather than a query string: one
+        # path serves every endpoint, so which one is being called is part of
+        # what is sent rather than part of where it is sent.
         try:
             request = await build_validated_request(
-                "GET",
-                url,
+                "POST",
+                _endpoints_url(registration),
                 headers={
                     "Accept": "application/json",
+                    "Content-Type": "application/json",
                     "Authorization": f"Bearer {token}",
                 },
+                content=json.dumps(
+                    {
+                        "endpoint": endpoint_id,
+                        "guild_id": app.guild_id,
+                        "params": dict(params),
+                    }
+                ).encode("utf-8"),
                 # An app service is an operator-configured destination and is
                 # typically a container on the deployment's own network. Plain
                 # http stays confined to those addresses by the target policy.
@@ -647,38 +668,40 @@ async def fetch_app_source(
     session: AsyncSession,
     *,
     app: GuildApp,
-    source_id: str,
+    endpoint_id: str,
     raw_params: str | None,
     user_id: int,
     is_guild_admin: bool,
     transport: httpx.AsyncBaseTransport | None = None,
 ) -> AppDataResult:
-    """Resolve one source for one caller.
+    """Resolve one endpoint for one caller.
 
     The install has already been loaded under the caller's own guild session, so
     the guild boundary and a guild admin's wider reach are settled before this
-    runs. What is decided here is the app's own vocabulary: the source exists,
+    runs. What is decided here is the app's own vocabulary: the endpoint exists,
     the caller is allowed to see it, both kill switches are open, the parameters
-    are ones the source declared, and the credentials it named are present.
+    are ones the endpoint declared, and the credentials it named are present.
     """
-    source = find_data_source(app.definition, source_id)
+    endpoint = find_read_endpoint(app.definition, endpoint_id)
     public_id = service_public_id(app.definition)
-    if source is None or public_id is None:
+    if endpoint is None or public_id is None:
         raise AppDataError(AppDataMessages.SOURCE_NOT_FOUND, 404)
 
     # Measured against the same ladder a manifest declares on, so the two
     # cannot come to mean different things.
-    if not clears_visibility(source.get("visibility"), is_guild_admin=is_guild_admin):
+    if not clears_visibility(endpoint.get("visibility"), is_guild_admin=is_guild_admin):
         raise AppDataError(AppDataMessages.ADMIN_ONLY, 403)
     if not app.enabled:
         raise AppDataError(AppDataMessages.APP_DISABLED, 409)
 
     registration = await _load_registration(public_id)
-    params, canonical = validate_params(source, raw_params)
-    refs = await _resolve_connections(session, app=app, source=source, user_id=user_id)
+    params, canonical = validate_params(endpoint, raw_params)
+    refs = await _resolve_connections(
+        session, app=app, endpoint=endpoint, user_id=user_id
+    )
 
     key = _cache_key(
-        app=app, source_id=source_id, canonical_params=canonical, refs=refs
+        app=app, endpoint_id=endpoint_id, canonical_params=canonical, refs=refs
     )
     cached = _cache_get(key)
     if cached is not None:
@@ -697,8 +720,8 @@ async def fetch_app_source(
         result = await _call_app(
             registration=registration,
             app=app,
-            source=source,
-            source_id=source_id,
+            endpoint=endpoint,
+            endpoint_id=endpoint_id,
             params=params,
             refs=refs,
             transport=transport,
@@ -713,7 +736,7 @@ async def fetch_app_source(
     else:
         if not future.done():
             future.set_result(result)
-        _cache_put(key, result, _effective_ttl(source))
+        _cache_put(key, result, _effective_ttl(endpoint))
         return result
     finally:
         _pending.pop(key, None)

--- a/backend/app/services/marketplace/app_data.py
+++ b/backend/app/services/marketplace/app_data.py
@@ -1,18 +1,18 @@
 """External data reaching a widget: the proxy behind the ``app`` binding.
 
-A widget never names an endpoint. It names a *endpoint* on an installed app, and
-this module turns that into one bounded call to the app's own service and hands
-back rows. Everything the call needs — where the app lives, which credentials it
-may use, how long an answer is good for — comes from state the guild and the
-operator already own, never from the request.
+A widget never names an address. It names a *read endpoint* on an installed
+app, and this module turns that into one bounded call to the app's own service
+and hands back rows. Everything the call needs — where the app lives, which
+credentials it may use, how long an answer is good for — comes from state the
+guild and the operator already own, never from the request.
 
-**Authorization happens before this module caches anything.** The endpoint runs
+**Authorization happens before this module caches anything.** The route runs
 under the caller's own guild session, so the install row is reachable only from
 inside that guild and a guild admin's wider reach is inherited rather than
 re-implemented. What is left here is the app-shaped part of the decision: the
-endpoint's declared visibility, the two kill switches (the guild's install and the
-operator's registration), and whether the credentials the endpoint declared it
-needs are actually present.
+endpoint's declared visibility, the two kill switches (the guild's install and
+the operator's registration), and whether the credentials the endpoint declared
+it needs are actually present.
 
 **The cache key contains every credential the response depended on.** That is
 the whole rule, and it is what makes a stored body safe to replay:
@@ -227,7 +227,7 @@ def _coerce_param(field_spec: Mapping[str, Any], value: Any) -> str:
 def validate_params(
     endpoint: Mapping[str, Any], raw: str | None
 ) -> tuple[dict[str, str], str]:
-    """Check a request's ``params`` against the endpoint's ``params_schema``.
+    """Check a request's parameters against the ones the endpoint declares.
 
     Returns the values to send upstream and their canonical form for the cache
     key. A parameter the endpoint does not declare is refused rather than
@@ -268,11 +268,11 @@ def validate_params(
     return values, canonical
 
 
-# --- which credentials this endpoint runs on ----------------------------------
+# --- which credentials this endpoint runs on --------------------------------
 
 
 def _required_connection_ids(endpoint: Mapping[str, Any]) -> tuple[list[str], bool]:
-    """The connections a endpoint names, and whether all of them are needed.
+    """The connections an endpoint names, and whether all of them are needed.
 
     ``requires`` is one level with one operator (§7.4). Absent means the endpoint
     needs no credential at all.
@@ -685,7 +685,7 @@ async def fetch_app_source(
     endpoint = find_read_endpoint(app.definition, endpoint_id)
     public_id = service_public_id(app.definition)
     if endpoint is None or public_id is None:
-        raise AppDataError(AppDataMessages.SOURCE_NOT_FOUND, 404)
+        raise AppDataError(AppDataMessages.ENDPOINT_NOT_FOUND, 404)
 
     # Measured against the same ladder a manifest declares on, so the two
     # cannot come to mean different things.

--- a/backend/app/services/marketplace/app_data_test.py
+++ b/backend/app/services/marketplace/app_data_test.py
@@ -23,14 +23,16 @@ from app.services.marketplace import app_data as service
 
 pytestmark = pytest.mark.unit
 
-URL = "http://127.0.0.1:9100/v1/data/orders"
+URL = "http://127.0.0.1:9100/v1/endpoints"
+
+ORDERS = "app.acme.shop.orders"
 
 SOURCE = {
-    "id": "orders",
-    "path": "/v1/data/orders",
+    "id": ORDERS,
+    "direction": "read",
     "visibility": "member",
     "cache_ttl_seconds": 60,
-    "params_schema": [
+    "params": [
         {"key": "range", "type": "select", "options": ["7d", "30d"], "label": {}},
         {"key": "limit", "type": "int", "label": {}},
         {"key": "team", "type": "string", "label": {}},
@@ -42,23 +44,36 @@ SOURCE = {
 
 async def _read(handler) -> list:
     return await service._read_rows(
-        httpx.Request("GET", URL), transport=httpx.MockTransport(handler)
+        httpx.Request("POST", URL), transport=httpx.MockTransport(handler)
     )
 
 
 # --- what an app may answer with --------------------------------------------
 
 
+def _answer(rows) -> dict:
+    """What an app answers a call with: what it ran, whose credential ran it,
+    and the result. The rows are one level in."""
+    return {"endpoint": ORDERS, "actor": "member", "result": {"rows": rows}}
+
+
 class TestUpstreamBounds:
     async def test_rows_come_back_verbatim(self):
         payload = [{"id": 1, "nested": {"deep": [1, 2]}}, {"id": 2}]
-        rows = await _read(lambda request: httpx.Response(200, json={"rows": payload}))
+        rows = await _read(lambda request: httpx.Response(200, json=_answer(payload)))
         assert rows == payload
+
+    async def test_an_answer_without_a_result_is_the_app_being_unavailable(self):
+        # From a dashboard's side "this app is not answering" is true whether
+        # the service is down or talking a shape this build does not accept.
+        with pytest.raises(service.AppDataError) as excinfo:
+            await _read(lambda request: httpx.Response(200, json={"rows": [{"id": 1}]}))
+        assert excinfo.value.code == AppDataMessages.SERVICE_UNAVAILABLE
 
     async def test_a_response_past_the_ceiling_is_abandoned(self):
         oversized = "x" * (service.MAX_RESPONSE_BYTES + 1024)
         with pytest.raises(service.AppDataError) as excinfo:
-            await _read(lambda request: httpx.Response(200, json={"rows": [oversized]}))
+            await _read(lambda request: httpx.Response(200, json=_answer([oversized])))
         assert excinfo.value.code == AppDataMessages.RESPONSE_TOO_LARGE
         assert excinfo.value.status_code == 502
 
@@ -177,7 +192,7 @@ class TestParams:
     def test_a_required_parameter_left_out_is_refused(self):
         source = {
             **SOURCE,
-            "params_schema": [
+            "params": [
                 {"key": "shop", "type": "string", "required": True, "label": {}}
             ],
         }
@@ -197,12 +212,23 @@ class TestParams:
 
 
 class TestDefinitionReading:
-    def test_a_source_is_found_on_the_pinned_definition(self):
-        definition = {"app_kind": "service", "data_sources": [SOURCE]}
-        assert service.find_data_source(definition, "orders") == SOURCE
-        assert service.find_data_source(definition, "other") is None
+    def test_a_read_is_found_on_the_pinned_definition(self):
+        definition = {"app_kind": "service", "endpoints": [SOURCE]}
+        assert service.find_read_endpoint(definition, ORDERS) == SOURCE
+        assert service.find_read_endpoint(definition, "app.acme.shop.other") is None
 
-    def test_a_source_is_read_over_the_wire_surface(self):
+    def test_only_a_read_is_reachable_from_here(self):
+        """A write and an emission are both real endpoints and neither belongs
+        on the fetch path: rendering a dashboard must not be a way to make an
+        app act."""
+        for direction in ("write", "emit"):
+            definition = {
+                "app_kind": "service",
+                "endpoints": [{**SOURCE, "direction": direction}],
+            }
+            assert service.find_read_endpoint(definition, ORDERS) is None
+
+    def test_an_app_is_called_over_the_wire_surface(self):
         """A registration may carry two addresses. This one is Initiative's own
         server calling the app, so it uses the address meant for that — the
         browser address is for what a browser opens."""
@@ -212,8 +238,8 @@ class TestDefinitionReading:
             embed_origin="https://shop.example.com",
         )
 
-        assert service._source_url(registration, SOURCE) == (
-            "http://acme-shop:8200/v1/data/orders"
+        assert service._endpoints_url(registration) == (
+            "http://acme-shop:8200/v1/endpoints"
         )
 
     def test_only_a_service_app_has_a_backing_service(self):

--- a/backend/app/services/marketplace/bundled_dashboards_test.py
+++ b/backend/app/services/marketplace/bundled_dashboards_test.py
@@ -32,6 +32,11 @@ DASH_UID = "J9H7S9T7GP7FAG"
 OTHER_DASH_UID = "P3R9WT5HZ2NM6D"
 
 
+#: The read a tile draws, spelled once. Namespaced under the app's own service
+#: id, which is what every endpoint id has to be.
+OPEN_ITEMS = "app.tests.tracker.open-items"
+
+
 def _dashboard(uid=DASH_UID, public_id="tests.tracker-overview", **overrides):
     entry = {
         "uid": uid,
@@ -44,7 +49,7 @@ def _dashboard(uid=DASH_UID, public_id="tests.tracker-overview", **overrides):
                 "type": "open-items",
                 "title": "Open",
                 "grid": {"x": 0, "y": 0, "w": 4, "h": 3},
-                "binding": {"source_id": "open-items"},
+                "binding": {"endpoint_id": OPEN_ITEMS},
             }
         ],
     }
@@ -56,14 +61,14 @@ def _app_manifest(dashboards=None, version="1.0.0"):
     definition = {
         "app_kind": "service",
         "service": {"public_id": "tests.tracker", "protocol": 1},
-        "features": ["data", "widgets"],
-        "data_sources": [{"id": "open-items", "path": "/data/open-items"}],
+        "features": ["endpoints", "widgets"],
+        "endpoints": [{"id": OPEN_ITEMS, "direction": "read"}],
         "widgets": [
             {
                 "id": "open-items",
                 "meta": {"name": {"en": "Open items"}},
                 "module_source": "export default () => ({});",
-                "sources": ["open-items"],
+                "endpoints": [OPEN_ITEMS],
             }
         ],
     }
@@ -132,7 +137,7 @@ class TestPublishing:
         assert widget["binding"] == {
             "source": "app",
             "app_uid": APP_UID,
-            "source_id": "open-items",
+            "endpoint_id": OPEN_ITEMS,
         }
 
     async def test_it_carries_no_artwork_of_its_own(self, session):

--- a/backend/app/services/marketplace/context_jwt.py
+++ b/backend/app/services/marketplace/context_jwt.py
@@ -55,10 +55,15 @@ __all__ = [
     "mint_context_token",
 ]
 
-#: What a token may authorize. Closed, and pinned per call: ``data`` fetches a
-#: source, ``action`` performs one declared operation, ``lifecycle`` tells an app
-#: an install changed. A token minted for one is not usable for another.
-CONTEXT_SCOPES: frozenset[str] = frozenset({"data", "action", "lifecycle"})
+#: What a token may authorize. Closed, and pinned per call: ``endpoint`` reaches
+#: one declared endpoint, ``lifecycle`` tells an app an install changed. A token
+#: minted for one is not usable for the other.
+#:
+#: One scope covers reads and writes because both are calls to a declared
+#: endpoint, and ``endpoint_id`` is what narrows it: a token minted to read the
+#: issue count cannot be spent closing an issue. The endpoint's own ``direction``
+#: says which it was, and the app knows it without being told.
+CONTEXT_SCOPES: frozenset[str] = frozenset({"endpoint", "lifecycle"})
 
 #: About a minute. Long enough to survive a slow round trip and a little clock
 #: skew, short enough that a captured token is spent before it is useful.
@@ -86,8 +91,7 @@ def mint_context_token(
     guild_id: int,
     app_install_id: int,
     scope: str,
-    source_id: Optional[str] = None,
-    action_id: Optional[str] = None,
+    endpoint_id: Optional[str] = None,
     connection_refs: Optional[Mapping[str, str]] = None,
     lifetime: timedelta = CONTEXT_TOKEN_LIFETIME,
 ) -> tuple[str, int]:
@@ -117,10 +121,8 @@ def mint_context_token(
     }
     # Each optional claim appears only when it means something, so an app can
     # read presence rather than having to distinguish null from absent.
-    if source_id is not None:
-        payload["source_id"] = source_id
-    if action_id is not None:
-        payload["action_id"] = action_id
+    if endpoint_id is not None:
+        payload["endpoint_id"] = endpoint_id
     if refs:
         payload["connection_refs"] = refs
 

--- a/backend/app/services/marketplace/context_jwt_test.py
+++ b/backend/app/services/marketplace/context_jwt_test.py
@@ -60,7 +60,7 @@ def _mint(**overrides) -> str:
             "public_id": PUBLIC_ID,
             "guild_id": 7,
             "app_install_id": 3,
-            "scope": "data",
+            "scope": "endpoint",
             **overrides,
         }
     )
@@ -81,7 +81,7 @@ class TestClaims:
         claims = _claims(_mint(guild_id=42, app_install_id=9))
         assert claims["guild_id"] == 42
         assert claims["app_install_id"] == 9
-        assert claims["scope"] == "data"
+        assert claims["scope"] == "endpoint"
 
     def test_the_audience_names_exactly_one_app(self):
         token = _mint()
@@ -124,8 +124,7 @@ class TestClaims:
             "guild_id",
             "app_install_id",
             "scope",
-            "source_id",
-            "action_id",
+            "endpoint_id",
             "connection_refs",
         }
         body = json.dumps(claims)
@@ -138,10 +137,12 @@ class TestClaims:
             "connection_refs"
         ] == {"github": "cr_1"}
 
-    def test_the_source_is_named_when_one_is_being_fetched(self):
-        claims = _claims(_mint(source_id="orders_summary"))
-        assert claims["source_id"] == "orders_summary"
-        assert "action_id" not in claims
+    def test_the_endpoint_is_named_on_every_call(self):
+        # One scope covers reads and writes, so the id is what narrows a token:
+        # one minted to read the order summary cannot be spent changing an order.
+        claims = _claims(_mint(endpoint_id="app.acme.tracker.orders-summary"))
+        assert claims["endpoint_id"] == "app.acme.tracker.orders-summary"
+        assert "endpoint_id" not in _claims(_mint())
 
     def test_every_token_has_its_own_jti(self):
         assert _claims(_mint())["jti"] != _claims(_mint())["jti"]
@@ -149,7 +150,7 @@ class TestClaims:
     def test_the_key_id_is_stamped_so_a_rotation_can_be_followed(self):
         assert jwt.get_unverified_header(_mint())["kid"] == KEY_ID
 
-    @pytest.mark.parametrize("scope", ["data", "action", "lifecycle"])
+    @pytest.mark.parametrize("scope", ["endpoint", "lifecycle"])
     def test_the_scope_vocabulary_is_what_it_declares(self, scope):
         assert _claims(_mint(scope=scope))["scope"] == scope
 

--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -162,7 +162,9 @@ class TestFeaturesMatchBlocks:
     def test_shipping_a_block_without_declaring_it_is_refused(self):
         with pytest.raises(ListingDefinitionError, match="is not declared"):
             _normalize(
-                events=["app.tests.widget-co.thing_happened"],
+                endpoints=[
+                    {"id": "app.tests.widget-co.thing-happened", "direction": "emit"}
+                ],
             )
 
     def test_an_unknown_feature_is_refused(self):
@@ -172,16 +174,16 @@ class TestFeaturesMatchBlocks:
     def test_an_empty_block_is_not_a_block(self):
         """Empty means absent, the same way for every block.
 
-        An automation block that is present but empty describes nothing.
-        Storing it would be a second shape meaning "none" — and one the feature
-        cross-check could read differently from the way it was stored, letting a
-        manifest carry a block its own ``features`` never declared.
+        A block that is present but empty describes nothing. Storing it would be
+        a second shape meaning "none" — and one the feature cross-check could
+        read differently from the way it was stored, letting a manifest carry a
+        block its own ``features`` never declared.
         """
-        definition = _normalize(automation={})
-        assert "automation" not in definition
+        definition = _normalize(endpoints=[])
+        assert "endpoints" not in definition
 
         with pytest.raises(ListingDefinitionError, match="is declared but"):
-            _normalize(features=["automations"], automation={})
+            _normalize(features=["endpoints"], endpoints=[])
 
     def test_an_app_may_offer_no_local_features(self):
         definition = _normalize()
@@ -190,11 +192,13 @@ class TestFeaturesMatchBlocks:
 
     def test_features_are_stored_in_a_stable_order(self):
         definition = _normalize(
-            features=["events", "automations", "events"],
-            events=["app.tests.widget-co.thing_happened"],
-            automation={"graph": []},
+            features=["endpoints", "embeds", "endpoints"],
+            endpoints=[
+                {"id": "app.tests.widget-co.thing-happened", "direction": "emit"}
+            ],
+            embeds=[{"id": "main", "path": "/embed", "name": _label()}],
         )
-        assert definition["features"] == ["automations", "events"]
+        assert definition["features"] == ["embeds", "endpoints"]
 
     @pytest.mark.parametrize("feature", sorted(service_apps.FEATURES))
     def test_every_feature_names_a_block(self, feature):
@@ -341,16 +345,21 @@ class TestConnections:
         ]
 
 
-def _with_source(**source_overrides) -> dict:
-    """A service app with one connection and one data source that needs it."""
-    source = {
-        "id": "orders",
-        "path": "/v1/data/orders",
+#: The id the fixtures below read, spelled once. Namespaced under the fixture
+#: app's own service id, which is what every endpoint id has to be.
+READ_ID = "app.tests.widget-co.orders"
+
+
+def _with_source(**endpoint_overrides) -> dict:
+    """A service app with one connection and one read endpoint that needs it."""
+    endpoint = {
+        "id": READ_ID,
+        "direction": "read",
         "requires": {"all_of": ["shop"]},
     }
-    source.update(source_overrides)
+    endpoint.update(endpoint_overrides)
     return _normalize(
-        features=["data"],
+        features=["endpoints"],
         connections=[
             {
                 "id": "shop",
@@ -359,7 +368,7 @@ def _with_source(**source_overrides) -> dict:
                 "fields": [{"key": "token", "type": "secret", "label": _label()}],
             }
         ],
-        data_sources=[source],
+        endpoints=[endpoint],
     )
 
 
@@ -378,39 +387,74 @@ class TestRequires:
 
     def test_omitting_it_means_always_available(self):
         definition = _with_source(requires=None)
-        assert "requires" not in definition["data_sources"][0]
+        assert "requires" not in definition["endpoints"][0]
 
     def test_a_repeated_term_is_stored_once(self):
         definition = _with_source(requires={"any_of": ["shop", "shop"]})
-        assert definition["data_sources"][0]["requires"] == {"any_of": ["shop"]}
+        assert definition["endpoints"][0]["requires"] == {"any_of": ["shop"]}
 
 
-class TestDataSources:
-    def test_a_path_is_a_path_and_not_an_address(self):
-        for value in ("https://widget.test/v1/data", "/v1/../admin", "v1/data"):
-            with pytest.raises(ListingDefinitionError, match="path"):
-                _with_source(path=value)
+class TestEndpoints:
+    def test_an_id_is_namespaced_under_the_app(self):
+        # Two apps offering `create-issue` would be two different things under
+        # one name, and a caller resolving the wrong one would do the wrong
+        # thing successfully.
+        for value in ("orders", "app.someone.else.orders", "app.tests.widget-co."):
+            with pytest.raises(ListingDefinitionError, match="must start with"):
+                _with_source(id=value)
+
+    def test_a_direction_is_required_and_closed(self):
+        # Direction decides who may call it, whether an answer may be cached,
+        # and whether a widget may bind it — so an endpoint without one is not a
+        # partial declaration, it is an unanswerable question.
+        with pytest.raises(ListingDefinitionError, match="direction"):
+            _with_source(direction=None)
+        with pytest.raises(ListingDefinitionError, match="direction"):
+            _with_source(direction="sideways")
 
     def test_an_unknown_visibility_is_refused(self):
         with pytest.raises(ListingDefinitionError, match="unknown visibility"):
             _with_source(visibility="everyone")
 
     def test_visibility_defaults_to_members_of_the_installing_guild(self):
-        assert _with_source()["data_sources"][0]["visibility"] == "member"
+        assert _with_source()["endpoints"][0]["visibility"] == "member"
 
     def test_a_cache_window_is_clamped_rather_than_refused(self):
         definition = _with_source(cache_ttl_seconds=10_000_000)
-        ttl = definition["data_sources"][0]["cache_ttl_seconds"]
+        ttl = definition["endpoints"][0]["cache_ttl_seconds"]
         assert ttl == service_apps.MAX_CACHE_TTL_SECONDS
+
+    def test_only_a_read_is_cached_or_gated(self):
+        # A write is authorized by the token that carried it and answers once,
+        # so neither a rung nor a window means anything on one.
+        for absent in ("cache_ttl_seconds", "visibility"):
+            with pytest.raises(ListingDefinitionError, match="only a read"):
+                _with_source(
+                    direction="write", **{absent: 60 if "cache" in absent else "member"}
+                )
+
+    def test_an_emission_carries_nothing_a_caller_would_send(self):
+        # Nobody calls it, so there is nothing to send, nothing to cache and
+        # nobody to gate. Carrying any of it would describe a call that never
+        # happens.
+        with pytest.raises(ListingDefinitionError, match="has no requires"):
+            _with_source(direction="emit")
+
+    def test_an_actor_list_is_drawn_from_the_closed_set(self):
+        with pytest.raises(ListingDefinitionError, match="actors"):
+            _with_source(actors=["nobody"])
+        with pytest.raises(ListingDefinitionError, match="no actor"):
+            _with_source(actors=[])
+        assert _with_source(actors=["member", "member"])["endpoints"][0]["actors"] == [
+            "member"
+        ]
 
     def test_a_parameter_cannot_be_a_secret(self):
         # A credential is supplied once and held in custody; it is never
         # restated as a query parameter.
         assert "secret" not in service_apps.PARAM_TYPES
         with pytest.raises(ListingDefinitionError, match="unknown field type"):
-            _with_source(
-                params_schema=[{"key": "token", "type": "secret", "label": _label()}]
-            )
+            _with_source(params=[{"key": "token", "type": "secret", "label": _label()}])
 
 
 def _with_widget(**widget_overrides) -> dict:
@@ -444,39 +488,62 @@ class TestWidgets:
         definition = _with_widget(module_source=source)
         assert definition["widgets"][0]["module_source"] == source
 
-    def test_a_widget_may_only_bind_a_source_the_app_declares(self):
-        with pytest.raises(ListingDefinitionError, match="unknown data source"):
-            _with_widget(sources=["orders"])
+    def test_a_widget_may_only_bind_an_endpoint_the_app_declares(self):
+        with pytest.raises(
+            ListingDefinitionError, match="not a declared read endpoint"
+        ):
+            _with_widget(endpoints=[READ_ID])
 
-    def test_sample_rows_are_kept_only_for_declared_sources(self):
+    def test_a_widget_may_only_bind_one_that_answers(self):
+        # A write and an emission are both real endpoints and neither fills a
+        # tile: one changes something and returns, the other is posted
+        # somewhere else entirely.
+        for direction in ("write", "emit"):
+            with pytest.raises(
+                ListingDefinitionError, match="not a declared read endpoint"
+            ):
+                _normalize(
+                    features=["endpoints", "widgets"],
+                    endpoints=[{"id": READ_ID, "direction": direction}],
+                    widgets=[
+                        {
+                            "id": "summary",
+                            "meta": {"name": {"en": "Sales summary"}},
+                            "module_source": "export const render = () => ({});",
+                            "endpoints": [READ_ID],
+                        }
+                    ],
+                )
+
+    def test_sample_rows_are_kept_only_for_declared_endpoints(self):
         definition = _normalize(
-            features=["data", "widgets"],
-            data_sources=[{"id": "orders", "path": "/v1/data/orders"}],
+            features=["endpoints", "widgets"],
+            endpoints=[{"id": READ_ID, "direction": "read"}],
             widgets=[
                 {
                     "id": "summary",
                     "meta": {"name": {"en": "Sales summary"}},
                     "module_source": "export const render = () => ({});",
-                    "sources": ["orders"],
-                    "sample_data": {"orders": [{"n": 1}], "elsewhere": [{"n": 2}]},
+                    "endpoints": [READ_ID],
+                    "sample_data": {READ_ID: [{"n": 1}], "elsewhere": [{"n": 2}]},
                 }
             ],
         )
-        assert definition["widgets"][0]["sample_data"] == {"orders": [{"n": 1}]}
+        assert definition["widgets"][0]["sample_data"] == {READ_ID: [{"n": 1}]}
 
     def test_sample_rows_are_size_capped(self):
         with pytest.raises(ListingDefinitionError, match="sample_data"):
             _normalize(
-                features=["data", "widgets"],
-                data_sources=[{"id": "orders", "path": "/v1/data/orders"}],
+                features=["endpoints", "widgets"],
+                endpoints=[{"id": READ_ID, "direction": "read"}],
                 widgets=[
                     {
                         "id": "summary",
                         "meta": {"name": {"en": "Sales summary"}},
                         "module_source": "export const render = () => ({});",
-                        "sources": ["orders"],
+                        "endpoints": [READ_ID],
                         "sample_data": {
-                            "orders": ["x" * service_apps.MAX_SAMPLE_DATA_BYTES]
+                            READ_ID: ["x" * service_apps.MAX_SAMPLE_DATA_BYTES]
                         },
                     }
                 ],
@@ -710,55 +777,43 @@ class TestVisibilityIsALadder:
         with pytest.raises(ListingDefinitionError, match="initiative audience"):
             self._embed(scopes=["guild"], visibility="initiative_manager")
 
-    def test_a_data_source_may_not_either(self):
+    def test_a_read_endpoint_may_not_either(self):
         with pytest.raises(ListingDefinitionError, match="initiative audience"):
             _with_source(visibility="initiative_manager")
 
 
-class TestEvents:
-    def test_an_event_is_namespaced_under_the_app(self):
+class TestEmissions:
+    def _emit(self, **overrides) -> dict:
+        endpoint = {"id": "app.tests.widget-co.order-created", "direction": "emit"}
+        endpoint.update(overrides)
+        return _normalize(features=["endpoints"], endpoints=[endpoint])
+
+    def test_an_id_is_namespaced_under_the_app(self):
+        for value in ("order_created", "app.someone.else.order_created"):
+            with pytest.raises(ListingDefinitionError, match="must start with"):
+                self._emit(id=value)
+
+    def test_the_namespace_alone_is_not_an_id(self):
         with pytest.raises(ListingDefinitionError, match="must start with"):
-            _normalize(features=["events"], events=["order_created"])
+            self._emit(id="app.tests.widget-co.")
 
-    def test_an_app_cannot_announce_another_app_s_events(self):
-        with pytest.raises(ListingDefinitionError, match="must start with"):
-            _normalize(features=["events"], events=["app.someone.else.order_created"])
+    def test_a_declared_one_is_kept(self):
+        definition = self._emit()
+        assert definition["endpoints"] == [
+            {"id": "app.tests.widget-co.order-created", "direction": "emit"}
+        ]
 
-    def test_the_namespace_alone_is_not_an_event(self):
-        with pytest.raises(ListingDefinitionError, match="must start with"):
-            _normalize(features=["events"], events=["app.tests.widget-co."])
-
-    def test_a_declared_event_is_kept(self):
-        definition = _normalize(
-            features=["events"],
-            events=[
-                "app.tests.widget-co.order_created",
-                "app.tests.widget-co.order_created",
-            ],
-        )
-        assert definition["events"] == ["app.tests.widget-co.order_created"]
-
-
-class TestAutomationIsOpaque:
-    def test_the_block_is_stored_verbatim(self):
-        """Initiative stores automation information and passes it through; the
-        service that owns automations is the only thing that reads it. So the
-        validator checks shape and size, and nothing about the contents."""
-        blob = {
-            "nodes": [{"anything": "at all", "nested": {"deeply": [1, 2, 3]}}],
-            "version": "whatever the service says",
-        }
-        definition = _normalize(features=["automations"], automation=blob)
-        assert definition["automation"] == blob
-
-    def test_it_must_still_be_an_object(self):
-        with pytest.raises(ListingDefinitionError, match="automation must be"):
-            _normalize(features=["automations"], automation=["not", "an", "object"])
-
-    def test_it_is_size_capped(self):
-        oversized = {"graph": "x" * service_apps.MAX_AUTOMATION_BYTES}
-        with pytest.raises(ListingDefinitionError, match="larger than"):
-            _normalize(features=["automations"], automation=oversized)
+    def test_two_of_the_same_id_are_refused(self):
+        # One id, two answers, and which one a caller reaches would depend on
+        # iteration order.
+        with pytest.raises(ListingDefinitionError, match="share the id"):
+            _normalize(
+                features=["endpoints"],
+                endpoints=[
+                    {"id": "app.tests.widget-co.order-created", "direction": "emit"},
+                    {"id": "app.tests.widget-co.order-created", "direction": "read"},
+                ],
+            )
 
 
 class TestCanonicalShape:
@@ -779,7 +834,7 @@ class TestCanonicalShape:
         """The governing rule, asserted on a manifest that tries: an app says
         which route, and the deployment's registration says where."""
         definition = _normalize(
-            features=["data", "embeds"],
+            features=["endpoints", "embeds"],
             service={
                 "public_id": "tests.widget-co",
                 "protocol": 1,
@@ -793,8 +848,8 @@ class TestCanonicalShape:
                     "connect_path": "/connect/shop",
                 }
             ],
-            data_sources=[
-                {"id": "orders", "path": "/v1/data/orders", "base_url": "http://x.test"}
+            endpoints=[
+                {"id": READ_ID, "direction": "read", "base_url": "http://x.test"}
             ],
             embeds=[
                 {

--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -17,14 +17,14 @@ rather than kept as a checked-in document somebody remembers to update.
 necessary, not sufficient. Four classes of rule cannot be expressed in JSON
 Schema and are enforced only by ``normalize_service_app_definition``:
 
-* **Cross-references** — a widget binding a data source that exists, a
-  ``requires`` term naming a declared connection, an event type prefixed with
+* **Cross-references** — a widget binding a read endpoint that exists, a
+  ``requires`` term naming a declared connection, an endpoint id prefixed with
   the app's own service id.
 * **The features cross-check** — every declared feature backed by a block, and
   every block declared as a feature, in both directions.
-* **Byte sizes** — the caps on ``module_source``, ``sample_data``, the
-  ``automation`` body and the whole document are measured in UTF-8 bytes, which
-  a character count cannot stand in for.
+* **Byte sizes** — the caps on ``module_source``, ``sample_data`` and the
+  whole document are measured in UTF-8 bytes, which a character count cannot
+  stand in for.
 * **Conditional vocabulary** — an embed may name ``initiative_manager`` only if
   it also renders in an initiative, and ``connect_path`` belongs to an
   interactive connection alone.
@@ -70,8 +70,10 @@ from app.services.marketplace.service_apps import (
     APP_PROTOCOL_VERSIONS,
     CONNECTION_SCOPES,
     EMBED_CAPABILITIES,
-    EVENT_TYPE_CHARS,
-    EVENT_TYPE_PREFIX,
+    ACTOR_KINDS,
+    DIRECTIONS,
+    ENDPOINT_ID_CHARS,
+    ENDPOINT_ID_PREFIX,
     FEATURES,
     FIELD_TYPES,
     GUILD_WIDE_VISIBILITIES,
@@ -82,18 +84,17 @@ from app.services.marketplace.service_apps import (
     MAX_DASHBOARD_BINDING_PARAMS,
     MAX_DASHBOARD_GRID_COLUMNS,
     MAX_DASHBOARD_WIDGETS,
-    MAX_DATA_SOURCES,
+    MAX_ENDPOINT_ID_LENGTH,
+    MAX_ENDPOINTS,
     MAX_DESCRIPTION_LENGTH,
     MAX_EMBED_CAPABILITIES,
     MAX_EMBEDS,
-    MAX_EVENT_TYPE_LENGTH,
-    MAX_EVENTS,
     MAX_FIELDS_PER_CONNECTION,
     MAX_PARAM_VALUE_LENGTH,
-    MAX_PARAMS_PER_SOURCE,
+    MAX_PARAMS_PER_ENDPOINT,
     MAX_REQUIRES_TERMS,
     MAX_SELECT_OPTIONS,
-    MAX_WIDGET_SOURCES,
+    MAX_WIDGET_ENDPOINTS,
     MAX_WIDGETS,
     PARAM_TYPES,
     SURFACE_SCOPES,
@@ -112,11 +113,12 @@ SCHEMA_ID = "https://initiative.morels.me/schemas/app-manifest-v1.json"
 #: reading only the file still learns it.
 _AUTHORITY_NOTE = (
     "A manifest that satisfies this schema is well-formed, not necessarily "
-    "acceptable. Cross-references (a widget's data sources, a requires term's "
-    "connection, an event's service prefix), the features/blocks cross-check in "
-    "both directions, UTF-8 byte-size caps, and the conditional rules for "
-    "connect_path and initiative visibility are enforced by the platform on "
-    "publish and are not expressible here."
+    "acceptable. Cross-references (a widget's endpoints, a requires term's "
+    "connection, an endpoint's service prefix), the direction-specific rules on "
+    "an endpoint, the features/blocks cross-check in both directions, UTF-8 "
+    "byte-size caps, and the conditional rules for connect_path and initiative "
+    "visibility are enforced by the platform on publish and are not expressible "
+    "here."
 )
 
 
@@ -299,36 +301,57 @@ def _access_hint() -> dict[str, Any]:
     }
 
 
-def _data_source() -> dict[str, Any]:
+def _endpoint() -> dict[str, Any]:
     return {
         "type": "object",
-        "required": ["id", "path"],
+        "required": ["id", "direction"],
         "properties": {
-            "id": {"$ref": "#/$defs/identifier"},
-            "path": {"$ref": "#/$defs/path"},
-            "visibility": {
-                "enum": _enum(GUILD_WIDE_VISIBILITIES),
+            "id": {"$ref": "#/$defs/namespacedId"},
+            "direction": {
+                "enum": _enum(DIRECTIONS),
                 "description": (
-                    "A source is fetched for a guild rather than an initiative, "
-                    "so the initiative rung is not on offer."
+                    "'read' and 'write' are called by the deployment or by a "
+                    "delegate and answer in place; 'emit' travels the other way "
+                    "— the app posts it to a subscriber that registered a URL, "
+                    "so it carries no parameters and nothing to gate."
                 ),
             },
+            "params": {
+                "type": "array",
+                "maxItems": MAX_PARAMS_PER_ENDPOINT,
+                "items": {"$ref": "#/$defs/endpointParam"},
+                "description": "What a caller may send. Read and write only.",
+            },
+            "actors": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": len(ACTOR_KINDS),
+                "items": {"enum": _enum(ACTOR_KINDS)},
+                "description": (
+                    "Whose credential the call runs on, best first. Read and "
+                    "write only. An endpoint offering only 'member' refuses "
+                    "when that member has connected nothing, rather than "
+                    "quietly acting as the app instead."
+                ),
+            },
+            "requires": {"$ref": "#/$defs/requires"},
             "cache_ttl_seconds": {
                 "type": "integer",
                 "default": 0,
                 "description": (
-                    "How long a response may be reused. Clamped into "
+                    "Read only. How long a response may be reused. Clamped into "
                     f"0..{MAX_CACHE_TTL_SECONDS} rather than refused, so a value "
                     "outside that range is accepted and takes effect at the "
                     "bound — which is why no range is asserted here."
                 ),
             },
-            "params_schema": {
-                "type": "array",
-                "maxItems": MAX_PARAMS_PER_SOURCE,
-                "items": {"$ref": "#/$defs/sourceParam"},
+            "visibility": {
+                "enum": _enum(GUILD_WIDE_VISIBILITIES),
+                "description": (
+                    "Read only. An endpoint is called for a guild rather than "
+                    "an initiative, so the initiative rung is not on offer."
+                ),
             },
-            "requires": {"$ref": "#/$defs/requires"},
         },
     }
 
@@ -356,18 +379,21 @@ def _widget() -> dict[str, Any]:
                     "cannot express."
                 ),
             },
-            "sources": {
+            "endpoints": {
                 "type": "array",
-                "maxItems": MAX_WIDGET_SOURCES,
-                "items": {"$ref": "#/$defs/identifier"},
-                "description": "Data source ids this manifest also declares.",
+                "maxItems": MAX_WIDGET_ENDPOINTS,
+                "items": {"$ref": "#/$defs/namespacedId"},
+                "description": (
+                    "Read endpoint ids this manifest also declares. Only a read "
+                    "answers with something to draw."
+                ),
             },
             "sample_data": {
                 "type": "object",
                 "description": (
-                    "Rows keyed by declared source id, so a preview renders with "
-                    "no network call. Keys naming an undeclared source are "
-                    "dropped."
+                    "Rows keyed by declared read endpoint id, so a preview "
+                    "renders with no network call. Keys naming an undeclared "
+                    "endpoint are dropped."
                 ),
             },
             "requires": {"$ref": "#/$defs/requires"},
@@ -457,11 +483,14 @@ def _bundled_dashboard_widget() -> dict[str, Any]:
             },
             "binding": {
                 "type": "object",
-                "required": ["source_id"],
+                "required": ["endpoint_id"],
                 "properties": {
-                    "source_id": {
-                        "$ref": "#/$defs/identifier",
-                        "description": "One of this manifest's own data source ids.",
+                    "endpoint_id": {
+                        "$ref": "#/$defs/namespacedId",
+                        "description": (
+                            "One of this manifest's own read endpoint ids. Only "
+                            "a read answers with something to draw."
+                        ),
                     },
                     "params": {
                         "type": "object",
@@ -579,10 +608,10 @@ def build_manifest_schema() -> dict[str, Any]:
                 "maxItems": MAX_CONNECTIONS,
                 "items": {"$ref": "#/$defs/connection"},
             },
-            "data_sources": {
+            "endpoints": {
                 "type": "array",
-                "maxItems": MAX_DATA_SOURCES,
-                "items": {"$ref": "#/$defs/dataSource"},
+                "maxItems": MAX_ENDPOINTS,
+                "items": {"$ref": "#/$defs/endpoint"},
             },
             "widgets": {
                 "type": "array",
@@ -593,28 +622,6 @@ def build_manifest_schema() -> dict[str, Any]:
                 "type": "array",
                 "maxItems": MAX_EMBEDS,
                 "items": {"$ref": "#/$defs/embed"},
-            },
-            "events": {
-                "type": "array",
-                "maxItems": MAX_EVENTS,
-                "items": {
-                    "type": "string",
-                    "maxLength": MAX_EVENT_TYPE_LENGTH,
-                    "pattern": _pattern(EVENT_TYPE_CHARS),
-                    "description": (
-                        "Namespaced under the app's own service id — "
-                        f"'{EVENT_TYPE_PREFIX}<public_id>.<name>'. The prefix is "
-                        "checked against the emitting registration at ingress."
-                    ),
-                },
-            },
-            "automation": {
-                "type": "object",
-                "description": (
-                    "The automation service's own block. Opaque to the platform: "
-                    "checked for shape and size, stored verbatim, and described "
-                    "by no vocabulary here."
-                ),
             },
             "dashboards": {
                 "type": "array",
@@ -649,9 +656,19 @@ def build_manifest_schema() -> dict[str, Any]:
             "requires": _requires(),
             "accessHint": _access_hint(),
             "connectionField": _field(types=FIELD_TYPES, allow_managed=True),
-            "sourceParam": _field(types=PARAM_TYPES, allow_managed=False),
+            "endpointParam": _field(types=PARAM_TYPES, allow_managed=False),
             "connection": _connection(),
-            "dataSource": _data_source(),
+            "namespacedId": {
+                "type": "string",
+                "maxLength": MAX_ENDPOINT_ID_LENGTH,
+                "pattern": _pattern(ENDPOINT_ID_CHARS),
+                "description": (
+                    "Namespaced under the app's own service id — "
+                    f"'{ENDPOINT_ID_PREFIX}<public_id>.<name>'. The prefix is "
+                    "checked against the declaring registration at ingress."
+                ),
+            },
+            "endpoint": _endpoint(),
             "widget": _widget(),
             "embed": _embed(),
             "bundledDashboard": _bundled_dashboard(),

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -40,7 +40,7 @@ from app.services.marketplace.service_apps import (
     FIELD_TYPES,
     GUILD_WIDE_VISIBILITIES,
     MAX_CONNECTIONS,
-    MAX_DATA_SOURCES,
+    MAX_ENDPOINTS,
     MAX_EMBEDS,
     MAX_WIDGETS,
     PARAM_TYPES,
@@ -151,7 +151,7 @@ def test_vocabularies_come_from_the_validator():
 def test_caps_come_from_the_validator():
     props = build_manifest_schema()["properties"]
     assert props["connections"]["maxItems"] == MAX_CONNECTIONS
-    assert props["data_sources"]["maxItems"] == MAX_DATA_SOURCES
+    assert props["endpoints"]["maxItems"] == MAX_ENDPOINTS
     assert props["widgets"]["maxItems"] == MAX_WIDGETS
     assert props["embeds"]["maxItems"] == MAX_EMBEDS
 

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -33,8 +33,10 @@ from app.services.marketplace.manifest_values import (
 from app.services.marketplace.definitions import normalize_listing_definition
 from app.services.marketplace.widget_meta import MAX_LOCALES, MAX_TEXT_LENGTH
 from app.services.marketplace.service_apps import (
+    ACTOR_KINDS,
     APP_PROTOCOL_VERSIONS,
     CONNECTION_SCOPES,
+    DIRECTIONS,
     EMBED_CAPABILITIES,
     FEATURES,
     FIELD_TYPES,
@@ -136,8 +138,10 @@ def test_vocabularies_come_from_the_validator():
     )
     assert set(defs["connection"]["properties"]["scope"]["enum"]) == CONNECTION_SCOPES
     assert set(defs["connectionField"]["properties"]["type"]["enum"]) == FIELD_TYPES
-    assert set(defs["sourceParam"]["properties"]["type"]["enum"]) == PARAM_TYPES
-    assert set(defs["dataSource"]["properties"]["visibility"]["enum"]) == (
+    assert set(defs["endpointParam"]["properties"]["type"]["enum"]) == PARAM_TYPES
+    assert set(defs["endpoint"]["properties"]["direction"]["enum"]) == DIRECTIONS
+    assert set(defs["endpoint"]["properties"]["actors"]["items"]["enum"]) == ACTOR_KINDS
+    assert set(defs["endpoint"]["properties"]["visibility"]["enum"]) == (
         GUILD_WIDE_VISIBILITIES
     )
     assert set(defs["embed"]["properties"]["visibility"]["enum"]) == VISIBILITIES
@@ -162,10 +166,10 @@ def test_a_secret_is_not_a_query_parameter():
     the schema must not blur the two by sharing one field definition."""
     defs = build_manifest_schema()["$defs"]
     assert "secret" in defs["connectionField"]["properties"]["type"]["enum"]
-    assert "secret" not in defs["sourceParam"]["properties"]["type"]["enum"]
+    assert "secret" not in defs["endpointParam"]["properties"]["type"]["enum"]
     # And only a connection field is written back by the app.
     assert "managed" in defs["connectionField"]["properties"]
-    assert "managed" not in defs["sourceParam"]["properties"]
+    assert "managed" not in defs["endpointParam"]["properties"]
 
 
 @pytest.mark.unit
@@ -193,7 +197,7 @@ ACCEPTED = [
     pytest.param(_manifest(), id="minimal"),
     pytest.param(
         _manifest(
-            features=["data"],
+            features=["endpoints"],
             connections=[
                 {
                     "id": "api",
@@ -205,13 +209,13 @@ ACCEPTED = [
                     "access_hint": {"api": "GitHub", "scopes": ["repo:read"]},
                 }
             ],
-            data_sources=[
+            endpoints=[
                 {
-                    "id": "issues",
-                    "path": "/data/issues",
+                    "id": "app.acme.tracker.issues",
+                    "direction": "read",
                     "visibility": "member",
                     "cache_ttl_seconds": 300,
-                    "params_schema": [
+                    "params": [
                         {
                             "key": "state",
                             "type": "select",
@@ -223,7 +227,7 @@ ACCEPTED = [
                 }
             ],
         ),
-        id="static-connection-and-source",
+        id="static-connection-and-read",
     ),
     pytest.param(
         _manifest(
@@ -253,11 +257,20 @@ ACCEPTED = [
     ),
     pytest.param(
         _manifest(
-            features=["events", "automations"],
-            events=["app.acme.tracker.issue-opened"],
-            automation={"nodes": [{"anything": "the service understands"}]},
+            features=["endpoints"],
+            endpoints=[
+                {"id": "app.acme.tracker.issue-opened", "direction": "emit"},
+                {
+                    "id": "app.acme.tracker.issue-open",
+                    "direction": "write",
+                    "actors": ["member", "installation"],
+                    "params": [
+                        {"key": "title", "type": "string", "label": {"en": "T"}}
+                    ],
+                },
+            ],
         ),
-        id="events-and-opaque-automation",
+        id="every-direction-in-one-block",
     ),
     # The three the platform takes rather than refuses. Each was a real
     # over-strict rule in the first cut of this schema, caught in review: a
@@ -265,15 +278,27 @@ ACCEPTED = [
     # is broken.
     pytest.param(
         _manifest(
-            features=["data"],
-            data_sources=[{"id": "s", "path": "/d", "cache_ttl_seconds": 10_000_000}],
+            features=["endpoints"],
+            endpoints=[
+                {
+                    "id": "app.acme.tracker.s",
+                    "direction": "read",
+                    "cache_ttl_seconds": 10_000_000,
+                }
+            ],
         ),
         id="cache-ttl-clamped-not-refused",
     ),
     pytest.param(
         _manifest(
-            features=["data"],
-            data_sources=[{"id": "s", "path": "/d", "invented_by_a_newer_app": 1}],
+            features=["endpoints"],
+            endpoints=[
+                {
+                    "id": "app.acme.tracker.s",
+                    "direction": "read",
+                    "invented_by_a_newer_app": 1,
+                }
+            ],
             some_future_block={"whatever": True},
         ),
         id="unknown-keys-dropped-not-refused",
@@ -289,7 +314,7 @@ ACCEPTED = [
     ),
     pytest.param(
         _manifest(
-            features=["data"],
+            features=["endpoints"],
             connections=[
                 {
                     "id": "api",
@@ -298,10 +323,10 @@ ACCEPTED = [
                     "fields": [{"key": "t", "type": "secret", "label": {"en": "T"}}],
                 }
             ],
-            data_sources=[
+            endpoints=[
                 {
-                    "id": "s",
-                    "path": "/d",
+                    "id": "app.acme.tracker.s",
+                    "direction": "read",
                     # One operator plus a key from a newer manifest revision.
                     # The platform reads the operator and drops the rest, so a
                     # rule that counted properties would refuse this.
@@ -313,14 +338,14 @@ ACCEPTED = [
     ),
     pytest.param(
         _manifest(
-            features=["data", "widgets", "dashboards"],
-            data_sources=[{"id": "s", "path": "/d"}],
+            features=["endpoints", "widgets", "dashboards"],
+            endpoints=[{"id": "app.acme.tracker.s", "direction": "read"}],
             widgets=[
                 {
                     "id": "w",
                     "meta": {"name": {"en": "W"}},
                     "module_source": "export default () => ({});",
-                    "sources": ["s"],
+                    "endpoints": ["app.acme.tracker.s"],
                 }
             ],
             dashboards=[
@@ -339,7 +364,7 @@ ACCEPTED = [
                             "title": "One",
                             "grid": {"x": 0, "y": 0, "w": 4, "h": 3},
                             "binding": {
-                                "source_id": "s",
+                                "endpoint_id": "app.acme.tracker.s",
                                 "params": {"label": "bug", "limit": 5, "open": True},
                             },
                         }
@@ -351,14 +376,14 @@ ACCEPTED = [
     ),
     pytest.param(
         _manifest(
-            features=["data", "widgets", "dashboards"],
-            data_sources=[{"id": "s", "path": "/d"}],
+            features=["endpoints", "widgets", "dashboards"],
+            endpoints=[{"id": "app.acme.tracker.s", "direction": "read"}],
             widgets=[
                 {
                     "id": "w",
                     "meta": {"name": {"en": "W"}},
                     "module_source": "export default () => ({});",
-                    "sources": ["s"],
+                    "endpoints": ["app.acme.tracker.s"],
                 }
             ],
             dashboards=[
@@ -368,7 +393,9 @@ ACCEPTED = [
                     "name": "Overview",
                     # No description, layout, widget id or grid: a publisher who
                     # wants one tile per widget writes almost nothing.
-                    "widgets": [{"type": "w", "binding": {"source_id": "s"}}],
+                    "widgets": [
+                        {"type": "w", "binding": {"endpoint_id": "app.acme.tracker.s"}}
+                    ],
                 }
             ],
         ),
@@ -402,17 +429,22 @@ REFUSED_BY_BOTH = [
     ),
     pytest.param(
         _manifest(
-            features=["data"],
-            data_sources=[{"id": "s", "path": "https://elsewhere.test/data"}],
+            features=["endpoints"],
+            # Direction decides who may call it and whether an answer may be
+            # cached, so a value outside the closed set is not a nuance the
+            # platform could resolve later.
+            endpoints=[{"id": "app.acme.tracker.s", "direction": "sideways"}],
         ),
-        id="path-that-is-an-address",
+        id="direction-outside-the-vocabulary",
     ),
     pytest.param(
-        _manifest(features=["data"], data_sources=[{"id": "s", "path": "/a/../b"}]),
+        _manifest(features=["endpoints"], endpoints=[{"id": "app.acme.tracker.s"}]),
         id="path-climbing-out",
     ),
     pytest.param(
-        _manifest(features=["data"], data_sources=[{"id": "UPPER", "path": "/x"}]),
+        _manifest(
+            features=["endpoints"], endpoints=[{"id": "UPPER", "direction": "read"}]
+        ),
         id="identifier-out-of-charset",
     ),
     pytest.param(
@@ -433,11 +465,11 @@ REFUSED_BY_BOTH = [
     # counts its properties.
     pytest.param(
         _manifest(
-            features=["data"],
-            data_sources=[
+            features=["endpoints"],
+            endpoints=[
                 {
-                    "id": "s",
-                    "path": "/d",
+                    "id": "app.acme.tracker.s",
+                    "direction": "read",
                     "requires": {"all_of": ["a"], "any_of": ["b"]},
                 }
             ],
@@ -446,8 +478,10 @@ REFUSED_BY_BOTH = [
     ),
     pytest.param(
         _manifest(
-            features=["data"],
-            data_sources=[{"id": "s", "path": "/d", "requires": {}}],
+            features=["endpoints"],
+            endpoints=[
+                {"id": "app.acme.tracker.s", "direction": "read", "requires": {}}
+            ],
         ),
         id="requires-naming-no-operator",
     ),
@@ -508,27 +542,30 @@ def test_a_localized_object_with_nothing_usable_is_refused(validator):
     "manifest,why",
     [
         (
-            _manifest(features=["data"]),
+            _manifest(features=["endpoints"]),
             "a declared feature with no block behind it",
         ),
         (
             _manifest(
-                features=["widgets", "data"],
-                data_sources=[{"id": "known", "path": "/d"}],
+                features=["widgets", "endpoints"],
+                endpoints=[{"id": "app.acme.tracker.known", "direction": "read"}],
                 widgets=[
                     {
                         "id": "w",
                         "meta": {"name": {"en": "W"}},
                         "module_source": "export default () => ({})",
-                        "sources": ["absent"],
+                        "endpoints": ["app.acme.tracker.absent"],
                     }
                 ],
             ),
-            "a widget binding a data source that does not exist",
+            "a widget binding a read endpoint that does not exist",
         ),
         (
-            _manifest(features=["events"], events=["app.someone-else.thing"]),
-            "an event namespaced under another app",
+            _manifest(
+                features=["endpoints"],
+                endpoints=[{"id": "app.someone-else.thing", "direction": "emit"}],
+            ),
+            "an endpoint namespaced under another app",
         ),
     ],
 )

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -53,9 +53,12 @@ from app.services.marketplace.widget_meta import (
 )
 
 __all__ = [
+    "ACTOR_KINDS",
     "APP_PROTOCOL_VERSIONS",
     "APP_WIDGET_TYPE_PREFIX",
+    "BINDABLE_DIRECTIONS",
     "CONNECTION_SCOPES",
+    "DIRECTIONS",
     "EMBED_CAPABILITIES",
     "FEATURES",
     "FEATURE_BLOCKS",
@@ -76,11 +79,9 @@ __all__ = [
 #: keeps a declaration and a manifest body from disagreeing — and, below, for
 #: the vocabulary itself.
 FEATURE_BLOCKS: dict[str, str] = {
-    "data": "data_sources",
+    "endpoints": "endpoints",
     "widgets": "widgets",
     "embeds": "embeds",
-    "events": "events",
-    "automations": "automation",
     "dashboards": "dashboards",
 }
 
@@ -181,9 +182,26 @@ APP_PROTOCOL_VERSIONS: frozenset[int] = frozenset({1})
 #: identifier character set, so the three parts stay separable.
 APP_WIDGET_TYPE_PREFIX = "app:"
 
-#: Every event an app emits is namespaced under its own service id.
-EVENT_TYPE_PREFIX = "app."
-EVENT_TYPE_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
+#: Every endpoint an app declares is namespaced under its own service id.
+ENDPOINT_ID_PREFIX = "app."
+ENDPOINT_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
+
+#: Which way a call across an endpoint travels.
+#:
+#: ``read`` and ``write`` are both request/response and differ only in whether
+#: the caller expects the app to change something at its vendor — which decides
+#: whether an answer may be cached and whether a widget may bind it. ``emit`` is
+#: the other direction: a subscriber registers a URL and the app posts to it, so
+#: there is nothing to call and nothing to cache.
+DIRECTIONS: frozenset[str] = frozenset({"read", "write", "emit"})
+
+#: Only a ``read`` answers with something to draw, so only a ``read`` fills a
+#: tile. Binding a write would declare a widget nothing renders.
+BINDABLE_DIRECTIONS: frozenset[str] = frozenset({"read"})
+
+#: Whose credential an endpoint runs on. The app resolves it; this is the
+#: vocabulary it states its preference in, best first.
+ACTOR_KINDS: frozenset[str] = frozenset({"member", "installation"})
 
 # --- caps -------------------------------------------------------------------
 #
@@ -198,9 +216,11 @@ MAX_SELECT_OPTIONS = 24
 MAX_ACCESS_HINT_SCOPES = 24
 MAX_REQUIRES_TERMS = 10
 MAX_WIDGETS = 12
-MAX_WIDGET_SOURCES = 8
-MAX_DATA_SOURCES = 24
-MAX_PARAMS_PER_SOURCE = 12
+MAX_WIDGET_ENDPOINTS = 8
+#: Reads, writes and emissions share one list, so this bounds all three
+#: together rather than each separately.
+MAX_ENDPOINTS = 64
+MAX_PARAMS_PER_ENDPOINT = 12
 MAX_EMBEDS = 12
 #: An app ships a handful of arrangements of its own widgets, not a library of
 #: them. Each becomes a catalog row, so this is also how many listings a single
@@ -217,9 +237,8 @@ MAX_DASHBOARD_BINDING_PARAMS = 12
 MAX_DESCRIPTION_LENGTH = 500
 #: A fixed parameter value on a tile's binding.
 MAX_PARAM_VALUE_LENGTH = 2_000
-MAX_EVENTS = 50
-MAX_EVENT_TYPE_LENGTH = 200
-#: A day. A source that wants a longer memory than that is asking for a stale
+MAX_ENDPOINT_ID_LENGTH = 200
+#: A day. A read that wants a longer memory than that is asking for a stale
 #: dashboard rather than a cheaper one.
 MAX_CACHE_TTL_SECONDS = 86_400
 
@@ -227,8 +246,6 @@ MAX_CACHE_TTL_SECONDS = 86_400
 MAX_MODULE_SOURCE_BYTES = 64 * 1024
 #: Rows powering a preview with no network call.
 MAX_SAMPLE_DATA_BYTES = 32 * 1024
-#: The automation service's own block, stored verbatim.
-MAX_AUTOMATION_BYTES = 64 * 1024
 #: The canonical definition, after normalization. Checked last, so a publisher
 #: is told the document is too large rather than which cap they happened to hit
 #: first.
@@ -445,13 +462,54 @@ def _connection(raw: Any) -> dict[str, Any]:
 # --- what an app offers -----------------------------------------------------
 
 
-def _data_source(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
-    source = require_mapping(raw, "data source")
-    source_id = check_identifier(source.get("id"), what="data source id")
-    what = f"data source {source_id!r}"
+def _endpoint_id(raw: Any, *, service_public_id: str, what: str) -> str:
+    """One endpoint id, namespaced under the app's own service id.
+
+    The prefix is checked here and again at ingress against the declaring
+    registration, so an app can answer and announce only under its own name. Two
+    apps offering ``create-issue`` would be two different things under one name,
+    and a caller that resolved the wrong one would do the wrong thing
+    successfully — which is worse than an error.
+    """
+    prefix = f"{ENDPOINT_ID_PREFIX}{service_public_id}."
+    if not isinstance(raw, str) or not raw:
+        fail(f"{what} is required")
+    if len(raw) > MAX_ENDPOINT_ID_LENGTH:
+        fail(f"{what} {raw[:40]!r}… is too long")
+    for character in raw:
+        if character not in ENDPOINT_ID_CHARS:
+            fail(f"{what} {raw!r} contains {character!r}")
+    if not raw.startswith(prefix) or len(raw) == len(prefix):
+        fail(f"{what} {raw!r} must start with {prefix!r}")
+    return raw
+
+
+def _endpoint(
+    raw: Any, *, connection_ids: set[str], service_public_id: str
+) -> dict[str, Any]:
+    """One thing the app will do when something connects to it.
+
+    A single vocabulary for every caller and every direction. A widget filling a
+    tile, an automation service asking the app to act, and a subscriber waiting
+    to be told all name an id from this list, and what separates them is which
+    token they prove themselves with rather than which route they found.
+
+    The id is the address. There is no path to choose, so two apps cannot answer
+    the same question at different URLs and a caller that knows the id needs
+    nothing else to make the call.
+    """
+    endpoint = require_mapping(raw, "endpoint")
+    endpoint_id = _endpoint_id(
+        endpoint.get("id"), service_public_id=service_public_id, what="endpoint id"
+    )
+    what = f"endpoint {endpoint_id!r}"
+
+    direction = endpoint.get("direction")
+    if direction not in DIRECTIONS:
+        fail(f"{what}: direction must be one of {sorted(DIRECTIONS)}")
 
     params_raw = require_list(
-        source.get("params_schema"), f"{what} params_schema", MAX_PARAMS_PER_SOURCE
+        endpoint.get("params"), f"{what} params", MAX_PARAMS_PER_ENDPOINT
     )
     params: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -464,24 +522,75 @@ def _data_source(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
         seen.add(param["key"])
         params.append(param)
 
-    cleaned: dict[str, Any] = {
-        "id": source_id,
-        "path": check_path(source.get("path"), what=f"{what} path"),
-        # A source is fetched for a guild, not for an initiative, so the rungs
-        # that need one are not on offer here.
-        "visibility": _visibility(
-            source.get("visibility"), what=what, allowed=GUILD_WIDE_VISIBILITIES
-        ),
-        "cache_ttl_seconds": _cache_ttl(source.get("cache_ttl_seconds"), what=what),
-    }
+    cleaned: dict[str, Any] = {"id": endpoint_id, "direction": direction}
+
+    # An emission travels the other way: nobody calls it, so there is nothing
+    # for a caller to send, nothing to cache and nobody to gate. Carrying any of
+    # it would describe a call that never happens.
+    if direction == "emit":
+        for absent in (
+            "params",
+            "requires",
+            "cache_ttl_seconds",
+            "visibility",
+            "actors",
+        ):
+            if endpoint.get(absent) is not None:
+                fail(f"{what}: an emit endpoint has no {absent}")
+        return cleaned
+
     if params:
-        cleaned["params_schema"] = params
+        cleaned["params"] = params
+
+    actors = _actors(endpoint.get("actors"), what=what)
+    if actors:
+        cleaned["actors"] = actors
+
+    # Only a read is answered from cache, and only a read is reached by an
+    # audience wide enough to need a rung. A write is authorized by the token
+    # that carried it.
+    if direction == "read":
+        # A read is answered for a guild, not for an initiative, so the rungs
+        # that need one are not on offer here.
+        cleaned["visibility"] = _visibility(
+            endpoint.get("visibility"), what=what, allowed=GUILD_WIDE_VISIBILITIES
+        )
+        cleaned["cache_ttl_seconds"] = _cache_ttl(
+            endpoint.get("cache_ttl_seconds"), what=what
+        )
+    else:
+        for absent in ("cache_ttl_seconds", "visibility"):
+            if endpoint.get(absent) is not None:
+                fail(f"{what}: only a read endpoint has {absent}")
+
     requires = _requires(
-        source.get("requires"), connection_ids=connection_ids, what=what
+        endpoint.get("requires"), connection_ids=connection_ids, what=what
     )
     if requires is not None:
         cleaned["requires"] = requires
     return cleaned
+
+
+def _actors(raw: Any, *, what: str) -> list[str]:
+    """Whose credential the app will run this on, best first.
+
+    A list rather than a set because the order is the app's preference, and a
+    caller reads it to know what it is asking for: an endpoint offering only
+    ``member`` refuses when the member has connected nothing, rather than
+    quietly acting as the app instead.
+    """
+    if raw is None:
+        return []
+    declared = require_list(raw, f"{what} actors", len(ACTOR_KINDS))
+    actors: list[str] = []
+    for entry in declared:
+        if entry not in ACTOR_KINDS:
+            fail(f"{what}: actors must be drawn from {sorted(ACTOR_KINDS)}")
+        if entry not in actors:
+            actors.append(entry)
+    if not actors:
+        fail(f"{what}: names no actor it could run as")
+    return actors
 
 
 def _cache_ttl(raw: Any, *, what: str) -> int:
@@ -496,7 +605,7 @@ def _cache_ttl(raw: Any, *, what: str) -> int:
 
 
 def _widget(
-    raw: Any, *, source_ids: set[str], connection_ids: set[str]
+    raw: Any, *, readable_ids: set[str], connection_ids: set[str]
 ) -> dict[str, Any]:
     widget = require_mapping(raw, "widget")
     widget_id = check_identifier(widget.get("id"), what="widget id")
@@ -515,24 +624,28 @@ def _widget(
     if len(encoded) > MAX_MODULE_SOURCE_BYTES:
         fail(f"{what}: module_source is larger than {MAX_MODULE_SOURCE_BYTES} bytes")
 
-    bound = require_list(widget.get("sources"), f"{what} sources", MAX_WIDGET_SOURCES)
-    sources: list[str] = []
+    bound = require_list(
+        widget.get("endpoints"), f"{what} endpoints", MAX_WIDGET_ENDPOINTS
+    )
+    endpoints: list[str] = []
     for entry in bound:
-        source_id = check_identifier(entry, what=f"{what} source")
-        if source_id not in source_ids:
-            fail(f"{what}: binds unknown data source {source_id!r}")
-        if source_id not in sources:
-            sources.append(source_id)
+        if not isinstance(entry, str) or entry not in readable_ids:
+            # Named rather than described: a write and an emission are both real
+            # endpoints, and neither fills a tile, so "unknown" would be the
+            # wrong word for the mistake somebody is most likely making.
+            fail(f"{what}: binds {entry!r}, which is not a declared read endpoint")
+        if entry not in endpoints:
+            endpoints.append(entry)
 
     cleaned: dict[str, Any] = {
         "id": widget_id,
         "meta": meta,
         "module_source": module_source,
     }
-    if sources:
-        cleaned["sources"] = sources
+    if endpoints:
+        cleaned["endpoints"] = endpoints
 
-    sample = _sample_data(widget.get("sample_data"), sources=sources, what=what)
+    sample = _sample_data(widget.get("sample_data"), sources=endpoints, what=what)
     if sample:
         cleaned["sample_data"] = sample
     requires = _requires(
@@ -544,7 +657,7 @@ def _widget(
 
 
 def _bundled_dashboard(
-    raw: Any, *, widget_ids: set[str], source_ids: set[str]
+    raw: Any, *, widget_ids: set[str], readable_ids: set[str]
 ) -> dict[str, Any]:
     """One dashboard an app ships with itself.
 
@@ -589,7 +702,7 @@ def _bundled_dashboard(
 
     widgets = [
         _bundled_dashboard_widget(
-            widget, widget_ids=widget_ids, source_ids=source_ids, what=what
+            widget, widget_ids=widget_ids, readable_ids=readable_ids, what=what
         )
         for widget in require_list(
             entry.get("widgets"), f"{what} widgets", MAX_DASHBOARD_WIDGETS
@@ -627,7 +740,7 @@ def _bundled_dashboard(
 
 
 def _bundled_dashboard_widget(
-    raw: Any, *, widget_ids: set[str], source_ids: set[str], what: str
+    raw: Any, *, widget_ids: set[str], readable_ids: set[str], what: str
 ) -> dict[str, Any]:
     """One tile, naming one of this app's widgets and one of its sources."""
     widget = require_mapping(raw, f"{what} widget")
@@ -636,13 +749,11 @@ def _bundled_dashboard_widget(
         fail(f"{what}: names unknown widget {widget_type!r}")
 
     binding = require_mapping(widget.get("binding"), f"{what} widget binding")
-    source_id = check_identifier(
-        binding.get("source_id"), what=f"{what} widget binding source_id"
-    )
-    if source_id not in source_ids:
-        fail(f"{what}: binds unknown data source {source_id!r}")
+    endpoint_id = binding.get("endpoint_id")
+    if not isinstance(endpoint_id, str) or endpoint_id not in readable_ids:
+        fail(f"{what}: binds {endpoint_id!r}, which is not a declared read endpoint")
 
-    bound: dict[str, Any] = {"source_id": source_id}
+    bound: dict[str, Any] = {"endpoint_id": endpoint_id}
     params = binding.get("params")
     if params is not None:
         bound["params"] = _bundled_binding_params(params, what=what)
@@ -811,46 +922,6 @@ def _embed(raw: Any, *, connection_ids: set[str]) -> dict[str, Any]:
     return cleaned
 
 
-def _events(raw: Any, *, service_public_id: str) -> list[str]:
-    """Event types the app emits, namespaced under its own service id.
-
-    The prefix is checked here and again at ingress against the emitting
-    registration, so an app can announce and emit only under its own name.
-    """
-    prefix = f"{EVENT_TYPE_PREFIX}{service_public_id}."
-    declared = require_list(raw, "events", MAX_EVENTS)
-    events: list[str] = []
-    for entry in declared:
-        if not isinstance(entry, str) or not entry:
-            fail("events must be a list of event type names")
-        if len(entry) > MAX_EVENT_TYPE_LENGTH:
-            fail(f"event type {entry[:40]!r}… is too long")
-        for character in entry:
-            if character not in EVENT_TYPE_CHARS:
-                fail(f"event type {entry!r} contains {character!r}")
-        if not entry.startswith(prefix) or len(entry) == len(prefix):
-            fail(f"event type {entry!r} must start with {prefix!r}")
-        if entry not in events:
-            events.append(entry)
-    return events
-
-
-def _automation(raw: Any) -> dict[str, Any] | None:
-    """The automation service's own block.
-
-    Opaque by design: this build checks that it is a JSON object within a size
-    cap and stores it verbatim. It holds no vocabulary describing what is inside
-    — descriptor shapes, triggers, and execution belong to the service that owns
-    automations, and duplicating any of it here would be a second definition of
-    a contract this repository does not own.
-    """
-    if raw is None:
-        return None
-    automation = require_mapping(raw, "automation")
-    check_json_size(automation, what="automation", limit=MAX_AUTOMATION_BYTES)
-    return automation
-
-
 # --- the definition ---------------------------------------------------------
 
 
@@ -936,20 +1007,29 @@ def normalize_service_app_definition(definition: Any) -> dict[str, Any]:
             fail(f"service app: two connections share the id {connection['id']!r}")
         connection_ids.add(connection["id"])
 
-    data_sources = [
-        _data_source(entry, connection_ids=connection_ids)
+    # One list for every direction, so a caller resolves an id without being
+    # told which kind of thing it is first.
+    endpoints = [
+        _endpoint(
+            entry,
+            connection_ids=connection_ids,
+            service_public_id=service["public_id"],
+        )
         for entry in require_list(
-            body.get("data_sources"), "service app: data_sources", MAX_DATA_SOURCES
+            body.get("endpoints"), "service app: endpoints", MAX_ENDPOINTS
         )
     ]
-    source_ids: set[str] = set()
-    for source in data_sources:
-        if source["id"] in source_ids:
-            fail(f"service app: two data sources share the id {source['id']!r}")
-        source_ids.add(source["id"])
+    endpoint_ids: set[str] = set()
+    readable_ids: set[str] = set()
+    for endpoint in endpoints:
+        if endpoint["id"] in endpoint_ids:
+            fail(f"service app: two endpoints share the id {endpoint['id']!r}")
+        endpoint_ids.add(endpoint["id"])
+        if endpoint["direction"] in BINDABLE_DIRECTIONS:
+            readable_ids.add(endpoint["id"])
 
     widgets = [
-        _widget(entry, source_ids=source_ids, connection_ids=connection_ids)
+        _widget(entry, readable_ids=readable_ids, connection_ids=connection_ids)
         for entry in require_list(
             body.get("widgets"), "service app: widgets", MAX_WIDGETS
         )
@@ -979,18 +1059,18 @@ def normalize_service_app_definition(definition: Any) -> dict[str, Any]:
     # one answer rather than two shapes that mean the same thing.
     if connections:
         cleaned["connections"] = connections
-    if data_sources:
-        cleaned["data_sources"] = data_sources
+    if endpoints:
+        cleaned["endpoints"] = endpoints
     if widgets:
         cleaned["widgets"] = widgets
     if embeds:
         cleaned["embeds"] = embeds
 
-    # After the widgets and sources it can name, because every tile is checked
+    # After the widgets and endpoints it can name, because every tile is checked
     # against them — the whole point of bundling rather than publishing
     # separately is that this cross-check is possible at all.
     dashboards = [
-        _bundled_dashboard(entry, widget_ids=widget_ids, source_ids=source_ids)
+        _bundled_dashboard(entry, widget_ids=widget_ids, readable_ids=readable_ids)
         for entry in require_list(
             body.get("dashboards"), "service app: dashboards", MAX_BUNDLED_DASHBOARDS
         )
@@ -1017,17 +1097,6 @@ def normalize_service_app_definition(definition: Any) -> dict[str, Any]:
             seen_uids.add(dashboard["uid"])
             seen_public_ids.add(dashboard["public_id"])
         cleaned["dashboards"] = dashboards
-
-    events = _events(body.get("events"), service_public_id=service["public_id"])
-    if events:
-        cleaned["events"] = events
-    automation = _automation(body.get("automation"))
-    # Same rule as every block above: an empty one is left out rather than
-    # stored as a second way of saying "none". An automation block that is
-    # present but empty describes nothing, and storing it would let a manifest
-    # carry a block its `features` never declared.
-    if automation:
-        cleaned["automation"] = automation
 
     default_name = clean_text(
         body.get("default_name"),

--- a/backend/app/services/tenant/app_channels.py
+++ b/backend/app/services/tenant/app_channels.py
@@ -43,7 +43,7 @@ from app.models.platform.app_service_registration import AppServiceRegistration
 from app.models.platform.guild import Guild, GuildStatus
 from app.models.tenant.guild_app import GuildApp
 from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
-from app.services.marketplace.service_apps import EVENT_TYPE_PREFIX
+from app.services.marketplace.service_apps import ENDPOINT_ID_PREFIX
 from app.services.tenant import app_config as app_config_service
 from app.services.tenant.webhook_dispatcher import dispatch_event
 
@@ -578,7 +578,7 @@ async def emit_event(
     """
     definition = app.definition if isinstance(app.definition, dict) else {}
     declared = definition.get("events")
-    prefix = f"{EVENT_TYPE_PREFIX}{registration.public_id}."
+    prefix = f"{ENDPOINT_ID_PREFIX}{registration.public_id}."
     if (
         not isinstance(declared, list)
         or event_type not in declared

--- a/backend/app/services/tenant/app_channels.py
+++ b/backend/app/services/tenant/app_channels.py
@@ -568,8 +568,12 @@ async def emit_event(
 
     The app has verified the third party's signature and worked out which of its
     installs the event belongs to; what this adds is the platform's half —
-    the event type is one the *pinned* definition declares, namespaced under the
-    calling app, and the guild has that app installed and enabled.
+    the type is an `emit` endpoint the *pinned* definition declares, namespaced
+    under the calling app, and the guild has that app installed and enabled.
+
+    `emit` and not merely declared: reads and writes share the id space, and an
+    app that could announce under a read's id would be emitting something a
+    subscriber has no way to have asked for.
 
     From there it is an ordinary event: the existing dispatcher delivers it to
     whatever the automation delegate subscribed to. Delivery targets are the
@@ -577,13 +581,18 @@ async def emit_event(
     subscribe.
     """
     definition = app.definition if isinstance(app.definition, dict) else {}
-    declared = definition.get("events")
+    declared = definition.get("endpoints")
     prefix = f"{ENDPOINT_ID_PREFIX}{registration.public_id}."
-    if (
-        not isinstance(declared, list)
-        or event_type not in declared
-        or not event_type.startswith(prefix)
-    ):
+    emitted = (
+        {
+            endpoint.get("id")
+            for endpoint in declared
+            if isinstance(endpoint, dict) and endpoint.get("direction") == "emit"
+        }
+        if isinstance(declared, list)
+        else set()
+    )
+    if event_type not in emitted or not event_type.startswith(prefix):
         raise AppChannelError(AppChannelMessages.UNKNOWN_EVENT_TYPE)
 
     if _payload_size(payload) > MAX_EVENT_PAYLOAD_BYTES:

--- a/backend/app/services/tenant/dashboard_definition.py
+++ b/backend/app/services/tenant/dashboard_definition.py
@@ -40,7 +40,11 @@ from app.services.marketplace.manifest_values import (
     IDENTIFIER_CHARS,
     MAX_IDENTIFIER_LENGTH,
 )
-from app.services.marketplace.service_apps import APP_WIDGET_TYPE_PREFIX
+from app.services.marketplace.service_apps import (
+    APP_WIDGET_TYPE_PREFIX,
+    ENDPOINT_ID_CHARS,
+    MAX_ENDPOINT_ID_LENGTH,
+)
 
 SCHEMA_VERSION = 1
 
@@ -275,7 +279,7 @@ APP_WIDGET_SPEC = WidgetSpec(
 
 #: What one app binding may carry, mirroring the manifest's per-source cap.
 MAX_APP_BINDING_PARAMS = 12
-#: A parameter value is a scalar the source declared a type for. Checked again
+#: A parameter value is a scalar the endpoint declared a type for. Checked again
 #: against that type at fetch time; bounded here so a definition stays small.
 MAX_APP_PARAM_LENGTH = 2_000
 
@@ -285,6 +289,22 @@ def _check_identifier(value: Any) -> str:
         _fail(DashboardMessages.BINDING_INVALID)
     for character in value:
         if character not in IDENTIFIER_CHARS:
+            _fail(DashboardMessages.BINDING_INVALID)
+    return value
+
+
+def _check_endpoint_id(value: Any) -> str:
+    """One endpoint id on a binding.
+
+    A different character set from an identifier: an endpoint id is namespaced
+    under its app's service id, so it carries dots. The prefix itself is checked
+    where the manifest is normalized — a dashboard definition is not the place
+    that knows which app it belongs to.
+    """
+    if not isinstance(value, str) or not value or len(value) > MAX_ENDPOINT_ID_LENGTH:
+        _fail(DashboardMessages.BINDING_INVALID)
+    for character in value:
+        if character not in ENDPOINT_ID_CHARS:
             _fail(DashboardMessages.BINDING_INVALID)
     return value
 
@@ -324,14 +344,14 @@ def _normalize_app_binding(binding: dict[str, Any], listing_uid: str) -> dict[st
     """An ``app`` binding: which installed app, which source, which parameters.
 
     ``app_uid`` has to be the app the widget came from. A widget is one app's
-    module and its sources are that app's, so letting a definition point one
+    module and its endpoints are that app's, so letting a definition point one
     app's widget at another app's data would be a definition choosing what
     crosses between two vendors.
     """
     declared_uid = _check_uid(binding.get("app_uid"), DashboardMessages.BINDING_INVALID)
     if declared_uid != listing_uid:
         _fail(DashboardMessages.BINDING_INVALID)
-    source_id = _check_identifier(binding.get("source_id"))
+    endpoint_id = _check_endpoint_id(binding.get("endpoint_id"))
 
     raw_params = binding.get("params")
     params: dict[str, Any] = {}
@@ -344,7 +364,7 @@ def _normalize_app_binding(binding: dict[str, Any], listing_uid: str) -> dict[st
     cleaned: dict[str, Any] = {
         "source": APP_BINDING_SOURCE,
         "app_uid": listing_uid,
-        "source_id": source_id,
+        "endpoint_id": endpoint_id,
     }
     if params:
         cleaned["params"] = params

--- a/backend/app/services/tenant/dashboard_definition_test.py
+++ b/backend/app/services/tenant/dashboard_definition_test.py
@@ -357,7 +357,7 @@ def _app_widget(**overrides) -> dict:
         "binding": {
             "source": "app",
             "app_uid": APP_UID,
-            "source_id": "orders_summary",
+            "endpoint_id": "app.acme.shop.orders-summary",
         },
         **overrides,
     }
@@ -371,7 +371,7 @@ def test_an_app_widget_keeps_its_namespaced_type():
     assert widget["binding"] == {
         "source": "app",
         "app_uid": APP_UID,
-        "source_id": "orders_summary",
+        "endpoint_id": "app.acme.shop.orders-summary",
     }
     # It still gets a grid, from the app-widget floor rather than a primitive's.
     assert widget["grid"]["w"] >= 2 and widget["grid"]["h"] >= 2
@@ -404,7 +404,7 @@ def test_declared_parameters_are_kept_as_the_scalars_they_are():
                 binding={
                     "source": "app",
                     "app_uid": APP_UID,
-                    "source_id": "orders",
+                    "endpoint_id": "app.acme.shop.orders",
                     "params": {"range": "30d", "limit": 5, "detailed": True},
                 }
             )
@@ -426,7 +426,7 @@ def test_an_app_widget_cannot_bind_another_apps_data():
                     binding={
                         "source": "app",
                         "app_uid": OTHER_UID,
-                        "source_id": "orders",
+                        "endpoint_id": "app.acme.shop.orders",
                     }
                 )
             )
@@ -454,7 +454,7 @@ def test_a_builtin_widget_cannot_bind_the_app_source():
                     "binding": {
                         "source": "app",
                         "app_uid": APP_UID,
-                        "source_id": "orders",
+                        "endpoint_id": "app.acme.shop.orders",
                     },
                 }
             )
@@ -491,20 +491,25 @@ def test_a_malformed_app_widget_type_is_refused(widget_type):
 @pytest.mark.parametrize(
     "binding",
     [
-        {"source": "app", "source_id": "orders"},  # no app named
+        {"source": "app", "endpoint_id": "app.acme.shop.orders"},  # no app named
         {"source": "app", "app_uid": APP_UID},  # no source named
-        {"source": "app", "app_uid": APP_UID, "source_id": "Orders!"},
-        {"source": "app", "app_uid": APP_UID, "source_id": "orders", "params": []},
+        {"source": "app", "app_uid": APP_UID, "endpoint_id": "Orders!"},
         {
             "source": "app",
             "app_uid": APP_UID,
-            "source_id": "orders",
+            "endpoint_id": "app.acme.shop.orders",
+            "params": [],
+        },
+        {
+            "source": "app",
+            "app_uid": APP_UID,
+            "endpoint_id": "app.acme.shop.orders",
             "params": {"range": {"nested": 1}},
         },
         {
             "source": "app",
             "app_uid": APP_UID,
-            "source_id": "orders",
+            "endpoint_id": "app.acme.shop.orders",
             "params": {"bad key": "x"},
         },
     ],
@@ -524,7 +529,7 @@ def test_an_app_binding_still_has_nowhere_to_put_an_address():
                 binding={
                     "source": "app",
                     "app_uid": APP_UID,
-                    "source_id": "orders",
+                    "endpoint_id": "app.acme.shop.orders",
                     "url": "https://evil.test/steal",
                     "base_url": "https://evil.test",
                 }
@@ -532,4 +537,4 @@ def test_an_app_binding_still_has_nowhere_to_put_an_address():
         )
     )
     binding = result["widgets"][0]["binding"]
-    assert set(binding) == {"source", "app_uid", "source_id"}
+    assert set(binding) == {"source", "app_uid", "endpoint_id"}

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -567,12 +567,12 @@
         "binding": {
           "type": "object",
           "required": [
-            "source_id"
+            "endpoint_id"
           ],
           "properties": {
-            "source_id": {
-              "$ref": "#/$defs/identifier",
-              "description": "One of this manifest's own data source ids."
+            "endpoint_id": {
+              "$ref": "#/$defs/namespacedId",
+              "description": "One of this manifest's own read endpoint ids. Only a read answers with something to draw."
             },
             "params": {
               "type": "object",

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://initiative.morels.me/schemas/app-manifest-v1.json",
   "title": "Initiative app manifest (the 'definition' body)",
-  "description": "What a service app declares it can do. This is the 'definition' field of the document served at /.well-known/initiative-app.json, NOT that whole document: a registrar also requires protocol_version, public_id and kind alongside it, and refuses a definition served bare. Generated from the platform's own validator vocabulary. A manifest that satisfies this schema is well-formed, not necessarily acceptable. Cross-references (a widget's data sources, a requires term's connection, an event's service prefix), the features/blocks cross-check in both directions, UTF-8 byte-size caps, and the conditional rules for connect_path and initiative visibility are enforced by the platform on publish and are not expressible here.",
+  "description": "What a service app declares it can do. This is the 'definition' field of the document served at /.well-known/initiative-app.json, NOT that whole document: a registrar also requires protocol_version, public_id and kind alongside it, and refuses a definition served bare. Generated from the platform's own validator vocabulary. A manifest that satisfies this schema is well-formed, not necessarily acceptable. Cross-references (a widget's endpoints, a requires term's connection, an endpoint's service prefix), the direction-specific rules on an endpoint, the features/blocks cross-check in both directions, UTF-8 byte-size caps, and the conditional rules for connect_path and initiative visibility are enforced by the platform on publish and are not expressible here.",
   "type": "object",
   "required": [
     "app_kind",
@@ -36,14 +36,12 @@
     },
     "features": {
       "type": "array",
-      "maxItems": 6,
+      "maxItems": 4,
       "items": {
         "enum": [
-          "automations",
           "dashboards",
-          "data",
           "embeds",
-          "events",
+          "endpoints",
           "widgets"
         ]
       },
@@ -60,11 +58,11 @@
         "$ref": "#/$defs/connection"
       }
     },
-    "data_sources": {
+    "endpoints": {
       "type": "array",
-      "maxItems": 24,
+      "maxItems": 64,
       "items": {
-        "$ref": "#/$defs/dataSource"
+        "$ref": "#/$defs/endpoint"
       }
     },
     "widgets": {
@@ -80,20 +78,6 @@
       "items": {
         "$ref": "#/$defs/embed"
       }
-    },
-    "events": {
-      "type": "array",
-      "maxItems": 50,
-      "items": {
-        "type": "string",
-        "maxLength": 200,
-        "pattern": "^[\\-.0123456789_abcdefghijklmnopqrstuvwxyz]+$",
-        "description": "Namespaced under the app's own service id \u2014 'app.<public_id>.<name>'. The prefix is checked against the emitting registration at ingress."
-      }
-    },
-    "automation": {
-      "type": "object",
-      "description": "The automation service's own block. Opaque to the platform: checked for shape and size, stored verbatim, and described by no vocabulary here."
     },
     "dashboards": {
       "type": "array",
@@ -236,7 +220,7 @@
         ]
       }
     },
-    "sourceParam": {
+    "endpointParam": {
       "type": "object",
       "required": [
         "key",
@@ -329,40 +313,64 @@
         }
       }
     },
-    "dataSource": {
+    "namespacedId": {
+      "type": "string",
+      "maxLength": 200,
+      "pattern": "^[\\-.0123456789_abcdefghijklmnopqrstuvwxyz]+$",
+      "description": "Namespaced under the app's own service id \u2014 'app.<public_id>.<name>'. The prefix is checked against the declaring registration at ingress."
+    },
+    "endpoint": {
       "type": "object",
       "required": [
         "id",
-        "path"
+        "direction"
       ],
       "properties": {
         "id": {
-          "$ref": "#/$defs/identifier"
+          "$ref": "#/$defs/namespacedId"
         },
-        "path": {
-          "$ref": "#/$defs/path"
+        "direction": {
+          "enum": [
+            "emit",
+            "read",
+            "write"
+          ],
+          "description": "'read' and 'write' are called by the deployment or by a delegate and answer in place; 'emit' travels the other way \u2014 the app posts it to a subscriber that registered a URL, so it carries no parameters and nothing to gate."
+        },
+        "params": {
+          "type": "array",
+          "maxItems": 12,
+          "items": {
+            "$ref": "#/$defs/endpointParam"
+          },
+          "description": "What a caller may send. Read and write only."
+        },
+        "actors": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "items": {
+            "enum": [
+              "installation",
+              "member"
+            ]
+          },
+          "description": "Whose credential the call runs on, best first. Read and write only. An endpoint offering only 'member' refuses when that member has connected nothing, rather than quietly acting as the app instead."
+        },
+        "requires": {
+          "$ref": "#/$defs/requires"
+        },
+        "cache_ttl_seconds": {
+          "type": "integer",
+          "default": 0,
+          "description": "Read only. How long a response may be reused. Clamped into 0..86400 rather than refused, so a value outside that range is accepted and takes effect at the bound \u2014 which is why no range is asserted here."
         },
         "visibility": {
           "enum": [
             "guild_admin",
             "member"
           ],
-          "description": "A source is fetched for a guild rather than an initiative, so the initiative rung is not on offer."
-        },
-        "cache_ttl_seconds": {
-          "type": "integer",
-          "default": 0,
-          "description": "How long a response may be reused. Clamped into 0..86400 rather than refused, so a value outside that range is accepted and takes effect at the bound \u2014 which is why no range is asserted here."
-        },
-        "params_schema": {
-          "type": "array",
-          "maxItems": 12,
-          "items": {
-            "$ref": "#/$defs/sourceParam"
-          }
-        },
-        "requires": {
-          "$ref": "#/$defs/requires"
+          "description": "Read only. An endpoint is called for a guild rather than an initiative, so the initiative rung is not on offer."
         }
       }
     },
@@ -386,17 +394,17 @@
           "minLength": 1,
           "description": "The widget's browser-side module. Stored as an opaque string and executed only inside the sandbox; the platform never parses it. Capped in UTF-8 bytes, which this schema cannot express."
         },
-        "sources": {
+        "endpoints": {
           "type": "array",
           "maxItems": 8,
           "items": {
-            "$ref": "#/$defs/identifier"
+            "$ref": "#/$defs/namespacedId"
           },
-          "description": "Data source ids this manifest also declares."
+          "description": "Read endpoint ids this manifest also declares. Only a read answers with something to draw."
         },
         "sample_data": {
           "type": "object",
-          "description": "Rows keyed by declared source id, so a preview renders with no network call. Keys naming an undeclared source are dropped."
+          "description": "Rows keyed by declared read endpoint id, so a preview renders with no network call. Keys naming an undeclared endpoint are dropped."
         },
         "requires": {
           "$ref": "#/$defs/requires"

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -441,7 +441,7 @@
   "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "Diesen Ereignistyp hat die App nicht angegeben.",
   "APP_CHANNEL_EVENT_TOO_LARGE": "Dieses Ereignis ist größer, als diese Version übertragen kann.",
   "APP_CHANNEL_INVALID_CONFIG_STATE": "Dieser App-Dienst hat einen Status gemeldet, den diese Version nicht kennt.",
-  "APP_DATA_SOURCE_NOT_FOUND": "Dieses Widget ist an Daten gebunden, die die App nicht mehr anbietet.",
+  "APP_DATA_ENDPOINT_NOT_FOUND": "Dieses Widget ist an Daten gebunden, die die App nicht mehr anbietet.",
   "APP_DATA_ADMIN_ONLY": "Nur die Gildenadministration sieht die Daten dieser App.",
   "APP_DATA_APP_DISABLED": "Diese App ist in dieser Gilde ausgeschaltet, ihre Widgets haben also nichts anzuzeigen.",
   "APP_DATA_SERVICE_NOT_REGISTERED": "Diese App ist auf dieser Installation nicht eingerichtet. Wende dich an deine Administration.",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -441,7 +441,7 @@
   "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "That event type isn't one this app declared.",
   "APP_CHANNEL_EVENT_TOO_LARGE": "That event is larger than this version will carry.",
   "APP_CHANNEL_INVALID_CONFIG_STATE": "That app service reported a status this version doesn't recognize.",
-  "APP_DATA_SOURCE_NOT_FOUND": "This widget is bound to data the app no longer offers.",
+  "APP_DATA_ENDPOINT_NOT_FOUND": "This widget is bound to data the app no longer offers.",
   "APP_DATA_ADMIN_ONLY": "Only guild admins can see this app's data.",
   "APP_DATA_APP_DISABLED": "This app is turned off in this guild, so its widgets have nothing to show.",
   "APP_DATA_SERVICE_NOT_REGISTERED": "This app isn't set up on this deployment. Contact your administrator.",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -441,7 +441,7 @@
   "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "Ese tipo de evento no es uno de los que declaró esta aplicación.",
   "APP_CHANNEL_EVENT_TOO_LARGE": "Ese evento es más grande de lo que esta versión puede transportar.",
   "APP_CHANNEL_INVALID_CONFIG_STATE": "Ese servicio de aplicación informó de un estado que esta versión no reconoce.",
-  "APP_DATA_SOURCE_NOT_FOUND": "Este widget está vinculado a datos que la aplicación ya no ofrece.",
+  "APP_DATA_ENDPOINT_NOT_FOUND": "Este widget está vinculado a datos que la aplicación ya no ofrece.",
   "APP_DATA_ADMIN_ONLY": "Solo la administración del gremio puede ver los datos de esta aplicación.",
   "APP_DATA_APP_DISABLED": "Esta aplicación está desactivada en este gremio, así que sus widgets no tienen nada que mostrar.",
   "APP_DATA_SERVICE_NOT_REGISTERED": "Esta aplicación no está configurada en esta instalación. Habla con tu administración.",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -441,7 +441,7 @@
   "APP_CHANNEL_UNKNOWN_EVENT_TYPE": "Ce type d'évènement ne fait pas partie de ceux déclarés par cette application.",
   "APP_CHANNEL_EVENT_TOO_LARGE": "Cet évènement dépasse ce que cette version peut transporter.",
   "APP_CHANNEL_INVALID_CONFIG_STATE": "Ce service applicatif a signalé un état que cette version ne reconnaît pas.",
-  "APP_DATA_SOURCE_NOT_FOUND": "Ce widget est lié à des données que l'application ne propose plus.",
+  "APP_DATA_ENDPOINT_NOT_FOUND": "Ce widget est lié à des données que l'application ne propose plus.",
   "APP_DATA_ADMIN_ONLY": "Seule l'administration de la guilde peut voir les données de cette application.",
   "APP_DATA_APP_DISABLED": "Cette application est désactivée dans cette guilde : ses widgets n'ont rien à afficher.",
   "APP_DATA_SERVICE_NOT_REGISTERED": "Cette application n'est pas configurée sur cette installation. Contactez votre administration.",

--- a/frontend/src/api/appData.ts
+++ b/frontend/src/api/appData.ts
@@ -3,81 +3,42 @@
  *
  * Hand-written rather than generated for the same reason `appConnections.ts` is
  * — these routes carry a rule worth keeping visible at the call site. **A widget
- * never names an endpoint.** It names a source on an installed app, and the
- * request below carries the dashboard that widget sits on, because the
+ * never names an address.** It names a read endpoint on an installed app, and
+ * the request below carries the dashboard that widget sits on, because the
  * dashboard's own gates are what decide whether this viewer may see anything
  * here at all. There is no variant of this call that omits it.
  *
- * The shapes mirror `backend/app/schemas/tenant/app_data.py`. Once Orval has run
- * against the new endpoints these can be swapped for the generated equivalents;
- * the field names are already the generated ones.
+ * The *shapes* are the generated ones, re-exported rather than restated. They
+ * were hand-copied here while the endpoints were being built, and a second
+ * declaration of one contract is a second thing to remember: the copy went
+ * stale through a vocabulary change without anything failing, because nothing
+ * outside this file read the generated originals.
  */
 
 import { apiClient } from "@/api/client";
+import type {
+  AppDataParam,
+  AppDataResponse,
+  AppEndpointRead,
+  AppWidgetCatalogEntry,
+  AppWidgetCatalogResponse,
+  AppWidgetRead,
+} from "@/api/generated/initiativeAPI.schemas";
+
+export type {
+  AppDataParam,
+  AppDataResponse,
+  AppEndpointRead,
+  AppWidgetCatalogEntry,
+  AppWidgetCatalogResponse,
+  AppWidgetRead,
+};
 
 /** A localized label, as the app's manifest supplies it. */
 export type LocalizedText = Record<string, string>;
 
-/** One parameter a source accepts. The manifest's closed enum, minus `secret` —
- *  a credential is supplied once and held in custody, never restated per call. */
-export interface AppDataParam {
-  key: string;
-  type: "string" | "url" | "bool" | "select" | "int";
-  label: LocalizedText;
-  required?: boolean;
-  options?: string[];
-}
-
-export interface AppEndpoint {
-  id: string;
-  /** `member` or `guild_admin`. Shown by the picker; enforced again on every
-   *  fetch under the caller's own session, so this is not what protects it. */
-  visibility: "member" | "guild_admin" | string;
-  /** What the app asks for. The proxy applies the deployment's own ceiling on
-   *  top, so this is a request rather than a guarantee. */
-  cache_ttl_seconds: number;
-  params: AppDataParam[];
-}
-
-export interface AppWidget {
-  /** Namespaced `app:<listing_uid>:<widget_id>` — an app's widget can never
-   *  resolve to a built-in renderer, or the other way round. */
-  type: string;
-  id: string;
-  meta: Record<string, unknown>;
-  /** The module the sandbox runs. Text everywhere outside that sandbox. */
-  module_source: string;
-  endpoints: string[];
-  /** Rows for a preview that issues no request at all, keyed by endpoint id. */
-  sample_data: Record<string, unknown>;
-}
-
-export interface AppWidgetCatalogEntry {
-  app_id: number;
-  app_uid: string;
-  name: string;
-  enabled: boolean;
-  widgets: AppWidget[];
-  /** Read endpoints only — a write does not fill a tile. */
-  endpoints: AppEndpoint[];
-}
-
-export interface AppWidgetCatalog {
-  items: AppWidgetCatalogEntry[];
-}
-
-export interface AppDataResponse {
-  /** Verbatim from the app. Nothing between there and the sandbox reads inside
-   *  them, and the sandbox receives them as values, never as markup. */
-  rows: unknown[];
-  /** When the upstream call happened — a cached body keeps the time it was
-   *  actually obtained, not the time it was asked for. */
-  fetched_at: string;
-  cached: boolean;
-}
-
 export const getAppWidgetCatalog = (guildId: number) =>
-  apiClient.get<AppWidgetCatalog>(`/g/${guildId}/apps/widget-catalog`).then((r) => r.data);
+  apiClient.get<AppWidgetCatalogResponse>(`/g/${guildId}/apps/widget-catalog`).then((r) => r.data);
 
 export interface AppDataRequest {
   guildId: number;
@@ -91,14 +52,17 @@ export interface AppDataRequest {
 
 export const getAppData = ({ guildId, appId, endpointId, dashboardId, params }: AppDataRequest) =>
   apiClient
-    .get<AppDataResponse>(`/g/${guildId}/apps/${appId}/data/${encodeURIComponent(endpointId)}`, {
-      params: {
-        dashboard_id: dashboardId,
-        // Sent as one encoded object so the server validates it against the
-        // endpoint's own `params` rather than reading loose query keys.
-        ...(params && Object.keys(params).length ? { params: JSON.stringify(params) } : {}),
-      },
-    })
+    .get<AppDataResponse>(
+      `/g/${guildId}/apps/${appId}/endpoints/${encodeURIComponent(endpointId)}`,
+      {
+        params: {
+          dashboard_id: dashboardId,
+          // Sent as one encoded object so the server validates it against the
+          // endpoint's own `params` rather than reading loose query keys.
+          ...(params && Object.keys(params).length ? { params: JSON.stringify(params) } : {}),
+        },
+      }
+    )
     .then((r) => r.data);
 
 /** Find the install backing a binding's `app_uid`, and the widget/endpoint it
@@ -106,13 +70,13 @@ export const getAppData = ({ guildId, appId, endpointId, dashboardId, params }: 
  *  what an imported definition referencing an app this guild does not have
  *  looks like. */
 export const resolveAppBinding = (
-  catalog: AppWidgetCatalog | undefined,
+  catalog: AppWidgetCatalogResponse | undefined,
   appUid: string | null | undefined,
   endpointId: string | null | undefined
-): { entry: AppWidgetCatalogEntry; source: AppEndpoint } | undefined => {
+): { entry: AppWidgetCatalogEntry; source: AppEndpointRead } | undefined => {
   if (!appUid || !endpointId) return undefined;
-  const entry = catalog?.items.find((item) => item.app_uid === appUid);
-  const source = entry?.endpoints.find((candidate) => candidate.id === endpointId);
+  const entry = (catalog?.items ?? []).find((item) => item.app_uid === appUid);
+  const source = (entry?.endpoints ?? []).find((candidate) => candidate.id === endpointId);
   return entry && source ? { entry, source } : undefined;
 };
 
@@ -120,11 +84,11 @@ export const resolveAppBinding = (
  *  the install carries. `undefined` means this build has nothing to run — the
  *  app was uninstalled, or its version stopped shipping that widget. */
 export const appWidgetSource = (
-  catalog: AppWidgetCatalog | undefined,
+  catalog: AppWidgetCatalogResponse | undefined,
   widgetType: string
 ): string | undefined => {
   for (const entry of catalog?.items ?? []) {
-    const widget = entry.widgets.find((candidate) => candidate.type === widgetType);
+    const widget = (entry.widgets ?? []).find((candidate) => candidate.type === widgetType);
     if (widget) return widget.module_source;
   }
   return undefined;
@@ -134,12 +98,12 @@ export const appWidgetSource = (
  *  hands to the sandbox. Previews never call the network, so this is the only
  *  thing a marketplace listing's widget is ever drawn with. */
 export const appWidgetSample = (
-  catalog: AppWidgetCatalog | undefined,
+  catalog: AppWidgetCatalogResponse | undefined,
   widgetType: string,
   endpointId: string | null | undefined
 ): unknown[] => {
   for (const entry of catalog?.items ?? []) {
-    const widget = entry.widgets.find((candidate) => candidate.type === widgetType);
+    const widget = (entry.widgets ?? []).find((candidate) => candidate.type === widgetType);
     if (!widget) continue;
     const rows = endpointId ? widget.sample_data?.[endpointId] : undefined;
     return Array.isArray(rows) ? rows : [];

--- a/frontend/src/api/appData.ts
+++ b/frontend/src/api/appData.ts
@@ -28,7 +28,7 @@ export interface AppDataParam {
   options?: string[];
 }
 
-export interface AppDataSource {
+export interface AppEndpoint {
   id: string;
   /** `member` or `guild_admin`. Shown by the picker; enforced again on every
    *  fetch under the caller's own session, so this is not what protects it. */
@@ -36,7 +36,7 @@ export interface AppDataSource {
   /** What the app asks for. The proxy applies the deployment's own ceiling on
    *  top, so this is a request rather than a guarantee. */
   cache_ttl_seconds: number;
-  params_schema: AppDataParam[];
+  params: AppDataParam[];
 }
 
 export interface AppWidget {
@@ -47,8 +47,8 @@ export interface AppWidget {
   meta: Record<string, unknown>;
   /** The module the sandbox runs. Text everywhere outside that sandbox. */
   module_source: string;
-  sources: string[];
-  /** Rows for a preview that issues no request at all, keyed by source id. */
+  endpoints: string[];
+  /** Rows for a preview that issues no request at all, keyed by endpoint id. */
   sample_data: Record<string, unknown>;
 }
 
@@ -58,7 +58,8 @@ export interface AppWidgetCatalogEntry {
   name: string;
   enabled: boolean;
   widgets: AppWidget[];
-  data_sources: AppDataSource[];
+  /** Read endpoints only — a write does not fill a tile. */
+  endpoints: AppEndpoint[];
 }
 
 export interface AppWidgetCatalog {
@@ -81,37 +82,37 @@ export const getAppWidgetCatalog = (guildId: number) =>
 export interface AppDataRequest {
   guildId: number;
   appId: number;
-  sourceId: string;
+  endpointId: string;
   /** The dashboard the widget sits on. Required: it is the surface whose gates
    *  decide this read. */
   dashboardId: number;
   params?: Record<string, unknown>;
 }
 
-export const getAppData = ({ guildId, appId, sourceId, dashboardId, params }: AppDataRequest) =>
+export const getAppData = ({ guildId, appId, endpointId, dashboardId, params }: AppDataRequest) =>
   apiClient
-    .get<AppDataResponse>(`/g/${guildId}/apps/${appId}/data/${encodeURIComponent(sourceId)}`, {
+    .get<AppDataResponse>(`/g/${guildId}/apps/${appId}/data/${encodeURIComponent(endpointId)}`, {
       params: {
         dashboard_id: dashboardId,
         // Sent as one encoded object so the server validates it against the
-        // source's own `params_schema` rather than reading loose query keys.
+        // endpoint's own `params` rather than reading loose query keys.
         ...(params && Object.keys(params).length ? { params: JSON.stringify(params) } : {}),
       },
     })
     .then((r) => r.data);
 
-/** Find the install backing a binding's `app_uid`, and the widget/source it
+/** Find the install backing a binding's `app_uid`, and the widget/endpoint it
  *  names. Returns `undefined` for an app that is not installed here, which is
  *  what an imported definition referencing an app this guild does not have
  *  looks like. */
 export const resolveAppBinding = (
   catalog: AppWidgetCatalog | undefined,
   appUid: string | null | undefined,
-  sourceId: string | null | undefined
-): { entry: AppWidgetCatalogEntry; source: AppDataSource } | undefined => {
-  if (!appUid || !sourceId) return undefined;
+  endpointId: string | null | undefined
+): { entry: AppWidgetCatalogEntry; source: AppEndpoint } | undefined => {
+  if (!appUid || !endpointId) return undefined;
   const entry = catalog?.items.find((item) => item.app_uid === appUid);
-  const source = entry?.data_sources.find((candidate) => candidate.id === sourceId);
+  const source = entry?.endpoints.find((candidate) => candidate.id === endpointId);
   return entry && source ? { entry, source } : undefined;
 };
 
@@ -135,12 +136,12 @@ export const appWidgetSource = (
 export const appWidgetSample = (
   catalog: AppWidgetCatalog | undefined,
   widgetType: string,
-  sourceId: string | null | undefined
+  endpointId: string | null | undefined
 ): unknown[] => {
   for (const entry of catalog?.items ?? []) {
     const widget = entry.widgets.find((candidate) => candidate.type === widgetType);
     if (!widget) continue;
-    const rows = sourceId ? widget.sample_data?.[sourceId] : undefined;
+    const rows = endpointId ? widget.sample_data?.[endpointId] : undefined;
     return Array.isArray(rows) ? rows : [];
   }
   return [];

--- a/frontend/src/api/generated/apps/apps.ts
+++ b/frontend/src/api/generated/apps/apps.ts
@@ -35,7 +35,7 @@ import type {
   GuildAppRead,
   GuildAppUpdate,
   HTTPValidationError,
-  ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams,
+  ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -63,8 +63,8 @@ const withQueryKey = <T extends object, K>(query: T, queryKey: K): T & { queryKe
  *
  * Every member may read it: an app's existence is guild-wide knowledge and the
  * palette carries no guild data — declarations, module source, and sample
- * rows, all from the pinned definition. A source declared for guild admins is
- * still listed, and still refused at fetch time to anyone else.
+ * rows, all from the pinned definition. An endpoint declared for guild admins
+ * is still listed, and still refused at fetch time to anyone else.
  *
  * Disabled installs are left out entirely: their widgets have nothing to draw,
  * so offering them would be offering a binding that cannot resolve.
@@ -233,7 +233,7 @@ export function useReadAppWidgetCatalogApiV1GGuildIdAppsWidgetCatalogGet<
 }
 
 /**
- * One app data source, resolved for this viewer.
+ * One of an app's read endpoints, resolved for this viewer.
  *
  * Returns the app's rows verbatim with the time they were obtained. An app
  * that is unreachable, slow, oversized, or answering in a shape this build
@@ -241,44 +241,49 @@ export function useReadAppWidgetCatalogApiV1GGuildIdAppsWidgetCatalogGet<
  * error tile instead of the request becoming a server fault.
  * @summary Read App Data
  */
-export const readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet = (
+export const readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet = (
   guildId: number,
   appId: number,
-  sourceId: string,
-  params: ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams,
+  endpointId: string,
+  params: ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
   return apiMutator<AppDataResponse>(
-    { url: `/api/v1/g/${guildId}/apps/${appId}/data/${sourceId}`, method: "GET", params, signal },
+    {
+      url: `/api/v1/g/${guildId}/apps/${appId}/endpoints/${endpointId}`,
+      method: "GET",
+      params,
+      signal,
+    },
     options
   );
 };
 
-export const getReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryKey = (
+export const getReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetQueryKey = (
   guildId: number,
   appId: number,
-  sourceId: string,
-  params?: ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams
+  endpointId: string,
+  params?: ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams
 ) => {
   return [
-    `/api/v1/g/${guildId}/apps/${appId}/data/${sourceId}`,
+    `/api/v1/g/${guildId}/apps/${appId}/endpoints/${endpointId}`,
     ...(params ? [params] : []),
   ] as const;
 };
 
-export const getReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryOptions = <
-  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+export const getReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
   guildId: number,
   appId: number,
-  sourceId: string,
-  params: ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams,
+  endpointId: string,
+  params: ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
         TError,
         TData
       >
@@ -290,15 +295,20 @@ export const getReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryOptions = <
 
   const queryKey =
     queryOptions?.queryKey ??
-    getReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryKey(guildId, appId, sourceId, params);
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>
-  > = ({ signal }) =>
-    readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet(
+    getReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetQueryKey(
       guildId,
       appId,
-      sourceId,
+      endpointId,
+      params
+    );
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>
+  > = ({ signal }) =>
+    readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet(
+      guildId,
+      appId,
+      endpointId,
       params,
       requestOptions,
       signal
@@ -312,43 +322,43 @@ export const getReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryOptions = <
       guildId !== undefined &&
       appId !== null &&
       appId !== undefined &&
-      sourceId !== null &&
-      sourceId !== undefined,
+      endpointId !== null &&
+      endpointId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
-    Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+    Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData, TError> };
 };
 
-export type ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryResult = NonNullable<
-  Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>
+export type ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>
 >;
-export type ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryError =
+export type ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetQueryError =
   ErrorType<HTTPValidationError>;
 
-export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
-  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+export function useReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet<
+  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
   guildId: number,
   appId: number,
-  sourceId: string,
-  params: ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams,
+  endpointId: string,
+  params: ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams,
   options: {
     query: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
         TError,
         TData
       >
     > &
       Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
           TError,
-          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>
+          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>
         >,
         "initialData"
       >;
@@ -356,27 +366,27 @@ export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
   },
   queryClient?: QueryClient
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
-  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+export function useReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet<
+  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
   guildId: number,
   appId: number,
-  sourceId: string,
-  params: ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams,
+  endpointId: string,
+  params: ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
         TError,
         TData
       >
     > &
       Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
           TError,
-          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>
+          Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>
         >,
         "initialData"
       >;
@@ -384,18 +394,18 @@ export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
-  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+export function useReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet<
+  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
   guildId: number,
   appId: number,
-  sourceId: string,
-  params: ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams,
+  endpointId: string,
+  params: ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
         TError,
         TData
       >
@@ -408,18 +418,18 @@ export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
  * @summary Read App Data
  */
 
-export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
-  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+export function useReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet<
+  TData = Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
   guildId: number,
   appId: number,
-  sourceId: string,
-  params: ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams,
+  endpointId: string,
+  params: ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet>>,
+        Awaited<ReturnType<typeof readAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGet>>,
         TError,
         TData
       >
@@ -428,10 +438,10 @@ export function useReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetQueryOptions(
+  const queryOptions = getReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetQueryOptions(
     guildId,
     appId,
-    sourceId,
+    endpointId,
     params,
     options
   );

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -374,7 +374,7 @@ export interface AppConfig {
 export type AppDataParamLabel = { [key: string]: string };
 
 /**
- * One parameter a source accepts, from its ``params_schema``.
+ * One parameter an endpoint accepts, from its ``params``.
  */
 export interface AppDataParam {
   key: string;
@@ -394,13 +394,16 @@ export interface AppDataResponse {
 }
 
 /**
- * A source a widget may bind to.
+ * A read endpoint a widget may bind to.
+ *
+ * Reads only. A write and an emission are both real endpoints and neither
+ * fills a tile, so neither belongs in a widget picker.
  */
-export interface AppDataSourceRead {
+export interface AppEndpointRead {
   id: string;
   visibility?: string;
   cache_ttl_seconds?: number;
-  params_schema?: AppDataParam[];
+  params?: AppDataParam[];
 }
 
 export type AppServiceRegistrationCreateDelegationJwks = { [key: string]: unknown } | null;
@@ -498,7 +501,7 @@ export interface AppWidgetRead {
   id: string;
   meta?: AppWidgetReadMeta;
   module_source: string;
-  sources?: string[];
+  endpoints?: string[];
   sample_data?: AppWidgetReadSampleData;
 }
 
@@ -512,7 +515,7 @@ export interface AppWidgetCatalogEntry {
   name: string;
   enabled?: boolean;
   widgets?: AppWidgetRead[];
-  data_sources?: AppDataSourceRead[];
+  endpoints?: AppEndpointRead[];
 }
 
 export interface AppWidgetCatalogResponse {
@@ -5443,7 +5446,7 @@ export type ReadDashboardApiV1GGuildIdDashboardsDashboardIdGetParams = {
   include_deleted?: boolean;
 };
 
-export type ReadAppDataApiV1GGuildIdAppsAppIdDataSourceIdGetParams = {
+export type ReadAppDataApiV1GGuildIdAppsAppIdEndpointsEndpointIdGetParams = {
   /**
    * The dashboard the widget sits on. Its own gates decide whether this caller may see anything here at all.
    */

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.app.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.app.test.tsx
@@ -79,7 +79,7 @@ const CATALOG = {
 };
 
 const catalogUrl = (url: string) => url.endsWith("/apps/widget-catalog");
-const dataUrl = (url: string) => url.includes("/data/");
+const dataUrl = (url: string) => url.includes("/endpoints/");
 
 beforeEach(() => {
   apiGet.mockReset();
@@ -143,7 +143,7 @@ describe("DashboardWidget with an app source", () => {
       string,
       { params: Record<string, unknown> },
     ];
-    expect(url).toBe("/g/2/apps/3/data/app.acme.shop.orders-summary");
+    expect(url).toBe("/g/2/apps/3/endpoints/app.acme.shop.orders-summary");
     expect(config.params.dashboard_id).toBe(11);
   });
 

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.app.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.app.test.tsx
@@ -46,7 +46,7 @@ const widget = { id: "w1", type: WIDGET_TYPE, grid: { x: 0, y: 0, w: 6, h: 4 } }
 const binding: WidgetBinding = {
   source: "app",
   app_uid: APP_UID,
-  source_id: "orders_summary",
+  endpoint_id: "app.acme.shop.orders-summary",
 };
 
 const CATALOG = {
@@ -62,16 +62,16 @@ const CATALOG = {
           id: "summary",
           meta: { name: { en: "Summary" } },
           module_source: MODULE,
-          sources: ["orders_summary"],
-          sample_data: { orders_summary: [{ day: "mon", total: 4 }] },
+          endpoints: ["app.acme.shop.orders-summary"],
+          sample_data: { "app.acme.shop.orders-summary": [{ day: "mon", total: 4 }] },
         },
       ],
-      data_sources: [
+      endpoints: [
         {
-          id: "orders_summary",
+          id: "app.acme.shop.orders-summary",
           visibility: "member",
           cache_ttl_seconds: 60,
-          params_schema: [],
+          params: [],
         },
       ],
     },
@@ -143,7 +143,7 @@ describe("DashboardWidget with an app source", () => {
       string,
       { params: Record<string, unknown> },
     ];
-    expect(url).toBe("/g/2/apps/3/data/orders_summary");
+    expect(url).toBe("/g/2/apps/3/data/app.acme.shop.orders-summary");
     expect(config.params.dashboard_id).toBe(11);
   });
 

--- a/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/DashboardWidget.tsx
@@ -102,7 +102,7 @@ export function DashboardWidget({
   const labels = useBindingLabels(binding, initiativeId, !sampleData);
   const [view, setView] = useState<"scene" | "table">("scene");
 
-  const appSampleRows = appWidgetSample(appCatalogQuery.data, widget.type, binding.source_id);
+  const appSampleRows = appWidgetSample(appCatalogQuery.data, widget.type, binding.endpoint_id);
   const data = sampleData
     ? isAppWidget
       ? { source: "app" as const, rows: appSampleRows }

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -40,7 +40,7 @@ export const appWidgetCatalogKey = (guildId: number) => ["app-widget-catalog", g
 export const appDataKey = (
   guildId: number,
   appId: number,
-  sourceId: string,
+  endpointId: string,
   dashboardId: number,
   params: Record<string, unknown> | undefined
 ) =>
@@ -48,7 +48,7 @@ export const appDataKey = (
     "app-data",
     guildId,
     appId,
-    sourceId,
+    endpointId,
     dashboardId,
     // Canonical, so two widgets that bound the same parameters in a different
     // order still share one request. Parameter values are scalars, so a sorted
@@ -72,7 +72,7 @@ export const useAppWidgetCatalog = (enabled = true) => {
 
 export interface AppDataQuery {
   appId: number | undefined;
-  sourceId: string | undefined;
+  endpointId: string | undefined;
   dashboardId: number | undefined;
   params?: Record<string, unknown>;
   /** The source's declared freshness, in seconds. Capped before use. */
@@ -83,7 +83,7 @@ export interface AppDataQuery {
 /** One app data source, for this viewer, on this dashboard. */
 export const useAppData = ({
   appId,
-  sourceId,
+  endpointId,
   dashboardId,
   params,
   cacheTtlSeconds,
@@ -99,18 +99,18 @@ export const useAppData = ({
     guildId > 0 &&
     typeof appId === "number" &&
     typeof dashboardId === "number" &&
-    typeof sourceId === "string" &&
-    sourceId.length > 0;
+    typeof endpointId === "string" &&
+    endpointId.length > 0;
 
   const staleSeconds = Math.max(0, Math.min(cacheTtlSeconds ?? 0, MAX_APP_STALE_SECONDS));
 
   return useQuery<AppDataResponse>({
-    queryKey: appDataKey(guildId, appId ?? 0, sourceId ?? "", dashboardId ?? 0, params),
+    queryKey: appDataKey(guildId, appId ?? 0, endpointId ?? "", dashboardId ?? 0, params),
     queryFn: () =>
       getAppData({
         guildId,
         appId: appId as number,
-        sourceId: sourceId as string,
+        endpointId: endpointId as string,
         dashboardId: dashboardId as number,
         params,
       }),

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -24,7 +24,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   type AppDataResponse,
-  type AppWidgetCatalog,
+  type AppWidgetCatalogResponse,
   getAppData,
   getAppWidgetCatalog,
 } from "@/api/appData";
@@ -60,7 +60,7 @@ export const appDataKey = (
  *  a disabled app's widgets have nothing to draw. */
 export const useAppWidgetCatalog = (enabled = true) => {
   const guildId = useActiveGuildId();
-  return useQuery<AppWidgetCatalog>({
+  return useQuery<AppWidgetCatalogResponse>({
     queryKey: appWidgetCatalogKey(guildId),
     queryFn: () => getAppWidgetCatalog(guildId),
     enabled: enabled && Number.isFinite(guildId) && guildId > 0,

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -72,7 +72,7 @@ export interface WidgetBinding {
    *  address. Where the app lives comes from the deployment's registration, and
    *  only the server ever reads it. */
   app_uid?: string | null;
-  source_id?: string | null;
+  endpoint_id?: string | null;
   params?: Record<string, unknown> | null;
 }
 
@@ -216,10 +216,10 @@ export function useWidgetData(
   // us what freshness the source asks for.
   const isApp = source === "app";
   const appCatalogQuery = useAppWidgetCatalog(scoped && isApp);
-  const appBinding = resolveAppBinding(appCatalogQuery.data, binding.app_uid, binding.source_id);
+  const appBinding = resolveAppBinding(appCatalogQuery.data, binding.app_uid, binding.endpoint_id);
   const appQuery = useAppData({
     appId: appBinding?.entry.app_id,
-    sourceId: binding.source_id ?? undefined,
+    endpointId: binding.endpoint_id ?? undefined,
     dashboardId,
     params: binding.params ?? undefined,
     cacheTtlSeconds: appBinding?.source.cache_ttl_seconds,
@@ -418,7 +418,7 @@ export function useWidgetData(
       case "app": {
         // A definition that never had the app filled in, or a canvas with no
         // dashboard behind it (a preview). Neither is an error.
-        if (!binding.app_uid || !binding.source_id || typeof dashboardId !== "number") {
+        if (!binding.app_uid || !binding.endpoint_id || typeof dashboardId !== "number") {
           return unbound();
         }
         if (appCatalogQuery.isLoading) {
@@ -519,7 +519,7 @@ export function useWidgetData(
     scoped,
     dashboardId,
     binding.app_uid,
-    binding.source_id,
+    binding.endpoint_id,
     appBinding,
     appCatalogQuery.data,
     appCatalogQuery.isLoading,

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -448,7 +448,7 @@ export function useWidgetData(
         // switched off. Said plainly rather than rendered as an access outcome
         // — the definition is the guild's and stays stored, and the tile
         // becomes the surface that asks for the app to be reconnected.
-        const appInstalled = appCatalogQuery.data?.items.some(
+        const appInstalled = (appCatalogQuery.data?.items ?? []).some(
           (item) => item.app_uid === binding.app_uid
         );
         if (!appInstalled) {

--- a/frontend/src/lib/widgets/sources.test.ts
+++ b/frontend/src/lib/widgets/sources.test.ts
@@ -67,7 +67,7 @@ describe("unboundSlots", () => {
   });
 
   it("names an app binding's two slots", () => {
-    expect(unboundSlots(binding({ source: "app" }))).toEqual(["app_uid", "source_id"]);
+    expect(unboundSlots(binding({ source: "app" }))).toEqual(["app_uid", "endpoint_id"]);
   });
 });
 

--- a/frontend/src/lib/widgets/sources.ts
+++ b/frontend/src/lib/widgets/sources.ts
@@ -160,7 +160,7 @@ export const SOURCES: Record<WidgetSource, SourceDescriptor> = {
     // fills: which installed app, and which of its sources.
     params: [
       { kind: "text", key: "app_uid", required: true },
-      { kind: "text", key: "source_id", required: true },
+      { kind: "text", key: "endpoint_id", required: true },
     ],
   },
 };


### PR DESCRIPTION
Ready. Backend and frontend are green; the reference app round-trips against the schema this generates.

## What changed

An app used to declare three things three ways:

| | Declared as | Called at | Reachable by |
|---|---|---|---|
| reads | `data_sources`, with a path the app chose | `GET <path>` | this platform only |
| writes | **nothing** | `/v1/operations` | a delegate only |
| emissions | `events`, bare strings | — | a delegate only |

A widget could not act and an automation could not read, and neither limit came from anything but the route each had been given.

Now there is one block:

```json
"endpoints": [
  { "id": "app.morelitea.github.open-issues", "direction": "read",
    "actors": ["member"], "cache_ttl_seconds": 60,
    "requires": { "all_of": ["workspace", "account"] } },
  { "id": "app.morelitea.github.open-issue", "direction": "write",
    "actors": ["member"], "params": [ ... ] },
  { "id": "app.morelitea.github.issue-opened", "direction": "emit" }
]
```

- **One namespace.** Every id is `app.<public_id>.<name>`, so a caller resolves an id without being told which kind of thing it is first.
- **One address.** Reads and writes are POSTed to the app's `/v1/endpoints` with the id in the body. A manifest names *what* to call; only a registration says *where*.
- **Direction is load-bearing.** An `emit` carries no params, no `requires` and nothing to cache — nobody calls it — and that is refused rather than ignored. `cache_ttl_seconds` and `visibility` belong to a `read` alone.
- **A tile cannot reach a write.** Widget bindings, bundled-dashboard bindings and the widget catalog all take read endpoints only, so rendering a dashboard is not a way to make an app act.

## Context tokens

`data` and `action` collapse into one `endpoint` scope, narrowed by a new `endpoint_id` claim. A token minted to read the issue count cannot be spent closing an issue, and the endpoint's own `direction` tells the app which it was without being asked.

## `automations` is gone from the vocabulary

A node executes inside a deployment, so it was never a surface an app supplies — the kit described none of its vocabulary even while the name was here.

## Verification

| | |
|---|---|
| marketplace + app-service + app-data + dashboard + channels | **667 passed** |
| rest of the backend | **559 passed** |
| frontend | **1732 passed** (138 files) |

One error in the long backend run — `users_test.py::test_update_user_as_member_forbidden` — passes on its own and touches nothing here; it looks like a pre-existing isolation flake after ~560 tenant tests.

The tests assert the same behaviours in the new vocabulary, plus four the split could not express: an emission carries nothing a caller would send, only a read is cached or gated, a widget cannot bind a write, and a token minted for one endpoint cannot be spent on another.

## Downstream

`initiative-github` and `initiative-app-kit` are already on this contract and merged to their mains. **Their CI is red until this lands** — both vendor `backend/schemas/app-manifest.json` from this repo at a pinned ref, so `npm ci` currently fetches the old vocabulary and their manifest fails validation. Locally, against the schema this PR generates, they pass 186 and 179.

- Morelitea/initiative_auto#123 — auto's side, draft, waiting on this
- Morelitea/initiative_infra#12 — a note against the chart's catalog files

## Review round

Greptile found three, all real:

**Emitted events were rejected.** `emit_event` still read the `events` block, which no longer exists, so every event an app announced came back as unknown. It reads the endpoint list now and takes `emit` alone — being *declared* is not enough, because reads and writes share the id space and an app announcing under a read's id would be emitting something no subscriber could have asked for. There is a case for that now. The existing tests passed only because their fixtures still fed the old block.

**The generated API types disagreed with the server**, and the reason they could is the more interesting half: nothing outside `src/api/generated/` imported a single app-data symbol, because `appData.ts` hand-declared its own copy of the same six models. Two declarations of one contract, and the unused one drifted silently. Regenerated, and the copy is gone — `appData.ts` re-exports the generated shapes and keeps only the calls and helpers that carry a rule. 80 lines lighter. The generated types are honest about optionality, so the call sites now default instead of assuming a block an app declared nothing for is present.

**The route was half-renamed.** `/apps/{id}/data/{endpoint_id}` kept a segment the vocabulary had left behind. It is `/apps/{id}/endpoints/{endpoint_id}` now, with `APP_DATA_SOURCE_NOT_FOUND` → `APP_DATA_ENDPOINT_NOT_FOUND` and its four locale keys.

On the fourth — **pinned definitions**: yes, an install pinned to a definition carrying `data_sources` stops resolving its widget reads. That is the intended break rather than an oversight; nothing is live, and `app_updates.py` already re-pins `app.definition` on upgrade, so publishing the new app version and letting guilds upgrade is the remedy. No compatibility shim, deliberately.

## One thing worth a decision

**The `rows` contract.** `_read_rows` requires `{"rows": [...]}` and now reads it out of the invoke envelope's `result`. The reference app's reads return shapes like `{"total": 42, "delta": -3}`, which its widgets draw directly — so that divergence predates this change and is still there. Worth settling which side moves.