### PR TITLE
Stop a connect-URL test pinning a query it is not about

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
@@ -26,6 +26,8 @@ let go at the vendor. The teardown tests assert on the rows *and* on the
 recorded revocations, because deleting our copy is only half of it.
 """
 
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 from httpx import AsyncClient
 from sqlmodel import select
@@ -375,11 +377,19 @@ class TestConnect:
         # path, the handle the app will store its result against, and the guild
         # to write it back under — the app addresses every install by guild and
         # cannot derive one from the ref.
-        assert body["connect_url"] == (
+        #
+        # Asserted as those four things rather than as one pasted string. The
+        # connect URL also carries a signed return address, which has its own
+        # tests (``guild_apps_platform_test``) and is not what this one is
+        # about: pinning the whole query here made a test about WHO MAY CONNECT
+        # fail the day the URL grew a parameter.
+        connect = urlparse(body["connect_url"])
+        assert f"{connect.scheme}://{connect.netloc}{connect.path}" == (
             "https://shop.example.test/connect/github"
-            f"?connection_ref={body['connection_ref']}"
-            f"&guild_id={a.guild.id}"
         )
+        query = parse_qs(connect.query)
+        assert query["connection_ref"] == [body["connection_ref"]]
+        assert query["guild_id"] == [str(a.guild.id)]
 
     async def test_the_handle_is_opaque_and_carries_nothing_about_the_person(
         self, client: AsyncClient, acting_user, session: AsyncSession


### PR DESCRIPTION
`test_any_member_may_connect_their_own_account` asserted the whole connect URL as one pasted string. It is a test about WHO MAY CONNECT, so the day that URL grew a signed return address it failed for a reason unrelated to its subject — and it is the only thing red on dev.

Asserted now as the four things it actually means: the operator's address, the manifest's path, the handle the app stores its result against, and the guild to write it back under. The return address has its own tests in `guild_apps_platform_test` — presence, the URL, a signature that verifies, and absence when there is nothing to sign with — so repeating it here bought nothing and cost this.