### PR TITLE
Let an endpoint describe itself and its answer

### DIFF
--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -888,3 +888,169 @@ class TestCanonicalShape:
                     for index in range(service_apps.MAX_EMBEDS + 1)
                 ],
             )
+
+
+class TestWhatAnEndpointSaysItIs:
+    """The half a consumer reads before it ever makes a call.
+
+    A widget binds a column and an automation offers a value for a later step,
+    and both have to be arrangeable — and refusable — before the endpoint has
+    run once. None of it means anything to THIS build, which is the point:
+    these are bounded and stored, never interpreted.
+    """
+
+    def test_a_label_and_description_are_kept(self):
+        cleaned = _with_source(
+            label=_label("Open issues"), description=_label("Everything still open")
+        )
+        endpoint = cleaned["endpoints"][0]
+        assert endpoint["label"] == _label("Open issues")
+        assert endpoint["description"] == _label("Everything still open")
+
+    def test_an_emission_may_be_labelled_too(self):
+        """The one endpoint chosen from a list without ever being called, so it
+        needs a name more than the others do — and the branch that strips
+        everything else from an emission must let it through."""
+        cleaned = _normalize(
+            features=["endpoints"],
+            endpoints=[
+                {
+                    "id": "app.tests.widget-co.order-created",
+                    "direction": "emit",
+                    "label": _label("An order is placed"),
+                    "returns": [{"key": "order_id", "type": "int"}],
+                    "group": "orders",
+                }
+            ],
+        )
+        endpoint = cleaned["endpoints"][0]
+        assert endpoint["label"] == _label("An order is placed")
+        assert endpoint["returns"] == [{"key": "order_id", "type": "int"}]
+        assert endpoint["group"] == "orders"
+
+    def test_an_emission_still_has_no_caller_side(self):
+        with pytest.raises(ListingDefinitionError, match="no params"):
+            _normalize(
+                features=["endpoints"],
+                endpoints=[
+                    {
+                        "id": "app.tests.widget-co.order-created",
+                        "direction": "emit",
+                        "label": _label("An order is placed"),
+                        "params": [{"key": "x", "type": "string", "label": _label()}],
+                    }
+                ],
+            )
+
+    def test_saying_nothing_stores_nothing(self):
+        """An absent label is absent, not an empty one — the same rule every
+        other optional block here follows."""
+        endpoint = _with_source()["endpoints"][0]
+        for key in ("label", "description", "returns", "group", "needs_subject"):
+            assert key not in endpoint
+
+
+class TestReturns:
+    def test_a_return_carries_a_key_a_type_and_optionally_a_label(self):
+        cleaned = _with_source(
+            returns=[
+                {"key": "count", "type": "int", "label": _label("How many")},
+                {"key": "url", "type": "url"},
+            ]
+        )
+        assert cleaned["endpoints"][0]["returns"] == [
+            {"key": "count", "type": "int", "label": _label("How many")},
+            {"key": "url", "type": "url"},
+        ]
+
+    def test_several_values_are_flagged_rather_than_typed_apart(self):
+        cleaned = _with_source(
+            returns=[{"key": "labels", "type": "string", "list": True}]
+        )
+        assert cleaned["endpoints"][0]["returns"][0]["list"] is True
+
+    def test_select_is_not_a_return_type(self):
+        """A select is a CONTROL, and the value behind one is a string."""
+        with pytest.raises(ListingDefinitionError, match="unknown type"):
+            _with_source(returns=[{"key": "k", "type": "select"}])
+
+    def test_a_credential_is_not_a_return_type_either(self):
+        with pytest.raises(ListingDefinitionError, match="unknown type"):
+            _with_source(returns=[{"key": "k", "type": "secret"}])
+
+    def test_two_returns_may_not_share_a_key(self):
+        with pytest.raises(ListingDefinitionError, match="share the key"):
+            _with_source(
+                returns=[{"key": "k", "type": "int"}, {"key": "k", "type": "string"}]
+            )
+
+    def test_a_return_needs_a_readable_key(self):
+        with pytest.raises(ListingDefinitionError):
+            _with_source(returns=[{"key": "Not An Id", "type": "int"}])
+
+
+class TestParamPickers:
+    def test_a_param_may_ask_for_a_richer_control(self):
+        cleaned = _with_source(
+            params=[
+                {
+                    "key": "project",
+                    "type": "int",
+                    "label": _label(),
+                    "picker": "project",
+                }
+            ]
+        )
+        assert cleaned["endpoints"][0]["params"][0]["picker"] == "project"
+
+    def test_the_hint_is_bounded_but_not_a_closed_list(self):
+        """The vocabulary belongs to whoever draws the control. A second reading
+        of it here could only ever drift from the one that matters."""
+        cleaned = _with_source(
+            params=[
+                {
+                    "key": "x",
+                    "type": "int",
+                    "label": _label(),
+                    "picker": "something-new",
+                }
+            ]
+        )
+        assert cleaned["endpoints"][0]["params"][0]["picker"] == "something-new"
+
+    def test_a_picker_that_is_not_an_identifier_is_refused(self):
+        with pytest.raises(ListingDefinitionError):
+            _with_source(
+                params=[
+                    {
+                        "key": "x",
+                        "type": "int",
+                        "label": _label(),
+                        "picker": "Not An Id",
+                    }
+                ]
+            )
+
+    def test_a_connection_field_has_no_picker(self):
+        """An admin filling in a settings form is typing a credential, and has
+        nothing to pick from — so the key is dropped rather than stored."""
+        cleaned = _normalize(
+            features=["endpoints"],
+            connections=[
+                {
+                    "id": "shop",
+                    "scope": "static",
+                    "label": _label(),
+                    "fields": [
+                        {
+                            "key": "token",
+                            "type": "secret",
+                            "label": _label(),
+                            "picker": "project",
+                        }
+                    ],
+                }
+            ],
+            endpoints=[{"id": READ_ID, "direction": "read"}],
+        )
+        assert "picker" not in cleaned["connections"][0]["fields"][0]

--- a/backend/app/services/marketplace/manifest_schema.py
+++ b/backend/app/services/marketplace/manifest_schema.py
@@ -92,11 +92,13 @@ from app.services.marketplace.service_apps import (
     MAX_FIELDS_PER_CONNECTION,
     MAX_PARAM_VALUE_LENGTH,
     MAX_PARAMS_PER_ENDPOINT,
+    MAX_RETURNS_PER_ENDPOINT,
     MAX_REQUIRES_TERMS,
     MAX_SELECT_OPTIONS,
     MAX_WIDGET_ENDPOINTS,
     MAX_WIDGETS,
     PARAM_TYPES,
+    RETURN_TYPES,
     SURFACE_SCOPES,
     VISIBILITIES,
 )
@@ -301,12 +303,101 @@ def _access_hint() -> dict[str, Any]:
     }
 
 
+def _endpoint_param() -> dict[str, Any]:
+    """One parameter a caller may send.
+
+    A connection's field with one thing added: a ``picker``, saying which richer
+    control a consumer should draw instead of the bare one the type implies.
+    Not on ``_field`` itself, which connections share — an admin filling in a
+    settings form is typing a credential and has nothing to pick from.
+    """
+    schema = _field(types=PARAM_TYPES, allow_managed=False)
+    schema["properties"]["picker"] = {
+        "$ref": "#/$defs/identifier",
+        "description": (
+            "A hint, not a promise: the value on the wire is the same either "
+            "way, so a consumer that does not know the name draws the plain "
+            "control rather than losing the parameter."
+        ),
+    }
+    return schema
+
+
+def _endpoint_return() -> dict[str, Any]:
+    """One value an endpoint hands back."""
+    return {
+        "type": "object",
+        "required": ["key", "type"],
+        "properties": {
+            "key": {"$ref": "#/$defs/identifier"},
+            "type": {
+                "enum": _enum(RETURN_TYPES),
+                "description": (
+                    "The parameter vocabulary minus 'select', because a select "
+                    "is a control and the value behind one is a string."
+                ),
+            },
+            "label": {"$ref": "#/$defs/localizedText"},
+            "list": {
+                "type": "boolean",
+                "description": (
+                    "Several values rather than one. It matters to a consumer "
+                    "with somewhere to put exactly one — a form field, a tile's "
+                    "number — which is why it is a flag rather than a second "
+                    "set of types."
+                ),
+            },
+        },
+    }
+
+
 def _endpoint() -> dict[str, Any]:
     return {
         "type": "object",
         "required": ["id", "direction"],
         "properties": {
             "id": {"$ref": "#/$defs/namespacedId"},
+            "label": {
+                "$ref": "#/$defs/localizedText",
+                "description": (
+                    "What this endpoint IS, in words somebody picks it out of a "
+                    "list by. Every direction, and an emission most of all: it "
+                    "is the one thing here chosen without ever being called."
+                ),
+            },
+            "description": {
+                "$ref": "#/$defs/localizedText",
+                "description": "A second line, where the label needs one.",
+            },
+            "returns": {
+                "type": "array",
+                "maxItems": MAX_RETURNS_PER_ENDPOINT,
+                "items": {"$ref": "#/$defs/endpointReturn"},
+                "description": (
+                    "What this hands back, by name and type — the response for a "
+                    "read or a write, the payload for an emission. Declared "
+                    "rather than discovered, because a consumer binds one of "
+                    "these before the endpoint has ever run and a bad binding "
+                    "has to be refusable when somebody arranges it."
+                ),
+            },
+            "group": {
+                "$ref": "#/$defs/identifier",
+                "description": (
+                    "Where a consumer that groups an app's endpoints should file "
+                    "this one. Opaque here: the grouping is the consumer's, and "
+                    "an endpoint that says nothing sits in the flat list."
+                ),
+            },
+            "needs_subject": {
+                "$ref": "#/$defs/identifier",
+                "description": (
+                    "What a caller must already have in hand for this to mean "
+                    "anything. Opaque here — the vocabulary belongs to whoever "
+                    "consumes it; the automation service names the subjects a "
+                    "run can be about."
+                ),
+            },
             "direction": {
                 "enum": _enum(DIRECTIONS),
                 "description": (
@@ -656,7 +747,8 @@ def build_manifest_schema() -> dict[str, Any]:
             "requires": _requires(),
             "accessHint": _access_hint(),
             "connectionField": _field(types=FIELD_TYPES, allow_managed=True),
-            "endpointParam": _field(types=PARAM_TYPES, allow_managed=False),
+            "endpointParam": _endpoint_param(),
+            "endpointReturn": _endpoint_return(),
             "connection": _connection(),
             "namespacedId": {
                 "type": "string",

--- a/backend/app/services/marketplace/manifest_schema_test.py
+++ b/backend/app/services/marketplace/manifest_schema_test.py
@@ -43,9 +43,11 @@ from app.services.marketplace.service_apps import (
     GUILD_WIDE_VISIBILITIES,
     MAX_CONNECTIONS,
     MAX_ENDPOINTS,
+    MAX_RETURNS_PER_ENDPOINT,
     MAX_EMBEDS,
     MAX_WIDGETS,
     PARAM_TYPES,
+    RETURN_TYPES,
     SURFACE_SCOPES,
     VISIBILITIES,
 )
@@ -139,6 +141,7 @@ def test_vocabularies_come_from_the_validator():
     assert set(defs["connection"]["properties"]["scope"]["enum"]) == CONNECTION_SCOPES
     assert set(defs["connectionField"]["properties"]["type"]["enum"]) == FIELD_TYPES
     assert set(defs["endpointParam"]["properties"]["type"]["enum"]) == PARAM_TYPES
+    assert set(defs["endpointReturn"]["properties"]["type"]["enum"]) == RETURN_TYPES
     assert set(defs["endpoint"]["properties"]["direction"]["enum"]) == DIRECTIONS
     assert set(defs["endpoint"]["properties"]["actors"]["items"]["enum"]) == ACTOR_KINDS
     assert set(defs["endpoint"]["properties"]["visibility"]["enum"]) == (
@@ -156,6 +159,12 @@ def test_caps_come_from_the_validator():
     props = build_manifest_schema()["properties"]
     assert props["connections"]["maxItems"] == MAX_CONNECTIONS
     assert props["endpoints"]["maxItems"] == MAX_ENDPOINTS
+    assert (
+        build_manifest_schema()["$defs"]["endpoint"]["properties"]["returns"][
+            "maxItems"
+        ]
+        == MAX_RETURNS_PER_ENDPOINT
+    )
     assert props["widgets"]["maxItems"] == MAX_WIDGETS
     assert props["embeds"]["maxItems"] == MAX_EMBEDS
 
@@ -575,3 +584,35 @@ def test_the_platform_enforces_what_the_schema_cannot(manifest, why, validator):
     assert list(validator.iter_errors(manifest)) == [], f"schema caught it: {why}"
     with pytest.raises(ValueError):
         platform_accepts(manifest)
+
+
+@pytest.mark.unit
+def test_a_return_is_not_a_control():
+    """A select is a control, and the value behind one is a string — so it is a
+    param type and never a return type. The schema must not blur the two."""
+    defs = build_manifest_schema()["$defs"]
+    assert "select" in defs["endpointParam"]["properties"]["type"]["enum"]
+    assert "select" not in defs["endpointReturn"]["properties"]["type"]["enum"]
+    assert "secret" not in defs["endpointReturn"]["properties"]["type"]["enum"]
+
+
+@pytest.mark.unit
+def test_every_direction_may_describe_itself_and_its_answer():
+    """``label`` and ``returns`` sit on the endpoint rather than beside the
+    caller-side keys, because an emission has neither caller nor response and
+    still needs both — it is the one endpoint chosen without being called."""
+    endpoint = build_manifest_schema()["$defs"]["endpoint"]["properties"]
+    for key in ("label", "description", "returns", "group", "needs_subject"):
+        assert key in endpoint, key
+    # None of them is required: an app that says nothing is still a valid app.
+    assert set(build_manifest_schema()["$defs"]["endpoint"]["required"]) == {
+        "id",
+        "direction",
+    }
+
+
+@pytest.mark.unit
+def test_a_param_may_ask_for_a_control_and_a_connection_field_may_not():
+    defs = build_manifest_schema()["$defs"]
+    assert "picker" in defs["endpointParam"]["properties"]
+    assert "picker" not in defs["connectionField"]["properties"]

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -209,6 +209,16 @@ WIDGET_BINDABLE_DIRECTIONS: frozenset[str] = frozenset({"read"})
 #: vocabulary it states its preference in, best first.
 ACTOR_KINDS: frozenset[str] = frozenset({"member", "installation"})
 
+#: What an endpoint may say it hands BACK — the param vocabulary minus
+#: ``select``, because a select is a *control* and the value behind one is a
+#: string. Nothing here is a credential for the same reason a param is not.
+#:
+#: A caller reads these to know what it can do with an answer before it has
+#: one: the automation service offers them as values a later step may bind, and
+#: it has to be able to refuse a bad binding when somebody SAVES rather than
+#: when the thing eventually runs.
+RETURN_TYPES: frozenset[str] = PARAM_TYPES - {"select"}
+
 # --- caps -------------------------------------------------------------------
 #
 # Counts first, then bodies. Together they bound what one published version can
@@ -227,6 +237,10 @@ MAX_WIDGET_ENDPOINTS = 8
 #: together rather than each separately.
 MAX_ENDPOINTS = 64
 MAX_PARAMS_PER_ENDPOINT = 12
+#: What one endpoint may name as coming back. Higher than the param cap on
+#: purpose: describing an answer is cheaper than asking for one, and an app
+#: that returns a dozen fields is ordinary where one taking a dozen is not.
+MAX_RETURNS_PER_ENDPOINT = 24
 MAX_EMBEDS = 12
 #: An app ships a handful of arrangements of its own widgets, not a library of
 #: them. Each becomes a catalog row, so this is also how many listings a single
@@ -526,9 +540,53 @@ def _endpoint(
         if param["key"] in seen:
             fail(f"{what}: two parameters share the key {param['key']!r}")
         seen.add(param["key"])
+        # Which richer control the consumer should draw instead of the bare one
+        # the type implies — "this int is a project". Read here rather than in
+        # ``_field``, which connections share: an admin filling in a settings
+        # form is typing a credential, and has nothing to pick from.
+        #
+        # A HINT, and stored as one: the value on the wire is the same either
+        # way, so a consumer that does not know the name falls back to the plain
+        # control rather than losing the parameter.
+        picker = entry.get("picker") if isinstance(entry, dict) else None
+        if picker is not None:
+            param["picker"] = check_identifier(
+                picker, what=f"{what} param {param['key']!r} picker"
+            )
         params.append(param)
 
     cleaned: dict[str, Any] = {"id": endpoint_id, "direction": direction}
+
+    # What this endpoint IS, in words, and what it hands back. Both belong to
+    # every direction: an emission is the one thing here a person picks out of a
+    # list without ever calling it, so it needs a name more than the others do,
+    # and its payload is exactly as worth describing as a response.
+    #
+    # Stored and never read here. A label is somebody else's to render and a
+    # return is somebody else's to bind, and this build assigns meaning to
+    # neither — it bounds them, which is the whole of what a store owes a
+    # document it passes on.
+    label = localized_text(endpoint.get("label"), MAX_TEXT_LENGTH)
+    if label is not None:
+        cleaned["label"] = label
+    description = localized_text(endpoint.get("description"), MAX_TEXT_LENGTH)
+    if description is not None:
+        cleaned["description"] = description
+    returns = _returns(endpoint.get("returns"), what=what)
+    if returns:
+        cleaned["returns"] = returns
+
+    # Where a consumer that groups an app's endpoints should file this one, and
+    # what it needs to already have in hand. Both are opaque identifiers: the
+    # vocabularies belong to whoever consumes them — the automation service
+    # names the subjects a run can be about — and a second reading of a list
+    # this build does not own would only ever drift from it.
+    group = endpoint.get("group")
+    if group is not None:
+        cleaned["group"] = check_identifier(group, what=f"{what} group")
+    needs = endpoint.get("needs_subject")
+    if needs is not None:
+        cleaned["needs_subject"] = check_identifier(needs, what=f"{what} needs_subject")
 
     # An emission travels the other way: nobody calls it, so there is nothing
     # for a caller to send, nothing to cache and nobody to gate. Carrying any of
@@ -575,6 +633,45 @@ def _endpoint(
     if requires is not None:
         cleaned["requires"] = requires
     return cleaned
+
+
+def _returns(raw: Any, *, what: str) -> list[dict[str, Any]]:
+    """What an endpoint hands back, by name and type.
+
+    Declared rather than discovered, because the consumer needs it before the
+    endpoint has ever run: a widget binds a column and an automation offers a
+    value for a later step to read, and both have to be refusable at the moment
+    somebody arranges them rather than the first time one fires.
+
+    ``list`` says several rather than one. It matters to a caller that has
+    somewhere to put exactly one value — a form field, a tile's number — which
+    is why it is a flag here rather than a second set of types.
+    """
+    if raw is None:
+        return []
+    declared = require_list(raw, f"{what} returns", MAX_RETURNS_PER_ENDPOINT)
+    returns: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in declared:
+        value = require_mapping(entry, f"{what} return")
+        key = check_identifier(value.get("key"), what=f"{what} return key")
+        if key in seen:
+            fail(f"{what}: two returns share the key {key!r}")
+        seen.add(key)
+        value_type = value.get("type")
+        if value_type not in RETURN_TYPES:
+            fail(f"{what} return {key!r}: unknown type {value_type!r}")
+        cleaned: dict[str, Any] = {"key": key, "type": value_type}
+        # Optional, unlike a param's: a param is a control somebody fills in and
+        # needs a word on it, while a return is read by name and is often shown
+        # under one the consumer supplies.
+        label = localized_text(value.get("label"), MAX_TEXT_LENGTH)
+        if label is not None:
+            cleaned["label"] = label
+        if value.get("list") is True:
+            cleaned["list"] = True
+        returns.append(cleaned)
+    return returns
 
 
 def _actors(raw: Any, *, what: str) -> list[str]:

--- a/backend/schemas/app-manifest.json
+++ b/backend/schemas/app-manifest.json
@@ -257,6 +257,10 @@
             "type": "string",
             "maxLength": 120
           }
+        },
+        "picker": {
+          "$ref": "#/$defs/identifier",
+          "description": "A hint, not a promise: the value on the wire is the same either way, so a consumer that does not know the name draws the plain control rather than losing the parameter."
         }
       },
       "if": {
@@ -273,6 +277,34 @@
         "required": [
           "options"
         ]
+      }
+    },
+    "endpointReturn": {
+      "type": "object",
+      "required": [
+        "key",
+        "type"
+      ],
+      "properties": {
+        "key": {
+          "$ref": "#/$defs/identifier"
+        },
+        "type": {
+          "enum": [
+            "bool",
+            "int",
+            "string",
+            "url"
+          ],
+          "description": "The parameter vocabulary minus 'select', because a select is a control and the value behind one is a string."
+        },
+        "label": {
+          "$ref": "#/$defs/localizedText"
+        },
+        "list": {
+          "type": "boolean",
+          "description": "Several values rather than one. It matters to a consumer with somewhere to put exactly one \u2014 a form field, a tile's number \u2014 which is why it is a flag rather than a second set of types."
+        }
       }
     },
     "connection": {
@@ -328,6 +360,30 @@
       "properties": {
         "id": {
           "$ref": "#/$defs/namespacedId"
+        },
+        "label": {
+          "$ref": "#/$defs/localizedText",
+          "description": "What this endpoint IS, in words somebody picks it out of a list by. Every direction, and an emission most of all: it is the one thing here chosen without ever being called."
+        },
+        "description": {
+          "$ref": "#/$defs/localizedText",
+          "description": "A second line, where the label needs one."
+        },
+        "returns": {
+          "type": "array",
+          "maxItems": 24,
+          "items": {
+            "$ref": "#/$defs/endpointReturn"
+          },
+          "description": "What this hands back, by name and type \u2014 the response for a read or a write, the payload for an emission. Declared rather than discovered, because a consumer binds one of these before the endpoint has ever run and a bad binding has to be refusable when somebody arranges it."
+        },
+        "group": {
+          "$ref": "#/$defs/identifier",
+          "description": "Where a consumer that groups an app's endpoints should file this one. Opaque here: the grouping is the consumer's, and an endpoint that says nothing sits in the flat list."
+        },
+        "needs_subject": {
+          "$ref": "#/$defs/identifier",
+          "description": "What a caller must already have in hand for this to mean anything. Opaque here \u2014 the vocabulary belongs to whoever consumes it; the automation service names the subjects a run can be about."
         },
         "direction": {
           "enum": [


### PR DESCRIPTION
## The problem

An endpoint says where it is called and who may call it, and nothing about what
it **is** or what comes back.

That was enough while every consumer knew each endpoint it would ever meet. It
is not enough for one deriving a control from an app it has never seen: the
automation service turns each endpoint into a step on a canvas, and it has to
name that step in a menu and offer its values to the step after it — before the
endpoint has ever run once. Today the best it can do is scrape a title off the
id (`app.acme.widgets.open-issue` → "Open issue", untranslatable) and offer
nothing downstream at all.

## What changes

Five additions to `_endpoint`, **all optional**, so every manifest that
validated before still does.

| Field | Shape | For |
|---|---|---|
| `label` / `description` | `localizedText` | what it is, in words |
| `returns` | `[{key, type, label?, list?}]` over `string \| int \| bool \| url` | what comes back |
| `group` | identifier | where a consumer files it |
| `needs_subject` | identifier | what a caller needs in hand |
| `picker` (on a param) | identifier | which richer control to draw |

## Three decisions worth review

**`label`, `description`, `returns` and `group` pass through the emit branch.**
That branch returns early and strips every caller-side key, which is right for
`params`, `requires`, `cache_ttl_seconds`, `visibility` and `actors` — nobody
calls an emission. But an emission is the one endpoint here **chosen without
ever being called**, so it needs a name more than the others do, and its payload
is exactly as worth describing as a response. A test covers that specifically.

**`group` and `needs_subject` are bounded and stored, never interpreted.** The
vocabularies belong to whoever consumes them — the automation service names the
subjects a run can be about (`tasks`, `any`, `nothing`) — so this build checks
they are identifiers and passes them on. A second reading of a list this
repository does not own could only ever drift from it. Same reasoning `picker`
follows, which is why an unrecognised picker is accepted rather than refused:
the value on the wire is identical either way, so a consumer that does not know
the name draws the plain control instead of losing the parameter.

**`picker` is read in the endpoint's own param loop, not in `_field`.**
Connections share `_field`, and an admin filling in a settings form is typing a
credential — there is nothing to pick from. A test asserts a connection field
carrying `picker` has it dropped.

**`select` is not a return type.** A select is a *control*, and the value behind
one is a string.

## Schema

`backend/schemas/app-manifest.json` is regenerated
(`python scripts/export_manifest_schema.py`). `endpointReturn` is new;
`endpointParam` gains `picker`; `endpoint` gains the other four. The conformance
tests read the enums and caps back out of the built schema, so the generated
file and the validator cannot disagree.

No migration, no env changes.

## Testing

```
uv run pytest app/services/marketplace/ app/api/v1/platform_endpoints/   # 981 passed
uv run ruff check app/services/marketplace && uv run ruff format --check app/services/marketplace
```

New coverage: a fully described endpoint round-tripping; an emission keeping its
label, returns and group while still refusing a caller side; `select` and
`secret` refused as return types; two returns sharing a key; a param asking for
a picker and a connection field not being allowed one; and every one of the five
being absent from the stored definition when the manifest says nothing.

## Downstream

- `initiative-app-kit` `main` already carries the mirrored types and two
  cross-checks JSON Schema cannot express. Its schema is fetched at `SCHEMA_REF`
  (`dev`), so **its CI validates against the old vocabulary until this merges**.
- `initiative_auto` then bumps its `SCHEMA_REF` and stops falling back — real
  labels, `returns` as bindable outputs, grouped drawers, real pickers.