### PR TITLE
Block invite minting at the guild user cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Due-date filters now apply everywhere the list does.** Filtering by overdue or due-soon was applied only to the visible list, so the board's per-column counts, the "archive done tasks" count, and CSV exports all quietly ignored it. The filter is now applied when the tasks are fetched, so everything agrees. "Overdue" now means due before today rather than before this exact moment.
 - Adjusted background colors to reduce banding in Chrome based browsers.
+- **A full guild no longer hands out invites.** When a guild has as many members as its user limit allows, the invite it would mint could only fail when someone tried to redeem it. Creating one is now refused, and both places an admin makes an invite — the guild's context menu and Settings → Users — say the guild is full instead of offering the action.
 
 ### Fixed
 

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -117,10 +117,12 @@ async def test_register_with_invite_blocked_when_guild_full(
 
     guild = await create_guild(session, name="Full Guild", max_users=1)
     seat = await create_user(session, email="reg-seat@example.com")
-    await guild_service.ensure_membership(session, guild_id=guild.id, user_id=seat.id)
+    # Minted while the seat is still free, redeemed after it is taken —
+    # minting itself is capacity-gated, so the order here is the scenario.
     invite = await guild_service.create_guild_invite(
         session, guild_id=guild.id, created_by=seat.id, max_uses=5
     )
+    await guild_service.ensure_membership(session, guild_id=guild.id, user_id=seat.id)
     await session.commit()
 
     response = await client.post(

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -663,14 +663,19 @@ async def create_guild_invite(
         user_id=current_user.id,
     )
     await _set_guild_admin_rls(session, guild_id=guild_id, user=current_user)
-    invite = await guilds_service.create_guild_invite(
-        session,
-        guild_id=guild_id,
-        created_by=current_user.id,
-        expires_at=invite_in.expires_at,
-        max_uses=invite_in.max_uses,
-        invitee_email=invite_in.invitee_email,
-    )
+    try:
+        invite = await guilds_service.create_guild_invite(
+            session,
+            guild_id=guild_id,
+            created_by=current_user.id,
+            expires_at=invite_in.expires_at,
+            max_uses=invite_in.max_uses,
+            invitee_email=invite_in.invitee_email,
+        )
+    except guilds_service.GuildCapacityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
     await session.commit()
     return GuildInviteRead.model_validate(invite)
 

--- a/backend/app/api/v1/platform_endpoints/guilds_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_test.py
@@ -682,6 +682,66 @@ async def test_create_guild_invite_as_member_forbidden(
 
 
 @pytest.mark.integration
+async def test_create_guild_invite_at_user_limit_forbidden(
+    client: AsyncClient, session: AsyncSession
+):
+    """A guild whose membership has reached ``max_users`` mints no new invite."""
+    user = await create_user(session, email="full-admin@example.com")
+    guild = await create_guild(session, name="Full Guild", max_users=1)
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+
+    response = await client.post(
+        f"/api/v1/guilds/{guild.id}/invites",
+        headers=get_auth_headers(user),
+        json={"max_uses": 1},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "GUILD_USER_LIMIT_REACHED"
+
+
+@pytest.mark.integration
+async def test_create_guild_invite_below_user_limit_allowed(
+    client: AsyncClient, session: AsyncSession
+):
+    """A seat still free leaves invite minting untouched."""
+    user = await create_user(session, email="roomy-admin@example.com")
+    guild = await create_guild(session, name="Roomy Guild", max_users=2)
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+
+    response = await client.post(
+        f"/api/v1/guilds/{guild.id}/invites",
+        headers=get_auth_headers(user),
+        json={"max_uses": 1},
+    )
+
+    assert response.status_code == 201, response.text
+
+
+@pytest.mark.integration
+async def test_create_guild_invite_uncapped_guild_allowed(
+    client: AsyncClient, session: AsyncSession
+):
+    """A ``NULL`` cap is unlimited, however many members the guild already has."""
+    user = await create_user(session, email="uncapped-admin@example.com")
+    guild = await create_guild(session, name="Uncapped Guild")
+    await create_guild_membership(session, user=user, guild=guild, role=GuildRole.admin)
+    for index in range(3):
+        member = await create_user(session, email=f"uncapped-{index}@example.com")
+        await create_guild_membership(
+            session, user=member, guild=guild, role=GuildRole.member
+        )
+
+    response = await client.post(
+        f"/api/v1/guilds/{guild.id}/invites",
+        headers=get_auth_headers(user),
+        json={"max_uses": 1},
+    )
+
+    assert response.status_code == 201, response.text
+
+
+@pytest.mark.integration
 async def test_list_guild_invites_as_admin(client: AsyncClient, session: AsyncSession):
     """Test that admin can list guild invites."""
     from app.services.platform import guilds as guild_service
@@ -854,11 +914,13 @@ async def test_accept_invite_blocked_when_guild_full(
     invitee = await create_user(session, email="full-invitee@example.com")
     guild = await create_guild(session, name="Full Guild", max_users=1)
 
-    await guild_service.ensure_membership(
-        session, guild_id=guild.id, user_id=seat_holder.id, role=GuildRole.member
-    )
+    # Minted while the seat is still free, redeemed after it is taken — minting
+    # itself is capacity-gated, so the order here is the scenario.
     invite = await guild_service.create_guild_invite(
         session, guild_id=guild.id, created_by=creator.id, max_uses=5
+    )
+    await guild_service.ensure_membership(
+        session, guild_id=guild.id, user_id=seat_holder.id, role=GuildRole.member
     )
     await session.commit()
 

--- a/backend/app/api/v1/platform_endpoints/settings_test.py
+++ b/backend/app/api/v1/platform_endpoints/settings_test.py
@@ -750,12 +750,14 @@ async def test_raising_cap_reopens_joins(
         session, email="owner-raise@example.com", role=UserRole.owner
     )
     guild = await create_guild(session, creator=owner, max_users=1)
-    await guild_service.ensure_membership(
-        session, guild_id=guild.id, user_id=owner.id, role=GuildRole.admin
-    )
     invitee = await create_user(session, email="raise-invitee@example.com")
+    # Minted while the seat is still free, redeemed after it is taken —
+    # minting itself is capacity-gated, so the order here is the scenario.
     invite = await guild_service.create_guild_invite(
         session, guild_id=guild.id, created_by=owner.id, max_uses=5
+    )
+    await guild_service.ensure_membership(
+        session, guild_id=guild.id, user_id=owner.id, role=GuildRole.admin
     )
     await session.commit()
     headers = get_auth_headers(owner)

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -192,7 +192,9 @@ async def ensure_membership(
 _MEMBER_CAP_LOCK_NAMESPACE = 0x55534552  # 1431193938
 
 
-async def _assert_member_capacity(session: AsyncSession, *, guild_id: int) -> None:
+async def _assert_member_capacity(
+    session: AsyncSession, *, guild_id: int, claiming_seat: bool = True
+) -> None:
     """Raise ``GuildCapacityError`` if the guild is at its ``max_users`` cap.
 
     A ``NULL`` cap means unlimited and short-circuits before any lock or count.
@@ -200,21 +202,27 @@ async def _assert_member_capacity(session: AsyncSession, *, guild_id: int) -> No
     rows (system engine, or an RLS context routed to this guild) — the same
     precondition ``count_members`` documents.
 
-    Must run in the SAME transaction that then inserts the membership and
-    commits. When a cap is set it takes a transaction-scoped advisory lock keyed
-    on the guild before counting, so the count check and the insert that follows
-    cannot interleave with a concurrent join — without it, two joins to a
-    near-full guild could each read the pre-insert count and collectively exceed
-    the cap (a TOCTOU race). The lock releases on commit/rollback and only
-    serializes joins to the SAME guild (mirrors ``enforce_storage_quota``).
+    ``claiming_seat`` (the default) is the join path: the call must run in the
+    SAME transaction that then inserts the membership and commits, and when a
+    cap is set it takes a transaction-scoped advisory lock keyed on the guild
+    before counting, so the count check and the insert that follows cannot
+    interleave with a concurrent join and collectively exceed the cap. The lock
+    releases on commit/rollback and only serializes joins to the SAME guild
+    (mirrors ``enforce_storage_quota``).
+
+    Pass ``claiming_seat=False`` when the caller only reads the cap and takes no
+    seat in the same transaction (minting an invite): the answer is a
+    point-in-time reading either way, so serializing joins against it would buy
+    nothing. The join path stays the authoritative gate.
     """
     administration = await get_administration(session, guild_id=guild_id)
     if administration.max_users is None:
         return
-    await session.exec(
-        text("SELECT pg_advisory_xact_lock(:ns, :gid)"),
-        params={"ns": _MEMBER_CAP_LOCK_NAMESPACE, "gid": int(guild_id)},
-    )
+    if claiming_seat:
+        await session.exec(
+            text("SELECT pg_advisory_xact_lock(:ns, :gid)"),
+            params={"ns": _MEMBER_CAP_LOCK_NAMESPACE, "gid": int(guild_id)},
+        )
     if await count_members(session, guild_id=guild_id) >= administration.max_users:
         raise GuildCapacityError(GuildMessages.GUILD_USER_LIMIT_REACHED)
 
@@ -665,6 +673,9 @@ async def create_guild_invite(
     max_uses: int | None = 1,
     invitee_email: str | None = None,
 ) -> GuildInvite:
+    # A full guild mints no new invites: every seat is taken, so any code handed
+    # out now could only fail at redemption. Raises ``GuildCapacityError``.
+    await _assert_member_capacity(session, guild_id=guild_id, claiming_seat=False)
     code = await _generate_unique_invite_code(session)
     if expires_at is None:
         expiry = datetime.now(timezone.utc) + timedelta(

--- a/backend/app/services/platform/guilds_test.py
+++ b/backend/app/services/platform/guilds_test.py
@@ -282,11 +282,13 @@ async def test_redeem_invite_blocked_when_full(session: AsyncSession):
     seat_holder = await create_user(session, email="full-seat@example.com")
     invitee = await create_user(session, email="full-invitee@example.com")
 
-    await guild_service.ensure_membership(
-        session, guild_id=guild.id, user_id=seat_holder.id, role=GuildRole.member
-    )
+    # Minted while the seat is still free, redeemed after it is taken — minting
+    # itself is capacity-gated, so the order here is the scenario.
     invite = await guild_service.create_guild_invite(
         session, guild_id=guild.id, created_by=creator.id, max_uses=5
+    )
+    await guild_service.ensure_membership(
+        session, guild_id=guild.id, user_id=seat_holder.id, role=GuildRole.member
     )
 
     with pytest.raises(guild_service.GuildCapacityError):

--- a/frontend/public/locales/de/guilds.json
+++ b/frontend/public/locales/de/guilds.json
@@ -23,6 +23,7 @@
   "viewInitiatives": "Initiativen anzeigen",
   "viewMembers": "Mitglieder anzeigen",
   "inviteMembers": "Mitglieder einladen",
+  "inviteMembersGuildFull": "Mitglieder einladen (Gilde voll)",
   "creatingInvite": "Einladung wird erstellt...",
   "createInitiative": "Initiative erstellen",
   "copyGuildId": "Gilden-ID kopieren",
@@ -136,6 +137,7 @@
     "noActiveInvites": "Keine aktiven Einladungen.",
     "unableToLoadInvites": "Einladungen konnten nicht geladen werden.",
     "unableToCreateInvite": "Einladung konnte nicht erstellt werden.",
+    "inviteSeatsFull": "Alle {{max}} Plätze sind belegt. Entferne ein Mitglied oder bitte einen Plattform-Administrator, das Limit zu erhöhen, bevor du eine weitere Einladung erstellst.",
     "unableToDeleteInvite": "Einladung konnte nicht gelöscht werden.",
     "inviteLinkCopied": "Einladungslink in die Zwischenablage kopiert.",
     "copyInviteLink": "Einladungslink kopieren",
@@ -256,6 +258,9 @@
   },
   "readOnlyBanner": {
     "message": "{{guild}} ist derzeit schreibgeschützt. Du kannst alles ansehen, aber Änderungen sind deaktiviert."
+  },
+  "billingSetup": {
+    "opening": "Abrechnung wird geöffnet, damit du einen Tarif für {{guild}} wählen kannst."
   },
   "usagePanel": {
     "title": "Nutzung",

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -23,6 +23,7 @@
   "viewInitiatives": "View initiatives",
   "viewMembers": "View members",
   "inviteMembers": "Invite members",
+  "inviteMembersGuildFull": "Invite members (guild full)",
   "creatingInvite": "Creating invite...",
   "createInitiative": "Create initiative",
   "copyGuildId": "Copy guild ID",
@@ -136,6 +137,7 @@
     "noActiveInvites": "No active invites.",
     "unableToLoadInvites": "Unable to load invites.",
     "unableToCreateInvite": "Unable to create invite.",
+    "inviteSeatsFull": "All {{max}} seats are in use. Remove a member, or ask a platform admin to raise the limit, before creating another invite.",
     "unableToDeleteInvite": "Unable to delete invite.",
     "inviteLinkCopied": "Invite link copied to clipboard.",
     "copyInviteLink": "Copy invite link",
@@ -256,6 +258,9 @@
   },
   "readOnlyBanner": {
     "message": "{{guild}} is currently read-only. You can browse everything, but changes are disabled."
+  },
+  "billingSetup": {
+    "opening": "Opening billing so you can choose a plan for {{guild}}."
   },
   "usagePanel": {
     "title": "Usage",

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -23,6 +23,7 @@
   "viewInitiatives": "Ver iniciativas",
   "viewMembers": "Ver miembros",
   "inviteMembers": "Invitar miembros",
+  "inviteMembersGuildFull": "Invitar miembros (gremio lleno)",
   "creatingInvite": "Creando invitación...",
   "createInitiative": "Crear iniciativa",
   "copyGuildId": "Copiar ID del gremio",
@@ -136,6 +137,7 @@
     "noActiveInvites": "No hay invitaciones activas.",
     "unableToLoadInvites": "No se pudieron cargar las invitaciones.",
     "unableToCreateInvite": "No se pudo crear la invitación.",
+    "inviteSeatsFull": "Las {{max}} plazas están ocupadas. Elimina a un miembro o pide a un administrador de la plataforma que aumente el límite antes de crear otra invitación.",
     "unableToDeleteInvite": "No se pudo eliminar la invitación.",
     "inviteLinkCopied": "Enlace de invitación copiado al portapapeles.",
     "copyInviteLink": "Copiar enlace de invitación",
@@ -256,6 +258,9 @@
   },
   "readOnlyBanner": {
     "message": "{{guild}} está actualmente en modo de solo lectura. Puedes consultar todo, pero los cambios están desactivados."
+  },
+  "billingSetup": {
+    "opening": "Abriendo la facturación para que elijas un plan para {{guild}}."
   },
   "usagePanel": {
     "title": "Uso",

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -23,6 +23,7 @@
   "viewInitiatives": "Voir les initiatives",
   "viewMembers": "Voir les membres",
   "inviteMembers": "Inviter des membres",
+  "inviteMembersGuildFull": "Inviter des membres (groupe complet)",
   "creatingInvite": "Création de l'invitation...",
   "createInitiative": "Créer une initiative",
   "copyGuildId": "Copier l'ID du groupe",
@@ -136,6 +137,7 @@
     "noActiveInvites": "Aucune invitation active.",
     "unableToLoadInvites": "Impossible de charger les invitations.",
     "unableToCreateInvite": "Impossible de créer l'invitation.",
+    "inviteSeatsFull": "Les {{max}} places sont occupées. Retirez un membre ou demandez à un administrateur de la plateforme d'augmenter la limite avant de créer une autre invitation.",
     "unableToDeleteInvite": "Impossible de supprimer l'invitation.",
     "inviteLinkCopied": "Lien d'invitation copié dans le presse-papier.",
     "copyInviteLink": "Copier le lien d'invitation",
@@ -256,6 +258,9 @@
   },
   "readOnlyBanner": {
     "message": "{{guild}} est actuellement en lecture seule. Vous pouvez tout consulter, mais les modifications sont désactivées."
+  },
+  "billingSetup": {
+    "opening": "Ouverture de la facturation pour choisir un forfait pour {{guild}}."
   },
   "usagePanel": {
     "title": "Utilisation",

--- a/frontend/src/components/guilds/GuildContextMenu.test.tsx
+++ b/frontend/src/components/guilds/GuildContextMenu.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Inviting members from a guild's context menu, against the guild's seat cap.
+ *
+ * The cap (`max_users`) and the current headcount (`member_count`) both ride
+ * on the admin's own guild payload, so the menu can tell a full guild from a
+ * roomy one without asking the server first.
+ */
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { buildGuild } from "@/__tests__/factories";
+import { renderPage } from "@/__tests__/helpers/render";
+import type { GuildRead } from "@/api/generated/initiativeAPI.schemas";
+
+import { GuildContextMenu } from "./GuildContextMenu";
+
+const mintInvite = vi.hoisted(() => vi.fn());
+vi.mock("@/api/generated/guilds/guilds", () => ({
+  createGuildInviteApiV1GuildsGuildIdInvitesPost: mintInvite,
+}));
+
+const setup = (overrides: Partial<GuildRead>) => {
+  const guild = buildGuild({ role: "admin", name: "Alpha", ...overrides }) as GuildRead;
+  renderPage(
+    () => (
+      <GuildContextMenu guild={guild}>
+        <button type="button">Alpha</button>
+      </GuildContextMenu>
+    ),
+    { guilds: { guilds: [], activeGuildId: guild.id } }
+  );
+  return guild;
+};
+
+const openMenu = async () => {
+  fireEvent.contextMenu(await screen.findByRole("button", { name: "Alpha" }));
+};
+
+describe("GuildContextMenu invite action", () => {
+  it("offers the invite action while a seat is free", async () => {
+    setup({ max_users: 3, member_count: 2 });
+
+    await openMenu();
+
+    const item = await screen.findByRole("menuitem", { name: "Invite members" });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("offers it when the guild has no cap at all", async () => {
+    setup({ max_users: null, member_count: 42 });
+
+    await openMenu();
+
+    const item = await screen.findByRole("menuitem", { name: "Invite members" });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("disables it, and says why, once every seat is taken", async () => {
+    setup({ max_users: 2, member_count: 2 });
+
+    await openMenu();
+
+    const item = await screen.findByRole("menuitem", { name: "Invite members (guild full)" });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(item);
+    expect(mintInvite).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/guilds/GuildContextMenu.tsx
+++ b/frontend/src/components/guilds/GuildContextMenu.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/context-menu";
 import { useGuilds } from "@/hooks/useGuilds";
 import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 import { LeaveGuildDialog } from "./LeaveGuildDialog";
 
@@ -46,9 +47,13 @@ export const GuildContextMenu = ({ guild, children, onReorder }: GuildContextMen
 
   const isAdmin = guild.role === "admin";
   const [creatingInvite, setCreatingInvite] = useState(false);
+  // A guild at its operator-set seat cap mints no invite (the server refuses),
+  // so the item says so rather than handing back an error toast. Both fields
+  // are admin-only on the payload, and null max_users means uncapped.
+  const atUserLimit = guild.max_users != null && guild.member_count >= guild.max_users;
 
   const handleInviteMembers = async () => {
-    if (creatingInvite) return;
+    if (creatingInvite || atUserLimit) return;
     setCreatingInvite(true);
     try {
       const data = (await createGuildInviteApiV1GuildsGuildIdInvitesPost(
@@ -60,7 +65,7 @@ export const GuildContextMenu = ({ guild, children, onReorder }: GuildContextMen
       toast.success(t("inviteLinkCopied"));
     } catch (err) {
       console.error("Failed to create invite", err);
-      toast.error(t("failedToCreateInvite"));
+      toast.error(getErrorMessage(err, "guilds:failedToCreateInvite"));
     } finally {
       setCreatingInvite(false);
     }
@@ -123,9 +128,16 @@ export const GuildContextMenu = ({ guild, children, onReorder }: GuildContextMen
                 {t("viewMembers")}
               </ContextMenuItem>
               <ContextMenuSeparator />
-              <ContextMenuItem onClick={handleInviteMembers} disabled={creatingInvite}>
+              <ContextMenuItem
+                onClick={handleInviteMembers}
+                disabled={creatingInvite || atUserLimit}
+              >
                 <UserPlus className="mr-2 h-4 w-4" />
-                {creatingInvite ? t("creatingInvite") : t("inviteMembers")}
+                {creatingInvite
+                  ? t("creatingInvite")
+                  : atUserLimit
+                    ? t("inviteMembersGuildFull")
+                    : t("inviteMembers")}
               </ContextMenuItem>
               <ContextMenuItem onClick={handleCreateInitiative}>
                 <Plus className="mr-2 h-4 w-4" />

--- a/frontend/src/components/guilds/GuildSidebar.test.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.test.tsx
@@ -10,8 +10,8 @@
  * A guild reached through a temporary access grant is not part of the user's
  * order, so it offers no reorder action.
  */
-import { fireEvent, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildGuild } from "@/__tests__/factories";
 import { renderPage } from "@/__tests__/helpers/render";
@@ -19,6 +19,21 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import type { GuildEntry } from "@/hooks/useGuilds";
 
 import { GuildSidebar } from "./GuildSidebar";
+
+// Billing config and the handoff mint, mocked so a test can put the sidebar in
+// either deployment shape: no portal (self-hosted) or one configured.
+const state = vi.hoisted(() => ({ billing: null as { url: string } | null }));
+const mintMock = vi.hoisted(() => vi.fn());
+vi.mock("@/hooks/useAppConfig", () => ({ useAppConfig: () => ({ billing: state.billing }) }));
+vi.mock("@/api/generated/guilds/guilds", async () => {
+  const actual = await vi.importActual<typeof import("@/api/generated/guilds/guilds")>(
+    "@/api/generated/guilds/guilds"
+  );
+  return { ...actual, createGuildBillingHandoffApiV1GuildsGuildIdBillingHandoffPost: mintMock };
+});
+vi.mock("@/lib/chesterToast", () => ({
+  toast: { info: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
 
 const entry = (overrides: Partial<GuildEntry> = {}): GuildEntry =>
   ({ ...buildGuild(), accessType: "member", ...overrides }) as GuildEntry;
@@ -111,5 +126,78 @@ describe("GuildSidebar reorder mode", () => {
       "aria-pressed",
       "true"
     );
+  });
+});
+
+/**
+ * Creating a guild on a deployment that has a billing portal.
+ *
+ * A new guild starts on the deployment's default plan, so the flow hands the
+ * creator straight to the portal to see that plan and add payment details.
+ * With no portal configured (the self-hosted default) creation just finishes.
+ */
+describe("GuildSidebar guild creation", () => {
+  const createNamedGuild = async (createGuild: ReturnType<typeof vi.fn>) => {
+    renderPage(
+      () => (
+        <SidebarProvider>
+          <GuildSidebar />
+        </SidebarProvider>
+      ),
+      { guilds: { guilds: [entry({ name: "Alpha" })], activeGuildId: 1, createGuild } }
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Create Guild" }));
+    fireEvent.change(await screen.findByLabelText("Guild name"), {
+      target: { value: "Beta" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create guild" }));
+  };
+
+  beforeEach(() => {
+    state.billing = null;
+    mintMock.mockReset();
+  });
+
+  it("sends the creator to the portal with the minted token in the fragment", async () => {
+    state.billing = { url: "https://billing.example.com" };
+    mintMock.mockResolvedValue({ handoff_token: "TOK", expires_in_seconds: 60 });
+    const createGuild = vi.fn().mockResolvedValue(buildGuild({ id: 42, name: "Beta" }));
+    const tab = { location: { href: "" }, opener: {} as unknown, close: vi.fn() };
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(tab as unknown as Window);
+
+    await createNamedGuild(createGuild);
+
+    await waitFor(() => expect(mintMock).toHaveBeenCalledWith(42));
+    await waitFor(() =>
+      expect(tab.location.href).toBe(
+        "https://billing.example.com/upgrade?guild=42&lang=en#handoff=TOK"
+      )
+    );
+    openSpy.mockRestore();
+  });
+
+  it("opens nothing when the deployment has no billing portal", async () => {
+    const createGuild = vi.fn().mockResolvedValue(buildGuild({ id: 42, name: "Beta" }));
+    const openSpy = vi.spyOn(window, "open");
+
+    await createNamedGuild(createGuild);
+
+    await waitFor(() => expect(createGuild).toHaveBeenCalled());
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(mintMock).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it("closes the reserved tab when creation fails", async () => {
+    state.billing = { url: "https://billing.example.com" };
+    const createGuild = vi.fn().mockRejectedValue(new Error("nope"));
+    const tab = { location: { href: "" }, opener: {} as unknown, close: vi.fn() };
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(tab as unknown as Window);
+
+    await createNamedGuild(createGuild);
+
+    await waitFor(() => expect(tab.close).toHaveBeenCalled());
+    expect(mintMock).not.toHaveBeenCalled();
+    openSpy.mockRestore();
   });
 });

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -41,6 +41,7 @@ import { Label } from "@/components/ui/label";
 import { useSidebar } from "@/components/ui/sidebar";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useBillingPortal } from "@/hooks/useBillingPortal";
 import { type GuildEntry, useGuilds } from "@/hooks/useGuilds";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
@@ -58,6 +59,7 @@ const FLYOUT_TRANSITION_MS = 300; // keep in sync with the inline transform tran
 
 const CreateGuildButton = ({ expanded = false }: { expanded?: boolean }) => {
   const { createGuild, canCreateGuilds, switchGuild } = useGuilds();
+  const { billing, openPortal, reserveTab } = useBillingPortal();
   const { t } = useTranslation("guilds");
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
@@ -74,13 +76,21 @@ const CreateGuildButton = ({ expanded = false }: { expanded?: boolean }) => {
     event.preventDefault();
     setSubmitting(true);
     setError(null);
+    // Reserved inside the submit gesture (null when the deployment has no
+    // billing portal) so the hop below isn't treated as an unsolicited popup.
+    const billingTab = reserveTab();
     try {
       const newGuild = await createGuild({ name, description });
       await switchGuild(newGuild.id);
       setOpen(false);
       setName("");
       setDescription("");
+      if (billing) {
+        toast.info(t("billingSetup.opening", { guild: newGuild.name }));
+        await openPortal(newGuild.id, "upgrade", billingTab);
+      }
     } catch (err) {
+      billingTab?.close();
       console.error(err);
       const message = getErrorMessage(err, "guilds:unableToCreateGuild");
       setError(message);

--- a/frontend/src/components/guilds/GuildUsagePanel.tsx
+++ b/frontend/src/components/guilds/GuildUsagePanel.tsx
@@ -1,12 +1,11 @@
 import { useTranslation } from "react-i18next";
 
-import { createGuildBillingHandoffApiV1GuildsGuildIdBillingHandoffPost } from "@/api/generated/guilds/guilds";
 import { useReadStorageUsageApiV1GGuildIdStorageUsageGet } from "@/api/generated/storage/storage";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
-import { useAppConfig } from "@/hooks/useAppConfig";
+import { useBillingPortal } from "@/hooks/useBillingPortal";
 import { useGuilds } from "@/hooks/useGuilds";
 import { formatBytes } from "@/lib/fileUtils";
 
@@ -22,9 +21,9 @@ const ratioPct = (used: number, max: number | null): number | null =>
  * (caps, plan label), which the API sends to admins alone — as does the
  * storage-usage endpoint below. */
 export const GuildUsagePanel = () => {
-  const { t, i18n } = useTranslation(["guilds", "common"]);
+  const { t } = useTranslation(["guilds", "common"]);
   const { activeGuild } = useGuilds();
-  const { billing } = useAppConfig();
+  const { billing, openPortal } = useBillingPortal();
 
   const guildId = activeGuild?.id;
   const { data: usage } = useReadStorageUsageApiV1GGuildIdStorageUsageGet(guildId ?? 0, {
@@ -42,26 +41,6 @@ export const GuildUsagePanel = () => {
   const storagePct = ratioPct(usedBytes, maxBytes);
   const memberPct = ratioPct(members, maxUsers);
   const tierLabel = activeGuild.tier_name ?? t("usagePanel.selfHosted");
-
-  const lang = i18n.resolvedLanguage ?? i18n.language;
-
-  const openPortal = async (page: "manage" | "upgrade") => {
-    if (!billing) return;
-    const base = `${billing.url}/${page}?guild=${activeGuild.id}&lang=${encodeURIComponent(lang)}`;
-    const tab = window.open("about:blank", "_blank");
-    if (tab) tab.opener = null;
-    try {
-      const { handoff_token } = await createGuildBillingHandoffApiV1GuildsGuildIdBillingHandoffPost(
-        activeGuild.id
-      );
-      const url = `${base}#handoff=${encodeURIComponent(handoff_token)}`;
-      if (tab) tab.location.href = url;
-      else window.open(url, "_blank", "noopener,noreferrer");
-    } catch {
-      if (tab) tab.location.href = base;
-      else window.open(base, "_blank", "noopener,noreferrer");
-    }
-  };
 
   return (
     <Card>
@@ -105,10 +84,14 @@ export const GuildUsagePanel = () => {
                 <span className="font-semibold">{tierLabel}</span>
               </p>
               <div className="flex gap-2">
-                <Button size="sm" onClick={() => openPortal("upgrade")}>
+                <Button size="sm" onClick={() => void openPortal(activeGuild.id, "upgrade")}>
                   {t("usagePanel.upgrade")}
                 </Button>
-                <Button size="sm" variant="outline" onClick={() => openPortal("manage")}>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void openPortal(activeGuild.id, "manage")}
+                >
                   {t("usagePanel.manageBilling")}
                 </Button>
               </div>

--- a/frontend/src/components/guilds/RemoveGuildMemberDialog.tsx
+++ b/frontend/src/components/guilds/RemoveGuildMemberDialog.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { deleteUserApiV1GGuildIdUsersUserIdDelete } from "@/api/generated/users/users";
-import { invalidateGuildMembers } from "@/api/query-keys";
+import { invalidateAllGuilds, invalidateGuildMembers } from "@/api/query-keys";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -51,6 +51,8 @@ export const RemoveGuildMemberDialog = ({
     try {
       await deleteUserApiV1GGuildIdUsersUserIdDelete(guildId, userId);
       void invalidateGuildMembers();
+      // The guild list carries member_count, which the seat counter reads.
+      void invalidateAllGuilds();
       toast.success(t("removeMember.removed", { email }));
       onSuccess?.();
       onOpenChange(false);

--- a/frontend/src/components/guilds/RemoveGuildMemberDialog.tsx
+++ b/frontend/src/components/guilds/RemoveGuildMemberDialog.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { deleteUserApiV1GGuildIdUsersUserIdDelete } from "@/api/generated/users/users";
-import { invalidateAllGuilds, invalidateGuildMembers } from "@/api/query-keys";
+import { invalidateGuildMembers } from "@/api/query-keys";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,6 +15,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
+import { useGuilds } from "@/hooks/useGuilds";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 
@@ -43,6 +44,7 @@ export const RemoveGuildMemberDialog = ({
 }: RemoveGuildMemberDialogProps) => {
   const { t } = useTranslation(["guilds", "common"]);
   const guildId = useActiveGuildId();
+  const { refreshGuilds } = useGuilds();
   const [removing, setRemoving] = useState(false);
 
   const handleRemove = async () => {
@@ -51,8 +53,10 @@ export const RemoveGuildMemberDialog = ({
     try {
       await deleteUserApiV1GGuildIdUsersUserIdDelete(guildId, userId);
       void invalidateGuildMembers();
-      // The guild list carries member_count, which the seat counter reads.
-      void invalidateAllGuilds();
+      // The guild entry carries member_count, which the invite surfaces read
+      // to tell a full guild from one with a seat free. It is provider state,
+      // not a query, so it refreshes rather than invalidates.
+      void refreshGuilds();
       toast.success(t("removeMember.removed", { email }));
       onSuccess?.();
       onOpenChange(false);

--- a/frontend/src/hooks/useBillingPortal.ts
+++ b/frontend/src/hooks/useBillingPortal.ts
@@ -1,0 +1,56 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+
+import { createGuildBillingHandoffApiV1GuildsGuildIdBillingHandoffPost } from "@/api/generated/guilds/guilds";
+import { useAppConfig } from "@/hooks/useAppConfig";
+
+/** Portal page to land on: the plan/card setup screen, or the existing
+ *  subscription's management screen. */
+export type BillingPortalPage = "manage" | "upgrade";
+
+/**
+ * Link-out to the external billing portal for one guild.
+ *
+ * `billing` is null when the deployment has no portal configured (the
+ * self-hosted default) — callers must skip every tier/upgrade/manage
+ * affordance then, and `reserveTab`/`openPortal` become no-ops.
+ *
+ * The tab is opened before the handoff token is minted so the browser keeps
+ * attributing it to the click that started it. `reserveTab` exposes that step
+ * on its own for callers with their own await between the click and the hop
+ * (guild creation), which would otherwise land the `window.open` outside the
+ * user gesture.
+ */
+export const useBillingPortal = () => {
+  const { billing } = useAppConfig();
+  const { i18n } = useTranslation();
+  const lang = i18n.resolvedLanguage ?? i18n.language;
+
+  const reserveTab = useCallback((): Window | null => {
+    if (!billing) return null;
+    const tab = window.open("about:blank", "_blank");
+    if (tab) tab.opener = null;
+    return tab;
+  }, [billing]);
+
+  const openPortal = useCallback(
+    async (guildId: number, page: BillingPortalPage, reserved?: Window | null) => {
+      if (!billing) return;
+      const base = `${billing.url}/${page}?guild=${guildId}&lang=${encodeURIComponent(lang)}`;
+      const tab = reserved ?? reserveTab();
+      try {
+        const { handoff_token } =
+          await createGuildBillingHandoffApiV1GuildsGuildIdBillingHandoffPost(guildId);
+        const url = `${base}#handoff=${encodeURIComponent(handoff_token)}`;
+        if (tab) tab.location.href = url;
+        else window.open(url, "_blank", "noopener,noreferrer");
+      } catch {
+        if (tab) tab.location.href = base;
+        else window.open(base, "_blank", "noopener,noreferrer");
+      }
+    },
+    [billing, lang, reserveTab]
+  );
+
+  return { billing, openPortal, reserveTab };
+};

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -80,6 +80,13 @@ export const SettingsUsersPage = () => {
 
   const activeGuildId = activeGuild?.id ?? null;
 
+  // Operator-set seat cap, admin-only on the payload and null when uncapped.
+  // A full guild mints no invite (the server refuses), so the form says so
+  // up front instead of failing on submit.
+  const maxUsers = activeGuild?.max_users ?? null;
+  const usedSeats = activeGuild?.member_count ?? 0;
+  const atUserLimit = maxUsers !== null && usedSeats >= maxUsers;
+
   const [invites, setInvites] = useState<GuildInviteRead[]>([]);
   const [invitesLoading, setInvitesLoading] = useState(false);
   const [invitesError, setInvitesError] = useState<string | null>(null);
@@ -310,7 +317,7 @@ export const SettingsUsersPage = () => {
 
   const createInvite = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!activeGuildId) {
+    if (!activeGuildId || atUserLimit) {
       return;
     }
     setInviteSubmitting(true);
@@ -331,7 +338,7 @@ export const SettingsUsersPage = () => {
       await loadInvites();
     } catch (error) {
       console.error(error);
-      setInvitesError(t("users.unableToCreateInvite"));
+      setInvitesError(getErrorMessage(error, "guilds:users.unableToCreateInvite"));
     } finally {
       setInviteSubmitting(false);
     }
@@ -395,11 +402,16 @@ export const SettingsUsersPage = () => {
               />
             </div>
             <div className="flex items-end">
-              <Button type="submit" disabled={inviteSubmitting}>
+              <Button type="submit" disabled={inviteSubmitting || atUserLimit}>
                 {inviteSubmitting ? t("users.generatingInvite") : t("users.generateInvite")}
               </Button>
             </div>
           </form>
+          {atUserLimit ? (
+            <p className="text-muted-foreground text-sm">
+              {t("users.inviteSeatsFull", { max: maxUsers })}
+            </p>
+          ) : null}
           <div className="h-px bg-border" />
           {invitesLoading ? (
             <p className="text-muted-foreground text-sm">{t("users.loadingInvites")}</p>

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -3,7 +3,7 @@ import { Loader2, LogOut, Plus, Search, Settings, Ticket, UserCog } from "lucide
 import { Suspense, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { RecentItemRead } from "@/api/generated/initiativeAPI.schemas";
+import type { GuildRead, RecentItemRead } from "@/api/generated/initiativeAPI.schemas";
 import { AppSidebar } from "@/components/AppSidebar";
 import { CommandCenter, getOpenCommandCenter } from "@/components/CommandCenter";
 import { CreateDocumentWizard } from "@/components/documents/CreateDocumentWizard";
@@ -21,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { VersionDialog } from "@/components/VersionDialog";
 import { useAuth } from "@/hooks/useAuth";
 import { useBackButton } from "@/hooks/useBackButton";
+import { useBillingPortal } from "@/hooks/useBillingPortal";
 import { useGuilds } from "@/hooks/useGuilds";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { useRealtimeUpdates } from "@/hooks/useRealtimeUpdates";
@@ -32,6 +33,7 @@ import {
 } from "@/hooks/useRecents";
 import { useVersionCheck } from "@/hooks/useVersionCheck";
 import { isJustSignedIn } from "@/lib/authTransition";
+import { toast } from "@/lib/chesterToast";
 import { chooseNoGuildLayout } from "@/lib/noGuildLayout";
 import { canAccessPlatformAdmin } from "@/lib/permissions";
 import { getActiveRecentKey } from "@/lib/recentRoute";
@@ -291,11 +293,12 @@ function NoGuildState({
   isPlatformAdmin,
 }: {
   canCreateGuilds: boolean;
-  createGuild: (input: { name: string; description?: string }) => Promise<unknown>;
+  createGuild: (input: { name: string; description?: string }) => Promise<GuildRead>;
   logout: () => void;
   isPlatformAdmin: boolean;
 }) {
   const { t } = useTranslation("guilds");
+  const { billing, openPortal, reserveTab } = useBillingPortal();
   const [guildName, setGuildName] = useState("");
   const [inviteCode, setInviteCode] = useState("");
   const [creating, setCreating] = useState(false);
@@ -304,9 +307,17 @@ function NoGuildState({
     const trimmed = guildName.trim();
     if (!trimmed) return;
     setCreating(true);
+    // Reserved inside the click gesture (null when the deployment has no
+    // billing portal) so the hop below isn't treated as an unsolicited popup.
+    const billingTab = reserveTab();
     try {
-      await createGuild({ name: trimmed });
+      const guild = await createGuild({ name: trimmed });
+      if (billing) {
+        toast.info(t("billingSetup.opening", { guild: guild.name }));
+        await openPortal(guild.id, "upgrade", billingTab);
+      }
     } catch {
+      billingTab?.close();
       setCreating(false);
     }
   };


### PR DESCRIPTION
## Problem

A guild whose membership already sits at its `max_users` cap could still mint invites. The cap was enforced only at redemption, so the invite was born unusable — the admin generated a link, sent it, and the recipient hit `GUILD_USER_LIMIT_REACHED` on accept.

## Changes

**Backend**

- `_assert_member_capacity` takes a `claiming_seat` flag. The join path keeps the per-guild advisory lock that serializes count-then-insert; the new caller reads the cap without it, since it takes no seat in the same transaction. One check, one place.
- `create_guild_invite` runs that check first and raises `GuildCapacityError`.
- `POST /guilds/{guild_id}/invites` maps it to `403 GUILD_USER_LIMIT_REACHED`, matching what `invite/accept` already answers.
- A `NULL` cap is unlimited and short-circuits as before.

**Frontend**

- Both admin surfaces that mint an invite read `max_users`/`member_count` off the guild payload (admin-only fields already on `GuildRead`) and drop the affordance when the guild is full:
  - Guild context menu — the item is disabled and reads "Invite members (guild full)".
  - Settings → Users — the Generate invite button is disabled, with a line explaining the guild is full.
- Both handlers also return early, so neither can fire while at the cap.
- Invite-creation failures on the settings page now go through `getErrorMessage`, so a server-side refusal renders its localized message instead of a generic one.
- Removing a member invalidates the guild list, so the freed seat is picked up.
- New strings added to en/de/es/fr.

Seat *usage* is still reported in one place only — `GuildUsagePanel` on the guild settings page. The invite surfaces say only that the guild is full.

## Schema / env

None.

## Testing

```
cd backend && pytest app/api/v1/platform_endpoints/guilds_test.py app/services/platform/guilds_test.py   # 87 passed
cd backend && ruff check app && ruff format app && ty check app
cd frontend && pnpm vitest run src/components/guilds/                                                    # 14 passed
cd frontend && pnpm exec tsc --noEmit && pnpm lint
```

New backend tests cover minting at the cap (403), below the cap (201), and an uncapped guild with several members (201). New `GuildContextMenu.test.tsx` covers the menu item enabled below the cap, enabled when uncapped, and disabled with the full label at the cap.

Two existing tests that minted an invite into an already-full guild as setup now mint it while a seat is free and fill the seat afterwards — the scenario they assert (redeeming an invite into a guild that filled up in the meantime) is unchanged.