### PR TITLE
Unify tab bars on one full-width bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adjusted the style of the personal space page headers.
-- **Tab bars are consistent and fill their container.** The tab bars across the app — an initiative's tools, settings and admin sections, a tag's content, the sidebar's Initiatives/Tags switch, the document side panel, and the tabbed dialogs — were each sized differently: some hugged their labels, some stopped at a fixed width. They now share one component that spans the full width of whatever holds them, divides that width between the tabs, and scrolls sideways once the labels stop fitting. The view switchers on tool lists (table, board, grid, calendar) are unchanged — they stay sized to their icons inside the toolbar.
+- **Tab bars are consistent and fill their container.** The tab bars across the app — an initiative's tools, settings and admin sections, a tag's content, the sidebar's Initiatives/Tags switch, the document side panel, and the tabbed dialogs — were each sized differently: some hugged their labels, some stopped at a fixed width. They now share one component that spans the full width of whatever holds them, keeps each tab sized to its label, and scrolls sideways once the labels stop fitting. The view switchers on tool lists (table, board, grid, calendar) are unchanged — they stay sized to their icons inside the toolbar.
 
 ## [0.63.3] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Adjusted the style of the personal space page headers.
+- **Tab bars are consistent and fill their container.** The tab bars across the app — an initiative's tools, settings and admin sections, a tag's content, the sidebar's Initiatives/Tags switch, the document side panel, and the tabbed dialogs — were each sized differently: some hugged their labels, some stopped at a fixed width. They now share one component that spans the full width of whatever holds them, divides that width between the tabs, and scrolls sideways once the labels stop fitting. The view switchers on tool lists (table, board, grid, calendar) are unchanged — they stay sized to their icons inside the toolbar.
+
 ## [0.63.3] - 2026-08-26
 
 ### Added

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -36,7 +36,7 @@ import {
   SidebarSeparator,
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAuth } from "@/hooks/useAuth";
@@ -333,16 +333,16 @@ export const AppSidebar = () => {
 
                 <Tabs defaultValue="initiatives" className="flex flex-1 flex-col overflow-hidden">
                   {/* <div className="border-b px-2"> */}
-                  <TabsList className="h-9 w-full rounded-none">
-                    <TabsTrigger value="initiatives" className="flex-1 text-xs">
+                  <TabsBar className="h-9 rounded-none">
+                    <TabsTrigger value="initiatives" className="text-xs">
                       <Users className="mr-2 h-3.5 w-3.5" />
                       {t("initiatives")}
                     </TabsTrigger>
-                    <TabsTrigger value="tags" className="flex-1 text-xs">
+                    <TabsTrigger value="tags" className="text-xs">
                       <Tag className="mr-2 h-3.5 w-3.5" />
                       {t("tags")}
                     </TabsTrigger>
-                  </TabsList>
+                  </TabsBar>
                   {/* </div> */}
 
                   <TabsContent value="initiatives" className="mt-0 flex-1 overflow-hidden">

--- a/frontend/src/components/access/BulkEditAccessDialog.tsx
+++ b/frontend/src/components/access/BulkEditAccessDialog.tsx
@@ -38,7 +38,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useAuth } from "@/hooks/useAuth";
 import { useInitiatives } from "@/hooks/useInitiatives";
@@ -586,17 +586,11 @@ export function BulkEditAccessDialog({
             setRolePickerOpen(false);
           }}
         >
-          <TabsList className="w-full">
-            <TabsTrigger value="people" className="flex-1">
-              {t("share.people")}
-            </TabsTrigger>
-            <TabsTrigger value="roles" className="flex-1">
-              {t("share.roles")}
-            </TabsTrigger>
-            <TabsTrigger value="all" className="flex-1">
-              {t("bulkAccess.tabAllMembers")}
-            </TabsTrigger>
-          </TabsList>
+          <TabsBar>
+            <TabsTrigger value="people">{t("share.people")}</TabsTrigger>
+            <TabsTrigger value="roles">{t("share.roles")}</TabsTrigger>
+            <TabsTrigger value="all">{t("bulkAccess.tabAllMembers")}</TabsTrigger>
+          </TabsBar>
 
           <TabsContent value="people" className="mt-4 space-y-3">
             <div className="space-y-2">

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -40,7 +40,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import {
   useCreateDocument,
@@ -231,7 +231,7 @@ export const CreateDocumentDialog = ({
           value={createDialogTab}
           onValueChange={(value) => setCreateDialogTab(value as "new" | "upload" | "smartLink")}
         >
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsBar>
             <TabsTrigger value="new" className="flex items-center gap-2">
               <Plus className="h-4 w-4" />
               {t("create.tabNew")}
@@ -244,7 +244,7 @@ export const CreateDocumentDialog = ({
               <LinkIcon className="h-4 w-4" />
               {t("create.tabSmartLink")}
             </TabsTrigger>
-          </TabsList>
+          </TabsBar>
 
           {/* Shared fields: Title and Initiative */}
           <div className="mt-4 space-y-4">

--- a/frontend/src/components/documents/DocumentSidePanel.tsx
+++ b/frontend/src/components/documents/DocumentSidePanel.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { getItem, setItem } from "@/lib/storage";
 
 const STORAGE_KEY = "document-side-panel-open";
@@ -63,14 +63,12 @@ export const DocumentSidePanel = ({
           className="flex flex-1 flex-col overflow-hidden"
         >
           {showSummaryTab && (
-            <TabsList className="mx-4 mt-3">
-              <TabsTrigger value="comments" className="flex-1">
-                {t("sidePanel.commentsTab")}
-              </TabsTrigger>
-              <TabsTrigger value="summary" className="flex-1">
-                {t("sidePanel.summaryTab")}
-              </TabsTrigger>
-            </TabsList>
+            <div className="px-3 pt-3">
+              <TabsBar>
+                <TabsTrigger value="comments">{t("sidePanel.commentsTab")}</TabsTrigger>
+                <TabsTrigger value="summary">{t("sidePanel.summaryTab")}</TabsTrigger>
+              </TabsBar>
+            </div>
           )}
 
           <div className="flex-1 overflow-y-auto">

--- a/frontend/src/components/settings/SettingsTabsNav.tsx
+++ b/frontend/src/components/settings/SettingsTabsNav.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsTrigger } from "@/components/ui/tabs";
 
 export interface SettingsTab {
   value: string;
@@ -25,8 +25,8 @@ export interface SettingsTabsNavProps {
 
 /**
  * Presentational tab bar shared by the settings/admin tabbed layouts: the
- * `<Tabs>` shell, an overflow-scroll `<TabsList>`, and a `<TabsTrigger>` per
- * tab. Each layout keeps its own guards, header, and active-tab derivation.
+ * `<Tabs>` shell, a full-width `<TabsBar>`, and a `<TabsTrigger>` per tab.
+ * Each layout keeps its own guards, header, and active-tab derivation.
  */
 export function SettingsTabsNav({ tabs, activeTab, onNavigate, children }: SettingsTabsNavProps) {
   return (
@@ -39,15 +39,13 @@ export function SettingsTabsNav({ tabs, activeTab, onNavigate, children }: Setti
         }
       }}
     >
-      <div className="-mx-4 overflow-x-auto pb-2 md:mx-0 md:overflow-visible">
-        <TabsList className="w-full min-w-max justify-start gap-2 px-1 md:min-w-0">
-          {tabs.map((tab) => (
-            <TabsTrigger key={tab.value} value={tab.value} className="shrink-0">
-              {tab.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </div>
+      <TabsBar containerClassName="pb-2" className="gap-1">
+        {tabs.map((tab) => (
+          <TabsTrigger key={tab.value} value={tab.value}>
+            {tab.label}
+          </TabsTrigger>
+        ))}
+      </TabsBar>
       {children}
     </Tabs>
   );

--- a/frontend/src/components/shared/BulkEditTagsDialog.tsx
+++ b/frontend/src/components/shared/BulkEditTagsDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import type { DialogWithSuccessProps } from "@/types/dialog";
@@ -151,14 +151,10 @@ export function BulkEditTagsDialog<T extends TaggableItem>({
         </DialogHeader>
 
         <Tabs value={mode} onValueChange={(v) => setMode(v as "add" | "remove")}>
-          <TabsList className="w-full">
-            <TabsTrigger value="add" className="flex-1">
-              {labels.tabAdd}
-            </TabsTrigger>
-            <TabsTrigger value="remove" className="flex-1">
-              {labels.tabRemove}
-            </TabsTrigger>
-          </TabsList>
+          <TabsBar>
+            <TabsTrigger value="add">{labels.tabAdd}</TabsTrigger>
+            <TabsTrigger value="remove">{labels.tabRemove}</TabsTrigger>
+          </TabsBar>
 
           <TabsContent value="add" className="mt-4">
             <TagPicker

--- a/frontend/src/components/tools/settings/ToolSettingsPage.tsx
+++ b/frontend/src/components/tools/settings/ToolSettingsPage.tsx
@@ -26,7 +26,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { useSetToolTags } from "@/hooks/useToolTags";
 import { toast } from "@/lib/chesterToast";
@@ -179,7 +179,7 @@ export const ToolSettingsPage = ({
         defaultValue={extraTabs.some((tab) => tab.value === defaultTab) ? defaultTab : "details"}
         className="space-y-4"
       >
-        <TabsList className="w-full max-w-xl justify-start">
+        <TabsBar>
           <TabsTrigger value="details">{t("common:toolSettings.tabDetails")}</TabsTrigger>
           {canManage && (
             <TabsTrigger value="access">{t("common:toolSettings.tabAccess")}</TabsTrigger>
@@ -190,7 +190,7 @@ export const ToolSettingsPage = ({
             </TabsTrigger>
           ))}
           <TabsTrigger value="advanced">{t("common:toolSettings.tabAdvanced")}</TabsTrigger>
-        </TabsList>
+        </TabsBar>
 
         <TabsContent value="details" className="space-y-6">
           {update && (

--- a/frontend/src/components/ui/editor/plugins/images-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/images-plugin.tsx
@@ -6,7 +6,7 @@ import { DialogFooter } from "@/components/ui/dialog";
 import type { ImagePayload } from "@/components/ui/editor/nodes/image-node";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { uploadAttachment } from "@/lib/attachmentUtils";
 
@@ -156,14 +156,10 @@ export function InsertImageDialog({
 
   return (
     <Tabs defaultValue="url">
-      <TabsList className="w-full">
-        <TabsTrigger value="url" className="w-full">
-          URL
-        </TabsTrigger>
-        <TabsTrigger value="file" className="w-full">
-          File
-        </TabsTrigger>
-      </TabsList>
+      <TabsBar>
+        <TabsTrigger value="url">URL</TabsTrigger>
+        <TabsTrigger value="file">File</TabsTrigger>
+      </TabsBar>
       <TabsContent value="url">
         <InsertImageUriDialogBody onClick={onClick} />
       </TabsContent>

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -20,6 +20,33 @@ const TabsList = React.forwardRef<
 ));
 TabsList.displayName = TabsPrimitive.List.displayName;
 
+/**
+ * The page-level tab bar: spans the width of its container, keeps its triggers
+ * at their label width and left-aligned, and scrolls horizontally (scrollbar
+ * hidden) once they stop fitting. Use this for every navigation-style tab bar;
+ * inline segmented controls (a view picker sitting in a toolbar) keep a bare
+ * `TabsList` so they stay sized to their content.
+ */
+const TabsBar = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+    /** Extra classes for the scroll container wrapping the list. */
+    containerClassName?: string;
+  }
+>(({ className, containerClassName, ...props }, ref) => (
+  <div
+    className={cn(
+      "-mx-1 overflow-x-auto px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+      containerClassName
+    )}
+  >
+    {/* `min-w-max` keeps the triggers at their label width once they overflow,
+        so the container scrolls rather than the labels shrinking. */}
+    <TabsList ref={ref} className={cn("w-full min-w-max justify-start", className)} {...props} />
+  </div>
+));
+TabsBar.displayName = "TabsBar";
+
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
@@ -50,4 +77,4 @@ const TabsContent = React.forwardRef<
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsContent, TabsList, TabsTrigger };
+export { Tabs, TabsBar, TabsContent, TabsList, TabsTrigger };

--- a/frontend/src/pages/InitiativeDetailPage.tsx
+++ b/frontend/src/pages/InitiativeDetailPage.tsx
@@ -9,7 +9,7 @@ import { StatusMessage } from "@/components/StatusMessage";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
 import {
@@ -236,21 +236,19 @@ export const InitiativeDetailPage = ({ tool }: InitiativeDetailPageProps = {}) =
       </Collapsible>
 
       <Tabs value={activeTab}>
-        <div className="-mx-1 overflow-x-auto px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <TabsList className="inline-flex w-max">
-            {TOOL_TABS.filter(([tabTool]) => availableTabs.includes(tabTool)).map(([tabTool]) => (
-              <TabsTrigger key={tabTool} value={tabTool} asChild>
-                {/* A real link, so a tab is shareable and answers the back
+        <TabsBar>
+          {TOOL_TABS.filter(([tabTool]) => availableTabs.includes(tabTool)).map(([tabTool]) => (
+            <TabsTrigger key={tabTool} value={tabTool} asChild>
+              {/* A real link, so a tab is shareable and answers the back
                     button. `search={{}}` clears the page cursor: all six tabs
                     now share one search schema, so a ?page from the queue tab
                     would otherwise follow the reader into documents. */}
-                <Link to={gp(toolListRoute(tabTool, initiative.id))} search={{}}>
-                  {t(`detail.${toolCamelPlural(tabTool)}` as never)}
-                </Link>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </div>
+              <Link to={gp(toolListRoute(tabTool, initiative.id))} search={{}}>
+                {t(`detail.${toolCamelPlural(tabTool)}` as never)}
+              </Link>
+            </TabsTrigger>
+          ))}
+        </TabsBar>
         {TOOL_TABS.filter(([tabTool]) => availableTabs.includes(tabTool)).map(([tabTool, View]) => (
           <TabsContent key={tabTool} value={tabTool} className="mt-6">
             <Suspense fallback={tabFallback}>

--- a/frontend/src/pages/InitiativeSettingsPage.tsx
+++ b/frontend/src/pages/InitiativeSettingsPage.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useInitiativeRoles } from "@/hooks/useInitiativeRoles";
@@ -242,14 +242,14 @@ export const InitiativeSettingsPage = () => {
       </div>
 
       <Tabs defaultValue="details" className="space-y-4">
-        <TabsList className="w-full max-w-xl justify-start">
+        <TabsBar>
           <TabsTrigger value="details">{t("settings.detailsTab")}</TabsTrigger>
           <TabsTrigger value="members">{t("settings.membersTab")}</TabsTrigger>
           <TabsTrigger value="roles">{t("settings.rolesTab")}</TabsTrigger>
           <TabsTrigger value="properties">{t("properties:manager.title")}</TabsTrigger>
           {canManageMembers && <TabsTrigger value="export">{t("settings.exportTab")}</TabsTrigger>}
           <TabsTrigger value="danger">{t("settings.dangerTab")}</TabsTrigger>
-        </TabsList>
+        </TabsBar>
         <InitiativeSettingsDetailsTab
           name={name}
           setName={setName}

--- a/frontend/src/pages/TagDetailPage.tsx
+++ b/frontend/src/pages/TagDetailPage.tsx
@@ -28,7 +28,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ColorPickerPopover } from "@/components/ui/color-picker-popover";
 import { Input } from "@/components/ui/input";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { useDeleteTag, useTag, useTagEntities, useUpdateTag } from "@/hooks/useTags";
 import { toast } from "@/lib/chesterToast";
 import { DocumentsView } from "@/pages/DocumentsPage";
@@ -202,7 +202,7 @@ export const TagDetailPage = () => {
 
       {/* Tabbed Content */}
       <Tabs defaultValue="tasks" className="space-y-4">
-        <TabsList>
+        <TabsBar>
           <TabsTrigger value="tasks" className="inline-flex items-center gap-2">
             <SquareCheckBig className="h-4 w-4" />
             {t("detail.tasksTab", { count: taskCount })}
@@ -215,7 +215,7 @@ export const TagDetailPage = () => {
             <ScrollText className="h-4 w-4" />
             {t("detail.documentsTab", { count: documentCount })}
           </TabsTrigger>
-        </TabsList>
+        </TabsBar>
         <TabsContent value="tasks">
           <TagTasksTable tagId={parsedTagId} />
         </TabsContent>

--- a/frontend/src/pages/user/GlobalTasksPage.tsx
+++ b/frontend/src/pages/user/GlobalTasksPage.tsx
@@ -186,7 +186,7 @@ export const GlobalTasksPage = ({
   return (
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="flex items-center justify-between">
             <div>
               <h1 className="font-semibold text-3xl tracking-tight">{t(`${i18nPrefix}.title`)}</h1>

--- a/frontend/src/pages/user/GlobalTasksPage.tsx
+++ b/frontend/src/pages/user/GlobalTasksPage.tsx
@@ -186,31 +186,33 @@ export const GlobalTasksPage = ({
   return (
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="font-semibold text-3xl tracking-tight">{t(`${i18nPrefix}.title`)}</h1>
-            <p className="text-muted-foreground">{t(`${i18nPrefix}.subtitle`)}</p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="font-semibold text-3xl tracking-tight">{t(`${i18nPrefix}.title`)}</h1>
+              <p className="text-muted-foreground">{t(`${i18nPrefix}.subtitle`)}</p>
+            </div>
           </div>
-        </div>
 
-        <ToolListToolbar
-          filters={
-            // The calendar view reads none of these task-table filters.
-            viewMode === "table"
-              ? {
-                  open: table.filtersOpen,
-                  onOpenChange: table.setFiltersOpen,
-                  activeCount: table.activeFilterCount,
-                }
-              : undefined
-          }
-          view={{
-            value: viewMode,
-            onChange: setViewMode,
-            options: viewOptions,
-            label: t("common:toolbar.view"),
-          }}
-        />
+          <ToolListToolbar
+            filters={
+              // The calendar view reads none of these task-table filters.
+              viewMode === "table"
+                ? {
+                    open: table.filtersOpen,
+                    onOpenChange: table.setFiltersOpen,
+                    activeCount: table.activeFilterCount,
+                  }
+                : undefined
+            }
+            view={{
+              value: viewMode,
+              onChange: setViewMode,
+              options: viewOptions,
+              label: t("common:toolbar.view"),
+            }}
+          />
+        </div>
 
         {showFocus ? (
           <FocusSummary

--- a/frontend/src/pages/user/MyDocumentsPage.tsx
+++ b/frontend/src/pages/user/MyDocumentsPage.tsx
@@ -270,18 +270,20 @@ export const MyDocumentsPage = () => {
   return (
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
-        <div>
-          <h1 className="font-semibold text-3xl tracking-tight">{t("myDocuments.title")}</h1>
-          <p className="text-muted-foreground">{t("myDocuments.subtitle")}</p>
-        </div>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="font-semibold text-3xl tracking-tight">{t("myDocuments.title")}</h1>
+            <p className="text-muted-foreground">{t("myDocuments.subtitle")}</p>
+          </div>
 
-        <ToolListToolbar
-          filters={{
-            open: filtersOpen,
-            onOpenChange: setFiltersOpen,
-            activeCount: activeFilterCount,
-          }}
-        />
+          <ToolListToolbar
+            filters={{
+              open: filtersOpen,
+              onOpenChange: setFiltersOpen,
+              activeCount: activeFilterCount,
+            }}
+          />
+        </div>
 
         <ToolFilterPanel
           open={filtersOpen}

--- a/frontend/src/pages/user/MyDocumentsPage.tsx
+++ b/frontend/src/pages/user/MyDocumentsPage.tsx
@@ -270,7 +270,7 @@ export const MyDocumentsPage = () => {
   return (
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div>
             <h1 className="font-semibold text-3xl tracking-tight">{t("myDocuments.title")}</h1>
             <p className="text-muted-foreground">{t("myDocuments.subtitle")}</p>

--- a/frontend/src/pages/user/MyProjectsPage.tsx
+++ b/frontend/src/pages/user/MyProjectsPage.tsx
@@ -320,7 +320,7 @@ export const MyProjectsPage = () => {
   return (
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div>
             <h1 className="font-semibold text-3xl tracking-tight">{t("myProjects.title")}</h1>
             <p className="text-muted-foreground">{t("myProjects.subtitle")}</p>

--- a/frontend/src/pages/user/MyProjectsPage.tsx
+++ b/frontend/src/pages/user/MyProjectsPage.tsx
@@ -320,18 +320,20 @@ export const MyProjectsPage = () => {
   return (
     <PullToRefresh onRefresh={handleRefresh}>
       <div className="space-y-6">
-        <div>
-          <h1 className="font-semibold text-3xl tracking-tight">{t("myProjects.title")}</h1>
-          <p className="text-muted-foreground">{t("myProjects.subtitle")}</p>
-        </div>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="font-semibold text-3xl tracking-tight">{t("myProjects.title")}</h1>
+            <p className="text-muted-foreground">{t("myProjects.subtitle")}</p>
+          </div>
 
-        <ToolListToolbar
-          filters={{
-            open: filtersOpen,
-            onOpenChange: setFiltersOpen,
-            activeCount: activeFilterCount,
-          }}
-        />
+          <ToolListToolbar
+            filters={{
+              open: filtersOpen,
+              onOpenChange: setFiltersOpen,
+              activeCount: activeFilterCount,
+            }}
+          />
+        </div>
 
         <ToolFilterPanel
           open={filtersOpen}

--- a/frontend/src/pages/user/MyStatsPage.tsx
+++ b/frontend/src/pages/user/MyStatsPage.tsx
@@ -33,7 +33,7 @@ export function MyStatsPage() {
   };
 
   return (
-    <div className="container mx-auto space-y-6 p-6">
+    <div className="space-y-6">
       {/* Header with Guild filter */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { useUpdateCurrentUser } from "@/hooks/useUsers";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
@@ -256,10 +256,10 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
                 value={avatarMode}
                 onValueChange={(value) => setAvatarMode(value as "upload" | "url")}
               >
-                <TabsList>
+                <TabsBar>
                   <TabsTrigger value="upload">{t("profile.avatarUploadTab")}</TabsTrigger>
                   <TabsTrigger value="url">{t("profile.avatarUrlTab")}</TabsTrigger>
-                </TabsList>
+                </TabsBar>
                 <TabsContent value="upload" className="space-y-2">
                   <Input type="file" accept="image/*" onChange={handleAvatarUpload} />
                   {avatarBase64 ? (


### PR DESCRIPTION
## Problem

Every tab bar in the app sized itself differently:

- the initiative tool tabs hugged their labels (`inline-flex w-max`) behind an ad-hoc scroller
- the settings and tool-settings bars stopped at `max-w-xl`
- the tag detail and avatar-source bars were content width
- the dialogs each re-derived "full width" their own way — `grid grid-cols-3` in one, `w-full` plus per-trigger `flex-1` in others, `w-full` on both list and trigger in a third
- the settings nav added a mobile `-mx-4` bleed that no other bar had

Same control, five different layouts, and no shared place to change it.

## Changes

- Add `TabsBar` to [tabs.tsx](frontend/src/components/ui/tabs.tsx) — a `TabsList` in a hidden-scrollbar horizontal scroller. It spans its container (`w-full`), keeps triggers at their label width and left-aligned (`justify-start`), and scrolls sideways rather than shrinking labels once they overflow (`min-w-max` + `overflow-x-auto`). Takes an optional `containerClassName` for per-site spacing on the scroller.
- Route every navigation-style bar through it, dropping the per-trigger `flex-1` / `w-full` / `shrink-0` overrides:
  - [InitiativeDetailPage.tsx](frontend/src/pages/InitiativeDetailPage.tsx) — initiative tool tabs
  - [SettingsTabsNav.tsx](frontend/src/components/settings/SettingsTabsNav.tsx) — guild, platform, user and admin settings layouts
  - [ToolSettingsPage.tsx](frontend/src/components/tools/settings/ToolSettingsPage.tsx), [InitiativeSettingsPage.tsx](frontend/src/pages/InitiativeSettingsPage.tsx) — `max-w-xl` cap removed
  - [TagDetailPage.tsx](frontend/src/pages/TagDetailPage.tsx), [UserSettingsProfilePage.tsx](frontend/src/pages/user/settings/UserSettingsProfilePage.tsx)
  - [AppSidebar.tsx](frontend/src/components/AppSidebar.tsx) — Initiatives/Tags switch, keeps `h-9 rounded-none` so it stays flush to the rail
  - [DocumentSidePanel.tsx](frontend/src/components/documents/DocumentSidePanel.tsx), [CreateDocumentDialog.tsx](frontend/src/components/documents/CreateDocumentDialog.tsx), [BulkEditAccessDialog.tsx](frontend/src/components/access/BulkEditAccessDialog.tsx), [BulkEditTagsDialog.tsx](frontend/src/components/shared/BulkEditTagsDialog.tsx), [images-plugin.tsx](frontend/src/components/ui/editor/plugins/images-plugin.tsx)
- **Deliberately unchanged:** the tool-list view switchers in [ToolListToolbar.tsx](frontend/src/components/initiativeTools/shared/ToolListToolbar.tsx) and [ProjectTasksSection.tsx](frontend/src/components/projects/ProjectTasksSection.tsx) keep a bare `TabsList`. They are inline segmented controls sitting in a toolbar and have to stay sized to their icons.
- Also carries in-progress personal-space header work already in the tree ([GlobalTasksPage](frontend/src/pages/user/GlobalTasksPage.tsx), [MyDocumentsPage](frontend/src/pages/user/MyDocumentsPage.tsx), [MyProjectsPage](frontend/src/pages/user/MyProjectsPage.tsx), [MyStatsPage](frontend/src/pages/user/MyStatsPage.tsx)), which moves each list toolbar inline with its page heading. Its changelog entry was already present.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check <17 changed files>` — clean
- `cd frontend && ./scripts/test-changed.sh` — 146 files, 1710 tests, all passing

UI-only change with no test coverage of its own; the bars were verified against the existing page/dialog suites.