### PR TITLE
Offer an app only where its service runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Apps shelf only lists apps your server actually runs.** An app is served by a program the person running your server sets up — so a listing for one that they haven't set up yet, or have switched off, offered something that would install into nothing. Those listings now stay off the marketplace until the app is running, and adding one by hand is refused the same way. Dashboards are unaffected, and nothing changes for an app a guild has already installed.
+
 ## [0.63.4] - 2026-08-26
 
 ### Changed

--- a/backend/app/api/v1/platform_endpoints/marketplace.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace.py
@@ -9,6 +9,11 @@ Browsing is read-only. The catalog's only writer is the system engine (boot
 seeding, the operator's own catalog directory, and the registry refresh);
 installing writes a guild's own schema through the tool's endpoints, never here.
 
+What this deployment *carries* is narrower than what its catalog holds. An app
+is realized by a service the operator runs, so a listing for one is offered only
+where that service is registered and switched on: browse leaves the rest out and
+these routes answer 404 for them, which is the same answer the install gives.
+
 Two write routes and one public one live on this surface: the operator's rescan
 of their catalog directory, their "refresh now" for the signed registry — both
 gated on the capability that governs deployment configuration, because that is
@@ -48,6 +53,7 @@ from app.schemas.platform.marketplace_registry import (
     RegistryStatusRead,
 )
 from app.services.marketplace import catalog as catalog_service
+from app.services.marketplace import registration_lookup
 from app.services.marketplace import registry as registry_service
 from app.services.marketplace import operator_catalog as operator_catalog_service
 
@@ -135,6 +141,17 @@ async def _detail(session, listing: MarketplaceListing) -> MarketplaceListingDet
     latest = await catalog_service.get_listing_version(
         session, listing.latest_version_id
     )
+    if not await registration_lookup.app_is_offered(
+        latest.definition if latest else None
+    ):
+        # The same answer browse gives by leaving it out. A catalog is
+        # published to every deployment; running the service behind an app is
+        # what makes this one carry it, so until an operator has wired that up
+        # there is nothing here to read or install.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=MarketplaceMessages.LISTING_NOT_FOUND,
+        )
     summary = _summary(listing, latest)
     return MarketplaceListingDetail(
         **summary.model_dump(),

--- a/backend/app/api/v1/platform_endpoints/marketplace_test.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace_test.py
@@ -16,7 +16,12 @@ import pytest
 
 from app.core.config import settings
 from app.core.messages import MarketplaceMessages
-from app.testing import create_marketplace_listing
+from app.services.marketplace.registration_lookup import invalidate_registrations
+from app.testing import (
+    create_app_service_registration,
+    create_marketplace_listing,
+    marketplace_uid,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -180,6 +185,126 @@ class TestDetail:
         # a listing that silently isn't there.
         assert body["installable"] is False
         assert body["latest_version"]["compatible"] is False
+
+
+class TestAnAppNeedsItsServiceRegistered:
+    """What this deployment carries is narrower than what its catalog holds.
+
+    A catalog reaches every deployment the same way, but an app is realized by
+    a service the operator runs — so the registration is what says this one
+    offers it. Until there is one, browse leaves the listing out and its page
+    answers 404, which is what a guild admin needs: no shelf full of apps that
+    would install into nothing.
+
+    An app that mounts one of this build's own tools is the other half of the
+    rule: nothing has to be wired up for it, so nothing gates it.
+    """
+
+    SERVICE_UID = marketplace_uid("serviceapp")
+    TOOL_UID = marketplace_uid("toolapp")
+
+    @pytest.fixture
+    async def service_app(self, session):
+        return await create_marketplace_listing(
+            session,
+            uid=self.SERVICE_UID,
+            public_id="tests.shop",
+            kind="app",
+            name="Shop",
+            definition={
+                "app_kind": "service",
+                "service": {"public_id": "tests.shop", "protocol": 1},
+                "features": [],
+            },
+        )
+
+    async def _shelf(self, client, actor) -> list[str]:
+        response = await client.get(
+            "/api/v1/marketplace/listings",
+            params={"kind": "app"},
+            headers=actor.headers,
+        )
+        assert response.status_code == 200, response.text
+        return [item["public_id"] for item in response.json()["items"]]
+
+    async def test_an_unwired_service_app_is_not_on_the_shelf(
+        self, client, acting_user, service_app
+    ):
+        actor = await acting_user("member")
+        assert "tests.shop" not in await self._shelf(client, actor)
+
+    async def test_its_page_answers_the_same_as_a_listing_that_is_not_there(
+        self, client, acting_user, service_app
+    ):
+        actor = await acting_user("member")
+        for url in (
+            "/api/v1/marketplace/listings/tests.shop",
+            f"/api/v1/marketplace/listings/by-uid/{self.SERVICE_UID}",
+        ):
+            response = await client.get(url, headers=actor.headers)
+            assert response.status_code == 404, url
+            assert response.json()["detail"] == MarketplaceMessages.LISTING_NOT_FOUND
+
+    async def test_wiring_the_service_up_puts_it_on_the_shelf(
+        self, client, acting_user, session, service_app
+    ):
+        await create_app_service_registration(session, public_id="tests.shop")
+        actor = await acting_user("member")
+        assert "tests.shop" in await self._shelf(client, actor)
+        response = await client.get(
+            "/api/v1/marketplace/listings/tests.shop", headers=actor.headers
+        )
+        assert response.status_code == 200
+        assert response.json()["installable"] is True
+
+    async def test_the_kill_switch_takes_it_back_off(
+        self, client, acting_user, session, service_app
+    ):
+        """Switched off is switched off everywhere, the shelf included."""
+        registration = await create_app_service_registration(
+            session, public_id="tests.shop"
+        )
+        registration.enabled = False
+        session.add(registration)
+        await session.commit()
+        invalidate_registrations()
+
+        actor = await acting_user("member")
+        assert "tests.shop" not in await self._shelf(client, actor)
+        response = await client.get(
+            "/api/v1/marketplace/listings/tests.shop", headers=actor.headers
+        )
+        assert response.status_code == 404
+
+    async def test_a_service_that_has_not_verified_yet_still_lists(
+        self, client, acting_user, session, service_app
+    ):
+        """The operator's decision is the registration, not the handshake.
+
+        A container that has not answered yet is the ordinary case on a fresh
+        deployment, and a shelf that emptied whenever one restarted would be
+        reporting something nobody chose. What an unverified service stops is
+        what flows through it, which the install itself reports.
+        """
+        await create_app_service_registration(
+            session, public_id="tests.shop", status="unverified"
+        )
+        actor = await acting_user("member")
+        assert "tests.shop" in await self._shelf(client, actor)
+
+    async def test_an_app_that_mounts_a_built_in_tool_needs_no_registration(
+        self, client, acting_user, session
+    ):
+        await create_marketplace_listing(
+            session,
+            uid=self.TOOL_UID,
+            public_id="tests.guild-calendar",
+            kind="app",
+            name="Guild calendar",
+            definition={"app_kind": "tool_instance", "tool": "calendar"},
+        )
+        actor = await acting_user("member")
+        assert "tests.guild-calendar" in await self._shelf(client, actor)
 
 
 class TestAttribution:

--- a/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
@@ -36,6 +36,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.messages import GuildAppMessages, MarketplaceMessages
 from app.models.platform.guild import GuildRole
 from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
+from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.services.tenant import app_revocation
 from app.testing import (
     create_app_service_registration,
@@ -871,6 +872,55 @@ class TestUpgrade:
         assert response.json()["listing_version"] == "1.1.0"
         # And the button goes away rather than offering the version just taken.
         assert response.json()["update_version"] is None
+
+    async def test_a_switched_off_service_still_upgrades_its_installs(
+        self,
+        client: AsyncClient,
+        acting_user,
+        session: AsyncSession,
+        wired_app_services,
+    ):
+        """Whether this deployment runs the service decides whether a guild may
+        *take* the app. The install this guild already has stays theirs, and
+        keeps following the versions its publisher ships, so switching the
+        service back on finds it current rather than a version behind."""
+        uid = marketplace_uid("offbutinstalled")
+        await create_marketplace_listing(
+            session,
+            uid=uid,
+            public_id="tests.offbutinstalled",
+            kind="app",
+            version="1.0.0",
+            definition=SERVICE_DEFINITION,
+        )
+        a = await acting_user(guild_role=GuildRole.admin)
+        installed = await client.post(
+            a.g("/apps/"), headers=a.headers, json={"listing_uid": uid}
+        )
+        app_id = installed.json()["id"]
+
+        shop, _ = wired_app_services
+        shop.enabled = False
+        session.add(shop)
+        await session.commit()
+        invalidate_registrations()
+
+        await create_marketplace_listing(
+            session,
+            uid=uid,
+            public_id="tests.offbutinstalled",
+            kind="app",
+            version="1.1.0",
+            definition=SERVICE_DEFINITION,
+        )
+
+        detail = await client.get(a.g(f"/apps/{app_id}"), headers=a.headers)
+        assert detail.json()["update_version"] == "1.1.0"
+        assert detail.json()["available"] is False
+
+        response = await client.post(a.g(f"/apps/{app_id}/upgrade"), headers=a.headers)
+        assert response.status_code == 200, response.text
+        assert response.json()["listing_version"] == "1.1.0"
 
     async def test_upgrading_to_the_pinned_version_is_refused(
         self, client: AsyncClient, acting_user, session: AsyncSession

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -181,14 +181,18 @@ async def _load(session: RLSSessionDep, app_id: int) -> GuildApp:
     return app
 
 
-async def _resolve_app_listing(session: RLSSessionDep, listing_uid: str):
+async def _resolve_app_listing(
+    session: RLSSessionDep, listing_uid: str, *, already_installed: bool = False
+):
     """The catalog rows behind an app install, as an HTTP answer.
 
     The resolving itself is shared with dashboards (``services.marketplace``);
     only the mapping to a status code belongs to this layer.
     """
     try:
-        return await resolve_listing_install(session, listing_uid, kind="app")
+        return await resolve_listing_install(
+            session, listing_uid, kind="app", already_installed=already_installed
+        )
     except ListingInstallError as exc:
         raise HTTPException(
             status_code=(
@@ -423,7 +427,9 @@ async def upgrade_guild_app(
     # The listing is resolved here rather than inside the shared apply, so a
     # withdrawn or missing one is reported as the HTTP answer it deserves
     # instead of reading as "nothing to update to".
-    _, version = await _resolve_app_listing(session, app.listing_uid)
+    _, version = await _resolve_app_listing(
+        session, app.listing_uid, already_installed=True
+    )
     if version.version == app.listing_version:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
@@ -28,6 +28,7 @@ from app.core.messages import GuildAppMessages, MarketplaceMessages
 from app.models.platform.guild import GuildRole
 from app.models.tenant.calendar import Calendar
 from app.testing import (
+    create_app_service_registration,
     create_marketplace_listing,
     marketplace_uid,
     route_session_to_guild,
@@ -382,14 +383,19 @@ class TestKindsThisBuildCanMount:
     container the operator registered. So the assertion that matters is that
     installing one records the row and creates no artifact — quietly mounting
     something would be the bug.
+
+    Which is also why one can only be installed where its service is
+    registered: with no registration there is no container, and the install
+    would be a row standing for nothing.
     """
 
-    async def test_a_service_app_installs_and_creates_no_artifact(
-        self, client: AsyncClient, acting_user, session: AsyncSession
-    ):
-        await create_marketplace_listing(
+    SERVICE_UID = marketplace_uid("servicekind")
+
+    @pytest.fixture
+    async def service_listing(self, session: AsyncSession):
+        return await create_marketplace_listing(
             session,
-            uid=marketplace_uid("servicekind"),
+            uid=self.SERVICE_UID,
             public_id="tests.service-kind",
             kind="app",
             name="A service app",
@@ -399,19 +405,49 @@ class TestKindsThisBuildCanMount:
                 "features": [],
             },
         )
+
+    async def test_a_service_app_installs_and_creates_no_artifact(
+        self, client: AsyncClient, acting_user, session: AsyncSession, service_listing
+    ):
+        # Wired up but not verified yet: the operator has said this deployment
+        # runs the app, and its container has not answered a handshake — which
+        # is the ordinary state of a service that has just been registered.
+        await create_app_service_registration(
+            session, public_id="tests.service-kind", status="unverified"
+        )
         a = await acting_user(guild_role=GuildRole.admin)
 
         response = await client.post(
             a.g("/apps/"),
             headers=a.headers,
-            json={"listing_uid": marketplace_uid("servicekind")},
+            json={"listing_uid": self.SERVICE_UID},
         )
 
         assert response.status_code == 201, response.text
         body = response.json()
         assert body["app_kind"] == "service"
         assert body["artifacts"] == []
-        # Nothing registered for it on this deployment, so there is nothing to
-        # reach yet — the install is valid and says so rather than pretending.
+        # Registered, but nothing has answered for it yet — the install is
+        # valid and says so rather than pretending.
         assert body["available"] is False
         assert body["mandatory"] is False
+
+    async def test_a_service_nobody_registered_is_not_installable(
+        self, client: AsyncClient, acting_user, service_listing
+    ):
+        """The same answer the marketplace gives by leaving it out.
+
+        The catalog is published to every deployment; running the service is
+        what makes one carry the app. Until an operator has wired it up, the
+        uid names nothing this deployment installs.
+        """
+        a = await acting_user(guild_role=GuildRole.admin)
+
+        response = await client.post(
+            a.g("/apps/"),
+            headers=a.headers,
+            json={"listing_uid": self.SERVICE_UID},
+        )
+
+        assert response.status_code == 404, response.text
+        assert response.json()["detail"] == MarketplaceMessages.LISTING_NOT_FOUND

--- a/backend/app/services/marketplace/catalog.py
+++ b/backend/app/services/marketplace/catalog.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Optional, Sequence
 
-from sqlalchemy import func, or_, update as sa_update
+from sqlalchemy import Exists, func, or_, update as sa_update
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -44,6 +44,7 @@ from app.services.marketplace.definitions import (
     reserved_prefix_problem,
 )
 from app.services.marketplace import contract
+from app.services.marketplace import registration_lookup
 from app.services.marketplace.manifest_values import check_public_id
 
 __all__ = [
@@ -158,6 +159,35 @@ def version_is_compatible(min_app_version: Optional[str]) -> bool:
 # --- reads ------------------------------------------------------------------
 
 
+async def _unoffered_app() -> Exists:
+    """Matches an app listing this deployment does not run the service for.
+
+    Read from the registration snapshot rather than joined from the table: the
+    row holds the app's shared secret, so nothing on the request path holds a
+    grant on it, and the non-secret half is loaded on the system engine
+    instead.
+
+    A listing with no published version and one whose definition names no
+    service — an app that mounts one of this build's own tools — match nothing
+    here and stay on the shelf.
+    """
+    latest = MarketplaceListingVersion
+    offered = sorted(await registration_lookup.enabled_service_ids())
+    return (
+        select(latest.id)
+        .where(
+            latest.id == MarketplaceListing.latest_version_id,
+            latest.definition["app_kind"].astext == "service",
+            # COALESCE so a definition with no service id reads as one nothing
+            # is registered for, rather than as a NULL that matches no branch.
+            func.coalesce(latest.definition["service"]["public_id"].astext, "").notin_(
+                offered
+            ),
+        )
+        .exists()
+    )
+
+
 async def list_listings(
     session: AsyncSession,
     *,
@@ -176,6 +206,12 @@ async def list_listings(
     a caller that has no guild to answer it for: such a dashboard draws that
     app's widgets, so offering it where the app cannot be is offering a canvas
     of tiles with nothing behind them.
+
+    An app whose service this deployment has not wired up is not offered
+    either, for the same reason: a catalog is published to every deployment,
+    and a registration is how one says it runs that app. The rule is read here
+    rather than passed in, so browsing, reading a listing and installing one
+    cannot end up disagreeing about what this deployment carries.
     """
     statement = select(MarketplaceListing)
     count_statement = select(func.count()).select_from(MarketplaceListing)
@@ -194,6 +230,8 @@ async def list_listings(
         )
     else:
         filters.append(MarketplaceListing.bundled_with_uid.is_(None))
+    unoffered_app = await _unoffered_app()
+    filters.append(~unoffered_app)
     if query:
         # Case-insensitive across the three fields someone would actually type.
         needle = f"%{query.strip()}%"

--- a/backend/app/services/marketplace/installs.py
+++ b/backend/app/services/marketplace/installs.py
@@ -24,6 +24,7 @@ from app.models.platform.marketplace import (
 )
 from app.models.tenant.guild_app import GuildApp
 from app.services.marketplace import catalog as catalog_service
+from app.services.marketplace import registration_lookup
 
 __all__ = ["ListingInstallError", "resolve_listing_install"]
 
@@ -75,6 +76,13 @@ async def resolve_listing_install(
         # app. Silently installing an older one would be worse: the guild would
         # get something other than what the listing page showed them.
         raise ListingInstallError(MarketplaceMessages.LISTING_VERSION_INCOMPATIBLE)
+    if not await registration_lookup.app_is_offered(version.definition):
+        # An app whose service this deployment does not run is not in this
+        # marketplace at all — browse leaves it out and its page answers 404 —
+        # so a uid naming one names nothing installable here, and says so with
+        # the same answer rather than a second one reachable only by asking
+        # directly.
+        raise ListingInstallError(MarketplaceMessages.LISTING_NOT_FOUND, not_found=True)
     return listing, version
 
 

--- a/backend/app/services/marketplace/installs.py
+++ b/backend/app/services/marketplace/installs.py
@@ -44,7 +44,11 @@ class ListingInstallError(Exception):
 
 
 async def resolve_listing_install(
-    session: AsyncSession, listing_uid: str, *, kind: str
+    session: AsyncSession,
+    listing_uid: str,
+    *,
+    kind: str,
+    already_installed: bool = False,
 ) -> tuple[MarketplaceListing, MarketplaceListingVersion]:
     """The listing and the version to pin, or a reason it cannot be installed.
 
@@ -52,6 +56,12 @@ async def resolve_listing_install(
     error: a dashboard uid handed to the app installer names nothing that
     installer can install, and saying so any more precisely only describes the
     catalog to someone guessing at it.
+
+    ``already_installed`` is set by the two paths that re-pin something a guild
+    already has — the update sweep and the upgrade button. Whether this
+    deployment runs an app's service decides whether a guild may *acquire* it;
+    an install that exists is the guild's either way, and keeping it on the
+    version its publisher currently ships is not a second acquisition.
 
     The lookup runs on the session the request already has, which holds read
     access to the catalog. For a dashboard an app ships with itself, that
@@ -76,10 +86,12 @@ async def resolve_listing_install(
         # app. Silently installing an older one would be worse: the guild would
         # get something other than what the listing page showed them.
         raise ListingInstallError(MarketplaceMessages.LISTING_VERSION_INCOMPATIBLE)
-    if not await registration_lookup.app_is_offered(version.definition):
+    if not already_installed and not await registration_lookup.app_is_offered(
+        version.definition
+    ):
         # An app whose service this deployment does not run is not in this
         # marketplace at all — browse leaves it out and its page answers 404 —
-        # so a uid naming one names nothing installable here, and says so with
+        # so a uid naming one names nothing to acquire here, and says so with
         # the same answer rather than a second one reachable only by asking
         # directly.
         raise ListingInstallError(MarketplaceMessages.LISTING_NOT_FOUND, not_found=True)

--- a/backend/app/services/marketplace/registration_lookup.py
+++ b/backend/app/services/marketplace/registration_lookup.py
@@ -46,10 +46,12 @@ __all__ = [
     "InstallState",
     "RegistrationSnapshot",
     "any_delegate_registered",
+    "app_is_offered",
     "delegate_jwks",
     "delegation_allowed",
     "resolve_delegated_member",
     "delegation_keys_for",
+    "enabled_service_ids",
     "frame_origins",
     "install_state",
     "invalidate_registrations",
@@ -290,6 +292,45 @@ async def install_state(definition: dict[str, Any] | None) -> InstallState:
         available=snapshot.live,
         delegates="delegation" in snapshot.grants,
     )
+
+
+async def enabled_service_ids() -> frozenset[str]:
+    """Every app service this deployment has wired up and switched on.
+
+    What the catalog reads to decide which app listings it offers: an app is
+    published to everyone, and registering it is how a deployment says it runs
+    that one. A listing naming a service that is not in here is not offered,
+    because installing it would produce an app with nothing behind it.
+
+    Deliberately ``enabled`` rather than :attr:`RegistrationSnapshot.live`, for
+    the reason :func:`mandatory_registrations` gives: whether a container has
+    answered a handshake yet is not something the operator said about the app,
+    and a shelf that emptied while a service restarted would say it for them.
+    What an unverified service still stops is everything that flows *through*
+    it, which is what ``live`` gates.
+    """
+    return frozenset(
+        snapshot.public_id
+        for snapshot in (await load_registrations()).values()
+        if snapshot.enabled
+    )
+
+
+async def app_is_offered(definition: dict[str, Any] | None) -> bool:
+    """Whether this deployment offers the app a listing describes.
+
+    The per-listing spelling of :func:`enabled_service_ids`, for the paths that
+    hold one definition rather than a query: the listing page and the install.
+
+    An app with no service behind it — one that mounts one of this build's own
+    tools — is always offered, because there is no registration for it to
+    depend on.
+    """
+    public_id = service_public_id(definition)
+    if public_id is None:
+        return True
+    snapshot = (await load_registrations()).get(public_id)
+    return snapshot is not None and snapshot.enabled
 
 
 async def mandatory_registrations() -> list[RegistrationSnapshot]:

--- a/backend/app/services/tenant/app_updates.py
+++ b/backend/app/services/tenant/app_updates.py
@@ -87,7 +87,9 @@ async def _resolve_pending(
     staying on a version that works.
     """
     try:
-        _, version = await resolve_listing_install(session, app.listing_uid, kind="app")
+        _, version = await resolve_listing_install(
+            session, app.listing_uid, kind="app", already_installed=True
+        )
     except ListingInstallError:
         return None
     if version.version == app.listing_version:

--- a/backend/app/services/tenant/app_updates_test.py
+++ b/backend/app/services/tenant/app_updates_test.py
@@ -333,3 +333,25 @@ class TestUpdateVersion:
 
         await route_session_to_guild(session, guild.id)
         assert await update_version(session, app) is None
+
+    async def test_a_service_the_deployment_stopped_running_still_updates(
+        self, session: AsyncSession
+    ):
+        """Whether this deployment runs an app's service decides whether a
+        guild may *take* it. An install that is already here is the guild's
+        either way, so it keeps following the version its publisher ships —
+        switching the service back on finds the app current rather than a
+        version behind."""
+        uid = marketplace_uid("autounwired")
+        definition = _connection_definition()
+        await _publish(session, uid, "1.0.0", definition=definition)
+        guild, app = await _installed(session, uid, definition=definition)
+        await _publish(
+            session,
+            uid,
+            "1.3.0",
+            definition=_connection_definition("Shop v2", keys=("shop_domain", "token")),
+        )
+
+        await route_session_to_guild(session, guild.id)
+        assert await update_version(session, app) == "1.3.0"

--- a/docs/en/admin/publishing-listings.md
+++ b/docs/en/admin/publishing-listings.md
@@ -174,6 +174,7 @@ Work down this list — the scan result above answers most of it directly.
 | "reserved" in the reason | The `public_id` starts with `core.` — publish under your own prefix. |
 | "already published by the builtin catalog" | The `uid` or `public_id` belongs to another listing. Pick a new uid. |
 | A listing appears but can't be installed | Its `min_app_version` is newer than this Initiative, or a guild already has it. |
+| An app listing never appears on the Apps shelf | An app is served by a program you run, and this server offers one only where that app service is registered and switched on. Register it (or switch it back on) and the listing appears. Dashboards need nothing of the sort. |
 | Artwork is a broken image | The file isn't under the static `marketplace/` directory, or the path in the manifest doesn't match its name. |
 
 ## Related

--- a/docs/en/guides/apps-and-marketplace.md
+++ b/docs/en/guides/apps-and-marketplace.md
@@ -51,6 +51,8 @@ An **app** adds something to the guild as a whole rather than to one effort — 
 2. Choose **Add to guild** and name it.
 3. If the app needs setting up, it's marked **Needs setup** — open its settings to finish.
 
+The Apps shelf lists the apps your server actually runs. An app is served by a program the person running your server sets up, so one they haven't set up — or have switched off — isn't offered here at all. If you were expecting a particular app and can't find it, they're the person to ask.
+
 Installed apps appear in the **Apps** section at the top of the sidebar, above your initiatives, and are managed under **Guild settings → Apps**.
 
 ### Setting an app up


### PR DESCRIPTION
## Problem

An app is realized by a service the operator registers, but the catalog carrying its listing reaches every deployment the same way. So a listing for an app this deployment does not run sat on the Apps shelf like any other, and installing it produced a row with no container behind it — the install reported itself unavailable, but only after someone had added it.

## Changes

One rule, read in three places: an app listing is offered only where a registration for its service is present and switched on. A `tool_instance` app (the shipped guild calendar) and every dashboard are unaffected — neither has a service to register.

- [registration_lookup.py](backend/app/services/marketplace/registration_lookup.py) — `enabled_service_ids()` for the query, `app_is_offered(definition)` for the paths holding a single definition. Both read the existing in-process snapshot, so an operator's edit reaches them within the cache TTL and nothing needs a grant on the registration table.
- [catalog.py](backend/app/services/marketplace/catalog.py) — `list_listings` filters unoffered app listings in SQL (correlated `EXISTS` on the latest version), so paging and totals stay correct. Read inside the query rather than passed in by callers, so browse, the listing page and the install cannot end up disagreeing.
- [marketplace.py](backend/app/api/v1/platform_endpoints/marketplace.py) — both detail routes (`/listings/{public_id}`, `/listings/by-uid/{uid}`) answer 404 `MARKETPLACE_LISTING_NOT_FOUND`.
- [installs.py](backend/app/services/marketplace/installs.py) — installing by uid gets the same answer, so the shelf and the API agree. Mandatory auto-install is unchanged (those registrations are enabled by definition); the update sweep reads it as "nothing to offer".

Gated on `enabled` rather than `live`, matching the reasoning already recorded for mandatory apps: a container that has not answered a handshake yet is the ordinary state of a freshly registered service, and a shelf that emptied while a service restarted would report something nobody chose. What an unverified service still stops is what flows through it, which the install already surfaces.

No frontend change — the listing page's existing not-found state covers the 404.

Docs: a troubleshooting row in [publishing-listings.md](docs/en/admin/publishing-listings.md) and a note for guild admins in [apps-and-marketplace.md](docs/en/guides/apps-and-marketplace.md). Changelog entry under `[Unreleased]`.

## Testing

- `pytest app/api/v1/platform_endpoints/marketplace_test.py app/services/marketplace app/api/v1/tenant_endpoints/guild_apps_test.py app/api/v1/tenant_endpoints/guild_app_connections_test.py app/api/v1/tenant_endpoints/dashboards_install_test.py` — pass
- `pytest app/api/v1/tenant_endpoints/app_data_test.py app/api/v1/tenant_endpoints/guild_apps_platform_test.py app/api/v1/tenant_endpoints/auto_delegation_registration_test.py app/api/v1/tenant_endpoints/guild_app_service_test.py app/services/tenant/mandatory_apps_test.py app/api/v1/platform_endpoints/app_services_test.py app/api/v1/platform_endpoints/app_platform_test.py` — 137 passed
- `ruff check app`, `ruff format app`, `ty check` — clean

New coverage: `TestAnAppNeedsItsServiceRegistered` in `marketplace_test.py` (off the shelf, 404 on both detail routes, on the shelf once registered, off again on the kill switch, still listed while unverified, tool-instance apps unaffected), and an install-refusal case in `guild_apps_test.py`. One existing test asserted the previous behaviour — a service app with no registration installing and reporting unavailable — and now registers the service as unverified, keeping its point (no artifact, not reachable yet).