### PR TITLE
Add a community directory guilds can list in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Guilds can list themselves in a community directory, and be joined without an invite.** "Join a community" sits under the add-a-guild button in the left rail: a search box above a category rail, and a card per guild with its icon, description, tags, and member count. A guild admin lists theirs from Settings → Guild, picking at least one category and certifying the guild holds no adult or illegal content. Guilds also carry an 18+ marker, unanswered by default; a guild marked 18+ — or one with room for only one member — is never listed. Unlisted guilds are unchanged.
+
 ### Changed
 
 - **The Apps shelf only lists apps your server actually runs.** An app is served by a program the person running your server sets up — so a listing for one that they haven't set up yet, or have switched off, offered something that would install into nothing. Those listings now stay off the marketplace until the app is running, and adding one by hand is refused the same way. Dashboards are unaffected, and nothing changes for an app a guild has already installed.

--- a/backend/alembic/versions/20260827_0196_guild_community_directory.py
+++ b/backend/alembic/versions/20260827_0196_guild_community_directory.py
@@ -1,0 +1,131 @@
+"""add the community-directory columns to guilds
+
+A guild that opts in is listed in the signed-in community directory and can be
+joined without an invite. The opt-in, its subject tags, and its 18+ declaration
+are guild identity — the guild's own admins set them from their settings page —
+so they live on ``public.guilds`` beside name/description/icon rather than on
+the operator-owned ``guild_administration`` row, and the column-scoped UPDATE
+grant added in 0138 is widened to cover them.
+
+``categories`` is a ``text[]`` with a CHECK that every element is a known
+category, mirroring how ``status`` is a CHECK-constrained string rather than a
+Postgres enum: adding a category later is an ordinary migration.
+
+Two more CHECKs make the listing rules database invariants rather than app
+rules, so no path can publish a guild that breaks them:
+
+* a listed guild is on at least one shelf, and
+* a listed guild has declared itself free of adult content. ``IS FALSE`` is
+  false for NULL as well as for true, so the unanswered default is refused by
+  the same predicate that refuses an 18+ guild.
+
+The third rule — a guild whose seat cap is 1 can never take a joiner, so it is
+never listed — cannot be a CHECK here: the cap lives on ``guild_administration``
+and an operator can lower it after the fact. That one is enforced when the
+listing is set and again when the directory is read.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260827_0196"
+down_revision = "20260826_0195"
+branch_labels = None
+depends_on = None
+
+# Spelled out rather than read from ``GuildCategory``: a revision must state
+# what it writes, so that adding a category later changes the next migration
+# rather than reaching back and changing what this one does.
+_CATEGORY_LITERALS = ", ".join(
+    f"'{value}'"
+    for value in (
+        "art",
+        "gaming",
+        "ttrpg",
+        "music",
+        "writing",
+        "education",
+        "technology",
+        "sports",
+        "business",
+        "health",
+        "social",
+        "other",
+    )
+)
+
+# Widened from 0138: the three directory columns join the identity columns a
+# guild's own admin edits through PATCH /guilds/{guild_id}.
+_GUILD_ADMIN_COLUMNS = (
+    "name, description, icon_base64, is_community, categories, "
+    "has_adult_content, updated_at"
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guilds",
+        sa.Column(
+            "is_community",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "guilds",
+        sa.Column(
+            "categories",
+            sa.ARRAY(sa.String(length=32)),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+    # Nullable with no default: unanswered is the normal state for a guild that
+    # never lists itself, and is distinct from an answer of "no".
+    op.add_column(
+        "guilds",
+        sa.Column("has_adult_content", sa.Boolean(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_guilds_categories",
+        "guilds",
+        f"categories <@ ARRAY[{_CATEGORY_LITERALS}]::varchar[]",
+    )
+    op.create_check_constraint(
+        "ck_guilds_community_categories",
+        "guilds",
+        "NOT is_community OR cardinality(categories) > 0",
+    )
+    op.create_check_constraint(
+        "ck_guilds_community_adult_content",
+        "guilds",
+        "NOT is_community OR has_adult_content IS FALSE",
+    )
+    # The directory's only query shape: listed guilds, optionally narrowed to
+    # one category. Partial on the opt-in so it stays the size of the directory
+    # rather than the size of the deployment.
+    op.execute(
+        "CREATE INDEX ix_guilds_community_categories ON public.guilds "
+        "USING gin (categories) WHERE is_community"
+    )
+    op.execute("REVOKE UPDATE ON TABLE public.guilds FROM app_guild_base")
+    op.execute(
+        f"GRANT UPDATE ({_GUILD_ADMIN_COLUMNS}) ON TABLE public.guilds "
+        "TO app_guild_base"
+    )
+
+
+def downgrade() -> None:
+    op.execute("REVOKE UPDATE ON TABLE public.guilds FROM app_guild_base")
+    op.execute(
+        "GRANT UPDATE (name, description, icon_base64, updated_at) "
+        "ON TABLE public.guilds TO app_guild_base"
+    )
+    op.execute("DROP INDEX IF EXISTS public.ix_guilds_community_categories")
+    op.drop_constraint("ck_guilds_community_adult_content", "guilds", type_="check")
+    op.drop_constraint("ck_guilds_community_categories", "guilds", type_="check")
+    op.drop_constraint("ck_guilds_categories", "guilds", type_="check")
+    op.drop_column("guilds", "has_adult_content")
+    op.drop_column("guilds", "categories")
+    op.drop_column("guilds", "is_community")

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -4,7 +4,7 @@ import logging
 from contextlib import suppress
 from typing import Annotated, List
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import text
 
 from app.api.deps import SessionDep, UserSessionDep, get_current_active_user
@@ -19,11 +19,19 @@ from app.core.security import (
 )
 from app.db.schema_provisioning import deprovision_guild
 from app.db.session import get_admin_session, set_rls_context
-from app.models.platform.guild import GuildRole, GuildMembership, Guild, GuildStatus
+from app.models.platform.guild import (
+    Guild,
+    GuildCategory,
+    GuildMembership,
+    GuildRole,
+    GuildStatus,
+)
 from app.models.platform.guild_administration import GuildAdministration
 from app.models.platform.user import User, UserStatus
 from app.schemas.platform.billing import BillingPortalHandoffResponse
 from app.schemas.platform.guild import (
+    CommunityGuildPage,
+    CommunityGuildRead,
     GuildAuthPolicyRead,
     GuildAuthPolicyUpdate,
     GuildCreate,
@@ -114,6 +122,12 @@ def _serialize_guild(
         content_read_only=(guild.status == GuildStatus.read_only.value),
         # Admins only: lets their settings UI show/hide the Authentication tab.
         guild_auth_enabled=admin_row.guild_auth_enabled if admin_row else None,
+        # Guild identity, not administration: the directory publishes both to
+        # strangers, so withholding them from the guild's own members would
+        # only mean the settings page could not render its own state.
+        is_community=guild.is_community,
+        categories=[GuildCategory(value) for value in guild.categories],
+        has_adult_content=guild.has_adult_content,
     )
 
 
@@ -192,6 +206,93 @@ async def reorder_guilds(
     )
     await session.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+#: Directory pages are card grids; a bigger page buys scrolling, not answers.
+MAX_COMMUNITY_PAGE_SIZE = 60
+
+
+@router.get("/communities", response_model=CommunityGuildPage)
+async def list_community_guilds(
+    session: AdminSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    q: str | None = Query(default=None, max_length=200),
+    category: GuildCategory | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=24, ge=1, le=MAX_COMMUNITY_PAGE_SIZE),
+) -> CommunityGuildPage:
+    """Browse the guilds that opted into the community directory.
+
+    Runs on the system engine for the reason ``GET /invite/{code}`` does: the
+    caller is a stranger to every guild here, so no guild-scoped role exists to
+    read them under, and the RLS policy that scopes ``guilds`` to the caller's
+    own memberships would return an empty directory. What that engine may see
+    is not what this returns — the filters live in the service (listed AND
+    active, always), and :class:`CommunityGuildRead` carries only what a guild
+    published by opting in: no lifecycle status, no administration, no roster,
+    and nothing at all from inside the guild's own schema.
+    """
+    rows, total = await guilds_service.list_community_guilds(
+        session,
+        user_id=current_user.id,
+        query=q,
+        category=category.value if category else None,
+        offset=(page - 1) * page_size,
+        limit=page_size,
+    )
+    return CommunityGuildPage(
+        items=[
+            CommunityGuildRead(
+                id=guild.id,
+                name=guild.name,
+                description=guild.description,
+                icon_base64=guild.icon_base64,
+                categories=[GuildCategory(value) for value in guild.categories],
+                member_count=member_count,
+                already_member=already_member,
+            )
+            for guild, member_count, already_member in rows
+        ],
+        total=total,
+    )
+
+
+@router.post("/communities/{guild_id}/join", response_model=GuildRead)
+async def join_community_guild(
+    guild_id: int,
+    session: AdminSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+) -> GuildRead:
+    """Join a listed community guild. Its listing is the authorization.
+
+    The system engine for the same reason ``accept_invite`` uses it — the user
+    has no membership yet, so there is no guild role to write one under. Joining
+    an already-joined guild is not an error; it returns the guild the caller is
+    already in.
+    """
+    try:
+        guild = await guilds_service.join_community_guild(
+            session, guild_id=guild_id, user=current_user
+        )
+    except guilds_service.CommunityJoinError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except guilds_service.GuildCapacityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
+    await session.commit()
+    membership = await guilds_service.get_membership(
+        session, guild_id=guild.id, user_id=current_user.id
+    )
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=GuildMessages.GUILD_MEMBERSHIP_MISSING,
+        )
+    member_count = await guilds_service.count_members(session, guild_id=guild.id)
+    return _serialize_guild(guild, membership, member_count=member_count)
 
 
 @router.get("/invite/{code}", response_model=GuildInviteStatus)
@@ -373,16 +474,35 @@ async def update_guild(
     await _set_guild_admin_rls(session, guild_id=guild_id, user=current_user)
     icon_provided = "icon_base64" in updates.model_fields_set
     retention_days_provided = "retention_days" in updates.model_fields_set
-    guild = await guilds_service.update_guild(
-        session,
-        guild_id=guild_id,
-        name=updates.name,
-        description=updates.description,
-        icon_base64=updates.icon_base64,
-        icon_provided=icon_provided,
-        retention_days=updates.retention_days,
-        retention_days_provided=retention_days_provided,
-    )
+    categories_provided = "categories" in updates.model_fields_set
+    has_adult_content_provided = "has_adult_content" in updates.model_fields_set
+    try:
+        guild = await guilds_service.update_guild(
+            session,
+            guild_id=guild_id,
+            name=updates.name,
+            description=updates.description,
+            icon_base64=updates.icon_base64,
+            icon_provided=icon_provided,
+            retention_days=updates.retention_days,
+            retention_days_provided=retention_days_provided,
+            is_community=updates.is_community,
+            categories=(
+                [category.value for category in updates.categories]
+                if updates.categories
+                else []
+            ),
+            categories_provided=categories_provided,
+            has_adult_content=updates.has_adult_content,
+            has_adult_content_provided=has_adult_content_provided,
+        )
+    except guilds_service.CommunityListingError as exc:
+        # The guild does not qualify to be listed. Named specifically (which
+        # rule) rather than as a generic rejection, so the settings page can say
+        # what to fix.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
     await session.commit()
     retention_days = await guilds_service.get_guild_retention_days(session, guild_id)
     member_count = await guilds_service.count_members(session, guild_id=guild_id)

--- a/backend/app/api/v1/platform_endpoints/guilds_community_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_community_test.py
@@ -1,0 +1,729 @@
+"""Integration tests for the community directory.
+
+Covers the two endpoints a guild's opt-in unlocks —
+``GET /api/v1/guilds/communities`` (browse) and
+``POST /api/v1/guilds/communities/{guild_id}/join`` (join without an invite) —
+plus the guild-admin PATCH that sets the opt-in and its categories.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.platform.guild import (
+    Guild,
+    GuildMembership,
+    GuildRole,
+    GuildStatus,
+)
+from app.testing.factories import (
+    create_guild,
+    create_guild_membership,
+    create_user,
+    get_auth_headers,
+    guild_administration,
+)
+
+
+async def _list_as_community(
+    session: AsyncSession,
+    guild: Guild,
+    *,
+    categories: list[str] | None = None,
+) -> Guild:
+    """Opt a guild into the directory directly, without the settings page.
+
+    A listed guild is always on a shelf and always declared free of adult
+    content — the database refuses to store one that is not — so the default
+    category keeps every test that does not care about shelves valid.
+    """
+    guild.is_community = True
+    guild.categories = categories or ["other"]
+    guild.has_adult_content = False
+    session.add(guild)
+    await session.commit()
+    await session.refresh(guild)
+    return guild
+
+
+@pytest.mark.integration
+async def test_directory_lists_only_opted_in_guilds(
+    client: AsyncClient, session: AsyncSession
+):
+    """A guild appears only once it has opted in — invite-only guilds do not."""
+    user = await create_user(session, email="browser@example.com")
+    listed = await create_guild(session, name="Open Table")
+    await create_guild(session, name="Private Office")
+    await _list_as_community(session, listed)
+
+    response = await client.get(
+        "/api/v1/guilds/communities", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert [item["name"] for item in data["items"]] == ["Open Table"]
+
+
+@pytest.mark.integration
+async def test_directory_hides_non_active_guilds(
+    client: AsyncClient, session: AsyncSession
+):
+    """A frozen or suspended guild takes no new members, so it is not offered."""
+    user = await create_user(session, email="browser@example.com")
+    for name, status_value in (
+        ("Suspended Hall", GuildStatus.suspended.value),
+        ("Frozen Hall", GuildStatus.read_only.value),
+    ):
+        guild = await create_guild(session, name=name)
+        await _list_as_community(session, guild)
+        guild.status = status_value
+        session.add(guild)
+    await session.commit()
+
+    response = await client.get(
+        "/api/v1/guilds/communities", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0}
+
+
+@pytest.mark.integration
+async def test_directory_card_carries_only_published_fields(
+    client: AsyncClient, session: AsyncSession
+):
+    """The card is what the guild published, plus its roster size — no more."""
+    user = await create_user(session, email="browser@example.com")
+    owner = await create_user(session, email="owner@example.com")
+    guild = await create_guild(
+        session, name="Riverside Players", description="Community theatre."
+    )
+    await create_guild_membership(session, user=owner, guild=guild)
+    await _list_as_community(session, guild, categories=["art", "writing"])
+
+    response = await client.get(
+        "/api/v1/guilds/communities", headers=get_auth_headers(user)
+    )
+
+    card = response.json()["items"][0]
+    assert card["name"] == "Riverside Players"
+    assert card["description"] == "Community theatre."
+    assert card["categories"] == ["art", "writing"]
+    assert card["member_count"] == 1
+    assert card["already_member"] is False
+    # Nothing about the guild's administration or lifecycle reaches a stranger.
+    assert "status" not in card
+    assert "tier_name" not in card
+    assert "max_users" not in card
+    assert "role" not in card
+
+
+@pytest.mark.integration
+async def test_directory_flags_guilds_the_caller_is_already_in(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="member@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await create_guild_membership(session, user=user, guild=guild)
+    await _list_as_community(session, guild)
+
+    response = await client.get(
+        "/api/v1/guilds/communities", headers=get_auth_headers(user)
+    )
+
+    assert response.json()["items"][0]["already_member"] is True
+
+
+@pytest.mark.integration
+async def test_directory_filters_by_category(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="browser@example.com")
+    await _list_as_community(
+        session, await create_guild(session, name="Dice Goblins"), categories=["ttrpg"]
+    )
+    await _list_as_community(
+        session, await create_guild(session, name="Life Drawing"), categories=["art"]
+    )
+    # A guild on two shelves is reachable from either.
+    await _list_as_community(
+        session,
+        await create_guild(session, name="Painted Minis"),
+        categories=["art", "ttrpg"],
+    )
+
+    response = await client.get(
+        "/api/v1/guilds/communities?category=ttrpg", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    assert sorted(item["name"] for item in response.json()["items"]) == [
+        "Dice Goblins",
+        "Painted Minis",
+    ]
+
+
+@pytest.mark.integration
+async def test_directory_rejects_an_unknown_category(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="browser@example.com")
+
+    response = await client.get(
+        "/api/v1/guilds/communities?category=nonsense", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.integration
+async def test_directory_searches_name_and_description(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="browser@example.com")
+    await _list_as_community(session, await create_guild(session, name="Dice Goblins"))
+    await _list_as_community(
+        session,
+        await create_guild(
+            session, name="Painted Minis", description="We paint dice trays too."
+        ),
+    )
+    await _list_as_community(session, await create_guild(session, name="Life Drawing"))
+
+    response = await client.get(
+        "/api/v1/guilds/communities?q=dice", headers=get_auth_headers(user)
+    )
+
+    assert sorted(item["name"] for item in response.json()["items"]) == [
+        "Dice Goblins",
+        "Painted Minis",
+    ]
+
+
+@pytest.mark.integration
+async def test_directory_paginates(client: AsyncClient, session: AsyncSession):
+    user = await create_user(session, email="browser@example.com")
+    for index in range(3):
+        await _list_as_community(
+            session, await create_guild(session, name=f"Guild {index}")
+        )
+
+    headers = get_auth_headers(user)
+    first = await client.get(
+        "/api/v1/guilds/communities?page=1&page_size=2", headers=headers
+    )
+    second = await client.get(
+        "/api/v1/guilds/communities?page=2&page_size=2", headers=headers
+    )
+
+    # The total counts everything that matched, not just this page.
+    assert first.json()["total"] == 3
+    assert len(first.json()["items"]) == 2
+    assert len(second.json()["items"]) == 1
+
+
+@pytest.mark.integration
+async def test_directory_requires_authentication(client: AsyncClient):
+    response = await client.get("/api/v1/guilds/communities")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_join_a_community_guild_without_an_invite(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="joiner@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == guild.id
+    assert response.json()["role"] == GuildRole.member.value
+    membership = (
+        await session.exec(
+            select(GuildMembership).where(
+                GuildMembership.guild_id == guild.id,
+                GuildMembership.user_id == user.id,
+            )
+        )
+    ).one_or_none()
+    assert membership is not None
+    assert membership.role == GuildRole.member
+
+
+@pytest.mark.integration
+async def test_join_is_idempotent(client: AsyncClient, session: AsyncSession):
+    """Joining twice returns the guild rather than erroring or duplicating."""
+    user = await create_user(session, email="joiner@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    headers = get_auth_headers(user)
+
+    first = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=headers
+    )
+    second = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=headers
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    memberships = (
+        await session.exec(
+            select(GuildMembership).where(
+                GuildMembership.guild_id == guild.id,
+                GuildMembership.user_id == user.id,
+            )
+        )
+    ).all()
+    assert len(memberships) == 1
+
+
+@pytest.mark.integration
+async def test_join_refuses_a_guild_that_is_not_listed(
+    client: AsyncClient, session: AsyncSession
+):
+    """An unlisted guild has published nothing, its id included — so, 404."""
+    user = await create_user(session, email="joiner@example.com")
+    guild = await create_guild(session, name="Private Office")
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "GUILD_NOT_A_COMMUNITY"
+    membership = (
+        await session.exec(
+            select(GuildMembership).where(
+                GuildMembership.guild_id == guild.id,
+                GuildMembership.user_id == user.id,
+            )
+        )
+    ).one_or_none()
+    assert membership is None
+
+
+@pytest.mark.integration
+async def test_join_refuses_a_suspended_community(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="joiner@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    guild.status = GuildStatus.suspended.value
+    session.add(guild)
+    await session.commit()
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "GUILD_NOT_A_COMMUNITY"
+
+
+@pytest.mark.integration
+async def test_join_refuses_a_missing_guild(client: AsyncClient, session: AsyncSession):
+    user = await create_user(session, email="joiner@example.com")
+
+    response = await client.post(
+        "/api/v1/guilds/communities/999999/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.integration
+async def test_join_respects_the_member_cap(client: AsyncClient, session: AsyncSession):
+    """The directory does not bypass the guild's operator-set seat limit.
+
+    Two seats, both taken: a listable guild (one seat could never admit anyone,
+    so it would be refused as unlisted instead) that happens to be full today.
+    """
+    user = await create_user(session, email="joiner@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await create_guild_membership(session, guild=guild)
+    await create_guild_membership(session, guild=guild)
+    await guild_administration(session, guild, max_users=2)
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "GUILD_USER_LIMIT_REACHED"
+
+
+@pytest.mark.integration
+async def test_guild_admin_opts_into_the_directory(
+    client: AsyncClient, session: AsyncSession
+):
+    admin = await create_user(session, email="admin@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={
+            "is_community": True,
+            "categories": ["gaming", "ttrpg"],
+            "has_adult_content": False,
+        },
+        headers=get_auth_headers(admin),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["is_community"] is True
+    assert response.json()["categories"] == ["gaming", "ttrpg"]
+    assert response.json()["has_adult_content"] is False
+    await session.refresh(guild)
+    assert guild.is_community is True
+    assert guild.categories == ["gaming", "ttrpg"]
+    assert guild.has_adult_content is False
+
+
+@pytest.mark.integration
+async def test_categories_are_deduplicated_and_ordered(
+    client: AsyncClient, session: AsyncSession
+):
+    """Whatever order the boxes were ticked in, storage is canonical."""
+    admin = await create_user(session, email="admin@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"categories": ["ttrpg", "art", "ttrpg"]},
+        headers=get_auth_headers(admin),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["categories"] == ["art", "ttrpg"]
+
+
+@pytest.mark.integration
+async def test_patch_leaves_the_listing_alone_when_not_mentioned(
+    client: AsyncClient, session: AsyncSession
+):
+    """Renaming a guild must not silently de-list it."""
+    admin = await create_user(session, email="admin@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    await _list_as_community(session, guild, categories=["gaming"])
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"name": "Open Table Renamed"},
+        headers=get_auth_headers(admin),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["is_community"] is True
+    assert response.json()["categories"] == ["gaming"]
+
+
+@pytest.mark.integration
+async def test_a_member_cannot_opt_the_guild_in(
+    client: AsyncClient, session: AsyncSession
+):
+    member = await create_user(session, email="member@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await create_guild_membership(
+        session, user=member, guild=guild, role=GuildRole.member
+    )
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"is_community": True},
+        headers=get_auth_headers(member),
+    )
+
+    assert response.status_code == 403
+    await session.refresh(guild)
+    assert guild.is_community is False
+
+
+@pytest.mark.integration
+async def test_an_unknown_category_is_rejected(
+    client: AsyncClient, session: AsyncSession
+):
+    admin = await create_user(session, email="admin@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"categories": ["underwater-basket-weaving"]},
+        headers=get_auth_headers(admin),
+    )
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# What a guild must be before it can be listed
+# ---------------------------------------------------------------------------
+
+
+async def _admin_of(session: AsyncSession, **guild_fields) -> tuple[Guild, dict]:
+    """A guild plus the headers of one of its admins."""
+    admin = await create_user(session)
+    guild = await create_guild(session, **guild_fields)
+    await create_guild_membership(
+        session, user=admin, guild=guild, role=GuildRole.admin
+    )
+    return guild, get_auth_headers(admin)
+
+
+@pytest.mark.integration
+async def test_the_adult_content_declaration_starts_unanswered(
+    client: AsyncClient, session: AsyncSession
+):
+    """It is a question only the directory asks, so an ordinary guild has no
+    answer on file rather than a default one."""
+    guild, headers = await _admin_of(session)
+
+    response = await client.get("/api/v1/guilds/", headers=headers)
+
+    assert response.status_code == 200
+    entry = next(item for item in response.json() if item["id"] == guild.id)
+    assert entry["has_adult_content"] is None
+    assert entry["is_community"] is False
+
+
+@pytest.mark.integration
+async def test_listing_needs_at_least_one_category(
+    client: AsyncClient, session: AsyncSession
+):
+    """A card nobody can reach by browsing is not a listing."""
+    guild, headers = await _admin_of(session)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"is_community": True, "has_adult_content": False},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GUILD_COMMUNITY_REQUIRES_CATEGORY"
+    await session.refresh(guild)
+    assert guild.is_community is False
+
+
+@pytest.mark.integration
+async def test_listing_needs_the_content_question_answered(
+    client: AsyncClient, session: AsyncSession
+):
+    """Unanswered is not the same as answered "no" — the admin has to certify."""
+    guild, headers = await _admin_of(session)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"is_community": True, "categories": ["art"]},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GUILD_COMMUNITY_CONTENT_NOT_DECLARED"
+    await session.refresh(guild)
+    assert guild.is_community is False
+
+
+@pytest.mark.integration
+async def test_an_adult_guild_cannot_be_listed(
+    client: AsyncClient, session: AsyncSession
+):
+    guild, headers = await _admin_of(session)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={
+            "is_community": True,
+            "categories": ["art"],
+            "has_adult_content": True,
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GUILD_COMMUNITY_ADULT_CONTENT"
+    await session.refresh(guild)
+    assert guild.is_community is False
+
+
+@pytest.mark.integration
+async def test_an_unlisted_guild_may_declare_adult_content(
+    client: AsyncClient, session: AsyncSession
+):
+    """The declaration is the guild's to make; it only closes off the directory."""
+    guild, headers = await _admin_of(session)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"has_adult_content": True},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["has_adult_content"] is True
+    await session.refresh(guild)
+    assert guild.has_adult_content is True
+
+
+@pytest.mark.integration
+async def test_a_one_seat_guild_cannot_be_listed(
+    client: AsyncClient, session: AsyncSession
+):
+    """One seat means no joiner can ever take one, so the card would be a
+    button that is guaranteed to fail."""
+    guild, headers = await _admin_of(session, max_users=1)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={
+            "is_community": True,
+            "categories": ["art"],
+            "has_adult_content": False,
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GUILD_COMMUNITY_REQUIRES_CAPACITY"
+    await session.refresh(guild)
+    assert guild.is_community is False
+
+
+@pytest.mark.integration
+async def test_a_two_seat_guild_can_be_listed(
+    client: AsyncClient, session: AsyncSession
+):
+    """Room for one more is room enough — the cap itself is not the objection."""
+    guild, headers = await _admin_of(session, max_users=2)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={
+            "is_community": True,
+            "categories": ["art"],
+            "has_adult_content": False,
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["is_community"] is True
+
+
+@pytest.mark.integration
+async def test_the_rules_are_checked_against_the_resulting_guild(
+    client: AsyncClient, session: AsyncSession
+):
+    """Clearing the shelves of a guild that is already listed has to fail for
+    the same reason as listing one with none — the rule is about the state the
+    guild ends up in, not about what this request happened to carry."""
+    guild, headers = await _admin_of(session)
+    await _list_as_community(session, guild, categories=["art"])
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"categories": []},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GUILD_COMMUNITY_REQUIRES_CATEGORY"
+    await session.refresh(guild)
+    assert guild.categories == ["art"]
+
+
+@pytest.mark.integration
+async def test_a_listed_guild_cannot_turn_itself_adult(
+    client: AsyncClient, session: AsyncSession
+):
+    guild, headers = await _admin_of(session)
+    await _list_as_community(session, guild, categories=["art"])
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"has_adult_content": True},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GUILD_COMMUNITY_ADULT_CONTENT"
+    await session.refresh(guild)
+    assert guild.has_adult_content is False
+
+
+@pytest.mark.integration
+async def test_delisting_is_never_blocked_by_the_listing_rules(
+    client: AsyncClient, session: AsyncSession
+):
+    """Coming off the directory asks nothing of the guild."""
+    guild, headers = await _admin_of(session)
+    await _list_as_community(session, guild, categories=["art"])
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"is_community": False, "categories": []},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["is_community"] is False
+
+
+@pytest.mark.integration
+async def test_the_directory_drops_a_guild_whose_cap_was_lowered_later(
+    client: AsyncClient, session: AsyncSession
+):
+    """Only an operator sets the cap, and they can set it after the listing was
+    made — so the directory re-checks it rather than trusting the opt-in."""
+    user = await create_user(session, email="browser@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await guild_administration(session, guild, max_users=1)
+
+    response = await client.get(
+        "/api/v1/guilds/communities", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0}
+
+
+@pytest.mark.integration
+async def test_join_refuses_a_guild_the_directory_would_not_show(
+    client: AsyncClient, session: AsyncSession
+):
+    """Asking for it by id is not a way around the directory's own filter."""
+    user = await create_user(session, email="joiner@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await guild_administration(session, guild, max_users=1)
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "GUILD_NOT_A_COMMUNITY"

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -60,6 +60,16 @@ class GuildMessages:
     GUILD_DELETE_FAILED = "GUILD_DELETE_FAILED"
     GUILD_MEMBERSHIP_MISSING = "GUILD_MEMBERSHIP_MISSING"
     GUILD_USER_LIMIT_REACHED = "GUILD_USER_LIMIT_REACHED"
+    # Asked to join a guild that is not listed in the community directory (or
+    # is no longer active). Reported as a 404 — an unlisted guild has published
+    # nothing, its existence at a given id included.
+    GUILD_NOT_A_COMMUNITY = "GUILD_NOT_A_COMMUNITY"
+    # The three things a guild must be before it can be listed: on at least one
+    # shelf, declared free of adult content, and able to admit anyone at all.
+    GUILD_COMMUNITY_REQUIRES_CATEGORY = "GUILD_COMMUNITY_REQUIRES_CATEGORY"
+    GUILD_COMMUNITY_CONTENT_NOT_DECLARED = "GUILD_COMMUNITY_CONTENT_NOT_DECLARED"
+    GUILD_COMMUNITY_ADULT_CONTENT = "GUILD_COMMUNITY_ADULT_CONTENT"
+    GUILD_COMMUNITY_REQUIRES_CAPACITY = "GUILD_COMMUNITY_REQUIRES_CAPACITY"
     CANNOT_CHANGE_OWN_ROLE = "CANNOT_CHANGE_OWN_ROLE"
     # 'support' is synthesized for PAM grantees only; it is never a stored
     # guild-membership role, so it cannot be assigned via the role endpoints.

--- a/backend/app/models/platform/guild.py
+++ b/backend/app/models/platform/guild.py
@@ -3,6 +3,8 @@ from enum import Enum
 from typing import List, Optional, TYPE_CHECKING
 
 from sqlalchemy import Boolean, Column, DateTime, String, Integer, Text
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.sql import text
 from sqlmodel import Field, Index, SQLModel, Enum as SQLEnum, Relationship
 from pydantic import ConfigDict
 
@@ -34,10 +36,50 @@ class GuildStatus(str, Enum):
     suspended = "suspended"
 
 
+class GuildCategory(str, Enum):
+    """A subject a guild can file itself under in the community directory.
+
+    A closed vocabulary rather than free-form tags: the directory's job is to
+    narrow a deployment's guilds down to a browsable shelf, and that only works
+    if two guilds about the same thing pick the same word. Guilds choose their
+    own (zero or more) from their settings page; the labels are localized
+    client-side from these keys, so the stored value is never user-facing text.
+
+    Stored as a ``text[]`` on ``guilds.categories`` with a CHECK that every
+    element is one of these, mirroring how ``status`` is a CHECK-constrained
+    string rather than a Postgres enum: adding a category is then an ordinary
+    migration instead of an enum alteration.
+    """
+
+    art = "art"
+    gaming = "gaming"
+    ttrpg = "ttrpg"
+    music = "music"
+    writing = "writing"
+    education = "education"
+    technology = "technology"
+    sports = "sports"
+    business = "business"
+    health = "health"
+    social = "social"
+    other = "other"
+
+
 class Guild(SQLModel, table=True):
     __tablename__ = "guilds"
     __allow_unmapped__ = True
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    __table_args__ = (
+        # The community directory's only query shape: listed guilds, optionally
+        # narrowed to one category. Partial on the opt-in so the index stays
+        # the size of the directory rather than the size of the deployment.
+        Index(
+            "ix_guilds_community_categories",
+            "categories",
+            postgresql_using="gin",
+            postgresql_where=text("is_community"),
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(nullable=False)
@@ -72,6 +114,34 @@ class Guild(SQLModel, table=True):
     # When the status last changed; NULL until the first operator change.
     status_changed_at: Optional[datetime] = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    # Community directory opt-in. False means the guild is reachable only by
+    # invite; True publishes its name, description, icon, categories, and roster
+    # size to the signed-in directory and lets anyone join without one. Set by
+    # the guild's own admins, alongside the identity columns above.
+    is_community: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default="false"),
+    )
+    # Which shelves the guild files itself under (see GuildCategory). A listed
+    # guild must be on at least one — a card nobody can find by browsing is not
+    # a listing — which the ck_guilds_community_categories CHECK enforces.
+    categories: List[str] = Field(
+        default_factory=list,
+        sa_column=Column(
+            ARRAY(String(32)), nullable=False, server_default=text("'{}'::varchar[]")
+        ),
+    )
+    # Whether this guild is 18+. NULL is the default and stays the answer for
+    # almost every guild: it is a question only the directory needs answered,
+    # and a guild that never lists itself is never asked it.
+    #
+    # Listing requires an explicit False — the admin certifies it as part of
+    # publishing. True and an unanswered NULL both keep the guild out, which is
+    # one CHECK (ck_guilds_community_adult_content) rather than an app rule,
+    # because ``IS FALSE`` is false for NULL too.
+    has_adult_content: Optional[bool] = Field(
+        default=None, sa_column=Column(Boolean, nullable=True)
     )
     # The operator-set caps, plan label, and sign-in entitlement — everything
     # this row is NOT. See GuildAdministration for why they live apart.

--- a/backend/app/schemas/platform/guild.py
+++ b/backend/app/schemas/platform/guild.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import ConfigDict, EmailStr, Field
 
 from app.schemas.base import RawTextStr, RichTextStr, SanitizedBaseModel
 
-from app.models.platform.guild import GuildRole, GuildStatus
+from app.models.platform.guild import GuildCategory, GuildRole, GuildStatus
 
 
 class GuildBase(SanitizedBaseModel):
@@ -78,6 +78,14 @@ class GuildRead(GuildBase):
     # ``None`` for non-admin members (they never configure auth). Only
     # meaningful under the per-guild AUTH_SCOPE posture.
     guild_auth_enabled: Optional[bool] = None
+    # Community directory opt-in and its subject tags. Guild identity, not
+    # administration: every member sees them (they are published to strangers
+    # anyway), and the settings page shows the controls to admins.
+    is_community: bool = False
+    categories: List[GuildCategory] = []
+    # The 18+ declaration. ``None`` — unanswered — is the normal state for a
+    # guild that has never been listed; listing requires an explicit ``False``.
+    has_adult_content: Optional[bool] = None
 
 
 class GuildInviteCreate(SanitizedBaseModel):
@@ -127,6 +135,19 @@ class GuildUpdate(SanitizedBaseModel):
     # Sentinel "unset" semantics: explicitly omit the field to leave the
     # current setting untouched; set null to switch to never-purge.
     retention_days: Optional[int] = Field(default=None, ge=1, le=3650)
+    # Community directory opt-in and subject tags. Omit-to-skip, like the
+    # fields above: the endpoint inspects ``model_fields_set``, so a PATCH that
+    # only renames a guild never disturbs its listing. A null ``categories``
+    # is read as "no categories" — the empty list means the same thing and the
+    # UI sends that — while a null ``is_community`` is a no-op (a boolean
+    # opt-in has no third state).
+    is_community: Optional[bool] = None
+    categories: Optional[List[GuildCategory]] = None
+    # The 18+ declaration, and the one field here where null is an ANSWER
+    # rather than a skip — it puts the guild back to undeclared. Omitting the
+    # field is how you leave it alone, so this is read from
+    # ``model_fields_set`` rather than from the value being non-null.
+    has_adult_content: Optional[bool] = None
     # NOTE: deliberately no cap/status/tier fields here. Those are
     # operator/billing enforcement inputs (the platform Guilds tab or the
     # verified billing path) — a guild's own admins must never set them, and
@@ -252,3 +273,33 @@ class LeaveGuildEligibilityResponse(SanitizedBaseModel):
 
     can_leave: bool
     is_last_admin: bool
+
+
+class CommunityGuildRead(SanitizedBaseModel):
+    """One card in the community directory.
+
+    Deliberately not a :class:`GuildRead`: the reader is a stranger, so this
+    carries only what the guild published by opting in — its identity, its
+    shelves, and how many people are already there. No membership fields (they
+    have none), no lifecycle status, no administration. ``already_member`` is
+    about the *caller*, and only says whether the Join button applies to them.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    id: int
+    name: str
+    description: Optional[RichTextStr] = None
+    icon_base64: Optional[RawTextStr] = None
+    categories: List[GuildCategory] = []
+    member_count: int = 0
+    already_member: bool = False
+
+
+class CommunityGuildPage(SanitizedBaseModel):
+    """A page of directory results, plus how many matched in total."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    items: List[CommunityGuildRead]
+    total: int

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 import secrets
 
-from sqlalchemy import Integer, bindparam, func, text
+from sqlalchemy import Integer, bindparam, func, or_, text
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -14,6 +14,7 @@ from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.core.messages import GuildMessages
 from app.models.platform.guild import (
     Guild,
+    GuildCategory,
     GuildInvite,
     GuildMembership,
     GuildRole,
@@ -36,6 +37,43 @@ class GuildInviteError(Exception):
 
 class GuildCapacityError(Exception):
     """Raised when adding a member would exceed the guild's ``max_users`` cap."""
+
+
+class CommunityJoinError(Exception):
+    """Raised when a guild cannot be joined from the community directory."""
+
+
+class CommunityListingError(Exception):
+    """Raised when a guild does not qualify to be listed in the directory."""
+
+
+# A guild whose seat cap is one can never admit a joiner, so listing it would
+# publish a card whose only button is guaranteed to fail. Unlike a guild that is
+# merely full today, this one can never have room, which is why it is refused
+# outright rather than left to the capacity check at join time.
+MIN_COMMUNITY_SEATS = 2
+
+
+# Canonical order for a guild's categories: the order they are declared in
+# ``GuildCategory``. Storing them sorted means every card, filter chip, and
+# assertion sees the same sequence regardless of the order they were checked.
+_CATEGORY_ORDER = {
+    category.value: index for index, category in enumerate(GuildCategory)
+}
+
+
+def normalize_categories(categories: Sequence[str] | None) -> list[str]:
+    """De-duplicate a category selection and put it in canonical order.
+
+    Unknown values are dropped rather than rejected: the schema layer has
+    already validated the request against ``GuildCategory``, and the database
+    CHECK is the backstop, so anything else reaching here is a value this build
+    no longer recognizes and simply has no shelf to sit on.
+    """
+    if not categories:
+        return []
+    unique = {value for value in categories if value in _CATEGORY_ORDER}
+    return sorted(unique, key=lambda value: _CATEGORY_ORDER[value])
 
 
 async def _persist_new_guild(session: AsyncSession, guild: Guild) -> Guild:
@@ -526,6 +564,11 @@ async def update_guild(
     icon_provided: bool = False,
     retention_days: int | None = None,
     retention_days_provided: bool = False,
+    is_community: bool | None = None,
+    categories: Sequence[str] | None = None,
+    categories_provided: bool = False,
+    has_adult_content: bool | None = None,
+    has_adult_content_provided: bool = False,
     max_storage_bytes: int | None = None,
     max_storage_bytes_provided: bool = False,
     max_users: int | None = None,
@@ -545,6 +588,31 @@ async def update_guild(
     if icon_provided and icon_base64 != guild.icon_base64:
         guild.icon_base64 = icon_base64
         updated = True
+    # An explicit ``null`` is meaningless for a boolean opt-in (mirroring
+    # ``guild_auth_enabled`` below), so null and omitted alike are a no-op.
+    if is_community is not None and guild.is_community != is_community:
+        guild.is_community = is_community
+        updated = True
+    if categories_provided:
+        normalized = normalize_categories(categories)
+        if guild.categories != normalized:
+            # Assigned, never mutated in place: SQLAlchemy does not track
+            # in-place changes to an ARRAY column, so an ``.append()`` here
+            # would flush nothing.
+            guild.categories = normalized
+            updated = True
+    # The one field here where an explicit null is an answer (back to
+    # undeclared) rather than "leave it alone", so it reads the provided flag.
+    if has_adult_content_provided and guild.has_adult_content != has_adult_content:
+        guild.has_adult_content = has_adult_content
+        updated = True
+    # Checked against the state the guild is ending up in, not against what this
+    # PATCH happened to carry: a request that only clears the categories of an
+    # already-listed guild has to fail for the same reason as one that lists a
+    # guild with none. Two of the three rules are also database CHECKs; this is
+    # what turns them into an error a person can read.
+    if guild.is_community:
+        await _assert_listable(session, guild)
     if updated:
         guild.updated_at = datetime.now(timezone.utc)
         session.add(guild)
@@ -786,6 +854,157 @@ async def redeem_invite_for_user(
     invite.uses += 1
     session.add(invite)
     guild = await get_guild(session, guild_id=invite.guild_id)
+    return guild
+
+
+async def _assert_listable(session: AsyncSession, guild: Guild) -> None:
+    """Raise ``CommunityListingError`` unless this guild may be listed.
+
+    Three conditions, each with its own message so the reply says which one:
+
+    - it is on at least one shelf,
+    - it has declared itself free of adult content (an unanswered NULL is not a
+      declaration and is refused separately from an 18+ guild), and
+    - its seat cap leaves room for somebody to join.
+    """
+    if not guild.categories:
+        raise CommunityListingError(GuildMessages.GUILD_COMMUNITY_REQUIRES_CATEGORY)
+    if guild.has_adult_content is None:
+        raise CommunityListingError(GuildMessages.GUILD_COMMUNITY_CONTENT_NOT_DECLARED)
+    if guild.has_adult_content:
+        raise CommunityListingError(GuildMessages.GUILD_COMMUNITY_ADULT_CONTENT)
+    administration = await get_administration(session, guild_id=guild.id)
+    if (
+        administration.max_users is not None
+        and administration.max_users < MIN_COMMUNITY_SEATS
+    ):
+        raise CommunityListingError(GuildMessages.GUILD_COMMUNITY_REQUIRES_CAPACITY)
+
+
+async def list_community_guilds(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    query: str | None = None,
+    category: str | None = None,
+    offset: int = 0,
+    limit: int = 24,
+) -> tuple[list[tuple[Guild, int, bool]], int]:
+    """The community directory: (guild, member_count, already_member) + total.
+
+    Three filters are not optional and are applied here rather than by the
+    caller. A guild appears only while it has opted in (``is_community``), only
+    while it is ``active`` — a suspended or frozen guild takes no new members,
+    and the invite path already refuses one — and only while its seat cap leaves
+    room for a joiner.
+
+    That last one is re-checked here, unlike the has-a-category and
+    no-adult-content rules: those are CHECK constraints on ``guilds``, so a row
+    that reaches this query already satisfies them. The cap lives on
+    ``guild_administration`` and only an operator sets it, so it can be lowered
+    long after the listing was made and no CHECK can see it.
+
+    Needs a session that can see every guild's ``guild_memberships`` rows to
+    count them (the system engine), the same precondition ``count_members``
+    documents. Nothing about a guild's *content* is read — only the identity it
+    published by opting in, plus how many people are already there.
+    """
+    member_count = (
+        select(func.count())
+        .select_from(GuildMembership)
+        .where(GuildMembership.guild_id == Guild.id)
+        .correlate(Guild)
+        .scalar_subquery()
+    )
+    already_member = (
+        select(func.count())
+        .select_from(GuildMembership)
+        .where(
+            GuildMembership.guild_id == Guild.id,
+            GuildMembership.user_id == user_id,
+        )
+        .correlate(Guild)
+        .scalar_subquery()
+    )
+
+    filters = [
+        Guild.is_community.is_(True),
+        Guild.status == GuildStatus.active.value,
+        # NULL is unlimited, hence the explicit null leg.
+        or_(
+            GuildAdministration.max_users.is_(None),
+            GuildAdministration.max_users >= MIN_COMMUNITY_SEATS,
+        ),
+    ]
+    if category:
+        filters.append(Guild.categories.contains([category]))
+    if query and query.strip():
+        # Case-insensitive across the two fields a card actually shows.
+        needle = f"%{query.strip()}%"
+        filters.append(or_(Guild.name.ilike(needle), Guild.description.ilike(needle)))
+
+    # Every guild has exactly one administration row, created with it, so this
+    # is an inner join by construction.
+    administration_join = (
+        GuildAdministration,
+        GuildAdministration.guild_id == Guild.id,
+    )
+    count_statement = select(func.count()).select_from(Guild).join(*administration_join)
+    statement = select(Guild, member_count, already_member > 0).join(
+        *administration_join
+    )
+    for condition in filters:
+        statement = statement.where(condition)
+        count_statement = count_statement.where(condition)
+
+    total = (await session.exec(count_statement)).one()
+    statement = statement.order_by(Guild.name.asc(), Guild.id.asc())
+    rows = (await session.exec(statement.offset(offset).limit(limit))).all()
+    return [(guild, int(count), bool(joined)) for guild, count, joined in rows], int(
+        total
+    )
+
+
+async def join_community_guild(
+    session: AsyncSession,
+    *,
+    guild_id: int,
+    user: User,
+) -> Guild:
+    """Join a listed community guild — the invite-free half of the directory.
+
+    The opt-in is the authorization, so this checks exactly what an invite
+    redemption checks in its place: the guild is listed, it is ``active``, and
+    it has room. A guild that is not listed is reported as not found rather
+    than as forbidden — an unlisted guild has published nothing, and its
+    existence at a given id is part of that.
+
+    Runs on the system engine for the same reason ``accept_invite`` does: the
+    caller is not a member yet, so no guild-scoped role exists to write the
+    membership under.
+    """
+    try:
+        guild = await get_guild(session, guild_id=guild_id)
+    except ValueError as exc:
+        raise CommunityJoinError(GuildMessages.GUILD_NOT_FOUND) from exc
+    if not guild.is_community or guild.status != GuildStatus.active.value:
+        raise CommunityJoinError(GuildMessages.GUILD_NOT_A_COMMUNITY)
+    # The same seat-cap floor the directory filters on, so a guild it does not
+    # show cannot be joined by asking for it directly either.
+    administration = await get_administration(session, guild_id=guild_id)
+    if (
+        administration.max_users is not None
+        and administration.max_users < MIN_COMMUNITY_SEATS
+    ):
+        raise CommunityJoinError(GuildMessages.GUILD_NOT_A_COMMUNITY)
+    # Capacity is enforced inside ensure_membership, which is also where a
+    # repeat join short-circuits to the existing membership.
+    await ensure_membership(
+        session,
+        guild_id=guild_id,
+        user_id=user.id,
+        role=GuildRole.member,
+    )
     return guild
 
 

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -460,5 +460,10 @@
   "FILTER_PRESET_DUPLICATE_ID": "Dieselbe Voreinstellung wurde zweimal aufgeführt.",
   "FILTER_PRESET_SLUG_TAKEN": "In diesem Projekt gibt es bereits eine Voreinstellung mit diesem Namen.",
   "FILTER_PRESET_INVALID_FILTERS": "Diese Filter lassen sich nicht als Voreinstellung speichern.",
-  "FILTER_PRESET_LIMIT_REACHED": "Dieses Projekt hat bereits die maximale Anzahl an Filter-Voreinstellungen."
+  "FILTER_PRESET_LIMIT_REACHED": "Dieses Projekt hat bereits die maximale Anzahl an Filter-Voreinstellungen.",
+  "GUILD_NOT_A_COMMUNITY": "Diese Gilde ist nicht im Community-Verzeichnis eingetragen.",
+  "GUILD_COMMUNITY_REQUIRES_CATEGORY": "Eine eingetragene Gilde braucht mindestens eine Kategorie.",
+  "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Bestätige, dass diese Gilde keine Inhalte für Erwachsene enthält, bevor du sie einträgst.",
+  "GUILD_COMMUNITY_ADULT_CONTENT": "Eine als 18+ markierte Gilde kann nicht im Community-Verzeichnis eingetragen werden.",
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Diese Gilde hat nur für eine Person Platz und kann deshalb nicht im Community-Verzeichnis eingetragen werden."
 }

--- a/frontend/public/locales/de/guilds.json
+++ b/frontend/public/locales/de/guilds.json
@@ -117,7 +117,18 @@
     "retentionDescription": "Wie lange gelöschte Elemente im Papierkorb verbleiben, bevor sie dauerhaft entfernt werden. Auf „Nie“ setzen, um sie zu behalten, bis ein Administrator sie manuell löscht.",
     "retentionDaysLabel": "Tage",
     "retentionNeverLabel": "Nie automatisch löschen",
-    "retentionUpdatedSuccessfully": "Aufbewahrung aktualisiert."
+    "retentionUpdatedSuccessfully": "Aufbewahrung aktualisiert.",
+    "discoveryTitle": "Community-Verzeichnis",
+    "discoveryDescription": "Eine eingetragene Gilde erscheint im Verzeichnis, wo alle angemeldeten Personen sie finden und ohne Einladung beitreten können.",
+    "discoveryToggleLabel": "Diese Gilde eintragen",
+    "discoveryCategoriesLabel": "Kategorien",
+    "discoveryCategoriesHint": "Wähle die Themen, die zu dieser Gilde passen. Sie bestimmen, unter welchen Kategorien sie erscheint.",
+    "discoveryAdultLabel": "Diese Gilde enthält Inhalte für Erwachsene (18+)",
+    "discoveryAdultHint": "Eine 18+-Gilde wird nie im Community-Verzeichnis eingetragen.",
+    "discoveryAdultLocked": "Nimm diese Gilde aus dem Verzeichnis, bevor du sie als 18+ markierst.",
+    "discoveryCapacityBlocked": "Diese Gilde hat nur für eine Person Platz, also könnte ihr niemand über das Verzeichnis beitreten. Bitte deinen Plattformbetreiber, das Mitgliederlimit zu erhöhen.",
+    "discoveryListed": "Im Community-Verzeichnis eingetragen.",
+    "discoveryNotListed": "Nicht eingetragen. Nur Personen mit Einladung können beitreten."
   },
   "users": {
     "adminRequired": "Du benötigst Administrator-Berechtigungen, um diese Seite anzuzeigen.",
@@ -185,7 +196,8 @@
     "accountSettings": "Kontoeinstellungen",
     "platformSettings": "Plattformeinstellungen",
     "shellBackToStart": "Zurück zum Start",
-    "logOut": "Abmelden"
+    "logOut": "Abmelden",
+    "browseCommunities": "Communitys durchsuchen"
   },
   "notifications": {
     "title": "Benachrichtigungen",
@@ -307,5 +319,57 @@
     "claimButton": "Alle übernehmen",
     "summary_one": "{{count}} Element hat keinen Besitzer",
     "summary_other": "{{count}} Elemente haben keinen Besitzer"
+  },
+  "community": {
+    "title": "Communitys",
+    "subtitle": "Gilden, die neue Mitglieder ohne Einladung aufnehmen.",
+    "browse": "Community beitreten",
+    "searchPlaceholder": "Communitys durchsuchen",
+    "categoriesHeading": "Kategorien",
+    "allCategories": "Alle",
+    "categories": {
+      "art": "Kunst & Design",
+      "gaming": "Gaming",
+      "ttrpg": "Pen & Paper",
+      "music": "Musik",
+      "writing": "Schreiben",
+      "education": "Bildung",
+      "technology": "Wissenschaft & Technik",
+      "sports": "Sport & Fitness",
+      "business": "Business",
+      "health": "Gesundheit & Wohlbefinden",
+      "social": "Community & Soziales",
+      "other": "Sonstiges"
+    },
+    "join": "Beitreten",
+    "joining": "Trete bei…",
+    "open": "Öffnen",
+    "joinedToast": "Du bist {{guild}} beigetreten.",
+    "joinFailed": "Beitritt zu dieser Community nicht möglich.",
+    "noDescription": "Noch keine Beschreibung.",
+    "resultCount_one": "{{count}} Community",
+    "resultCount_other": "{{count}} Communitys",
+    "showMore": "Mehr anzeigen",
+    "emptyTitle": "Noch keine Communitys",
+    "emptyDescription": "Keine Gilde ist hier im Verzeichnis eingetragen. Gildenadmins können ihre Gilde in den Gildeneinstellungen eintragen.",
+    "noResultsTitle": "Keine Treffer",
+    "noResultsDescription": "Keine Community passt zu „{{query}}“. Versuche eine andere Suche oder Kategorie.",
+    "unavailableTitle": "Verzeichnis nicht verfügbar",
+    "unavailableDescription": "Das Community-Verzeichnis konnte nicht geladen werden. Versuche es gleich noch einmal.",
+    "publish": {
+      "title": "Diese Gilde im Verzeichnis eintragen",
+      "description": "Alle angemeldeten Personen können diese Gilde dann finden und ohne Einladung beitreten.",
+      "categoriesLabel": "Wähle mindestens eine Kategorie",
+      "categoriesHint": "Sie bestimmen, wo die Gilde beim Stöbern erscheint.",
+      "certifyLabel": "Diese Gilde enthält keine Inhalte für Erwachsene",
+      "certifyIntro": "Mit dem Eintrag dieser Gilde bestätigst du, dass sie nichts davon enthält:",
+      "certifyPorn": "Pornografie, sexuelle Inhalte oder Nacktheit",
+      "certifyMinors": "Jegliche sexuellen Inhalte, die Minderjährige betreffen",
+      "certifyIllegal": "Illegale Aktivitäten — Drogenkonsum oder -handel, Waffen, Betrug, Hehlerei",
+      "certifyViolence": "Drastische Gewalt, Gore oder Aufrufe zur Selbstverletzung",
+      "certifyHate": "Hassrede, Belästigung oder Drohungen",
+      "certifyDuty": "Du bist Admin dieser Gilde, also liegt die Durchsetzung bei dir. Von dir wird erwartet, dass du auf solche Inhalte achtest und sie entfernst. Eine Gilde, die das nicht mehr erfüllt, wird aus dem Verzeichnis entfernt.",
+      "confirm": "Gilde eintragen"
+    }
   }
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -460,5 +460,10 @@
   "FILTER_PRESET_DUPLICATE_ID": "The same preset was listed twice.",
   "FILTER_PRESET_SLUG_TAKEN": "A preset with that name already exists in this project.",
   "FILTER_PRESET_INVALID_FILTERS": "Those filters can’t be saved as a preset.",
-  "FILTER_PRESET_LIMIT_REACHED": "This project already has the maximum number of filter presets."
+  "FILTER_PRESET_LIMIT_REACHED": "This project already has the maximum number of filter presets.",
+  "GUILD_NOT_A_COMMUNITY": "That guild is not open to the community directory.",
+  "GUILD_COMMUNITY_REQUIRES_CATEGORY": "A listed guild needs at least one category.",
+  "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Confirm this guild contains no adult content before listing it.",
+  "GUILD_COMMUNITY_ADULT_CONTENT": "A guild marked 18+ cannot be listed in the community directory.",
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "This guild has room for only one person, so it cannot be listed in the community directory."
 }

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -117,7 +117,18 @@
     "retentionDescription": "How long deleted items stay in the trash before they're permanently removed. Set to \"Never\" to keep them until an admin manually deletes them.",
     "retentionDaysLabel": "Days",
     "retentionNeverLabel": "Never auto-purge",
-    "retentionUpdatedSuccessfully": "Retention updated."
+    "retentionUpdatedSuccessfully": "Retention updated.",
+    "discoveryTitle": "Community directory",
+    "discoveryDescription": "A listed guild appears in the directory, where anyone signed in can find it and join without an invite.",
+    "discoveryToggleLabel": "List this guild",
+    "discoveryCategoriesLabel": "Categories",
+    "discoveryCategoriesHint": "Pick the subjects that describe this guild. They decide which shelves it appears under.",
+    "discoveryAdultLabel": "This guild contains adult content (18+)",
+    "discoveryAdultHint": "An 18+ guild is never listed in the community directory.",
+    "discoveryAdultLocked": "Un-list this guild from the directory before marking it 18+.",
+    "discoveryCapacityBlocked": "This guild has room for only one person, so nobody could join it from the directory. Ask your platform operator to raise its member limit.",
+    "discoveryListed": "Listed in the community directory.",
+    "discoveryNotListed": "Not listed. Only people with an invite can join."
   },
   "users": {
     "adminRequired": "You need admin permissions to view this page.",
@@ -185,7 +196,8 @@
     "accountSettings": "Account settings",
     "platformSettings": "Platform settings",
     "shellBackToStart": "Back to start",
-    "logOut": "Log out"
+    "logOut": "Log out",
+    "browseCommunities": "Browse communities"
   },
   "notifications": {
     "title": "Notifications",
@@ -307,5 +319,57 @@
     "claimButton": "Claim all",
     "summary_one": "{{count}} item has no owner",
     "summary_other": "{{count}} items have no owner"
+  },
+  "community": {
+    "title": "Communities",
+    "subtitle": "Guilds that welcome new members without an invite.",
+    "browse": "Join a community",
+    "searchPlaceholder": "Search communities",
+    "categoriesHeading": "Categories",
+    "allCategories": "All",
+    "categories": {
+      "art": "Art & design",
+      "gaming": "Gaming",
+      "ttrpg": "Tabletop RPG",
+      "music": "Music",
+      "writing": "Writing",
+      "education": "Education",
+      "technology": "Science & tech",
+      "sports": "Sports & fitness",
+      "business": "Business",
+      "health": "Health & wellness",
+      "social": "Community & social",
+      "other": "Other"
+    },
+    "join": "Join",
+    "joining": "Joining…",
+    "open": "Open",
+    "joinedToast": "You joined {{guild}}.",
+    "joinFailed": "Unable to join that community.",
+    "noDescription": "No description yet.",
+    "resultCount_one": "{{count}} community",
+    "resultCount_other": "{{count}} communities",
+    "showMore": "Show more",
+    "emptyTitle": "No communities yet",
+    "emptyDescription": "No guild here has listed itself in the directory. A guild admin can list theirs from guild settings.",
+    "noResultsTitle": "Nothing matched",
+    "noResultsDescription": "No community matches “{{query}}”. Try another search or category.",
+    "unavailableTitle": "Directory unavailable",
+    "unavailableDescription": "The community directory could not be loaded. Try again in a moment.",
+    "publish": {
+      "title": "List this guild in the directory",
+      "description": "Anyone signed in will be able to find this guild and join it without an invite.",
+      "categoriesLabel": "Pick at least one category",
+      "categoriesHint": "These decide where the guild shows up when people browse.",
+      "certifyLabel": "This guild contains no adult content",
+      "certifyIntro": "By listing this guild you certify that it contains none of the following:",
+      "certifyPorn": "Pornography, sexual content, or nudity",
+      "certifyMinors": "Any sexual content involving a minor",
+      "certifyIllegal": "Illegal activity — drug use or sale, weapons, fraud, stolen goods",
+      "certifyViolence": "Graphic violence, gore, or encouragement of self-harm",
+      "certifyHate": "Hate speech, harassment, or threats",
+      "certifyDuty": "You are an admin of this guild, so this is yours to enforce. You are expected to watch for this content and remove it. A guild that stops meeting this is removed from the directory.",
+      "confirm": "List this guild"
+    }
   }
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -460,5 +460,10 @@
   "FILTER_PRESET_DUPLICATE_ID": "El mismo preajuste aparece dos veces.",
   "FILTER_PRESET_SLUG_TAKEN": "Ya existe un preajuste con ese nombre en este proyecto.",
   "FILTER_PRESET_INVALID_FILTERS": "Esos filtros no se pueden guardar como preajuste.",
-  "FILTER_PRESET_LIMIT_REACHED": "Este proyecto ya tiene el número máximo de preajustes de filtro."
+  "FILTER_PRESET_LIMIT_REACHED": "Este proyecto ya tiene el número máximo de preajustes de filtro.",
+  "GUILD_NOT_A_COMMUNITY": "Ese gremio no está publicado en el directorio de comunidades.",
+  "GUILD_COMMUNITY_REQUIRES_CATEGORY": "Un gremio publicado necesita al menos una categoría.",
+  "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Confirma que este gremio no contiene contenido para adultos antes de publicarlo.",
+  "GUILD_COMMUNITY_ADULT_CONTENT": "Un gremio marcado como +18 no puede publicarse en el directorio de comunidades.",
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Este gremio solo tiene sitio para una persona, así que no puede publicarse en el directorio de comunidades."
 }

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -117,7 +117,18 @@
     "retentionDescription": "Cuánto tiempo permanecen los elementos eliminados en la papelera antes de ser borrados permanentemente. Selecciona \"Nunca\" para conservarlos hasta que un administrador los elimine manualmente.",
     "retentionDaysLabel": "Días",
     "retentionNeverLabel": "Nunca purgar automáticamente",
-    "retentionUpdatedSuccessfully": "Retención actualizada."
+    "retentionUpdatedSuccessfully": "Retención actualizada.",
+    "discoveryTitle": "Directorio de comunidades",
+    "discoveryDescription": "Un gremio publicado aparece en el directorio, donde cualquier persona con la sesión iniciada puede encontrarlo y unirse sin invitación.",
+    "discoveryToggleLabel": "Publicar este gremio",
+    "discoveryCategoriesLabel": "Categorías",
+    "discoveryCategoriesHint": "Elige los temas que describen este gremio. Determinan en qué categorías aparece.",
+    "discoveryAdultLabel": "Este gremio contiene contenido para adultos (+18)",
+    "discoveryAdultHint": "Un gremio +18 nunca se publica en el directorio de comunidades.",
+    "discoveryAdultLocked": "Retira este gremio del directorio antes de marcarlo como +18.",
+    "discoveryCapacityBlocked": "Este gremio solo tiene sitio para una persona, así que nadie podría unirse desde el directorio. Pide a tu operador de plataforma que suba el límite de miembros.",
+    "discoveryListed": "Publicado en el directorio de comunidades.",
+    "discoveryNotListed": "Sin publicar. Solo puede unirse quien tenga una invitación."
   },
   "users": {
     "adminRequired": "Necesitas permisos de administrador para ver esta página.",
@@ -185,7 +196,8 @@
     "accountSettings": "Configuración de la cuenta",
     "platformSettings": "Configuración de la plataforma",
     "shellBackToStart": "Volver al inicio",
-    "logOut": "Cerrar sesión"
+    "logOut": "Cerrar sesión",
+    "browseCommunities": "Explorar comunidades"
   },
   "notifications": {
     "title": "Notificaciones",
@@ -307,5 +319,57 @@
     "claimButton": "Reclamar todo",
     "summary_one": "{{count}} elemento no tiene propietario",
     "summary_other": "{{count}} elementos no tienen propietario"
+  },
+  "community": {
+    "title": "Comunidades",
+    "subtitle": "Gremios que aceptan nuevos miembros sin invitación.",
+    "browse": "Unirse a una comunidad",
+    "searchPlaceholder": "Buscar comunidades",
+    "categoriesHeading": "Categorías",
+    "allCategories": "Todas",
+    "categories": {
+      "art": "Arte y diseño",
+      "gaming": "Videojuegos",
+      "ttrpg": "Rol de mesa",
+      "music": "Música",
+      "writing": "Escritura",
+      "education": "Educación",
+      "technology": "Ciencia y tecnología",
+      "sports": "Deporte y forma física",
+      "business": "Negocios",
+      "health": "Salud y bienestar",
+      "social": "Comunidad y social",
+      "other": "Otros"
+    },
+    "join": "Unirse",
+    "joining": "Uniéndose…",
+    "open": "Abrir",
+    "joinedToast": "Te has unido a {{guild}}.",
+    "joinFailed": "No se ha podido unir a esa comunidad.",
+    "noDescription": "Todavía no hay descripción.",
+    "resultCount_one": "{{count}} comunidad",
+    "resultCount_other": "{{count}} comunidades",
+    "showMore": "Mostrar más",
+    "emptyTitle": "Aún no hay comunidades",
+    "emptyDescription": "Ningún gremio de aquí aparece en el directorio. Un administrador de gremio puede publicarlo desde los ajustes del gremio.",
+    "noResultsTitle": "Sin resultados",
+    "noResultsDescription": "Ninguna comunidad coincide con «{{query}}». Prueba con otra búsqueda o categoría.",
+    "unavailableTitle": "Directorio no disponible",
+    "unavailableDescription": "No se ha podido cargar el directorio de comunidades. Inténtalo de nuevo en un momento.",
+    "publish": {
+      "title": "Publicar este gremio en el directorio",
+      "description": "Cualquier persona con la sesión iniciada podrá encontrar este gremio y unirse sin invitación.",
+      "categoriesLabel": "Elige al menos una categoría",
+      "categoriesHint": "Determinan dónde aparece el gremio cuando la gente explora.",
+      "certifyLabel": "Este gremio no contiene contenido para adultos",
+      "certifyIntro": "Al publicar este gremio certificas que no contiene nada de lo siguiente:",
+      "certifyPorn": "Pornografía, contenido sexual o desnudos",
+      "certifyMinors": "Cualquier contenido sexual que implique a un menor",
+      "certifyIllegal": "Actividad ilegal: consumo o venta de drogas, armas, fraude, bienes robados",
+      "certifyViolence": "Violencia gráfica, contenido sangriento o incitación a la autolesión",
+      "certifyHate": "Discurso de odio, acoso o amenazas",
+      "certifyDuty": "Eres administrador de este gremio, así que hacerlo cumplir te corresponde a ti. Se espera que vigiles este tipo de contenido y lo elimines. Un gremio que deje de cumplirlo se retira del directorio.",
+      "confirm": "Publicar gremio"
+    }
   }
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -460,5 +460,10 @@
   "FILTER_PRESET_DUPLICATE_ID": "Le même préréglage a été listé deux fois.",
   "FILTER_PRESET_SLUG_TAKEN": "Un préréglage portant ce nom existe déjà dans ce projet.",
   "FILTER_PRESET_INVALID_FILTERS": "Ces filtres ne peuvent pas être enregistrés comme préréglage.",
-  "FILTER_PRESET_LIMIT_REACHED": "Ce projet a déjà atteint le nombre maximal de préréglages de filtre."
+  "FILTER_PRESET_LIMIT_REACHED": "Ce projet a déjà atteint le nombre maximal de préréglages de filtre.",
+  "GUILD_NOT_A_COMMUNITY": "Cette guilde n’est pas inscrite à l’annuaire des communautés.",
+  "GUILD_COMMUNITY_REQUIRES_CATEGORY": "Une guilde inscrite doit avoir au moins une catégorie.",
+  "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Confirmez que cette guilde ne contient aucun contenu pour adultes avant de l’inscrire.",
+  "GUILD_COMMUNITY_ADULT_CONTENT": "Une guilde marquée 18+ ne peut pas être inscrite à l’annuaire des communautés.",
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Cette guilde n’a de place que pour une personne : elle ne peut pas être inscrite à l’annuaire des communautés."
 }

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -117,7 +117,18 @@
     "retentionDescription": "Combien de temps les éléments supprimés restent dans la corbeille avant d'être supprimés définitivement. Réglez sur \"Jamais\" pour les conserver jusqu'à ce qu'un administrateur les supprime manuellement.",
     "retentionDaysLabel": "Jours",
     "retentionNeverLabel": "Ne jamais purger automatiquement",
-    "retentionUpdatedSuccessfully": "Rétention mise à jour."
+    "retentionUpdatedSuccessfully": "Rétention mise à jour.",
+    "discoveryTitle": "Annuaire des communautés",
+    "discoveryDescription": "Une guilde inscrite apparaît dans l’annuaire, où toute personne connectée peut la trouver et la rejoindre sans invitation.",
+    "discoveryToggleLabel": "Inscrire cette guilde",
+    "discoveryCategoriesLabel": "Catégories",
+    "discoveryCategoriesHint": "Choisissez les sujets qui décrivent cette guilde. Ils déterminent les catégories où elle apparaît.",
+    "discoveryAdultLabel": "Cette guilde contient du contenu pour adultes (18+)",
+    "discoveryAdultHint": "Une guilde 18+ n’est jamais inscrite à l’annuaire des communautés.",
+    "discoveryAdultLocked": "Retirez cette guilde de l’annuaire avant de la marquer 18+.",
+    "discoveryCapacityBlocked": "Cette guilde n’a de place que pour une personne : personne ne pourrait la rejoindre depuis l’annuaire. Demandez à votre opérateur de plateforme d’augmenter la limite de membres.",
+    "discoveryListed": "Inscrite à l’annuaire des communautés.",
+    "discoveryNotListed": "Non inscrite. Seules les personnes disposant d’une invitation peuvent la rejoindre."
   },
   "users": {
     "adminRequired": "Vous avez besoin des permissions administrateur pour voir cette page.",
@@ -185,7 +196,8 @@
     "accountSettings": "Paramètres du compte",
     "platformSettings": "Paramètres de la plateforme",
     "shellBackToStart": "Retour à l'accueil",
-    "logOut": "Se déconnecter"
+    "logOut": "Se déconnecter",
+    "browseCommunities": "Parcourir les communautés"
   },
   "notifications": {
     "title": "Notifications",
@@ -307,5 +319,57 @@
     "claimButton": "Tout récupérer",
     "summary_one": "{{count}} élément n'a pas de propriétaire",
     "summary_other": "{{count}} éléments n'ont pas de propriétaire"
+  },
+  "community": {
+    "title": "Communautés",
+    "subtitle": "Les guildes qui accueillent de nouveaux membres sans invitation.",
+    "browse": "Rejoindre une communauté",
+    "searchPlaceholder": "Rechercher des communautés",
+    "categoriesHeading": "Catégories",
+    "allCategories": "Toutes",
+    "categories": {
+      "art": "Art et design",
+      "gaming": "Jeux vidéo",
+      "ttrpg": "Jeu de rôle sur table",
+      "music": "Musique",
+      "writing": "Écriture",
+      "education": "Éducation",
+      "technology": "Sciences et technologies",
+      "sports": "Sport et forme",
+      "business": "Entreprise",
+      "health": "Santé et bien-être",
+      "social": "Communauté et social",
+      "other": "Autre"
+    },
+    "join": "Rejoindre",
+    "joining": "Adhésion…",
+    "open": "Ouvrir",
+    "joinedToast": "Vous avez rejoint {{guild}}.",
+    "joinFailed": "Impossible de rejoindre cette communauté.",
+    "noDescription": "Pas encore de description.",
+    "resultCount_one": "{{count}} communauté",
+    "resultCount_other": "{{count}} communautés",
+    "showMore": "Afficher plus",
+    "emptyTitle": "Aucune communauté pour l’instant",
+    "emptyDescription": "Aucune guilde n’est inscrite à l’annuaire ici. Un administrateur de guilde peut inscrire la sienne depuis les paramètres de la guilde.",
+    "noResultsTitle": "Aucun résultat",
+    "noResultsDescription": "Aucune communauté ne correspond à « {{query}} ». Essayez une autre recherche ou catégorie.",
+    "unavailableTitle": "Annuaire indisponible",
+    "unavailableDescription": "Impossible de charger l’annuaire des communautés. Réessayez dans un instant.",
+    "publish": {
+      "title": "Inscrire cette guilde à l’annuaire",
+      "description": "Toute personne connectée pourra trouver cette guilde et la rejoindre sans invitation.",
+      "categoriesLabel": "Choisissez au moins une catégorie",
+      "categoriesHint": "Elles déterminent où la guilde apparaît quand on parcourt l’annuaire.",
+      "certifyLabel": "Cette guilde ne contient aucun contenu pour adultes",
+      "certifyIntro": "En inscrivant cette guilde, vous certifiez qu’elle ne contient rien de ce qui suit :",
+      "certifyPorn": "Pornographie, contenu sexuel ou nudité",
+      "certifyMinors": "Tout contenu sexuel impliquant un mineur",
+      "certifyIllegal": "Activité illégale — consommation ou vente de drogue, armes, fraude, biens volés",
+      "certifyViolence": "Violence graphique, contenu gore ou incitation à l’automutilation",
+      "certifyHate": "Discours haineux, harcèlement ou menaces",
+      "certifyDuty": "Vous êtes administrateur de cette guilde : c’est à vous de le faire respecter. Vous êtes censé surveiller ce type de contenu et le supprimer. Une guilde qui cesse de respecter cela est retirée de l’annuaire.",
+      "confirm": "Inscrire la guilde"
+    }
   }
 }

--- a/frontend/src/__tests__/factories/guild.factory.ts
+++ b/frontend/src/__tests__/factories/guild.factory.ts
@@ -20,6 +20,9 @@ export function buildGuild(overrides: Partial<GuildRead> = {}): GuildRead {
     member_count: 1,
     tier_name: null,
     content_read_only: false,
+    is_community: false,
+    categories: [],
+    has_adult_content: null,
     ...overrides,
   };
 }

--- a/frontend/src/api/generated/guilds/guilds.ts
+++ b/frontend/src/api/generated/guilds/guilds.ts
@@ -22,6 +22,7 @@ import type {
 
 import type {
   BillingPortalHandoffResponse,
+  CommunityGuildPage,
   GuildAuthPolicyRead,
   GuildAuthPolicyUpdate,
   GuildCreate,
@@ -36,6 +37,7 @@ import type {
   GuildUpdate,
   HTTPValidationError,
   LeaveGuildEligibilityResponse,
+  ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -357,6 +359,261 @@ export const useReorderGuildsApiV1GuildsOrderPut = <
   TContext
 > => {
   return useMutation(getReorderGuildsApiV1GuildsOrderPutMutationOptions(options), queryClient);
+};
+/**
+ * Browse the guilds that opted into the community directory.
+ *
+ * Runs on the system engine for the reason ``GET /invite/{code}`` does: the
+ * caller is a stranger to every guild here, so no guild-scoped role exists to
+ * read them under, and the RLS policy that scopes ``guilds`` to the caller's
+ * own memberships would return an empty directory. What that engine may see
+ * is not what this returns — the filters live in the service (listed AND
+ * active, always), and :class:`CommunityGuildRead` carries only what a guild
+ * published by opting in: no lifecycle status, no administration, no roster,
+ * and nothing at all from inside the guild's own schema.
+ * @summary List Community Guilds
+ */
+export const listCommunityGuildsApiV1GuildsCommunitiesGet = (
+  params?: ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<CommunityGuildPage>(
+    { url: `/api/v1/guilds/communities`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getListCommunityGuildsApiV1GuildsCommunitiesGetQueryKey = (
+  params?: ListCommunityGuildsApiV1GuildsCommunitiesGetParams
+) => {
+  return [`/api/v1/guilds/communities`, ...(params ? [params] : [])] as const;
+};
+
+export const getListCommunityGuildsApiV1GuildsCommunitiesGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getListCommunityGuildsApiV1GuildsCommunitiesGetQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>
+  > = ({ signal }) => listCommunityGuildsApiV1GuildsCommunitiesGet(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListCommunityGuildsApiV1GuildsCommunitiesGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>
+>;
+export type ListCommunityGuildsApiV1GuildsCommunitiesGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useListCommunityGuildsApiV1GuildsCommunitiesGet<
+  TData = Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params: undefined | ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+          TError,
+          Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListCommunityGuildsApiV1GuildsCommunitiesGet<
+  TData = Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+          TError,
+          Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListCommunityGuildsApiV1GuildsCommunitiesGet<
+  TData = Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List Community Guilds
+ */
+
+export function useListCommunityGuildsApiV1GuildsCommunitiesGet<
+  TData = Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listCommunityGuildsApiV1GuildsCommunitiesGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getListCommunityGuildsApiV1GuildsCommunitiesGetQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * Join a listed community guild. Its listing is the authorization.
+ *
+ * The system engine for the same reason ``accept_invite`` uses it — the user
+ * has no membership yet, so there is no guild role to write one under. Joining
+ * an already-joined guild is not an error; it returns the guild the caller is
+ * already in.
+ * @summary Join Community Guild
+ */
+export const joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost = (
+  guildId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<GuildRead>(
+    { url: `/api/v1/guilds/communities/${guildId}/join`, method: "POST", signal },
+    options
+  );
+};
+
+export const getJoinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost>>,
+    TError,
+    { guildId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost>>,
+  TError,
+  { guildId: number },
+  TContext
+> => {
+  const mutationKey = ["joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost>>,
+    { guildId: number }
+  > = (props) => {
+    const { guildId } = props ?? {};
+
+    return joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost(guildId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type JoinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost>>
+>;
+
+export type JoinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Join Community Guild
+ */
+export const useJoinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost>>,
+      TError,
+      { guildId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost>>,
+  TError,
+  { guildId: number },
+  TContext
+> => {
+  return useMutation(
+    getJoinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPostMutationOptions(options),
+    queryClient
+  );
 };
 /**
  * @summary Get Invite Status

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1272,6 +1272,64 @@ export interface CommentUpdate {
   content: string;
 }
 
+/**
+ * A subject a guild can file itself under in the community directory.
+ *
+ * A closed vocabulary rather than free-form tags: the directory's job is to
+ * narrow a deployment's guilds down to a browsable shelf, and that only works
+ * if two guilds about the same thing pick the same word. Guilds choose their
+ * own (zero or more) from their settings page; the labels are localized
+ * client-side from these keys, so the stored value is never user-facing text.
+ *
+ * Stored as a ``text[]`` on ``guilds.categories`` with a CHECK that every
+ * element is one of these, mirroring how ``status`` is a CHECK-constrained
+ * string rather than a Postgres enum: adding a category is then an ordinary
+ * migration instead of an enum alteration.
+ */
+export type GuildCategory = (typeof GuildCategory)[keyof typeof GuildCategory];
+
+export const GuildCategory = {
+  art: "art",
+  gaming: "gaming",
+  ttrpg: "ttrpg",
+  music: "music",
+  writing: "writing",
+  education: "education",
+  technology: "technology",
+  sports: "sports",
+  business: "business",
+  health: "health",
+  social: "social",
+  other: "other",
+} as const;
+
+/**
+ * One card in the community directory.
+ *
+ * Deliberately not a :class:`GuildRead`: the reader is a stranger, so this
+ * carries only what the guild published by opting in — its identity, its
+ * shelves, and how many people are already there. No membership fields (they
+ * have none), no lifecycle status, no administration. ``already_member`` is
+ * about the *caller*, and only says whether the Join button applies to them.
+ */
+export interface CommunityGuildRead {
+  id: number;
+  name: string;
+  description: string | null;
+  icon_base64: string | null;
+  categories: GuildCategory[];
+  member_count: number;
+  already_member: boolean;
+}
+
+/**
+ * A page of directory results, plus how many matched in total.
+ */
+export interface CommunityGuildPage {
+  items: CommunityGuildRead[];
+  total: number;
+}
+
 export type CounterViewMode = (typeof CounterViewMode)[keyof typeof CounterViewMode];
 
 export const CounterViewMode = {
@@ -2426,6 +2484,9 @@ export interface GuildRead {
   status: GuildStatus | null;
   content_read_only: boolean;
   guild_auth_enabled: boolean | null;
+  is_community: boolean;
+  categories: GuildCategory[];
+  has_adult_content: boolean | null;
 }
 
 export interface GuildStorageUsageRead {
@@ -2456,6 +2517,9 @@ export interface GuildUpdate {
   description?: string | null;
   icon_base64?: string | null;
   retention_days?: number | null;
+  is_community?: boolean | null;
+  categories?: GuildCategory[] | null;
+  has_adult_content?: boolean | null;
 }
 
 export type ValidationErrorCtx = { [key: string]: unknown };
@@ -4874,6 +4938,20 @@ export type AdminUpdateInitiativeMemberRoleApiV1AdminInitiativesInitiativeIdMemb
   {
     guild_id: number;
   };
+
+export type ListCommunityGuildsApiV1GuildsCommunitiesGetParams = {
+  q?: string | null;
+  category?: GuildCategory | null;
+  /**
+   * @minimum 1
+   */
+  page?: number;
+  /**
+   * @minimum 1
+   * @maximum 60
+   */
+  page_size?: number;
+};
 
 export type GetMyInitiativeMembersApiV1UsersMeInitiativeMembersInitiativeIdGetParams = {
   guild_id: number;

--- a/frontend/src/components/guilds/CommunityCard.tsx
+++ b/frontend/src/components/guilds/CommunityCard.tsx
@@ -1,0 +1,108 @@
+/**
+ * One guild in the community directory.
+ *
+ * Everything on this card is what the guild published by opting in — its name,
+ * description, icon, shelves, and how many people are already there. A guild
+ * the caller is already in keeps its card (so a search still finds it) but
+ * offers a way in rather than a way to join twice.
+ */
+
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2, Users } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import type { CommunityGuildRead } from "@/api/generated/initiativeAPI.schemas";
+import { GuildAvatar } from "@/components/guilds/GuildSidebar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useJoinCommunityGuild } from "@/hooks/useCommunities";
+import { useGuilds } from "@/hooks/useGuilds";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { guildCategoryLabel } from "@/lib/guildCategories";
+import { guildPath } from "@/lib/guildUrl";
+
+export const CommunityCard = ({ guild }: { guild: CommunityGuildRead }) => {
+  const { t } = useTranslation(["guilds", "common"]);
+  const navigate = useNavigate();
+  const { refreshGuilds, switchGuild } = useGuilds();
+  const join = useJoinCommunityGuild();
+
+  const open = () => {
+    void switchGuild(guild.id);
+    void navigate({ to: guildPath(guild.id, "/") });
+  };
+
+  const handleJoin = async () => {
+    try {
+      await join.mutateAsync(guild.id);
+      // The switcher is built from the caller's memberships, so it has to learn
+      // about the new one before we navigate into it.
+      await refreshGuilds();
+      toast.success(t("guilds:community.joinedToast", { guild: guild.name }));
+      open();
+    } catch (error) {
+      console.error(error);
+      toast.error(getErrorMessage(error, "guilds:community.joinFailed"));
+    }
+  };
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardContent className="flex flex-1 flex-col gap-3 p-4">
+        <div className="flex items-start gap-3">
+          <GuildAvatar name={guild.name} icon={guild.icon_base64} active={false} />
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate font-semibold text-base" title={guild.name}>
+              {guild.name}
+            </h3>
+            <p className="flex items-center gap-1 text-muted-foreground text-xs">
+              <Users className="h-3 w-3" aria-hidden="true" />
+              {t("guilds:memberCount", { count: guild.member_count })}
+            </p>
+          </div>
+        </div>
+
+        <p
+          className={
+            guild.description
+              ? "line-clamp-3 text-muted-foreground text-sm"
+              : "text-muted-foreground/70 text-sm italic"
+          }
+        >
+          {guild.description || t("guilds:community.noDescription")}
+        </p>
+
+        {guild.categories.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {guild.categories.map((category) => (
+              <Badge key={category} variant="secondary" className="font-normal">
+                {guildCategoryLabel(category, t)}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="mt-auto pt-1">
+          {guild.already_member ? (
+            <Button variant="outline" className="w-full" onClick={open}>
+              {t("guilds:community.open")}
+            </Button>
+          ) : (
+            <Button className="w-full" onClick={handleJoin} disabled={join.isPending}>
+              {join.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  {t("guilds:community.joining")}
+                </>
+              ) : (
+                t("guilds:community.join")
+              )}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/components/guilds/GuildDiscoveryPanel.test.tsx
+++ b/frontend/src/components/guilds/GuildDiscoveryPanel.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Opting a guild into the community directory.
+ *
+ * Listing publishes a guild to everyone signed in, so the interesting cases are
+ * all about what has to be true first: at least one category, an explicit
+ * certification that the guild is free of adult content, and room for somebody
+ * to actually join. The server enforces all three; what is checked here is that
+ * the UI asks before the request rather than reporting after it.
+ */
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildGuild } from "@/__tests__/factories";
+import { renderWithProviders } from "@/__tests__/helpers/render";
+import type { GuildRead } from "@/api/generated/initiativeAPI.schemas";
+
+import { GuildDiscoveryPanel } from "./GuildDiscoveryPanel";
+
+const patchGuild = vi.fn();
+
+vi.mock("@/api/generated/guilds/guilds", () => ({
+  updateGuildApiV1GuildsGuildIdPatch: (...args: unknown[]) => patchGuild(...args),
+}));
+
+const renderPanel = (guild: GuildRead) =>
+  renderWithProviders(<GuildDiscoveryPanel />, {
+    guilds: {
+      guilds: [guild],
+      activeGuildId: guild.id,
+      activeGuild: guild,
+      loading: false,
+      error: null,
+      refreshGuilds: vi.fn(),
+      switchGuild: vi.fn(),
+      syncGuildFromUrl: vi.fn(),
+      createGuild: vi.fn(),
+      updateGuildInState: vi.fn(),
+      reorderGuilds: vi.fn(),
+      canCreateGuilds: true,
+    },
+  });
+
+const adminGuild = (overrides: Partial<GuildRead> = {}) =>
+  buildGuild({ id: 7, role: "admin", ...overrides });
+
+const listingToggle = () => screen.getByLabelText("List this guild");
+const adultToggle = () => screen.getByLabelText("This guild contains adult content (18+)");
+const dialog = () => screen.getByRole("dialog");
+const certify = () => within(dialog()).getByLabelText("This guild contains no adult content");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  patchGuild.mockResolvedValue(adminGuild({ is_community: true }));
+});
+
+describe("GuildDiscoveryPanel", () => {
+  it("is absent for a member", () => {
+    renderPanel(buildGuild({ id: 7, role: "member" }));
+
+    expect(screen.queryByText("Community directory")).not.toBeInTheDocument();
+  });
+
+  it("offers the opt-in to a guild admin", () => {
+    renderPanel(adminGuild());
+
+    expect(screen.getByText("Community directory")).toBeInTheDocument();
+    expect(listingToggle()).not.toBeChecked();
+  });
+
+  describe("the publish dialog", () => {
+    it("stands between the toggle and the listing", async () => {
+      renderPanel(adminGuild());
+
+      await userEvent.click(listingToggle());
+
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      // Nothing is published by opening it.
+      expect(patchGuild).not.toHaveBeenCalled();
+    });
+
+    it("will not confirm without a category", async () => {
+      renderPanel(adminGuild());
+      await userEvent.click(listingToggle());
+      await screen.findByRole("dialog");
+
+      await userEvent.click(certify());
+
+      expect(within(dialog()).getByRole("button", { name: "List this guild" })).toBeDisabled();
+    });
+
+    it("will not confirm without the certification", async () => {
+      renderPanel(adminGuild());
+      await userEvent.click(listingToggle());
+      await screen.findByRole("dialog");
+
+      await userEvent.click(within(dialog()).getByRole("button", { name: "Gaming" }));
+
+      expect(within(dialog()).getByRole("button", { name: "List this guild" })).toBeDisabled();
+    });
+
+    it("spells out what the certification covers", async () => {
+      renderPanel(adminGuild());
+      await userEvent.click(listingToggle());
+      const panel = await screen.findByRole("dialog");
+
+      // The criminal-liability line especially must be stated, not implied.
+      expect(within(panel).getByText("Any sexual content involving a minor")).toBeInTheDocument();
+      expect(within(panel).getByText("Pornography, sexual content, or nudity")).toBeInTheDocument();
+      expect(within(panel).getByText(/Illegal activity — drug use or sale/)).toBeInTheDocument();
+      expect(within(panel).getByText(/you are expected to watch for/i)).toBeInTheDocument();
+    });
+
+    it("publishes with the categories picked and the 18+ question answered", async () => {
+      renderPanel(adminGuild());
+      await userEvent.click(listingToggle());
+      await screen.findByRole("dialog");
+
+      await userEvent.click(within(dialog()).getByRole("button", { name: "Gaming" }));
+      await userEvent.click(within(dialog()).getByRole("button", { name: "Tabletop RPG" }));
+      await userEvent.click(certify());
+      await userEvent.click(within(dialog()).getByRole("button", { name: "List this guild" }));
+
+      await waitFor(() => {
+        expect(patchGuild).toHaveBeenCalledWith(7, {
+          is_community: true,
+          categories: ["gaming", "ttrpg"],
+          has_adult_content: false,
+        });
+      });
+    });
+
+    it("asks for the certification again every time it opens", async () => {
+      renderPanel(adminGuild());
+
+      await userEvent.click(listingToggle());
+      await screen.findByRole("dialog");
+      await userEvent.click(certify());
+      await userEvent.click(within(dialog()).getByRole("button", { name: "Cancel" }));
+
+      await userEvent.click(listingToggle());
+      await screen.findByRole("dialog");
+      expect(certify()).not.toBeChecked();
+    });
+  });
+
+  it("un-lists on the click, with nothing to confirm", async () => {
+    renderPanel(adminGuild({ is_community: true, categories: ["art"] }));
+
+    await userEvent.click(listingToggle());
+
+    await waitFor(() => {
+      expect(patchGuild).toHaveBeenCalledWith(7, { is_community: false });
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("edits the shelves of an already-listed guild in place", async () => {
+    renderPanel(adminGuild({ is_community: true, categories: ["art"] }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Gaming" }));
+
+    await waitFor(() => {
+      expect(patchGuild).toHaveBeenCalledWith(7, { categories: ["art", "gaming"] });
+    });
+  });
+
+  describe("the carve-outs", () => {
+    it("does not offer the toggle to a guild with room for one", async () => {
+      renderPanel(adminGuild({ max_users: 1 }));
+
+      expect(listingToggle()).toBeDisabled();
+      expect(screen.getByText(/room for only one person/)).toBeInTheDocument();
+    });
+
+    it("offers it once there is room for two", () => {
+      renderPanel(adminGuild({ max_users: 2 }));
+
+      expect(listingToggle()).toBeEnabled();
+    });
+
+    it("does not offer the toggle to a guild that has declared itself 18+", () => {
+      renderPanel(adminGuild({ has_adult_content: true }));
+
+      expect(listingToggle()).toBeDisabled();
+      expect(adultToggle()).toBeChecked();
+    });
+
+    it("declares adult content on a guild that is not listed", async () => {
+      renderPanel(adminGuild());
+
+      await userEvent.click(adultToggle());
+
+      await waitFor(() => {
+        expect(patchGuild).toHaveBeenCalledWith(7, { has_adult_content: true });
+      });
+    });
+
+    it("makes a listed guild come off the directory before turning 18+", () => {
+      renderPanel(adminGuild({ is_community: true, categories: ["art"] }));
+
+      expect(adultToggle()).toBeDisabled();
+      expect(screen.getByText(/Un-list this guild/)).toBeInTheDocument();
+    });
+  });
+
+  it("reports a refused save rather than looking like it worked", async () => {
+    patchGuild.mockRejectedValue(new Error("nope"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    renderPanel(adminGuild({ is_community: true, categories: ["art"] }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Gaming" }));
+
+    expect(await screen.findByText("Unable to update guild.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/guilds/GuildDiscoveryPanel.tsx
+++ b/frontend/src/components/guilds/GuildDiscoveryPanel.tsx
@@ -1,0 +1,217 @@
+/**
+ * The community-directory opt-in, on the guild settings page.
+ *
+ * Guild admins only — the API refuses these fields from anyone else, and the
+ * whole settings section is admin-gated — so the panel is simply absent for a
+ * member rather than shown disabled.
+ *
+ * Saved on its own rather than folded into the details form above: listing a
+ * guild publishes it to everyone signed in, which is a different decision from
+ * renaming it, and the PATCH treats omitted fields as untouched so the two
+ * never overwrite each other.
+ *
+ * Three conditions gate a listing, and the server enforces all three (two of
+ * them as database CHECKs). What the UI adds is that they are asked *before*
+ * the request rather than reported after it: the publish dialog collects the
+ * categories and the content certification together, and a guild whose seat
+ * limit leaves no room to join is told so instead of being offered a toggle
+ * that can only fail.
+ */
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { updateGuildApiV1GuildsGuildIdPatch } from "@/api/generated/guilds/guilds";
+import type { GuildCategory, GuildRead } from "@/api/generated/initiativeAPI.schemas";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useGuilds } from "@/hooks/useGuilds";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { GUILD_CATEGORIES, guildCategoryLabel } from "@/lib/guildCategories";
+import { cn } from "@/lib/utils";
+
+import { PublishGuildDialog } from "./PublishGuildDialog";
+
+/** A guild with one seat can never admit a joiner, so it is never listed.
+ *  Mirrors MIN_COMMUNITY_SEATS on the server, which is what enforces it. */
+const MIN_COMMUNITY_SEATS = 2;
+
+export const GuildDiscoveryPanel = () => {
+  const { t } = useTranslation(["guilds", "common"]);
+  const { activeGuild, refreshGuilds, updateGuildInState } = useGuilds();
+  const [publishing, setPublishing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMessage(null);
+    setError(null);
+  }, [activeGuild]);
+
+  if (activeGuild?.role !== "admin") {
+    return null;
+  }
+
+  const listed = activeGuild.is_community;
+  const isAdult = activeGuild.has_adult_content === true;
+  // null is unlimited. Only an operator sets this, so an admin who hits it is
+  // told who to ask rather than offered a control they cannot satisfy.
+  const seatLimited = activeGuild.max_users != null && activeGuild.max_users < MIN_COMMUNITY_SEATS;
+  const canList = !isAdult && !seatLimited;
+
+  const save = async (updates: Partial<GuildRead>) => {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const result = (await updateGuildApiV1GuildsGuildIdPatch(
+        activeGuild.id,
+        updates as Parameters<typeof updateGuildApiV1GuildsGuildIdPatch>[1]
+      )) as unknown as GuildRead;
+      updateGuildInState(result);
+      await refreshGuilds();
+      setMessage(t("guilds:settings.updatedSuccessfully"));
+      return true;
+    } catch (err) {
+      console.error(err);
+      setError(getErrorMessage(err, "guilds:settings.unableToUpdate"));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Listing is a publication, so it goes through the dialog that collects the
+  // categories and the certification. Un-listing publishes nothing and asks
+  // nothing — it takes effect on the click.
+  const handleToggle = (next: boolean) => {
+    if (next) {
+      setPublishing(true);
+      return;
+    }
+    void save({ is_community: false });
+  };
+
+  const toggleCategory = (category: GuildCategory) => {
+    const next = activeGuild.categories.includes(category)
+      ? activeGuild.categories.filter((value) => value !== category)
+      : [...activeGuild.categories, category];
+    void save({ categories: next });
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("guilds:settings.discoveryTitle")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground text-sm">
+            {t("guilds:settings.discoveryDescription")}
+          </p>
+
+          <div className="flex items-center gap-3">
+            <Switch
+              id="guild-is-community"
+              checked={listed}
+              disabled={saving || (!listed && !canList)}
+              onCheckedChange={handleToggle}
+            />
+            <Label htmlFor="guild-is-community">{t("guilds:settings.discoveryToggleLabel")}</Label>
+          </div>
+
+          {/* Why the toggle is unavailable, rather than an inert control. */}
+          {!listed && seatLimited ? (
+            <p className="text-muted-foreground text-sm">
+              {t("guilds:settings.discoveryCapacityBlocked")}
+            </p>
+          ) : null}
+          {!listed && isAdult && !seatLimited ? (
+            <p className="text-muted-foreground text-sm">
+              {t("guilds:settings.discoveryAdultHint")}
+            </p>
+          ) : null}
+
+          {/* The shelves only matter once the guild is on one. They are editable
+              here afterwards; the dialog is only for the first publication. */}
+          {listed ? (
+            <fieldset className="space-y-2">
+              <legend className="font-medium text-sm">
+                {t("guilds:settings.discoveryCategoriesLabel")}
+              </legend>
+              <p className="text-muted-foreground text-sm">
+                {t("guilds:settings.discoveryCategoriesHint")}
+              </p>
+              <div className="flex flex-wrap gap-2 pt-1">
+                {GUILD_CATEGORIES.map((category) => {
+                  const selected = activeGuild.categories.includes(category);
+                  return (
+                    <button
+                      key={category}
+                      type="button"
+                      onClick={() => toggleCategory(category)}
+                      aria-pressed={selected}
+                      disabled={saving}
+                      className={cn(
+                        "rounded-full border px-3 py-1 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50",
+                        selected
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-input text-muted-foreground hover:bg-muted hover:text-foreground"
+                      )}
+                    >
+                      {guildCategoryLabel(category, t)}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+          ) : null}
+
+          {/* The 18+ declaration. Its own decision, and one a guild that never
+              lists itself is free to make either way — but a listed guild has
+              already certified the opposite, so it is de-list-first. */}
+          <div className="space-y-2 border-t pt-4">
+            <div className="flex items-center gap-3">
+              <Switch
+                id="guild-has-adult-content"
+                checked={isAdult}
+                disabled={saving || listed}
+                onCheckedChange={(next) => void save({ has_adult_content: next })}
+              />
+              <Label htmlFor="guild-has-adult-content">
+                {t("guilds:settings.discoveryAdultLabel")}
+              </Label>
+            </div>
+            <p className="text-muted-foreground text-sm">
+              {listed
+                ? t("guilds:settings.discoveryAdultLocked")
+                : t("guilds:settings.discoveryAdultHint")}
+            </p>
+          </div>
+
+          {error ? <p className="text-destructive text-sm">{error}</p> : null}
+          {message ? <p className="text-primary text-sm">{message}</p> : null}
+        </CardContent>
+      </Card>
+
+      <PublishGuildDialog
+        open={publishing}
+        saving={saving}
+        initialCategories={activeGuild.categories}
+        onCancel={() => setPublishing(false)}
+        onConfirm={async (categories) => {
+          const ok = await save({
+            is_community: true,
+            categories,
+            // Ticking the certification in the dialog is what answers the 18+
+            // question; there is no other path from unanswered to "no".
+            has_adult_content: false,
+          });
+          if (ok) setPublishing(false);
+        }}
+      />
+    </>
+  );
+};

--- a/frontend/src/components/guilds/GuildSidebar.test.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.test.tsx
@@ -201,3 +201,35 @@ describe("GuildSidebar guild creation", () => {
     openSpy.mockRestore();
   });
 });
+
+describe("the way into the community directory", () => {
+  it("sits in the rail under the add-a-guild button", async () => {
+    setup([entry({ id: 1, name: "Alpha" })]);
+
+    const link = await screen.findByRole("link", { name: "Join a community" });
+    expect(link).toHaveAttribute("href", "/communities");
+  });
+
+  it("is offered even where guilds cannot be created", async () => {
+    // A deployment with guild creation switched off is exactly where joining an
+    // existing guild is the only way into one.
+    renderPage(
+      () => (
+        <SidebarProvider>
+          <GuildSidebar />
+        </SidebarProvider>
+      ),
+      { guilds: { guilds: [entry({ id: 1, name: "Alpha" })], canCreateGuilds: false } }
+    );
+
+    expect(await screen.findByRole("link", { name: "Join a community" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create guild" })).not.toBeInTheDocument();
+  });
+
+  it("is repeated in the expanded guild list", async () => {
+    setup([entry({ id: 1, name: "Alpha" })]);
+    const { panel } = await openFlyout();
+
+    expect(within(panel).getByRole("link", { name: "Join a community" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -19,7 +19,15 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Link, useRouter } from "@tanstack/react-router";
-import { Check, ChevronsLeft, ChevronsRight, Clock, GripVertical, Plus } from "lucide-react";
+import {
+  Check,
+  ChevronsLeft,
+  ChevronsRight,
+  Clock,
+  Compass,
+  GripVertical,
+  Plus,
+} from "lucide-react";
 import type { CSSProperties, FormEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -171,6 +179,58 @@ const CreateGuildButton = ({ expanded = false }: { expanded?: boolean }) => {
         </form>
       </DialogContent>
     </Dialog>
+  );
+};
+
+// Way in to the community directory, under "add a guild": the other way to end
+// up in a new guild, for anyone without an invite to redeem. Unlike creating
+// one this is never hidden — a deployment that has switched guild creation off
+// is exactly where joining an existing guild is the only way in.
+const JoinCommunityButton = ({
+  expanded = false,
+  onNavigate,
+}: {
+  expanded?: boolean;
+  /** Closes the flyout on the way out, so the directory is not behind it. */
+  onNavigate?: () => void;
+}) => {
+  const { t } = useTranslation("guilds");
+  const label = t("community.browse");
+
+  if (expanded) {
+    return (
+      <Link
+        to="/communities"
+        onClick={onNavigate}
+        className="flex w-full items-center gap-3 rounded-lg border border-muted-foreground/40 border-dashed px-3 py-2 text-left text-muted-foreground transition hover:bg-muted hover:text-foreground"
+      >
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center">
+          <Compass className="h-5 w-5" />
+        </span>
+        <span className="truncate font-medium text-sm">{label}</span>
+      </Link>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="secondary"
+          size="icon"
+          className="h-12 w-12 rounded-2xl border border-muted-foreground/40 border-dashed bg-transparent text-muted-foreground hover:bg-muted"
+          aria-label={label}
+          asChild
+        >
+          <Link to="/communities" onClick={onNavigate}>
+            <Compass className="h-5 w-5" />
+          </Link>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="right" sideOffset={12}>
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
   );
 };
 
@@ -831,6 +891,7 @@ export const GuildSidebar = ({ isHomeMode = false }: { isHomeMode?: boolean }) =
             </TooltipContent>
           </Tooltip>
           {canCreateGuilds ? <CreateGuildButton /> : null}
+          <JoinCommunityButton />
         </div>
       </TooltipProvider>
 
@@ -945,11 +1006,10 @@ export const GuildSidebar = ({ isHomeMode = false }: { isHomeMode?: boolean }) =
                 </div>
               ) : null}
             </div>
-            {canCreateGuilds ? (
-              <div className="shrink-0 border-t p-2">
-                <CreateGuildButton expanded />
-              </div>
-            ) : null}
+            <div className="shrink-0 space-y-2 border-t p-2">
+              {canCreateGuilds ? <CreateGuildButton expanded /> : null}
+              <JoinCommunityButton expanded onNavigate={collapse} />
+            </div>
           </div>
         </>
       ) : null}

--- a/frontend/src/components/guilds/PublishGuildDialog.tsx
+++ b/frontend/src/components/guilds/PublishGuildDialog.tsx
@@ -1,0 +1,158 @@
+/**
+ * The gate between a private guild and a listed one.
+ *
+ * Listing publishes a guild to everyone signed in, so it is a decision made
+ * once, deliberately, with both of its conditions in front of you: at least one
+ * category, and a certification about what the guild contains. Neither is a
+ * default anyone can click past — Confirm stays disabled until both are met,
+ * and the server refuses the same two conditions independently.
+ *
+ * The certification is what answers the guild's 18+ question. Ticking it here
+ * is the only path from unanswered to "no", which is why the statement sits
+ * with the checkbox rather than in a policy page nobody opens.
+ */
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { GuildCategory } from "@/api/generated/initiativeAPI.schemas";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { GUILD_CATEGORIES, guildCategoryLabel } from "@/lib/guildCategories";
+import { cn } from "@/lib/utils";
+
+/** One key per line of the certification, so a translator sees each claim on
+ *  its own rather than one paragraph to keep in sync. */
+const CERTIFY_KEYS = [
+  "certifyPorn",
+  "certifyMinors",
+  "certifyIllegal",
+  "certifyViolence",
+  "certifyHate",
+] as const;
+
+export const PublishGuildDialog = ({
+  open,
+  saving,
+  initialCategories,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean;
+  saving: boolean;
+  initialCategories: GuildCategory[];
+  onCancel: () => void;
+  onConfirm: (categories: GuildCategory[]) => void | Promise<void>;
+}) => {
+  const { t } = useTranslation(["guilds", "common"]);
+  const [categories, setCategories] = useState<GuildCategory[]>(initialCategories);
+  const [certified, setCertified] = useState(false);
+
+  // Every opening starts from the guild's current shelves and an un-ticked
+  // certification: it is an assertion made now, not one a previous visit made.
+  useEffect(() => {
+    if (open) {
+      setCategories(initialCategories);
+      setCertified(false);
+    }
+  }, [open, initialCategories]);
+
+  const toggleCategory = (category: GuildCategory) => {
+    setCategories((current) =>
+      current.includes(category)
+        ? current.filter((value) => value !== category)
+        : [...current, category]
+    );
+  };
+
+  const ready = categories.length > 0 && certified;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && !saving && onCancel()}>
+      <DialogContent className="max-h-screen overflow-y-auto bg-card sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("guilds:community.publish.title")}</DialogTitle>
+          <DialogDescription>{t("guilds:community.publish.description")}</DialogDescription>
+        </DialogHeader>
+
+        <fieldset className="space-y-2">
+          <legend className="font-medium text-sm">
+            {t("guilds:community.publish.categoriesLabel")}
+          </legend>
+          <p className="text-muted-foreground text-sm">
+            {t("guilds:community.publish.categoriesHint")}
+          </p>
+          <div className="flex flex-wrap gap-2 pt-1">
+            {GUILD_CATEGORIES.map((category) => {
+              const selected = categories.includes(category);
+              return (
+                <button
+                  key={category}
+                  type="button"
+                  onClick={() => toggleCategory(category)}
+                  aria-pressed={selected}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    selected
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-input text-muted-foreground hover:bg-muted hover:text-foreground"
+                  )}
+                >
+                  {guildCategoryLabel(category, t)}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <div className="space-y-3 rounded-lg border bg-muted/40 p-3">
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="guild-certify-no-adult-content"
+              checked={certified}
+              onCheckedChange={(next) => setCertified(next === true)}
+              className="mt-0.5"
+            />
+            <Label
+              htmlFor="guild-certify-no-adult-content"
+              className="font-medium text-sm leading-snug"
+            >
+              {t("guilds:community.publish.certifyLabel")}
+            </Label>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            {t("guilds:community.publish.certifyIntro")}
+          </p>
+          <ul className="list-disc space-y-1 pl-5 text-sm">
+            {CERTIFY_KEYS.map((key) => (
+              <li key={key}>{t(`guilds:community.publish.${key}`)}</li>
+            ))}
+          </ul>
+          <p className="font-medium text-sm">{t("guilds:community.publish.certifyDuty")}</p>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel} disabled={saving}>
+            {t("common:cancel")}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void onConfirm(categories)}
+            disabled={!ready || saving}
+          >
+            {saving ? t("guilds:settings.saving") : t("guilds:community.publish.confirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/hooks/useCommunities.ts
+++ b/frontend/src/hooks/useCommunities.ts
@@ -1,0 +1,58 @@
+/**
+ * The community directory.
+ *
+ * Platform-level, like the marketplace: one shared surface with no guild in the
+ * request, so entries are keyed on what was asked for and nothing else. Joining
+ * changes which guilds the caller belongs to, so the mutation refreshes the
+ * guild switcher as well as the directory it was invoked from.
+ */
+
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost,
+  listCommunityGuildsApiV1GuildsCommunitiesGet,
+} from "@/api/generated/guilds/guilds";
+import type {
+  CommunityGuildPage,
+  GuildRead,
+  ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+} from "@/api/generated/initiativeAPI.schemas";
+import type { QueryOpts } from "@/types/query";
+
+/** Shared prefix, so joining can invalidate every filter combination at once
+ *  (a card that was `already_member: false` no longer is, on any page). */
+export const COMMUNITIES_QUERY_KEY = ["communities"] as const;
+
+const communitiesQueryKey = (params: ListCommunityGuildsApiV1GuildsCommunitiesGetParams) =>
+  [...COMMUNITIES_QUERY_KEY, params] as const;
+
+/** The directory turns over when a guild opts in or out, not while someone
+ *  scrolls it. */
+const DIRECTORY_STALE_MS = 60 * 1000;
+
+export const useCommunityGuilds = (
+  params: ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  options?: QueryOpts<CommunityGuildPage>
+) =>
+  useQuery<CommunityGuildPage>({
+    queryKey: communitiesQueryKey(params),
+    queryFn: ({ signal }) =>
+      listCommunityGuildsApiV1GuildsCommunitiesGet(params, undefined, signal),
+    // Keeps the grid on screen while the next search or category loads, rather
+    // than blanking it out on every keystroke.
+    placeholderData: keepPreviousData,
+    staleTime: DIRECTORY_STALE_MS,
+    ...options,
+  });
+
+export const useJoinCommunityGuild = () => {
+  const queryClient = useQueryClient();
+  return useMutation<GuildRead, unknown, number>({
+    mutationFn: (guildId: number) =>
+      joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost(guildId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: COMMUNITIES_QUERY_KEY });
+    },
+  });
+};

--- a/frontend/src/hooks/useCommunities.ts
+++ b/frontend/src/hooks/useCommunities.ts
@@ -7,7 +7,12 @@
  * guild switcher as well as the directory it was invoked from.
  */
 
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import {
   joinCommunityGuildApiV1GuildsCommunitiesGuildIdJoinPost,
@@ -18,32 +23,46 @@ import type {
   GuildRead,
   ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
 } from "@/api/generated/initiativeAPI.schemas";
-import type { QueryOpts } from "@/types/query";
 
 /** Shared prefix, so joining can invalidate every filter combination at once
  *  (a card that was `already_member: false` no longer is, on any page). */
 export const COMMUNITIES_QUERY_KEY = ["communities"] as const;
 
-const communitiesQueryKey = (params: ListCommunityGuildsApiV1GuildsCommunitiesGetParams) =>
-  [...COMMUNITIES_QUERY_KEY, params] as const;
-
 /** The directory turns over when a guild opts in or out, not while someone
  *  scrolls it. */
 const DIRECTORY_STALE_MS = 60 * 1000;
 
-export const useCommunityGuilds = (
-  params: ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
-  options?: QueryOpts<CommunityGuildPage>
-) =>
-  useQuery<CommunityGuildPage>({
-    queryKey: communitiesQueryKey(params),
-    queryFn: ({ signal }) =>
-      listCommunityGuildsApiV1GuildsCommunitiesGet(params, undefined, signal),
+/** Cards per request. The endpoint caps a page at 60, so "show more" fetches
+ *  the next page rather than asking for a bigger one — a growing page_size
+ *  runs into that ceiling and takes the whole grid down with it. */
+export const COMMUNITIES_PAGE_SIZE = 24;
+
+/** Everything except the page number, which the query owns. */
+export type CommunityFilters = Omit<
+  ListCommunityGuildsApiV1GuildsCommunitiesGetParams,
+  "page" | "page_size"
+>;
+
+export const useCommunityGuilds = (filters: CommunityFilters) =>
+  useInfiniteQuery<CommunityGuildPage>({
+    queryKey: [...COMMUNITIES_QUERY_KEY, filters],
+    queryFn: ({ pageParam, signal }) =>
+      listCommunityGuildsApiV1GuildsCommunitiesGet(
+        { ...filters, page: pageParam as number, page_size: COMMUNITIES_PAGE_SIZE },
+        undefined,
+        signal
+      ),
+    initialPageParam: 1,
+    // ``total`` is how many matched, not how many were returned, so the page
+    // after the last full one is the end.
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce((count, page) => count + page.items.length, 0);
+      return loaded < lastPage.total ? allPages.length + 1 : undefined;
+    },
     // Keeps the grid on screen while the next search or category loads, rather
     // than blanking it out on every keystroke.
     placeholderData: keepPreviousData,
     staleTime: DIRECTORY_STALE_MS,
-    ...options,
   });
 
 export const useJoinCommunityGuild = () => {

--- a/frontend/src/hooks/useGuilds.tsx
+++ b/frontend/src/hooks/useGuilds.tsx
@@ -108,6 +108,12 @@ const grantEntry = (grant: AccessGrantRead): GuildEntry => ({
   content_read_only: false,
   // Admin-only entitlement; a grantee acts as a member here, so it's absent.
   guild_auth_enabled: null,
+  // A grant reaches one named guild directly; the directory is not how the
+  // grantee got here, and this synthetic entry is never listed in it.
+  is_community: false,
+  categories: [],
+  // Guild-admin territory, and a grantee acts as a member — so, unanswered.
+  has_adult_content: null,
   created_at: grant.requested_at,
   updated_at: grant.requested_at,
   accessType: "grant",

--- a/frontend/src/lib/guildCategories.ts
+++ b/frontend/src/lib/guildCategories.ts
@@ -1,0 +1,30 @@
+/**
+ * The community directory's shelves.
+ *
+ * Derived from the generated `GuildCategory` enum rather than restated, so a
+ * category added server-side reaches the filter rail and the settings picker
+ * without an edit here — and in the order the backend declares, which is also
+ * the order it stores a guild's selection in.
+ *
+ * Labels are looked up per category key in the `guilds` namespace, so a new
+ * category shows its own key until it is translated rather than silently
+ * rendering as another one's name.
+ */
+
+import type { TFunction } from "i18next";
+
+import { GuildCategory } from "@/api/generated/initiativeAPI.schemas";
+
+export const GUILD_CATEGORIES: GuildCategory[] = Object.values(GuildCategory);
+
+/** The namespaces every surface that draws a category label already loads. */
+export type GuildCategoryT = TFunction<readonly ["guilds", "common"]>;
+
+export const guildCategoryLabel = (category: GuildCategory, t: GuildCategoryT): string =>
+  // The default is the key itself: a category this build has no label for
+  // yet should read as something rather than as nothing.
+  t(`guilds:community.categories.${category}`, { defaultValue: category });
+
+/** Narrow an unvalidated value (a URL search param) to a category, or nothing. */
+export const asGuildCategory = (value: unknown): GuildCategory | undefined =>
+  GUILD_CATEGORIES.includes(value as GuildCategory) ? (value as GuildCategory) : undefined;

--- a/frontend/src/lib/noGuildLayout.test.ts
+++ b/frontend/src/lib/noGuildLayout.test.ts
@@ -77,6 +77,28 @@ describe("chooseNoGuildLayout", () => {
     });
   });
 
+  describe("the community directory (no guilds)", () => {
+    it("renders the chromeless shell so a guild-less user can join one", () => {
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/communities",
+          isPlatformAdmin: false,
+        })
+      ).toBe("shell");
+    });
+
+    it("does not match a partial-prefix collision like /communitiesX", () => {
+      expect(
+        chooseNoGuildLayout({
+          hasGuilds: false,
+          pathname: "/communitiesx",
+          isPlatformAdmin: false,
+        })
+      ).toBe("empty");
+    });
+  });
+
   describe("platform-admin settings routes (no guilds)", () => {
     it("renders the shell when the user is a platform admin", () => {
       expect(

--- a/frontend/src/lib/noGuildLayout.ts
+++ b/frontend/src/lib/noGuildLayout.ts
@@ -10,11 +10,13 @@
  * Outcomes:
  * - ``"main"``  — user has at least one guild; render the standard
  *                 sidebar layout.
- * - ``"shell"`` — no guilds, but the current path is a user-scoped
- *                 settings route (or a platform-admin settings
- *                 route for an admin); render the chromeless
- *                 ``NoGuildSettingsShell`` so the user can still
- *                 reach Danger Zone / platform configuration.
+ * - ``"shell"`` — no guilds, but the current path is one that works
+ *                 without guild context: a user-scoped settings route,
+ *                 a platform-admin settings route for an admin, or the
+ *                 community directory. Render the chromeless
+ *                 ``NoGuildSettingsShell`` so the user can still reach
+ *                 Danger Zone / platform configuration — or join a guild
+ *                 without waiting for an invite.
  * - ``"empty"`` — no guilds and no exempt path; show
  *                 ``NoGuildState`` (the create / join / logout
  *                 landing page).
@@ -35,6 +37,12 @@ export interface NoGuildLayoutInputs {
 const isUserSettingsPath = (path: string): boolean =>
   path === "/profile" || path.startsWith("/profile/");
 
+// The community directory is how someone with no memberships joins a guild
+// without an invite, so it has to survive the empty state rather than being
+// replaced by it.
+const isCommunityPath = (path: string): boolean =>
+  path === "/communities" || path.startsWith("/communities/");
+
 // Both platform areas: the Admin dashboard (/settings/admin) and Platform
 // settings (/settings/platform). A guild-less platform user must still reach
 // either via the chromeless shell.
@@ -51,6 +59,7 @@ export function chooseNoGuildLayout({
 }: NoGuildLayoutInputs): NoGuildLayoutChoice {
   if (hasGuilds) return "main";
   if (isUserSettingsPath(pathname)) return "shell";
+  if (isCommunityPath(pathname)) return "shell";
   if (isAdminSettingsPath(pathname) && isPlatformAdmin) return "shell";
   return "empty";
 }

--- a/frontend/src/pages/SettingsGuildPage.tsx
+++ b/frontend/src/pages/SettingsGuildPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { updateGuildApiV1GuildsGuildIdPatch } from "@/api/generated/guilds/guilds";
 import type { GuildRead } from "@/api/generated/initiativeAPI.schemas";
+import { GuildDiscoveryPanel } from "@/components/guilds/GuildDiscoveryPanel";
 import { GuildUsagePanel } from "@/components/guilds/GuildUsagePanel";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -166,6 +167,7 @@ export const SettingsGuildPage = () => {
           </form>
         </CardContent>
       </Card>
+      <GuildDiscoveryPanel />
       <GuildUsagePanel />
     </div>
   );

--- a/frontend/src/pages/communities/CommunitiesPage.test.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.test.tsx
@@ -17,6 +17,7 @@ import { CommunitiesPage } from "./CommunitiesPage";
 
 const directoryFor = vi.fn();
 const join = vi.fn();
+const fetchNextPage = vi.fn();
 
 vi.mock("@/hooks/useCommunities", () => ({
   useCommunityGuilds: (params: unknown) => directoryFor(params),
@@ -36,14 +37,21 @@ const community = (overrides: Partial<CommunityGuildRead> = {}): CommunityGuildR
 
 const renderDirectory = () => renderPage(CommunitiesPage, { initialRoute: "/communities" });
 
+/** The infinite-query shape the page reads: pages of items plus the paging
+ *  flags. `total` is how many matched, so it can exceed what is loaded. */
+const directoryResult = (items: CommunityGuildRead[], overrides: Record<string, unknown> = {}) => ({
+  data: { pages: [{ items, total: items.length }] },
+  isLoading: false,
+  isError: false,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage,
+  ...overrides,
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
-  directoryFor.mockReturnValue({
-    data: { items: [community()], total: 1 },
-    isLoading: false,
-    isError: false,
-    isFetching: false,
-  });
+  directoryFor.mockReturnValue(directoryResult([community()]));
 });
 
 describe("CommunitiesPage", () => {
@@ -62,7 +70,7 @@ describe("CommunitiesPage", () => {
     renderDirectory();
 
     await screen.findByText("Riverside Players");
-    expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ category: undefined }));
+    expect(directoryFor).toHaveBeenCalledWith({ q: undefined, category: undefined });
   });
 
   it("narrows the request when a category is picked", async () => {
@@ -98,12 +106,7 @@ describe("CommunitiesPage", () => {
   });
 
   it("offers a way in, not a second join, for a guild already joined", async () => {
-    directoryFor.mockReturnValue({
-      data: { items: [community({ already_member: true })], total: 1 },
-      isLoading: false,
-      isError: false,
-      isFetching: false,
-    });
+    directoryFor.mockReturnValue(directoryResult([community({ already_member: true })]));
     renderDirectory();
 
     expect(await screen.findByRole("button", { name: "Open" })).toBeInTheDocument();
@@ -111,12 +114,7 @@ describe("CommunitiesPage", () => {
   });
 
   it("distinguishes an unreachable directory from an empty one", async () => {
-    directoryFor.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      isFetching: false,
-    });
+    directoryFor.mockReturnValue(directoryResult([], { data: undefined, isError: true }));
     renderDirectory();
 
     expect(await screen.findByText("Directory unavailable")).toBeInTheDocument();
@@ -124,30 +122,31 @@ describe("CommunitiesPage", () => {
   });
 
   it("says nobody has listed a guild when the directory is genuinely empty", async () => {
-    directoryFor.mockReturnValue({
-      data: { items: [], total: 0 },
-      isLoading: false,
-      isError: false,
-      isFetching: false,
-    });
+    directoryFor.mockReturnValue(directoryResult([]));
     renderDirectory();
 
     expect(await screen.findByText("No communities yet")).toBeInTheDocument();
   });
 
-  it("offers more only while results are being held back", async () => {
-    directoryFor.mockReturnValue({
-      data: { items: [community()], total: 30 },
-      isLoading: false,
-      isError: false,
-      isFetching: false,
-    });
+  it("fetches the next page rather than asking for a bigger one", async () => {
+    // A growing page_size runs into the endpoint's 60-per-page ceiling and
+    // takes the whole grid down with it, so "show more" pages instead.
+    directoryFor.mockReturnValue(directoryResult([community()], { hasNextPage: true }));
     renderDirectory();
 
     await userEvent.click(await screen.findByRole("button", { name: "Show more" }));
 
-    await waitFor(() => {
-      expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ page_size: 48 }));
-    });
+    await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
+    expect(directoryFor).not.toHaveBeenCalledWith(
+      expect.objectContaining({ page_size: expect.anything() })
+    );
+  });
+
+  it("offers no more once every match is on screen", async () => {
+    directoryFor.mockReturnValue(directoryResult([community()], { hasNextPage: false }));
+    renderDirectory();
+
+    await screen.findByText("Riverside Players");
+    expect(screen.queryByRole("button", { name: "Show more" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/communities/CommunitiesPage.test.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Browsing the community directory.
+ *
+ * The load-bearing details are that the filter rail actually narrows the
+ * request (rather than filtering client-side, which would only ever narrow the
+ * current page), and that a guild the caller is already in offers a way in
+ * rather than a second way to join.
+ */
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+import type { CommunityGuildRead } from "@/api/generated/initiativeAPI.schemas";
+
+import { CommunitiesPage } from "./CommunitiesPage";
+
+const directoryFor = vi.fn();
+const join = vi.fn();
+
+vi.mock("@/hooks/useCommunities", () => ({
+  useCommunityGuilds: (params: unknown) => directoryFor(params),
+  useJoinCommunityGuild: () => ({ mutateAsync: join, isPending: false }),
+}));
+
+const community = (overrides: Partial<CommunityGuildRead> = {}): CommunityGuildRead => ({
+  id: 1,
+  name: "Riverside Players",
+  description: "Community theatre.",
+  icon_base64: null,
+  categories: ["art"],
+  member_count: 12,
+  already_member: false,
+  ...overrides,
+});
+
+const renderDirectory = () => renderPage(CommunitiesPage, { initialRoute: "/communities" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  directoryFor.mockReturnValue({
+    data: { items: [community()], total: 1 },
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+  });
+});
+
+describe("CommunitiesPage", () => {
+  it("shows a card per community", async () => {
+    renderDirectory();
+
+    expect(await screen.findByText("Riverside Players")).toBeInTheDocument();
+    expect(screen.getByText("Community theatre.")).toBeInTheDocument();
+    expect(screen.getByText("12 members")).toBeInTheDocument();
+    // The same label is also a filter in the rail, so pin this to the card
+    // badge (a div) rather than the rail entry (a button).
+    expect(screen.getByText("Art & design", { selector: "div" })).toBeInTheDocument();
+  });
+
+  it("asks for everything until a category is picked", async () => {
+    renderDirectory();
+
+    await screen.findByText("Riverside Players");
+    expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ category: undefined }));
+  });
+
+  it("narrows the request when a category is picked", async () => {
+    renderDirectory();
+    await screen.findByText("Riverside Players");
+
+    await userEvent.click(screen.getByRole("button", { name: "Tabletop RPG" }));
+
+    await waitFor(() => {
+      expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ category: "ttrpg" }));
+    });
+  });
+
+  it("narrows the request when a search is typed", async () => {
+    renderDirectory();
+    await screen.findByText("Riverside Players");
+
+    await userEvent.type(screen.getByLabelText("Search communities"), "dice");
+
+    await waitFor(() => {
+      expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ q: "dice" }));
+    });
+  });
+
+  it("joins a community from its card", async () => {
+    join.mockResolvedValue({ id: 1 });
+    renderDirectory();
+    await screen.findByText("Riverside Players");
+
+    await userEvent.click(screen.getByRole("button", { name: "Join" }));
+
+    await waitFor(() => expect(join).toHaveBeenCalledWith(1));
+  });
+
+  it("offers a way in, not a second join, for a guild already joined", async () => {
+    directoryFor.mockReturnValue({
+      data: { items: [community({ already_member: true })], total: 1 },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
+    renderDirectory();
+
+    expect(await screen.findByRole("button", { name: "Open" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Join" })).not.toBeInTheDocument();
+  });
+
+  it("distinguishes an unreachable directory from an empty one", async () => {
+    directoryFor.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      isFetching: false,
+    });
+    renderDirectory();
+
+    expect(await screen.findByText("Directory unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("No communities yet")).not.toBeInTheDocument();
+  });
+
+  it("says nobody has listed a guild when the directory is genuinely empty", async () => {
+    directoryFor.mockReturnValue({
+      data: { items: [], total: 0 },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
+    renderDirectory();
+
+    expect(await screen.findByText("No communities yet")).toBeInTheDocument();
+  });
+
+  it("offers more only while results are being held back", async () => {
+    directoryFor.mockReturnValue({
+      data: { items: [community()], total: 30 },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
+    renderDirectory();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Show more" }));
+
+    await waitFor(() => {
+      expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ page_size: 48 }));
+    });
+  });
+});

--- a/frontend/src/pages/communities/CommunitiesPage.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.tsx
@@ -1,0 +1,178 @@
+/**
+ * The community directory, as a place you browse.
+ *
+ * A filter rail beside a card grid: search at the top, then the shelves a guild
+ * can file itself under, starting with "All". The rail is the page's own — it
+ * narrows results rather than navigating, so it stays next to what it filters
+ * instead of joining the app's navigation sidebar. On a narrow screen it
+ * becomes a row of chips above the grid.
+ *
+ * The directory is platform-level, so this asks nothing about the caller's
+ * current guild. Whether they are already in one of these is answered by the
+ * card payload itself.
+ */
+
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { CloudOff, SearchX } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { GuildCategory } from "@/api/generated/initiativeAPI.schemas";
+import { CommunityCard } from "@/components/guilds/CommunityCard";
+import { StatusMessage } from "@/components/StatusMessage";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCommunityGuilds } from "@/hooks/useCommunities";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { asGuildCategory, GUILD_CATEGORIES, guildCategoryLabel } from "@/lib/guildCategories";
+import { cn } from "@/lib/utils";
+
+const PAGE_SIZE = 24;
+/** Stable keys for the loading placeholders — an index key on a list that can
+ *  change is the lint rule this avoids. */
+const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
+
+export function CommunitiesPage() {
+  const { t } = useTranslation(["guilds", "common"]);
+  const navigate = useNavigate();
+  // The category lives in the URL so a filtered directory can be linked and
+  // survives a reload; the search box does not, because it changes per keystroke.
+  //
+  // Read loosely and re-narrowed here rather than trusted from the route:
+  // `useSearch({ strict: false })` returns the params as they are and does not
+  // run the route's `validateSearch`, so anywhere this page is mounted another
+  // way an unrecognized value would otherwise filter the grid down to nothing.
+  const rawSearch = useSearch({ strict: false }) as { category?: unknown };
+  const category = asGuildCategory(rawSearch.category);
+  const [query, setQuery] = useState("");
+  const search = useDebouncedValue(query, 250);
+  // Grows a page at a time rather than paginating: the grid is a shelf, and
+  // sending someone to page 2 to see three more guilds is a worse answer.
+  const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+  const directory = useCommunityGuilds({
+    q: search.trim() || undefined,
+    category: category ?? undefined,
+    page: 1,
+    page_size: pageSize,
+  });
+
+  const selectCategory = (next: GuildCategory | undefined) => {
+    setPageSize(PAGE_SIZE);
+    void navigate({
+      to: "/communities",
+      search: next ? { category: next } : {},
+      replace: true,
+    });
+  };
+
+  const guilds = directory.data?.items ?? [];
+  const total = directory.data?.total ?? 0;
+  const hasMore = guilds.length < total;
+
+  const categoryButton = (value: GuildCategory | undefined, label: string) => {
+    const selected = category === value || (!category && !value);
+    return (
+      <button
+        key={value ?? "all"}
+        type="button"
+        onClick={() => selectCategory(value)}
+        aria-pressed={selected}
+        className={cn(
+          "shrink-0 rounded-lg px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:w-full",
+          selected
+            ? "bg-primary/10 font-medium text-primary"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground"
+        )}
+      >
+        {label}
+      </button>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="font-semibold text-3xl tracking-tight">{t("guilds:community.title")}</h1>
+        <p className="text-muted-foreground text-sm">{t("guilds:community.subtitle")}</p>
+      </div>
+
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+        <aside className="lg:sticky lg:top-20 lg:w-56 lg:shrink-0">
+          <Input
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setPageSize(PAGE_SIZE);
+            }}
+            placeholder={t("guilds:community.searchPlaceholder")}
+            aria-label={t("guilds:community.searchPlaceholder")}
+          />
+          <nav aria-label={t("guilds:community.categoriesHeading")} className="mt-4">
+            <h2 className="px-3 pb-1 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+              {t("guilds:community.categoriesHeading")}
+            </h2>
+            {/* A scrolling row on narrow screens, a list beside the grid on wide ones. */}
+            <div className="scrollbar-thin flex gap-1 overflow-x-auto pb-1 lg:flex-col lg:overflow-visible lg:pb-0">
+              {categoryButton(undefined, t("guilds:community.allCategories"))}
+              {GUILD_CATEGORIES.map((value) => categoryButton(value, guildCategoryLabel(value, t)))}
+            </div>
+          </nav>
+        </aside>
+
+        <div className="min-w-0 flex-1 space-y-4">
+          {directory.isError ? (
+            // A directory that failed to answer is not a directory with nothing
+            // in it, and saying so would send someone looking for guilds that exist.
+            <StatusMessage
+              icon={<CloudOff />}
+              title={t("guilds:community.unavailableTitle")}
+              description={t("guilds:community.unavailableDescription")}
+            />
+          ) : directory.isLoading ? (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {SKELETON_KEYS.map((key) => (
+                <Skeleton key={key} className="h-52 w-full rounded-xl" />
+              ))}
+            </div>
+          ) : guilds.length ? (
+            <>
+              <p className="text-muted-foreground text-sm">
+                {t("guilds:community.resultCount", { count: total })}
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {guilds.map((guild) => (
+                  <CommunityCard key={guild.id} guild={guild} />
+                ))}
+              </div>
+              {hasMore ? (
+                <div className="flex justify-center pt-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => setPageSize((size) => size + PAGE_SIZE)}
+                    disabled={directory.isFetching}
+                  >
+                    {t("guilds:community.showMore")}
+                  </Button>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <StatusMessage
+              icon={<SearchX />}
+              title={
+                search ? t("guilds:community.noResultsTitle") : t("guilds:community.emptyTitle")
+              }
+              description={
+                search
+                  ? t("guilds:community.noResultsDescription", { query: search })
+                  : t("guilds:community.emptyDescription")
+              }
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/communities/CommunitiesPage.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.tsx
@@ -28,7 +28,6 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { asGuildCategory, GUILD_CATEGORIES, guildCategoryLabel } from "@/lib/guildCategories";
 import { cn } from "@/lib/utils";
 
-const PAGE_SIZE = 24;
 /** Stable keys for the loading placeholders — an index key on a list that can
  *  change is the lint rule this avoids. */
 const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
@@ -47,19 +46,13 @@ export function CommunitiesPage() {
   const category = asGuildCategory(rawSearch.category);
   const [query, setQuery] = useState("");
   const search = useDebouncedValue(query, 250);
-  // Grows a page at a time rather than paginating: the grid is a shelf, and
-  // sending someone to page 2 to see three more guilds is a worse answer.
-  const [pageSize, setPageSize] = useState(PAGE_SIZE);
 
   const directory = useCommunityGuilds({
     q: search.trim() || undefined,
     category: category ?? undefined,
-    page: 1,
-    page_size: pageSize,
   });
 
   const selectCategory = (next: GuildCategory | undefined) => {
-    setPageSize(PAGE_SIZE);
     void navigate({
       to: "/communities",
       search: next ? { category: next } : {},
@@ -67,9 +60,11 @@ export function CommunitiesPage() {
     });
   };
 
-  const guilds = directory.data?.items ?? [];
-  const total = directory.data?.total ?? 0;
-  const hasMore = guilds.length < total;
+  // The grid is a shelf that grows, so the loaded pages are shown as one list.
+  const guilds = directory.data?.pages.flatMap((page) => page.items) ?? [];
+  // How many matched, not how many are on screen — every page carries the
+  // same figure, so the first one answers it.
+  const total = directory.data?.pages[0]?.total ?? 0;
 
   const categoryButton = (value: GuildCategory | undefined, label: string) => {
     const selected = category === value || (!category && !value);
@@ -102,10 +97,7 @@ export function CommunitiesPage() {
         <aside className="lg:sticky lg:top-20 lg:w-56 lg:shrink-0">
           <Input
             value={query}
-            onChange={(event) => {
-              setQuery(event.target.value);
-              setPageSize(PAGE_SIZE);
-            }}
+            onChange={(event) => setQuery(event.target.value)}
             placeholder={t("guilds:community.searchPlaceholder")}
             aria-label={t("guilds:community.searchPlaceholder")}
           />
@@ -146,12 +138,12 @@ export function CommunitiesPage() {
                   <CommunityCard key={guild.id} guild={guild} />
                 ))}
               </div>
-              {hasMore ? (
+              {directory.hasNextPage ? (
                 <div className="flex justify-center pt-2">
                   <Button
                     variant="outline"
-                    onClick={() => setPageSize((size) => size + PAGE_SIZE)}
-                    disabled={directory.isFetching}
+                    onClick={() => void directory.fetchNextPage()}
+                    disabled={directory.isFetchingNextPage}
                   >
                     {t("guilds:community.showMore")}
                   </Button>

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as ServerRequiredVerifyEmailRouteImport } from './routes/_serverR
 import { Route as ServerRequiredWelcomeRouteImport } from './routes/_serverRequired/welcome'
 import { Route as AppsConnectedRouteImport } from './routes/apps.connected'
 import { Route as ServerRequiredAuthenticatedIndexRouteImport } from './routes/_serverRequired/_authenticated/index'
+import { Route as ServerRequiredAuthenticatedCommunitiesRouteImport } from './routes/_serverRequired/_authenticated/communities'
 import { Route as ServerRequiredAuthenticatedCreatedTasksRouteImport } from './routes/_serverRequired/_authenticated/created-tasks'
 import { Route as ServerRequiredAuthenticatedDocumentsRouteImport } from './routes/_serverRequired/_authenticated/documents'
 import { Route as ServerRequiredAuthenticatedInitiativesRouteImport } from './routes/_serverRequired/_authenticated/initiatives'
@@ -164,6 +165,12 @@ const ServerRequiredAuthenticatedIndexRoute =
   ServerRequiredAuthenticatedIndexRouteImport.update({
     id: '/',
     path: '/',
+    getParentRoute: () => ServerRequiredAuthenticatedRoute,
+  } as any)
+const ServerRequiredAuthenticatedCommunitiesRoute =
+  ServerRequiredAuthenticatedCommunitiesRouteImport.update({
+    id: '/communities',
+    path: '/communities',
     getParentRoute: () => ServerRequiredAuthenticatedRoute,
   } as any)
 const ServerRequiredAuthenticatedCreatedTasksRoute =
@@ -776,6 +783,7 @@ export interface FileRoutesByFullPath {
   '/verify-email': typeof ServerRequiredVerifyEmailRoute
   '/welcome': typeof ServerRequiredWelcomeRoute
   '/apps/connected': typeof AppsConnectedRoute
+  '/communities': typeof ServerRequiredAuthenticatedCommunitiesRoute
   '/created-tasks': typeof ServerRequiredAuthenticatedCreatedTasksRoute
   '/documents': typeof ServerRequiredAuthenticatedDocumentsRoute
   '/initiatives': typeof ServerRequiredAuthenticatedInitiativesRoute
@@ -874,6 +882,7 @@ export interface FileRoutesByTo {
   '/verify-email': typeof ServerRequiredVerifyEmailRoute
   '/welcome': typeof ServerRequiredWelcomeRoute
   '/apps/connected': typeof AppsConnectedRoute
+  '/communities': typeof ServerRequiredAuthenticatedCommunitiesRoute
   '/created-tasks': typeof ServerRequiredAuthenticatedCreatedTasksRoute
   '/documents': typeof ServerRequiredAuthenticatedDocumentsRoute
   '/initiatives': typeof ServerRequiredAuthenticatedInitiativesRoute
@@ -968,6 +977,7 @@ export interface FileRoutesById {
   '/_serverRequired/verify-email': typeof ServerRequiredVerifyEmailRoute
   '/_serverRequired/welcome': typeof ServerRequiredWelcomeRoute
   '/apps/connected': typeof AppsConnectedRoute
+  '/_serverRequired/_authenticated/communities': typeof ServerRequiredAuthenticatedCommunitiesRoute
   '/_serverRequired/_authenticated/created-tasks': typeof ServerRequiredAuthenticatedCreatedTasksRoute
   '/_serverRequired/_authenticated/documents': typeof ServerRequiredAuthenticatedDocumentsRoute
   '/_serverRequired/_authenticated/initiatives': typeof ServerRequiredAuthenticatedInitiativesRoute
@@ -1069,6 +1079,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/welcome'
     | '/apps/connected'
+    | '/communities'
     | '/created-tasks'
     | '/documents'
     | '/initiatives'
@@ -1167,6 +1178,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/welcome'
     | '/apps/connected'
+    | '/communities'
     | '/created-tasks'
     | '/documents'
     | '/initiatives'
@@ -1260,6 +1272,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/verify-email'
     | '/_serverRequired/welcome'
     | '/apps/connected'
+    | '/_serverRequired/_authenticated/communities'
     | '/_serverRequired/_authenticated/created-tasks'
     | '/_serverRequired/_authenticated/documents'
     | '/_serverRequired/_authenticated/initiatives'
@@ -1433,6 +1446,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof ServerRequiredAuthenticatedIndexRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedRoute
+    }
+    '/_serverRequired/_authenticated/communities': {
+      id: '/_serverRequired/_authenticated/communities'
+      path: '/communities'
+      fullPath: '/communities'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedCommunitiesRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedRoute
     }
     '/_serverRequired/_authenticated/created-tasks': {
@@ -2345,6 +2365,7 @@ const ServerRequiredAuthenticatedGGuildIdRouteWithChildren =
   )
 
 interface ServerRequiredAuthenticatedRouteChildren {
+  ServerRequiredAuthenticatedCommunitiesRoute: typeof ServerRequiredAuthenticatedCommunitiesRoute
   ServerRequiredAuthenticatedCreatedTasksRoute: typeof ServerRequiredAuthenticatedCreatedTasksRoute
   ServerRequiredAuthenticatedDocumentsRoute: typeof ServerRequiredAuthenticatedDocumentsRoute
   ServerRequiredAuthenticatedInitiativesRoute: typeof ServerRequiredAuthenticatedInitiativesRoute
@@ -2363,6 +2384,8 @@ interface ServerRequiredAuthenticatedRouteChildren {
 
 const ServerRequiredAuthenticatedRouteChildren: ServerRequiredAuthenticatedRouteChildren =
   {
+    ServerRequiredAuthenticatedCommunitiesRoute:
+      ServerRequiredAuthenticatedCommunitiesRoute,
     ServerRequiredAuthenticatedCreatedTasksRoute:
       ServerRequiredAuthenticatedCreatedTasksRoute,
     ServerRequiredAuthenticatedDocumentsRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, Outlet, redirect, useLocation } from "@tanstack/react-router";
-import { Loader2, LogOut, Plus, Search, Settings, Ticket, UserCog } from "lucide-react";
+import { Compass, Loader2, LogOut, Plus, Search, Settings, Ticket, UserCog } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -362,6 +362,16 @@ function NoGuildState({
             </Link>
           </Button>
         </div>
+
+        {/* The other way out of this screen: a guild that opened itself to
+            the directory can be joined here and now, with no invite to wait
+            for and nobody to ask. */}
+        <Button variant="outline" asChild className="w-full">
+          <Link to="/communities">
+            <Compass className="h-4 w-4" />
+            {t("noGuild.browseCommunities")}
+          </Link>
+        </Button>
 
         {/* Direct entry points to the user/platform settings pages so a
             user with no memberships can still manage their account

--- a/frontend/src/routes/_serverRequired/_authenticated/communities.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/communities.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+import type { GuildCategory } from "@/api/generated/initiativeAPI.schemas";
+import { asGuildCategory } from "@/lib/guildCategories";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/communities")({
+  // Which shelf is showing, so a filtered directory can be linked and survives
+  // a reload. Anything unrecognized falls back to "all" rather than filtering
+  // the grid down to nothing.
+  validateSearch: (search: Record<string, unknown>): { category?: GuildCategory } => {
+    const category = asGuildCategory(search.category);
+    return category ? { category } : {};
+  },
+  component: lazyRouteComponent(() =>
+    import("@/pages/communities/CommunitiesPage").then((m) => ({
+      default: m.CommunitiesPage,
+    }))
+  ),
+});


### PR DESCRIPTION
## Problem

Joining a guild required an invite from someone already in it. There was no way to find a guild you weren't already connected to, and no way for a guild that wants new people to say so.

## Changes

### Backend

- `guilds.is_community`, `guilds.categories` (`text[]`), and `guilds.has_adult_content` (nullable — unanswered is the normal state, and stays that way for a guild that never lists itself) in [20260827_0196](backend/alembic/versions/20260827_0196_guild_community_directory.py). The guild-admin column grant from 0138 is widened to cover them; the operator/billing columns stay out of reach as before.
- `GET /guilds/communities` and `POST /guilds/communities/{id}/join` in [guilds.py](backend/app/api/v1/platform_endpoints/guilds.py). Both run on the system engine for the same reason `GET /invite/{code}` and `accept_invite` do — the caller is not a member of these guilds yet, so no guild-scoped role exists to read or write them under. `CommunityGuildRead` carries only what a guild published by opting in: no lifecycle status, no administration, nothing from inside a guild's own schema.
- Three rules gate a listing, checked against the state the guild ends up in rather than what the request happened to carry: at least one category, an explicit no-adult-content declaration, and a seat cap above one. The first two are CHECK constraints on `guilds`. The cap lives on `guild_administration` and only an operator sets it, so the directory re-checks it at read time and the join endpoint agrees.
- `GuildCategory` (12 values) is the one place the vocabulary is defined; the migration spells the literals out rather than importing it, per `migration_imports_test`.

### Frontend

- **"Join a community"** under the add-a-guild button in the left rail — both the collapsed rail and the expanded flyout. Shown even where guild creation is disabled, since that's where it's the only way into a guild.
- [`/communities`](frontend/src/pages/communities/CommunitiesPage.tsx): a search box above a category rail, card grid beside it, collapsing to a chip row on narrow screens. The category is in the URL so a filtered view is linkable. Reachable from the no-guild empty state too.
- Guild settings gains the listing toggle ([GuildDiscoveryPanel](frontend/src/components/guilds/GuildDiscoveryPanel.tsx)). Turning it on opens [PublishGuildDialog](frontend/src/components/guilds/PublishGuildDialog.tsx), which collects the categories and the content certification together; Confirm stays disabled until both are satisfied. Un-listing takes effect on the click.
- Category labels derive from the generated `GuildCategory` enum, so a category added server-side reaches the filter rail and the settings picker without a frontend edit.
- Strings in all four locales, plus the four new error codes in `errors.json`.

## Testing

- `cd backend && pytest app/api/v1/platform_endpoints/guilds_community_test.py app/api/v1/platform_endpoints/guilds_test.py app/services/platform app/db` — passed (32 new tests)
- `cd backend && ruff check app alembic`, `ruff format app alembic`, `ty check` — passed
- `cd frontend && pnpm vitest run src/components/guilds src/pages/communities src/lib/noGuildLayout.test.ts src/__tests__/locale-keys.test.ts` — 337 passed (23 new)
- `cd frontend && pnpm typecheck`, `pnpm biome check src/`, `pnpm exec vite build` — passed