### PR TITLE
Let the owner switch the community directory on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Guilds can list themselves in a community directory, and be joined without an invite.** "Join a community" sits under the add-a-guild button in the left rail: a search box above a category rail, and a card per guild with its icon, description, tags, and member count. A guild admin lists theirs from Settings → Guild, picking at least one category and certifying the guild holds no adult or illegal content. Guilds also carry an 18+ marker, unanswered by default; a guild marked 18+ — or one with room for only one member — is never listed. Unlisted guilds are unchanged.
 
+  Whether a server has a directory at all is the platform owner's decision, under Settings → Platform → Community, and it starts off. While it is off there is nothing to browse, nobody can join a guild without an invite, and the listing control is absent from guild settings. Turning it off later hides the directory rather than un-listing anyone: switch it back on and the same guilds are there.
+
 ### Changed
 
 - **The Apps shelf only lists apps your server actually runs.** An app is served by a program the person running your server sets up — so a listing for one that they haven't set up yet, or have switched off, offered something that would install into nothing. Those listings now stay off the marketplace until the app is running, and adding one by hand is refused the same way. Dashboards are unaffected, and nothing changes for an app a guild has already installed.

--- a/backend/alembic/versions/20260827_0197_community_directory_toggle.py
+++ b/backend/alembic/versions/20260827_0197_community_directory_toggle.py
@@ -1,0 +1,41 @@
+"""add the community-directory switch to app_settings
+
+Whether this deployment runs a community directory at all is the platform
+owner's call, not a guild admin's: 0196 gave a guild the ability to list itself,
+and this decides whether that listing goes anywhere. It defaults to off, so an
+existing install upgrades without acquiring a browsable front door, and a guild
+that had already opted in stays opted in but unlisted until an owner turns the
+directory on.
+
+It lives on ``app_settings`` — the owner-writable singleton — rather than in the
+environment, so it can be flipped from the platform settings page instead of a
+redeploy.
+
+Revision ID: 20260827_0197
+Revises: 20260827_0196
+Create Date: 2026-08-27
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260827_0197"
+down_revision = "20260827_0196"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "app_settings",
+        sa.Column(
+            "community_directory_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("app_settings", "community_directory_enabled")

--- a/backend/app/api/v1/platform_endpoints/config.py
+++ b/backend/app/api/v1/platform_endpoints/config.py
@@ -13,8 +13,10 @@ from typing import Optional
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from app.api.deps import SessionDep
 from app.core.config import settings
 from app.core.security import billing_support_handoff_enabled
+from app.services.platform import app_settings as app_settings_service
 from app.services.tenant.attachments import MAX_DOCUMENT_FILE_SIZE
 
 router = APIRouter()
@@ -60,13 +62,19 @@ class AppConfig(BaseModel):
     # The upload size cap the server enforces on file endpoints. The SPA reads
     # it for pre-flight checks so the number lives in exactly one place.
     max_upload_bytes: int
+    # Whether this deployment runs a community directory (owner-set, default
+    # off). The SPA hides every way into it when false — the way in from the
+    # guild rail, the directory page itself, and a guild admin's listing
+    # control. Unlike the fields above this one is a database setting rather
+    # than an env var, so it changes without a redeploy.
+    community_directory_enabled: bool
 
 
 _SUPPORTED_CAPTCHA_PROVIDERS = {"hcaptcha", "turnstile", "recaptcha"}
 
 
 @router.get("/config", response_model=AppConfig)
-def get_app_config() -> AppConfig:
+async def get_app_config(session: SessionDep) -> AppConfig:
     # Captcha: only expose when all three of provider / site key / secret
     # are present and the provider name is one we recognise. The SPA
     # treats a missing ``captcha`` field as "no captcha for this
@@ -93,8 +101,11 @@ def get_app_config() -> AppConfig:
         else None
     )
 
+    app_settings = await app_settings_service.get_app_settings(session)
+
     return AppConfig(
         captcha=captcha,
         billing=billing,
         max_upload_bytes=MAX_DOCUMENT_FILE_SIZE,
+        community_directory_enabled=app_settings.community_directory_enabled,
     )

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -231,15 +231,24 @@ async def list_community_guilds(
     active, always), and :class:`CommunityGuildRead` carries only what a guild
     published by opting in: no lifecycle status, no administration, no roster,
     and nothing at all from inside the guild's own schema.
+
+    The directory is a deployment-level feature an owner switches on; where it
+    is off there is nothing to browse and the request is refused rather than
+    answered with an empty page.
     """
-    rows, total = await guilds_service.list_community_guilds(
-        session,
-        user_id=current_user.id,
-        query=q,
-        category=category.value if category else None,
-        offset=(page - 1) * page_size,
-        limit=page_size,
-    )
+    try:
+        rows, total = await guilds_service.list_community_guilds(
+            session,
+            user_id=current_user.id,
+            query=q,
+            category=category.value if category else None,
+            offset=(page - 1) * page_size,
+            limit=page_size,
+        )
+    except guilds_service.CommunityDirectoryDisabledError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
     return CommunityGuildPage(
         items=[
             CommunityGuildRead(
@@ -274,6 +283,10 @@ async def join_community_guild(
         guild = await guilds_service.join_community_guild(
             session, guild_id=guild_id, user=current_user
         )
+    except guilds_service.CommunityDirectoryDisabledError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
     except guilds_service.CommunityJoinError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
@@ -496,6 +509,11 @@ async def update_guild(
             has_adult_content=updates.has_adult_content,
             has_adult_content_provided=has_adult_content_provided,
         )
+    except guilds_service.CommunityDirectoryDisabledError as exc:
+        # No directory on this deployment, so there is nothing to list in.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
     except guilds_service.CommunityListingError as exc:
         # The guild does not qualify to be listed. Named specifically (which
         # rule) rather than as a generic rejection, so the settings page can say

--- a/backend/app/api/v1/platform_endpoints/guilds_community_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_community_test.py
@@ -17,6 +17,7 @@ from app.models.platform.guild import (
     GuildRole,
     GuildStatus,
 )
+from app.services.platform import app_settings as app_settings_service
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
@@ -24,6 +25,20 @@ from app.testing.factories import (
     get_auth_headers,
     guild_administration,
 )
+
+
+@pytest.fixture(autouse=True)
+async def community_directory_on(session: AsyncSession) -> None:
+    """Run the directory for this module.
+
+    The switch is a platform-owner setting that starts off, so every test below
+    would otherwise be testing a deployment with no directory. Stated once here
+    instead of in each test; the tests about the switch itself set it
+    themselves.
+    """
+    await app_settings_service.update_community_settings(
+        session, community_directory_enabled=True
+    )
 
 
 async def _list_as_community(
@@ -727,3 +742,125 @@ async def test_join_refuses_a_guild_the_directory_would_not_show(
 
     assert response.status_code == 404
     assert response.json()["detail"] == "GUILD_NOT_A_COMMUNITY"
+
+
+# ---------------------------------------------------------------------------
+# The platform-owner switch
+# ---------------------------------------------------------------------------
+
+
+async def _switch_directory_off(session: AsyncSession) -> None:
+    await app_settings_service.update_community_settings(
+        session, community_directory_enabled=False
+    )
+
+
+@pytest.mark.integration
+async def test_browsing_is_refused_where_the_directory_is_off(
+    client: AsyncClient, session: AsyncSession
+):
+    """Refused outright, not answered with an empty page: a deployment without a
+    directory has no directory, as distinct from one where nobody has listed."""
+    user = await create_user(session, email="browser@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await _switch_directory_off(session)
+
+    response = await client.get(
+        "/api/v1/guilds/communities", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "COMMUNITY_DIRECTORY_DISABLED"
+
+
+@pytest.mark.integration
+async def test_joining_is_refused_where_the_directory_is_off(
+    client: AsyncClient, session: AsyncSession
+):
+    """The invite-free join exists only as the directory's other half."""
+    user = await create_user(session, email="joiner@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await _switch_directory_off(session)
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "COMMUNITY_DIRECTORY_DISABLED"
+    membership = (
+        await session.exec(
+            select(GuildMembership).where(
+                GuildMembership.guild_id == guild.id,
+                GuildMembership.user_id == user.id,
+            )
+        )
+    ).one_or_none()
+    assert membership is None
+
+
+@pytest.mark.integration
+async def test_a_guild_cannot_list_itself_where_the_directory_is_off(
+    client: AsyncClient, session: AsyncSession
+):
+    guild, headers = await _admin_of(session, name="Open Table")
+    await _switch_directory_off(session)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={
+            "is_community": True,
+            "categories": ["gaming"],
+            "has_adult_content": False,
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "COMMUNITY_DIRECTORY_DISABLED"
+    await session.refresh(guild)
+    assert guild.is_community is False
+
+
+@pytest.mark.integration
+async def test_a_listed_guild_can_still_unlist_where_the_directory_is_off(
+    client: AsyncClient, session: AsyncSession
+):
+    """Switching the directory off must not strand a guild inside a listing it
+    can no longer withdraw."""
+    guild, headers = await _admin_of(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await _switch_directory_off(session)
+
+    response = await client.patch(
+        f"/api/v1/guilds/{guild.id}",
+        json={"is_community": False},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["is_community"] is False
+
+
+@pytest.mark.integration
+async def test_switching_the_directory_off_keeps_the_guilds_opt_in(
+    client: AsyncClient, session: AsyncSession
+):
+    """Off hides the listings; it does not unpublish anybody. Switching it back
+    on shows the same guilds."""
+    user = await create_user(session, email="browser@example.com")
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await _switch_directory_off(session)
+    await app_settings_service.update_community_settings(
+        session, community_directory_enabled=True
+    )
+
+    response = await client.get(
+        "/api/v1/guilds/communities", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    assert [item["name"] for item in response.json()["items"]] == ["Open Table"]

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -27,6 +27,8 @@ from app.models.platform.oidc_claim_mapping import (
     OIDCMappingTargetType,
 )
 from app.schemas.platform.settings import (
+    CommunitySettingsResponse,
+    CommunitySettingsUpdate,
     EmailSettingsResponse,
     EmailSettingsUpdate,
     EmailTestRequest,
@@ -185,6 +187,32 @@ async def update_interface_settings(
         light_accent_color=settings_obj.light_accent_color,
         dark_accent_color=settings_obj.dark_accent_color,
         auth_scope=app_config.AUTH_SCOPE,
+    )
+
+
+@router.put("/community", response_model=CommunitySettingsResponse)
+async def update_community_settings(
+    payload: CommunitySettingsUpdate,
+    session: UserSessionDep,
+    _admin: ConfigManageDep,
+) -> CommunitySettingsResponse:
+    """Turn the community directory on or off for the whole deployment.
+
+    Write-only on purpose: the current value is public — every signed-in page
+    needs it to decide whether to offer the directory — so it is served from
+    ``GET /config`` with the rest of the SPA's boot configuration rather than
+    from a second, capability-gated read of the same boolean.
+
+    Switching it off hides the directory and refuses new listings; it does not
+    clear the opt-in a guild already made, so switching it back on restores the
+    same set of listed guilds.
+    """
+    settings_obj = await app_settings_service.update_community_settings(
+        session,
+        community_directory_enabled=payload.community_directory_enabled,
+    )
+    return CommunitySettingsResponse(
+        community_directory_enabled=settings_obj.community_directory_enabled,
     )
 
 

--- a/backend/app/api/v1/platform_endpoints/settings_test.py
+++ b/backend/app/api/v1/platform_endpoints/settings_test.py
@@ -1556,3 +1556,67 @@ async def test_billing_grant_does_not_block_a_content_request(session):
         ),
     )
     assert requested.purpose == "content"
+
+
+# ---------------------------------------------------------------------------
+# The community-directory switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_owner_switches_the_community_directory_on_and_off(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """The write is owner-only; the value it sets is read back from /config,
+    which is where the SPA learns whether to offer the directory at all."""
+    owner = await create_user(
+        session, email="owner-community@example.com", role=UserRole.owner
+    )
+    headers = get_auth_headers(owner)
+
+    assert (await client.get("/api/v1/config")).json()[
+        "community_directory_enabled"
+    ] is False
+
+    on = await client.put(
+        "/api/v1/settings/community",
+        json={"community_directory_enabled": True},
+        headers=headers,
+    )
+    assert on.status_code == 200, on.text
+    assert on.json()["community_directory_enabled"] is True
+    assert (await client.get("/api/v1/config")).json()[
+        "community_directory_enabled"
+    ] is True
+
+    off = await client.put(
+        "/api/v1/settings/community",
+        json={"community_directory_enabled": False},
+        headers=headers,
+    )
+    assert off.status_code == 200
+    assert off.json()["community_directory_enabled"] is False
+    assert (await client.get("/api/v1/config")).json()[
+        "community_directory_enabled"
+    ] is False
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "role",
+    [UserRole.member, UserRole.support, UserRole.moderator, UserRole.operator],
+)
+async def test_community_switch_is_owner_only(
+    client: AsyncClient, session: AsyncSession, role: UserRole
+) -> None:
+    """Everything below owner lacks ``config.manage``, operator included."""
+    user = await create_user(session, role=role)
+
+    resp = await client.put(
+        "/api/v1/settings/community",
+        json={"community_directory_enabled": True},
+        headers=get_auth_headers(user),
+    )
+
+    assert resp.status_code == 403, f"{role.value}: {resp.status_code}"
+    assert resp.json()["detail"] == "INSUFFICIENT_PRIVILEGES"

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -70,6 +70,10 @@ class GuildMessages:
     GUILD_COMMUNITY_CONTENT_NOT_DECLARED = "GUILD_COMMUNITY_CONTENT_NOT_DECLARED"
     GUILD_COMMUNITY_ADULT_CONTENT = "GUILD_COMMUNITY_ADULT_CONTENT"
     GUILD_COMMUNITY_REQUIRES_CAPACITY = "GUILD_COMMUNITY_REQUIRES_CAPACITY"
+    # The deployment runs no community directory: an owner has not switched it
+    # on. Distinct from the four rules above, which are about one guild — this
+    # one says the surface does not exist here at all.
+    COMMUNITY_DIRECTORY_DISABLED = "COMMUNITY_DIRECTORY_DISABLED"
     CANNOT_CHANGE_OWN_ROLE = "CANNOT_CHANGE_OWN_ROLE"
     # 'support' is synthesized for PAM grantees only; it is never a stored
     # guild-membership role, so it cannot be assigned via the role endpoints.

--- a/backend/app/models/platform/app_setting.py
+++ b/backend/app/models/platform/app_setting.py
@@ -53,6 +53,15 @@ class AppSetting(SQLModel, table=True):
         default=None, sa_column=Column(String(255), nullable=True)
     )
 
+    # Whether this deployment runs a community directory at all: the browsable
+    # list of guilds that have opted in, and the invite-free join that goes with
+    # it. Off until an owner turns it on, so a deployment that never wanted a
+    # public front door does not grow one on upgrade.
+    community_directory_enabled: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default="false"),
+    )
+
     # AI config ownership mode: "platform" (the operator's connections apply to
     # every guild), "guild" (each guild admin configures its own), or "disabled".
     # Provider config itself lives in platform_ai_connections /

--- a/backend/app/schemas/platform/settings.py
+++ b/backend/app/schemas/platform/settings.py
@@ -140,6 +140,23 @@ class InterfaceSettingsUpdate(SanitizedBaseModel):
     dark_accent_color: str
 
 
+class CommunitySettingsResponse(SanitizedBaseModel):
+    """Whether this deployment runs a community directory.
+
+    Read back by the owner's settings page after a write; everyone else learns
+    the same fact from ``GET /config``, which is where the SPA reads it to
+    decide whether to offer the directory at all.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    community_directory_enabled: bool
+
+
+class CommunitySettingsUpdate(SanitizedBaseModel):
+    community_directory_enabled: bool
+
+
 class EmailSettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 

--- a/backend/app/services/platform/app_settings.py
+++ b/backend/app/services/platform/app_settings.py
@@ -158,6 +158,36 @@ async def update_interface_colors(
     return settings_row
 
 
+async def community_directory_enabled(session: AsyncSession) -> bool:
+    """Whether the platform owner has the community directory switched on.
+
+    The one read of the switch. Everything the directory consists of — browsing
+    it, joining from it, and a guild listing itself in it — asks this first, so
+    turning it off closes all three at once.
+    """
+    settings_row = await get_app_settings(session)
+    return bool(settings_row.community_directory_enabled)
+
+
+async def update_community_settings(
+    session: AsyncSession,
+    *,
+    community_directory_enabled: bool,
+) -> AppSetting:
+    """Turn the community directory on or off for the whole deployment.
+
+    Switching it off leaves every guild's own opt-in exactly as it was: the
+    listings simply have nowhere to appear until it is switched back on, so an
+    operator flipping this twice does not silently unpublish anybody.
+    """
+    settings_row = await _ensure_app_settings(session)
+    settings_row.community_directory_enabled = bool(community_directory_enabled)
+    session.add(settings_row)
+    await session.commit()
+    await session.refresh(settings_row)
+    return settings_row
+
+
 async def update_email_settings(
     session: AsyncSession,
     *,

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -47,6 +47,10 @@ class CommunityListingError(Exception):
     """Raised when a guild does not qualify to be listed in the directory."""
 
 
+class CommunityDirectoryDisabledError(Exception):
+    """Raised when the deployment runs no community directory at all."""
+
+
 # A guild whose seat cap is one can never admit a joiner, so listing it would
 # publish a card whose only button is guaranteed to fail. Unlike a guild that is
 # merely full today, this one can never have room, which is why it is refused
@@ -591,6 +595,11 @@ async def update_guild(
     # An explicit ``null`` is meaningless for a boolean opt-in (mirroring
     # ``guild_auth_enabled`` below), so null and omitted alike are a no-op.
     if is_community is not None and guild.is_community != is_community:
+        # Only the way in is gated. Un-listing is always available — a guild
+        # that opted in while the directory was running must still be able to
+        # opt back out after an owner switches it off.
+        if is_community:
+            await assert_community_directory_enabled(session)
         guild.is_community = is_community
         updated = True
     if categories_provided:
@@ -857,6 +866,21 @@ async def redeem_invite_for_user(
     return guild
 
 
+async def assert_community_directory_enabled(session: AsyncSession) -> None:
+    """Raise unless the platform owner has switched the directory on.
+
+    Read here rather than at each call site so the three surfaces the directory
+    consists of — browsing, joining, and a guild listing itself — cannot drift
+    apart. Imported lazily because the app-settings service reads guilds.
+    """
+    from app.services.platform import app_settings as app_settings_service
+
+    if not await app_settings_service.community_directory_enabled(session):
+        raise CommunityDirectoryDisabledError(
+            GuildMessages.COMMUNITY_DIRECTORY_DISABLED
+        )
+
+
 async def _assert_listable(session: AsyncSession, guild: Guild) -> None:
     """Raise ``CommunityListingError`` unless this guild may be listed.
 
@@ -909,6 +933,7 @@ async def list_community_guilds(
     documents. Nothing about a guild's *content* is read — only the identity it
     published by opting in, plus how many people are already there.
     """
+    await assert_community_directory_enabled(session)
     member_count = (
         select(func.count())
         .select_from(GuildMembership)
@@ -983,6 +1008,7 @@ async def join_community_guild(
     caller is not a member yet, so no guild-scoped role exists to write the
     membership under.
     """
+    await assert_community_directory_enabled(session)
     try:
         guild = await get_guild(session, guild_id=guild_id)
     except ValueError as exc:

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -465,5 +465,6 @@
   "GUILD_COMMUNITY_REQUIRES_CATEGORY": "Eine eingetragene Gilde braucht mindestens eine Kategorie.",
   "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Bestätige, dass diese Gilde keine Inhalte für Erwachsene enthält, bevor du sie einträgst.",
   "GUILD_COMMUNITY_ADULT_CONTENT": "Eine als 18+ markierte Gilde kann nicht im Community-Verzeichnis eingetragen werden.",
-  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Diese Gilde hat nur für eine Person Platz und kann deshalb nicht im Community-Verzeichnis eingetragen werden."
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Diese Gilde hat nur für eine Person Platz und kann deshalb nicht im Community-Verzeichnis eingetragen werden.",
+  "COMMUNITY_DIRECTORY_DISABLED": "Diese Instanz betreibt kein Community-Verzeichnis."
 }

--- a/frontend/public/locales/de/guilds.json
+++ b/frontend/public/locales/de/guilds.json
@@ -356,6 +356,8 @@
     "noResultsDescription": "Keine Community passt zu „{{query}}“. Versuche eine andere Suche oder Kategorie.",
     "unavailableTitle": "Verzeichnis nicht verfügbar",
     "unavailableDescription": "Das Community-Verzeichnis konnte nicht geladen werden. Versuche es gleich noch einmal.",
+    "disabledTitle": "Hier gibt es kein Community-Verzeichnis",
+    "disabledDescription": "Diese Instanz betreibt kein Community-Verzeichnis. Ein Plattform-Eigentümer kann es in den Plattformeinstellungen aktivieren.",
     "publish": {
       "title": "Diese Gilde im Verzeichnis eintragen",
       "description": "Alle angemeldeten Personen können diese Gilde dann finden und ohne Einladung beitreten.",

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -733,11 +733,12 @@
   },
   "platformLayout": {
     "title": "Plattformeinstellungen",
-    "subtitle": "Konfiguriere Authentifizierung, Branding, E-Mail, KI, Gildenspeicher und App-Dienste für die gesamte Plattform.",
+    "subtitle": "Konfiguriere Authentifizierung, Branding, E-Mail, das Community-Verzeichnis, KI, Gildenspeicher und App-Dienste für die gesamte Plattform.",
     "tabs": {
       "auth": "Authentifizierung",
       "branding": "Branding",
       "email": "E-Mail",
+      "community": "Community",
       "ai": "KI",
       "storage": "Speicher",
       "appServices": "App-Dienste"
@@ -1074,5 +1075,16 @@
     "prefError": "Einstellung konnte nicht aktualisiert werden",
     "test": "Testen",
     "testSuccess": "Verbindung erfolgreich"
+  },
+  "community": {
+    "title": "Community-Verzeichnis",
+    "description": "Erlaube Gilden, sich dort einzutragen, wo alle Angemeldeten sie finden und ohne Einladung beitreten können.",
+    "toggleLabel": "Community-Verzeichnis betreiben",
+    "helpText": "Solange dies aktiv ist, können Gildenadministratoren ihre Gilde in den Gildeneinstellungen eintragen, und „Einer Community beitreten“ erscheint neben den Gilden aller. Ist es deaktiviert, gibt es nichts zu durchsuchen und keine Gilde kann sich eintragen.",
+    "reversibleNote": "Deaktivieren blendet das Verzeichnis aus; die Einträge der Gilden bleiben bestehen. Wird es wieder aktiviert, sind dieselben Gilden erneut gelistet.",
+    "enabledToast": "Das Community-Verzeichnis ist aktiv.",
+    "disabledToast": "Das Community-Verzeichnis ist deaktiviert.",
+    "saveError": "Das Community-Verzeichnis konnte nicht geändert werden. Bitte versuche es erneut.",
+    "adminOnly": "Du benötigst die Plattform-Eigentümerrolle, um ein Community-Verzeichnis zu betreiben."
   }
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -465,5 +465,6 @@
   "GUILD_COMMUNITY_REQUIRES_CATEGORY": "A listed guild needs at least one category.",
   "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Confirm this guild contains no adult content before listing it.",
   "GUILD_COMMUNITY_ADULT_CONTENT": "A guild marked 18+ cannot be listed in the community directory.",
-  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "This guild has room for only one person, so it cannot be listed in the community directory."
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "This guild has room for only one person, so it cannot be listed in the community directory.",
+  "COMMUNITY_DIRECTORY_DISABLED": "This deployment doesn't run a community directory."
 }

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -356,6 +356,8 @@
     "noResultsDescription": "No community matches “{{query}}”. Try another search or category.",
     "unavailableTitle": "Directory unavailable",
     "unavailableDescription": "The community directory could not be loaded. Try again in a moment.",
+    "disabledTitle": "No community directory here",
+    "disabledDescription": "This deployment doesn't run a community directory. A platform owner can turn one on from platform settings.",
     "publish": {
       "title": "List this guild in the directory",
       "description": "Anyone signed in will be able to find this guild and join it without an invite.",

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -733,11 +733,12 @@
   },
   "platformLayout": {
     "title": "Platform settings",
-    "subtitle": "Configure authentication, branding, email, AI, guild storage, and app services for the entire platform.",
+    "subtitle": "Configure authentication, branding, email, the community directory, AI, guild storage, and app services for the entire platform.",
     "tabs": {
       "auth": "Authentication",
       "branding": "Branding",
       "email": "Email",
+      "community": "Community",
       "ai": "AI",
       "storage": "Storage",
       "appServices": "App services"
@@ -1074,5 +1075,16 @@
     "prefError": "Unable to update preference",
     "test": "Test",
     "testSuccess": "Connection successful"
+  },
+  "community": {
+    "title": "Community directory",
+    "description": "Let guilds list themselves where anyone signed in can find them and join without an invite.",
+    "toggleLabel": "Run a community directory",
+    "helpText": "While this is on, a guild admin can list their guild from guild settings, and “Join a community” appears beside everyone's guilds. While it is off, there is nothing to browse and no guild can list itself.",
+    "reversibleNote": "Turning this off hides the directory; it does not un-list the guilds that opted in. Turn it back on and the same guilds are listed again.",
+    "enabledToast": "The community directory is on.",
+    "disabledToast": "The community directory is off.",
+    "saveError": "Could not change the community directory. Please try again.",
+    "adminOnly": "You need the platform owner role to run a community directory."
   }
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -465,5 +465,6 @@
   "GUILD_COMMUNITY_REQUIRES_CATEGORY": "Un gremio publicado necesita al menos una categoría.",
   "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Confirma que este gremio no contiene contenido para adultos antes de publicarlo.",
   "GUILD_COMMUNITY_ADULT_CONTENT": "Un gremio marcado como +18 no puede publicarse en el directorio de comunidades.",
-  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Este gremio solo tiene sitio para una persona, así que no puede publicarse en el directorio de comunidades."
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Este gremio solo tiene sitio para una persona, así que no puede publicarse en el directorio de comunidades.",
+  "COMMUNITY_DIRECTORY_DISABLED": "Esta instalación no ofrece un directorio de comunidades."
 }

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -356,6 +356,8 @@
     "noResultsDescription": "Ninguna comunidad coincide con «{{query}}». Prueba con otra búsqueda o categoría.",
     "unavailableTitle": "Directorio no disponible",
     "unavailableDescription": "No se ha podido cargar el directorio de comunidades. Inténtalo de nuevo en un momento.",
+    "disabledTitle": "Aquí no hay directorio de comunidades",
+    "disabledDescription": "Esta instalación no ofrece un directorio de comunidades. Un propietario de la plataforma puede activarlo en la configuración de la plataforma.",
     "publish": {
       "title": "Publicar este gremio en el directorio",
       "description": "Cualquier persona con la sesión iniciada podrá encontrar este gremio y unirse sin invitación.",

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -733,11 +733,12 @@
   },
   "platformLayout": {
     "title": "Configuración de la plataforma",
-    "subtitle": "Configura la autenticación, la personalización, el email, la IA, el almacenamiento de los gremios y los servicios de aplicación de toda la plataforma.",
+    "subtitle": "Configura la autenticación, la personalización, el email, el directorio de comunidades, la IA, el almacenamiento de los gremios y los servicios de aplicación de toda la plataforma.",
     "tabs": {
       "auth": "Autenticación",
       "branding": "Personalización",
       "email": "Email",
+      "community": "Comunidad",
       "ai": "IA",
       "storage": "Almacenamiento",
       "appServices": "Servicios de aplicación"
@@ -1074,5 +1075,16 @@
     "prefError": "No se pudo actualizar la preferencia",
     "test": "Probar",
     "testSuccess": "Conexión correcta"
+  },
+  "community": {
+    "title": "Directorio de comunidades",
+    "description": "Permite que los gremios se publiquen donde cualquier persona con sesión iniciada pueda encontrarlos y unirse sin invitación.",
+    "toggleLabel": "Ofrecer un directorio de comunidades",
+    "helpText": "Mientras esté activado, quien administre un gremio puede publicarlo desde la configuración del gremio y «Unirse a una comunidad» aparece junto a los gremios de todo el mundo. Mientras esté desactivado, no hay nada que explorar y ningún gremio puede publicarse.",
+    "reversibleNote": "Desactivarlo oculta el directorio; no retira a los gremios que se publicaron. Al volver a activarlo, aparecen los mismos gremios.",
+    "enabledToast": "El directorio de comunidades está activado.",
+    "disabledToast": "El directorio de comunidades está desactivado.",
+    "saveError": "No se pudo cambiar el directorio de comunidades. Inténtalo de nuevo.",
+    "adminOnly": "Necesitas el rol de propietario de la plataforma para ofrecer un directorio de comunidades."
   }
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -465,5 +465,6 @@
   "GUILD_COMMUNITY_REQUIRES_CATEGORY": "Une guilde inscrite doit avoir au moins une catégorie.",
   "GUILD_COMMUNITY_CONTENT_NOT_DECLARED": "Confirmez que cette guilde ne contient aucun contenu pour adultes avant de l’inscrire.",
   "GUILD_COMMUNITY_ADULT_CONTENT": "Une guilde marquée 18+ ne peut pas être inscrite à l’annuaire des communautés.",
-  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Cette guilde n’a de place que pour une personne : elle ne peut pas être inscrite à l’annuaire des communautés."
+  "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Cette guilde n’a de place que pour une personne : elle ne peut pas être inscrite à l’annuaire des communautés.",
+  "COMMUNITY_DIRECTORY_DISABLED": "Cette instance ne propose pas d'annuaire des communautés."
 }

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -356,6 +356,8 @@
     "noResultsDescription": "Aucune communauté ne correspond à « {{query}} ». Essayez une autre recherche ou catégorie.",
     "unavailableTitle": "Annuaire indisponible",
     "unavailableDescription": "Impossible de charger l’annuaire des communautés. Réessayez dans un instant.",
+    "disabledTitle": "Pas d'annuaire des communautés ici",
+    "disabledDescription": "Cette instance ne propose pas d'annuaire des communautés. Un propriétaire de la plateforme peut l'activer dans les paramètres de la plateforme.",
     "publish": {
       "title": "Inscrire cette guilde à l’annuaire",
       "description": "Toute personne connectée pourra trouver cette guilde et la rejoindre sans invitation.",

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -733,11 +733,12 @@
   },
   "platformLayout": {
     "title": "Paramètres de la plateforme",
-    "subtitle": "Configurez l'authentification, la personnalisation, l'email, l'IA, le stockage des guildes et les services applicatifs pour toute la plateforme.",
+    "subtitle": "Configurez l'authentification, la personnalisation, l'email, l'annuaire des communautés, l'IA, le stockage des guildes et les services applicatifs pour toute la plateforme.",
     "tabs": {
       "auth": "Authentification",
       "branding": "Image de marque",
       "email": "E-mail",
+      "community": "Communauté",
       "ai": "IA",
       "storage": "Stockage",
       "appServices": "Services applicatifs"
@@ -1074,5 +1075,16 @@
     "prefError": "Impossible de mettre à jour la préférence",
     "test": "Tester",
     "testSuccess": "Connexion réussie"
+  },
+  "community": {
+    "title": "Annuaire des communautés",
+    "description": "Permettez aux guildes de se référencer là où toute personne connectée peut les trouver et les rejoindre sans invitation.",
+    "toggleLabel": "Proposer un annuaire des communautés",
+    "helpText": "Tant que c'est activé, un administrateur de guilde peut référencer sa guilde depuis les paramètres de la guilde, et « Rejoindre une communauté » apparaît à côté des guildes de chacun. Une fois désactivé, il n'y a rien à parcourir et aucune guilde ne peut se référencer.",
+    "reversibleNote": "Désactiver masque l'annuaire ; les guildes référencées le restent. En le réactivant, les mêmes guildes réapparaissent.",
+    "enabledToast": "L'annuaire des communautés est activé.",
+    "disabledToast": "L'annuaire des communautés est désactivé.",
+    "saveError": "Impossible de modifier l'annuaire des communautés. Veuillez réessayer.",
+    "adminOnly": "Vous devez avoir le rôle de propriétaire de la plateforme pour proposer un annuaire des communautés."
   }
 }

--- a/frontend/src/api/generated/guilds/guilds.ts
+++ b/frontend/src/api/generated/guilds/guilds.ts
@@ -371,6 +371,10 @@ export const useReorderGuildsApiV1GuildsOrderPut = <
  * active, always), and :class:`CommunityGuildRead` carries only what a guild
  * published by opting in: no lifecycle status, no administration, no roster,
  * and nothing at all from inside the guild's own schema.
+ *
+ * The directory is a deployment-level feature an owner switches on; where it
+ * is off there is nothing to browse and the request is refused rather than
+ * answered with an empty page.
  * @summary List Community Guilds
  */
 export const listCommunityGuildsApiV1GuildsCommunitiesGet = (

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -369,6 +369,7 @@ export interface AppConfig {
   captcha?: CaptchaConfig | null;
   billing?: BillingConfig | null;
   max_upload_bytes: number;
+  community_directory_enabled: boolean;
 }
 
 export type AppDataParamLabel = { [key: string]: string };
@@ -1328,6 +1329,21 @@ export interface CommunityGuildRead {
 export interface CommunityGuildPage {
   items: CommunityGuildRead[];
   total: number;
+}
+
+/**
+ * Whether this deployment runs a community directory.
+ *
+ * Read back by the owner's settings page after a write; everyone else learns
+ * the same fact from ``GET /config``, which is where the SPA reads it to
+ * decide whether to offer the directory at all.
+ */
+export interface CommunitySettingsResponse {
+  community_directory_enabled: boolean;
+}
+
+export interface CommunitySettingsUpdate {
+  community_directory_enabled: boolean;
 }
 
 export type CounterViewMode = (typeof CounterViewMode)[keyof typeof CounterViewMode];

--- a/frontend/src/api/generated/settings/settings.ts
+++ b/frontend/src/api/generated/settings/settings.ts
@@ -22,6 +22,8 @@ import type {
 
 import type {
   BillingPortalHandoffResponse,
+  CommunitySettingsResponse,
+  CommunitySettingsUpdate,
   EmailSettingsResponse,
   EmailSettingsUpdate,
   EmailTestRequest,
@@ -535,6 +537,108 @@ export const useUpdateInterfaceSettingsApiV1SettingsInterfacePut = <
 > => {
   return useMutation(
     getUpdateInterfaceSettingsApiV1SettingsInterfacePutMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Turn the community directory on or off for the whole deployment.
+ *
+ * Write-only on purpose: the current value is public — every signed-in page
+ * needs it to decide whether to offer the directory — so it is served from
+ * ``GET /config`` with the rest of the SPA's boot configuration rather than
+ * from a second, capability-gated read of the same boolean.
+ *
+ * Switching it off hides the directory and refuses new listings; it does not
+ * clear the opt-in a guild already made, so switching it back on restores the
+ * same set of listed guilds.
+ * @summary Update Community Settings
+ */
+export const updateCommunitySettingsApiV1SettingsCommunityPut = (
+  communitySettingsUpdate: BodyType<CommunitySettingsUpdate>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<CommunitySettingsResponse>(
+    {
+      url: `/api/v1/settings/community`,
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      data: communitySettingsUpdate,
+      signal,
+    },
+    options
+  );
+};
+
+export const getUpdateCommunitySettingsApiV1SettingsCommunityPutMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateCommunitySettingsApiV1SettingsCommunityPut>>,
+    TError,
+    { data: BodyType<CommunitySettingsUpdate> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateCommunitySettingsApiV1SettingsCommunityPut>>,
+  TError,
+  { data: BodyType<CommunitySettingsUpdate> },
+  TContext
+> => {
+  const mutationKey = ["updateCommunitySettingsApiV1SettingsCommunityPut"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateCommunitySettingsApiV1SettingsCommunityPut>>,
+    { data: BodyType<CommunitySettingsUpdate> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return updateCommunitySettingsApiV1SettingsCommunityPut(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateCommunitySettingsApiV1SettingsCommunityPutMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateCommunitySettingsApiV1SettingsCommunityPut>>
+>;
+export type UpdateCommunitySettingsApiV1SettingsCommunityPutMutationBody =
+  BodyType<CommunitySettingsUpdate>;
+export type UpdateCommunitySettingsApiV1SettingsCommunityPutMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Update Community Settings
+ */
+export const useUpdateCommunitySettingsApiV1SettingsCommunityPut = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateCommunitySettingsApiV1SettingsCommunityPut>>,
+      TError,
+      { data: BodyType<CommunitySettingsUpdate> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateCommunitySettingsApiV1SettingsCommunityPut>>,
+  TError,
+  { data: BodyType<CommunitySettingsUpdate> },
+  TContext
+> => {
+  return useMutation(
+    getUpdateCommunitySettingsApiV1SettingsCommunityPutMutationOptions(options),
     queryClient
   );
 };

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -228,6 +228,11 @@ export const invalidateAuthProviders = () =>
 export const invalidateStorageSettings = () =>
   invalidatePersonalExact([`/api/v1/settings/storage`]);
 
+// The community-directory switch is written under /settings but read from the
+// SPA's boot config, so an owner's write has to reach the config key rather
+// than a settings one.
+export const invalidateAppConfig = () => invalidatePersonalExact([`/api/v1/config`]);
+
 export const invalidateOidcMappings = () =>
   invalidatePersonalPrefix("/api/v1/settings/oidc-mappings");
 

--- a/frontend/src/components/guilds/GuildDiscoveryPanel.test.tsx
+++ b/frontend/src/components/guilds/GuildDiscoveryPanel.test.tsx
@@ -19,6 +19,14 @@ import { GuildDiscoveryPanel } from "./GuildDiscoveryPanel";
 
 const patchGuild = vi.fn();
 
+// Listing is offered only where the platform owner runs a directory; the tests
+// below are about a deployment that does, except the one that says otherwise.
+const config = vi.hoisted(() => ({ communityDirectory: true }));
+
+vi.mock("@/hooks/useAppConfig", () => ({
+  useAppConfig: () => ({ communityDirectoryEnabled: config.communityDirectory }),
+}));
+
 vi.mock("@/api/generated/guilds/guilds", () => ({
   updateGuildApiV1GuildsGuildIdPatch: (...args: unknown[]) => patchGuild(...args),
 }));
@@ -51,10 +59,18 @@ const certify = () => within(dialog()).getByLabelText("This guild contains no ad
 
 beforeEach(() => {
   vi.clearAllMocks();
+  config.communityDirectory = true;
   patchGuild.mockResolvedValue(adminGuild({ is_community: true }));
 });
 
 describe("GuildDiscoveryPanel", () => {
+  it("is absent where the platform owner runs no directory", () => {
+    config.communityDirectory = false;
+    renderPanel(adminGuild());
+
+    expect(screen.queryByLabelText("List this guild")).not.toBeInTheDocument();
+  });
+
   it("is absent for a member", () => {
     renderPanel(buildGuild({ id: 7, role: "member" }));
 

--- a/frontend/src/components/guilds/GuildDiscoveryPanel.tsx
+++ b/frontend/src/components/guilds/GuildDiscoveryPanel.tsx
@@ -3,7 +3,8 @@
  *
  * Guild admins only — the API refuses these fields from anyone else, and the
  * whole settings section is admin-gated — so the panel is simply absent for a
- * member rather than shown disabled.
+ * member rather than shown disabled. Absent too where the platform owner runs
+ * no directory: there would be nothing to list in.
  *
  * Saved on its own rather than folded into the details form above: listing a
  * guild publishes it to everyone signed in, which is a different decision from
@@ -26,6 +27,7 @@ import type { GuildCategory, GuildRead } from "@/api/generated/initiativeAPI.sch
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { useAppConfig } from "@/hooks/useAppConfig";
 import { useGuilds } from "@/hooks/useGuilds";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { GUILD_CATEGORIES, guildCategoryLabel } from "@/lib/guildCategories";
@@ -40,6 +42,7 @@ const MIN_COMMUNITY_SEATS = 2;
 export const GuildDiscoveryPanel = () => {
   const { t } = useTranslation(["guilds", "common"]);
   const { activeGuild, refreshGuilds, updateGuildInState } = useGuilds();
+  const { communityDirectoryEnabled } = useAppConfig();
   const [publishing, setPublishing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
@@ -50,7 +53,7 @@ export const GuildDiscoveryPanel = () => {
     setError(null);
   }, [activeGuild]);
 
-  if (activeGuild?.role !== "admin") {
+  if (!communityDirectoryEnabled || activeGuild?.role !== "admin") {
     return null;
   }
 

--- a/frontend/src/components/guilds/GuildSidebar.test.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.test.tsx
@@ -20,11 +20,20 @@ import type { GuildEntry } from "@/hooks/useGuilds";
 
 import { GuildSidebar } from "./GuildSidebar";
 
-// Billing config and the handoff mint, mocked so a test can put the sidebar in
-// either deployment shape: no portal (self-hosted) or one configured.
-const state = vi.hoisted(() => ({ billing: null as { url: string } | null }));
+// Deployment config, mocked so a test can put the sidebar in whichever shape it
+// is about: no billing portal (self-hosted) or one configured, and a community
+// directory the platform owner is running or has switched off.
+const state = vi.hoisted(() => ({
+  billing: null as { url: string } | null,
+  communityDirectory: true,
+}));
 const mintMock = vi.hoisted(() => vi.fn());
-vi.mock("@/hooks/useAppConfig", () => ({ useAppConfig: () => ({ billing: state.billing }) }));
+vi.mock("@/hooks/useAppConfig", () => ({
+  useAppConfig: () => ({
+    billing: state.billing,
+    communityDirectoryEnabled: state.communityDirectory,
+  }),
+}));
 vi.mock("@/api/generated/guilds/guilds", async () => {
   const actual = await vi.importActual<typeof import("@/api/generated/guilds/guilds")>(
     "@/api/generated/guilds/guilds"
@@ -203,6 +212,10 @@ describe("GuildSidebar guild creation", () => {
 });
 
 describe("the way into the community directory", () => {
+  beforeEach(() => {
+    state.communityDirectory = true;
+  });
+
   it("sits in the rail under the add-a-guild button", async () => {
     setup([entry({ id: 1, name: "Alpha" })]);
 
@@ -231,5 +244,14 @@ describe("the way into the community directory", () => {
     const { panel } = await openFlyout();
 
     expect(within(panel).getByRole("link", { name: "Join a community" })).toBeInTheDocument();
+  });
+
+  it("is absent where the platform owner runs no directory", async () => {
+    state.communityDirectory = false;
+    setup([entry({ id: 1, name: "Alpha" })]);
+    const { panel } = await openFlyout();
+
+    expect(screen.queryByRole("link", { name: "Join a community" })).not.toBeInTheDocument();
+    expect(within(panel).queryByRole("link", { name: "Join a community" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -49,6 +49,7 @@ import { Label } from "@/components/ui/label";
 import { useSidebar } from "@/components/ui/sidebar";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAppConfig } from "@/hooks/useAppConfig";
 import { useBillingPortal } from "@/hooks/useBillingPortal";
 import { type GuildEntry, useGuilds } from "@/hooks/useGuilds";
 import { toast } from "@/lib/chesterToast";
@@ -183,9 +184,10 @@ const CreateGuildButton = ({ expanded = false }: { expanded?: boolean }) => {
 };
 
 // Way in to the community directory, under "add a guild": the other way to end
-// up in a new guild, for anyone without an invite to redeem. Unlike creating
-// one this is never hidden — a deployment that has switched guild creation off
-// is exactly where joining an existing guild is the only way in.
+// up in a new guild, for anyone without an invite to redeem. Shown wherever the
+// directory runs, guild creation on or off — a deployment that has switched
+// creation off is exactly where joining an existing guild is the only way in.
+// Absent entirely where the platform owner runs no directory.
 const JoinCommunityButton = ({
   expanded = false,
   onNavigate,
@@ -195,7 +197,12 @@ const JoinCommunityButton = ({
   onNavigate?: () => void;
 }) => {
   const { t } = useTranslation("guilds");
+  const { communityDirectoryEnabled } = useAppConfig();
   const label = t("community.browse");
+
+  if (!communityDirectoryEnabled) {
+    return null;
+  }
 
   if (expanded) {
     return (

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -14,9 +14,11 @@ import type { AppConfig } from "@/api/generated/initiativeAPI.schemas";
  * bundle at build time and can't change between deployments. One image,
  * many envs.
  *
- * Stays cached effectively forever within a session — the values only
+ * Stays cached effectively forever within a session — most of the values only
  * change when the operator restarts the backend with new env vars, at
- * which point a page reload will re-fetch.
+ * which point a page reload will re-fetch. The one setting stored in the
+ * database rather than the environment (the community directory) invalidates
+ * this query when an owner writes it, so their own session updates at once.
  */
 export const useAppConfig = () => {
   const query = useQuery<AppConfig>({
@@ -41,5 +43,9 @@ export const useAppConfig = () => {
      *  config loads — skip the client-side check then; the server still
      *  rejects oversized uploads. */
     maxUploadBytes: query.data?.max_upload_bytes ?? null,
+    /** Whether this deployment runs a community directory. False until the
+     *  config loads, and false is also the default — every way into the
+     *  directory stays hidden unless the platform owner turned it on. */
+    communityDirectoryEnabled: query.data?.community_directory_enabled ?? false,
   };
 };

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -14,18 +14,33 @@ import type { AppConfig } from "@/api/generated/initiativeAPI.schemas";
  * bundle at build time and can't change between deployments. One image,
  * many envs.
  *
- * Stays cached effectively forever within a session — most of the values only
- * change when the operator restarts the backend with new env vars, at
- * which point a page reload will re-fetch. The one setting stored in the
- * database rather than the environment (the community directory) invalidates
- * this query when an owner writes it, so their own session updates at once.
+ * Cached hard, but not forever. Most of these only change when the operator
+ * restarts the backend with new env vars, at which point a page reload
+ * re-fetches. The community directory is the exception: it is a database
+ * setting an owner can change while people are using the app, and everyone
+ * else's client has to arrive at the same answer.
+ *
+ * So the owner's own write invalidates this query (immediate for them), and
+ * every other client re-checks when it next comes back to the tab or mounts a
+ * consumer — at most once per CONFIG_STALE_MS. That is one small request on
+ * returning to a tab, against a config that would otherwise stay wrong until
+ * the page was reloaded.
  */
+/** How long a client may go on believing what it was told. Long enough that
+ *  this is not a poll, short enough that the community directory being
+ *  switched on or off reaches an open tab on its own. */
+const CONFIG_STALE_MS = 5 * 60 * 1000;
+
 export const useAppConfig = () => {
   const query = useQuery<AppConfig>({
     queryKey: getGetAppConfigApiV1ConfigGetQueryKey(),
     queryFn: () => getAppConfigApiV1ConfigGet(),
-    staleTime: Infinity,
+    staleTime: CONFIG_STALE_MS,
     gcTime: Infinity,
+    // Opted in against the client-wide default: this is the query whose answer
+    // can change without the viewer doing anything, and coming back to the tab
+    // is the moment to find that out.
+    refetchOnWindowFocus: true,
     retry: 1,
   });
 

--- a/frontend/src/hooks/useCommunities.ts
+++ b/frontend/src/hooks/useCommunities.ts
@@ -43,7 +43,10 @@ export type CommunityFilters = Omit<
   "page" | "page_size"
 >;
 
-export const useCommunityGuilds = (filters: CommunityFilters) =>
+/** ``enabled`` is how the page skips the request where the platform owner runs
+ *  no directory — the endpoint refuses it there, and a refusal is not a result
+ *  worth rendering. */
+export const useCommunityGuilds = (filters: CommunityFilters, options?: { enabled?: boolean }) =>
   useInfiniteQuery<CommunityGuildPage>({
     queryKey: [...COMMUNITIES_QUERY_KEY, filters],
     queryFn: ({ pageParam, signal }) =>
@@ -63,6 +66,7 @@ export const useCommunityGuilds = (filters: CommunityFilters) =>
     // than blanking it out on every keystroke.
     placeholderData: keepPreviousData,
     staleTime: DIRECTORY_STALE_MS,
+    ...options,
   });
 
 export const useJoinCommunityGuild = () => {

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -12,6 +12,8 @@ import type {
   AuthProviderCreate,
   AuthProviderUpdate,
   ChangelogResponse,
+  CommunitySettingsResponse,
+  CommunitySettingsUpdate,
   EmailSettingsResponse,
   EmailSettingsUpdate,
   FCMConfigResponse,
@@ -57,6 +59,7 @@ import {
   sendTestEmailApiV1SettingsEmailTestPost,
   startStorageBackfillApiV1SettingsStorageBackfillPost,
   testStorageConnectionApiV1SettingsStorageTestPost,
+  updateCommunitySettingsApiV1SettingsCommunityPut,
   updateEmailSettingsApiV1SettingsEmailPut,
   updateInterfaceSettingsApiV1SettingsInterfacePut,
   updateOidcClaimPathApiV1SettingsOidcMappingsClaimPathPut,
@@ -70,6 +73,7 @@ import {
   getGetChangelogApiV1ChangelogGetQueryKey,
 } from "@/api/generated/version/version";
 import {
+  invalidateAppConfig,
   invalidateAuthProviders,
   invalidateAuthSettings,
   invalidateEmailSettings,
@@ -237,6 +241,27 @@ export const useUpdateInterfaceSettings = (
           data as Parameters<typeof updateInterfaceSettingsApiV1SettingsInterfacePut>[0]
         ),
       invalidate: () => invalidateInterfaceSettings(),
+    },
+    options
+  );
+
+/**
+ * Turn the community directory on or off for the whole deployment (owner only).
+ *
+ * There is no matching query: the value is public and every signed-in page
+ * needs it, so it rides along with the SPA's boot config — which is what this
+ * invalidates, so the owner's own session reflects the switch immediately.
+ */
+export const useUpdateCommunitySettings = (
+  options?: MutationOpts<CommunitySettingsResponse, CommunitySettingsUpdate>
+) =>
+  useApiMutation<CommunitySettingsResponse, CommunitySettingsUpdate>(
+    {
+      mutationFn: (data) =>
+        updateCommunitySettingsApiV1SettingsCommunityPut(
+          data as Parameters<typeof updateCommunitySettingsApiV1SettingsCommunityPut>[0]
+        ),
+      invalidate: () => invalidateAppConfig(),
     },
     options
   );

--- a/frontend/src/lib/errorMessage.ts
+++ b/frontend/src/lib/errorMessage.ts
@@ -41,6 +41,21 @@ export function getErrorMessage(error: unknown, fallbackKey?: string): string {
 }
 
 /**
+ * The backend error code carried in `detail`, if the error has one.
+ *
+ * For the callers that have to branch on *which* failure it was rather than
+ * just show it — the codes (`app/core/messages.py`) are the machine-readable
+ * half of the same contract `getErrorMessage` localizes.
+ */
+export function getErrorCode(error: unknown): string | null {
+  if (!isAxiosError(error)) {
+    return null;
+  }
+  const detail = (error.response?.data as { detail?: unknown } | undefined)?.detail;
+  return typeof detail === "string" ? detail : null;
+}
+
+/**
  * Extract the HTTP status code from an error, if available.
  */
 export function getHttpStatus(error: unknown): number | null {

--- a/frontend/src/pages/PlatformSettingsLayout.tsx
+++ b/frontend/src/pages/PlatformSettingsLayout.tsx
@@ -35,6 +35,11 @@ export const PlatformSettingsLayout = () => {
         path: "/settings/platform/branding",
       },
       { value: "email", label: t("platformLayout.tabs.email"), path: "/settings/platform/email" },
+      {
+        value: "community",
+        label: t("platformLayout.tabs.community"),
+        path: "/settings/platform/community",
+      },
       { value: "ai", label: t("platformLayout.tabs.ai"), path: "/settings/platform/ai" },
       {
         value: "storage",

--- a/frontend/src/pages/SettingsCommunityPage.test.tsx
+++ b/frontend/src/pages/SettingsCommunityPage.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * The platform owner's community-directory switch.
+ *
+ * The switch reflects the deployment's boot config rather than a settings read
+ * of its own, so the interesting part is that the two stay one value: what the
+ * page shows is what every other page reads to decide whether to offer the
+ * directory.
+ */
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildUser } from "@/__tests__/factories";
+import { renderWithProviders } from "@/__tests__/helpers/render";
+
+const updateMutate = vi.fn();
+const config = vi.hoisted(() => ({ communityDirectory: false }));
+
+vi.mock("@/hooks/useAppConfig", () => ({
+  useAppConfig: () => ({
+    communityDirectoryEnabled: config.communityDirectory,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useSettings", () => ({
+  useUpdateCommunitySettings: () => ({ mutate: updateMutate, isPending: false }),
+}));
+
+import { SettingsCommunityPage } from "./SettingsCommunityPage";
+
+const renderPage = (role: "owner" | "operator" = "owner") =>
+  renderWithProviders(<SettingsCommunityPage />, {
+    auth: { user: buildUser({ role }) },
+  });
+
+const toggle = () => screen.getByLabelText("Run a community directory");
+
+describe("SettingsCommunityPage", () => {
+  beforeEach(() => {
+    updateMutate.mockClear();
+    config.communityDirectory = false;
+  });
+
+  it("starts off, matching a deployment that has never turned it on", async () => {
+    renderPage();
+
+    expect(await screen.findByLabelText("Run a community directory")).not.toBeChecked();
+  });
+
+  it("turns the directory on", async () => {
+    renderPage();
+    fireEvent.click(await screen.findByLabelText("Run a community directory"));
+
+    expect(updateMutate).toHaveBeenCalledWith({ community_directory_enabled: true });
+  });
+
+  it("turns it back off", async () => {
+    config.communityDirectory = true;
+    renderPage();
+
+    expect(toggle()).toBeChecked();
+    fireEvent.click(toggle());
+
+    expect(updateMutate).toHaveBeenCalledWith({ community_directory_enabled: false });
+  });
+
+  it("is not offered below the owner tier", () => {
+    renderPage("operator");
+
+    expect(screen.queryByLabelText("Run a community directory")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("You need the platform owner role to run a community directory.")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SettingsCommunityPage.tsx
+++ b/frontend/src/pages/SettingsCommunityPage.tsx
@@ -1,0 +1,75 @@
+/**
+ * The community-directory switch (platform settings → Community).
+ *
+ * One decision, and it belongs to the platform owner rather than to any guild:
+ * whether this deployment has a community directory at all. Guilds decide
+ * whether to be *in* it from their own settings page; this decides whether it
+ * exists for them to be in.
+ *
+ * The current value comes from the SPA's boot config rather than a settings
+ * read, because it is the same value every other page reads to decide whether
+ * to offer the directory — there is one source, not an owner's copy and
+ * everyone else's.
+ */
+
+import { useTranslation } from "react-i18next";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useAppConfig } from "@/hooks/useAppConfig";
+import { useAuth } from "@/hooks/useAuth";
+import { useUpdateCommunitySettings } from "@/hooks/useSettings";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { Capability, hasCapability } from "@/lib/permissions";
+
+export const SettingsCommunityPage = () => {
+  const { t } = useTranslation("settings");
+  const { user } = useAuth();
+  const isPlatformAdmin = hasCapability(user, Capability.configManage);
+  const { communityDirectoryEnabled, isLoading } = useAppConfig();
+
+  const update = useUpdateCommunitySettings({
+    onSuccess: (result) => {
+      toast.success(
+        result.community_directory_enabled
+          ? t("community.enabledToast")
+          : t("community.disabledToast")
+      );
+    },
+    onError: (err) => {
+      toast.error(getErrorMessage(err, "settings:community.saveError"));
+    },
+  });
+
+  if (!isPlatformAdmin) {
+    return <p className="text-muted-foreground text-sm">{t("community.adminOnly")}</p>;
+  }
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle>{t("community.title")}</CardTitle>
+        <CardDescription>{t("community.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-3">
+          <Switch
+            id="community-directory-enabled"
+            checked={communityDirectoryEnabled}
+            disabled={isLoading || update.isPending}
+            onCheckedChange={(checked) =>
+              update.mutate({ community_directory_enabled: Boolean(checked) })
+            }
+          />
+          <Label htmlFor="community-directory-enabled">{t("community.toggleLabel")}</Label>
+        </div>
+        <p className="text-muted-foreground text-sm">{t("community.helpText")}</p>
+        {/* Turning it back off is not a punishment for the guilds that opted
+            in, and saying so up front stops it reading like one. */}
+        <p className="text-muted-foreground text-xs">{t("community.reversibleNote")}</p>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/pages/communities/CommunitiesPage.test.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.test.tsx
@@ -77,6 +77,31 @@ describe("CommunitiesPage", () => {
     expect(directoryFor).toHaveBeenCalledWith(expect.anything(), { enabled: false });
   });
 
+  it("reads a refusal as the off state, not a failed load", async () => {
+    // A tab that was open when the owner switched the directory off still has
+    // it cached as on: it asks, and the answer settles it.
+    directoryFor.mockReturnValue(
+      directoryResult([], {
+        isError: true,
+        error: {
+          isAxiosError: true,
+          response: { status: 403, data: { detail: "COMMUNITY_DIRECTORY_DISABLED" } },
+        },
+      })
+    );
+    renderDirectory();
+
+    expect(await screen.findByText("No community directory here")).toBeInTheDocument();
+    expect(screen.queryByText("Directory unavailable")).not.toBeInTheDocument();
+  });
+
+  it("still reports a directory that failed to load", async () => {
+    directoryFor.mockReturnValue(directoryResult([], { isError: true, error: new Error("boom") }));
+    renderDirectory();
+
+    expect(await screen.findByText("Directory unavailable")).toBeInTheDocument();
+  });
+
   it("shows a card per community", async () => {
     renderDirectory();
 

--- a/frontend/src/pages/communities/CommunitiesPage.test.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.test.tsx
@@ -20,8 +20,19 @@ const join = vi.fn();
 const fetchNextPage = vi.fn();
 
 vi.mock("@/hooks/useCommunities", () => ({
-  useCommunityGuilds: (params: unknown) => directoryFor(params),
+  useCommunityGuilds: (params: unknown, options?: unknown) => directoryFor(params, options),
   useJoinCommunityGuild: () => ({ mutateAsync: join, isPending: false }),
+}));
+
+// Whether this deployment has a directory at all is the platform owner's
+// setting; everything below is about one that does, bar the test that says so.
+const config = vi.hoisted(() => ({ communityDirectory: true }));
+
+vi.mock("@/hooks/useAppConfig", () => ({
+  useAppConfig: () => ({
+    communityDirectoryEnabled: config.communityDirectory,
+    isLoading: false,
+  }),
 }));
 
 const community = (overrides: Partial<CommunityGuildRead> = {}): CommunityGuildRead => ({
@@ -51,10 +62,21 @@ const directoryResult = (items: CommunityGuildRead[], overrides: Record<string, 
 
 beforeEach(() => {
   vi.clearAllMocks();
+  config.communityDirectory = true;
   directoryFor.mockReturnValue(directoryResult([community()]));
 });
 
 describe("CommunitiesPage", () => {
+  it("says so, and asks nothing, where the owner runs no directory", async () => {
+    config.communityDirectory = false;
+    renderDirectory();
+
+    expect(await screen.findByText("No community directory here")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search communities")).not.toBeInTheDocument();
+    // The endpoint refuses the request there, so the page must not make it.
+    expect(directoryFor).toHaveBeenCalledWith(expect.anything(), { enabled: false });
+  });
+
   it("shows a card per community", async () => {
     renderDirectory();
 
@@ -70,7 +92,10 @@ describe("CommunitiesPage", () => {
     renderDirectory();
 
     await screen.findByText("Riverside Players");
-    expect(directoryFor).toHaveBeenCalledWith({ q: undefined, category: undefined });
+    expect(directoryFor).toHaveBeenCalledWith(
+      { q: undefined, category: undefined },
+      { enabled: true }
+    );
   });
 
   it("narrows the request when a category is picked", async () => {
@@ -80,7 +105,10 @@ describe("CommunitiesPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Tabletop RPG" }));
 
     await waitFor(() => {
-      expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ category: "ttrpg" }));
+      expect(directoryFor).toHaveBeenCalledWith(
+        expect.objectContaining({ category: "ttrpg" }),
+        expect.anything()
+      );
     });
   });
 
@@ -91,7 +119,10 @@ describe("CommunitiesPage", () => {
     await userEvent.type(screen.getByLabelText("Search communities"), "dice");
 
     await waitFor(() => {
-      expect(directoryFor).toHaveBeenCalledWith(expect.objectContaining({ q: "dice" }));
+      expect(directoryFor).toHaveBeenCalledWith(
+        expect.objectContaining({ q: "dice" }),
+        expect.anything()
+      );
     });
   });
 
@@ -138,7 +169,8 @@ describe("CommunitiesPage", () => {
 
     await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
     expect(directoryFor).not.toHaveBeenCalledWith(
-      expect.objectContaining({ page_size: expect.anything() })
+      expect.objectContaining({ page_size: expect.anything() }),
+      expect.anything()
     );
   });
 

--- a/frontend/src/pages/communities/CommunitiesPage.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.tsx
@@ -10,6 +10,10 @@
  * The directory is platform-level, so this asks nothing about the caller's
  * current guild. Whether they are already in one of these is answered by the
  * card payload itself.
+ *
+ * Whether there is a directory at all is the platform owner's setting. Where it
+ * is off the page still exists — it can be linked to, and a link should say
+ * what happened — but it says so instead of searching.
  */
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
@@ -23,6 +27,7 @@ import { StatusMessage } from "@/components/StatusMessage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useAppConfig } from "@/hooks/useAppConfig";
 import { useCommunityGuilds } from "@/hooks/useCommunities";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { asGuildCategory, GUILD_CATEGORIES, guildCategoryLabel } from "@/lib/guildCategories";
@@ -47,10 +52,15 @@ export function CommunitiesPage() {
   const [query, setQuery] = useState("");
   const search = useDebouncedValue(query, 250);
 
-  const directory = useCommunityGuilds({
-    q: search.trim() || undefined,
-    category: category ?? undefined,
-  });
+  const { communityDirectoryEnabled, isLoading: configLoading } = useAppConfig();
+
+  const directory = useCommunityGuilds(
+    {
+      q: search.trim() || undefined,
+      category: category ?? undefined,
+    },
+    { enabled: communityDirectoryEnabled }
+  );
 
   const selectCategory = (next: GuildCategory | undefined) => {
     void navigate({
@@ -86,12 +96,30 @@ export function CommunitiesPage() {
     );
   };
 
+  const heading = (
+    <div className="space-y-1">
+      <h1 className="font-semibold text-3xl tracking-tight">{t("guilds:community.title")}</h1>
+      <p className="text-muted-foreground text-sm">{t("guilds:community.subtitle")}</p>
+    </div>
+  );
+
+  // No directory on this deployment: no search box, no shelves, and no request.
+  if (!configLoading && !communityDirectoryEnabled) {
+    return (
+      <div className="space-y-6">
+        {heading}
+        <StatusMessage
+          icon={<CloudOff />}
+          title={t("guilds:community.disabledTitle")}
+          description={t("guilds:community.disabledDescription")}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
-      <div className="space-y-1">
-        <h1 className="font-semibold text-3xl tracking-tight">{t("guilds:community.title")}</h1>
-        <p className="text-muted-foreground text-sm">{t("guilds:community.subtitle")}</p>
-      </div>
+      {heading}
 
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
         <aside className="lg:sticky lg:top-20 lg:w-56 lg:shrink-0">
@@ -122,7 +150,7 @@ export function CommunitiesPage() {
               title={t("guilds:community.unavailableTitle")}
               description={t("guilds:community.unavailableDescription")}
             />
-          ) : directory.isLoading ? (
+          ) : configLoading || directory.isLoading ? (
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {SKELETON_KEYS.map((key) => (
                 <Skeleton key={key} className="h-52 w-full rounded-xl" />

--- a/frontend/src/pages/communities/CommunitiesPage.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.tsx
@@ -13,7 +13,9 @@
  *
  * Whether there is a directory at all is the platform owner's setting. Where it
  * is off the page still exists — it can be linked to, and a link should say
- * what happened — but it says so instead of searching.
+ * what happened — but it says so instead of searching. A client that had not
+ * heard yet asks and is refused, which lands in the same place: the server's
+ * answer is what settles it, not the config this page loaded with.
  */
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
@@ -30,6 +32,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { useCommunityGuilds } from "@/hooks/useCommunities";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { getErrorCode } from "@/lib/errorMessage";
 import { asGuildCategory, GUILD_CATEGORIES, guildCategoryLabel } from "@/lib/guildCategories";
 import { cn } from "@/lib/utils";
 
@@ -96,6 +99,13 @@ export function CommunitiesPage() {
     );
   };
 
+  // Either this client was told there is no directory, or it asked and was told
+  // so. The second is how a tab that was open when an owner switched it off
+  // finds out — a refusal is an answer, not the momentary failure the
+  // unavailable message describes.
+  const directoryOff =
+    !communityDirectoryEnabled || getErrorCode(directory.error) === "COMMUNITY_DIRECTORY_DISABLED";
+
   const heading = (
     <div className="space-y-1">
       <h1 className="font-semibold text-3xl tracking-tight">{t("guilds:community.title")}</h1>
@@ -104,7 +114,7 @@ export function CommunitiesPage() {
   );
 
   // No directory on this deployment: no search box, no shelves, and no request.
-  if (!configLoading && !communityDirectoryEnabled) {
+  if (!configLoading && directoryOff) {
     return (
       <div className="space-y-6">
         {heading}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -60,6 +60,7 @@ import { Route as ServerRequiredAuthenticatedSettingsPlatformAiRouteImport } fro
 import { Route as ServerRequiredAuthenticatedSettingsPlatformAppServicesRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/app-services'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformAuthRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/auth'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformBrandingRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/branding'
+import { Route as ServerRequiredAuthenticatedSettingsPlatformCommunityRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/community'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformEmailRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/email'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformStorageRouteImport } from './routes/_serverRequired/_authenticated/settings/platform/storage'
 import { Route as ServerRequiredAuthenticatedGGuildIdAppsAppIdRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/apps_.$appId'
@@ -405,6 +406,12 @@ const ServerRequiredAuthenticatedSettingsPlatformBrandingRoute =
   ServerRequiredAuthenticatedSettingsPlatformBrandingRouteImport.update({
     id: '/branding',
     path: '/branding',
+    getParentRoute: () => ServerRequiredAuthenticatedSettingsPlatformRoute,
+  } as any)
+const ServerRequiredAuthenticatedSettingsPlatformCommunityRoute =
+  ServerRequiredAuthenticatedSettingsPlatformCommunityRouteImport.update({
+    id: '/community',
+    path: '/community',
     getParentRoute: () => ServerRequiredAuthenticatedSettingsPlatformRoute,
   } as any)
 const ServerRequiredAuthenticatedSettingsPlatformEmailRoute =
@@ -820,6 +827,7 @@ export interface FileRoutesByFullPath {
   '/settings/platform/app-services': typeof ServerRequiredAuthenticatedSettingsPlatformAppServicesRoute
   '/settings/platform/auth': typeof ServerRequiredAuthenticatedSettingsPlatformAuthRoute
   '/settings/platform/branding': typeof ServerRequiredAuthenticatedSettingsPlatformBrandingRoute
+  '/settings/platform/community': typeof ServerRequiredAuthenticatedSettingsPlatformCommunityRoute
   '/settings/platform/email': typeof ServerRequiredAuthenticatedSettingsPlatformEmailRoute
   '/settings/platform/storage': typeof ServerRequiredAuthenticatedSettingsPlatformStorageRoute
   '/g/$guildId/': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
@@ -914,6 +922,7 @@ export interface FileRoutesByTo {
   '/settings/platform/app-services': typeof ServerRequiredAuthenticatedSettingsPlatformAppServicesRoute
   '/settings/platform/auth': typeof ServerRequiredAuthenticatedSettingsPlatformAuthRoute
   '/settings/platform/branding': typeof ServerRequiredAuthenticatedSettingsPlatformBrandingRoute
+  '/settings/platform/community': typeof ServerRequiredAuthenticatedSettingsPlatformCommunityRoute
   '/settings/platform/email': typeof ServerRequiredAuthenticatedSettingsPlatformEmailRoute
   '/settings/platform/storage': typeof ServerRequiredAuthenticatedSettingsPlatformStorageRoute
   '/g/$guildId': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
@@ -1015,6 +1024,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/settings/platform/app-services': typeof ServerRequiredAuthenticatedSettingsPlatformAppServicesRoute
   '/_serverRequired/_authenticated/settings/platform/auth': typeof ServerRequiredAuthenticatedSettingsPlatformAuthRoute
   '/_serverRequired/_authenticated/settings/platform/branding': typeof ServerRequiredAuthenticatedSettingsPlatformBrandingRoute
+  '/_serverRequired/_authenticated/settings/platform/community': typeof ServerRequiredAuthenticatedSettingsPlatformCommunityRoute
   '/_serverRequired/_authenticated/settings/platform/email': typeof ServerRequiredAuthenticatedSettingsPlatformEmailRoute
   '/_serverRequired/_authenticated/settings/platform/storage': typeof ServerRequiredAuthenticatedSettingsPlatformStorageRoute
   '/_serverRequired/_authenticated/g/$guildId/': typeof ServerRequiredAuthenticatedGGuildIdIndexRoute
@@ -1116,6 +1126,7 @@ export interface FileRouteTypes {
     | '/settings/platform/app-services'
     | '/settings/platform/auth'
     | '/settings/platform/branding'
+    | '/settings/platform/community'
     | '/settings/platform/email'
     | '/settings/platform/storage'
     | '/g/$guildId/'
@@ -1210,6 +1221,7 @@ export interface FileRouteTypes {
     | '/settings/platform/app-services'
     | '/settings/platform/auth'
     | '/settings/platform/branding'
+    | '/settings/platform/community'
     | '/settings/platform/email'
     | '/settings/platform/storage'
     | '/g/$guildId'
@@ -1310,6 +1322,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/settings/platform/app-services'
     | '/_serverRequired/_authenticated/settings/platform/auth'
     | '/_serverRequired/_authenticated/settings/platform/branding'
+    | '/_serverRequired/_authenticated/settings/platform/community'
     | '/_serverRequired/_authenticated/settings/platform/email'
     | '/_serverRequired/_authenticated/settings/platform/storage'
     | '/_serverRequired/_authenticated/g/$guildId/'
@@ -1728,6 +1741,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsPlatformBrandingRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedSettingsPlatformRoute
     }
+    '/_serverRequired/_authenticated/settings/platform/community': {
+      id: '/_serverRequired/_authenticated/settings/platform/community'
+      path: '/community'
+      fullPath: '/settings/platform/community'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsPlatformCommunityRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedSettingsPlatformRoute
+    }
     '/_serverRequired/_authenticated/settings/platform/email': {
       id: '/_serverRequired/_authenticated/settings/platform/email'
       path: '/email'
@@ -2132,6 +2152,7 @@ interface ServerRequiredAuthenticatedSettingsPlatformRouteChildren {
   ServerRequiredAuthenticatedSettingsPlatformAppServicesRoute: typeof ServerRequiredAuthenticatedSettingsPlatformAppServicesRoute
   ServerRequiredAuthenticatedSettingsPlatformAuthRoute: typeof ServerRequiredAuthenticatedSettingsPlatformAuthRoute
   ServerRequiredAuthenticatedSettingsPlatformBrandingRoute: typeof ServerRequiredAuthenticatedSettingsPlatformBrandingRoute
+  ServerRequiredAuthenticatedSettingsPlatformCommunityRoute: typeof ServerRequiredAuthenticatedSettingsPlatformCommunityRoute
   ServerRequiredAuthenticatedSettingsPlatformEmailRoute: typeof ServerRequiredAuthenticatedSettingsPlatformEmailRoute
   ServerRequiredAuthenticatedSettingsPlatformStorageRoute: typeof ServerRequiredAuthenticatedSettingsPlatformStorageRoute
   ServerRequiredAuthenticatedSettingsPlatformIndexRoute: typeof ServerRequiredAuthenticatedSettingsPlatformIndexRoute
@@ -2147,6 +2168,8 @@ const ServerRequiredAuthenticatedSettingsPlatformRouteChildren: ServerRequiredAu
       ServerRequiredAuthenticatedSettingsPlatformAuthRoute,
     ServerRequiredAuthenticatedSettingsPlatformBrandingRoute:
       ServerRequiredAuthenticatedSettingsPlatformBrandingRoute,
+    ServerRequiredAuthenticatedSettingsPlatformCommunityRoute:
+      ServerRequiredAuthenticatedSettingsPlatformCommunityRoute,
     ServerRequiredAuthenticatedSettingsPlatformEmailRoute:
       ServerRequiredAuthenticatedSettingsPlatformEmailRoute,
     ServerRequiredAuthenticatedSettingsPlatformStorageRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { VersionDialog } from "@/components/VersionDialog";
+import { useAppConfig } from "@/hooks/useAppConfig";
 import { useAuth } from "@/hooks/useAuth";
 import { useBackButton } from "@/hooks/useBackButton";
 import { useBillingPortal } from "@/hooks/useBillingPortal";
@@ -299,6 +300,7 @@ function NoGuildState({
 }) {
   const { t } = useTranslation("guilds");
   const { billing, openPortal, reserveTab } = useBillingPortal();
+  const { communityDirectoryEnabled } = useAppConfig();
   const [guildName, setGuildName] = useState("");
   const [inviteCode, setInviteCode] = useState("");
   const [creating, setCreating] = useState(false);
@@ -365,13 +367,16 @@ function NoGuildState({
 
         {/* The other way out of this screen: a guild that opened itself to
             the directory can be joined here and now, with no invite to wait
-            for and nobody to ask. */}
-        <Button variant="outline" asChild className="w-full">
-          <Link to="/communities">
-            <Compass className="h-4 w-4" />
-            {t("noGuild.browseCommunities")}
-          </Link>
-        </Button>
+            for and nobody to ask. Only where the platform owner runs a
+            directory — otherwise an invite is the only way in. */}
+        {communityDirectoryEnabled && (
+          <Button variant="outline" asChild className="w-full">
+            <Link to="/communities">
+              <Compass className="h-4 w-4" />
+              {t("noGuild.browseCommunities")}
+            </Link>
+          </Button>
+        )}
 
         {/* Direct entry points to the user/platform settings pages so a
             user with no memberships can still manage their account

--- a/frontend/src/routes/_serverRequired/_authenticated/settings/platform/community.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/settings/platform/community.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/settings/platform/community")(
+  {
+    component: lazyRouteComponent(() =>
+      import("@/pages/SettingsCommunityPage").then((m) => ({ default: m.SettingsCommunityPage }))
+    ),
+  }
+);

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -8,7 +8,9 @@ Designed to run from the backend/ directory (CWD) so app imports resolve.
 Saves created IDs to .vscode/.dev_seed_ids.json for cleanup.
 
 Creates 3 guilds with multiple users, initiatives, projects, tasks, documents,
-tags, and comments to exercise all features of the app.
+tags, and comments to exercise all features of the app, plus six small guilds
+that exist to fill the community directory (which this switches on). Guilds 1
+and 2 stay invite-only so the unlisted case is still there to look at.
 
 Seeded logins (all password "changeme"):
 - admin1..admin4@example.com — dedicated guild admins (platform tier: member).
@@ -84,7 +86,12 @@ from app.models.platform.access_grant import (  # noqa: E402
     AccessGrantStatus,
     AccessLevel,
 )
-from app.models.platform.guild import Guild, GuildMembership, GuildRole  # noqa: E402
+from app.models.platform.guild import (  # noqa: E402
+    Guild,
+    GuildCategory,
+    GuildMembership,
+    GuildRole,
+)
 from app.models.tenant.queue import (  # noqa: E402
     Queue,
     QueueItem,
@@ -123,8 +130,11 @@ from app.models.tenant.task import (  # noqa: E402
     TaskStatusCategory,
 )
 from app.models.platform.user import User, UserRole, UserStatus  # noqa: E402
-from app.services.platform.app_settings import get_or_create_guild_settings  # noqa: E402
-from app.services.platform.guilds import get_primary_guild  # noqa: E402
+from app.services.platform.app_settings import (  # noqa: E402
+    get_app_settings,
+    get_or_create_guild_settings,
+)
+from app.services.platform import guilds as guilds_service  # noqa: E402
 from app.services.tenant.initiatives import (  # noqa: E402
     create_builtin_roles,
     ensure_default_initiative,
@@ -456,28 +466,27 @@ async def _create_guild(
     description: str,
     creator: User,
 ) -> Guild:
-    """Create a guild and admin membership for the creator."""
+    """Create a guild and admin membership for the creator.
+
+    Goes through the service rather than inserting the row here, so a seeded
+    guild is built the same way one made in the app is — in particular it gets
+    the ``guild_administration`` companion every reader assumes exists (the
+    community directory joins against it, and ``get_administration`` raises
+    without it).
+    """
     # Creating a public.guilds row is a bootstrap write: there is no guild to be
     # admin of yet, so no guild-admin RLS leg can authorize it — it must run on the
     # BYPASSRLS login role (app_admin). After seeding a previous guild's content the
     # session is still SET ROLE'd into that guild_<id> (and the admin-role
     # dual-path bypass is retired), so reset to the bare login-role baseline first.
     await set_rls_context(session)
-    guild = Guild(
+    guild = await guilds_service.create_guild(
+        session,
         name=name,
         description=description,
-        created_by=creator.id,
+        creator=creator,
     )
-    session.add(guild)
-    await session.flush()
     ids.add("guilds", guild.id)
-
-    membership = GuildMembership(
-        guild_id=guild.id,
-        user_id=creator.id,
-        role=GuildRole.admin,
-    )
-    session.add(membership)
     ids.add("guild_memberships", {"guild_id": guild.id, "user_id": creator.id})
     await session.flush()
     return guild
@@ -588,6 +597,98 @@ async def _create_initiative(
 
     await session.flush()
     return initiative, pm_role, member_role
+
+
+async def _enable_community_directory(session: AsyncSession) -> None:
+    """Switch the platform's community directory on.
+
+    It is a platform-owner setting that ships off, so a dev database has no
+    directory until this says otherwise — and the listings below would have
+    nowhere to appear.
+    """
+    settings_row = await get_app_settings(session)
+    settings_row.community_directory_enabled = True
+    session.add(settings_row)
+    await session.flush()
+
+
+async def _list_guild_in_directory(
+    session: AsyncSession,
+    guild: Guild,
+    *,
+    categories: list[GuildCategory],
+) -> None:
+    """Opt a guild into the directory.
+
+    A listing is the shelves plus the 18+ declaration together — the database
+    refuses a listed guild missing either — and the categories are stored in the
+    same order the app stores them in.
+
+    Writes ``public.guilds``, so the session must not be routed into a guild
+    schema when this is called.
+    """
+    guild.is_community = True
+    guild.categories = guilds_service.normalize_categories(
+        [c.value for c in categories]
+    )
+    guild.has_adult_content = False
+    session.add(guild)
+    await session.flush()
+
+
+async def _create_community_guild(
+    session: AsyncSession,
+    ids: IDTracker,
+    *,
+    name: str,
+    description: str,
+    categories: list[GuildCategory],
+    admin: User,
+    members: list[User],
+    initiative_name: str,
+    initiative_description: str,
+    initiative_color: str,
+) -> Guild:
+    """A small guild that exists to be found in the directory.
+
+    Enough to be a believable card — a name, a description, its shelves, and a
+    roster whose size shows on it — plus one initiative everybody in it belongs
+    to, so joining from the directory lands somewhere rather than in a guild
+    that looks broken. The deep content stays in guilds 1-3.
+    """
+    guild = await _create_guild(
+        session,
+        ids,
+        name=name,
+        description=description,
+        creator=admin,
+    )
+    await _list_guild_in_directory(session, guild, categories=categories)
+    guild_id = guild.id
+
+    # Same order the guild sections above use: commit the shared rows, provision
+    # the schema, add the roster, then route in to write the guild's content.
+    await session.commit()
+    _expunge_guild_scoped(session)
+    await provision_guild(guild_id)
+    await _add_guild_members(session, ids, guild, members)
+    await set_rls_context(
+        session, user_id=admin.id, guild_id=guild_id, guild_role="admin"
+    )
+    await _create_initiative(
+        session,
+        ids,
+        guild=guild,
+        name=initiative_name,
+        description=initiative_description,
+        color=initiative_color,
+        pm_user=admin,
+        member_users=members,
+    )
+    await session.commit()
+    _expunge_guild_scoped(session)
+    await set_rls_context(session)
+    return guild
 
 
 async def _create_project(
@@ -1941,7 +2042,7 @@ async def seed() -> None:
     async with AdminSessionLocal() as session:
         # -- Discover existing entities --
         admin_user = await _find_superuser(session)
-        primary_guild = await get_primary_guild(session)
+        primary_guild = await guilds_service.get_primary_guild(session)
 
         # ==============================================================
         # Users (all password: "changeme")
@@ -6862,6 +6963,96 @@ async def seed() -> None:
         await session.commit()
 
         # ==============================================================
+        # COMMUNITY DIRECTORY
+        # ==============================================================
+        # Guilds 1 and 2 stay invite-only, so the private case is still there to
+        # look at: an unlisted guild has no categories, no 18+ answer, and no
+        # card. Guild 3 is listed, which puts one guild with real content behind
+        # a directory card — the superuser is already in it, so it shows the
+        # already-a-member state next to the joinable ones. The rest are small
+        # guilds that exist to fill the shelves.
+        print("\n  --- Community directory ---")
+        await set_rls_context(session)  # shared/public tables — no guild routing
+        await _enable_community_directory(session)
+        await _list_guild_in_directory(
+            session, g3, categories=[GuildCategory.ttrpg, GuildCategory.social]
+        )
+        await session.commit()
+
+        # One shelf (music) is deliberately left empty, so the "nothing on this
+        # shelf" state is reachable without editing anything.
+        community_specs = [
+            {
+                "name": "The Cartographers' Table",
+                "description": "Hand-drawn maps for tables that want one. "
+                "Weekly critique thread, monthly swap.",
+                "categories": [GuildCategory.art, GuildCategory.ttrpg],
+                "admin": elara,
+                "members": [thorn, vex],
+                "initiative_name": "Map Swap",
+                "initiative_description": "The running map exchange and its critique threads.",
+                "initiative_color": "#0891b2",
+            },
+            {
+                "name": "Midnight Homebrew",
+                "description": "Homebrew rules, monsters, and subclasses — "
+                "brought here to be broken before a table finds the cracks.",
+                "categories": [GuildCategory.ttrpg, GuildCategory.writing],
+                "admin": dm,
+                "members": [sera, kael, aurelia, thorn],
+                "initiative_name": "Playtest Queue",
+                "initiative_description": "Everything waiting on a table to try it.",
+                "initiative_color": "#7c3aed",
+            },
+            {
+                "name": "Sunday Session Zero",
+                "description": "Pick-up games for people without a regular table. "
+                "Say what you play, find four others.",
+                "categories": [GuildCategory.gaming, GuildCategory.social],
+                "admin": finley,
+                "members": [vex, kael, p_member, p_support],
+                "initiative_name": "This Month's Tables",
+                "initiative_description": "Who is running what, and which seats are open.",
+                "initiative_color": "#ea580c",
+            },
+            {
+                "name": "Pixel & Palette",
+                "description": "Digital art, tooling, and the pipelines behind them.",
+                "categories": [GuildCategory.art, GuildCategory.technology],
+                "admin": vex,
+                "members": [elara, sera],
+                "initiative_name": "Studio",
+                "initiative_description": "Works in progress and the tools that made them.",
+                "initiative_color": "#db2777",
+            },
+            {
+                "name": "Dawn Patrol",
+                "description": "An early-morning running club. Routes, times, "
+                "and a standing excuse to be outside before work.",
+                "categories": [GuildCategory.sports, GuildCategory.health],
+                "admin": sera,
+                "members": [thorn, aurelia, finley, dm, kael],
+                "initiative_name": "Season Plan",
+                "initiative_description": "The training block everyone is on.",
+                "initiative_color": "#16a34a",
+            },
+            {
+                "name": "Founders' Roundtable",
+                "description": "Small-company operators comparing notes. "
+                "No pitches, no recruiting.",
+                "categories": [GuildCategory.business, GuildCategory.education],
+                "admin": thorn,
+                "members": [p_operator, p_moderator],
+                "initiative_name": "Roundtable",
+                "initiative_description": "The standing agenda and its notes.",
+                "initiative_color": "#0f766e",
+            },
+        ]
+        for spec in community_specs:
+            print(f"  Listing community guild: {spec['name']}")
+            await _create_community_guild(session, ids, **spec)
+
+        # ==============================================================
         # PAM access grants (platform-role testing paths)
         # ==============================================================
         # Every grant targets a guild the grantee is NOT a member of — PAM
@@ -6950,7 +7141,11 @@ async def seed() -> None:
 
     print("\nDone! Dev data seeded successfully.")
     print(f"  {total_users} users (password: changeme)")
-    print(f"  3 guilds, {len(ids.data['initiatives'])} initiatives")
+    print(
+        f"  {len(ids.data['guilds']) + 1} guilds "
+        f"({len(ids.data['initiatives'])} initiatives); "
+        "community directory on"
+    )
     print(f"  {total_projects} projects, {total_tasks} tasks")
     print(f"  {total_docs} documents, {len(ids.data['tags'])} tags")
     print(
@@ -7014,7 +7209,6 @@ async def clean() -> None:
 
     print("Cleaning up dev data (dropping guild schemas + wiping shared rows)...")
     async with db_session.provisioning_engine.begin() as conn:
-        await conn.exec_driver_sql("SET lock_timeout = '10s'")
         schemas = [
             s
             for (s,) in (
@@ -7023,8 +7217,6 @@ async def clean() -> None:
                 )
             ).all()
         ]
-        for schema in schemas:
-            await conn.exec_driver_sql(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         roles = [
             r
             for (r,) in (
@@ -7033,7 +7225,20 @@ async def clean() -> None:
                 )
             ).all()
         ]
-        await conn.exec_driver_sql(
+
+    # One transaction per schema, and the truncate in its own. A guild schema is
+    # ~40 tables plus their indexes, so dropping every one of them and cascading
+    # a truncate in a single transaction holds more locks than a default
+    # `max_locks_per_transaction` allows — and the whole clean then rolls back,
+    # leaving the state it was asked to clear.
+    for schema in schemas:
+        async with db_session.provisioning_engine.begin() as sconn:
+            await sconn.exec_driver_sql("SET lock_timeout = '10s'")
+            await sconn.exec_driver_sql(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+
+    async with db_session.provisioning_engine.begin() as tconn:
+        await tconn.exec_driver_sql("SET lock_timeout = '10s'")
+        await tconn.exec_driver_sql(
             "TRUNCATE TABLE users, guilds RESTART IDENTITY CASCADE"
         )
 
@@ -7051,6 +7256,18 @@ async def clean() -> None:
     print(
         f"  Dropped {len(schemas)} guild schema(s) + {dropped}/{len(roles)} role(s); wiped users + guilds"
     )
+
+    # The directory switch is a platform setting, so it outlives every guild
+    # that was listed in it. Put it back to the off state a fresh install has,
+    # or the next un-seeded dev database starts with a directory nobody asked
+    # for. app_settings is not truncated above, so this is its own write.
+    async with AdminSessionLocal() as session:
+        await set_rls_context(session)
+        app_settings = await get_app_settings(session)
+        app_settings.community_directory_enabled = False
+        session.add(app_settings)
+        await session.commit()
+    print("  Community directory switched back off")
 
     STATE_FILE.unlink(missing_ok=True)
     print(


### PR DESCRIPTION
## Problem

The community directory landed switched on for everyone. Whether a server has a browsable, invite-free front door is the platform owner's decision, not something an install should acquire on upgrade — so it needs a switch, and the switch needs to start off.

## Changes

**The setting**
- `app_settings.community_directory_enabled`, default `false` ([app_setting.py](backend/app/models/platform/app_setting.py)), added by [migration 0197](backend/alembic/versions/20260827_0197_community_directory_toggle.py).
- `PUT /api/v1/settings/community` ([settings.py](backend/app/api/v1/platform_endpoints/settings.py)) — gated on `config.manage`, so owner only.
- The value rides along with `GET /api/v1/config` ([config.py](backend/app/api/v1/platform_endpoints/config.py)) rather than getting a second, capability-gated read of its own: it is public, and every signed-in page needs it to decide whether to offer the directory. One source, not an owner's copy and everyone else's.

**Enforcement in one place**
- `assert_community_directory_enabled` ([guilds.py](backend/app/services/platform/guilds.py)) is called by all three surfaces the directory consists of — browsing it, joining from it, and a guild listing itself — so they cannot drift apart. Each answers `403 COMMUNITY_DIRECTORY_DISABLED`.
- Un-listing is deliberately not gated: a guild that opted in while the directory ran can still opt back out after it is switched off.
- Switching off hides the listings; it does not clear anyone's opt-in, so switching back on restores the same set of guilds.

**Frontend**
- New Settings → Platform → Community tab ([SettingsCommunityPage.tsx](frontend/src/pages/SettingsCommunityPage.tsx)).
- Every way in is absent while it is off: the guild rail's "Join a community" ([GuildSidebar.tsx](frontend/src/components/guilds/GuildSidebar.tsx)), the no-guild empty state ([_authenticated.tsx](frontend/src/routes/_serverRequired/_authenticated.tsx)), the listing control in guild settings ([GuildDiscoveryPanel.tsx](frontend/src/components/guilds/GuildDiscoveryPanel.tsx)), and `/communities` itself ([CommunitiesPage.tsx](frontend/src/pages/communities/CommunitiesPage.tsx)), which says why and makes no request.
- Strings in all four locales, plus the error code.

**Seeder** ([seed_dev_data.py](scripts/seed_dev_data.py))
- Switches the directory on, lists Realm of Tides, and adds six small guilds across varied categories and roster sizes. Primary Guild and Starforge Collective stay invite-only so the unlisted case is still there to look at. The `music` shelf is left empty so the no-results state is reachable.
- Two fixes this surfaced: a seeded guild never got its `guild_administration` companion row (the directory joins against it, and `get_administration` raises without it) — guild creation now goes through the service, the same path the app uses; and `--clean` dropped every schema and cascaded a truncate in one transaction, which exceeds a default `max_locks_per_transaction` once there are nine guilds and rolls the whole clean back.

## Testing

Backend, all passing:
- `pytest app/api/v1/platform_endpoints/guilds_community_test.py` — 37 passed (5 new: browse / join / list-yourself refused while off, un-listing still allowed, opt-ins survive an off→on cycle)
- `pytest app/api/v1/platform_endpoints/config_test.py app/api/v1/platform_endpoints/settings_test.py` — 72 passed (2 new: the owner round-trip through `/config`, and every tier below owner refused)
- `pytest app/api/v1/platform_endpoints/guilds_test.py app/db/security_invariants_test.py` — 69 passed
- `pytest app/db/system_grants_test.py app/db/tenancy_test.py alembic/migrations_test.py` — 26 passed
- `ruff check app` + `ruff format app` + `ty check` — clean

Frontend, all passing:
- `pnpm vitest run src/routes src/components/guilds src/pages/communities src/pages/SettingsCommunityPage.test.tsx` — 59 passed
- `pnpm vitest run src/__tests__/locale-keys.test.ts` — 282 passed
- `pnpm tsc --noEmit` + `pnpm lint` — clean

End to end against a dev database (migrate → init_db → seed): 7 guilds listed, category filter, empty shelf, and search all correct; owner flips the switch off → browse, join, and list-yourself all `403 COMMUNITY_DIRECTORY_DISABLED`, a non-owner gets `403` on the switch itself; flipped back on, the same 7 guilds are listed.