### PR TITLE
Fix broken marketplace artwork on native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The Apps shelf only lists apps your server actually runs.** An app is served by a program the person running your server sets up — so a listing for one that they haven't set up yet, or have switched off, offered something that would install into nothing. Those listings now stay off the marketplace until the app is running, and adding one by hand is refused the same way. Dashboards are unaffected, and nothing changes for an app a guild has already installed.
 
+### Fixed
+
+- **App and dashboard artwork now loads in the mobile app.** Marketplace listings whose artwork comes from the app registry — and the icons those apps show in the sidebar — were addressed as a path on the server, which the mobile app resolved inside its own bundle and drew as a broken image. They are now fetched from the server the app is signed in to.
+
 ## [0.63.4] - 2026-08-26
 
 ### Changed

--- a/frontend/src/components/guilds/GuildSidebar.tsx
+++ b/frontend/src/components/guilds/GuildSidebar.tsx
@@ -19,20 +19,13 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Link, useRouter } from "@tanstack/react-router";
-import {
-  Check,
-  ChevronsLeft,
-  ChevronsRight,
-  Clock,
-  GripVertical,
-  Plus,
-  UsersRound,
-} from "lucide-react";
+import { Check, ChevronsLeft, ChevronsRight, Clock, GripVertical, Plus } from "lucide-react";
 import type { CSSProperties, FormEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GuildRead } from "@/api/generated/initiativeAPI.schemas";
+import { Galaxy } from "@/components/icons/Galaxy";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -212,7 +205,7 @@ const JoinCommunityButton = ({
         className="flex w-full items-center gap-3 rounded-lg border border-muted-foreground/40 border-dashed px-3 py-2 text-left text-muted-foreground transition hover:bg-muted hover:text-foreground"
       >
         <span className="flex h-10 w-10 shrink-0 items-center justify-center">
-          <UsersRound className="h-5 w-5" />
+          <Galaxy className="h-5 w-5" />
         </span>
         <span className="truncate font-medium text-sm">{label}</span>
       </Link>
@@ -230,7 +223,7 @@ const JoinCommunityButton = ({
           asChild
         >
           <Link to="/communities" onClick={onNavigate}>
-            <UsersRound className="h-5 w-5" />
+            <Galaxy className="h-5 w-5" />
           </Link>
         </Button>
       </TooltipTrigger>

--- a/frontend/src/components/icons/Galaxy.tsx
+++ b/frontend/src/components/icons/Galaxy.tsx
@@ -1,0 +1,33 @@
+/**
+ * Lucide's `galaxy`, vendored.
+ *
+ * The icon is in the lucide icon set but has not shipped in a `lucide-react`
+ * release yet (1.34.0, the latest, has no `Galaxy` export), so it is built here
+ * from the same path data with lucide's own factory: identical props, sizing,
+ * and stroke behaviour to every other icon in the app. Delete this file and
+ * import `Galaxy` from `lucide-react` once a release carries it.
+ *
+ * Source: https://github.com/lucide-icons/lucide/blob/main/icons/galaxy.svg (ISC)
+ */
+
+import { createLucideIcon } from "lucide-react";
+
+export const Galaxy = createLucideIcon("galaxy", [
+  [
+    "path",
+    {
+      d: "M16.005 15.108a5.041 6.52 28.25 00-8.008-6.217 5.041 6.52 28.25 008.008 6.217A11.884 7.288-60.76 014.029 7.001",
+      key: "galaxy-arm-a",
+    },
+  ],
+  ["path", { d: "M17 21h.01", key: "galaxy-dot-a" }],
+  ["path", { d: "M7 3h.01", key: "galaxy-dot-b" }],
+  [
+    "path",
+    {
+      d: "M7.997 8.891a11.885 7.288-60.756 0111.977 8.107",
+      key: "galaxy-arm-b",
+    },
+  ],
+  ["circle", { cx: "12", cy: "12", r: "1", fill: "currentColor", key: "galaxy-core" }],
+]);

--- a/frontend/src/components/marketplace/MarketplaceCard.tsx
+++ b/frontend/src/components/marketplace/MarketplaceCard.tsx
@@ -14,6 +14,7 @@ import { ListingProvenance } from "@/components/marketplace/ListingProvenance";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { useGuildPath } from "@/lib/guildUrl";
+import { resolveArtworkUrl } from "@/lib/uploadUrl";
 import { cn } from "@/lib/utils";
 
 export interface MarketplaceCardProps {
@@ -37,7 +38,7 @@ export function MarketplaceCard({ listing, installedCount = 0 }: MarketplaceCard
       >
         <CardContent className="flex h-full gap-3 p-4">
           <img
-            src={listing.avatar_url}
+            src={resolveArtworkUrl(listing.avatar_url) ?? undefined}
             alt=""
             aria-hidden
             className="h-12 w-12 shrink-0 rounded-lg object-cover"

--- a/frontend/src/components/sidebar/AppsSection.tsx
+++ b/frontend/src/components/sidebar/AppsSection.tsx
@@ -59,6 +59,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useGuildApps } from "@/hooks/useGuildApps";
 import { appHasConnections, guildAppPath } from "@/lib/appSurfaces";
 import { useGuildPath } from "@/lib/guildUrl";
+import { resolveArtworkUrl } from "@/lib/uploadUrl";
 import { cn } from "@/lib/utils";
 
 export interface AppsSectionProps {
@@ -189,7 +190,7 @@ function AppEntry({ app, isGuildAdmin }: { app: GuildAppRead; isGuildAdmin: bool
   // fall back to.
   const icon = app.avatar_url ? (
     <img
-      src={app.avatar_url}
+      src={resolveArtworkUrl(app.avatar_url) ?? undefined}
       alt=""
       aria-hidden
       className="h-4 w-4 shrink-0 rounded-sm object-cover"

--- a/frontend/src/components/sidebar/InitiativeSection.tsx
+++ b/frontend/src/components/sidebar/InitiativeSection.tsx
@@ -33,6 +33,7 @@ import {
   toolListRoute,
   toolNavLabelKey,
 } from "@/lib/tools";
+import { resolveArtworkUrl } from "@/lib/uploadUrl";
 import { cn } from "@/lib/utils";
 
 export interface InitiativeSectionProps {
@@ -236,7 +237,7 @@ export const InitiativeSection = memo(
                     <Link to={gp(path)} className="flex min-w-0 items-center gap-2">
                       {app.avatar_url ? (
                         <img
-                          src={app.avatar_url}
+                          src={resolveArtworkUrl(app.avatar_url) ?? undefined}
                           alt=""
                           aria-hidden
                           className="h-4 w-4 shrink-0 rounded-sm object-cover"

--- a/frontend/src/lib/uploadUrl.test.ts
+++ b/frontend/src/lib/uploadUrl.test.ts
@@ -75,6 +75,18 @@ describe("resolveUploadUrl (native)", () => {
     expect(getUploadTokenMock).toHaveBeenCalled();
   });
 
+  it("keeps the server's path prefix on native", () => {
+    vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(true);
+    vi.spyOn(apiClient.defaults, "baseURL", "get").mockReturnValue(
+      "https://example.test/initiative/api/v1"
+    );
+    getUploadTokenMock.mockReturnValue(null);
+
+    expect(resolveUploadUrl("/uploads/avatars/abc.png")).toBe(
+      "https://example.test/initiative/uploads/avatars/abc.png"
+    );
+  });
+
   it("omits the token when none is available yet", () => {
     vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(true);
     vi.spyOn(apiClient.defaults, "baseURL", "get").mockReturnValue("http://10.0.2.2:8000/api/v1");
@@ -120,6 +132,19 @@ describe("resolveArtworkUrl", () => {
 
     expect(resolveArtworkUrl("/api/v1/marketplace/media/abc123")).toBe(
       "http://10.0.2.2:8000/api/v1/marketplace/media/abc123"
+    );
+  });
+
+  it("keeps the server's path prefix on native", () => {
+    // A server reached at https://host/initiative serves its API — and its
+    // mirrored artwork — under that prefix too, so the prefix has to survive.
+    vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(true);
+    vi.spyOn(apiClient.defaults, "baseURL", "get").mockReturnValue(
+      "https://example.test/initiative/api/v1"
+    );
+
+    expect(resolveArtworkUrl("/api/v1/marketplace/media/abc123")).toBe(
+      "https://example.test/initiative/api/v1/marketplace/media/abc123"
     );
   });
 

--- a/frontend/src/lib/uploadUrl.test.ts
+++ b/frontend/src/lib/uploadUrl.test.ts
@@ -5,6 +5,7 @@ import { apiClient } from "@/api/client";
 
 import { getUploadToken } from "./uploadToken";
 import {
+  resolveArtworkUrl,
   resolveDocumentDownloadUrl,
   resolveDocumentVersionDownloadUrl,
   resolveUploadUrl,
@@ -82,5 +83,61 @@ describe("resolveUploadUrl (native)", () => {
     expect(resolveUploadUrl("/uploads/avatars/abc.png")).toBe(
       "http://10.0.2.2:8000/uploads/avatars/abc.png"
     );
+  });
+});
+
+describe("resolveArtworkUrl", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("leaves catalog artwork paths alone on web", () => {
+    expect(resolveArtworkUrl("/marketplace/core-guild-calendar.svg")).toBe(
+      "/marketplace/core-guild-calendar.svg"
+    );
+    expect(resolveArtworkUrl("/api/v1/marketplace/media/abc123")).toBe(
+      "/api/v1/marketplace/media/abc123"
+    );
+  });
+
+  it("keeps bundled artwork bundle-relative on native", () => {
+    // Shipped with the web bundle: the native app already holds the file, so
+    // sending the request to the API origin would be a needless round trip.
+    vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(true);
+    vi.spyOn(apiClient.defaults, "baseURL", "get").mockReturnValue("http://10.0.2.2:8000/api/v1");
+
+    expect(resolveArtworkUrl("/marketplace/core-guild-calendar.svg")).toBe(
+      "/marketplace/core-guild-calendar.svg"
+    );
+    expect(resolveArtworkUrl("/icons/logo.svg")).toBe("/icons/logo.svg");
+  });
+
+  it("addresses mirrored registry artwork at the API origin on native", () => {
+    // Served only by the API: bundle-relative it resolves inside the app's own
+    // origin and the image breaks.
+    vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(true);
+    vi.spyOn(apiClient.defaults, "baseURL", "get").mockReturnValue("http://10.0.2.2:8000/api/v1");
+
+    expect(resolveArtworkUrl("/api/v1/marketplace/media/abc123")).toBe(
+      "http://10.0.2.2:8000/api/v1/marketplace/media/abc123"
+    );
+  });
+
+  it("adds no token — the media route is public", () => {
+    vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(true);
+    vi.spyOn(apiClient.defaults, "baseURL", "get").mockReturnValue("http://10.0.2.2:8000/api/v1");
+    getUploadTokenMock.mockReturnValue("scoped-upload-token");
+
+    expect(resolveArtworkUrl("/api/v1/marketplace/media/abc123")).not.toContain("token=");
+  });
+
+  it("passes absolute URLs and data URIs through, and null for nothing", () => {
+    expect(resolveArtworkUrl("https://cdn.example.test/icon.svg")).toBe(
+      "https://cdn.example.test/icon.svg"
+    );
+    expect(resolveArtworkUrl("data:image/png;base64,AAAA")).toBe("data:image/png;base64,AAAA");
+    expect(resolveArtworkUrl(null)).toBeNull();
+    expect(resolveArtworkUrl(undefined)).toBeNull();
+    expect(resolveArtworkUrl("")).toBeNull();
   });
 });

--- a/frontend/src/lib/uploadUrl.ts
+++ b/frontend/src/lib/uploadUrl.ts
@@ -4,6 +4,26 @@ import { apiClient } from "@/api/client";
 import { getUploadToken } from "@/lib/uploadToken";
 
 /**
+ * The API server's origin, or "" when it can't be determined.
+ *
+ * Only meaningful on native: there the web bundle is served from its own local
+ * origin, so a same-origin path resolves inside the bundle rather than at the
+ * server that returned it.
+ */
+function apiOrigin(): string {
+  const baseUrl = apiClient.defaults.baseURL;
+  if (!baseUrl) {
+    return "";
+  }
+  try {
+    return new URL(baseUrl).origin;
+  } catch {
+    // A base URL that isn't parseable as absolute: strip the API suffix instead.
+    return baseUrl.replace(/\/api\/v1\/?$/, "");
+  }
+}
+
+/**
  * Resolve an `/api/v1/...` path for a request that can't carry an Authorization
  * header — a download served via iframe/window.open, or a `keepalive`/sendBeacon
  * POST fired on page unload. On native platforms, prepends the API server origin
@@ -18,15 +38,7 @@ export function resolveHeaderlessApiUrl(apiPath: string): string {
     return apiPath;
   }
 
-  const baseUrl = apiClient.defaults.baseURL;
-  let origin = "";
-  if (baseUrl) {
-    try {
-      origin = new URL(baseUrl).origin;
-    } catch {
-      origin = baseUrl.replace(/\/api\/v1\/?$/, "");
-    }
-  }
+  const origin = apiOrigin();
   const resolved = origin ? `${origin}${apiPath}` : apiPath;
   const token = getUploadToken();
   if (token) {
@@ -99,20 +111,9 @@ export function resolveUploadUrl(path: string | null | undefined): string | null
 
   // On native platforms, prepend the API server origin (no Vite proxy)
   if (Capacitor.isNativePlatform()) {
-    const baseUrl = apiClient.defaults.baseURL;
-    if (baseUrl) {
-      try {
-        // Extract origin from the API base URL (e.g., "http://10.0.2.2:8000/api/v1" -> "http://10.0.2.2:8000")
-        const url = new URL(baseUrl);
-        resolved = `${url.origin}${normalizedPath}`;
-      } catch {
-        // If URL parsing fails, try stripping /api/v1 suffix
-        const origin = baseUrl.replace(/\/api\/v1\/?$/, "");
-        resolved = origin ? `${origin}${normalizedPath}` : normalizedPath;
-      }
-    } else {
-      resolved = normalizedPath;
-    }
+    // e.g. "http://10.0.2.2:8000/api/v1" -> "http://10.0.2.2:8000/uploads/..."
+    const origin = apiOrigin();
+    resolved = origin ? `${origin}${normalizedPath}` : normalizedPath;
   } else {
     // On web, return path as-is - Vite proxies /uploads in dev, same-origin in prod
     resolved = normalizedPath;
@@ -132,4 +133,34 @@ export function resolveUploadUrl(path: string | null | undefined): string | null
   }
 
   return resolved;
+}
+
+/**
+ * Resolve a catalog artwork path — a marketplace listing's icon or screenshot,
+ * and the artwork an installed app carries — to something a native WebView can
+ * load.
+ *
+ * Two kinds of same-origin path arrive here. Artwork this build ships
+ * (`/marketplace/…`, `/icons/…`) is already inside the native bundle, so it
+ * stays relative — resolving it against the server would fetch a file that is
+ * local. Artwork a registry's listings are served from lives only on the API
+ * (`/api/v1/marketplace/media/…`); on native the bundle is its own origin, so
+ * that path has to be addressed at the API origin or it resolves to nothing.
+ * The media route is public and unauthenticated, so no token is added.
+ */
+export function resolveArtworkUrl(path: string | null | undefined): string | null {
+  if (!path) {
+    return null;
+  }
+  if (path.startsWith("http://") || path.startsWith("https://") || path.startsWith("data:")) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  if (!Capacitor.isNativePlatform() || !normalizedPath.startsWith("/api/")) {
+    return normalizedPath;
+  }
+
+  const origin = apiOrigin();
+  return origin ? `${origin}${normalizedPath}` : normalizedPath;
 }

--- a/frontend/src/lib/uploadUrl.ts
+++ b/frontend/src/lib/uploadUrl.ts
@@ -151,7 +151,7 @@ export function resolveUploadUrl(path: string | null | undefined): string | null
  * stays relative — resolving it against the server would fetch a file that is
  * local. Artwork a registry's listings are served from lives only on the API
  * (`/api/v1/marketplace/media/…`); on native the bundle is its own origin, so
- * that path has to be addressed at the API origin or it resolves to nothing.
+ * that path has to be addressed at the API server or it resolves to nothing.
  * The media route is public and unauthenticated, so no token is added.
  */
 export function resolveArtworkUrl(path: string | null | undefined): string | null {

--- a/frontend/src/lib/uploadUrl.ts
+++ b/frontend/src/lib/uploadUrl.ts
@@ -4,22 +4,28 @@ import { apiClient } from "@/api/client";
 import { getUploadToken } from "@/lib/uploadToken";
 
 /**
- * The API server's origin, or "" when it can't be determined.
+ * The root the API server is addressed at: its origin plus whatever path the
+ * deployment is served under — "https://example.com/initiative" for a base URL
+ * of "https://example.com/initiative/api/v1". "" when it can't be determined.
  *
  * Only meaningful on native: there the web bundle is served from its own local
  * origin, so a same-origin path resolves inside the bundle rather than at the
- * server that returned it.
+ * server that returned it. The path prefix is kept because a server reached at
+ * one is reached there for everything — `normalizeServerUrl` preserves it when
+ * the address is entered, so dropping it here would address a different root.
  */
-function apiOrigin(): string {
+function apiServerBase(): string {
   const baseUrl = apiClient.defaults.baseURL;
   if (!baseUrl) {
     return "";
   }
+  const withoutApiPath = baseUrl.replace(/\/api\/v1\/?$/, "");
   try {
-    return new URL(baseUrl).origin;
+    const url = new URL(withoutApiPath);
+    return `${url.origin}${url.pathname.replace(/\/$/, "")}`;
   } catch {
-    // A base URL that isn't parseable as absolute: strip the API suffix instead.
-    return baseUrl.replace(/\/api\/v1\/?$/, "");
+    // Not parseable as absolute (a same-origin base URL): nothing to prepend.
+    return withoutApiPath.replace(/\/$/, "");
   }
 }
 
@@ -38,7 +44,7 @@ export function resolveHeaderlessApiUrl(apiPath: string): string {
     return apiPath;
   }
 
-  const origin = apiOrigin();
+  const origin = apiServerBase();
   const resolved = origin ? `${origin}${apiPath}` : apiPath;
   const token = getUploadToken();
   if (token) {
@@ -112,7 +118,7 @@ export function resolveUploadUrl(path: string | null | undefined): string | null
   // On native platforms, prepend the API server origin (no Vite proxy)
   if (Capacitor.isNativePlatform()) {
     // e.g. "http://10.0.2.2:8000/api/v1" -> "http://10.0.2.2:8000/uploads/..."
-    const origin = apiOrigin();
+    const origin = apiServerBase();
     resolved = origin ? `${origin}${normalizedPath}` : normalizedPath;
   } else {
     // On web, return path as-is - Vite proxies /uploads in dev, same-origin in prod
@@ -161,6 +167,6 @@ export function resolveArtworkUrl(path: string | null | undefined): string | nul
     return normalizedPath;
   }
 
-  const origin = apiOrigin();
+  const origin = apiServerBase();
   return origin ? `${origin}${normalizedPath}` : normalizedPath;
 }

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -40,6 +40,7 @@ import { useGuildApps } from "@/hooks/useGuildApps";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useMarketplaceListing } from "@/hooks/useMarketplace";
 import { useGuildPath } from "@/lib/guildUrl";
+import { resolveArtworkUrl } from "@/lib/uploadUrl";
 import { readConfig, readDefinition } from "@/lib/widgets/definition";
 
 export function MarketplaceListingPage() {
@@ -114,7 +115,7 @@ export function MarketplaceListingPage() {
       <div className="flex flex-wrap items-start gap-4">
         {listing ? (
           <img
-            src={listing.avatar_url}
+            src={resolveArtworkUrl(listing.avatar_url) ?? undefined}
             alt=""
             aria-hidden
             className="h-16 w-16 shrink-0 rounded-xl object-cover"
@@ -192,7 +193,7 @@ export function MarketplaceListingPage() {
           {listing.images.map((image) => (
             <img
               key={image}
-              src={image}
+              src={resolveArtworkUrl(image) ?? undefined}
               alt=""
               aria-hidden
               className="h-48 shrink-0 rounded-lg border object-cover"


### PR DESCRIPTION
## Problem

On the native app, marketplace listing icons and the sidebar icons for installed apps drew as broken images.

Listing artwork arrives as a same-origin path, and two kinds exist: artwork this build ships (`/marketplace/*.svg`, `/icons/logo.svg`) and artwork mirrored from the signed registry, which only the API serves, from `/api/v1/marketplace/media/<digest>`. On native the web bundle is its own origin, so the mirrored kind resolved *inside the bundle* and 404'd. That is the split visible in the report: Guild calendar (a shipped SVG) drew; Automations and GitHub (registry listings) did not. Unlike user avatars, these `<img src>` values were used raw, with no native resolution.

Also swaps the icon on the community directory button, which is part of the unreleased directory feature.

## Changes

- New `resolveArtworkUrl` in [uploadUrl.ts](frontend/src/lib/uploadUrl.ts): on native it addresses only `/api/` paths at the API server, leaving shipped artwork bundle-relative so the app doesn't go to the network for a file it already holds. No token is attached — the media route is public and unauthenticated.
- Native URL resolution now keeps a server's path prefix. `normalizeServerUrl` preserves one when a native install's address is entered, so a base URL of `https://example.com/initiative/api/v1` is real; resolving against a bare origin addressed a different root. Resolution runs against the base URL minus its `/api/v1` suffix instead, in one `apiServerBase` helper shared by the three resolvers — which fixes the same latent bug for uploads and document downloads. Unchanged where there is no prefix.
- Applied at the four render sites: [MarketplaceCard.tsx](frontend/src/components/marketplace/MarketplaceCard.tsx), [MarketplaceListingPage.tsx](frontend/src/pages/marketplace/MarketplaceListingPage.tsx) (icon *and* screenshots — same bug, and always mirrored for registry listings), [AppsSection.tsx](frontend/src/components/sidebar/AppsSection.tsx), [InitiativeSection.tsx](frontend/src/components/sidebar/InitiativeSection.tsx).
- [Galaxy.tsx](frontend/src/components/icons/Galaxy.tsx): lucide's `galaxy`, vendored. It is in the lucide icon set but has not shipped in any `lucide-react` release (1.34.0, the latest, has no `Galaxy` export), so it is built from the same path data with lucide's own `createLucideIcon` — identical props, sizing and stroke to every other icon. Used for "Join a community" in [GuildSidebar.tsx](frontend/src/components/guilds/GuildSidebar.tsx), replacing `UsersRound`. The file goes away once a release carries the icon.
- `CHANGELOG.md` entry under `[Unreleased] → Fixed` for the artwork fix. The icon swap is inside a feature that is itself unreleased, so it gets no separate entry.

## Testing

- `pnpm vitest run src/lib/uploadUrl.test.ts` — 15 passed. New cases: web pass-through, shipped artwork stays bundle-relative on native, mirrored artwork gets the API server on native, no token on the public route, absolute/data/null inputs, and a path-prefixed server for both `resolveArtworkUrl` and `resolveUploadUrl`.
- `pnpm vitest run src/components/marketplace src/pages/marketplace src/components/sidebar src/components/guilds` — 94 passed.
- `pnpm typecheck` — clean. `pnpm biome check` on the changed files — clean.
- `./scripts/test-changed.sh` — 1766/1767 passed; the one failure was an `afterEach` hook timeout in `PropertyFilter.test.tsx` under parallel load, which passes on its own and is untouched by this branch.
- Vendored galaxy path data diffed against lucide's `galaxy.svg` upstream — exact match.