### PR TITLE
Fix stale content on collab doc rejoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Rejoining a shared document no longer shows — or spreads — an outdated copy.** Coming back to a spreadsheet or whiteboard someone else kept editing could show the document as it stood when you left, until a page refresh; on spreadsheets, the outdated copy could even be pushed back into the live session and roll back the other person's work. Spreadsheets now wait for the live session's state before adopting any locally held copy, and whiteboards no longer treat another user's incoming edits as their own unsaved work — while correctly recognizing a live session when deciding whether local unsaved work should still win.
 - **App and dashboard artwork now loads in the mobile app.** Marketplace listings whose artwork comes from the app registry — and the icons those apps show in the sidebar — were addressed as a path on the server, which the mobile app resolved inside its own bundle and drew as a broken image. They are now fetched from the server the app is signed in to.
 
 ## [0.63.4] - 2026-08-26

--- a/frontend/public/locales/de/documents.json
+++ b/frontend/public/locales/de/documents.json
@@ -324,6 +324,7 @@
     "readOnly": "Du hast nur Lesezugriff auf dieses Whiteboard."
   },
   "spreadsheet": {
+    "syncing": "Tabelle wird synchronisiert…",
     "exportCsv": "Als CSV exportieren",
     "exportXlsx": "Als Excel exportieren",
     "importFile": "Importieren",

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -324,6 +324,7 @@
     "readOnly": "You have read-only access to this whiteboard."
   },
   "spreadsheet": {
+    "syncing": "Syncing spreadsheet…",
     "exportCsv": "Export CSV",
     "exportXlsx": "Export Excel",
     "importFile": "Import",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -324,6 +324,7 @@
     "readOnly": "Tienes acceso de solo lectura a esta pizarra."
   },
   "spreadsheet": {
+    "syncing": "Sincronizando hoja de cálculo…",
     "exportCsv": "Exportar CSV",
     "exportXlsx": "Exportar Excel",
     "importFile": "Importar",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -324,6 +324,7 @@
     "readOnly": "Vous avez accès en lecture seule à ce tableau blanc."
   },
   "spreadsheet": {
+    "syncing": "Synchronisation de la feuille de calcul…",
     "exportCsv": "Exporter en CSV",
     "exportXlsx": "Exporter en Excel",
     "importFile": "Importer",

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -1,5 +1,6 @@
 import type { ProviderAwareness } from "@lexical/yjs";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { Loader2 } from "lucide-react";
 import {
   type ClipboardEvent,
   type CSSProperties,
@@ -105,6 +106,10 @@ interface SpreadsheetDocumentEditorProps {
    *  not yet ready), the editor falls back to local component state
    *  with the same UX. */
   yDoc?: Y.Doc | null;
+  /** Whether the collaboration provider has completed its initial sync.
+   *  Until then the workbook must not be seeded from ``initialContent``
+   *  (see ``useSpreadsheetSheets``). Ignored when ``yDoc`` is null. */
+  isSynced?: boolean;
   /** Awareness handle from the same provider as ``yDoc``. Used to
    *  publish / observe selected-cell presence rings. */
   awareness?: ProviderAwareness | null;
@@ -156,6 +161,7 @@ export const SpreadsheetDocumentEditor = ({
   readOnly,
   className,
   yDoc = null,
+  isSynced = true,
   awareness = null,
   currentUser = null,
 }: SpreadsheetDocumentEditorProps) => {
@@ -180,7 +186,13 @@ export const SpreadsheetDocumentEditor = ({
   // The workbook level: which sheets exist, and every sheet's cells (the
   // evaluator needs all of them to resolve ``=Sheet2!A1``). Called before
   // the per-sheet hooks because it is what creates their Y.Maps.
-  const workbook = useSpreadsheetSheets({ yDoc: docForData, initialContent: parsedInitial });
+  const workbook = useSpreadsheetSheets({
+    yDoc: docForData,
+    initialContent: parsedInitial,
+    // A provider-backed doc is empty until the initial sync lands; seeding
+    // it earlier would push the stale REST snapshot into the live room.
+    seedAllowed: yDoc === null || isSynced,
+  });
   const { sheets, cellsBySheet, version: workbookVersion } = workbook;
 
   // The sheet on screen. Tracked by id and re-resolved against the live
@@ -1656,10 +1668,18 @@ export const SpreadsheetDocumentEditor = ({
   return (
     <div
       className={cn(
-        "flex flex-col overflow-hidden rounded-lg border border-border bg-background",
+        "relative flex flex-col overflow-hidden rounded-lg border border-border bg-background",
         className
       )}
     >
+      {yDoc !== null && !isSynced && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            <span>{t("documents:spreadsheet.syncing")}</span>
+          </div>
+        </div>
+      )}
       <div className="flex shrink-0 items-center gap-2 overflow-x-auto border-border border-b bg-muted/20 px-3 py-2">
         <SpreadsheetToolbar
           selection={

--- a/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
+++ b/frontend/src/components/documents/WhiteboardDocumentEditor.tsx
@@ -11,7 +11,7 @@
 
 import { CaptureUpdateAction, Excalidraw, serializeAsJSON } from "@excalidraw/excalidraw";
 import { Loader2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import "@excalidraw/excalidraw/index.css";
 
@@ -48,8 +48,12 @@ export interface WhiteboardDocumentEditorProps {
    *  state to catch up to a live room where another user has been
    *  editing. */
   initialSceneFromCache?: boolean;
-  /** Called on every change with the pruned, persistable scene. */
-  onSerializedChange: (scene: WhiteboardScene) => void;
+  /** Called on every change with the pruned, persistable scene.
+   *  ``isLocal`` is false when the change is a remote-applied update (or
+   *  an echo of one) — the parent needs those to keep the periodic REST
+   *  content-sync fresh, but must not treat them as unsaved local work
+   *  (e.g. for the write-ahead cache). */
+  onSerializedChange: (scene: WhiteboardScene, opts?: { isLocal: boolean }) => void;
   readOnly?: boolean;
   className?: string;
   /** Live collaboration: an already-attached Yjs doc. Null => REST-only mode. */
@@ -61,6 +65,12 @@ export interface WhiteboardDocumentEditorProps {
    *  stale (another user has continued editing while we were gone) and
    *  the Yjs state wins on bootstrap. */
   hasOtherCollaborators?: boolean;
+  /** True once the server's collaborator roster has arrived. The bootstrap
+   *  decision reads ``hasOtherCollaborators``, and the roster lands on the
+   *  socket *after* the sync message — deciding at the moment ``isSynced``
+   *  flips would always see an empty roster and mistake a live room for an
+   *  empty one. Defaults to true for REST-only mode. */
+  collaboratorsReady?: boolean;
   /** Yjs awareness for peer cursor presence. Null in REST-only mode. */
   awareness?: ProviderAwareness | null;
   /** Current user for the cursor label + color. Null-safe. */
@@ -91,6 +101,7 @@ export function WhiteboardDocumentEditor({
   yDoc = null,
   isSynced = true,
   hasOtherCollaborators = false,
+  collaboratorsReady = true,
   awareness = null,
   currentUser = null,
 }: WhiteboardDocumentEditorProps) {
@@ -98,6 +109,11 @@ export function WhiteboardDocumentEditor({
   const { resolvedTheme } = useTheme();
 
   const excalidrawAPIRef = useRef<ExcalidrawImperativeAPI | null>(null);
+  // Mirrors the ref as state so effects that must not run before Excalidraw
+  // is ready (the post-sync bootstrap, peer cursors) re-fire when the API
+  // arrives — the imperative callback can land before or after the provider
+  // reports synced, and a ref alone can't re-trigger an effect.
+  const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawImperativeAPI | null>(null);
   const yMapRef = useRef<Y.Map<string> | null>(null);
   const applyingRemoteRef = useRef(false);
   // Tracks the most recently seen serialized scene (either a local write
@@ -159,12 +175,12 @@ export function WhiteboardDocumentEditor({
   // because handleExcalidrawChange uses the "database" serializer which strips
   // ephemeral appState fields including collaborators.
   useEffect(() => {
-    if (!excalidrawAPIRef.current) return;
-    excalidrawAPIRef.current.updateScene({
+    if (!excalidrawAPI) return;
+    excalidrawAPI.updateScene({
       collaborators: peerCollaborators,
       captureUpdate: CaptureUpdateAction.NEVER,
     });
-  }, [peerCollaborators]);
+  }, [peerCollaborators, excalidrawAPI]);
 
   // Only compute initialData once per mount (the Excalidraw key in the parent
   // forces remount on document switch, so this is safe).
@@ -279,13 +295,22 @@ export function WhiteboardDocumentEditor({
   // After the decision, flip writesAllowedRef so subsequent local edits
   // flow to Yjs, and bootstrapDoneRef so remote updates flow in.
   useEffect(() => {
-    if (!yDoc || !isSynced) return;
+    // Wait for the collaborator roster as well as the sync: the roster
+    // arrives on the socket right after the sync message, and deciding
+    // before it lands would read hasOtherCollaborators as false even in
+    // a live room. Wait for the Excalidraw API too — this effect can win
+    // the race against Excalidraw's mount callback, and completing the
+    // bootstrap without applying the room state would arm writes while
+    // the canvas still shows the REST snapshot: the mount onChange would
+    // then push that older scene into the live room and roll every other
+    // user back to it.
+    if (!yDoc || !isSynced || !collaboratorsReady || !excalidrawAPI) return;
     if (seededForDocRef.current === yDoc) return;
     seededForDocRef.current = yDoc;
 
     const shouldApplyYjsState = hasOtherCollaborators || !initialSceneFromCache;
 
-    if (shouldApplyYjsState && excalidrawAPIRef.current) {
+    if (shouldApplyYjsState) {
       const yMap = yDoc.getMap<string>("excalidraw");
       const raw = yMap.get("scene");
       if (raw) {
@@ -300,10 +325,10 @@ export function WhiteboardDocumentEditor({
           if (parsed.files) {
             const fileArr = Object.values(parsed.files);
             if (fileArr.length > 0) {
-              excalidrawAPIRef.current.addFiles(fileArr);
+              excalidrawAPI.addFiles(fileArr);
             }
           }
-          excalidrawAPIRef.current.updateScene({
+          excalidrawAPI.updateScene({
             elements: parsed.elements,
             appState: parsed.appState as Partial<AppState> as AppState,
             captureUpdate: CaptureUpdateAction.NEVER,
@@ -320,7 +345,14 @@ export function WhiteboardDocumentEditor({
 
     bootstrapDoneRef.current = true;
     writesAllowedRef.current = true;
-  }, [yDoc, isSynced, initialSceneFromCache, hasOtherCollaborators]);
+  }, [
+    yDoc,
+    isSynced,
+    initialSceneFromCache,
+    hasOtherCollaborators,
+    collaboratorsReady,
+    excalidrawAPI,
+  ]);
 
   // ── Local change handler ─────────────────────────────────────────────
   // Excalidraw fires onChange on every re-render (unlike Lexical which
@@ -361,23 +393,26 @@ export function WhiteboardDocumentEditor({
       // downstream writes.
       const serializedWithFiles = JSON.stringify(parsed);
 
+      // An echo is an onChange for state we already know about: either
+      // we're mid-apply of a remote update, or the serialized scene matches
+      // what we last saw (local or remote).
+      const isEcho = applyingRemoteRef.current || serializedWithFiles === prevSerializedRef.current;
+
       // Notify the parent only when the serialized scene actually changed
       // since the last notification. This dedupe is independent of the Yjs
       // dedupe below: we want the parent to see remote-applied updates
       // (so REST content-sync isn't stale), but we must not call the
-      // parent on every echo render or we cause an infinite loop.
+      // parent on every echo render or we cause an infinite loop. The
+      // isLocal flag lets the parent treat only genuine local edits as
+      // unsaved work.
       if (serializedWithFiles !== lastNotifiedSerializedRef.current) {
         lastNotifiedSerializedRef.current = serializedWithFiles;
-        onSerializedChange(parsed);
+        onSerializedChange(parsed, { isLocal: !isEcho });
       }
 
-      // Skip the Yjs write if either (a) we're currently applying a remote
-      // update, or (b) the serialized scene matches what we last saw. Both
-      // conditions indicate this onChange is an echo of state we already
-      // know about, and writing it back to Yjs would interrupt the original
-      // sender's in-progress drag.
-      if (applyingRemoteRef.current) return;
-      if (serializedWithFiles === prevSerializedRef.current) return;
+      // Skip the Yjs write for echoes — writing them back to Yjs would
+      // interrupt the original sender's in-progress drag.
+      if (isEcho) return;
       prevSerializedRef.current = serializedWithFiles;
 
       // Mirror to Yjs when collaborative — but only after the bootstrap has
@@ -410,6 +445,7 @@ export function WhiteboardDocumentEditor({
       <Excalidraw
         excalidrawAPI={(api) => {
           excalidrawAPIRef.current = api;
+          setExcalidrawAPI(api);
         }}
         initialData={initialData}
         onChange={handleExcalidrawChange}

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.test.tsx
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+
+import { useSpreadsheetSheets } from "@/components/documents/spreadsheet/useSpreadsheetSheets";
+import {
+  SHEET_CELLS,
+  sheetContainer,
+  sheetPart,
+  sheetsRoot,
+} from "@/components/documents/spreadsheet/workbookDoc";
+import { parseSpreadsheetContent } from "@/lib/spreadsheet/content";
+
+const content = (cells: Record<string, unknown>) =>
+  parseSpreadsheetContent({ cells: cells as Record<string, string | number> });
+
+const cellsOf = (doc: Y.Doc, id: string): Record<string, unknown> =>
+  (sheetPart(sheetContainer(doc, id), SHEET_CELLS)?.toJSON() ?? {}) as Record<string, unknown>;
+
+/** Apply one doc's full state to another, the way the provider applies the
+ *  server's initial sync. */
+const applyState = (target: Y.Doc, source: Y.Doc) =>
+  Y.applyUpdate(target, Y.encodeStateAsUpdate(source));
+
+describe("useSpreadsheetSheets — seeding gate", () => {
+  it("seeds immediately by default (local / non-collaborative doc)", () => {
+    const doc = new Y.Doc();
+    const { result } = renderHook(() =>
+      useSpreadsheetSheets({ yDoc: doc, initialContent: content({ "0:0": "hello" }) })
+    );
+    expect(result.current.sheets).toHaveLength(1);
+    expect(cellsOf(doc, "s1")).toEqual({ "0:0": "hello" });
+  });
+
+  it("does not seed while seedAllowed is false", () => {
+    const doc = new Y.Doc();
+    const { result } = renderHook(() =>
+      useSpreadsheetSheets({
+        yDoc: doc,
+        initialContent: content({ "0:0": "stale" }),
+        seedAllowed: false,
+      })
+    );
+    expect(sheetsRoot(doc).size).toBe(0);
+    expect(result.current.sheets).toHaveLength(0);
+  });
+
+  it("seeds a still-empty doc once seedAllowed flips true (first-ever collab session)", () => {
+    const doc = new Y.Doc();
+    const { result, rerender } = renderHook(
+      ({ seedAllowed }: { seedAllowed: boolean }) =>
+        useSpreadsheetSheets({
+          yDoc: doc,
+          initialContent: content({ "0:0": "bootstrap" }),
+          seedAllowed,
+        }),
+      { initialProps: { seedAllowed: false } }
+    );
+    expect(sheetsRoot(doc).size).toBe(0);
+
+    rerender({ seedAllowed: true });
+    expect(result.current.sheets).toHaveLength(1);
+    expect(cellsOf(doc, "s1")).toEqual({ "0:0": "bootstrap" });
+  });
+
+  it("leaves synced remote state untouched when seedAllowed flips true (rejoin)", () => {
+    // The rejoin scenario the gate exists for: another user's edits arrive
+    // via the initial sync while our REST snapshot is stale. Seeding before
+    // (or after) that sync must not push the stale snapshot into the doc.
+    const server = new Y.Doc();
+    renderHook(() =>
+      useSpreadsheetSheets({ yDoc: server, initialContent: content({ "0:0": "edited-by-A" }) })
+    );
+
+    const doc = new Y.Doc();
+    const { result, rerender } = renderHook(
+      ({ seedAllowed }: { seedAllowed: boolean }) =>
+        useSpreadsheetSheets({
+          yDoc: doc,
+          initialContent: content({ "0:0": "stale-snapshot" }),
+          seedAllowed,
+        }),
+      { initialProps: { seedAllowed: false } }
+    );
+    expect(sheetsRoot(doc).size).toBe(0);
+
+    // Initial sync lands, then the provider reports synced.
+    act(() => applyState(doc, server));
+    rerender({ seedAllowed: true });
+
+    expect(cellsOf(doc, "s1")).toEqual({ "0:0": "edited-by-A" });
+    expect(result.current.cellsBySheet.get("s1")?.get("0:0")).toBe("edited-by-A");
+    // And nothing was broadcast back that the server doesn't already have.
+    expect(Y.encodeStateAsUpdate(doc, Y.encodeStateVector(server)).length).toBeLessThanOrEqual(2);
+  });
+});

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.ts
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.ts
@@ -143,18 +143,30 @@ interface UseSpreadsheetSheetsArgs {
   yDoc: Y.Doc | null;
   /** Parsed v3 content, used only to seed a doc that has no workbook yet. */
   initialContent: SpreadsheetContent;
+  /** Gate for the one-shot seed. A collaborative doc must not be seeded
+   *  before the provider's initial sync completes: the doc looks empty
+   *  only because the server state hasn't arrived yet, and seeding it
+   *  from the (possibly stale) REST snapshot creates writes concurrent
+   *  with everything other users did since — which last-write-wins can
+   *  resolve in the stale seed's favor, for every connected client.
+   *  Pass ``false`` until the provider reports synced; defaults to
+   *  ``true`` for local (non-collaborative) docs. */
+  seedAllowed?: boolean;
 }
 
 export const useSpreadsheetSheets = ({
   yDoc,
   initialContent,
+  seedAllowed = true,
 }: UseSpreadsheetSheetsArgs): SpreadsheetSheetsStore => {
   // Seeding runs during render, not in an effect, because the per-sheet
   // hooks called after this one resolve their Y.Maps during *their* render
   // — an effect would leave them pointed at nothing for the first frame.
   // ``ensureWorkbook`` returns immediately when the doc already has sheets,
   // so a re-render (or StrictMode's double invoke) costs nothing.
-  useMemo(() => ensureWorkbook(yDoc, initialContent), [yDoc, initialContent]);
+  useMemo(() => {
+    if (seedAllowed) ensureWorkbook(yDoc, initialContent);
+  }, [yDoc, initialContent, seedAllowed]);
 
   const [sheets, setSheets] = useState<SheetMeta[]>(() => readSheetOrder(yDoc));
   const [cellsBySheet, setCellsBySheet] = useState<Map<SheetId, Map<string, CellValue>>>(() => {

--- a/frontend/src/components/documents/whiteboardSceneCache.test.ts
+++ b/frontend/src/components/documents/whiteboardSceneCache.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { WhiteboardScene } from "@/components/documents/WhiteboardDocumentEditor";
+import {
+  clearWhiteboardSceneCache,
+  loadWhiteboardScene,
+  stampWhiteboardSceneCache,
+} from "@/components/documents/whiteboardSceneCache";
+
+const DOC_ID = 42;
+const KEY = `wb-scene-${DOC_ID}`;
+
+const scene = (label: string): WhiteboardScene =>
+  ({
+    elements: [{ id: label }],
+    appState: {},
+    files: {},
+  }) as unknown as WhiteboardScene;
+
+const writeCache = (label: string, savedAt: string) =>
+  localStorage.setItem(KEY, JSON.stringify({ scene: scene(label), savedAt }));
+
+afterEach(() => localStorage.clear());
+
+describe("loadWhiteboardScene", () => {
+  it("prefers the cached scene when it is newer than the server copy", () => {
+    writeCache("cached", "2026-08-27T12:00:10Z");
+    const result = loadWhiteboardScene(DOC_ID, "2026-08-27T12:00:00Z", scene("rest"));
+    expect(result.fromCache).toBe(true);
+    expect(result.scene.elements).toEqual([{ id: "cached" }]);
+    // A winning cache entry is kept (it still represents unsaved work).
+    expect(localStorage.getItem(KEY)).not.toBeNull();
+  });
+
+  it("discards a cache entry that is older than the server copy", () => {
+    // The rejoin case: another user kept editing after we left, so the
+    // server's updated_at moved past our stamp — the cache must lose and
+    // be removed so it can't shadow newer state later.
+    writeCache("stale", "2026-08-27T12:00:00Z");
+    const result = loadWhiteboardScene(DOC_ID, "2026-08-27T12:05:00Z", scene("rest"));
+    expect(result.fromCache).toBe(false);
+    expect(result.scene.elements).toEqual([{ id: "rest" }]);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("removes an unparseable cache entry and falls back to REST content", () => {
+    localStorage.setItem(KEY, "{not json");
+    const result = loadWhiteboardScene(DOC_ID, "2026-08-27T12:00:00Z", scene("rest"));
+    expect(result.fromCache).toBe(false);
+    expect(result.scene.elements).toEqual([{ id: "rest" }]);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("normalizes missing REST content to an empty scene", () => {
+    const result = loadWhiteboardScene(DOC_ID, "2026-08-27T12:00:00Z", null);
+    expect(result.fromCache).toBe(false);
+    expect(result.scene).toEqual({ elements: [], appState: {}, files: {} });
+  });
+});
+
+describe("stampWhiteboardSceneCache / clearWhiteboardSceneCache", () => {
+  it("stamps a scene that a subsequent load resolves as newer than an older server copy", () => {
+    stampWhiteboardSceneCache(DOC_ID, scene("local"));
+    const result = loadWhiteboardScene(DOC_ID, "2000-01-01T00:00:00Z", scene("rest"));
+    expect(result.fromCache).toBe(true);
+    expect(result.scene.elements).toEqual([{ id: "local" }]);
+  });
+
+  it("clear removes the entry", () => {
+    stampWhiteboardSceneCache(DOC_ID, scene("local"));
+    clearWhiteboardSceneCache(DOC_ID);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/frontend/src/components/documents/whiteboardSceneCache.test.ts
+++ b/frontend/src/components/documents/whiteboardSceneCache.test.ts
@@ -6,6 +6,7 @@ import {
   loadWhiteboardScene,
   stampWhiteboardSceneCache,
 } from "@/components/documents/whiteboardSceneCache";
+import { getItem, removeItem, setItem } from "@/lib/storage";
 
 const DOC_ID = 42;
 const KEY = `wb-scene-${DOC_ID}`;
@@ -18,9 +19,9 @@ const scene = (label: string): WhiteboardScene =>
   }) as unknown as WhiteboardScene;
 
 const writeCache = (label: string, savedAt: string) =>
-  localStorage.setItem(KEY, JSON.stringify({ scene: scene(label), savedAt }));
+  setItem(KEY, JSON.stringify({ scene: scene(label), savedAt }));
 
-afterEach(() => localStorage.clear());
+afterEach(() => removeItem(KEY));
 
 describe("loadWhiteboardScene", () => {
   it("prefers the cached scene when it is newer than the server copy", () => {
@@ -29,7 +30,7 @@ describe("loadWhiteboardScene", () => {
     expect(result.fromCache).toBe(true);
     expect(result.scene.elements).toEqual([{ id: "cached" }]);
     // A winning cache entry is kept (it still represents unsaved work).
-    expect(localStorage.getItem(KEY)).not.toBeNull();
+    expect(getItem(KEY)).not.toBeNull();
   });
 
   it("discards a cache entry that is older than the server copy", () => {
@@ -40,15 +41,15 @@ describe("loadWhiteboardScene", () => {
     const result = loadWhiteboardScene(DOC_ID, "2026-08-27T12:05:00Z", scene("rest"));
     expect(result.fromCache).toBe(false);
     expect(result.scene.elements).toEqual([{ id: "rest" }]);
-    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(getItem(KEY)).toBeNull();
   });
 
   it("removes an unparseable cache entry and falls back to REST content", () => {
-    localStorage.setItem(KEY, "{not json");
+    setItem(KEY, "{not json");
     const result = loadWhiteboardScene(DOC_ID, "2026-08-27T12:00:00Z", scene("rest"));
     expect(result.fromCache).toBe(false);
     expect(result.scene.elements).toEqual([{ id: "rest" }]);
-    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(getItem(KEY)).toBeNull();
   });
 
   it("normalizes missing REST content to an empty scene", () => {
@@ -69,6 +70,6 @@ describe("stampWhiteboardSceneCache / clearWhiteboardSceneCache", () => {
   it("clear removes the entry", () => {
     stampWhiteboardSceneCache(DOC_ID, scene("local"));
     clearWhiteboardSceneCache(DOC_ID);
-    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(getItem(KEY)).toBeNull();
   });
 });

--- a/frontend/src/components/documents/whiteboardSceneCache.ts
+++ b/frontend/src/components/documents/whiteboardSceneCache.ts
@@ -1,0 +1,80 @@
+/**
+ * The whiteboard write-ahead cache: on every local edit the scene is written
+ * to storage synchronously, so if the user leaves before the keepalive PATCH
+ * lands the latest scene survives a refresh. Reading it back compares
+ * timestamps against the server's `updated_at` — the cache only wins while
+ * it is strictly newer than what the server has, and it must only ever be
+ * stamped for *local* edits (a remote-applied update is not unsaved work,
+ * and stamping it would make a watching session's cache shadow the live
+ * room's newer state on a later revisit).
+ */
+
+import type { WhiteboardScene } from "@/components/documents/WhiteboardDocumentEditor";
+import { getItem, removeItem, setItem } from "@/lib/storage";
+
+const cacheKey = (documentId: number) => `wb-scene-${documentId}`;
+
+export interface WhiteboardSceneLoad {
+  scene: WhiteboardScene;
+  /** True when the returned scene came from the write-ahead cache (i.e.
+   *  there are local edits newer than the server's copy). */
+  fromCache: boolean;
+}
+
+/** Write the scene to the write-ahead cache, stamped with the current time.
+ *  Best-effort: storage being full or unavailable is not an error. */
+export const stampWhiteboardSceneCache = (documentId: number, scene: WhiteboardScene): void => {
+  try {
+    setItem(cacheKey(documentId), JSON.stringify({ scene, savedAt: new Date().toISOString() }));
+  } catch {
+    // Storage full or unavailable — best-effort
+  }
+};
+
+/** Drop the write-ahead cache (the server copy is now authoritative). */
+export const clearWhiteboardSceneCache = (documentId: number): void => {
+  removeItem(cacheKey(documentId));
+};
+
+/**
+ * Resolve the scene to load for a whiteboard: the write-ahead cache when it
+ * is strictly newer than the server's `updated_at`, otherwise the
+ * REST-fetched `content`. A cache entry that loses the comparison (or fails
+ * to parse) is removed. `updatedAt` must come from a fresh fetch — comparing
+ * against a stale client-cached document makes the local cache look newer
+ * than it is.
+ */
+export const loadWhiteboardScene = (
+  documentId: number,
+  updatedAt: string,
+  content: Partial<WhiteboardScene> | null | undefined
+): WhiteboardSceneLoad => {
+  const key = cacheKey(documentId);
+  try {
+    const cached = getItem(key);
+    if (cached) {
+      const parsed = JSON.parse(cached) as {
+        scene: WhiteboardScene;
+        savedAt: string;
+      };
+      const cachedTs = new Date(parsed.savedAt).getTime();
+      const serverTs = new Date(updatedAt).getTime();
+      if (cachedTs > serverTs && parsed.scene?.elements) {
+        return { scene: parsed.scene, fromCache: true };
+      }
+      removeItem(key);
+    }
+  } catch {
+    removeItem(key);
+  }
+
+  const raw = content ?? {};
+  return {
+    scene: {
+      elements: raw.elements ?? [],
+      appState: raw.appState ?? {},
+      files: raw.files ?? {},
+    },
+    fromCache: false,
+  };
+};

--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -45,6 +45,12 @@ export interface UseCollaborationResult {
   isSynced: boolean;
   /** List of current collaborators */
   collaborators: CollaboratorInfo[];
+  /** Whether the server's collaborator roster has been received for this
+   *  session. The roster arrives on the socket right after the initial
+   *  sync, so consumers that branch on "is anyone else here?" (e.g. the
+   *  whiteboard bootstrap) must wait for this — at the moment `isSynced`
+   *  flips true, `collaborators` is still the empty initial state. */
+  collaboratorsReady: boolean;
   /** Whether collaboration is active (connected and synced) */
   isCollaborating: boolean;
   /** Whether the hook is ready to provide collaboration */
@@ -67,6 +73,7 @@ export function useCollaboration({
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("disconnected");
   const [isSynced, setIsSynced] = useState(false);
   const [collaborators, setCollaborators] = useState<CollaboratorInfo[]>([]);
+  const [collaboratorsReady, setCollaboratorsReady] = useState(false);
 
   // Store the provider reference so we can track its state
   const providerRef = useRef<CollaborationProvider | null>(null);
@@ -115,6 +122,7 @@ export function useCollaboration({
       setConnectionStatus("disconnected");
       setIsSynced(false);
       setCollaborators([]);
+      setCollaboratorsReady(false);
     }
     currentWsUrlRef.current = wsUrl;
   }, [wsUrl]);
@@ -150,6 +158,7 @@ export function useCollaboration({
       setConnectionStatus("disconnected");
       setIsSynced(false);
       setCollaborators([]);
+      setCollaboratorsReady(false);
 
       // Update the URL ref BEFORE creating the provider
       // This prevents the wsUrl effect from destroying the new provider
@@ -248,12 +257,14 @@ export function useCollaboration({
         // Listen for collaborator changes
         provider.onCollaborators((newCollaborators) => {
           setCollaborators(newCollaborators);
+          setCollaboratorsReady(true);
         });
       } else {
         // For an existing provider, sync current state to React
         // This is critical after quick navigation where React state resets but provider is reused
         const currentProvider = providerRef.current!;
         setCollaborators(currentProvider.collaborators);
+        setCollaboratorsReady(currentProvider.collaborators.length > 0);
         setIsSynced(currentProvider.synced);
         // Use the provider's tracked status instead of inferring it
         const providerStatus = currentProvider.status;
@@ -277,6 +288,7 @@ export function useCollaboration({
       setConnectionStatus("disconnected");
       setIsSynced(false);
       setCollaborators([]);
+      setCollaboratorsReady(false);
     }
   }, [isReady]);
 
@@ -318,6 +330,7 @@ export function useCollaboration({
       connectionStatus,
       isSynced,
       collaborators,
+      collaboratorsReady,
       isCollaborating,
       isReady,
       connect,
@@ -328,6 +341,7 @@ export function useCollaboration({
       connectionStatus,
       isSynced,
       collaborators,
+      collaboratorsReady,
       isCollaborating,
       isReady,
       connect,

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -88,6 +88,11 @@ import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import type { SmartLinkContent } from "@/components/documents/SmartLinkDocumentViewer";
 import type { SpreadsheetContent } from "@/components/documents/SpreadsheetDocumentEditor";
 import type { WhiteboardScene } from "@/components/documents/WhiteboardDocumentEditor";
+import {
+  clearWhiteboardSceneCache,
+  loadWhiteboardScene,
+  stampWhiteboardSceneCache,
+} from "@/components/documents/whiteboardSceneCache";
 import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -110,7 +115,7 @@ import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
 import { findNewMentions } from "@/lib/mentionUtils";
 import { hasWriteAccess } from "@/lib/permissions";
-import { getItem, removeItem, setItem } from "@/lib/storage";
+import { getItem, setItem } from "@/lib/storage";
 import { initiativeRoute, toolDetailRoute, toolListRoute, toolSettingsRoute } from "@/lib/tools";
 import { resolveHeaderlessApiUrl, resolveUploadUrl } from "@/lib/uploadUrl";
 import { getUserDisplayName } from "@/lib/userDisplay";
@@ -305,45 +310,28 @@ export const DocumentDetailPage = () => {
         setTags(document.tags ?? []);
         return;
       }
+      // The cache-vs-server decision below compares against
+      // document.updated_at, so it must not run against a React Query
+      // cache hit from a previous visit — that snapshot's updated_at
+      // predates everything other users did since, making any local cache
+      // look newer than it is. Wait for this mount's fetch to settle (an
+      // errored fetch settles too, so offline still falls back to the
+      // cached document).
+      if (!documentQuery.isFetchedAfterMount) {
+        return;
+      }
       loadedWhiteboardForRef.current = document.id;
 
-      // Check the write-ahead cache first. On every edit the scene is
+      // Check the write-ahead cache first. On every local edit the scene is
       // written to localStorage synchronously (survives refresh), so if
       // the user refreshes before the keepalive PATCH lands, we still
-      // have the latest scene. We compare timestamps: if the cached scene
-      // is newer than document.updated_at, use it instead of the (stale)
-      // REST-fetched content.
-      const cacheKey = `wb-scene-${document.id}`;
-      let scene: WhiteboardScene | null = null;
-      let fromCache = false;
-      try {
-        const cached = getItem(cacheKey);
-        if (cached) {
-          const parsed = JSON.parse(cached) as {
-            scene: WhiteboardScene;
-            savedAt: string;
-          };
-          const cachedTs = new Date(parsed.savedAt).getTime();
-          const serverTs = new Date(document.updated_at).getTime();
-          if (cachedTs > serverTs && parsed.scene?.elements) {
-            scene = parsed.scene;
-            fromCache = true;
-          } else {
-            removeItem(cacheKey);
-          }
-        }
-      } catch {
-        removeItem(cacheKey);
-      }
-
-      if (!scene) {
-        const raw = (document.content ?? {}) as Partial<WhiteboardScene>;
-        scene = {
-          elements: raw.elements ?? [],
-          appState: raw.appState ?? {},
-          files: raw.files ?? {},
-        };
-      }
+      // have the latest scene. The cache wins only while it is strictly
+      // newer than document.updated_at.
+      const { scene, fromCache } = loadWhiteboardScene(
+        document.id,
+        document.updated_at,
+        document.content as Partial<WhiteboardScene> | null
+      );
       setWhiteboardScene(scene);
       setWhiteboardSceneFromCache(fromCache);
       setWhiteboardSceneReady(true);
@@ -356,7 +344,7 @@ export const DocumentDetailPage = () => {
     }
     setFeaturedImageUrl(document.featured_image_url ?? null);
     setTags(document.tags ?? []);
-  }, [document, normalizedDocumentContent]);
+  }, [document, normalizedDocumentContent, documentQuery.isFetchedAfterMount]);
 
   const documentContentJson = useMemo(() => {
     if (document?.document_type === "whiteboard") {
@@ -528,7 +516,7 @@ export const DocumentDetailPage = () => {
         toast.success(t("detail.saved"));
       }
       // Clear the write-ahead cache — the DB is now up-to-date.
-      removeItem(`wb-scene-${parsedId}`);
+      clearWhiteboardSceneCache(parsedId);
       // Fire-and-forget: notify users who were newly mentioned
       const newMentionIds = findNewMentions(normalizedDocumentContent, contentState);
       if (newMentionIds.length > 0) {
@@ -613,22 +601,21 @@ export const DocumentDetailPage = () => {
 
   // Whiteboard scene change handler — mirrors handleContentChange for Lexical.
   // Also writes a write-ahead cache to localStorage so the scene survives
-  // a page refresh even if the keepalive PATCH hasn't landed yet.
+  // a page refresh even if the keepalive PATCH hasn't landed yet. Only
+  // genuine local edits stamp the cache: remote-applied updates flow
+  // through here too (the periodic REST sync needs them), and stamping on
+  // those would leave every *watching* session holding a fresh-looking
+  // cache of whatever it last saw — which a later revisit would then
+  // prefer over the live room's newer state.
   const handleWhiteboardChange = useCallback(
-    (scene: WhiteboardScene) => {
+    (scene: WhiteboardScene, opts?: { isLocal: boolean }) => {
       contentStateRef.current = {
         documentId: parsedId,
         content: scene as unknown as SerializedEditorState,
       };
       setWhiteboardScene(scene);
-      try {
-        setItem(
-          `wb-scene-${parsedId}`,
-          JSON.stringify({ scene, savedAt: new Date().toISOString() })
-        );
-      } catch {
-        // Storage full or unavailable — best-effort
-      }
+      if (opts?.isLocal === false) return;
+      stampWhiteboardSceneCache(parsedId, scene);
     },
     [parsedId]
   );
@@ -1366,7 +1353,13 @@ export const DocumentDetailPage = () => {
                     readOnly={!canEditDocument}
                     yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}
                     isSynced={collaboration.isSynced}
-                    hasOtherCollaborators={collaboration.collaborators.length > 0}
+                    // The server roster includes ourselves — only *other*
+                    // users make the room's Yjs state authoritative over a
+                    // local write-ahead cache.
+                    hasOtherCollaborators={collaboration.collaborators.some(
+                      (c) => c.user_id !== user?.id
+                    )}
+                    collaboratorsReady={collaboration.collaboratorsReady}
                     awareness={
                       collaborationEnabled && collaboration.isReady ? whiteboardAwareness : null
                     }
@@ -1396,6 +1389,7 @@ export const DocumentDetailPage = () => {
                   documentTitle={title || document.name}
                   readOnly={!canEditDocument}
                   yDoc={collaborationEnabled && collaboration.isReady ? spreadsheetYDoc : null}
+                  isSynced={collaboration.isSynced}
                   awareness={
                     collaborationEnabled && collaboration.isReady ? spreadsheetAwareness : null
                   }


### PR DESCRIPTION
## Problem

Rejoining a collaborative document that another user kept editing could show the document as it stood when you left (a refresh fixed it) — and worse, push that stale copy back into the live session. Reported for spreadsheets and whiteboards; Lexical text docs were unaffected (their bootstrap already waits for sync). Investigation task: [task 2725](https://initiative.morels.me/g/3/i/5/projects/1/tasks/2725).

Two distinct mechanisms:

- **Spreadsheets** seeded a fresh provider-backed Y.Doc from the REST snapshot **during first render**, before the initial sync arrived ([useSpreadsheetSheets.ts](frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.ts)). The snapshot was often the React Query cache from the previous visit, and the seed's writes were CRDT-concurrent with everything other users did since — last-write-wins could resolve cells back to the stale values for **every** client, and the seed was broadcast into the room.
- **Whiteboards** stamped the `wb-scene` write-ahead cache on remote-applied updates too (so a watching session always left with a fresh-looking cache), compared it against a stale client-cached `updated_at`, and made the post-sync bootstrap decision before the collaborator roster arrived (`hasOtherCollaborators` also counted yourself). A follow-up race surfaced in testing: the bootstrap effect could run before Excalidraw's imperative API existed, skipping the apply but still arming writes — the mount `onChange` then wrote the rejoin-time scene into the live room, rolling other users back.

## Changes

- [useSpreadsheetSheets.ts](frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.ts): new `seedAllowed` gate; [SpreadsheetDocumentEditor.tsx](frontend/src/components/documents/SpreadsheetDocumentEditor.tsx) passes `yDoc === null || isSynced` so a collaborative doc is only seeded after the initial sync (still bootstraps a truly-empty doc; local docs unchanged). Adds a "Syncing spreadsheet…" overlay until sync.
- [whiteboardSceneCache.ts](frontend/src/components/documents/whiteboardSceneCache.ts): write-ahead cache logic extracted from the page into a testable module; only genuinely local edits stamp it (new `isLocal` flag on `onSerializedChange`).
- [DocumentDetailPage.tsx](frontend/src/pages/DocumentDetailPage.tsx): whiteboard cache-vs-server timestamp check waits for `isFetchedAfterMount` (fresh `updated_at`); `hasOtherCollaborators` excludes self; passes `isSynced` / `collaboratorsReady` down.
- [useCollaboration.ts](frontend/src/hooks/useCollaboration.ts): exposes `collaboratorsReady` (roster received — it lands on the socket after the sync message).
- [WhiteboardDocumentEditor.tsx](frontend/src/components/documents/WhiteboardDocumentEditor.tsx): post-sync bootstrap waits for sync + roster + Excalidraw API (API mirrored into state) before applying room state and arming writes.
- Locales: new `documents:spreadsheet.syncing` key in en/de/es/fr. CHANGELOG entry under Unreleased.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && ./scripts/test-changed.sh` — 153 files / 1779 tests passed (includes new specs: `useSpreadsheetSheets.test.tsx` covering the seeding gate + a rejoin simulation asserting the stale snapshot never reaches the doc or the wire; `whiteboardSceneCache.test.ts` covering the cache win/lose/parse-error paths)
- `pnpm lint` — clean apart from a pre-existing unrelated warning (MatrixNode.tsx)
- Manual two-browser repro (leave → other user edits → rejoin): spreadsheet confirmed fixed; whiteboard confirmed fixed after the Excalidraw-API race fix (the 1-in-5 rollback repro)