### PR TITLE
Grant a guild-wide connection at the vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A guild-wide app connection can be granted at the vendor instead of typed.** A guild admin connects it once for everybody: the settings panel opens the vendor's install page rather than a form, and what comes back is written in by the app itself. 
 - **Guilds can list themselves in a community directory, and be joined without an invite.** "Join a community" sits under the add-a-guild button in the left rail. It opens the directory: the search box and the category shelves take over the app's sidebar, and the page beside them is a card per guild with its icon, description, tags, and member count. Both the search and the shelf are in the address, so a filtered directory is a link. A guild admin lists theirs from Settings → Guild, picking at least one category and certifying the guild holds no adult or illegal content. Guilds also carry an 18+ marker, unanswered by default; a guild marked 18+ — or one with room for only one member — is never listed. Unlisted guilds are unchanged.
 
   Whether a server has a directory at all is the platform owner's decision, under Settings → Platform → Community, and it starts off. While it is off there is nothing to browse, nobody can join a guild without an invite, and the listing control is absent from guild settings. Turning it off later hides the directory rather than un-listing anyone: switch it back on and the same guilds are there.

--- a/backend/alembic/versions/20260828_0198_app_guild_connection_refs.py
+++ b/backend/alembic/versions/20260828_0198_app_guild_connection_refs.py
@@ -11,9 +11,8 @@ A ``static`` connection may now declare a ``connect_path``, which makes it a
 flow a guild admin runs once for everybody. This column is what the two ends are
 joined by: an opaque handle minted when the admin starts, carried to the app in
 the browser, and named again when the app writes the result back over its own
-authenticated channel. A write-back naming a handle this column never held is
-refused — which is what keeps somebody who merely knows a guild id from binding
-their own organization to that guild.
+authenticated channel. A write-back is accepted for the connection its handle
+names, and only for a handle this column holds.
 
 Keyed by connection id, because an app may declare more than one. Empty for
 every install that exists today, and for every app that has no such flow.

--- a/backend/alembic/versions/20260828_0198_app_guild_connection_refs.py
+++ b/backend/alembic/versions/20260828_0198_app_guild_connection_refs.py
@@ -1,0 +1,60 @@
+"""hold the handle a guild-wide vendor flow writes back against
+
+Some vendors do not authorize an organization by anything an admin can type.
+GitHub, Slack and Linear all put the organization-wide install behind a page of
+their own, where somebody who owns the account chooses what the app may see —
+and what comes back is an installation, not a name. Until now the only way to
+join that to a guild was an admin retyping the organization's login into a text
+box and hoping it matched whatever somebody had installed.
+
+A ``static`` connection may now declare a ``connect_path``, which makes it a
+flow a guild admin runs once for everybody. This column is what the two ends are
+joined by: an opaque handle minted when the admin starts, carried to the app in
+the browser, and named again when the app writes the result back over its own
+authenticated channel. A write-back naming a handle this column never held is
+refused — which is what keeps somebody who merely knows a guild id from binding
+their own organization to that guild.
+
+Keyed by connection id, because an app may declare more than one. Empty for
+every install that exists today, and for every app that has no such flow.
+
+Revision ID: 20260828_0198
+Revises: 20260827_0197
+Create Date: 2026-08-28
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.db.guild_migrations import run_for_each_guild_schema
+
+revision = "20260828_0198"
+down_revision = "20260827_0197"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_upgrade)
+
+
+def _apply_upgrade() -> None:
+    with op.batch_alter_table("guild_apps", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "connection_refs",
+                postgresql.JSONB(astext_type=sa.Text()),
+                server_default="{}",
+                nullable=False,
+            )
+        )
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_downgrade)
+
+
+def _apply_downgrade() -> None:
+    with op.batch_alter_table("guild_apps", schema=None) as batch_op:
+        batch_op.drop_column("connection_refs")

--- a/backend/app/api/v1/app_service_endpoints/__init__.py
+++ b/backend/app/api/v1/app_service_endpoints/__init__.py
@@ -14,7 +14,9 @@ The channels, all under ``/api/v1/app-service``:
 * ``GET /installs/{guild_id}/connections`` — the app's per-member connections,
   by opaque reference, with status only.
 * ``PUT /installs/{guild_id}/connections/{connection_ref}`` — what a vendor flow
-  produced, written back into the platform's custody.
+  produced, written back into the platform's custody. The handle says which of
+  two things it was: a member's own credential, or the one the whole guild uses
+  and a guild admin obtained.
 * ``POST /installs/{guild_id}/status`` — the app's verdict on the configuration
   it was handed.
 * ``POST /events`` — third-party events, re-emitted through the dispatcher the

--- a/backend/app/api/v1/app_service_endpoints/installs_test.py
+++ b/backend/app/api/v1/app_service_endpoints/installs_test.py
@@ -80,6 +80,24 @@ MEMBER_CONNECTION = {
     "fields": [_field("access_token", "secret", managed=True)],
 }
 
+#: The guild's own credential, obtained by an admin rather than typed.
+WORKSPACE_CONNECTION = {
+    "id": "workspace",
+    "scope": "static",
+    "label": {"en": "Organization"},
+    "connect_path": "/install/github",
+    "fields": [_field("owner", "string", managed=True, required=True)],
+}
+
+
+def _workspace_definition(public_id: str = "tests.shop") -> dict:
+    return {
+        "app_kind": "service",
+        "service": {"public_id": public_id, "protocol": 1},
+        "features": [],
+        "connections": [WORKSPACE_CONNECTION],
+    }
+
 
 def _definition(public_id: str = "tests.shop") -> dict:
     return {
@@ -958,6 +976,129 @@ class TestConnectionWriteBack:
 
         assert response.status_code == 400
         assert response.json()["detail"] == GuildAppMessages.CONFIG_UNKNOWN_FIELD
+
+
+# ---------------------------------------------------------------------------
+# The same channel, for the credential the whole guild uses
+# ---------------------------------------------------------------------------
+
+
+class TestGuildConnectionWriteBack:
+    """A vendor flow an admin ran, landing where a guild-wide value lives.
+
+    The app cannot tell the two kinds apart and does not have to: it is handed a
+    handle and writes to it. Which store the values land in is decided here, by
+    which handle it turns out to be.
+    """
+
+    async def test_what_the_admin_s_flow_produced_becomes_the_guild_s_config(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _user, app = await _install(
+            session,
+            definition=_workspace_definition(),
+            connection_refs={"workspace": "gcr_workspace"},
+        )
+
+        written = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/gcr_workspace",
+            {"values": {"owner": "morelitea"}},
+        )
+
+        assert written.status_code == 200, written.text
+        assert written.json()["connection_id"] == "workspace"
+        assert written.json()["status"] == "connected"
+
+        # Beside the values an admin types, which is what makes clearing the
+        # connection, uninstalling, or moving version take this with them.
+        config = await _get(client, f"{BASE}/installs/{guild.id}/config")
+        assert config.json()["connections"]["workspace"] == {"owner": "morelitea"}
+        # And it is the guild's, so there is no member row anywhere in it.
+        assert config.json()["member_connections"] == []
+
+    async def test_an_install_that_needed_configuring_stops_needing_it(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """The whole point: nobody typed anything, and the install is set up.
+
+        Before the flow the settings page says an admin still has something to
+        fill in — which is true, and what they have to do is run the flow.
+        """
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _user, app = await _install(
+            session,
+            definition=_workspace_definition(),
+            connection_refs={"workspace": "gcr_workspace"},
+        )
+
+        before = await _get(client, f"{BASE}/installs")
+        assert before.json()["items"][0]["needs_config"] is True
+
+        await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/gcr_workspace",
+            {"values": {"owner": "morelitea"}},
+        )
+
+        after = await _get(client, f"{BASE}/installs")
+        assert after.json()["items"][0]["needs_config"] is False
+
+    async def test_a_handle_nobody_minted_is_refused(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """The one that matters, and the reason the handle is stored at all.
+
+        An app is handed this in a browser, where anybody can type a guild id.
+        If a write-back were believed on the strength of naming a connection,
+        a member could complete the vendor's flow against their own
+        organization and hand the guild a boundary its admin never chose.
+        """
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _user, _app = await _install(session, definition=_workspace_definition())
+
+        response = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/gcr_never_minted",
+            {"values": {"owner": "somebody-elses-org"}},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == AppChannelMessages.CONNECTION_NOT_FOUND
+
+        config = await _get(client, f"{BASE}/installs/{guild.id}/config")
+        assert config.json()["connections"] == {}
+
+    async def test_clearing_the_values_leaves_the_connection_unsatisfied(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """A ``None`` is a clear, on this path as on the member's.
+
+        A required field cleared is the exception the config service already
+        makes: taking a credential back has to work whether or not what is left
+        adds up to a working connection.
+        """
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _user, app = await _install(
+            session,
+            definition=_workspace_definition(),
+            connection_refs={"workspace": "gcr_workspace"},
+            config={"workspace": {"owner": "morelitea"}},
+        )
+
+        written = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/gcr_workspace",
+            {"values": {"owner": None}},
+        )
+
+        assert written.status_code == 200, written.text
+        assert written.json()["status"] == "pending"
+        config = await _get(client, f"{BASE}/installs/{guild.id}/config")
+        # Absent rather than an empty map, so "is anything configured here?"
+        # has one shape.
+        assert config.json()["connections"] == {}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/v1/app_service_endpoints/installs_test.py
+++ b/backend/app/api/v1/app_service_endpoints/installs_test.py
@@ -1048,13 +1048,8 @@ class TestGuildConnectionWriteBack:
     async def test_a_handle_nobody_minted_is_refused(
         self, client: AsyncClient, session: AsyncSession
     ):
-        """The one that matters, and the reason the handle is stored at all.
-
-        An app is handed this in a browser, where anybody can type a guild id.
-        If a write-back were believed on the strength of naming a connection,
-        a member could complete the vendor's flow against their own
-        organization and hand the guild a boundary its admin never chose.
-        """
+        """A write-back is accepted for a handle this install minted, and only
+        for one it minted — naming the connection is not enough."""
         await register_app_service(session, listing_uid=SHOP_UID)
         guild, _user, _app = await _install(session, definition=_workspace_definition())
 

--- a/backend/app/api/v1/app_service_endpoints/installs_test.py
+++ b/backend/app/api/v1/app_service_endpoints/installs_test.py
@@ -1045,6 +1045,37 @@ class TestGuildConnectionWriteBack:
         after = await _get(client, f"{BASE}/installs")
         assert after.json()["items"][0]["needs_config"] is False
 
+    async def test_a_handle_the_clear_dropped_is_refused(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """Clearing the connection ends the flow that was routing to it.
+
+        An admin who clears a credential has said to forget it. A result still
+        in flight from before must not put it back, so the clear drops the
+        handle and a write-back carrying the old one is refused.
+        """
+        await register_app_service(session, listing_uid=SHOP_UID)
+        guild, _user, app = await _install(
+            session,
+            definition=_workspace_definition(),
+            connection_refs={"workspace": "gcr_workspace"},
+        )
+
+        await route_session_to_guild(session, guild.id)
+        app.connection_refs = {}
+        session.add(app)
+        await session.commit()
+
+        refused = await _put(
+            client,
+            f"{BASE}/installs/{guild.id}/connections/gcr_workspace",
+            {"values": {"owner": "morelitea"}},
+        )
+        assert refused.status_code == 404
+
+        config = await _get(client, f"{BASE}/installs/{guild.id}/config")
+        assert "workspace" not in config.json()["connections"]
+
     async def test_a_handle_nobody_minted_is_refused(
         self, client: AsyncClient, session: AsyncSession
     ):

--- a/backend/app/api/v1/tenant_endpoints/calendars.py
+++ b/backend/app/api/v1/tenant_endpoints/calendars.py
@@ -276,8 +276,14 @@ async def create_calendar(
     initiative: Optional[Initiative] = None
 
     if calendar_in.initiative_id is None:
+        # Held until this request commits, so the calendar and the app it
+        # belongs to cannot part company midway: an uninstall arriving now waits
+        # and takes this calendar with it.
         app = await guild_apps_service.find_mounting_app(
-            session, guild_id=guild_context.guild_id, tool=Tool.calendar.value
+            session,
+            guild_id=guild_context.guild_id,
+            tool=Tool.calendar.value,
+            for_update=True,
         )
         if app is None:
             raise HTTPException(

--- a/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
@@ -73,11 +73,37 @@ GITHUB_CONNECTION = {
     "fields": [_field("access_token", "secret", managed=True)],
 }
 
+#: A guild-wide credential the app fills in rather than the admin typing it.
+#:
+#: The case this exists for is the one no text box can express: a vendor whose
+#: organization-wide install is a page of its own, where somebody who owns the
+#: account chooses what the app may see. What comes back is an installation, and
+#: the app writes down what it says — so every field is ``managed``.
+WORKSPACE_CONNECTION = {
+    "id": "workspace",
+    "scope": "static",
+    "label": {"en": "Organization"},
+    "connect_path": "/install/github",
+    "fields": [_field("owner", "string", managed=True)],
+}
+
 SERVICE_DEFINITION = {
     "app_kind": "service",
     "service": {"public_id": "tests.shop", "protocol": 1},
     "features": [],
     "connections": [ADMIN_CONNECTION, GITHUB_CONNECTION],
+}
+
+#: The same app, where the guild-wide half is obtained rather than typed.
+#:
+#: Kept apart from ``SERVICE_DEFINITION`` on purpose: an unsatisfied static
+#: connection is an install that needs configuring, and every test about
+#: something else would start asserting around one.
+WORKSPACE_DEFINITION = {
+    "app_kind": "service",
+    "service": {"public_id": "tests.shop", "protocol": 1},
+    "features": [],
+    "connections": [WORKSPACE_CONNECTION, GITHUB_CONNECTION],
 }
 
 MEMBER_ONLY_DEFINITION = {
@@ -443,9 +469,14 @@ class TestConnect:
         assert first.json()["connection_ref"] == second.json()["connection_ref"]
         assert len(await _rows(session, a.guild.id)) == 1
 
-    async def test_a_guild_scoped_connection_is_not_connected_to(
+    async def test_a_typed_connection_is_not_connected_to(
         self, client: AsyncClient, acting_user, session: AsyncSession
     ):
+        """No ``connect_path``, so there is no vendor to send anybody to.
+
+        The scope is not what decides this — a guild-wide connection may run a
+        flow of its own. Declaring one is.
+        """
         a = await acting_user(guild_role=GuildRole.admin)
         app = await _install(session, a)
         response = await client.post(
@@ -453,6 +484,83 @@ class TestConnect:
         )
         assert response.status_code == 409
         assert response.json()["detail"] == GuildAppMessages.CONNECTION_NOT_INTERACTIVE
+
+    async def test_an_admin_starts_the_guild_s_own_vendor_flow(
+        self, client: AsyncClient, acting_user, session: AsyncSession
+    ):
+        """One credential for everybody, obtained rather than typed.
+
+        The same shape a member gets — a handle, a guild, an address to open —
+        because it is the same trip. What differs is who it belongs to when it
+        comes back.
+        """
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _install(session, a, definition=WORKSPACE_DEFINITION)
+
+        response = await client.post(
+            a.g(f"/apps/{app.id}/connections/workspace/connect"), headers=a.headers
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["connect_path"] == "/install/github"
+        assert body["status"] == "pending"
+
+        connect = urlparse(body["connect_url"])
+        assert f"{connect.scheme}://{connect.netloc}{connect.path}" == (
+            "https://shop.example.test/install/github"
+        )
+        query = parse_qs(connect.query)
+        assert query["connection_ref"] == [body["connection_ref"]]
+        assert query["guild_id"] == [str(a.guild.id)]
+
+        # On the install row, because that is where a guild-wide credential
+        # lives — and no member row was minted for it.
+        await route_session_to_guild(session, a.guild.id)
+        await session.refresh(app)
+        assert app.connection_refs["workspace"] == body["connection_ref"]
+        assert await _rows(session, a.guild.id) == []
+
+    async def test_a_member_may_not_start_the_guild_s_flow(
+        self, client: AsyncClient, acting_user, session: AsyncSession
+    ):
+        """The install it produces is the guild's boundary.
+
+        Any member may connect their own account, because the vendor authorizes
+        them and the credential reaches what they already reach. This one
+        reaches whatever the organization grants, for everybody — which is the
+        admin's to decide, exactly as typing the same connection would be.
+        """
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _install(session, a, definition=WORKSPACE_DEFINITION)
+        member = await acting_user(guild_role=GuildRole.member, guild=a.guild)
+
+        response = await client.post(
+            member.g(f"/apps/{app.id}/connections/workspace/connect"),
+            headers=member.headers,
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == GuildAppMessages.ADMIN_REQUIRED
+
+        await route_session_to_guild(session, a.guild.id)
+        await session.refresh(app)
+        assert app.connection_refs == {}
+
+    async def test_the_guild_handle_survives_starting_again(
+        self, client: AsyncClient, acting_user, session: AsyncSession
+    ):
+        """Moving to another organization writes over one connection.
+
+        A fresh handle each time would leave the app holding one Initiative no
+        longer recognizes, and the write-back at the end of the flow the admin
+        actually completed would be refused.
+        """
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _install(session, a, definition=WORKSPACE_DEFINITION)
+        path = a.g(f"/apps/{app.id}/connections/workspace/connect")
+
+        first = await client.post(path, headers=a.headers)
+        second = await client.post(path, headers=a.headers)
+        assert first.json()["connection_ref"] == second.json()["connection_ref"]
 
     async def test_an_unknown_connection_is_a_404(
         self, client: AsyncClient, acting_user, session: AsyncSession

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -5,12 +5,16 @@ and an app's existence is guild-wide knowledge. Installing, renaming, disabling,
 upgrading, configuring and removing are guild-admin actions: an app mounts a
 guild-wide surface, which is the guild's shape rather than any one member's.
 
-**Connecting is not an admin action.** Where a vendor authorizes a person rather
-than an organization, each member connects their own account, and installation
-never waits for anyone to do so. Admins govern the install and its guild-wide
-credentials; they can see who connected as which vendor account and end that
-access, but they neither perform another member's connection nor read its
-values.
+**Who connects follows what the credential is.** Where a vendor authorizes a
+person, each member connects their own account, no admin is involved, and
+installation never waits for anyone to do so. Where it authorizes an
+organization — through a page of its own, which is the only way some vendors
+grant one — a guild admin runs that flow once for everybody, exactly as they
+would fill in the same connection by hand.
+
+Admins govern the install and its guild-wide credentials either way; they can
+see who connected as which vendor account and end that access, but they neither
+perform another member's connection nor read its values.
 
 What a member may *do* inside an app is not decided here. The content an app
 creates carries its own grants, and the tool that owns it enforces them exactly
@@ -171,8 +175,22 @@ async def _normalized_placement(session: RLSSessionDep, raw: Any) -> dict[str, A
         ) from exc
 
 
-async def _load(session: RLSSessionDep, app_id: int) -> GuildApp:
-    app = (await session.exec(select(GuildApp).where(GuildApp.id == app_id))).first()
+async def _load(
+    session: RLSSessionDep, app_id: int, *, for_update: bool = False
+) -> GuildApp:
+    """This guild's install, or a 404.
+
+    ``for_update`` holds the row for the rest of the transaction. Removal wants
+    it: what an install is answerable for is a list that a member adding a
+    calendar appends to, so removal has to settle which of the two goes first
+    rather than reading a list that is still being written.
+    """
+    statement = select(GuildApp).where(GuildApp.id == app_id)
+    if for_update:
+        statement = statement.with_for_update().execution_options(
+            populate_existing=True
+        )
+    app = (await session.exec(statement)).first()
     if app is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -529,7 +547,10 @@ async def uninstall_guild_app(
     the operator's registration decides whether it exists at all.
     """
     _require_guild_admin(guild_context)
-    app = await _load(session, app_id)
+    # Held for the rest of this transaction, so a member adding a calendar to
+    # the app either lands before this read and is trashed with everything else,
+    # or finds no install and is refused.
+    app = await _load(session, app_id, for_update=True)
     await _require_removable(app)
 
     retention_days = await guilds_service.get_guild_retention_days(
@@ -746,7 +767,7 @@ def _handoff_response(handoff: handoff_service.EmbedHandoff) -> GuildAppHandoff:
 
 
 # ---------------------------------------------------------------------------
-# A member's own connection
+# Starting a vendor's flow
 # ---------------------------------------------------------------------------
 
 
@@ -761,13 +782,21 @@ async def connect_guild_app(
     current_user: CurrentUser,
     guild_context: GuildContextDep,
 ) -> GuildAppConnectStart:
-    """Start this member's own connection to an app's vendor.
+    """Start the vendor flow behind one connection.
 
-    Any member may: the vendor is going to authorize *them*, and what the
-    resulting credential reaches is what they already reach. The row and its
-    opaque handle are minted here so the app has something to write its result
-    against; the vendor flow itself runs at the app's own URL.
+    Two kinds run through here, and the connection's scope decides which:
 
+    * **A member's own account.** Any member may, because the vendor is going to
+      authorize *them* and what the resulting credential reaches is what they
+      already reach.
+    * **The guild's own credential**, where the vendor authorizes an
+      organization through a page of its own rather than through anything an
+      admin could type. A guild admin only — it is one credential for everybody,
+      and the install it produces is the guild's boundary, so this is governance
+      in exactly the way configuring the same connection by hand is.
+
+    Either way the opaque handle is minted here so the app has something to
+    write its result against, and the flow itself runs at the app's own URL.
     That URL is assembled server-side — the registration supplies the address,
     the manifest supplies the path — and carries the ``connection_ref`` so the
     app knows which credential it is about to hold. The ref is an identifier,
@@ -781,23 +810,30 @@ async def connect_guild_app(
         )
 
     connection = _connection_or_404(app, connection_id)
-    if connection.get("scope") != "interactive":
+    if not app_config_service.runs_vendor_flow(connection):
+        # Nothing to run and nowhere to send anybody. A guild-wide connection
+        # without a flow is a form, and is filled in through the config route.
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=GuildAppMessages.CONNECTION_NOT_INTERACTIVE,
         )
-    connect_path = connection.get("connect_path")
-    if not connect_path:
-        # The validator requires one on an interactive connection, so this is a
-        # definition pinned before that rule — there is nowhere to send anyone.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=GuildAppMessages.CONNECT_PATH_MISSING,
-        )
+    connect_path = connection["connect_path"]
+    guild_wide = connection.get("scope") == "static"
+    if guild_wide:
+        _require_guild_admin(guild_context)
 
     # The vendor flow runs at the app's own URL, so it has to be wired up and
-    # switched on before a member is sent anywhere.
+    # switched on before anyone is sent anywhere.
     registration = await handoff_service.require_live_registration(app)
+
+    if guild_wide:
+        return await _start_guild_connect(
+            session,
+            app,
+            connection=connection,
+            connect_path=connect_path,
+            registration=registration,
+        )
 
     existing = await connections_service.get_connection(
         session, app_id=app.id, connection_id=connection_id, user_id=current_user.id
@@ -814,22 +850,85 @@ async def connect_guild_app(
     await session.commit()
     await session.refresh(row)
 
-    # The member's browser is what follows this, so it is built from the address
-    # a browser can resolve.
-    #
-    # The guild travels with the ref because the channel addresses every install
-    # by guild: the app writes its result back to
-    # ``/installs/{guild_id}/connections/{ref}``, and a ref on its own names
-    # nothing it can look up.
+    return await _connect_start(
+        registration,
+        guild_id=app.guild_id,
+        connection_id=row.connection_id,
+        connection_ref=row.connection_ref,
+        connect_path=connect_path,
+        status=row.status,
+    )
+
+
+async def _start_guild_connect(
+    session: AsyncSession,
+    app: GuildApp,
+    *,
+    connection: dict[str, Any],
+    connect_path: str,
+    registration: Any,
+) -> GuildAppConnectStart:
+    """Start the flow behind the guild's own credential.
+
+    There is no row to mint: a guild-wide credential lives on the install, and
+    so does the handle the app writes it back against. Kept once minted, so an
+    admin repeating the flow — moving to a different organization, widening what
+    it may see — writes over the same connection rather than creating a second.
+
+    The status is read off what is stored rather than set to ``pending``, so an
+    admin who opens the vendor's page and then closes the tab has changed
+    nothing about a credential that was already working.
+    """
+    connection_id = connection["id"]
+    connection_ref = app_config_service.guild_connection_ref(app, connection_id)
+    app.updated_at = datetime.now(timezone.utc)
+    session.add(app)
+    await session.commit()
+    await session.refresh(app)
+
+    satisfied = app_config_service.is_satisfied(
+        connection,
+        (app.config or {}).get(connection_id) or {},
+        (app.config_secrets or {}).get(connection_id) or {},
+    )
+    return await _connect_start(
+        registration,
+        guild_id=app.guild_id,
+        connection_id=connection_id,
+        connection_ref=connection_ref,
+        connect_path=connect_path,
+        status="connected" if satisfied else "pending",
+    )
+
+
+async def _connect_start(
+    registration: Any,
+    *,
+    guild_id: int,
+    connection_id: str,
+    connection_ref: str,
+    connect_path: str,
+    status: str,
+) -> GuildAppConnectStart:
+    """Where to send somebody, and what they are about to connect.
+
+    A browser is what follows this, so it is built from the address a browser
+    can resolve rather than the one Initiative's own server calls the app on.
+
+    The guild travels with the ref because the channel addresses every install
+    by guild: the app writes its result back to
+    ``/installs/{guild_id}/connections/{ref}``, and a ref on its own names
+    nothing it can look up.
+    """
     query = [
-        ("connection_ref", row.connection_ref),
-        ("guild_id", str(app.guild_id)),
+        ("connection_ref", connection_ref),
+        ("guild_id", str(guild_id)),
     ]
     query += await _return_address(registration.public_id, connection_id)
 
     return GuildAppConnectStart(
-        connection_id=row.connection_id,
-        connection_ref=row.connection_ref,
+        connection_id=connection_id,
+        connection_ref=connection_ref,
         connect_path=connect_path,
         connect_url=(
             # ``urlencode`` percent-encodes every reserved character, which
@@ -838,7 +937,7 @@ async def connect_guild_app(
             # separators of this one.
             f"{registration.browser_base}{connect_path}?{urlencode(query)}"
         ),
-        status=row.status,
+        status=status,
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -440,7 +440,10 @@ async def upgrade_guild_app(
     than orphaned.
     """
     _require_guild_admin(guild_context)
-    app = await _load(session, app_id)
+    # Upgrading prunes both configuration maps to the new definition, so it
+    # takes the row: an app writing a flow's result back at the same moment
+    # must land on one side of the prune or the other.
+    app = await _load(session, app_id, for_update=True)
 
     # The listing is resolved here rather than inside the shared apply, so a
     # withdrawn or missing one is reported as the HTTP answer it deserves
@@ -605,7 +608,10 @@ async def update_guild_app_config(
     app's own write-back path rather than through a form.
     """
     _require_guild_admin(guild_context)
-    app = await _load(session, app_id)
+    # Both configuration maps are rewritten whole below, so the row is taken
+    # first — an app writing a flow's result back is doing the same thing to
+    # the same values.
+    app = await _load(session, app_id, for_update=True)
 
     config = dict(app.config or {})
     secrets = dict(app.config_secrets or {})
@@ -997,7 +1003,9 @@ async def disconnect_guild_app(
     else's uses the Members endpoints, which record who acted. Clearing a
     guild-wide credential is an admin action, since it is the guild's.
     """
-    app = await _load(session, app_id)
+    # Clearing rewrites both configuration maps, so it takes the row: an app
+    # writing back at the same moment must not put back what was cleared.
+    app = await _load(session, app_id, for_update=True)
     connection = _connection_or_404(app, connection_id)
 
     if connection.get("scope") == "static":

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -1033,6 +1033,15 @@ async def disconnect_guild_app(
             for key, value in (app.config_secrets or {}).items()
             if key != connection_id
         }
+        # The handle goes with them. It is what a write-back is matched on, so
+        # keeping it would leave a flow the admin has just ended still able to
+        # land its result and bring the connection back. Starting the flow again
+        # mints a fresh one, which is the whole of what reconnecting needs.
+        app.connection_refs = {
+            key: value
+            for key, value in (app.connection_refs or {}).items()
+            if key != connection_id
+        }
         app.config_state = "unverified"
         app.config_state_detail = None
         guild_apps_service.touch(app)

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -180,17 +180,17 @@ async def _load(
 ) -> GuildApp:
     """This guild's install, or a 404.
 
-    ``for_update`` holds the row for the rest of the transaction. Removal wants
-    it: what an install is answerable for is a list that a member adding a
-    calendar appends to, so removal has to settle which of the two goes first
-    rather than reading a list that is still being written.
+    ``for_update`` holds the row for the rest of the transaction — see
+    :func:`~app.services.tenant.guild_apps.lock_install`. Anything that rewrites
+    a value on this row wants it: removal reads the list of what the install is
+    answerable for, and a connect writes the handle map, both of which someone
+    else may be changing at the same moment.
     """
-    statement = select(GuildApp).where(GuildApp.id == app_id)
-    if for_update:
-        statement = statement.with_for_update().execution_options(
-            populate_existing=True
-        )
-    app = (await session.exec(statement)).first()
+    app = (
+        await guild_apps_service.lock_install(session, app_id)
+        if for_update
+        else (await session.exec(select(GuildApp).where(GuildApp.id == app_id))).first()
+    )
     if app is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -880,6 +880,17 @@ async def _start_guild_connect(
     nothing about a credential that was already working.
     """
     connection_id = connection["id"]
+    # The handle map is rewritten whole, so the row is taken first: two admins
+    # starting the same flow at once would otherwise each mint against a map
+    # read before the other's, and the handle one of them carried to the vendor
+    # would no longer be one the write-back finds.
+    locked = await guild_apps_service.lock_install(session, app.id)
+    if locked is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=GuildAppMessages.NOT_FOUND,
+        )
+    app = locked
     connection_ref = app_config_service.guild_connection_ref(app, connection_id)
     app.updated_at = datetime.now(timezone.utc)
     session.add(app)

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
@@ -363,6 +363,33 @@ class TestUninstall:
         # And gone from the ordinary view, like anything else in the trash.
         assert await _read_calendar(session, a.guild.id, calendar_id) is None
 
+    async def test_removal_trashes_a_calendar_added_after_the_install(
+        self, client: AsyncClient, acting_user, session: AsyncSession, calendar_app
+    ):
+        """An app is answerable for everything made inside it, not only for what
+        it created on the way in. Removal reads that list under the same lock a
+        create takes, so a calendar added later goes to the trash with the rest
+        rather than staying live with nothing that reaches it."""
+        a = await acting_user(guild_role=GuildRole.admin)
+        app = await _install(client, a)
+        mounted_id = _artifact_id(app)
+
+        added = await client.post(
+            a.g("/calendars/"), headers=a.headers, json={"name": "Holidays"}
+        )
+        assert added.status_code == 201, added.text
+        added_id = added.json()["id"]
+
+        response = await client.delete(a.g(f"/apps/{app['id']}"), headers=a.headers)
+        assert response.status_code == 204
+
+        for calendar_id in (mounted_id, added_id):
+            trashed = await _read_calendar(
+                session, a.guild.id, calendar_id, include_deleted=True
+            )
+            assert trashed is not None and trashed.deleted_at is not None, calendar_id
+            assert await _read_calendar(session, a.guild.id, calendar_id) is None
+
     async def test_the_listing_can_be_installed_again_afterwards(
         self, client: AsyncClient, acting_user, calendar_app
     ):

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -636,8 +636,10 @@ class GuildAppMessages:
     # --- connections ---
     #: No such connection on this install, or no such member connection.
     CONNECTION_NOT_FOUND = "GUILD_APP_CONNECTION_NOT_FOUND"
-    #: Connecting an account is for the connections a vendor authorizes per
-    #: person; a guild-wide credential is configured instead.
+    #: Connecting runs a vendor's flow, and this connection declares none —
+    #: its values are typed into the settings form instead. Named for the
+    #: scope because that is what it meant when only one scope could have a
+    #: flow; a guild-wide connection may now have one too.
     CONNECTION_NOT_INTERACTIVE = "GUILD_APP_CONNECTION_NOT_INTERACTIVE"
     #: Guild-wide values are configured through the config endpoint; a
     #: per-member connection is not.
@@ -671,9 +673,6 @@ class GuildAppMessages:
     #: guild's admins, or for an initiative's managers where the caller manages
     #: nothing.
     SURFACE_ADMIN_ONLY = "GUILD_APP_SURFACE_ADMIN_ONLY"
-    #: An interactive connection whose pinned definition carries no
-    #: ``connect_path``, so there is no vendor flow to send the member to.
-    CONNECT_PATH_MISSING = "GUILD_APP_CONNECT_PATH_MISSING"
     #: The placement sent is not a shape this build stores, or it names an
     #: initiative that is not one of this guild's.
     PLACEMENT_INVALID = "GUILD_APP_PLACEMENT_INVALID"

--- a/backend/app/models/tenant/guild_app.py
+++ b/backend/app/models/tenant/guild_app.py
@@ -112,6 +112,24 @@ class GuildApp(CreatedByMixin, table=True):
         default=None, sa_column=Column(String(120), nullable=True)
     )
 
+    # The opaque handle the app writes a guild-wide connection's result
+    # against, keyed by connection id: ``{"workspace": "9f3c…"}``.
+    #
+    # Only for a ``static`` connection the app fills by running the vendor's own
+    # flow — an organization-wide install, which a guild admin performs once for
+    # everybody. A typed connection needs none: nothing comes back from anywhere
+    # to be matched to it.
+    #
+    # Minted when an admin starts the flow and kept afterwards, so reconnecting
+    # keeps one identity rather than minting a new one each time. That it exists
+    # at all is what says an admin authorized this flow: the app is handed the
+    # ref in the browser, and a write-back naming one nobody minted is refused
+    # rather than believed.
+    connection_refs: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSONB, nullable=False, server_default="{}"),
+    )
+
     # What this install created: ``[{"type": "calendar", "id": 7}, …]``.
     artifacts: list[Any] = Field(
         default_factory=list,

--- a/backend/app/models/tenant/guild_app.py
+++ b/backend/app/models/tenant/guild_app.py
@@ -121,10 +121,9 @@ class GuildApp(CreatedByMixin, table=True):
     # to be matched to it.
     #
     # Minted when an admin starts the flow and kept afterwards, so reconnecting
-    # keeps one identity rather than minting a new one each time. That it exists
-    # at all is what says an admin authorized this flow: the app is handed the
-    # ref in the browser, and a write-back naming one nobody minted is refused
-    # rather than believed.
+    # keeps one identity rather than minting a new one each time. The handle is
+    # what a write-back is matched on: it is accepted for the connection its
+    # handle names, and only for a handle this map holds.
     connection_refs: dict[str, Any] = Field(
         default_factory=dict,
         sa_column=Column(JSONB, nullable=False, server_default="{}"),

--- a/backend/app/models/tenant/guild_app.py
+++ b/backend/app/models/tenant/guild_app.py
@@ -121,9 +121,10 @@ class GuildApp(CreatedByMixin, table=True):
     # to be matched to it.
     #
     # Minted when an admin starts the flow and kept afterwards, so reconnecting
-    # keeps one identity rather than minting a new one each time. The handle is
-    # what a write-back is matched on: it is accepted for the connection its
-    # handle names, and only for a handle this map holds.
+    # keeps one identity rather than minting a new one each time; clearing the
+    # connection drops it. The handle is what a write-back is matched on: it is
+    # accepted for the connection its handle names, and only for a handle this
+    # map holds.
     connection_refs: dict[str, Any] = Field(
         default_factory=dict,
         sa_column=Column(JSONB, nullable=False, server_default="{}"),

--- a/backend/app/schemas/tenant/guild_app.py
+++ b/backend/app/schemas/tenant/guild_app.py
@@ -100,7 +100,8 @@ class GuildAppConnectionRead(SanitizedBaseModel):
     has_value: Dict[str, bool] = {}
     #: Whether everything this connection declared it needs is present.
     satisfied: bool = False
-    #: Where the app runs its vendor flow, for an interactive connection.
+    #: Where the app runs its vendor flow. Present on an interactive connection,
+    #: and on a guild-wide one an admin connects rather than types.
     connect_path: Optional[str] = None
     #: The viewer's own state on an interactive connection.
     status: Optional[str] = None

--- a/backend/app/services/marketplace/definitions_test.py
+++ b/backend/app/services/marketplace/definitions_test.py
@@ -230,8 +230,43 @@ class TestConnections:
                 ]
             )
 
-    def test_a_static_connection_has_nowhere_to_send_anyone(self):
-        with pytest.raises(ListingDefinitionError, match="connect_path"):
+    def test_a_guild_credential_may_come_from_a_vendor_flow(self):
+        """An admin runs the vendor's install once, for the whole guild.
+
+        The alternative this replaces is an admin retyping an organization's
+        name into a text box and hoping it names the same organization somebody
+        installed at the vendor. Nothing about that is per-member, so the scope
+        stays ``static``; the ``connect_path`` is how the value arrives.
+        """
+        [connection] = _normalize(
+            connections=[
+                {
+                    "id": "workspace",
+                    "scope": "static",
+                    "label": _label(),
+                    "connect_path": "/install/github",
+                    "fields": [
+                        {
+                            "key": "owner",
+                            "type": "string",
+                            "label": _label(),
+                            "managed": True,
+                        }
+                    ],
+                }
+            ]
+        )["connections"]
+        assert connection["connect_path"] == "/install/github"
+        assert connection["fields"][0]["managed"] is True
+
+    def test_a_guild_flow_needs_somewhere_to_put_its_result(self):
+        """Every field typed means the app can never write the answer back.
+
+        A static connection is satisfied by the values it holds, and only a
+        ``managed`` field is one the app may write. So a flow with none can run
+        to completion and leave the install exactly as unconfigured as it was.
+        """
+        with pytest.raises(ListingDefinitionError, match="managed field"):
             _normalize(
                 connections=[
                     {

--- a/backend/app/services/marketplace/service_apps.py
+++ b/backend/app/services/marketplace/service_apps.py
@@ -88,11 +88,18 @@ FEATURES: frozenset[str] = contract.enum("feature")
 #: added to one of them.
 FEATURE_BLOCKS: dict[str, str] = {feature: feature for feature in sorted(FEATURES)}
 
-#: Who supplies a connection's credential, which decides its scope.
+#: Whose credential a connection holds — not how it is obtained.
 #:
-#: ``static`` — a guild admin types it in, and the whole guild uses it.
-#: ``interactive`` — the app runs a vendor flow behind its ``connect_path`` and
-#: each member connects their own account.
+#: ``static`` — one credential the whole guild uses.
+#: ``interactive`` — each member's own account at a vendor that authorizes
+#: people, and never anybody else's.
+#:
+#: A ``connect_path`` is the second question, asked of either: with one, the app
+#: runs the vendor's flow, and the scope decides who is sent — every member for
+#: their own account, or a guild admin once, for the guild. Without one, a
+#: static connection is a form an admin types into. Some vendors leave no
+#: choice: an organization-wide install is a page at the vendor with a button
+#: on it, and no string an admin retypes here is the same thing.
 CONNECTION_SCOPES: frozenset[str] = contract.enum("connectionScope")
 
 #: Field kinds a connection form can render. The same closed enum the automation
@@ -386,8 +393,8 @@ def _field(
     # value or an array is not something a consumer can infer.
     if allow_list and field.get("list") is True:
         cleaned["list"] = True
-    # Keys the app writes back itself, rather than the admin typing them: an
-    # interactive flow returns its result through the app's own write path.
+    # Keys the app writes back itself, rather than the admin typing them: a
+    # vendor flow returns its result through the app's own write path.
     if allow_managed and field.get("managed") is True:
         cleaned["managed"] = True
     return cleaned
@@ -463,11 +470,26 @@ def _connection(raw: Any) -> dict[str, Any]:
         fail(f"{what}: a static connection must declare at least one field")
 
     connect_path = connection.get("connect_path")
-    if scope == "interactive":
-        # The route the member is sent to so the app can run the vendor's flow.
+    if scope == "interactive" or connect_path is not None:
+        # Where a person is sent so the app can run the vendor's flow. Required
+        # on an interactive connection, which has no other way to be filled at
+        # all; offered on a static one, where it is the difference between an
+        # admin typing an organization's name into a box and an admin running
+        # the vendor's own install, on the vendor's page, for the whole guild.
         cleaned["connect_path"] = check_path(connect_path, what=f"{what} connect_path")
-    elif connect_path is not None:
-        fail(f"{what}: only an interactive connection has a connect_path")
+
+    if (
+        scope == "static"
+        and connect_path is not None
+        and not any(field.get("managed") is True for field in fields)
+    ):
+        # The app writing back is the only way a static connection with a flow
+        # is ever satisfied, so one with nothing managed to write into can do
+        # nothing but leave the install unconfigured forever.
+        fail(
+            f"{what}: a static connection with a connect_path must declare a "
+            "managed field for the flow to write into"
+        )
 
     hint = _access_hint(connection.get("access_hint"), what=what)
     if hint is not None:

--- a/backend/app/services/tenant/app_channels.py
+++ b/backend/app/services/tenant/app_channels.py
@@ -478,7 +478,7 @@ async def write_connection_values(
     status: Optional[str] = None,
     account_label: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Store what a vendor flow produced for one member's connection.
+    """Store what a vendor flow produced.
 
     The app runs the flow at its own URL and writes the result here, which is
     what makes Initiative the custodian of a credential the app obtained: the
@@ -486,9 +486,25 @@ async def write_connection_values(
     at 03:05. Only fields the manifest marked ``managed`` may be written this
     way — everything else on a connection is typed by a person.
 
+    The handle says which of two things is being written. A ref this install
+    minted for one of its own guild-wide connections is the credential the whole
+    guild uses, and it lives on the install row; anything else is looked up
+    among the per-member rows. An app cannot confuse them, because it never
+    invents a ref: it is handed one, and one nobody minted resolves to neither.
+
     A connection an admin blocked is refused: the block exists precisely to stop
     that member's access coming back.
     """
+    guild_connection = app_config_service.connection_id_for_ref(app, connection_ref)
+    if guild_connection is not None:
+        return await _write_guild_connection(
+            session,
+            app,
+            connection_id=guild_connection,
+            connection_ref=connection_ref,
+            values=values,
+        )
+
     row = await _row_by_ref(session, app, connection_ref)
     if row.blocked_at is not None:
         raise AppChannelError(AppChannelMessages.CONNECTION_BLOCKED, status_code=403)
@@ -529,6 +545,81 @@ async def write_connection_values(
         "created_at": row.created_at,
         "updated_at": row.updated_at,
     }
+
+
+async def _write_guild_connection(
+    session: AsyncSession,
+    app: GuildApp,
+    *,
+    connection_id: str,
+    connection_ref: str,
+    values: dict[str, Any],
+) -> dict[str, Any]:
+    """Store what an admin's vendor flow produced for the whole guild.
+
+    The same custody as a member's, one row up: the values land on the install
+    beside the ones an admin types, so clearing the connection, uninstalling the
+    app or moving to a version that no longer declares it take this with them.
+
+    Two arguments the member path has are absent here, and their absence is the
+    point rather than an omission. A ``status`` is not one of them, because a
+    guild connection has no row of its own to hold one — what it holds is
+    values, and whether they add up to a working connection is read off them
+    wherever it is asked. And there is no ``account_label``: a member's is the
+    only way an admin can see whose account was connected without being shown
+    the credential, whereas a guild connection's non-secret values are already
+    visible to the admin who governs it, so the vendor account belongs in a
+    field the manifest declares rather than in a label beside one.
+    """
+    connection = app_config_service.connection_by_id(app.definition, connection_id)
+    if connection is None:
+        # The install moved to a version that no longer declares this
+        # connection; its values are on their way out with it.
+        raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
+
+    try:
+        config, secrets = app_config_service.apply_connection_values(
+            connection,
+            values,
+            current=(app.config or {}).get(connection_id) or {},
+            current_secrets=(app.config_secrets or {}).get(connection_id) or {},
+            allow_managed=True,
+        )
+    except app_config_service.AppConfigError as exc:
+        raise AppChannelError(exc.code) from exc
+
+    # An emptied connection is stored as absent rather than as an empty map, so
+    # "has anything been configured here?" has one shape — the same rule the
+    # pruning and the admin's own form already keep.
+    app.config = _stored(app.config, connection_id, config)
+    app.config_secrets = _stored(app.config_secrets, connection_id, secrets)
+    app.updated_at = datetime.now(timezone.utc)
+    session.add(app)
+    await session.commit()
+    await session.refresh(app)
+
+    return {
+        "connection_id": connection_id,
+        "connection_ref": connection_ref,
+        "status": "connected"
+        if app_config_service.is_satisfied(connection, config, secrets)
+        else "pending",
+        "blocked": False,
+        "account_label": None,
+        "created_at": app.created_at,
+        "updated_at": app.updated_at,
+    }
+
+
+def _stored(
+    current: dict[str, Any] | None, connection_id: str, values: dict[str, Any]
+) -> dict[str, Any]:
+    kept = {
+        key: value for key, value in (current or {}).items() if key != connection_id
+    }
+    if values:
+        kept[connection_id] = values
+    return kept
 
 
 def _resolved_status(

--- a/backend/app/services/tenant/app_channels.py
+++ b/backend/app/services/tenant/app_channels.py
@@ -572,12 +572,6 @@ async def _write_guild_connection(
     visible to the admin who governs it, so the vendor account belongs in a
     field the manifest declares rather than in a label beside one.
     """
-    connection = app_config_service.connection_by_id(app.definition, connection_id)
-    if connection is None:
-        # The install moved to a version that no longer declares this
-        # connection; its values are on their way out with it.
-        raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
-
     # Both configuration maps are rewritten whole below, so the row is taken
     # first: a second write-back, or an admin saving the settings form, would
     # otherwise rebuild from a copy read before this one landed and put back
@@ -586,6 +580,20 @@ async def _write_guild_connection(
     if locked is None:
         raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
     app = locked
+
+    # Asked again now the row is held, because the wait is long enough for the
+    # answer to have changed: an upgrade may have moved the install to a version
+    # that declares no such connection, and an admin may have cleared this one,
+    # which drops the handle. Whatever was true when this request arrived is not
+    # what it gets to act on.
+    if app_config_service.connection_id_for_ref(app, connection_ref) != connection_id:
+        raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
+
+    connection = app_config_service.connection_by_id(app.definition, connection_id)
+    if connection is None:
+        # The install moved to a version that no longer declares this
+        # connection; its values are on their way out with it.
+        raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
 
     try:
         config, secrets = app_config_service.apply_connection_values(

--- a/backend/app/services/tenant/app_channels.py
+++ b/backend/app/services/tenant/app_channels.py
@@ -45,6 +45,7 @@ from app.models.tenant.guild_app import GuildApp
 from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
 from app.services.marketplace.service_apps import ENDPOINT_ID_PREFIX
 from app.services.tenant import app_config as app_config_service
+from app.services.tenant import guild_apps as guild_apps_service
 from app.services.tenant.webhook_dispatcher import dispatch_event
 
 logger = logging.getLogger(__name__)
@@ -576,6 +577,15 @@ async def _write_guild_connection(
         # The install moved to a version that no longer declares this
         # connection; its values are on their way out with it.
         raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
+
+    # Both configuration maps are rewritten whole below, so the row is taken
+    # first: a second write-back, or an admin saving the settings form, would
+    # otherwise rebuild from a copy read before this one landed and put back
+    # what it never saw.
+    locked = await guild_apps_service.lock_install(session, app.id)
+    if locked is None:
+        raise AppChannelError(AppChannelMessages.CONNECTION_NOT_FOUND, status_code=404)
+    app = locked
 
     try:
         config, secrets = app_config_service.apply_connection_values(

--- a/backend/app/services/tenant/app_config.py
+++ b/backend/app/services/tenant/app_config.py
@@ -158,10 +158,8 @@ def guild_connection_ref(app: Any, connection_id: str) -> str:
     holding the row inside a transaction it is about to commit, and a ref handed
     out but not stored is one the write-back would refuse.
 
-    That the ref exists at all is the authorization. The app is handed it in a
-    browser, where anyone can type a guild id, so a write-back naming a handle
-    nobody minted has to be refused rather than believed — which is what stops a
-    member binding their own organization to a guild whose admin never asked.
+    The ref is the authorization: a write-back is accepted for the connection
+    its handle names, and only for one this install actually minted.
     """
     refs = dict(app.connection_refs or {})
     existing = refs.get(connection_id)

--- a/backend/app/services/tenant/app_config.py
+++ b/backend/app/services/tenant/app_config.py
@@ -15,6 +15,14 @@ Two custody rules run through everything here:
   is written by the app itself when it completes a vendor flow, so this path
   refuses one rather than letting a form overwrite it.
 
+A guild-wide connection is not always typed. One that declares a
+``connect_path`` is filled by the app instead: a guild admin runs the vendor's
+own flow once — an organization-wide install, on the vendor's page, where
+somebody who owns the account grants what it may see — and the app writes what
+came back into that connection's managed fields. The scope is unchanged, since
+the credential is still the guild's; what changes is who fills it and how, and
+:func:`guild_connection_ref` is the handle the two ends are joined by.
+
 Satisfaction is computed from presence alone — which fields have values. This
 build never inspects a credential, calls a vendor, or learns a scope; whether a
 credential carries the permissions it needs is the app's to report, and arrives
@@ -28,6 +36,7 @@ from typing import Any, Optional
 
 from app.core.encryption import SALT_APP_CONFIG, decrypt_field, encrypt_field
 from app.core.messages import GuildAppMessages
+from app.services.tenant.app_connections import mint_connection_ref
 
 __all__ = [
     "AppConfigError",
@@ -38,13 +47,16 @@ __all__ = [
     "apply_connection_values",
     "config_state",
     "connection_by_id",
+    "connection_id_for_ref",
     "decrypt_connection_secrets",
     "definition_connections",
+    "guild_connection_ref",
     "has_value_map",
     "is_satisfied",
     "member_connection_ids",
     "needs_configuration",
     "prune_to_definition",
+    "runs_vendor_flow",
 ]
 
 #: What a plain field may hold. Generous for a hostname or an account name,
@@ -117,6 +129,63 @@ def connection_by_id(
     for connection in definition_connections(definition):
         if connection.get("id") == connection_id:
             return connection
+    return None
+
+
+def runs_vendor_flow(connection: dict[str, Any] | None) -> bool:
+    """Whether this connection is filled by the app rather than by typing.
+
+    The question a ``connect_path`` answers, asked of either scope. The scope
+    answers a different one — whose credential comes back — and the two are
+    independent: a member authorizing their own account and an admin installing
+    for the whole guild are the same flow run by different people.
+    """
+    return bool(connection) and bool(connection.get("connect_path"))
+
+
+# --- the handle a guild-wide flow is joined by -------------------------------
+
+
+def guild_connection_ref(app: Any, connection_id: str) -> str:
+    """The opaque handle the app writes this guild connection's result against.
+
+    Minted on the admin's first connect and kept, so reconnecting keeps one
+    identity rather than minting a new one each time — the rule a member's ref
+    already follows. It lives on the install row because a guild-wide credential
+    does.
+
+    Mutating rather than returning a new mapping is deliberate: the caller is
+    holding the row inside a transaction it is about to commit, and a ref handed
+    out but not stored is one the write-back would refuse.
+
+    That the ref exists at all is the authorization. The app is handed it in a
+    browser, where anyone can type a guild id, so a write-back naming a handle
+    nobody minted has to be refused rather than believed — which is what stops a
+    member binding their own organization to a guild whose admin never asked.
+    """
+    refs = dict(app.connection_refs or {})
+    existing = refs.get(connection_id)
+    if isinstance(existing, str) and existing:
+        return existing
+
+    refs[connection_id] = mint_connection_ref()
+    # Reassigned rather than mutated in place: SQLAlchemy tracks a JSONB column
+    # by identity, and a dict changed under it is a change that never lands.
+    app.connection_refs = refs
+    return refs[connection_id]
+
+
+def connection_id_for_ref(app: Any, connection_ref: str) -> Optional[str]:
+    """Which guild connection a handle names, or ``None`` for none of them.
+
+    ``None`` is the ordinary answer for a member's ref, which this install keeps
+    nowhere: the caller tries the per-member rows and finds it there.
+    """
+    if not connection_ref:
+        return None
+    for connection_id, ref in (app.connection_refs or {}).items():
+        if ref == connection_ref:
+            return connection_id
     return None
 
 

--- a/backend/app/services/tenant/app_config.py
+++ b/backend/app/services/tenant/app_config.py
@@ -151,8 +151,9 @@ def guild_connection_ref(app: Any, connection_id: str) -> str:
 
     Minted on the admin's first connect and kept, so reconnecting keeps one
     identity rather than minting a new one each time — the rule a member's ref
-    already follows. It lives on the install row because a guild-wide credential
-    does.
+    already follows. Clearing the connection drops it, since the flow it was
+    routing is over; starting again mints a fresh one. It lives on the install
+    row because a guild-wide credential does.
 
     Mutating rather than returning a new mapping is deliberate: the caller is
     holding the row inside a transaction it is about to commit, and a ref handed

--- a/backend/app/services/tenant/app_config_test.py
+++ b/backend/app/services/tenant/app_config_test.py
@@ -20,12 +20,15 @@ from app.services.tenant.app_config import (
     AppConfigError,
     apply_connection_values,
     connection_by_id,
+    connection_id_for_ref,
     decrypt_connection_secrets,
     definition_connections,
+    guild_connection_ref,
     has_value_map,
     is_satisfied,
     needs_configuration,
     prune_to_definition,
+    runs_vendor_flow,
 )
 
 pytestmark = pytest.mark.unit
@@ -57,10 +60,31 @@ MEMBER_CONNECTION = {
     "fields": [_field("access_token", "secret", managed=True)],
 }
 
+#: A guild-wide credential obtained rather than typed.
+#:
+#: The vendor authorizes an organization through a page of its own, so an admin
+#: is sent there and the app writes down what came back. Same scope as
+#: ``ADMIN_CONNECTION`` — one credential for everybody — and a different way of
+#: arriving at one.
+WORKSPACE_CONNECTION = {
+    "id": "workspace",
+    "scope": "static",
+    "label": {"en": "Organization"},
+    "connect_path": "/install/github",
+    "fields": [_field("owner", "string", required=True, managed=True)],
+}
+
 DEFINITION = {
     "app_kind": "service",
     "connections": [ADMIN_CONNECTION, MEMBER_CONNECTION],
 }
+
+
+class _Install:
+    """Just enough of a ``GuildApp`` row for the handle helpers."""
+
+    def __init__(self, refs=None):
+        self.connection_refs = refs if refs is not None else {}
 
 
 def _apply(submitted: dict, *, current=None, secrets=None, **kwargs):
@@ -294,3 +318,91 @@ class TestPruningToANewDefinition:
         config, _, dropped = prune_to_definition(DEFINITION, stored, {})
         assert config == stored
         assert dropped == set()
+
+
+class TestWhichConnectionsRunAFlow:
+    def test_a_flow_is_a_connect_path_and_not_a_scope(self):
+        """Two independent questions, and they used to look like one.
+
+        The scope says whose credential comes back. The ``connect_path`` says
+        whether a vendor is involved in getting it. A guild-wide connection may
+        have one, and an admin running an organization-wide install is the case
+        it exists for.
+        """
+        assert runs_vendor_flow(MEMBER_CONNECTION) is True
+        assert runs_vendor_flow(WORKSPACE_CONNECTION) is True
+        assert runs_vendor_flow(ADMIN_CONNECTION) is False
+        assert runs_vendor_flow(None) is False
+
+
+class TestTheHandleAGuildFlowIsJoinedBy:
+    def test_a_handle_is_minted_onto_the_install_and_kept(self):
+        """Reconnecting writes over one connection rather than making a second.
+
+        A fresh handle each time would leave the app holding one this side no
+        longer recognizes, so the write-back at the end of the flow an admin
+        actually completed would be refused.
+        """
+        install = _Install()
+        first = guild_connection_ref(install, "workspace")
+
+        assert first
+        assert install.connection_refs == {"workspace": first}
+        assert guild_connection_ref(install, "workspace") == first
+
+    def test_each_connection_gets_its_own(self):
+        install = _Install()
+        one = guild_connection_ref(install, "workspace")
+        two = guild_connection_ref(install, "billing")
+
+        assert one != two
+        assert set(install.connection_refs) == {"workspace", "billing"}
+
+    def test_the_column_is_reassigned_rather_than_mutated(self):
+        """SQLAlchemy tracks a JSONB column by identity.
+
+        A dict changed in place under it is a change that never lands, and the
+        symptom is a handle handed to an app that this side then refuses.
+        """
+        held = {}
+        install = _Install(held)
+        guild_connection_ref(install, "workspace")
+
+        assert held == {}
+        assert install.connection_refs != held
+
+    def test_a_handle_resolves_back_to_the_connection_it_names(self):
+        install = _Install()
+        ref = guild_connection_ref(install, "workspace")
+
+        assert connection_id_for_ref(install, ref) == "workspace"
+
+    def test_a_handle_nobody_minted_names_nothing(self):
+        """The refusal the whole handle exists for.
+
+        An app is handed one of these in a browser, where anybody can type a
+        guild id. ``None`` is also the ordinary answer for a member's handle,
+        which lives on a row of its own and not here.
+        """
+        install = _Install({"workspace": "gcr_real"})
+
+        assert connection_id_for_ref(install, "gcr_invented") is None
+        assert connection_id_for_ref(install, "") is None
+        assert connection_id_for_ref(_Install(), "gcr_real") is None
+
+
+class TestAFlowFilledConnectionIsStillConfiguration:
+    def test_an_install_needs_configuring_until_the_flow_has_run(self):
+        """Nobody types anything, and it is still unfinished until it is done.
+
+        Satisfaction is presence, wherever the values came from — so the
+        settings page says an admin still has something to do, and what they
+        have to do is press Connect.
+        """
+        definition = {"app_kind": "service", "connections": [WORKSPACE_CONNECTION]}
+
+        assert needs_configuration(definition, {}, {}) is True
+        assert (
+            needs_configuration(definition, {"workspace": {"owner": "acme"}}, {})
+            is False
+        )

--- a/backend/app/services/tenant/app_config_test.py
+++ b/backend/app/services/tenant/app_config_test.py
@@ -378,11 +378,10 @@ class TestTheHandleAGuildFlowIsJoinedBy:
         assert connection_id_for_ref(install, ref) == "workspace"
 
     def test_a_handle_nobody_minted_names_nothing(self):
-        """The refusal the whole handle exists for.
+        """A handle this install never minted names none of its connections.
 
-        An app is handed one of these in a browser, where anybody can type a
-        guild id. ``None`` is also the ordinary answer for a member's handle,
-        which lives on a row of its own and not here.
+        ``None`` is also the ordinary answer for a member's handle, which lives
+        on a row of its own and not here.
         """
         install = _Install({"workspace": "gcr_real"})
 

--- a/backend/app/services/tenant/guild_apps.py
+++ b/backend/app/services/tenant/guild_apps.py
@@ -210,7 +210,7 @@ def get_app_content_id(app: GuildApp) -> Optional[int]:
 
 
 async def find_mounting_app(
-    session: AsyncSession, *, guild_id: int, tool: str
+    session: AsyncSession, *, guild_id: int, tool: str, for_update: bool = False
 ) -> Optional[GuildApp]:
     """The install that mounts ``tool`` at guild scope, if this guild has one.
 
@@ -219,6 +219,14 @@ async def find_mounting_app(
     asked before creating one, and answered from the install rows rather than
     from the content, since an install with everything trashed is still the
     container.
+
+    ``for_update`` holds the row for the rest of the transaction, and is how
+    putting something *into* an app orders itself against removing the app.
+    Removal takes the same lock before it reads what to trash, so the two happen
+    in an order rather than at once: whichever is second either trashes the new
+    content along with the rest, or finds no install and refuses. Without the
+    lock a calendar could be committed just as its app went away, and would then
+    be live with nothing that reaches it and no removal that knows about it.
     """
     apps = (
         await session.exec(select(GuildApp).where(GuildApp.guild_id == guild_id))
@@ -227,7 +235,19 @@ async def find_mounting_app(
         if (app.definition or {}).get("app_kind") != "tool_instance":
             continue
         if (app.definition or {}).get("tool") == tool:
-            return app
+            if not for_update:
+                return app
+            # Read again under the lock. It answers None if the row went away
+            # between finding it and holding it, which is the same answer as
+            # this guild never having had one.
+            return (
+                await session.exec(
+                    select(GuildApp)
+                    .where(GuildApp.id == app.id)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                )
+            ).first()
     return None
 
 

--- a/backend/app/services/tenant/guild_apps.py
+++ b/backend/app/services/tenant/guild_apps.py
@@ -61,6 +61,7 @@ __all__ = [
     "get_app_content_id",
     "install_app",
     "legacy_artifacts",
+    "lock_install",
     "normalize_placement",
     "placed_in",
     "record_artifact",
@@ -209,6 +210,29 @@ def get_app_content_id(app: GuildApp) -> Optional[int]:
     return artifacts[0]["id"] if artifacts else None
 
 
+async def lock_install(session: AsyncSession, app_id: int) -> Optional[GuildApp]:
+    """Hold one install's row for the rest of this transaction.
+
+    Several things on this row are values rewritten whole rather than appended
+    to — the configuration maps, the connection handles — so writing one means
+    reading it, changing it, and putting the result back. Two of those
+    overlapping would have the second write carry a value read before the first
+    landed, and the first change would be gone with no sign that it had been
+    made. Taking the row first puts them in an order instead.
+
+    Answers ``None`` if the row is gone, which is the same answer as this guild
+    never having had the install.
+    """
+    return (
+        await session.exec(
+            select(GuildApp)
+            .where(GuildApp.id == app_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+    ).first()
+
+
 async def find_mounting_app(
     session: AsyncSession, *, guild_id: int, tool: str, for_update: bool = False
 ) -> Optional[GuildApp]:
@@ -235,19 +259,7 @@ async def find_mounting_app(
         if (app.definition or {}).get("app_kind") != "tool_instance":
             continue
         if (app.definition or {}).get("tool") == tool:
-            if not for_update:
-                return app
-            # Read again under the lock. It answers None if the row went away
-            # between finding it and holding it, which is the same answer as
-            # this guild never having had one.
-            return (
-                await session.exec(
-                    select(GuildApp)
-                    .where(GuildApp.id == app.id)
-                    .with_for_update()
-                    .execution_options(populate_existing=True)
-                )
-            ).first()
+            return app if not for_update else await lock_install(session, app.id)
     return None
 
 

--- a/frontend/public/locales/de/apps.json
+++ b/frontend/public/locales/de/apps.json
@@ -63,6 +63,7 @@
     "cleared": "Zugangsdaten gelöscht.",
     "memberSet": "Eine Gildenadministration hat das eingerichtet.",
     "memberNotSet": "Eine Gildenadministration muss das noch einrichten.",
+    "guildFlowExplainer": "Diese wird beim Anbieter erteilt statt eingetippt. Beim Verbinden öffnet sich dessen Installationsseite, wo du das Konto wählst und was diese App sehen darf.",
     "personalExplainer": "Hier meldest du dich als du selbst an, deshalb verbindet jedes Mitglied sein eigenes Konto. Deins sieht sonst niemand.",
     "connect": "Verbinden",
     "reconnect": "Neu verbinden",

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -415,7 +415,7 @@
   "GUILD_APP_CONFIG_REQUIRED_FIELD": "Fülle vor dem Speichern alle Pflichtfelder aus.",
   "GUILD_APP_CONFIG_MANAGED_FIELD": "Das trägt die App beim Verbinden selbst ein — hier kannst du es nicht eingeben.",
   "GUILD_APP_CONNECTION_NOT_FOUND": "Diese Verbindung gehört nicht zu dieser App.",
-  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Diese Verbindung nutzt eine Zugangsberechtigung für die ganze Gilde, es gibt also kein Konto zu verbinden.",
+  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Diese Verbindung wird über das Einstellungsformular ausgefüllt, es gibt also keinen Anbieter, zu dem du geschickt werden könntest.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "Diese Verbindung gehört jedem Mitglied selbst und wird verbunden statt ausgefüllt.",
   "GUILD_APP_CONNECTION_BLOCKED": "Eine Gildenadministration hat dir diese Verbindung untersagt.",
   "GUILD_APP_DISABLED": "Diese App ist ausgeschaltet, es läuft nichts über sie.",

--- a/frontend/public/locales/en/apps.json
+++ b/frontend/public/locales/en/apps.json
@@ -63,6 +63,7 @@
     "cleared": "Credential cleared.",
     "memberSet": "A guild admin has set this up.",
     "memberNotSet": "A guild admin still has to set this up.",
+    "guildFlowExplainer": "This one is granted at the vendor rather than typed. Connecting opens their install page, where you choose the account and what this app may see.",
     "personalExplainer": "This one signs you in as yourself, so each member connects their own account. Nobody else sees yours.",
     "connect": "Connect",
     "reconnect": "Reconnect",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -415,7 +415,7 @@
   "GUILD_APP_CONFIG_REQUIRED_FIELD": "Fill in every required field before saving.",
   "GUILD_APP_CONFIG_MANAGED_FIELD": "The app fills this in itself when you connect — you can't type it here.",
   "GUILD_APP_CONNECTION_NOT_FOUND": "That connection isn't part of this app.",
-  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "This connection uses one credential for the whole guild, so there's no account to connect.",
+  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "This connection is filled in from the settings form, so there is no vendor to send you to.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "This connection is each member's own, so it's connected rather than filled in.",
   "GUILD_APP_CONNECTION_BLOCKED": "A guild admin has stopped you connecting this.",
   "GUILD_APP_DISABLED": "This app is turned off, so nothing flows through it.",

--- a/frontend/public/locales/es/apps.json
+++ b/frontend/public/locales/es/apps.json
@@ -63,6 +63,7 @@
     "cleared": "Credencial borrada.",
     "memberSet": "Un administrador del gremio ya la ha configurado.",
     "memberNotSet": "Un administrador del gremio todavía tiene que configurarla.",
+    "guildFlowExplainer": "Esta se concede en el proveedor en lugar de escribirse. Al conectar se abre su página de instalación, donde eliges la cuenta y qué puede ver esta app.",
     "personalExplainer": "Esta te identifica a ti, así que cada miembro conecta su propia cuenta. Nadie más ve la tuya.",
     "connect": "Conectar",
     "reconnect": "Volver a conectar",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -415,7 +415,7 @@
   "GUILD_APP_CONFIG_REQUIRED_FIELD": "Rellena todos los campos obligatorios antes de guardar.",
   "GUILD_APP_CONFIG_MANAGED_FIELD": "La aplicación lo rellena sola al conectarte: aquí no puedes escribirlo.",
   "GUILD_APP_CONNECTION_NOT_FOUND": "Esa conexión no forma parte de esta aplicación.",
-  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Esta conexión usa una sola credencial para todo el gremio, así que no hay ninguna cuenta que conectar.",
+  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Esta conexión se rellena desde el formulario de ajustes, así que no hay ningún proveedor al que enviarte.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "Esta conexión es la de cada miembro, así que se conecta en lugar de rellenarse.",
   "GUILD_APP_CONNECTION_BLOCKED": "Un administrador del gremio te ha impedido conectar esto.",
   "GUILD_APP_DISABLED": "Esta aplicación está desactivada, así que no pasa nada por ella.",

--- a/frontend/public/locales/fr/apps.json
+++ b/frontend/public/locales/fr/apps.json
@@ -63,6 +63,7 @@
     "cleared": "Identifiant effacé.",
     "memberSet": "Une administratrice ou un administrateur de la guilde l'a configuré.",
     "memberNotSet": "Une administratrice ou un administrateur de la guilde doit encore le configurer.",
+    "guildFlowExplainer": "Celle-ci s'accorde chez le fournisseur plutôt qu'en la saisissant. Se connecter ouvre sa page d'installation, où vous choisissez le compte et ce que cette app peut voir.",
     "personalExplainer": "Celle-ci vous identifie en tant que vous, donc chaque membre connecte son propre compte. Personne d'autre ne voit le vôtre.",
     "connect": "Connecter",
     "reconnect": "Reconnecter",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -415,7 +415,7 @@
   "GUILD_APP_CONFIG_REQUIRED_FIELD": "Renseignez tous les champs obligatoires avant d'enregistrer.",
   "GUILD_APP_CONFIG_MANAGED_FIELD": "L'application le renseigne elle-même lors de la connexion : vous ne pouvez pas le saisir ici.",
   "GUILD_APP_CONNECTION_NOT_FOUND": "Cette connexion ne fait pas partie de cette application.",
-  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Cette connexion utilise un seul identifiant pour toute la guilde : il n'y a donc aucun compte à connecter.",
+  "GUILD_APP_CONNECTION_NOT_INTERACTIVE": "Cette connexion se remplit depuis le formulaire de réglages : il n'y a donc aucun fournisseur vers lequel vous envoyer.",
   "GUILD_APP_CONNECTION_NOT_STATIC": "Cette connexion appartient à chaque membre : elle se connecte au lieu de se remplir.",
   "GUILD_APP_CONNECTION_BLOCKED": "L'administration de la guilde vous a interdit cette connexion.",
   "GUILD_APP_DISABLED": "Cette application est désactivée : rien ne passe par elle.",

--- a/frontend/src/api/generated/apps/apps.ts
+++ b/frontend/src/api/generated/apps/apps.ts
@@ -1380,13 +1380,21 @@ export const useCreateGuildAppHandoffApiV1GGuildIdAppsAppIdHandoffSurfaceIdPost 
   );
 };
 /**
- * Start this member's own connection to an app's vendor.
+ * Start the vendor flow behind one connection.
  *
- * Any member may: the vendor is going to authorize *them*, and what the
- * resulting credential reaches is what they already reach. The row and its
- * opaque handle are minted here so the app has something to write its result
- * against; the vendor flow itself runs at the app's own URL.
+ * Two kinds run through here, and the connection's scope decides which:
  *
+ * * **A member's own account.** Any member may, because the vendor is going to
+ *   authorize *them* and what the resulting credential reaches is what they
+ *   already reach.
+ * * **The guild's own credential**, where the vendor authorizes an
+ *   organization through a page of its own rather than through anything an
+ *   admin could type. A guild admin only — it is one credential for everybody,
+ *   and the install it produces is the guild's boundary, so this is governance
+ *   in exactly the way configuring the same connection by hand is.
+ *
+ * Either way the opaque handle is minted here so the app has something to
+ * write its result against, and the flow itself runs at the app's own URL.
  * That URL is assembled server-side — the registration supplies the address,
  * the manifest supplies the path — and carries the ``connection_ref`` so the
  * app knows which credential it is about to hold. The ref is an identifier,

--- a/frontend/src/components/apps/AppConnectionsPanel.test.tsx
+++ b/frontend/src/components/apps/AppConnectionsPanel.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * How a guild's own credential is drawn, now that not all of them are typed.
+ *
+ * The panel has always split connections by who supplies them. The newer split
+ * is inside the guild half: some are a form an admin fills in, and some are
+ * granted at the vendor — an organization-wide install on the vendor's own
+ * page, which no text box can express. A connection with a `connect_path` gets
+ * a button instead of inputs, and what came back is shown rather than reduced
+ * to "Set", because an admin who just chose an account needs to be able to see
+ * which one they chose.
+ */
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+import type { AppConnection } from "@/api/appConnections";
+
+import { AppConnectionsPanel } from "./AppConnectionsPanel";
+
+const connect = vi.fn();
+const save = vi.fn();
+const disconnect = vi.fn();
+
+vi.mock("@/hooks/useGuildAppDetail", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useGuildAppDetail")>()),
+  useConnectApp: () => ({ mutate: connect, isPending: false }),
+  useUpdateAppConfig: () => ({ mutate: save, isPending: false }),
+  useDisconnectApp: () => ({ mutate: disconnect, isPending: false }),
+}));
+
+const opened = vi.fn();
+
+const base: AppConnection = {
+  id: "workspace",
+  scope: "static",
+  label: { en: "GitHub organization" },
+  fields: [],
+  values: {},
+  has_value: {},
+  satisfied: false,
+  blocked: false,
+};
+
+/** The guild's own credential, granted at the vendor rather than typed. */
+const vendorFlow: AppConnection = {
+  ...base,
+  connect_path: "/install/github",
+  fields: [{ key: "owner", type: "string", label: { en: "Owner" }, required: true, managed: true }],
+};
+
+/** The other kind: a form an admin fills in. */
+const typed: AppConnection = {
+  ...base,
+  id: "admin",
+  label: { en: "Admin API" },
+  fields: [{ key: "shop_domain", type: "string", label: { en: "Shop domain" }, required: true }],
+};
+
+const render = (connection: AppConnection, isGuildAdmin = true) =>
+  renderPage(() => (
+    <AppConnectionsPanel appId={3} connections={[connection]} isGuildAdmin={isGuildAdmin} />
+  ));
+
+beforeEach(() => {
+  connect.mockReset();
+  save.mockReset();
+  disconnect.mockReset();
+  opened.mockReset();
+  vi.stubGlobal("open", opened);
+});
+
+describe("a guild credential granted at the vendor", () => {
+  it("offers a button rather than a form", async () => {
+    render(vendorFlow);
+
+    expect(await screen.findByRole("button", { name: "Connect" })).toBeInTheDocument();
+    // Every field is written back by the app, so there is nothing to type and
+    // nothing to save.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+  });
+
+  it("sends the admin to the address the server built", async () => {
+    connect.mockImplementation((_id, options) =>
+      options.onSuccess({ connect_url: "https://github-app.test/install/github?x=1" })
+    );
+    render(vendorFlow);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Connect" }));
+
+    await waitFor(() => expect(connect).toHaveBeenCalledWith("workspace", expect.anything()));
+    // A new tab, and one that cannot reach back into this page.
+    expect(opened).toHaveBeenCalledWith(
+      "https://github-app.test/install/github?x=1",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("shows what the flow recorded, not just that something is set", async () => {
+    render({
+      ...vendorFlow,
+      satisfied: true,
+      has_value: { owner: true },
+      values: { owner: "morelitea" },
+    });
+
+    expect(await screen.findByText("morelitea")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
+  });
+
+  it("tells a member who cannot manage it what they are waiting on", async () => {
+    render(vendorFlow, false);
+
+    expect(await screen.findByText(/guild admin still has to set this up/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+  });
+});
+
+describe("a guild credential that is typed", () => {
+  it("still draws its form, and no vendor button", async () => {
+    render(typed);
+
+    expect(await screen.findByLabelText(/Shop domain/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/apps/AppConnectionsPanel.tsx
+++ b/frontend/src/components/apps/AppConnectionsPanel.tsx
@@ -9,7 +9,10 @@
  *
  * - A **guild connection** is one credential the whole guild uses. A guild
  *   admin fills it in; everyone else sees whether it is set, because whether an
- *   app can do its job is not a secret.
+ *   app can do its job is not a secret. Some are typed and some are not: where
+ *   the vendor authorizes an organization through a page of its own, the admin
+ *   is sent there and the app writes down what came back, so the form has
+ *   nothing in it and a button instead.
  * - A **personal connection** is each member's own account at a vendor that
  *   authorizes people rather than organizations. Every member sees their own
  *   state and only their own — the server answers per viewer, so there is
@@ -24,7 +27,7 @@
  */
 
 import { KeyRound, Loader2, Plug, ShieldCheck, TriangleAlert } from "lucide-react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { AppConfigValue, AppConnection, AppConnectionField } from "@/api/appConnections";
@@ -136,14 +139,46 @@ function GuildConnection({
   connection: AppConnection;
   canManage: boolean;
 }) {
-  const { t } = useTranslation(["apps", "common"]);
+  const { t, i18n } = useTranslation(["apps", "common"]);
   const [draft, setDraft] = useState<Record<string, AppConfigValue>>({});
   const save = useUpdateAppConfig(appId);
   const clear = useDisconnectApp(appId);
+  const connect = useConnectApp(appId);
 
   // Only what was touched. A secret already stored renders empty, so sending
   // untouched keys would clear the values the admin came here to keep.
   const touched = Object.keys(draft);
+
+  // A field the app writes back itself is never typed here, so a connection
+  // whose every field is managed has no form at all — which is exactly the
+  // case a `connect_path` exists for.
+  const typed = connection.fields.filter((field) => !field.managed);
+  const vendorFlow = Boolean(connection.connect_path);
+
+  // What the app wrote back, shown rather than reduced to "Set". Otherwise the
+  // admin who just chose an account at a vendor has no way to see which one
+  // they chose — and no way to notice they chose the wrong one. Secrets are
+  // absent by construction: `values` carries the non-secret half and the other
+  // one is never sent back.
+  const recorded = connection.fields.filter(
+    (field) => field.managed && connection.values[field.key] !== undefined
+  );
+
+  const start = () =>
+    connect.mutate(connection.id, {
+      onSuccess: (started) => {
+        // A new tab rather than a redirect, so the admin comes back to where
+        // they were; `noopener` keeps the app's page from reaching into this
+        // one. The address is the server's to build — see PersonalConnection.
+        if (started.connect_url) {
+          window.open(started.connect_url, "_blank", "noopener,noreferrer");
+          toast.success(t("apps:connections.connectOpened"));
+          return;
+        }
+        toast.error(t("apps:connections.connectUnavailable"));
+      },
+      onError: (error) => toast.error(getErrorMessage(error, "apps:error")),
+    });
 
   const submit = () => {
     save.mutate(
@@ -166,10 +201,26 @@ function GuildConnection({
     >
       {canManage ? (
         <>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {connection.fields
-              .filter((field) => !field.managed)
-              .map((field) => (
+          {vendorFlow && (
+            <p className="text-muted-foreground text-sm">
+              {t("apps:connections.guildFlowExplainer")}
+            </p>
+          )}
+          {recorded.length > 0 && (
+            <dl className="grid gap-x-3 gap-y-1 text-sm sm:grid-cols-[max-content_1fr]">
+              {recorded.map((field) => (
+                <Fragment key={field.key}>
+                  <dt className="text-muted-foreground">
+                    {localized(field.label, i18n.language) ?? field.key}
+                  </dt>
+                  <dd className="break-all">{String(connection.values[field.key])}</dd>
+                </Fragment>
+              ))}
+            </dl>
+          )}
+          {typed.length > 0 && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {typed.map((field) => (
                 <ConnectionFieldInput
                   key={field.key}
                   field={field}
@@ -178,12 +229,23 @@ function GuildConnection({
                   onChange={(value) => setDraft((prev) => ({ ...prev, [field.key]: value }))}
                 />
               ))}
-          </div>
+            </div>
+          )}
           <div className="flex flex-wrap items-center gap-2">
-            <Button size="sm" onClick={submit} disabled={!touched.length || save.isPending}>
-              {save.isPending && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
-              {t("common:save")}
-            </Button>
+            {vendorFlow && (
+              <Button size="sm" onClick={start} disabled={connect.isPending}>
+                {connect.isPending && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                {connection.satisfied
+                  ? t("apps:connections.reconnect")
+                  : t("apps:connections.connect")}
+              </Button>
+            )}
+            {typed.length > 0 && (
+              <Button size="sm" onClick={submit} disabled={!touched.length || save.isPending}>
+                {save.isPending && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                {t("common:save")}
+              </Button>
+            )}
             {connection.satisfied && (
               <Button
                 size="sm"


### PR DESCRIPTION
## Problem

Two unrelated things, bundled at the author's request.

**A guild-wide connection could only be typed.** Some vendors don't authorize an organization by anything an admin can put in a text box — the organization-wide install lives behind a page of their own, where somebody who owns the account chooses what the app may see, and what comes back is an installation rather than a name. The only way to join that to a guild was an admin retyping the organization's login and hoping it matched whatever somebody had installed.

**A guild calendar and its app could part company.** Follow-up to the review on #1262 (merged). Creating a guild calendar and removing the calendar app both touch the install row, without agreeing on an order.

## Changes

### Guild-wide vendor flows

- [service_apps.py](backend/app/services/marketplace/service_apps.py) — a `static` connection may now declare a `connect_path`. Scope stays the question of *whose* credential it is; `connect_path` is the second question, of how it is obtained, and either scope may answer it. A static connection with a `connect_path` but no `managed` field is refused — the app writing back is the only way such a connection is ever satisfied, so one with nothing to write into could never be configured.
- [20260828_0198](backend/alembic/versions/20260828_0198_app_guild_connection_refs.py) — `guild_apps.connection_refs`, keyed by connection id. The handle the two ends are joined by: minted when the admin starts, carried to the app in the browser, and named again when the app writes back over its own authenticated channel. A write-back naming a handle the column never held is refused.
- [AppConnectionsPanel.tsx](frontend/src/components/apps/AppConnectionsPanel.tsx) — such a connection offers Connect rather than a form, with copy saying where it sends you.
- Copy added to all four locales; `GUILD_APP_CONNECTION_NOT_INTERACTIVE` reworded, since "there's no account to connect" stopped being the reason.

### Calendar/app ordering

- [guild_apps.py](backend/app/services/tenant/guild_apps.py) / [guild_apps.py](backend/app/api/v1/tenant_endpoints/guild_apps.py) / [calendars.py](backend/app/api/v1/tenant_endpoints/calendars.py) — both sides take the install row's lock before reading what it holds. Whichever arrives second either trashes the new calendar along with everything else, or finds no install and refuses. Previously a create could commit its calendar just as the app went away, leaving it live with nothing that reaches it, or removal could walk an artifact list taken before the create appended to it.

## Testing

```
cd backend && ruff check app && ruff format app && ty check app          # clean
cd backend && pytest app/api/v1/app_service_endpoints/installs_test.py \
  app/api/v1/tenant_endpoints/guild_app_connections_test.py \
  app/api/v1/tenant_endpoints/guild_apps_test.py \
  app/services/marketplace/definitions_test.py                           # 234 passed
cd backend && pytest app/api/v1/tenant_endpoints/guild_apps_test.py \
  app/api/v1/tenant_endpoints/calendars_test.py \
  app/services/tenant/guild_apps_test.py                                 # 65 passed
cd frontend && pnpm typecheck                                            # clean
cd frontend && ./scripts/test-changed.sh                                 # 1801 passed (155 files)
```

Note for anyone running the suite locally: this adds a migration, so drop the persisted `initiative_test_*` database first or every `guild_apps` read fails on the missing column.

New test `test_removal_trashes_a_calendar_added_after_the_install` covers the ordering end to end — a calendar added through the API after install goes to the trash with the one the install mounted.