### PR TITLE
Always run dev cleanup on shutdown

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,16 @@
   "version": "0.2.0",
   "configurations": [
     {
+      // Runs the same orchestration script as the Zed task and `claude --debug`,
+      // so startup and teardown behave identically everywhere. The script traps
+      // signals and runs dev:cleanup itself when the terminal is interrupted or
+      // closed; postDebugTask is the backstop for a hard stop that never reaches
+      // the trap.
       "name": "Dev Environment",
       "type": "node-terminal",
       "request": "launch",
-      "command": "echo 'Dev environment is running. Press Ctrl+C to stop.'",
-      "preLaunchTask": "dev:setup",
+      "command": "bash ${workspaceFolder}/scripts/dev-pre-launch.sh",
+      "cwd": "${workspaceFolder}",
       "postDebugTask": "dev:cleanup"
     }
   ]

--- a/scripts/dev-cleanup.sh
+++ b/scripts/dev-cleanup.sh
@@ -1,39 +1,79 @@
 #!/usr/bin/env bash
-# Stop dev servers and remove seeded dev data
-set -e
+# Stop dev servers and remove seeded dev data.
+#
+# This is the teardown path, so it never aborts partway: a missing venv or an
+# unreachable database must not leave the servers running or skip the data
+# clean. Each step reports what went wrong and the exit code reflects it.
+set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+status=0
+
+# PIDs listening on a TCP port, via whichever tool this machine has.
+port_pids() {
+    if command -v lsof &>/dev/null; then
+        lsof -ti:"$1" 2>/dev/null
+    elif command -v fuser &>/dev/null; then
+        fuser "$1"/tcp 2>/dev/null | tr ' ' '\n'
+    fi
+}
+
+# Ask the listeners on a port to stop, then force whatever is still holding it.
+stop_port() {
+    local port="$1" label="$2" pids
+    pids=$(port_pids "$port")
+    [ -n "$pids" ] || return 0
+
+    echo "  stopping $label on port $port"
+    kill $pids 2>/dev/null || true
+
+    # Poll against a wall-clock deadline rather than a fixed iteration count —
+    # looking the port up is itself slow enough to stretch a counted loop well
+    # past the grace period it was meant to allow.
+    local deadline=$((SECONDS + 5))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        pids=$(port_pids "$port")
+        [ -n "$pids" ] || return 0
+        sleep 0.2
+    done
+    pids=$(port_pids "$port")
+    [ -n "$pids" ] || return 0
+
+    echo "  $label did not stop on its own — forcing"
+    kill -9 $pids 2>/dev/null || true
+}
+
 echo "Stopping dev servers..."
+stop_port 8000 "backend"
+stop_port 5173 "frontend"
 
-# Stop backend (uvicorn on port 8000)
-if command -v lsof &>/dev/null; then
-    lsof -ti:8000 2>/dev/null | xargs kill 2>/dev/null || true
-elif command -v fuser &>/dev/null; then
-    fuser -k 8000/tcp 2>/dev/null || true
-fi
-# Also kill by process name as fallback
+# Fallbacks for servers that are up but not listening yet (killed mid-startup,
+# or still binding the port).
 pkill -f "uvicorn app.main:app" 2>/dev/null || true
-
-# Stop frontend (Vite on port 5173)
-if command -v lsof &>/dev/null; then
-    lsof -ti:5173 2>/dev/null | xargs kill 2>/dev/null || true
-elif command -v fuser &>/dev/null; then
-    fuser -k 5173/tcp 2>/dev/null || true
-fi
-# Also kill by process name as fallback
 pkill -f "vite" 2>/dev/null || true
-
-# Give processes a moment to shut down
-sleep 1
 
 echo "Servers stopped."
 
-cd "$SCRIPT_DIR/../backend"
+if ! cd "$SCRIPT_DIR/../backend"; then
+    echo "Could not enter backend/ — seeded dev data left in place." >&2
+    exit 1
+fi
 
 # Dev superuser defaults
 export FIRST_SUPERUSER_EMAIL="${FIRST_SUPERUSER_EMAIL:-admin@example.com}"
 export FIRST_SUPERUSER_PASSWORD="${FIRST_SUPERUSER_PASSWORD:-changeme}"
 export FIRST_SUPERUSER_FULL_NAME="${FIRST_SUPERUSER_FULL_NAME:-Admin User}"
 
+if [ ! -f .venv/bin/activate ]; then
+    echo "Skipping dev data clean: backend/.venv is missing (run: cd backend && uv sync)." >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
 source .venv/bin/activate
-python "$SCRIPT_DIR/seed_dev_data.py" --clean
+if ! python "$SCRIPT_DIR/seed_dev_data.py" --clean; then
+    echo "Dev data clean failed — is the database up? (docker compose up db -d)" >&2
+    status=1
+fi
+
+exit $status

--- a/scripts/dev-cleanup.sh
+++ b/scripts/dev-cleanup.sh
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
 # Stop dev servers and remove seeded dev data.
 #
+#   dev-cleanup.sh                stop the servers, then remove the seeded data
+#   dev-cleanup.sh --data-only    remove the seeded data, leave the ports alone
+#
+# --data-only is for a launch that failed before it started a server: the data
+# is this launch's to remove, the ports belong to whoever is listening on them.
+#
 # This is the teardown path, so it never aborts partway: a missing venv or an
 # unreachable database must not leave the servers running or skip the data
 # clean. Each step reports what went wrong and the exit code reflects it.
 set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+stop_servers=true
+case "${1:-}" in
+    --data-only) stop_servers=false ;;
+    "") ;;
+    *) echo "usage: dev-cleanup.sh [--data-only]" >&2; exit 2 ;;
+esac
 
 status=0
 
@@ -43,16 +56,18 @@ stop_port() {
     kill -9 $pids 2>/dev/null || true
 }
 
-echo "Stopping dev servers..."
-stop_port 8000 "backend"
-stop_port 5173 "frontend"
+if [ "$stop_servers" = true ]; then
+    echo "Stopping dev servers..."
+    stop_port 8000 "backend"
+    stop_port 5173 "frontend"
 
-# Fallbacks for servers that are up but not listening yet (killed mid-startup,
-# or still binding the port).
-pkill -f "uvicorn app.main:app" 2>/dev/null || true
-pkill -f "vite" 2>/dev/null || true
+    # Fallbacks for servers that are up but not listening yet (killed
+    # mid-startup, or still binding the port).
+    pkill -f "uvicorn app.main:app" 2>/dev/null || true
+    pkill -f "vite" 2>/dev/null || true
 
-echo "Servers stopped."
+    echo "Servers stopped."
+fi
 
 if ! cd "$SCRIPT_DIR/../backend"; then
     echo "Could not enter backend/ — seeded dev data left in place." >&2

--- a/scripts/dev-pre-launch.sh
+++ b/scripts/dev-pre-launch.sh
@@ -2,10 +2,9 @@
 # Orchestrate the dev environment startup chain. Equivalent of the VSCode dev:setup
 # task chain: db -> migrate -> seed -> backend (bg) -> frontend (bg) -> browser.
 #
-# Cleanup runs on every exit path: Ctrl+C (SIGINT), kill (SIGTERM), closing the
-# terminal (SIGHUP), a startup step that fails, or either dev server exiting on
-# its own. The trap is armed before the first step so there is no window where a
-# signal or an error can leave the environment half-up with its data seeded.
+# Once this launch owns something to clean up, cleanup runs on every exit path:
+# Ctrl+C (SIGINT), kill (SIGTERM), closing the terminal (SIGHUP), a startup step
+# that fails, or either dev server exiting on its own.
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
@@ -13,9 +12,10 @@ cd "$SCRIPT_DIR/.."
 BACKEND_PID=""
 FRONTEND_PID=""
 
-# The guard makes the function idempotent so the signal path (trap fires, `wait`
-# returns, EXIT trap fires) and the natural-exit path (a server died, or a
-# startup step failed under `set -e`) both end in exactly one cleanup pass.
+# The guard makes the function idempotent so the signal path (trap fires, the
+# poll loop below falls through, EXIT trap fires) and the natural-exit path (a
+# server died, or a startup step failed under `set -e`) both end in exactly one
+# cleanup pass.
 cleanup_done=false
 cleanup() {
     if [ "$cleanup_done" = true ]; then
@@ -33,10 +33,16 @@ cleanup() {
     done
     bash "$SCRIPT_DIR/dev-cleanup.sh" || true
 }
-trap cleanup INT TERM HUP EXIT
 
 docker compose up db -d --wait
 bash scripts/dev-migrate.sh
+
+# Arm the teardown here rather than at the top of the script. Everything above
+# is shared, idempotent setup that leaves nothing of ours running, and the dev
+# ports and seeded data may still belong to another environment. From the seed
+# onward this launch owns them, so every exit path below runs the cleanup.
+trap cleanup INT TERM HUP EXIT
+
 bash scripts/dev-seed.sh
 
 # Start the backend in the background (uvicorn with --reload, port-cleanup built in).
@@ -56,19 +62,22 @@ echo "  Frontend: http://localhost:5173   (logs: /tmp/initiative-frontend.log)"
 echo "  Stop:     press Ctrl+C in this terminal (or run bash scripts/dev-cleanup.sh)"
 echo
 
-# Block until a signal arrives or one of the servers exits. `wait -n` returns on
-# the FIRST child to exit — plain `wait BACKEND_PID FRONTEND_PID` sits on the
-# survivor instead, so a backend that died at startup would leave the terminal
-# blocked and the cleanup unrun. `wait` is interruptible: a signal fires the trap
-# above and aborts it. `set -e` is off from here so a server exiting non-zero
-# doesn't bypass the trap on its way out.
+# Block until a signal arrives or one of the servers exits. Poll rather than
+# `wait`: plain `wait BACKEND_PID FRONTEND_PID` sits on the survivor when only
+# one server goes down, so a backend that died at startup would leave the
+# terminal blocked and the cleanup unrun, and `wait -n` (which returns on the
+# first exit) needs bash 4.3+ — macOS still ships 3.2. `sleep` is interruptible,
+# so a signal fires the trap above promptly. `set -e` is off from here so a
+# server exiting non-zero doesn't bypass the trap on its way out.
 set +e
-wait -n
+while kill -0 "$BACKEND_PID" 2>/dev/null && kill -0 "$FRONTEND_PID" 2>/dev/null; do
+    sleep 1
+done
 
 # Ctrl+C reaches both servers, so both go down and there is nothing to explain.
 # One down while the other is still up means that server fell over on its own —
 # point at its log, since the environment is about to disappear either way. The
-# pause lets the second server finish exiting before the two cases are told apart.
+# pause lets the second server finish exiting before the two are told apart.
 sleep 0.5
 backend_up=false
 frontend_up=false

--- a/scripts/dev-pre-launch.sh
+++ b/scripts/dev-pre-launch.sh
@@ -53,11 +53,16 @@ trap cleanup INT TERM HUP EXIT
 
 bash scripts/dev-seed.sh
 
+# Claim the dev ports before the first server is spawned, not after: a signal
+# landing between the spawn and the assignment would otherwise reach a cleanup
+# that skips both the pid and the port sweep, leaving that server behind. The
+# cost the other way is a full sweep for a launch that got no further than here,
+# which is the same sweep dev-backend.sh does to port 8000 on its way up.
+servers_started=true
+
 # Start the backend in the background (uvicorn with --reload, port-cleanup built in).
 nohup bash scripts/dev-backend.sh > /tmp/initiative-backend.log 2>&1 &
 BACKEND_PID=$!
-# From here the dev ports are this launch's to sweep on the way out.
-servers_started=true
 
 # Start the frontend in the background (Vite, port-cleanup built in). --open makes
 # Vite open the app in the browser once it's listening; its `open` dependency is

--- a/scripts/dev-pre-launch.sh
+++ b/scripts/dev-pre-launch.sh
@@ -2,12 +2,38 @@
 # Orchestrate the dev environment startup chain. Equivalent of the VSCode dev:setup
 # task chain: db -> migrate -> seed -> backend (bg) -> frontend (bg) -> browser.
 #
-# After launching, this script blocks waiting on the backend and frontend so
-# Ctrl+C (SIGINT), kill (SIGTERM), or closing the terminal (SIGHUP) tears
-# the dev environment back down via dev-cleanup.sh.
+# Cleanup runs on every exit path: Ctrl+C (SIGINT), kill (SIGTERM), closing the
+# terminal (SIGHUP), a startup step that fails, or either dev server exiting on
+# its own. The trap is armed before the first step so there is no window where a
+# signal or an error can leave the environment half-up with its data seeded.
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
+
+BACKEND_PID=""
+FRONTEND_PID=""
+
+# The guard makes the function idempotent so the signal path (trap fires, `wait`
+# returns, EXIT trap fires) and the natural-exit path (a server died, or a
+# startup step failed under `set -e`) both end in exactly one cleanup pass.
+cleanup_done=false
+cleanup() {
+    if [ "$cleanup_done" = true ]; then
+        return 0
+    fi
+    cleanup_done=true
+    echo
+    echo "Stopping dev environment..."
+    # Stop the servers this script started, then let dev-cleanup.sh sweep up
+    # whatever is still on the ports and remove the seeded data.
+    for pid in "$BACKEND_PID" "$FRONTEND_PID"; do
+        if [ -n "$pid" ]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+    bash "$SCRIPT_DIR/dev-cleanup.sh" || true
+}
+trap cleanup INT TERM HUP EXIT
 
 docker compose up db -d --wait
 bash scripts/dev-migrate.sh
@@ -30,22 +56,28 @@ echo "  Frontend: http://localhost:5173   (logs: /tmp/initiative-frontend.log)"
 echo "  Stop:     press Ctrl+C in this terminal (or run bash scripts/dev-cleanup.sh)"
 echo
 
-# Run dev-cleanup.sh on Ctrl+C / kill / hangup. The guard makes the function
-# idempotent so the INT path (trap fires, wait returns, EXIT trap fires) and
-# the natural-exit path (children died -> EXIT trap fires) both end in exactly
-# one cleanup pass.
-cleanup_done=false
-cleanup() {
-    [ "$cleanup_done" = true ] && return
-    cleanup_done=true
-    echo
-    echo "Stopping dev environment..."
-    bash "$SCRIPT_DIR/dev-cleanup.sh"
-}
-trap cleanup INT TERM HUP EXIT
-
-# Block. `wait` is interruptible — a signal fires the trap above and aborts
-# the wait. Disable `set -e` here so a child exiting non-zero doesn't bypass
-# the trap on its way out.
+# Block until a signal arrives or one of the servers exits. `wait -n` returns on
+# the FIRST child to exit — plain `wait BACKEND_PID FRONTEND_PID` sits on the
+# survivor instead, so a backend that died at startup would leave the terminal
+# blocked and the cleanup unrun. `wait` is interruptible: a signal fires the trap
+# above and aborts it. `set -e` is off from here so a server exiting non-zero
+# doesn't bypass the trap on its way out.
 set +e
-wait "$BACKEND_PID" "$FRONTEND_PID"
+wait -n
+
+# Ctrl+C reaches both servers, so both go down and there is nothing to explain.
+# One down while the other is still up means that server fell over on its own —
+# point at its log, since the environment is about to disappear either way. The
+# pause lets the second server finish exiting before the two cases are told apart.
+sleep 0.5
+backend_up=false
+frontend_up=false
+kill -0 "$BACKEND_PID" 2>/dev/null && backend_up=true
+kill -0 "$FRONTEND_PID" 2>/dev/null && frontend_up=true
+if [ "$cleanup_done" = false ]; then
+    if [ "$backend_up" = false ] && [ "$frontend_up" = true ]; then
+        echo "Backend exited — see /tmp/initiative-backend.log"
+    elif [ "$frontend_up" = false ] && [ "$backend_up" = true ]; then
+        echo "Frontend exited — see /tmp/initiative-frontend.log"
+    fi
+fi

--- a/scripts/dev-pre-launch.sh
+++ b/scripts/dev-pre-launch.sh
@@ -11,6 +11,7 @@ cd "$SCRIPT_DIR/.."
 
 BACKEND_PID=""
 FRONTEND_PID=""
+servers_started=false
 
 # The guard makes the function idempotent so the signal path (trap fires, the
 # poll loop below falls through, EXIT trap fires) and the natural-exit path (a
@@ -23,6 +24,13 @@ cleanup() {
     fi
     cleanup_done=true
     echo
+    if [ "$servers_started" = false ]; then
+        # The seed ran but no server did, so the dev ports are still whoever
+        # else's — take back only the data this launch put in the database.
+        echo "Removing seeded dev data..."
+        bash "$SCRIPT_DIR/dev-cleanup.sh" --data-only || true
+        return 0
+    fi
     echo "Stopping dev environment..."
     # Stop the servers this script started, then let dev-cleanup.sh sweep up
     # whatever is still on the ports and remove the seeded data.
@@ -48,6 +56,8 @@ bash scripts/dev-seed.sh
 # Start the backend in the background (uvicorn with --reload, port-cleanup built in).
 nohup bash scripts/dev-backend.sh > /tmp/initiative-backend.log 2>&1 &
 BACKEND_PID=$!
+# From here the dev ports are this launch's to sweep on the way out.
+servers_started=true
 
 # Start the frontend in the background (Vite, port-cleanup built in). --open makes
 # Vite open the app in the browser once it's listening; its `open` dependency is

--- a/scripts/dev-pre-launch.sh
+++ b/scripts/dev-pre-launch.sh
@@ -53,12 +53,12 @@ trap cleanup INT TERM HUP EXIT
 
 bash scripts/dev-seed.sh
 
-# Claim the dev ports before the first server is spawned, not after: a signal
-# landing between the spawn and the assignment would otherwise reach a cleanup
-# that skips both the pid and the port sweep, leaving that server behind. The
-# cost the other way is a full sweep for a launch that got no further than here,
-# which is the same sweep dev-backend.sh does to port 8000 on its way up.
-servers_started=true
+# Spawning a server and recording its pid are two statements, and a signal
+# landing between them would reach a cleanup that cannot see that server. Note
+# the signal instead of acting on it, and let the check below run the teardown
+# once both pids are recorded and the ports are known to be this launch's.
+pending_signal=false
+trap 'pending_signal=true' INT TERM HUP
 
 # Start the backend in the background (uvicorn with --reload, port-cleanup built in).
 nohup bash scripts/dev-backend.sh > /tmp/initiative-backend.log 2>&1 &
@@ -69,6 +69,14 @@ BACKEND_PID=$!
 # WSL-aware (launches the Windows browser) and handles macOS/Linux too.
 nohup bash scripts/dev-frontend.sh --open > /tmp/initiative-frontend.log 2>&1 &
 FRONTEND_PID=$!
+
+# Both servers are recorded, so the dev ports are now this launch's to sweep.
+servers_started=true
+trap cleanup INT TERM HUP
+
+if [ "$pending_signal" = true ]; then
+    exit 0
+fi
 
 echo
 echo "Dev environment starting:"


### PR DESCRIPTION
## Problem

`scripts/dev-pre-launch.sh` is supposed to tear the dev environment back down
on the way out, but there were four paths where the cleanup never ran:

1. `wait "$BACKEND_PID" "$FRONTEND_PID"` waits for **both** PIDs, not the first
   one to exit. A backend that died at startup (port conflict, bad migration,
   import error) left the terminal blocked on the still-running frontend, so
   cleanup only ran once the frontend was also stopped by hand.
2. The trap was armed *after* db/migrate/seed and after both servers were
   launched, so under `set -e` a failing seed exited with no cleanup at all.
3. `dev-cleanup.sh` ran under `set -e` with a bare `source .venv/bin/activate`.
   A missing venv (or a database that was down) ended the script before the
   data clean, with only a raw bash error to show for it. It also printed
   "Servers stopped." after a fixed `sleep 1`, whether or not anything had
   actually stopped.
4. The VSCode debug config ran the task chain plus an `echo` and never touched
   the trap-protected script, so teardown rested entirely on `postDebugTask`.

## Changes

- [scripts/dev-pre-launch.sh](scripts/dev-pre-launch.sh): arm the cleanup trap
  before the first startup step, track the server PIDs and stop them there, and
  block on `wait -n` so the first server to exit brings the environment down.
  When only one side is down, name it and point at its log; on Ctrl+C both go
  down together and it stays quiet.
- [scripts/dev-cleanup.sh](scripts/dev-cleanup.sh): never stop partway. Ports
  get a graceful kill, a wall-clock-bounded grace period, then `SIGKILL` for
  anything still holding them; a missing `backend/.venv` or a failed data clean
  is reported and reflected in the exit code instead of silently skipping the
  rest of the teardown.
- [.vscode/launch.json](.vscode/launch.json): point the debug config at
  `dev-pre-launch.sh` so it takes the same path as the Zed task and
  `.claude/launch.json`, keeping `postDebugTask: dev:cleanup` as the backstop
  for a stop that never reaches the trap.

## Testing

Dev tooling only — no backend or frontend sources changed, so the lint/test
gates have nothing to cover here.

- `bash -n scripts/dev-pre-launch.sh scripts/dev-cleanup.sh` — syntax clean.
- Stubbed sandbox exercising every exit path (docker fails, migrate fails, seed
  fails, backend exits while the frontend is still up, SIGINT, SIGTERM,
  SIGHUP): cleanup ran exactly once in all seven, with no orphaned children
  after the signal cases. On `main` the backend-exits case blocks instead.
- Port teardown against a real listener that ignores `SIGTERM`: freed via the
  force path, 5.6s worst case, 0.6s when nothing is listening.
- `bash scripts/dev-cleanup.sh` in a venv-less worktree: stops the servers,
  reports the skipped data clean, exits 1 (previously a bare
  `.venv/bin/activate: No such file or directory`).

Not run end-to-end against a live database, since `--clean` wipes seeded dev
data.