### PR TITLE
Show who is in a guild now, and key rooms by guild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Whether a server has a directory at all is the platform owner's decision, under Settings → Platform → Community, and it starts off. While it is off there is nothing to browse, nobody can join a guild without an invite, and the listing control is absent from guild settings. Turning it off later hides the directory rather than un-listing anyone: switch it back on and the same guilds are there.
 - **An app service can be granted the app directory from Settings → Platform → App services.** Alongside "Act as members", the form now offers "Find other apps", which lets a service ask where another app installed in the same guild answers. An automation service needs both. It could previously only be conferred outside the app.
+- **The community directory says who is in a guild right now.** A card carries the number of members with that guild open, beside the number of members it has in all. It is a live reading rather than a stored one, so it follows people arriving and leaving, and a guild nobody is in at that moment simply says how many members it has.
 
 ### Changed
 

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -52,6 +52,7 @@ from app.models.platform.guild_auth_policy import GuildAuthPolicy
 from app.services.auth.identity import has_federated_identity
 from app.services.auth.platform_provider import is_login_ready
 from app.services.platform import guilds as guilds_service
+from app.services.realtime import manager as realtime_manager
 from app.services.tenant import app_connections as app_connections_service
 from app.services.tenant import app_revocation as app_revocation_service
 from app.services import rls as rls_service
@@ -230,7 +231,8 @@ async def list_community_guilds(
     is not what this returns — the filters live in the service (listed AND
     active, always), and :class:`CommunityGuildRead` carries only what a guild
     published by opting in: no lifecycle status, no administration, no roster,
-    and nothing at all from inside the guild's own schema.
+    and nothing at all from inside the guild's own schema. How many people have
+    it open is a count of live connections, named to nobody.
 
     The directory is a deployment-level feature an owner switches on; where it
     is off there is nothing to browse and the request is refused rather than
@@ -249,6 +251,9 @@ async def list_community_guilds(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
         ) from exc
+    # Who is present is live state held by the process, not a column, so it is
+    # read here for the page being returned rather than joined in the query.
+    online = realtime_manager.present_counts(guild.id for guild, _, _ in rows)
     return CommunityGuildPage(
         items=[
             CommunityGuildRead(
@@ -258,6 +263,7 @@ async def list_community_guilds(
                 icon_base64=guild.icon_base64,
                 categories=[GuildCategory(value) for value in guild.categories],
                 member_count=member_count,
+                online_count=online.get(guild.id, 0),
                 already_member=already_member,
             )
             for guild, member_count, already_member in rows

--- a/backend/app/api/v1/tenant_endpoints/collaboration.py
+++ b/backend/app/api/v1/tenant_endpoints/collaboration.py
@@ -214,7 +214,9 @@ async def websocket_collaborate(
         can_write = level in ("write", "owner")
 
         # Get or create the document room (needs session for initial load)
-        room = await collaboration_manager.get_or_create_room(document_id, session)
+        room = await collaboration_manager.get_or_create_room(
+            guild_id, document_id, session
+        )
 
     logger.info(f"Collaboration: {user.email} authenticated for document {document_id}")
 
@@ -389,8 +391,8 @@ async def websocket_collaborate(
         # Persist and potentially clean up room (using a new short-lived session)
         async with AsyncSessionLocal() as session:
             await set_rls_context(session, user_id=user.id, guild_id=guild_id)
-            await collaboration_manager.persist_room(document_id, session)
-        await collaboration_manager.remove_room(document_id)
+            await collaboration_manager.persist_room(guild_id, document_id, session)
+        await collaboration_manager.remove_room(guild_id, document_id)
 
 
 @router.get("/documents/{document_id}/collaborators")
@@ -398,10 +400,10 @@ async def get_document_collaborators(
     document_id: int,
     session: RLSSessionDep,
     _current_user: Annotated[User, Depends(get_current_active_user)],
-    _guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
 ) -> list[dict]:
     """Get the list of current collaborators on a document."""
-    room = collaboration_manager.get_room(document_id)
+    room = collaboration_manager.get_room(guild_context.guild_id, document_id)
     if not room:
         return []
     return room.get_collaborator_list()

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1531,7 +1531,9 @@ async def update_document(
         # Clearing only when the room is inactive still solves PR #347's
         # original problem: non-collab edits need to override any stale
         # pre-existing yjs_state the next time the user re-enables collab.
-        if not collaboration_manager.has_active_collaborators(document.id):
+        if not collaboration_manager.has_active_collaborators(
+            guild_context.guild_id, document.id
+        ):
             document.yjs_state = None
         content_updated = True
         updated = True
@@ -1568,7 +1570,9 @@ async def update_document(
         # loads fresh state from the database. If a room has active
         # collaborators their in-memory state wins until they disconnect.
         if content_updated:
-            await collaboration_manager.invalidate_room_if_empty(document.id)
+            await collaboration_manager.invalidate_room_if_empty(
+                guild_context.guild_id, document.id
+            )
     hydrated = await _get_document_or_404(
         session, document_id=document.id, guild_id=guild_context.guild_id
     )

--- a/backend/app/api/v1/tenant_endpoints/events.py
+++ b/backend/app/api/v1/tenant_endpoints/events.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 from typing import Optional
@@ -144,7 +145,13 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
             # Keep the connection alive by awaiting incoming messages
             await websocket.receive_text()
     except WebSocketDisconnect:
-        await manager.disconnect(websocket)
+        pass
     except Exception:
+        with contextlib.suppress(Exception):
+            await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
+    finally:
+        # Unconditional, including the task being cancelled — which arrives as a
+        # BaseException and so past both excepts above. A room entry left behind
+        # is corrected by the first send that fails, but the socket's user would
+        # stay counted present in this guild with nothing to notice it.
         await manager.disconnect(websocket)
-        await websocket.close(code=status.WS_1011_INTERNAL_ERROR)

--- a/backend/app/api/v1/tenant_endpoints/events.py
+++ b/backend/app/api/v1/tenant_endpoints/events.py
@@ -133,8 +133,9 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
     # Initiative-scoped subscription: the socket joins exactly the rooms whose
     # content the user can read, so a signal for an initiative never reaches a
     # non-member. (A member of no initiative joins nothing — correct: they have
-    # no content to be notified about.)
-    await manager.connect(guild_id, initiative_ids, websocket)
+    # no content to be notified about. The user is still present in the guild,
+    # which the manager tracks separately from the rooms.)
+    await manager.connect(guild_id, initiative_ids, websocket, user_id=user.id)
     logger.info(
         f"Events WS: user {user.id} joined {len(initiative_ids)} initiative room(s) in guild {guild_id}"
     )

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -379,6 +379,20 @@ async def set_rls_context(
         await _apply_stored_context(session)
 
 
+def routed_guild_id(session: AsyncSession) -> int | None:
+    """The guild this session is currently routed to, or ``None`` if it is not.
+
+    Ids of things that live in a guild schema — documents, initiatives — are
+    per-schema sequences, so the same number names a different row in each
+    guild. Anything keyed by one of them outside the database needs the guild
+    beside it, and where the id was read through a routed session, that routing
+    is the answer.
+    """
+    params = session.info.get(_RLS_PARAMS_INFO_KEY) or {}
+    guild_id = params.get("guild_id")
+    return int(guild_id) if guild_id is not None else None
+
+
 async def set_billing_context(session: AsyncSession, *, guild_id: int) -> None:
     """Route a verified billing-service request — transaction-local.
 

--- a/backend/app/schemas/platform/guild.py
+++ b/backend/app/schemas/platform/guild.py
@@ -283,6 +283,11 @@ class CommunityGuildRead(SanitizedBaseModel):
     shelves, and how many people are already there. No membership fields (they
     have none), no lifecycle status, no administration. ``already_member`` is
     about the *caller*, and only says whether the Join button applies to them.
+
+    ``online_count`` is how many of those people have the guild open right now.
+    It is a live reading rather than a stored one, taken from the process
+    answering the request, so it is a sense of how busy a guild is rather than a
+    figure to reconcile against anything.
     """
 
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
@@ -293,6 +298,7 @@ class CommunityGuildRead(SanitizedBaseModel):
     icon_base64: Optional[RawTextStr] = None
     categories: List[GuildCategory] = []
     member_count: int = 0
+    online_count: int = 0
     already_member: bool = False
 
 

--- a/backend/app/services/realtime.py
+++ b/backend/app/services/realtime.py
@@ -31,27 +31,51 @@ class ConnectionManager:
 
     A socket may live in several rooms at once (a user reaches several
     initiatives), so we keep a reverse index for O(1) disconnect.
+
+    It also answers who is *present* in a guild. A socket on this stream is a
+    user with the app open in that guild, which is the thing "online" means, and
+    it is tracked per guild rather than per room: a member of no initiative
+    joins no rooms and is still here. Presence is counted per user, not per
+    socket, so two tabs are one person.
+
+    What that count is bounded by is worth stating: this is one process's own
+    sockets, held in memory. Where the API runs as more than one worker each
+    holds a share, and a count read from one of them is that share rather than
+    the whole. A number that is only ever compared with itself (how busy is this
+    guild) survives that; anything that has to be exact does not, and wants a
+    store the processes share.
     """
 
     def __init__(self) -> None:
         self._rooms: Dict[RoomKey, Set[WebSocket]] = {}
         self._socket_rooms: Dict[WebSocket, Set[RoomKey]] = {}
+        # guild_id -> user_id -> how many of that user's sockets are open here.
+        self._present: Dict[int, Dict[int, int]] = {}
+        self._socket_identity: Dict[WebSocket, Tuple[int, int]] = {}
         self._lock = asyncio.Lock()
 
     async def connect(
-        self, guild_id: int, initiative_ids: Iterable[int], websocket: WebSocket
+        self,
+        guild_id: int,
+        initiative_ids: Iterable[int],
+        websocket: WebSocket,
+        *,
+        user_id: int,
     ) -> None:
         """Register an already-accepted socket under each of its initiative rooms,
-        namespaced to ``guild_id``."""
+        namespaced to ``guild_id``, and mark its user present in that guild."""
         async with self._lock:
             joined = self._socket_rooms.setdefault(websocket, set())
             for initiative_id in initiative_ids:
                 key = (guild_id, initiative_id)
                 self._rooms.setdefault(key, set()).add(websocket)
                 joined.add(key)
+            self._socket_identity[websocket] = (guild_id, user_id)
+            present = self._present.setdefault(guild_id, {})
+            present[user_id] = present.get(user_id, 0) + 1
 
     async def disconnect(self, websocket: WebSocket) -> None:
-        """Remove a socket from every room it joined."""
+        """Remove a socket from every room it joined, and from its guild's roll."""
         async with self._lock:
             for key in self._socket_rooms.pop(websocket, set()):
                 room = self._rooms.get(key)
@@ -59,6 +83,22 @@ class ConnectionManager:
                     room.discard(websocket)
                     if not room:
                         del self._rooms[key]
+            identity = self._socket_identity.pop(websocket, None)
+            if identity is None:
+                return
+            guild_id, user_id = identity
+            present = self._present.get(guild_id)
+            if present is None:
+                return
+            # A user's last socket takes the user out; the last user takes the
+            # guild out, so an empty guild costs nothing to have had someone in.
+            remaining = present.get(user_id, 0) - 1
+            if remaining > 0:
+                present[user_id] = remaining
+            else:
+                present.pop(user_id, None)
+                if not present:
+                    del self._present[guild_id]
 
     async def broadcast(
         self, guild_id: int, initiative_id: int, message: Dict[str, Any]
@@ -74,6 +114,14 @@ class ConnectionManager:
 
     def room_size(self, guild_id: int, initiative_id: int) -> int:
         return len(self._rooms.get((guild_id, initiative_id), set()))
+
+    def present_count(self, guild_id: int) -> int:
+        """How many distinct users have this guild open on this process."""
+        return len(self._present.get(guild_id, {}))
+
+    def present_counts(self, guild_ids: Iterable[int]) -> Dict[int, int]:
+        """``present_count`` for several guilds, for a page of them at a time."""
+        return {guild_id: self.present_count(guild_id) for guild_id in guild_ids}
 
 
 manager = ConnectionManager()

--- a/backend/app/services/realtime_test.py
+++ b/backend/app/services/realtime_test.py
@@ -74,6 +74,28 @@ async def test_presence_counts_people_not_sockets() -> None:
 
 
 @pytest.mark.unit
+async def test_disconnecting_a_socket_twice_takes_its_user_out_once() -> None:
+    """Both paths that drop a socket can run for the same socket.
+
+    A send that fails drops it, and the connection's own cleanup drops it again
+    when the loop ends. The second one must be a no-op rather than taking a
+    still-connected tab's user out of the count.
+    """
+    cm = ConnectionManager()
+    first_tab, second_tab = FakeWebSocket(), FakeWebSocket()
+    await cm.connect(1, [5], first_tab, user_id=7)
+    await cm.connect(1, [5], second_tab, user_id=7)
+
+    await cm.disconnect(first_tab)
+    await cm.disconnect(first_tab)
+
+    assert cm.present_count(1) == 1  # user 7, still on their second tab
+
+    await cm.disconnect(second_tab)
+    assert cm.present_count(1) == 0
+
+
+@pytest.mark.unit
 async def test_presence_is_per_guild() -> None:
     """One person in two guilds is present in both, and counted once in each."""
     cm = ConnectionManager()

--- a/backend/app/services/realtime_test.py
+++ b/backend/app/services/realtime_test.py
@@ -47,6 +47,60 @@ class FakeWebSocket:
 
 
 # ---------------------------------------------------------------------------
+# ConnectionManager / presence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_presence_counts_people_not_sockets() -> None:
+    """Two tabs are one person; the second closing does not empty the guild."""
+    cm = ConnectionManager()
+    first_tab, second_tab, someone_else = (
+        FakeWebSocket(),
+        FakeWebSocket(),
+        FakeWebSocket(),
+    )
+    await cm.connect(1, [5], first_tab, user_id=7)
+    await cm.connect(1, [5], second_tab, user_id=7)
+    await cm.connect(1, [5], someone_else, user_id=8)
+
+    assert cm.present_count(1) == 2
+
+    await cm.disconnect(second_tab)
+    assert cm.present_count(1) == 2  # user 7 still has a tab open
+
+    await cm.disconnect(first_tab)
+    assert cm.present_count(1) == 1
+
+
+@pytest.mark.unit
+async def test_presence_is_per_guild() -> None:
+    """One person in two guilds is present in both, and counted once in each."""
+    cm = ConnectionManager()
+    here, there = FakeWebSocket(), FakeWebSocket()
+    await cm.connect(1, [5], here, user_id=7)
+    await cm.connect(2, [5], there, user_id=7)
+
+    assert cm.present_count(1) == 1
+    assert cm.present_count(2) == 1
+    assert cm.present_count(3) == 0
+    assert cm.present_counts([1, 2, 3]) == {1: 1, 2: 1, 3: 0}
+
+
+@pytest.mark.unit
+async def test_presence_includes_a_member_of_no_initiative() -> None:
+    """Presence is the guild, not the rooms: joining none of them is still here."""
+    cm = ConnectionManager()
+    socket = FakeWebSocket()
+    await cm.connect(1, [], socket, user_id=7)
+
+    assert cm.present_count(1) == 1
+
+    await cm.disconnect(socket)
+    assert cm.present_count(1) == 0
+
+
+# ---------------------------------------------------------------------------
 # ConnectionManager / broadcast fan-out isolation
 # ---------------------------------------------------------------------------
 
@@ -60,9 +114,11 @@ async def test_broadcast_isolated_by_guild_and_initiative() -> None:
     same_room = FakeWebSocket()
     other_guild_same_id = FakeWebSocket()
     same_guild_other_init = FakeWebSocket()
-    await cm.connect(1, [5], same_room)
-    await cm.connect(2, [5], other_guild_same_id)  # SAME local id, different guild
-    await cm.connect(1, [6], same_guild_other_init)
+    await cm.connect(1, [5], same_room, user_id=1)
+    await cm.connect(
+        2, [5], other_guild_same_id, user_id=2
+    )  # SAME local id, different guild
+    await cm.connect(1, [6], same_guild_other_init, user_id=3)
 
     await cm.broadcast(1, 5, {"hello": "g1-i5"})
 
@@ -78,7 +134,7 @@ async def test_broadcast_event_envelope_carries_no_content() -> None:
     through the real module ``manager``/``broadcast_event`` every endpoint uses."""
     guild_id, initiative_id = 101, 9
     socket = FakeWebSocket()
-    await manager.connect(guild_id, [initiative_id], socket)
+    await manager.connect(guild_id, [initiative_id], socket, user_id=1)
     try:
         await broadcast_event(
             guild_id,
@@ -103,7 +159,7 @@ async def test_broadcast_event_envelope_carries_no_content() -> None:
 async def test_disconnect_removes_socket_from_all_rooms() -> None:
     cm = ConnectionManager()
     socket = FakeWebSocket()
-    await cm.connect(5, [1, 2], socket)
+    await cm.connect(5, [1, 2], socket, user_id=1)
     assert cm.room_size(5, 1) == 1
     assert cm.room_size(5, 2) == 1
 
@@ -122,7 +178,7 @@ async def test_failed_send_prunes_socket() -> None:
 
     cm = ConnectionManager()
     bad = ExplodingWebSocket()
-    await cm.connect(9, [1], bad)
+    await cm.connect(9, [1], bad, user_id=1)
 
     await cm.broadcast(9, 1, {"x": 1})  # must not raise
     assert cm.room_size(9, 1) == 0  # the dead socket was pruned

--- a/backend/app/services/tenant/collaboration.py
+++ b/backend/app/services/tenant/collaboration.py
@@ -63,6 +63,40 @@ class DocumentRoom:
         self._lock = asyncio.Lock()
         self._initialized = False
         self._pending_updates: list[bytes] = []
+        # Reading this room's state out of the database is the one slow thing a
+        # room does, and it happens once. It gets a lock of its own so it is not
+        # done under the lock the collaborators use, nor the registry's.
+        self._load_lock = asyncio.Lock()
+        self._loaded = False
+
+    @property
+    def is_loaded(self) -> bool:
+        """Whether this room has had its one read of the database."""
+        return self._loaded
+
+    async def load_once(self, session: AsyncSession) -> None:
+        """Read this room's stored state, once, however many callers arrive.
+
+        Callers can reach a room the moment it is claimed, before anyone has
+        loaded it. The first one through does the read and the rest wait on it
+        rather than repeating it. A document that is no longer there still
+        counts as read: the room stays empty rather than asking again.
+
+        ``session`` must be routed to the guild whose schema holds the row.
+        """
+        if self._loaded:
+            return
+        async with self._load_lock:
+            if self._loaded:
+                return
+            statement = select(Document).where(Document.id == self.document_id)
+            document = (await session.exec(statement)).one_or_none()
+            if document:
+                await self.initialize_from_db(
+                    yjs_state=document.yjs_state,
+                    lexical_content=document.content,
+                )
+            self._loaded = True
 
     async def initialize_from_db(
         self, yjs_state: Optional[bytes], lexical_content: Optional[dict]
@@ -270,28 +304,22 @@ class CollaborationManager:
         through it, from that guild's schema.
         """
         key = (guild_id, document_id)
+        # The registry lock is held only long enough to claim the room's slot.
+        # Reading its state is database I/O, and doing that here would make one
+        # slow document a wait for every other room in the process, in every
+        # guild. It happens below, guarded by the room itself.
         async with self._lock:
-            if key not in self._rooms:
+            room = self._rooms.get(key)
+            if room is None:
                 room = DocumentRoom(document_id)
-
-                # Load document from database
-                stmt = select(Document).where(Document.id == document_id)
-                result = await session.exec(stmt)
-                document = result.one_or_none()
-
-                if document:
-                    await room.initialize_from_db(
-                        yjs_state=document.yjs_state,
-                        lexical_content=document.content,
-                    )
-
                 self._rooms[key] = room
                 logger.info(
                     f"Created collaboration room for document {document_id} "
                     f"in guild {guild_id}"
                 )
 
-            return self._rooms[key]
+        await room.load_once(session)
+        return room
 
     async def remove_room(self, guild_id: int, document_id: int) -> None:
         """Remove a room if it exists and is empty.
@@ -303,6 +331,11 @@ class CollaborationManager:
         async with self._lock:
             room = self._rooms.get(key)
             if not room:
+                return
+            # A room that has been claimed but not yet read in is empty because
+            # nobody has arrived yet, not because everyone has left. Whoever is
+            # loading it is about to join it.
+            if not room.is_loaded:
                 return
             # Acquire room lock to ensure no collaborator is joining concurrently
             # This prevents the race where add_collaborator runs between our check and delete
@@ -328,6 +361,10 @@ class CollaborationManager:
             room = self._rooms.get(key)
             if not room:
                 return True  # No room, nothing to invalidate
+            if not room.is_loaded:
+                # Being read in right now: leave it to the caller doing that,
+                # who is about to join it.
+                return False
             if room.is_empty():
                 del self._rooms[key]
                 logger.info(

--- a/backend/app/services/tenant/collaboration.py
+++ b/backend/app/services/tenant/collaboration.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Optional, Set, Tuple
 
 from fastapi import WebSocket
 from pycrdt import Doc
@@ -233,6 +233,15 @@ class DocumentRoom:
             return len(self.collaborators) == 0
 
 
+# A room is identified by (guild_id, document_id). The guild_id is part of the
+# key because documents live in per-guild schemas (`guild_<id>.documents`, `id
+# SERIAL`): document ids are per-schema sequences, so id 5 names a different
+# document in every guild that has one. This manager is a single process-global
+# structure, so the id alone does not identify a document. Never key
+# collaboration state by a guild-schema-local id alone.
+RoomKey = Tuple[int, int]
+
+
 class CollaborationManager:
     """
     Manages all active document collaboration rooms.
@@ -244,19 +253,25 @@ class CollaborationManager:
     """
 
     def __init__(self):
-        self._rooms: Dict[int, DocumentRoom] = {}
+        self._rooms: Dict[RoomKey, DocumentRoom] = {}
         self._lock = asyncio.Lock()
         self._persistence_interval = 30  # seconds
         self._persistence_task: Optional[asyncio.Task] = None
 
     async def get_or_create_room(
         self,
+        guild_id: int,
         document_id: int,
         session: AsyncSession,
     ) -> DocumentRoom:
-        """Get an existing room or create a new one."""
+        """Get an existing room or create a new one.
+
+        ``session`` must be routed to ``guild_id`` — the document is loaded
+        through it, from that guild's schema.
+        """
+        key = (guild_id, document_id)
         async with self._lock:
-            if document_id not in self._rooms:
+            if key not in self._rooms:
                 room = DocumentRoom(document_id)
 
                 # Load document from database
@@ -270,31 +285,35 @@ class CollaborationManager:
                         lexical_content=document.content,
                     )
 
-                self._rooms[document_id] = room
-                logger.info(f"Created collaboration room for document {document_id}")
+                self._rooms[key] = room
+                logger.info(
+                    f"Created collaboration room for document {document_id} "
+                    f"in guild {guild_id}"
+                )
 
-            return self._rooms[document_id]
+            return self._rooms[key]
 
-    async def remove_room(self, document_id: int) -> None:
+    async def remove_room(self, guild_id: int, document_id: int) -> None:
         """Remove a room if it exists and is empty.
 
         Uses two-phase check to prevent race condition where a collaborator
         joins between checking is_empty() and deleting the room.
         """
+        key = (guild_id, document_id)
         async with self._lock:
-            room = self._rooms.get(document_id)
+            room = self._rooms.get(key)
             if not room:
                 return
             # Acquire room lock to ensure no collaborator is joining concurrently
             # This prevents the race where add_collaborator runs between our check and delete
             async with room._lock:
                 if room.is_empty():
-                    del self._rooms[document_id]
+                    del self._rooms[key]
                     logger.info(
                         f"Removed empty collaboration room for document {document_id}"
                     )
 
-    async def invalidate_room_if_empty(self, document_id: int) -> bool:
+    async def invalidate_room_if_empty(self, guild_id: int, document_id: int) -> bool:
         """Remove a room if it exists and has no active collaborators.
 
         Used when document content is modified externally (e.g., unresolving wikilinks
@@ -304,12 +323,13 @@ class CollaborationManager:
         Returns True if room was removed, False if room has active collaborators
         (in which case they'll have stale state until they reload).
         """
+        key = (guild_id, document_id)
         async with self._lock:
-            room = self._rooms.get(document_id)
+            room = self._rooms.get(key)
             if not room:
                 return True  # No room, nothing to invalidate
             if room.is_empty():
-                del self._rooms[document_id]
+                del self._rooms[key]
                 logger.info(
                     f"Invalidated empty collaboration room for document {document_id}"
                 )
@@ -321,11 +341,17 @@ class CollaborationManager:
                 )
                 return False
 
-    async def persist_room(self, document_id: int, session: AsyncSession) -> None:
-        """Persist the current room state to the database."""
+    async def persist_room(
+        self, guild_id: int, document_id: int, session: AsyncSession
+    ) -> None:
+        """Persist the current room state to the database.
+
+        ``session`` must be routed to ``guild_id``, whose schema holds the row
+        being written.
+        """
         # Capture state while holding the lock to ensure consistency
         async with self._lock:
-            room = self._rooms.get(document_id)
+            room = self._rooms.get((guild_id, document_id))
             if not room:
                 return
             # Get state snapshot while holding lock to prevent concurrent modifications
@@ -347,17 +373,17 @@ class CollaborationManager:
             logger.error(f"Failed to persist Yjs state for document {document_id}: {e}")
             await session.rollback()
 
-    def get_active_rooms(self) -> Set[int]:
-        """Get the set of document IDs with active rooms."""
+    def get_active_rooms(self) -> Set[RoomKey]:
+        """Get the set of (guild, document) pairs with active rooms."""
         return set(self._rooms.keys())
 
-    def get_room(self, document_id: int) -> Optional[DocumentRoom]:
+    def get_room(self, guild_id: int, document_id: int) -> Optional[DocumentRoom]:
         """Get a room without creating it."""
-        return self._rooms.get(document_id)
+        return self._rooms.get((guild_id, document_id))
 
-    def has_active_collaborators(self, document_id: int) -> bool:
+    def has_active_collaborators(self, guild_id: int, document_id: int) -> bool:
         """Check if a document has active collaborators."""
-        room = self._rooms.get(document_id)
+        room = self._rooms.get((guild_id, document_id))
         return room is not None and not room.is_empty()
 
 

--- a/backend/app/services/tenant/collaboration_test.py
+++ b/backend/app/services/tenant/collaboration_test.py
@@ -6,16 +6,52 @@ sequences, so the id alone does not name a document and the registry key has to
 carry the guild with it.
 """
 
+import asyncio
+
 import pytest
 
 from app.services.tenant.collaboration import CollaborationManager, DocumentRoom
 
 
+class FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def one_or_none(self):
+        return self._value
+
+
+class SlowSession:
+    """A session whose read takes as long as the test says it does.
+
+    Standing in for the database lets a test say what the registry does *while*
+    a room is being read in, which is the whole point of doing that read outside
+    the registry's lock.
+    """
+
+    def __init__(self, document=None, delay: float = 0.05):
+        self.document = document
+        self.delay = delay
+        self.reads = 0
+
+    async def exec(self, _statement):
+        self.reads += 1
+        await asyncio.sleep(self.delay)
+        return FakeResult(self.document)
+
+
+def loaded_room(document_id: int) -> DocumentRoom:
+    """A room as it stands once its one read of the database is done."""
+    room = DocumentRoom(document_id)
+    room._loaded = True
+    return room
+
+
 @pytest.mark.unit
 async def test_the_same_document_id_in_two_guilds_is_two_rooms() -> None:
     manager = CollaborationManager()
-    manager._rooms[(1, 5)] = DocumentRoom(5)
-    manager._rooms[(2, 5)] = DocumentRoom(5)
+    manager._rooms[(1, 5)] = loaded_room(5)
+    manager._rooms[(2, 5)] = loaded_room(5)
 
     first = manager.get_room(1, 5)
     second = manager.get_room(2, 5)
@@ -29,7 +65,7 @@ async def test_the_same_document_id_in_two_guilds_is_two_rooms() -> None:
 @pytest.mark.unit
 async def test_a_room_is_reached_only_from_its_own_guild() -> None:
     manager = CollaborationManager()
-    manager._rooms[(1, 5)] = DocumentRoom(5)
+    manager._rooms[(1, 5)] = loaded_room(5)
 
     assert manager.get_room(1, 5) is not None
     assert manager.get_room(2, 5) is None
@@ -39,8 +75,8 @@ async def test_a_room_is_reached_only_from_its_own_guild() -> None:
 @pytest.mark.unit
 async def test_removing_a_room_leaves_the_other_guild_alone() -> None:
     manager = CollaborationManager()
-    manager._rooms[(1, 5)] = DocumentRoom(5)
-    manager._rooms[(2, 5)] = DocumentRoom(5)
+    manager._rooms[(1, 5)] = loaded_room(5)
+    manager._rooms[(2, 5)] = loaded_room(5)
 
     # Both are empty of collaborators, so both are removable — only the one
     # named should go.
@@ -53,10 +89,73 @@ async def test_removing_a_room_leaves_the_other_guild_alone() -> None:
 @pytest.mark.unit
 async def test_invalidating_a_room_leaves_the_other_guild_alone() -> None:
     manager = CollaborationManager()
-    manager._rooms[(1, 5)] = DocumentRoom(5)
-    manager._rooms[(2, 5)] = DocumentRoom(5)
+    manager._rooms[(1, 5)] = loaded_room(5)
+    manager._rooms[(2, 5)] = loaded_room(5)
 
     assert await manager.invalidate_room_if_empty(1, 5) is True
 
     assert manager.get_room(1, 5) is None
     assert manager.get_room(2, 5) is not None
+
+
+@pytest.mark.unit
+async def test_loading_one_room_does_not_stall_another() -> None:
+    """The registry lock is not held across the read.
+
+    A slow document in one guild must not hold up a room in another, which is
+    what a lock held across I/O would do.
+    """
+    manager = CollaborationManager()
+    slow = SlowSession(delay=0.2)
+    quick = SlowSession(delay=0.0)
+
+    async def open_slow():
+        await manager.get_or_create_room(1, 5, slow)
+
+    slow_task = asyncio.create_task(open_slow())
+    await asyncio.sleep(0.01)  # let it get as far as the read
+
+    # While that one is still reading, another room opens and returns.
+    await asyncio.wait_for(manager.get_or_create_room(2, 9, quick), timeout=0.1)
+
+    await slow_task
+    assert manager.get_active_rooms() == {(1, 5), (2, 9)}
+
+
+@pytest.mark.unit
+async def test_a_room_is_read_once_however_many_arrive_together() -> None:
+    """Two callers on the same new room make one read between them."""
+    manager = CollaborationManager()
+    session = SlowSession(delay=0.05)
+
+    first, second = await asyncio.gather(
+        manager.get_or_create_room(1, 5, session),
+        manager.get_or_create_room(1, 5, session),
+    )
+
+    assert first is second
+    assert session.reads == 1
+    # And a later arrival does not read again.
+    await manager.get_or_create_room(1, 5, session)
+    assert session.reads == 1
+
+
+@pytest.mark.unit
+async def test_a_room_being_read_in_is_not_collected_as_idle() -> None:
+    """An unread room is empty because nobody has arrived, not because they left."""
+    manager = CollaborationManager()
+    slow = SlowSession(delay=0.2)
+
+    opening = asyncio.create_task(manager.get_or_create_room(1, 5, slow))
+    await asyncio.sleep(0.01)
+
+    await manager.remove_room(1, 5)
+    assert await manager.invalidate_room_if_empty(1, 5) is False
+    assert manager.get_room(1, 5) is not None
+
+    room = await opening
+    assert room is manager.get_room(1, 5)
+
+    # Once it has been read in, an empty room is collectable as before.
+    assert await manager.invalidate_room_if_empty(1, 5) is True
+    assert manager.get_room(1, 5) is None

--- a/backend/app/services/tenant/collaboration_test.py
+++ b/backend/app/services/tenant/collaboration_test.py
@@ -1,0 +1,62 @@
+"""Unit tests for the collaboration room registry.
+
+The rooms themselves are exercised through the WebSocket endpoint; what is
+covered here is how they are *addressed*. Document ids are per-guild-schema
+sequences, so the id alone does not name a document and the registry key has to
+carry the guild with it.
+"""
+
+import pytest
+
+from app.services.tenant.collaboration import CollaborationManager, DocumentRoom
+
+
+@pytest.mark.unit
+async def test_the_same_document_id_in_two_guilds_is_two_rooms() -> None:
+    manager = CollaborationManager()
+    manager._rooms[(1, 5)] = DocumentRoom(5)
+    manager._rooms[(2, 5)] = DocumentRoom(5)
+
+    first = manager.get_room(1, 5)
+    second = manager.get_room(2, 5)
+
+    assert first is not None
+    assert second is not None
+    assert first is not second
+    assert manager.get_active_rooms() == {(1, 5), (2, 5)}
+
+
+@pytest.mark.unit
+async def test_a_room_is_reached_only_from_its_own_guild() -> None:
+    manager = CollaborationManager()
+    manager._rooms[(1, 5)] = DocumentRoom(5)
+
+    assert manager.get_room(1, 5) is not None
+    assert manager.get_room(2, 5) is None
+    assert manager.has_active_collaborators(2, 5) is False
+
+
+@pytest.mark.unit
+async def test_removing_a_room_leaves_the_other_guild_alone() -> None:
+    manager = CollaborationManager()
+    manager._rooms[(1, 5)] = DocumentRoom(5)
+    manager._rooms[(2, 5)] = DocumentRoom(5)
+
+    # Both are empty of collaborators, so both are removable — only the one
+    # named should go.
+    await manager.remove_room(1, 5)
+
+    assert manager.get_room(1, 5) is None
+    assert manager.get_room(2, 5) is not None
+
+
+@pytest.mark.unit
+async def test_invalidating_a_room_leaves_the_other_guild_alone() -> None:
+    manager = CollaborationManager()
+    manager._rooms[(1, 5)] = DocumentRoom(5)
+    manager._rooms[(2, 5)] = DocumentRoom(5)
+
+    assert await manager.invalidate_room_if_empty(1, 5) is True
+
+    assert manager.get_room(1, 5) is None
+    assert manager.get_room(2, 5) is not None

--- a/backend/app/services/tenant/documents.py
+++ b/backend/app/services/tenant/documents.py
@@ -34,6 +34,7 @@ from app.core.messages import DocumentMessages
 from app.services.tenant import attachments as attachments_service
 from app.services.tenant import tags as tags_service
 from app.services.tenant.collaboration import collaboration_manager
+from app.db.session import routed_guild_id
 
 
 def _empty_paragraph() -> dict[str, Any]:
@@ -727,5 +728,10 @@ async def unresolve_wikilinks_to_document(
     # Invalidate any in-memory collaboration rooms for affected documents
     # This prevents persist_room from overwriting our changes when users disconnect
     # Note: If a room has active collaborators, they'll have stale wikilinks until reload
-    for doc_id in affected_doc_ids:
-        await collaboration_manager.invalidate_room_if_empty(doc_id)
+    # Rooms are keyed by (guild, document), and the documents above were read
+    # through this session, so the guild it is routed to is theirs. An unrouted
+    # session reaches no guild schema and so has no room to invalidate.
+    guild_id = routed_guild_id(session)
+    if guild_id is not None:
+        for doc_id in affected_doc_ids:
+            await collaboration_manager.invalidate_room_if_empty(guild_id, doc_id)

--- a/backend/app/services/tenant/mention_parser.py
+++ b/backend/app/services/tenant/mention_parser.py
@@ -24,6 +24,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.tenant.comment import Comment
 from app.models.tenant.document import Document
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
+from app.db.session import routed_guild_id
 
 USER_PATTERN = re.compile(r"@\[[^\]]+\]\((\d+)\)")
 TASK_PATTERN = re.compile(r"#task\[[^\]]+\]\((\d+)\)")
@@ -144,6 +145,9 @@ async def anonymize_user_mentions(session: AsyncSession, *, user_id: int) -> Non
     await session.flush()
 
     # Drop idle collaboration rooms so persist_room can't overwrite the
-    # scrubbed content with a stale in-memory copy on next disconnect.
-    for doc_id in affected_doc_ids:
-        await collaboration_manager.invalidate_room_if_empty(doc_id)
+    # scrubbed content with a stale in-memory copy on next disconnect. Rooms are
+    # keyed by (guild, document) and this runs once per guild, routed to it.
+    guild_id = routed_guild_id(session)
+    if guild_id is not None:
+        for doc_id in affected_doc_ids:
+            await collaboration_manager.invalidate_room_if_empty(guild_id, doc_id)

--- a/frontend/public/locales/de/guilds.json
+++ b/frontend/public/locales/de/guilds.json
@@ -325,6 +325,8 @@
     "heroTitle": "Niemand baut eine Welt allein",
     "heroSubtitle": "Egal ob Pen & Paper, Musik oder Wissenschaft: Hier wartet eine Gilde mit einem Platz für dich.",
     "browse": "Community beitreten",
+    "onlineCount_one": "{{count}} online",
+    "onlineCount_other": "{{count}} online",
     "searchPlaceholder": "Communitys durchsuchen",
     "categoriesHeading": "Kategorien",
     "allCategories": "Alle",

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -325,6 +325,8 @@
     "heroTitle": "Nobody builds a world alone",
     "heroSubtitle": "Whatever you're into, from tabletop to music to science, a guild here has a seat with your name on it.",
     "browse": "Join a community",
+    "onlineCount_one": "{{count}} online",
+    "onlineCount_other": "{{count}} online",
     "searchPlaceholder": "Search communities",
     "categoriesHeading": "Categories",
     "allCategories": "All",

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -325,6 +325,8 @@
     "heroTitle": "Nadie construye un mundo solo",
     "heroSubtitle": "Sea lo que sea lo tuyo, del rol de mesa a la música o la ciencia, aquí hay un gremio con un sitio reservado para ti.",
     "browse": "Unirse a una comunidad",
+    "onlineCount_one": "{{count}} en línea",
+    "onlineCount_other": "{{count}} en línea",
     "searchPlaceholder": "Buscar comunidades",
     "categoriesHeading": "Categorías",
     "allCategories": "Todas",

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -325,6 +325,8 @@
     "heroTitle": "Personne ne bâtit un monde seul",
     "heroSubtitle": "Quelle que soit votre passion, du jeu de rôle à la musique en passant par les sciences, une guilde ici vous garde une place.",
     "browse": "Rejoindre une communauté",
+    "onlineCount_one": "{{count}} en ligne",
+    "onlineCount_other": "{{count}} en ligne",
     "searchPlaceholder": "Rechercher des communautés",
     "categoriesHeading": "Catégories",
     "allCategories": "Toutes",

--- a/frontend/src/api/generated/guilds/guilds.ts
+++ b/frontend/src/api/generated/guilds/guilds.ts
@@ -370,7 +370,8 @@ export const useReorderGuildsApiV1GuildsOrderPut = <
  * is not what this returns — the filters live in the service (listed AND
  * active, always), and :class:`CommunityGuildRead` carries only what a guild
  * published by opting in: no lifecycle status, no administration, no roster,
- * and nothing at all from inside the guild's own schema.
+ * and nothing at all from inside the guild's own schema. How many people have
+ * it open is a count of live connections, named to nobody.
  *
  * The directory is a deployment-level feature an owner switches on; where it
  * is off there is nothing to browse and the request is refused rather than

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1312,6 +1312,11 @@ export const GuildCategory = {
  * shelves, and how many people are already there. No membership fields (they
  * have none), no lifecycle status, no administration. ``already_member`` is
  * about the *caller*, and only says whether the Join button applies to them.
+ *
+ * ``online_count`` is how many of those people have the guild open right now.
+ * It is a live reading rather than a stored one, taken from the process
+ * answering the request, so it is a sense of how busy a guild is rather than a
+ * figure to reconcile against anything.
  */
 export interface CommunityGuildRead {
   id: number;
@@ -1320,6 +1325,7 @@ export interface CommunityGuildRead {
   icon_base64: string | null;
   categories: GuildCategory[];
   member_count: number;
+  online_count: number;
   already_member: boolean;
 }
 

--- a/frontend/src/components/guilds/CommunityCard.tsx
+++ b/frontend/src/components/guilds/CommunityCard.tsx
@@ -57,9 +57,23 @@ export const CommunityCard = ({ guild }: { guild: CommunityGuildRead }) => {
             <h3 className="truncate font-semibold text-base" title={guild.name}>
               {guild.name}
             </h3>
-            <p className="flex items-center gap-1 text-muted-foreground text-xs">
-              <Users className="h-3 w-3" aria-hidden="true" />
-              {t("guilds:memberCount", { count: guild.member_count })}
+            <p className="flex flex-wrap items-center gap-x-1.5 text-muted-foreground text-xs">
+              {/* Who is here now, then how many there are in all. A guild with
+                  nobody in it says nothing rather than "0 online", which reads
+                  as a verdict on the guild rather than on the moment. */}
+              {guild.online_count > 0 ? (
+                <>
+                  <span className="flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+                    <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
+                    {t("guilds:community.onlineCount", { count: guild.online_count })}
+                  </span>
+                  <span aria-hidden="true">·</span>
+                </>
+              ) : null}
+              <span className="flex items-center gap-1">
+                <Users className="h-3 w-3" aria-hidden="true" />
+                {t("guilds:memberCount", { count: guild.member_count })}
+              </span>
             </p>
           </div>
         </div>

--- a/frontend/src/pages/communities/CommunitiesPage.test.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.test.tsx
@@ -42,6 +42,7 @@ const community = (overrides: Partial<CommunityGuildRead> = {}): CommunityGuildR
   icon_base64: null,
   categories: ["art"],
   member_count: 12,
+  online_count: 0,
   already_member: false,
   ...overrides,
 });
@@ -129,6 +130,21 @@ describe("CommunitiesPage", () => {
     expect(screen.getByText("Community theatre.")).toBeInTheDocument();
     expect(screen.getByText("12 members")).toBeInTheDocument();
     expect(screen.getByText("Art & design")).toBeInTheDocument();
+  });
+
+  it("says who is there now beside how many there are", async () => {
+    directoryFor.mockReturnValue(directoryResult([community({ online_count: 3 })]));
+    renderDirectory();
+
+    expect(await screen.findByText("3 online")).toBeInTheDocument();
+    expect(screen.getByText("12 members")).toBeInTheDocument();
+  });
+
+  it("says nothing about presence in a guild nobody is in", async () => {
+    renderDirectory();
+
+    await screen.findByText("Riverside Players");
+    expect(screen.queryByText("0 online")).not.toBeInTheDocument();
   });
 
   it("asks for everything until a category is picked", async () => {


### PR DESCRIPTION
## Problem

Two things, both about state the API holds in memory per guild.

The community directory could say how many members a guild has, but not
whether any of them are there. That is the thing someone with no guild yet is
actually choosing between, and the events stream already knew it — a socket on
`/events/updates` is a person with the app open in that guild — it just never
recorded who the socket belonged to.

Separately, `CollaborationManager` addressed its rooms by `document_id` alone.
Documents live in per-guild schemas with per-schema `SERIAL` ids, so that
number does not identify a document on its own; `realtime.py` already carries
the guild in its room key for the same reason.

## Changes

**Presence**
- [`ConnectionManager`](backend/app/services/realtime.py) records `guild_id → user_id → open socket count` beside its initiative rooms, and drops it on disconnect. Counted per user, so two tabs are one person; kept per guild rather than per room, so a member of no initiative is still present.
- [`events.py`](backend/app/api/v1/tenant_endpoints/events.py) passes the `user_id` it already resolved.
- `CommunityGuildRead` gains `online_count`, filled in [`guilds.py`](backend/app/api/v1/platform_endpoints/guilds.py) for the page being returned — live state, so read there rather than joined in the query.
- [`CommunityCard`](frontend/src/components/guilds/CommunityCard.tsx) shows `3 online · 12 members`. A guild nobody is in shows only its member count.
- Bounded on purpose, and documented as such: this is one process's own sockets, so under multiple workers each holds a share. Enough for "how busy is this guild"; not a figure to reconcile against anything.

**Room addressing**
- [`CollaborationManager`](backend/app/services/tenant/collaboration.py) keys rooms `(guild_id, document_id)`, and the guild travels through `get_or_create_room`, `remove_room`, `invalidate_room_if_empty`, `persist_room`, `get_room` and `has_active_collaborators`.
- Six call sites updated. Four had a guild to hand. The two service paths (`unresolve_wikilinks_to_document`, `anonymize_user_mentions`) only had their session, so `routed_guild_id` in [`session.py`](backend/app/db/session.py) reads it off the RLS context — the same routing that made those ids meaningful when the documents were read.

## Testing

- `pytest app/services/realtime_test.py app/services/tenant/collaboration_test.py app/api/v1/platform_endpoints/guilds_community_test.py` — 54 passed (7 new: presence counting, per-guild presence, presence without an initiative, and four on room addressing)
- `pytest app/api/v1/tenant_endpoints/documents_test.py app/api/v1/tenant_endpoints/documents_scope_test.py` — 44 passed
- `pnpm vitest run src/pages/communities src/__tests__/locale-keys.test.ts` — 300 passed
- `ruff check app`, `ty check app`, `pnpm typecheck`, `pnpm lint` — clean
- Orval types regenerated and committed

## Notes

`online_count` strings are in all four locales. The changelog covers the
directory change; the room addressing is internal plumbing with no visible
behaviour change, so it has no entry.

This branch and the member-count sort currently in `dev`'s working tree both
touch `list_community_guilds` — whichever lands second needs a one-line merge.