### PR TITLE
Give seeded dev users a handle

### DIFF
--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -428,6 +428,13 @@ async def _create_users(
             )
         ).one_or_none()
         if existing is not None:
+            # A row seeded before handles existed was given one by the
+            # backfill, which marks it unchosen — so signing in would land on
+            # the choose-your-handle screen, unlike a freshly seeded account.
+            # Seeded logins are set up ready to use either way.
+            if not existing.username_chosen:
+                existing.username_chosen = True
+                session.add(existing)
             ids.add("users", existing.id)
             users[ud["full_name"]] = existing
             continue

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -53,6 +53,7 @@ from app.core.config import settings  # noqa: E402
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
 from app.db.schema_provisioning import provision_guild  # noqa: E402
+from app.services.platform.usernames import allocate_from_seed  # noqa: E402
 from app.db.session import AdminSessionLocal, set_rls_context  # noqa: E402
 from app.db.tenancy import GUILD_SCOPED_TABLES  # noqa: E402
 from app.services.tenant.dashboard_definition import (  # noqa: E402
@@ -430,9 +431,20 @@ async def _create_users(
             ids.add("users", existing.id)
             users[ud["full_name"]] = existing
             continue
+        # Seeded people get a handle the way a real account does: from their
+        # name, with the number drawn for them. ``username`` may be given
+        # explicitly where a scenario wants a recognisable one.
+        handle, discriminator = await allocate_from_seed(
+            session, seed=ud.get("username") or ud["full_name"]
+        )
         user = User(
             email_hash=hash_email(ud["email"]),
             email_encrypted=encrypt_field(ud["email"], SALT_EMAIL),
+            username=handle,
+            discriminator=discriminator,
+            # Seeded accounts are set up ready to use, so they never meet the
+            # choose-your-handle screen.
+            username_chosen=True,
             full_name=ud["full_name"],
             hashed_password=get_password_hash("changeme"),
             role=ud.get("role", UserRole.member),


### PR DESCRIPTION
## Problem

Every `python scripts/seed_dev_data.py` run has failed since #1276:

```
asyncpg.exceptions.NotNullViolationError: null value in column "username"
of relation "users" violates not-null constraint
```

The seeder builds `User(...)` rows by hand and predates handles. It lives at the repo root in `scripts/` rather than under `backend/app`, which is why the sweep that fixed the test factories and `init_db` missed it — it is the only file outside that tree that constructs a user.

Worth saying plainly: this is not a migration problem. The failure is proof the migration ran, since the column exists and is `NOT NULL`.

## What changed

Seeded people get a handle the way an account provisioned without a form does — through `allocate_from_seed`, the same helper SSO provisioning uses — and are marked `username_chosen=True`, so a seeded login lands in the app rather than on the choose-your-handle screen.

A `user_def` may name a `username` explicitly where a scenario wants a recognisable one; nothing does yet, so every seeded handle comes from the person's name.

## Testing

```
cd backend && ruff check ../scripts/seed_dev_data.py
cd backend && python ../scripts/seed_dev_data.py
```

Full seed completes: 3 guilds, the six directory guilds, all users, and the 5 PAM grants.