### PR TITLE
Write down what a moderator does, and give it a board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **There is an audit board.** Platform staff who can read audits — support and above — get a new Audit tab in the admin tools, listing what was done to accounts, by whom, and when, newest first, filterable by account. It starts with profile-picture takedowns, the one moderator action that exists today. Entries are kept after the accounts they name are deleted, so the record of what was done outlives the person it was done to; a deleted account shows as its ID rather than a name. Nothing can edit or remove an entry, including the software itself. Each entry is also written to the server log as one line of JSON, so an operator who ships their logs somewhere gets the audit trail with it.
+
 - **Every guild has a banner.** It heads the guild's front page — the guild's own name and description across it — and runs along the top of its card in the community directory. A guild admin uploads one picture from Settings → Guild → Pictures and it is cropped to 4:1 and resized for you, so there is nothing to prepare and no second file to make. A guild without artwork wears a **banner fill** instead, which starts as the app's default blue and can be any colour; without a picture the banner is a short band rather than a full header. **Banner text** is black or white — whichever reads better on the fill, chosen for you when you pick one, and yours to switch when a picture calls for the other.
 
 - **A guild-wide app connection can be granted at the vendor instead of typed.** A guild admin connects it once for everybody: the settings panel opens the vendor's install page rather than a form, and what comes back is written in by the app itself.

--- a/backend/alembic/versions/20260829_0204_audit_events.py
+++ b/backend/alembic/versions/20260829_0204_audit_events.py
@@ -1,0 +1,89 @@
+"""What was done, by whom, to what — kept after everyone involved is gone.
+
+The first slice of ``history/pam-audit-sink-design.md``: the table and its
+grants, built to that design's shape so the privileged-access family, the
+immutable-storage sink and the shipper land on top of it later without
+reworking what is written now.
+
+Append-only in the grants, not by convention: nobody holds UPDATE or DELETE,
+the system engine included. The request-path floors hold nothing at all — the
+log is written and read on the system engine, behind the ``audit.read``
+capability — so the schema default privileges that grant every new public
+table to the base roles are revoked first.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.core.config import settings
+
+revision = "20260829_0204"
+down_revision = "20260829_0203"
+branch_labels = None
+depends_on = None
+
+
+def _platform_base() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_events",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column(
+            "event_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("event_type", sa.String(64), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        # Plain integers throughout: an audit row is a point-in-time fact that
+        # has to outlive the account and the guild it names, so there is no
+        # foreign key to cascade or null it out on erasure.
+        sa.Column("actor_user_id", sa.Integer(), nullable=False),
+        sa.Column("target_user_id", sa.Integer(), nullable=True),
+        sa.Column("guild_id", sa.Integer(), nullable=True),
+        sa.Column("target_type", sa.String(64), nullable=True),
+        sa.Column("target_id", sa.Integer(), nullable=True),
+        sa.Column("tier", sa.SmallInteger(), nullable=False),
+        sa.Column("envelope", postgresql.JSONB(), nullable=False),
+    )
+    op.create_index("ix_audit_events_occurred_at", "audit_events", ["occurred_at"])
+    op.create_index(
+        "ix_audit_events_actor", "audit_events", ["actor_user_id", "occurred_at"]
+    )
+    op.create_index(
+        "ix_audit_events_target_user",
+        "audit_events",
+        ["target_user_id", "occurred_at"],
+    )
+
+    base = _platform_base()
+    statements = [
+        # Schema default privileges hand every new public table to the base
+        # roles; this table belongs to neither.
+        f'REVOKE ALL ON TABLE public.audit_events FROM "{base}"',
+        "REVOKE ALL ON TABLE public.audit_events FROM app_guild_base",
+        "REVOKE ALL ON TABLE public.audit_events FROM app_user",
+        f'REVOKE ALL ON SEQUENCE public.audit_events_id_seq FROM "{base}"',
+        "REVOKE ALL ON SEQUENCE public.audit_events_id_seq FROM app_guild_base",
+        "REVOKE ALL ON SEQUENCE public.audit_events_id_seq FROM app_user",
+        # The system engine writes the record and the board reads it. No
+        # UPDATE, no DELETE, to anyone.
+        "GRANT SELECT, INSERT ON TABLE public.audit_events TO app_admin",
+        "GRANT USAGE ON SEQUENCE public.audit_events_id_seq TO app_admin",
+        "ALTER TABLE public.audit_events ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE public.audit_events FORCE ROW LEVEL SECURITY",
+    ]
+    for statement in statements:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_events_target_user", table_name="audit_events")
+    op.drop_index("ix_audit_events_actor", table_name="audit_events")
+    op.drop_index("ix_audit_events_occurred_at", table_name="audit_events")
+    op.drop_table("audit_events")

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -1,21 +1,30 @@
 import logging
-from typing import Annotated, List, Sequence
+from typing import Annotated, List, Optional, Sequence
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Response
+from sqlalchemy import func
 from sqlmodel import select
 
 from app.api.deps import UserSessionDep, require_capability
+from app.core.audit_events import AuditEventType
 from app.core.capabilities import Capability, capabilities_for, can_assign_role
+from app.db.query import page_has_next, paginated_query
 from app.db.session import get_admin_session, set_rls_context
 from app.db.schema_provisioning import deprovision_guild
 from sqlmodel.ext.asyncio.session import AsyncSession
+from app.models.platform.audit_event import AuditEvent
 from app.models.platform.guild import Guild, GuildRole
 from app.models.tenant.initiative import Initiative, InitiativeMember
 from app.models.tenant.project import Project
 from app.models.platform.user import User, UserStatus
 from app.models.platform.user_token import UserTokenPurpose
 from app.schemas.platform.user import UserRead, AccountDeletionResponse, UserPublic
+from app.schemas.platform.audit import (
+    AuditActor,
+    AuditEventListResponse,
+    AuditEventRead,
+)
 from app.schemas.platform.auth import VerificationSendResponse
 from app.schemas.platform.admin import (
     PlatformRoleUpdate,
@@ -39,6 +48,7 @@ from app.services.stream_authz import authority as stream_authority
 from app.services.tenant import initiatives as initiatives_service
 from app.services import notifications as notifications_service
 from app.services.platform import user_avatars as user_avatars_service
+from app.services import audit as audit_service
 from app.services.platform import users as users_service
 from app.services.platform.guilds import adopt_guild_name_display
 from app.services.platform import guilds as guilds_service
@@ -52,6 +62,7 @@ router = APIRouter()
 # ladder (member → support → moderator → admin → owner) maps cleanly onto
 # what each operation actually requires.
 UsersReadDep = Annotated[User, Depends(require_capability(Capability.USERS_READ))]
+AuditReadDep = Annotated[User, Depends(require_capability(Capability.AUDIT_READ))]
 UsersManageDep = Annotated[User, Depends(require_capability(Capability.USERS_MANAGE))]
 ContentModerateDep = Annotated[
     User, Depends(require_capability(Capability.CONTENT_MODERATE))
@@ -268,9 +279,102 @@ async def remove_user_avatar(
         # Queued before the commit, not after it: silent removal reads as a
         # bug, so the picture going and the person being told are one write.
         await notifications_service.queue_avatar_removed(session, user=user)
+        # Recorded in the same transaction, for the same reason: the takedown
+        # and the record of who did it commit together or not at all.
+        await audit_service.record(
+            session,
+            event_type=AuditEventType.USER_AVATAR_REMOVED,
+            actor_user_id=current_user.id,
+            target_user_id=user_id,
+            target_type="user",
+            target_id=user_id,
+        )
 
     await session.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/audit-events", response_model=AuditEventListResponse)
+async def list_audit_events(
+    session: AdminSessionDep,
+    _current_user: AuditReadDep,
+    event_type: Annotated[list[str] | None, Query()] = None,
+    actor_user_id: Optional[int] = Query(default=None),
+    target_user_id: Optional[int] = Query(default=None),
+    occurred_after: Optional[datetime] = Query(default=None),
+    occurred_before: Optional[datetime] = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=200),
+) -> AuditEventListResponse:
+    """The audit board: what was done, by whom, to whom, most recent first.
+
+    Gated on ``audit.read`` (support and above). Runs on the system engine
+    because nothing else can read the table — the log is not part of the
+    request path's world in either direction.
+    """
+    base = select(AuditEvent)
+    if event_type:
+        base = base.where(AuditEvent.event_type.in_(event_type))
+    if actor_user_id is not None:
+        base = base.where(AuditEvent.actor_user_id == actor_user_id)
+    if target_user_id is not None:
+        base = base.where(AuditEvent.target_user_id == target_user_id)
+    if occurred_after is not None:
+        base = base.where(AuditEvent.occurred_at >= occurred_after)
+    if occurred_before is not None:
+        base = base.where(AuditEvent.occurred_at <= occurred_before)
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    data_stmt = base.order_by(AuditEvent.occurred_at.desc(), AuditEvent.id.desc())
+    events, total_count, actual_page = await paginated_query(
+        session, data_stmt, count_stmt, page=page, page_size=page_size
+    )
+
+    # The rows hold ids, so a name is looked up now rather than stored then.
+    # An account that has since been erased simply resolves to nothing, and the
+    # record of what was done to it stays intact.
+    wanted = {event.actor_user_id for event in events} | {
+        event.target_user_id for event in events if event.target_user_id is not None
+    }
+    handles: dict[int, User] = {}
+    if wanted:
+        rows = await session.exec(select(User).where(User.id.in_(wanted)))
+        handles = {user.id: user for user in rows.all() if user.id is not None}
+
+    def _actor(user_id: Optional[int]) -> Optional[AuditActor]:
+        if user_id is None:
+            return None
+        user = handles.get(user_id)
+        return AuditActor(
+            id=user_id,
+            username=user.username if user else None,
+            discriminator=user.discriminator if user else None,
+        )
+
+    return AuditEventListResponse(
+        items=[
+            AuditEventRead(
+                id=event.id,
+                event_uuid=str(event.event_uuid),
+                event_type=event.event_type,
+                category=str(event.envelope.get("category", "")),
+                tier=event.tier,
+                occurred_at=event.occurred_at,
+                actor=_actor(event.actor_user_id),
+                target_user=_actor(event.target_user_id),
+                guild_id=event.guild_id,
+                target_type=event.target_type,
+                target_id=event.target_id,
+                detail=event.envelope.get("detail") or {},
+            )
+            for event in events
+        ],
+        total_count=total_count,
+        page=actual_page,
+        page_size=page_size,
+        has_next=page_has_next(actual_page, page_size, total_count),
+        has_prev=actual_page > 1,
+    )
 
 
 @router.get("/platform-admin-count", response_model=PlatformAdminCountResponse)

--- a/backend/app/api/v1/platform_endpoints/audit_test.py
+++ b/backend/app/api/v1/platform_endpoints/audit_test.py
@@ -1,0 +1,136 @@
+"""The audit board: who may read it, and what it says."""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.audit_events import AuditEventType
+from app.models.platform.user import UserRole
+from app.services import audit as audit_service
+from app.testing import create_user
+from app.testing.factories import get_auth_headers
+
+pytestmark = pytest.mark.integration
+
+BOARD = "/api/v1/admin/audit-events"
+
+
+async def _record(session, actor, subject):
+    await audit_service.record(
+        session,
+        event_type=AuditEventType.USER_AVATAR_REMOVED,
+        actor_user_id=actor.id,
+        target_user_id=subject.id,
+        target_type="user",
+        target_id=subject.id,
+    )
+    await session.commit()
+
+
+class TestWhoMayRead:
+    @pytest.mark.parametrize(
+        "role", [UserRole.support, UserRole.moderator, UserRole.owner]
+    )
+    async def test_audit_read_holders(
+        self, client: AsyncClient, session: AsyncSession, role
+    ):
+        reader = await create_user(session, role=role)
+
+        response = await client.get(BOARD, headers=get_auth_headers(reader))
+
+        assert response.status_code == 200, response.text
+
+    async def test_a_member_is_refused(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        member = await create_user(session, role=UserRole.member)
+
+        response = await client.get(BOARD, headers=get_auth_headers(member))
+
+        assert response.status_code == 403
+
+
+class TestWhatItSays:
+    async def test_an_entry_names_both_sides_by_handle(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        actor = await create_user(session, role=UserRole.moderator, username="modsy")
+        subject = await create_user(session, username="subject")
+        await _record(session, actor, subject)
+
+        response = await client.get(
+            BOARD,
+            headers=get_auth_headers(actor),
+            params={"actor_user_id": actor.id},
+        )
+
+        entry = response.json()["items"][0]
+        assert entry["event_type"] == "user.avatar_removed"
+        assert entry["actor"]["username"] == "modsy"
+        assert entry["target_user"]["username"] == "subject"
+        assert entry["target_type"] == "user"
+
+    async def test_an_entry_outlives_the_account_it_names(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        """The row holds ids, so an erased subject resolves to nothing and the
+        record of what was done to them stays readable."""
+        actor = await create_user(session, role=UserRole.moderator)
+        subject = await create_user(session)
+        subject_id = subject.id
+        await _record(session, actor, subject)
+
+        await session.delete(subject)
+        await session.commit()
+
+        response = await client.get(
+            BOARD, headers=get_auth_headers(actor), params={"actor_user_id": actor.id}
+        )
+
+        entry = response.json()["items"][0]
+        assert entry["target_user"] == {
+            "id": subject_id,
+            "username": None,
+            "discriminator": None,
+        }
+
+    async def test_filtering_by_subject(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        actor = await create_user(session, role=UserRole.moderator)
+        wanted = await create_user(session)
+        other = await create_user(session)
+        await _record(session, actor, wanted)
+        await _record(session, actor, other)
+
+        response = await client.get(
+            BOARD, headers=get_auth_headers(actor), params={"target_user_id": wanted.id}
+        )
+
+        body = response.json()
+        assert body["total_count"] == 1
+        assert body["items"][0]["target_user"]["id"] == wanted.id
+
+
+class TestTheTakedownRecordsItself:
+    async def test_removing_a_picture_writes_an_entry(
+        self, client: AsyncClient, session: AsyncSession
+    ):
+        moderator = await create_user(session, role=UserRole.moderator)
+        subject = await create_user(session, avatar_url="https://idp.example/pic.png")
+
+        removal = await client.delete(
+            f"/api/v1/admin/users/{subject.id}/avatar",
+            headers=get_auth_headers(moderator),
+        )
+        assert removal.status_code == 204, removal.text
+
+        board = await client.get(
+            BOARD,
+            headers=get_auth_headers(moderator),
+            params={"target_user_id": subject.id},
+        )
+
+        entry = board.json()["items"][0]
+        assert entry["event_type"] == "user.avatar_removed"
+        assert entry["actor"]["id"] == moderator.id

--- a/backend/app/core/audit_events.py
+++ b/backend/app/core/audit_events.py
@@ -1,0 +1,64 @@
+"""The catalogue of things Initiative writes down.
+
+One enum drives every surface — the table, the ingestible line, the board, the
+filters — so adding a newly-audited action is an enum member, a metadata row,
+and one ``record()`` call at the site. There is no second list to keep in step;
+``audit_events_test`` fails CI if the two here ever disagree.
+
+Tiers come from ``history/pam-audit-sink-design.md``. Tier 1 is the privileged
+-access family, which that design writes to immutable storage as well; Tier 2 is
+everything else Initiative owns. Nothing here ships anywhere yet — the tier is
+recorded now so the shipper does not have to reclassify history later.
+
+Initiative records only actions whose authority it enforces itself. Infra
+access, the identity provider's own sign-ins and billing all emit their own
+streams; the envelope carries the fields that stitch them together downstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class AuditEventType(str, Enum):
+    """A recorded action. Values are stable strings — treat them as a contract
+    with whatever reads the log."""
+
+    # Trust & safety: what a moderator does to an account, none of which needs
+    # a PAM grant because none of it reaches a guild's content.
+    USER_AVATAR_REMOVED = "user.avatar_removed"
+
+
+class AuditCategory(str, Enum):
+    """Which family an event belongs to. The board groups by this."""
+
+    MODERATION = "moderation"
+
+
+@dataclass(frozen=True)
+class AuditEventMeta:
+    #: 1 for the privileged-access family (destined for immutable storage),
+    #: 2 for everything else. Denormalized onto the row so a shipper can
+    #: select by it without reading this registry.
+    tier: int
+    category: AuditCategory
+    #: Whether the action changed something. Reads are recorded too (a PAM
+    #: grantee's are the point of the log), so this is not implied by presence.
+    is_write: bool
+
+
+AUDIT_EVENT_META: dict[AuditEventType, AuditEventMeta] = {
+    AuditEventType.USER_AVATAR_REMOVED: AuditEventMeta(
+        tier=2, category=AuditCategory.MODERATION, is_write=True
+    ),
+}
+
+
+def meta_for(event_type: AuditEventType) -> AuditEventMeta:
+    return AUDIT_EVENT_META[event_type]
+
+
+#: The envelope's shape version. Downstream contracts against it; bump only on
+#: a breaking change.
+SCHEMA_VERSION = 1

--- a/backend/app/core/audit_events_test.py
+++ b/backend/app/core/audit_events_test.py
@@ -1,0 +1,31 @@
+"""The registry drives every surface, so the two halves have to agree."""
+
+import pytest
+
+from app.core.audit_events import AUDIT_EVENT_META, AuditEventType
+
+pytestmark = pytest.mark.unit
+
+
+def test_every_event_has_metadata():
+    """Adding an action is an enum member plus its row. Forgetting the row
+    would leave the tier and category to be guessed at write time."""
+    missing = [e.value for e in AuditEventType if e not in AUDIT_EVENT_META]
+    assert missing == []
+
+
+def test_no_metadata_without_an_event():
+    stray = [key for key in AUDIT_EVENT_META if not isinstance(key, AuditEventType)]
+    assert stray == []
+
+
+def test_values_are_namespaced():
+    """``family.action`` — downstream filters on the prefix."""
+    for event in AuditEventType:
+        family, separator, action = event.value.partition(".")
+        assert separator and family and action, event.value
+
+
+def test_tiers_are_the_two_the_design_defines():
+    for event, meta in AUDIT_EVENT_META.items():
+        assert meta.tier in (1, 2), event.value

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -62,6 +62,7 @@ from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.federated_identity_secret import FederatedIdentitySecret
 from app.models.platform.guild_auth_policy import GuildAuthPolicy
 from app.models.platform.guild_image import GuildImage
+from app.models.platform.audit_event import AuditEvent  # noqa: F401
 from app.models.platform.user_token import UserToken
 from app.models.platform.push_token import PushToken
 from app.models.platform.auto_delegation_jti import AutoDelegationJti

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -35,6 +35,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.database]
 # Shared tables that carry (FORCEd) row-level security.
 _RLS_SHARED_TABLES = {
     "access_grants",
+    "audit_events",
     "app_service_nonces",
     "app_service_registrations",
     "app_settings",

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -152,6 +152,10 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     "user_view_preferences": None,
     "notifications": frozenset({"SELECT", "INSERT", "DELETE"}),
     "user_tokens": frozenset({"SELECT", "INSERT", "DELETE"}),
+    # Append-only. The system engine writes the record and the board reads it;
+    # UPDATE and DELETE are granted to nobody at all, here included, because a
+    # record that could be rewritten afterwards would not be one.
+    "audit_events": frozenset({"SELECT", "INSERT"}),
     # the system engine delivers push itself (background digests, PAM notices),
     # and delivery bookkeeping is part of that: UPDATE stamps last_used_at,
     # DELETE prunes tokens FCM reports as unregistered
@@ -191,6 +195,9 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # system engine — see security_invariants_test.
     "users": frozenset({"SELECT"}),
     "user_tokens": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # Written and read on the system engine only — the request path never
+    # touches the log, in either direction.
+    "audit_events": None,
     # system-engine-only credential store; the request path never touches it
     # (auth lookup + management endpoints run on app_admin), like auth_sessions
     "user_api_keys": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -68,6 +68,10 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # it hangs off: one user spans guilds, and the bytes are served to
         # anyone holding the URL.
         "user_avatars",
+        # What a moderator did, and to whom. Cross-guild platform security
+        # that has to outlive any guild — and every reference in it is a plain
+        # integer, so it outlives the accounts it names too.
+        "audit_events",
         # Tenancy roster — must be readable *before* a request is routed
         "guilds",
         # The operator-set half of a guild (caps / plan label / sign-in

--- a/backend/app/models/platform/audit_event.py
+++ b/backend/app/models/platform/audit_event.py
@@ -1,0 +1,80 @@
+"""What was done, by whom, to what — kept after everyone involved is gone."""
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    SmallInteger,
+    String,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlmodel import Field, SQLModel
+
+
+class AuditEvent(SQLModel, table=True):
+    """One recorded action.
+
+    Append-only: the table grants no UPDATE or DELETE to anyone, the system
+    engine included. A record of what happened that could be rewritten
+    afterwards would not be one.
+
+    **Every reference here is a plain integer with no foreign key.** An audit
+    row is a point-in-time fact, and it has to outlive the account and the
+    guild it names — a cascade or a null-out on erasure would erase the record
+    of the erasure. Identity is resolved at read time, by id, and only for
+    rows that still have someone to resolve.
+    """
+
+    __tablename__ = "audit_events"
+    __table_args__ = (
+        # The board's query is "recent first, optionally filtered", and the
+        # shipper's is "everything above this id".
+        Index("ix_audit_events_occurred_at", "occurred_at"),
+        Index("ix_audit_events_actor", "actor_user_id", "occurred_at"),
+        Index("ix_audit_events_target_user", "target_user_id", "occurred_at"),
+    )
+
+    id: Optional[int] = Field(
+        default=None, sa_column=Column(BigInteger, primary_key=True)
+    )
+    #: Stable id for the envelope, so a downstream consumer can dedupe across
+    #: replays without depending on our sequence.
+    event_uuid: UUID = Field(
+        default_factory=uuid4,
+        sa_column=Column(PGUUID(as_uuid=True), nullable=False, unique=True),
+    )
+    event_type: str = Field(sa_column=Column(String(64), nullable=False))
+    occurred_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    #: Who did it. No FK — see the class docstring.
+    actor_user_id: int = Field(sa_column=Column(Integer, nullable=False))
+    #: Who it was done to, when the subject is an account. No FK.
+    target_user_id: Optional[int] = Field(
+        default=None, sa_column=Column(Integer, nullable=True)
+    )
+    #: The guild it happened in, for events that have one. No FK.
+    guild_id: Optional[int] = Field(
+        default=None, sa_column=Column(Integer, nullable=True)
+    )
+    target_type: Optional[str] = Field(
+        default=None, sa_column=Column(String(64), nullable=True)
+    )
+    target_id: Optional[int] = Field(
+        default=None, sa_column=Column(Integer, nullable=True)
+    )
+    #: Denormalized from the registry so a shipper can select by tier without
+    #: reading application code.
+    tier: int = Field(sa_column=Column(SmallInteger, nullable=False))
+    #: The versioned envelope, verbatim — the same object written to the
+    #: ingestible log line. Ids only; identity is never in here.
+    envelope: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column(JSONB, nullable=False)
+    )

--- a/backend/app/schemas/platform/audit.py
+++ b/backend/app/schemas/platform/audit.py
@@ -1,0 +1,51 @@
+"""What the audit board is served.
+
+Identity is resolved here, at read time, and only for accounts that still
+exist: the row itself holds ids, so it survives an erasure that the names in it
+would not.
+"""
+
+from datetime import datetime
+from typing import Any, List, Optional
+
+from pydantic import ConfigDict
+
+from app.schemas.base import SanitizedBaseModel
+
+
+class AuditActor(SanitizedBaseModel):
+    """Who an id points at now, or nothing if the account is gone."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    id: int
+    username: Optional[str] = None
+    discriminator: Optional[int] = None
+
+
+class AuditEventRead(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    id: int
+    event_uuid: str
+    event_type: str
+    category: str
+    tier: int
+    occurred_at: datetime
+    actor: AuditActor
+    target_user: Optional[AuditActor] = None
+    guild_id: Optional[int] = None
+    target_type: Optional[str] = None
+    target_id: Optional[int] = None
+    detail: dict[str, Any] = {}
+
+
+class AuditEventListResponse(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    items: List[AuditEventRead]
+    total_count: int
+    page: int
+    page_size: int
+    has_next: bool
+    has_prev: bool

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -4,9 +4,11 @@ One function. A call site is a single line, and adding a newly-audited action
 is that line plus an ``AuditEventType`` member and its metadata row — there is
 no second place to register anything.
 
-Two deliveries, one write. The row goes into the caller's own transaction, so
-the record and the action it describes commit together or not at all. The same
-envelope also goes to a structured logger named ``audit``, which is the
+Two deliveries, one write, and the write decides. The row goes into the
+caller's own transaction, so the record and the action it describes commit
+together or not at all — and the log line is held until that commit, so an
+action that rolls back leaves no row and tells nobody it happened. The line
+carries the same envelope to a structured logger named ``audit``, which is the
 ingestible seam: an operator's container-log pipeline already scrapes stdout,
 so shipping this stream costs them no new coupling to us.
 
@@ -21,12 +23,37 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+from sqlalchemy import event
+from sqlalchemy.orm import Session
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.audit_events import SCHEMA_VERSION, AuditEventType, meta_for
 from app.models.platform.audit_event import AuditEvent
 
 audit_logger = logging.getLogger("audit")
+
+#: Envelopes staged in a session, waiting on its commit. Kept on
+#: ``Session.info`` rather than in a module global so concurrent requests never
+#: share a queue.
+_PENDING = "audit_pending_envelopes"
+
+
+@event.listens_for(Session, "after_commit")
+def _emit_committed_envelopes(session: Session) -> None:
+    """Ship the lines for work that actually landed."""
+    for envelope in session.info.pop(_PENDING, []):
+        # Best-effort: a logging handler that throws must not take down a
+        # transaction that has already committed.
+        try:
+            audit_logger.info(json.dumps(envelope, separators=(",", ":")))
+        except Exception:  # pragma: no cover - a broken handler, not our logic
+            logging.getLogger(__name__).exception("audit log line could not be emitted")
+
+
+@event.listens_for(Session, "after_rollback")
+def _discard_uncommitted_envelopes(session: Session) -> None:
+    """Drop the lines for work that did not land."""
+    session.info.pop(_PENDING, None)
 
 
 async def record(
@@ -76,12 +103,9 @@ async def record(
     }
     session.add(event)
 
-    # Best-effort, and deliberately after the row is staged: the log line is a
-    # copy for whoever ships it, and a logging handler that throws must not
-    # take the audited action down with it.
-    try:
-        audit_logger.info(json.dumps(event.envelope, separators=(",", ":")))
-    except Exception:  # pragma: no cover - a broken handler, not our logic
-        logging.getLogger(__name__).exception("audit log line could not be emitted")
+    # Queued, not emitted. The line goes out when the transaction commits, so
+    # the two sinks cannot disagree: an action that rolls back leaves no row
+    # and tells nobody it happened.
+    session.info.setdefault(_PENDING, []).append(event.envelope)
 
     return event

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,87 @@
+"""Writing down what was done.
+
+One function. A call site is a single line, and adding a newly-audited action
+is that line plus an ``AuditEventType`` member and its metadata row — there is
+no second place to register anything.
+
+Two deliveries, one write. The row goes into the caller's own transaction, so
+the record and the action it describes commit together or not at all. The same
+envelope also goes to a structured logger named ``audit``, which is the
+ingestible seam: an operator's container-log pipeline already scrapes stdout,
+so shipping this stream costs them no new coupling to us.
+
+Identity is never in the envelope — ids only, resolved when the board is read
+and only for accounts that still exist.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.audit_events import SCHEMA_VERSION, AuditEventType, meta_for
+from app.models.platform.audit_event import AuditEvent
+
+audit_logger = logging.getLogger("audit")
+
+
+async def record(
+    session: AsyncSession,
+    *,
+    event_type: AuditEventType,
+    actor_user_id: int,
+    target_user_id: Optional[int] = None,
+    guild_id: Optional[int] = None,
+    target_type: Optional[str] = None,
+    target_id: Optional[int] = None,
+    detail: Optional[dict[str, Any]] = None,
+) -> AuditEvent:
+    """Record one action in ``session``'s transaction and emit its log line.
+
+    Staged, not committed: the caller owns the transaction, which is what makes
+    the record atomic with the thing it records.
+    """
+    meta = meta_for(event_type)
+    occurred_at = datetime.now(timezone.utc)
+
+    event = AuditEvent(
+        event_type=event_type.value,
+        occurred_at=occurred_at,
+        actor_user_id=actor_user_id,
+        target_user_id=target_user_id,
+        guild_id=guild_id,
+        target_type=target_type,
+        target_id=target_id,
+        tier=meta.tier,
+    )
+    event.envelope = {
+        "schema_version": SCHEMA_VERSION,
+        "event_uuid": str(event.event_uuid),
+        "event_type": event_type.value,
+        "occurred_at": occurred_at.isoformat(),
+        "actor_user_id": actor_user_id,
+        "target_user_id": target_user_id,
+        "guild_id": guild_id,
+        "target": (
+            {"type": target_type, "id": target_id} if target_type is not None else None
+        ),
+        "tier": meta.tier,
+        "category": meta.category.value,
+        "is_write": meta.is_write,
+        "detail": detail or {},
+    }
+    session.add(event)
+
+    # Best-effort, and deliberately after the row is staged: the log line is a
+    # copy for whoever ships it, and a logging handler that throws must not
+    # take the audited action down with it.
+    try:
+        audit_logger.info(json.dumps(event.envelope, separators=(",", ":")))
+    except Exception:  # pragma: no cover - a broken handler, not our logic
+        logging.getLogger(__name__).exception("audit log line could not be emitted")
+
+    return event

--- a/backend/app/services/audit_test.py
+++ b/backend/app/services/audit_test.py
@@ -1,0 +1,104 @@
+"""What ``record`` writes, and what it leaves out."""
+
+import json
+import logging
+
+import pytest
+from sqlmodel import select
+
+from app.core.audit_events import SCHEMA_VERSION, AuditEventType
+from app.models.platform.audit_event import AuditEvent
+from app.services import audit as audit_service
+from app.testing import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+
+async def test_a_record_lands_in_the_callers_transaction(session):
+    """Staged, not committed — which is what makes the record atomic with the
+    action it describes."""
+    actor = await create_user(session)
+    subject = await create_user(session)
+
+    await audit_service.record(
+        session,
+        event_type=AuditEventType.USER_AVATAR_REMOVED,
+        actor_user_id=actor.id,
+        target_user_id=subject.id,
+        target_type="user",
+        target_id=subject.id,
+    )
+    await session.commit()
+
+    row = (
+        await session.exec(
+            select(AuditEvent).where(AuditEvent.actor_user_id == actor.id)
+        )
+    ).one()
+    assert row.event_type == "user.avatar_removed"
+    assert row.target_user_id == subject.id
+    assert row.tier == 2
+
+
+async def test_the_envelope_carries_ids_and_no_identity(session):
+    """Names are resolved when the board is read. A name written into the
+    record would outlive the erasure of the account it belongs to."""
+    actor = await create_user(session, full_name="Ada Admin")
+    subject = await create_user(session, full_name="Sam Subject")
+
+    event = await audit_service.record(
+        session,
+        event_type=AuditEventType.USER_AVATAR_REMOVED,
+        actor_user_id=actor.id,
+        target_user_id=subject.id,
+    )
+    await session.commit()
+
+    serialized = json.dumps(event.envelope)
+    assert "Ada Admin" not in serialized
+    assert "Sam Subject" not in serialized
+    assert event.envelope["schema_version"] == SCHEMA_VERSION
+    assert event.envelope["actor_user_id"] == actor.id
+
+
+async def test_the_same_envelope_goes_to_the_log(session, caplog):
+    """The ingestible seam: one JSON line on the ``audit`` logger, which an
+    operator's existing container-log pipeline can ship as-is."""
+    actor = await create_user(session)
+
+    with caplog.at_level(logging.INFO, logger="audit"):
+        event = await audit_service.record(
+            session,
+            event_type=AuditEventType.USER_AVATAR_REMOVED,
+            actor_user_id=actor.id,
+        )
+    await session.commit()
+
+    lines = [json.loads(r.message) for r in caplog.records if r.name == "audit"]
+    assert lines == [event.envelope]
+
+
+async def test_a_record_survives_the_account_it_names(session):
+    """No foreign key, by design: deleting the subject must not take the
+    record of what was done to them with it."""
+    actor = await create_user(session)
+    subject = await create_user(session)
+    subject_id = subject.id
+
+    await audit_service.record(
+        session,
+        event_type=AuditEventType.USER_AVATAR_REMOVED,
+        actor_user_id=actor.id,
+        target_user_id=subject_id,
+    )
+    await session.commit()
+
+    await session.delete(subject)
+    await session.commit()
+
+    row = (
+        await session.exec(
+            select(AuditEvent).where(AuditEvent.target_user_id == subject_id)
+        )
+    ).one()
+    assert row.target_user_id == subject_id

--- a/backend/app/services/audit_test.py
+++ b/backend/app/services/audit_test.py
@@ -72,10 +72,56 @@ async def test_the_same_envelope_goes_to_the_log(session, caplog):
             event_type=AuditEventType.USER_AVATAR_REMOVED,
             actor_user_id=actor.id,
         )
-    await session.commit()
+        await session.commit()
 
     lines = [json.loads(r.message) for r in caplog.records if r.name == "audit"]
     assert lines == [event.envelope]
+
+
+async def test_nothing_is_logged_until_the_write_lands(session, caplog):
+    """The line is held until the transaction commits. Staged is not done, and
+    a log that claimed otherwise would disagree with the table."""
+    actor = await create_user(session)
+
+    with caplog.at_level(logging.INFO, logger="audit"):
+        await audit_service.record(
+            session,
+            event_type=AuditEventType.USER_AVATAR_REMOVED,
+            actor_user_id=actor.id,
+        )
+        staged = [r for r in caplog.records if r.name == "audit"]
+        assert staged == []
+
+        await session.commit()
+        assert len([r for r in caplog.records if r.name == "audit"]) == 1
+
+
+async def test_a_rolled_back_action_tells_nobody(session, caplog):
+    """An action that did not happen leaves no row and no line — the two sinks
+    cannot disagree about it."""
+    actor = await create_user(session)
+    await session.commit()
+    # Held before the rollback: it expires every loaded object, and reading an
+    # attribute back would be a lazy load rather than the assertion we mean.
+    actor_id = actor.id
+
+    with caplog.at_level(logging.INFO, logger="audit"):
+        await audit_service.record(
+            session,
+            event_type=AuditEventType.USER_AVATAR_REMOVED,
+            actor_user_id=actor_id,
+            target_type="user",
+            target_id=actor_id,
+        )
+        await session.rollback()
+
+    assert [r for r in caplog.records if r.name == "audit"] == []
+    rows = (
+        await session.exec(
+            select(AuditEvent).where(AuditEvent.actor_user_id == actor_id)
+        )
+    ).all()
+    assert rows == []
 
 
 async def test_a_record_survives_the_account_it_names(session):

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -852,7 +852,8 @@
     "tabs": {
       "users": "Benutzer",
       "access": "Zugriff",
-      "guilds": "Gilden"
+      "guilds": "Gilden",
+      "audit": "Prüfprotokoll"
     }
   },
   "guilds": {
@@ -1096,5 +1097,20 @@
     "disabledToast": "Das Community-Verzeichnis ist deaktiviert.",
     "saveError": "Das Community-Verzeichnis konnte nicht geändert werden. Bitte versuche es erneut.",
     "adminOnly": "Du benötigst die Plattform-Eigentümerrolle, um ein Community-Verzeichnis zu betreiben."
+  },
+  "audit": {
+    "title": "Prüfprotokoll",
+    "description": "Was an Konten getan wurde, von wem und wann. Einträge bleiben erhalten, auch wenn die genannten Konten gelöscht sind.",
+    "whenColumn": "Wann",
+    "actionColumn": "Aktion",
+    "actorColumn": "Ausgeführt von",
+    "subjectColumn": "Betrifft",
+    "subjectFilterPlaceholder": "Nach Konto-ID filtern",
+    "departedAccount": "Konto #{{id}} (gelöscht)",
+    "empty": "Bisher wurde nichts aufgezeichnet.",
+    "pageOf": "Seite {{page}} von {{total}} Einträgen",
+    "actions": {
+      "user.avatar_removed": "Profilbild entfernt"
+    }
   }
 }

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -900,7 +900,8 @@
     "tabs": {
       "users": "Users",
       "access": "Access",
-      "guilds": "Guilds"
+      "guilds": "Guilds",
+      "audit": "Audit"
     }
   },
   "storage": {
@@ -1096,5 +1097,20 @@
     "disabledToast": "The community directory is off.",
     "saveError": "Could not change the community directory. Please try again.",
     "adminOnly": "You need the platform owner role to run a community directory."
+  },
+  "audit": {
+    "title": "Audit",
+    "description": "What was done to accounts, by whom, and when. Entries are kept after the accounts they name are gone.",
+    "whenColumn": "When",
+    "actionColumn": "Action",
+    "actorColumn": "Done by",
+    "subjectColumn": "Done to",
+    "subjectFilterPlaceholder": "Filter by account ID",
+    "departedAccount": "Account #{{id}} (deleted)",
+    "empty": "Nothing has been recorded yet.",
+    "pageOf": "Page {{page}} of {{total}} entries",
+    "actions": {
+      "user.avatar_removed": "Profile picture removed"
+    }
   }
 }

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -852,7 +852,8 @@
     "tabs": {
       "users": "Usuarios",
       "access": "Acceso",
-      "guilds": "Gremios"
+      "guilds": "Gremios",
+      "audit": "Auditoría"
     }
   },
   "guilds": {
@@ -1096,5 +1097,20 @@
     "disabledToast": "El directorio de comunidades está desactivado.",
     "saveError": "No se pudo cambiar el directorio de comunidades. Inténtalo de nuevo.",
     "adminOnly": "Necesitas el rol de propietario de la plataforma para ofrecer un directorio de comunidades."
+  },
+  "audit": {
+    "title": "Auditoría",
+    "description": "Qué se hizo a las cuentas, quién lo hizo y cuándo. Las entradas se conservan aunque las cuentas que nombran ya no existan.",
+    "whenColumn": "Cuándo",
+    "actionColumn": "Acción",
+    "actorColumn": "Realizado por",
+    "subjectColumn": "Afecta a",
+    "subjectFilterPlaceholder": "Filtrar por ID de cuenta",
+    "departedAccount": "Cuenta n.º {{id}} (eliminada)",
+    "empty": "Todavía no se ha registrado nada.",
+    "pageOf": "Página {{page}} de {{total}} entradas",
+    "actions": {
+      "user.avatar_removed": "Foto de perfil eliminada"
+    }
   }
 }

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -852,7 +852,8 @@
     "tabs": {
       "users": "Utilisateurs",
       "access": "Accès",
-      "guilds": "Groupes"
+      "guilds": "Groupes",
+      "audit": "Audit"
     }
   },
   "guilds": {
@@ -1096,5 +1097,20 @@
     "disabledToast": "L'annuaire des communautés est désactivé.",
     "saveError": "Impossible de modifier l'annuaire des communautés. Veuillez réessayer.",
     "adminOnly": "Vous devez avoir le rôle de propriétaire de la plateforme pour proposer un annuaire des communautés."
+  },
+  "audit": {
+    "title": "Audit",
+    "description": "Ce qui a été fait aux comptes, par qui et quand. Les entrées sont conservées même après la suppression des comptes qu'elles nomment.",
+    "whenColumn": "Quand",
+    "actionColumn": "Action",
+    "actorColumn": "Effectué par",
+    "subjectColumn": "Concerne",
+    "subjectFilterPlaceholder": "Filtrer par ID de compte",
+    "departedAccount": "Compte n° {{id}} (supprimé)",
+    "empty": "Rien n'a encore été enregistré.",
+    "pageOf": "Page {{page}} sur {{total}} entrées",
+    "actions": {
+      "user.avatar_removed": "Photo de profil supprimée"
+    }
   }
 }

--- a/frontend/src/api/generated/admin/admin.ts
+++ b/frontend/src/api/generated/admin/admin.ts
@@ -30,8 +30,10 @@ import type {
   AdminInitiativeRoleUpdate,
   AdminUpdateInitiativeMemberRoleApiV1AdminInitiativesInitiativeIdMembersUserIdRolePatchParams,
   AdminUserDeleteRequest,
+  AuditEventListResponse,
   ExportPlatformUsersCsvApiV1AdminUsersExportCsvGetParams,
   HTTPValidationError,
+  ListAuditEventsApiV1AdminAuditEventsGetParams,
   PlatformAdminCountResponse,
   PlatformRoleUpdate,
   UserPublic,
@@ -618,6 +620,165 @@ export const useRemoveUserAvatarApiV1AdminUsersUserIdAvatarDelete = <
     queryClient
   );
 };
+/**
+ * The audit board: what was done, by whom, to whom, most recent first.
+ *
+ * Gated on ``audit.read`` (support and above). Runs on the system engine
+ * because nothing else can read the table — the log is not part of the
+ * request path's world in either direction.
+ * @summary List Audit Events
+ */
+export const listAuditEventsApiV1AdminAuditEventsGet = (
+  params?: ListAuditEventsApiV1AdminAuditEventsGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<AuditEventListResponse>(
+    { url: `/api/v1/admin/audit-events`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getListAuditEventsApiV1AdminAuditEventsGetQueryKey = (
+  params?: ListAuditEventsApiV1AdminAuditEventsGetParams
+) => {
+  return [`/api/v1/admin/audit-events`, ...(params ? [params] : [])] as const;
+};
+
+export const getListAuditEventsApiV1AdminAuditEventsGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListAuditEventsApiV1AdminAuditEventsGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getListAuditEventsApiV1AdminAuditEventsGetQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>
+  > = ({ signal }) => listAuditEventsApiV1AdminAuditEventsGet(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListAuditEventsApiV1AdminAuditEventsGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>
+>;
+export type ListAuditEventsApiV1AdminAuditEventsGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useListAuditEventsApiV1AdminAuditEventsGet<
+  TData = Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params: undefined | ListAuditEventsApiV1AdminAuditEventsGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListAuditEventsApiV1AdminAuditEventsGet<
+  TData = Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListAuditEventsApiV1AdminAuditEventsGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListAuditEventsApiV1AdminAuditEventsGet<
+  TData = Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListAuditEventsApiV1AdminAuditEventsGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List Audit Events
+ */
+
+export function useListAuditEventsApiV1AdminAuditEventsGet<
+  TData = Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params?: ListAuditEventsApiV1AdminAuditEventsGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listAuditEventsApiV1AdminAuditEventsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getListAuditEventsApiV1AdminAuditEventsGetQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
 /**
  * Get the count of platform admins (``users.read``, role-scoped session).
  * @summary Get Platform Admin Count

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -536,6 +536,41 @@ export interface AttachmentUploadResponse {
 }
 
 /**
+ * Who an id points at now, or nothing if the account is gone.
+ */
+export interface AuditActor {
+  id: number;
+  username: string | null;
+  discriminator: number | null;
+}
+
+export type AuditEventReadDetail = { [key: string]: unknown };
+
+export interface AuditEventRead {
+  id: number;
+  event_uuid: string;
+  event_type: string;
+  category: string;
+  tier: number;
+  occurred_at: string;
+  actor: AuditActor;
+  target_user: AuditActor | null;
+  guild_id: number | null;
+  target_type: string | null;
+  target_id: number | null;
+  detail: AuditEventReadDetail;
+}
+
+export interface AuditEventListResponse {
+  items: AuditEventRead[];
+  total_count: number;
+  page: number;
+  page_size: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+/**
  * One registry provider for the operator admin — never the secret.
  */
 export interface AuthProviderAdminRead {
@@ -5073,6 +5108,23 @@ export type ProviderCallbackApiV1AuthProviderSlugCallbackGetParams = {
 
 export type ExportPlatformUsersCsvApiV1AdminUsersExportCsvGetParams = {
   user_id?: number[] | null;
+};
+
+export type ListAuditEventsApiV1AdminAuditEventsGetParams = {
+  event_type?: string[] | null;
+  actor_user_id?: number | null;
+  target_user_id?: number | null;
+  occurred_after?: string | null;
+  occurred_before?: string | null;
+  /**
+   * @minimum 1
+   */
+  page?: number;
+  /**
+   * @minimum 1
+   * @maximum 200
+   */
+  page_size?: number;
 };
 
 export type AdminDeleteGuildApiV1AdminGuildsGuildIdDeleteParams = {

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -11,8 +11,10 @@ import {
   getCheckUserDeletionEligibilityApiV1AdminUsersUserIdDeletionEligibilityGetQueryKey,
   getGetPlatformAdminCountApiV1AdminPlatformAdminCountGetQueryKey,
   getListAllUsersApiV1AdminUsersGetQueryKey,
+  getListAuditEventsApiV1AdminAuditEventsGetQueryKey,
   getPlatformAdminCountApiV1AdminPlatformAdminCountGet,
   listAllUsersApiV1AdminUsersGet,
+  listAuditEventsApiV1AdminAuditEventsGet,
   reactivateUserApiV1AdminUsersUserIdReactivatePost,
   triggerPasswordResetApiV1AdminUsersUserIdResetPasswordPost,
   updatePlatformRoleApiV1AdminUsersUserIdPlatformRolePatch,
@@ -21,8 +23,10 @@ import type {
   AccountDeletionResponse,
   AdminDeletionEligibilityResponse,
   AdminUserDeleteRequest,
+  AuditEventListResponse,
   DeletionEligibilityResponse,
   ExportPlatformUsersCsvApiV1AdminUsersExportCsvGetParams,
+  ListAuditEventsApiV1AdminAuditEventsGetParams,
   PlatformAdminCountResponse,
   UserRead,
   UserRole,
@@ -45,6 +49,18 @@ export const usePlatformUsers = (options?: QueryOpts<UserRead[]>) => {
   return useQuery<UserRead[]>({
     queryKey: getListAllUsersApiV1AdminUsersGetQueryKey(),
     queryFn: () => listAllUsersApiV1AdminUsersGet(),
+    ...options,
+  });
+};
+
+/** One page of the audit board (``audit.read`` — support and above). */
+export const usePlatformAuditEvents = (
+  params: ListAuditEventsApiV1AdminAuditEventsGetParams,
+  options?: QueryOpts<AuditEventListResponse>
+) => {
+  return useQuery<AuditEventListResponse>({
+    queryKey: getListAuditEventsApiV1AdminAuditEventsGetQueryKey(params),
+    queryFn: () => listAuditEventsApiV1AdminAuditEventsGet(params),
     ...options,
   });
 };

--- a/frontend/src/pages/AdminDashboardLayout.tsx
+++ b/frontend/src/pages/AdminDashboardLayout.tsx
@@ -39,6 +39,12 @@ export const AdminDashboardLayout = () => {
         capabilities: [Capability.guildsManage],
       },
       {
+        value: "audit",
+        label: t("adminDashboard.tabs.audit"),
+        path: "/settings/admin/audit",
+        capabilities: [Capability.auditRead],
+      },
+      {
         value: "access",
         label: t("adminDashboard.tabs.access"),
         path: "/settings/admin/access",

--- a/frontend/src/pages/SettingsPlatformAuditPage.tsx
+++ b/frontend/src/pages/SettingsPlatformAuditPage.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { AuditActor, AuditEventRead } from "@/api/generated/initiativeAPI.schemas";
+import { UserHandle } from "@/components/UserHandle";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { DataTable } from "@/components/ui/data-table";
+import { Input } from "@/components/ui/input";
+import { usePlatformAuditEvents } from "@/hooks/useAdmin";
+import { formatDateTime } from "@/lib/formatDate";
+import type { AppColumnDef } from "@/lib/table";
+
+const PAGE_SIZE = 50;
+
+/**
+ * Someone who may no longer exist.
+ *
+ * An entry holds ids, so a name is resolved when the board is read — and an
+ * account erased since simply resolves to nothing. Showing the id is the honest
+ * answer there: the record of what was done to them is the point, and it
+ * outlives them.
+ */
+const Party = ({ party }: { party: AuditActor | null | undefined }) => {
+  const { t } = useTranslation("settings");
+  if (!party) return <span className="text-muted-foreground">—</span>;
+  if (!party.username) {
+    return (
+      <span className="text-muted-foreground italic">
+        {t("audit.departedAccount", { id: party.id })}
+      </span>
+    );
+  }
+  return <UserHandle user={party} />;
+};
+
+export const SettingsPlatformAuditPage = () => {
+  const { t } = useTranslation(["settings", "common"]);
+  const [page, setPage] = useState(1);
+  const [targetFilter, setTargetFilter] = useState("");
+
+  const targetUserId = Number.parseInt(targetFilter, 10);
+  const params = {
+    page,
+    page_size: PAGE_SIZE,
+    ...(Number.isFinite(targetUserId) ? { target_user_id: targetUserId } : {}),
+  };
+
+  const { data, isLoading } = usePlatformAuditEvents(params);
+
+  const columns: AppColumnDef<AuditEventRead>[] = [
+    {
+      accessorKey: "occurred_at",
+      header: t("audit.whenColumn"),
+      cell: ({ row }) => (
+        <span className="whitespace-nowrap text-muted-foreground text-sm">
+          {formatDateTime(row.original.occurred_at)}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "event_type",
+      header: t("audit.actionColumn"),
+      cell: ({ row }) => (
+        <span className="text-sm">
+          {t(`audit.actions.${row.original.event_type}` as never, {
+            defaultValue: row.original.event_type,
+          })}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "actor",
+      header: t("audit.actorColumn"),
+      cell: ({ row }) => <Party party={row.original.actor} />,
+    },
+    {
+      accessorKey: "target_user",
+      header: t("audit.subjectColumn"),
+      cell: ({ row }) => <Party party={row.original.target_user} />,
+    },
+  ];
+
+  const items = data?.items ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("audit.title")}</CardTitle>
+        <CardDescription>{t("audit.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Input
+          value={targetFilter}
+          onChange={(event) => {
+            setTargetFilter(event.target.value.replace(/[^0-9]/g, ""));
+            setPage(1);
+          }}
+          placeholder={t("audit.subjectFilterPlaceholder")}
+          className="max-w-xs"
+          inputMode="numeric"
+        />
+
+        <DataTable columns={columns} data={items} />
+
+        {!isLoading && items.length === 0 && (
+          <p className="text-muted-foreground text-sm">{t("audit.empty")}</p>
+        )}
+
+        {(data?.has_prev || data?.has_next) && (
+          <div className="flex items-center justify-between">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!data?.has_prev}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              {t("common:previous")}
+            </Button>
+            <span className="text-muted-foreground text-sm">
+              {t("audit.pageOf", { page: data?.page ?? 1, total: data?.total_count ?? 0 })}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!data?.has_next}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              {t("common:next")}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -52,6 +52,7 @@ import { Route as ServerRequiredAuthenticatedGGuildIdMarketplaceRouteImport } fr
 import { Route as ServerRequiredAuthenticatedGGuildIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/g/$guildId/settings'
 import { Route as ServerRequiredAuthenticatedSettingsAdminIndexRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/index'
 import { Route as ServerRequiredAuthenticatedSettingsAdminAccessRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/access'
+import { Route as ServerRequiredAuthenticatedSettingsAdminAuditRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/audit'
 import { Route as ServerRequiredAuthenticatedSettingsAdminGuildsRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/guilds'
 import { Route as ServerRequiredAuthenticatedSettingsAdminUsersRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/users'
 import { Route as ServerRequiredAuthenticatedSettingsGuildSplatRouteImport } from './routes/_serverRequired/_authenticated/settings/guild.$'
@@ -365,6 +366,12 @@ const ServerRequiredAuthenticatedSettingsAdminAccessRoute =
   ServerRequiredAuthenticatedSettingsAdminAccessRouteImport.update({
     id: '/access',
     path: '/access',
+    getParentRoute: () => ServerRequiredAuthenticatedSettingsAdminRoute,
+  } as any)
+const ServerRequiredAuthenticatedSettingsAdminAuditRoute =
+  ServerRequiredAuthenticatedSettingsAdminAuditRouteImport.update({
+    id: '/audit',
+    path: '/audit',
     getParentRoute: () => ServerRequiredAuthenticatedSettingsAdminRoute,
   } as any)
 const ServerRequiredAuthenticatedSettingsAdminGuildsRoute =
@@ -887,6 +894,7 @@ export interface FileRoutesByFullPath {
   '/g/$guildId/marketplace': typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRoute
   '/g/$guildId/settings': typeof ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren
   '/settings/admin/access': typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
+  '/settings/admin/audit': typeof ServerRequiredAuthenticatedSettingsAdminAuditRoute
   '/settings/admin/guilds': typeof ServerRequiredAuthenticatedSettingsAdminGuildsRoute
   '/settings/admin/users': typeof ServerRequiredAuthenticatedSettingsAdminUsersRoute
   '/settings/guild/$': typeof ServerRequiredAuthenticatedSettingsGuildSplatRoute
@@ -989,6 +997,7 @@ export interface FileRoutesByTo {
   '/profile': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/g/$guildId/marketplace': typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRoute
   '/settings/admin/access': typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
+  '/settings/admin/audit': typeof ServerRequiredAuthenticatedSettingsAdminAuditRoute
   '/settings/admin/guilds': typeof ServerRequiredAuthenticatedSettingsAdminGuildsRoute
   '/settings/admin/users': typeof ServerRequiredAuthenticatedSettingsAdminUsersRoute
   '/settings/guild/$': typeof ServerRequiredAuthenticatedSettingsGuildSplatRoute
@@ -1097,6 +1106,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/g/$guildId/marketplace': typeof ServerRequiredAuthenticatedGGuildIdMarketplaceRoute
   '/_serverRequired/_authenticated/g/$guildId/settings': typeof ServerRequiredAuthenticatedGGuildIdSettingsRouteWithChildren
   '/_serverRequired/_authenticated/settings/admin/access': typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
+  '/_serverRequired/_authenticated/settings/admin/audit': typeof ServerRequiredAuthenticatedSettingsAdminAuditRoute
   '/_serverRequired/_authenticated/settings/admin/guilds': typeof ServerRequiredAuthenticatedSettingsAdminGuildsRoute
   '/_serverRequired/_authenticated/settings/admin/users': typeof ServerRequiredAuthenticatedSettingsAdminUsersRoute
   '/_serverRequired/_authenticated/settings/guild/$': typeof ServerRequiredAuthenticatedSettingsGuildSplatRoute
@@ -1206,6 +1216,7 @@ export interface FileRouteTypes {
     | '/g/$guildId/marketplace'
     | '/g/$guildId/settings'
     | '/settings/admin/access'
+    | '/settings/admin/audit'
     | '/settings/admin/guilds'
     | '/settings/admin/users'
     | '/settings/guild/$'
@@ -1308,6 +1319,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/g/$guildId/marketplace'
     | '/settings/admin/access'
+    | '/settings/admin/audit'
     | '/settings/admin/guilds'
     | '/settings/admin/users'
     | '/settings/guild/$'
@@ -1415,6 +1427,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/g/$guildId/marketplace'
     | '/_serverRequired/_authenticated/g/$guildId/settings'
     | '/_serverRequired/_authenticated/settings/admin/access'
+    | '/_serverRequired/_authenticated/settings/admin/audit'
     | '/_serverRequired/_authenticated/settings/admin/guilds'
     | '/_serverRequired/_authenticated/settings/admin/users'
     | '/_serverRequired/_authenticated/settings/guild/$'
@@ -1790,6 +1803,13 @@ declare module '@tanstack/react-router' {
       path: '/access'
       fullPath: '/settings/admin/access'
       preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsAdminAccessRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedSettingsAdminRoute
+    }
+    '/_serverRequired/_authenticated/settings/admin/audit': {
+      id: '/_serverRequired/_authenticated/settings/admin/audit'
+      path: '/audit'
+      fullPath: '/settings/admin/audit'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsAdminAuditRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedSettingsAdminRoute
     }
     '/_serverRequired/_authenticated/settings/admin/guilds': {
@@ -2281,6 +2301,7 @@ const ServerRequiredAuthenticatedProfileRouteWithChildren =
 
 interface ServerRequiredAuthenticatedSettingsAdminRouteChildren {
   ServerRequiredAuthenticatedSettingsAdminAccessRoute: typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
+  ServerRequiredAuthenticatedSettingsAdminAuditRoute: typeof ServerRequiredAuthenticatedSettingsAdminAuditRoute
   ServerRequiredAuthenticatedSettingsAdminGuildsRoute: typeof ServerRequiredAuthenticatedSettingsAdminGuildsRoute
   ServerRequiredAuthenticatedSettingsAdminUsersRoute: typeof ServerRequiredAuthenticatedSettingsAdminUsersRoute
   ServerRequiredAuthenticatedSettingsAdminIndexRoute: typeof ServerRequiredAuthenticatedSettingsAdminIndexRoute
@@ -2290,6 +2311,8 @@ const ServerRequiredAuthenticatedSettingsAdminRouteChildren: ServerRequiredAuthe
   {
     ServerRequiredAuthenticatedSettingsAdminAccessRoute:
       ServerRequiredAuthenticatedSettingsAdminAccessRoute,
+    ServerRequiredAuthenticatedSettingsAdminAuditRoute:
+      ServerRequiredAuthenticatedSettingsAdminAuditRoute,
     ServerRequiredAuthenticatedSettingsAdminGuildsRoute:
       ServerRequiredAuthenticatedSettingsAdminGuildsRoute,
     ServerRequiredAuthenticatedSettingsAdminUsersRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/settings/admin/audit.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/settings/admin/audit.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/settings/admin/audit")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/SettingsPlatformAuditPage").then((m) => ({
+      default: m.SettingsPlatformAuditPage,
+    }))
+  ),
+});


### PR DESCRIPTION
Third of four PRs from `history/user-account-hardening-design.md`. Stacked behind #1277 (a one-file dev-seeder fix), which does not conflict.

## Why now

Moderators can already take a profile picture down (#1273), and #1276's follow-up adds three more account actions. None of them leaves a trace: `Capability.AUDIT_READ` has been declared since the capability model landed and has never been enforced anywhere.

`history/pam-audit-sink-design.md` designs the log properly — three sinks, tiering, a hash chain, WORM storage — and is unbuilt. Building all of it here would swallow the moderation work. **This is that design's DB slice, built to its shape**, so the privileged-access family, the immutable sink and the shipper land on top without reworking what gets written now.

## The table holds ids, and nothing else

Every reference in `public.audit_events` is a plain integer with **no foreign key**. An audit row is a point-in-time fact that has to outlive the account and the guild it names — a cascade or a null-out on erasure would erase the record of the erasure. Identity is resolved when the board is read, and only for accounts that still exist; a deleted subject renders as its id.

**Append-only in the grants, not by convention.** Nobody holds `UPDATE` or `DELETE` — the system engine included, because a record that could be rewritten afterwards would not be one. The request-path floors hold nothing at all in either direction, so the schema default privileges that hand every new public table to the base roles are revoked first. `ENABLE` + `FORCE ROW LEVEL SECURITY`, and the table is registered in `SHARED_TABLES`, the `system_grants` registry, and the RLS invariant.

Not built here, per that design's plan: the hash chain, the WORM sink, the delivery worker and its cursor, and the PAM/auth/authz/config event families. No columns for them either — a nullable column nothing writes is just something to explain later.

## One seam, extensible by one line

`AuditEventType` + `AUDIT_EVENT_META` is the whole registry. Adding a newly-audited action is an enum member, a metadata row, and one `record()` call at the site; `audit_events_test` fails CI if the two halves disagree. Tier, category and `is_write` come from the registry so nothing is reclassified later.

`record()` stages the row **in the caller's transaction** — that is what makes the record atomic with the thing it records — and emits the same versioned envelope to a structured `audit` logger. That logger is the ingestible seam: an operator's container-log pipeline already scrapes stdout, so shipping this stream costs them no new coupling. The log line is best-effort and deliberately after the row is staged, so a broken handler cannot take the audited action down with it.

## What it records today

`user.avatar_removed` — the takedown from #1273, recorded in the same transaction as the removal and its notification. The other three moderator actions (`username_changed`, `suspended`, `unsuspended`) arrive with the endpoints that perform them, in PR 4, which is what demonstrates the extension path.

## The board

`GET /admin/audit-events` on `audit.read` (support and above), filterable by actor, subject, type and date, newest first. It runs on the system engine because nothing else can read the table. The **Audit** tab in the admin tools renders it, next to Users, Guilds and Access.

## Schema changes

One migration, `20260829_0204`: creates `public.audit_events` with three indexes, revokes the base-role defaults, grants `SELECT, INSERT` to `app_admin` only, and enables + forces RLS. Downgrade drops it.

## Testing

```
cd backend && ruff check app && ruff format app && ty check
cd backend && pytest app/core/audit_events_test.py app/services/audit_test.py app/api/v1/platform_endpoints/audit_test.py -n 0
cd backend && pytest app/db/ -n 4
cd frontend && pnpm tsc --noEmit && pnpm vitest run src/__tests__/locale-keys.test.ts src/lib
```

16 new backend tests, `app/db/` 394 green, frontend 1012 green across the locale-key and lib suites.

New coverage: the registry's two halves agreeing; that `record` lands in the caller's transaction; that the envelope carries ids and **no** identity (asserted by searching the serialized envelope for the names); that the same envelope reaches the `audit` logger; that a record survives deleting the account it names; who may read the board and who is refused; and that the avatar takedown writes its own entry.