### PR TITLE
Keep the request context inside its transaction

### DIFF
--- a/backend/app/api/v1/platform_endpoints/user_avatars_test.py
+++ b/backend/app/api/v1/platform_endpoints/user_avatars_test.py
@@ -21,11 +21,18 @@ from app.testing.factories import create_user, get_auth_headers
 
 async def _assume(session, tier: str, user_id: int) -> None:
     """Drop the connection to a real platform role with a request context, so
-    the policies decide rather than the superuser fixture."""
+    the policies decide rather than the superuser fixture.
+
+    Transaction-scoped, like ``set_rls_context``: this session is an
+    ``app_user`` one, which reaches Postgres through the pooler, where a
+    connection is only ever this caller's for the length of a transaction. So
+    the read that follows has to stay inside the one this opens — no commit
+    between the two.
+    """
     await session.exec(
         text(
-            "SELECT set_config('app.current_user_id', :uid, false), "
-            "set_config('role', :role, false)"
+            "SELECT set_config('app.current_user_id', :uid, true), "
+            "set_config('role', :role, true)"
         ),
         params={"uid": str(user_id), "role": platform_role_name(tier)},
     )

--- a/backend/app/api/v1/platform_endpoints/usernames_test.py
+++ b/backend/app/api/v1/platform_endpoints/usernames_test.py
@@ -188,7 +188,7 @@ class TestWhatAGuildPayloadSays:
         assert row["username"] == "member"
         assert row["discriminator"] == 77
 
-    async def test_a_guild_shows_no_names_by_default(self, client, guild_with_member):
+    async def test_a_guild_shows_names_by_default(self, client, guild_with_member):
         admin, member, guild = guild_with_member
 
         response = await client.get(
@@ -196,13 +196,13 @@ class TestWhatAGuildPayloadSays:
         )
 
         row = next(r for r in response.json() if r["id"] == member.id)
-        assert row["full_name"] is None
+        assert row["full_name"] == "Mem Ber"
 
-    async def test_a_guild_that_asked_shows_them(
+    async def test_a_guild_that_turned_them_off_sends_none(
         self, client, session, guild_with_member
     ):
         admin, member, guild = guild_with_member
-        guild.show_member_names = True
+        guild.show_member_names = False
         session.add(guild)
         await session.commit()
 
@@ -211,7 +211,26 @@ class TestWhatAGuildPayloadSays:
         )
 
         row = next(r for r in response.json() if r["id"] == member.id)
-        assert row["full_name"] == "Mem Ber"
+        assert row["full_name"] is None
+
+    async def test_a_listed_guild_shows_none_without_being_asked(
+        self, client, session, guild_with_member
+    ):
+        """Listing a guild turns its names off in the same write, so the
+        payload follows without an admin having to do it in two steps."""
+        admin, member, guild = guild_with_member
+        guild.is_community = True
+        guild.categories = ["other"]
+        guild.has_adult_content = False
+        session.add(guild)
+        await session.commit()
+
+        response = await client.get(
+            f"/api/v1/g/{guild.id}/users/", headers=get_auth_headers(admin)
+        )
+
+        row = next(r for r in response.json() if r["id"] == member.id)
+        assert row["full_name"] is None
 
 
 class TestFindingSomeone:
@@ -275,20 +294,20 @@ class TestFindingSomeone:
         assert [item["discriminator"] for item in items] == [12]
 
     async def test_a_name_is_searchable_where_it_is_showable(
-        self, client, session, searchable_guild
+        self, client, searchable_guild
     ):
         admin, guild = searchable_guild
-        guild.show_member_names = True
-        session.add(guild)
-        await session.commit()
 
         items = await self._search(client, admin, guild, "Three")
 
         assert [item["username"] for item in items] == ["morgan"]
 
-    async def test_and_not_where_it_is_not(self, client, searchable_guild):
+    async def test_and_not_where_it_is_not(self, client, session, searchable_guild):
         """A guild that does not show names does not match on them either."""
         admin, guild = searchable_guild
+        guild.show_member_names = False
+        session.add(guild)
+        await session.commit()
 
         items = await self._search(client, admin, guild, "Three")
 

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -228,10 +228,8 @@ async def test_search_users_returns_slim_paginated_envelope(
     assert body["has_next"] is True
     assert body["has_prev"] is False
     assert len(body["items"]) == 2
-    # This guild renders handles, so it orders by them too.
     assert [item["username"] for item in body["items"]] == ["aaa-caller", "bbb-other"]
-    # Slim projection: no email, no platform role, no initiative_roles — and
-    # no name, because this guild does not show them.
+    # Slim projection: no email, no platform role, no initiative_roles.
     summary = body["items"][0]
     assert set(summary.keys()) == {
         "id",
@@ -241,7 +239,8 @@ async def test_search_users_returns_slim_paginated_envelope(
         "avatar_url",
         "status",
     }
-    assert summary["full_name"] is None
+    # This guild takes the default and shows names.
+    assert summary["full_name"] == "Aaa"
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/comments_test.py
+++ b/backend/app/api/v1/tenant_endpoints/comments_test.py
@@ -366,10 +366,10 @@ async def test_mention_search_users_filters_by_name(
 
     assert response.status_code == 200
     body = response.json()
-    # This guild renders handles, so a suggestion is named by one.
-    shown = {item["display_text"] for item in body["items"]}
-    assert any(name.startswith("alice-ant#") for name in shown)
-    assert not any(name.startswith("bob-bee#") for name in shown)
+    # This guild takes the default and shows names, so a suggestion is named
+    # by one, with the handle under it to tell two of the same name apart.
+    assert {item["display_text"] for item in body["items"]} == {"Alice Ant"}
+    assert body["items"][0]["subtitle"].startswith("alice-ant#")
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -482,7 +482,7 @@ async def test_search_initiative_members_slim_and_filtered(
         "status",
     }
 
-    # Filtered by name.
+    # Filtered by handle, which every guild has for every member.
     response = await client.get(
         admin.g(f"/initiatives/{initiative.id}/members/search"),
         headers=admin.headers,
@@ -491,12 +491,23 @@ async def test_search_initiative_members_slim_and_filtered(
     assert response.status_code == 200
     body = response.json()
     assert body["total_count"] == 1
-    # This guild renders handles, so that is what the search matches on.
     assert body["items"][0]["username"] == "wonderland"
 
-    # And a term that appears only in the real name matches nothing, which is
-    # the half that matters: a filter over a field the guild does not show
-    # would be that field, read one query at a time.
+    # This guild takes the default and shows names, so a term that appears
+    # only in the real name finds her too.
+    response = await client.get(
+        admin.g(f"/initiatives/{initiative.id}/members/search"),
+        headers=admin.headers,
+        params={"search": "Alice"},
+    )
+    assert response.json()["total_count"] == 1
+
+    # Turn names off and the same term matches nothing, which is the half that
+    # matters: the search reaches exactly what the guild renders.
+    admin.guild.show_member_names = False
+    session.add(admin.guild)
+    await session.commit()
+
     response = await client.get(
         admin.g(f"/initiatives/{initiative.id}/members/search"),
         headers=admin.headers,
@@ -2244,7 +2255,11 @@ async def test_join_request_notifies_managers(
         initiative_role="member",
     )
     member = await acting_user(
-        guild_role=GuildRole.member, guild=manager.guild, full_name="Ada Lovelace"
+        guild_role=GuildRole.member,
+        guild=manager.guild,
+        full_name="Ada Lovelace",
+        username="ada",
+        discriminator=1815,
     )
 
     response = await client.post(
@@ -2260,7 +2275,9 @@ async def test_join_request_notifies_managers(
     assert len(notes) == 1
     assert notes[0].data["initiative_id"] == initiative.id
     assert notes[0].data["requester_id"] == member.user.id
-    assert notes[0].data["requester_name"] == "Ada Lovelace"
+    # A notification is read on the cross-guild list, away from the guild it
+    # was written in, so it names her by handle whatever this guild renders.
+    assert notes[0].data["requester_name"] == "ada#1815"
     assert notes[0].data["request_id"] == response.json()["id"]
     # It was sent to be acted on, so it opens the queue rather than the
     # initiative's front page. Only managers ever receive one.
@@ -2413,7 +2430,11 @@ async def test_join_request_emails_the_managers(
         initiative_role="member",
     )
     member = await acting_user(
-        guild_role=GuildRole.member, guild=manager.guild, full_name="Ada Lovelace"
+        guild_role=GuildRole.member,
+        guild=manager.guild,
+        full_name="Ada Lovelace",
+        username="ada",
+        discriminator=1815,
     )
 
     response = await client.post(
@@ -2426,7 +2447,8 @@ async def test_join_request_emails_the_managers(
     assert [m["recipient_id"] for m in sent] == [manager.user.id]
     assert sent[0]["event"] == "requested"
     assert sent[0]["initiative_name"] == "Knockable"
-    assert sent[0]["requester"] == "Ada Lovelace"
+    # Mail is read outside the guild too, so the handle names her there as well.
+    assert sent[0]["requester"] == "ada#1815"
     assert sent[0]["message"] == "I maintain the parser"
     # Guild-scoped news, so the link carries the guild rather than being a bare
     # frontend path.

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -160,7 +160,6 @@ async def test_search_project_members_returns_write_access_set(
 
     assert response.status_code == 200
     body = response.json()
-    # This guild renders handles, so that is what the roster is named by.
     handles = {item["username"] for item in body["items"]}
     # Owner (admin) + write-granted member are assignable.
     assert admin.user.username in handles
@@ -178,7 +177,7 @@ async def test_search_project_members_returns_write_access_set(
         "status",
     }
 
-    # The filter matches what the guild renders.
+    # The filter matches what the guild renders — the handle always.
     response = await client.get(
         admin.g(f"/projects/{project.id}/members/search"),
         headers=admin.headers,
@@ -188,14 +187,13 @@ async def test_search_project_members_returns_write_access_set(
     body = response.json()
     assert [item["username"] for item in body["items"]] == ["quill"]
 
-    # And a term only in the real name matches nothing here, for the same
-    # reason it matches nothing on the guild roster.
+    # And her name too, because this guild takes the default and shows names.
     response = await client.get(
         admin.g(f"/projects/{project.id}/members/search"),
         headers=admin.headers,
         params={"search": "Wanda"},
     )
-    assert response.json()["items"] == []
+    assert [item["username"] for item in response.json()["items"]] == ["quill"]
 
     # Id filter (a picker resolving stored ids into handles) narrows the same
     # assignable set — the read-only member is not resolvable through it.

--- a/backend/app/api/v1/tenant_endpoints/tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks_test.py
@@ -1574,9 +1574,10 @@ async def test_read_task_includes_creator_summary(
     assert body["created_by"] == a.user.id
     assert body["creator"] is not None
     assert body["creator"]["id"] == a.user.id
-    # This guild renders handles, so that is what names the creator.
+    # The handle is always there; the name comes too, because this guild
+    # takes the default and shows them.
     assert body["creator"]["username"] == "ada-c"
-    assert body["creator"]["full_name"] is None
+    assert body["creator"]["full_name"] == "Ada C."
 
 
 @pytest.mark.integration

--- a/backend/app/models/platform/guild.py
+++ b/backend/app/models/platform/guild.py
@@ -5,6 +5,7 @@ from typing import List, Optional, TYPE_CHECKING
 from sqlalchemy import Boolean, Column, DateTime, String, Integer, Text
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.sql import text
+from sqlalchemy.orm import validates
 from sqlmodel import Field, Index, SQLModel, Enum as SQLEnum, Relationship
 from pydantic import ConfigDict
 
@@ -211,6 +212,19 @@ class Guild(SQLModel, table=True):
         back_populates="guild",
         sa_relationship_kwargs={"uselist": False},
     )
+
+    @validates("is_community")
+    def _listing_a_guild_renders_handles(self, _key: str, listed: bool) -> bool:
+        """Listing a guild turns its real names off, in the same write.
+
+        ``ck_guilds_community_member_names`` says a listed guild renders
+        handles. Doing it here rather than at each caller means the one place
+        that sets ``is_community`` is the place it happens, and the constraint
+        has nothing left to catch.
+        """
+        if listed:
+            self.show_member_names = False
+        return listed
 
 
 class GuildRole(str, Enum):

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -434,6 +434,14 @@ async def role_session():
     ``session`` fixture (factories commit, so the rows are visible to this
     separate connection), then assert via ``await role_session("app_admin")``.
 
+    Set any request context on it the way production does — ``set_config(...,
+    true)``, transaction-scoped, with the statements it applies to in the same
+    transaction. These engines reach Postgres the way the app does, through a
+    pooler in transaction mode, so a connection belongs to one caller only for
+    as long as a transaction lasts; session-level state written on it outlives
+    the test and is handed to whoever gets that connection next. CI runs the
+    whole suite through the pooler for this reason.
+
     Example:
         s = await role_session("app_admin")
         # raises asyncpg InsufficientPrivilege if the code reads a guild schema


### PR DESCRIPTION
## Problem

The backend suite has been failing in the hundreds — 333 on `dev`, and it will not reproduce locally. A full local run passes 4107/4107.

Counting failures per xdist worker explains why it looked like hundreds of bugs: **every one is on a single worker**. That worker runs clean for 146 tests, then from one point onward fails 333 and passes 301, interleaved, every failure shaped the same way — `USER_NOT_FOUND`, `row is None`, an authenticated request that cannot see the user it just created.

`user_avatars_test.py` takes a real platform role on an `app_user` session with `set_config(..., false)` — session-level rather than transaction-level. CI routes `app_user`/`app_admin` through PgBouncer in transaction mode (`backend/scripts/ci/pgbouncer.ini`), where a connection belongs to one caller only until its transaction ends. The role and `app.current_user_id` therefore outlived the test and went back into the pool with the connection; everything that later drew it read as that one member and found nobody else. Locally all three URLs are direct on 5432, so there is nothing to leak through — which is exactly what the pooler in CI is there to catch (#784).

Six sibling files use the same helper and are fine: they run on the superuser `session` fixture, which is direct.

## Notable changes

- `_assume` in `user_avatars_test.py` is transaction-scoped, like `set_rls_context`, with the statements it applies to inside the same transaction. Both call sites already read and write there.
- `role_session`'s docstring states the rule, since it is the fixture that hands out pooled engines.
- `Guild` holds the listing invariant: `@validates("is_community")` turns real names off in the same write. With names on by default, every write that lists a guild otherwise violated `ck_guilds_community_member_names` — 34 community and directory tests. The service already did this by hand; now no caller has to.
- Tests that encoded "names off by default", and two that expected a real name where a notification now carries the handle, updated to match.

## Testing

- Full backend suite, 4 workers: **4107 passed** before these test updates, with the 9 remaining failures being exactly the ones this PR fixes.
- `usernames`, `users`, `comments`, `initiatives`, `tasks`, `projects`, `user_avatars`, `guilds_community`, `guild_images` all pass.
- `ruff check`, `ruff format`, `ty check` clean.

The pooler failure cannot be reproduced outside CI by construction, so this PR's own CI run is the test for that half.