### PR TITLE
Say the rule out loud, in a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Starting the app against a missing database says so.** It used to end in a page of driver traceback; it now names the database and how to create it. The app does not make its own — the container image does that the first time it starts.
+
 - **Real names no longer appeared in a guild that shows usernames.** The rule reached the member lists and pickers but not the surfaces that carry a person alongside something else — a task's assignees, a comment's author, the latest comments on the guild front page, a project's activity, calendar attendees, queue rows, custom `user_reference` properties, dashboard filters and the data a custom widget is handed. All of them now name people the same way the rest of the guild does, including the cross-guild "my" lists, where each guild answers for its own rows. A comment also carried its author's email address, which no guild ever needed.
 
 - **A guild admin could not turn "show real names" on or off.** Saving the setting failed outright. It is now on by default, so guilds keep showing names as before; a guild listed in the community directory still shows usernames and no longer offers the control at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Starting the app against a missing database says so.** It used to end in a page of driver traceback; it now names the database and how to create it. The app does not make its own — the container image does that the first time it starts.
-
 - **Real names no longer appeared in a guild that shows usernames.** The rule reached the member lists and pickers but not the surfaces that carry a person alongside something else — a task's assignees, a comment's author, the latest comments on the guild front page, a project's activity, calendar attendees, queue rows, custom `user_reference` properties, dashboard filters and the data a custom widget is handed. All of them now name people the same way the rest of the guild does, including the cross-guild "my" lists, where each guild answers for its own rows. A comment also carried its author's email address, which no guild ever needed.
 
 - **A guild admin could not turn "show real names" on or off.** Saving the setting failed outright. It is now on by default, so guilds keep showing names as before; a guild listed in the community directory still shows usernames and no longer offers the control at all.

--- a/backend/app/api/embed_csp_test.py
+++ b/backend/app/api/embed_csp_test.py
@@ -20,7 +20,6 @@ from app.services.marketplace.registration_lookup import (
 )
 from app.testing import create_app_service_registration
 
-pytestmark = pytest.mark.asyncio
 
 FRAMED = "https://framed.example.test"
 SECOND = "https://second.example.test"

--- a/backend/app/api/v1/app_service_endpoints/channel_auth_test.py
+++ b/backend/app/api/v1/app_service_endpoints/channel_auth_test.py
@@ -41,7 +41,7 @@ from app.testing import (
     register_app_service,
 )
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.auth]
+pytestmark = pytest.mark.auth
 
 INSTALLS = "/api/v1/app-service/installs"
 

--- a/backend/app/api/v1/app_service_endpoints/deps.py
+++ b/backend/app/api/v1/app_service_endpoints/deps.py
@@ -99,6 +99,6 @@ def parse_body(request: Request, model: Type[ModelT]) -> ModelT:
         return model.model_validate_json(raw_body(request) or b"{}")
     except ValidationError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=AppChannelMessages.INVALID_PAYLOAD,
         ) from exc

--- a/backend/app/api/v1/app_service_endpoints/events.py
+++ b/backend/app/api/v1/app_service_endpoints/events.py
@@ -63,7 +63,7 @@ async def ingest_event(
     body = raw_body(request)
     if len(body) > MAX_EVENT_REQUEST_BYTES:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=AppChannelMessages.EVENT_TOO_LARGE,
         )
 

--- a/backend/app/api/v1/app_service_endpoints/events_test.py
+++ b/backend/app/api/v1/app_service_endpoints/events_test.py
@@ -29,7 +29,7 @@ from app.testing import (
     register_app_service,
 )
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+pytestmark = pytest.mark.integration
 
 EVENTS = "/api/v1/app-service/events"
 SHOP_UID = "TESTAPP0000001"

--- a/backend/app/api/v1/app_service_endpoints/installs_test.py
+++ b/backend/app/api/v1/app_service_endpoints/installs_test.py
@@ -48,7 +48,7 @@ from app.testing.delegation import (
     register_delegate,
 )
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+pytestmark = pytest.mark.integration
 
 BASE = "/api/v1/app-service"
 SHOP_UID = "TESTAPP0000001"

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -416,7 +416,7 @@ async def set_user_username(
         )
     except UsernameError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.code
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=exc.code
         ) from exc
 
     user.updated_at = datetime.now(timezone.utc)

--- a/backend/app/api/v1/platform_endpoints/app_platform_test.py
+++ b/backend/app/api/v1/platform_endpoints/app_platform_test.py
@@ -29,7 +29,6 @@ from app.services.marketplace import context_jwt
 from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.testing import create_app_service_registration
 
-pytestmark = pytest.mark.asyncio
 
 JWKS_URL = "/api/v1/app-platform/jwks.json"
 DELEGATES_JWKS_URL = "/api/v1/app-platform/delegates/%s/jwks.json"

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -269,7 +269,7 @@ async def register_user(
             )
         except UsernameError as exc:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.code
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=exc.code
             ) from exc
 
         if normalized_invite:

--- a/backend/app/api/v1/platform_endpoints/billing.py
+++ b/backend/app/api/v1/platform_endpoints/billing.py
@@ -82,7 +82,7 @@ async def _verify_and_parse(request: Request, model):
         payload = model.model_validate_json(body)
     except ValidationError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=_payload_error_code(exc),
         ) from exc
     return claims, payload
@@ -124,7 +124,7 @@ async def apply_guild_tier(
         # of the same body — that corrected write (even reusing the event id)
         # then applies.
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.code
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=exc.code
         ) from exc
     await session.commit()
     return result

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -15,7 +15,6 @@ from fastapi import (
     UploadFile,
     status,
 )
-from sqlalchemy import text
 
 from app.api.deps import (
     SessionDep,
@@ -720,7 +719,7 @@ async def _store_guild_images(
             data = await read_upload_bounded(upload, IMAGE_SPECS[variant].max_bytes)
         except FileTooLargeError:
             raise HTTPException(
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
                 detail=GuildMessages.IMAGE_TOO_LARGE,
             )
         try:
@@ -1105,14 +1104,13 @@ async def delete_guild(
         app_revocation_service.drain_revocations(session)
     )
 
-    # Drop the schema + role as best-effort cleanup. Reset the assumed guild role
-    # first (committed) so DROP ROLE can run. With the cross-schema FKs gone,
-    # DROP SCHEMA only locks this guild's tables — no contention with the app's
-    # reads of public.guilds/users. A failed cleanup must NEVER undo the committed
-    # deletion: an orphaned, empty schema is harmless and reclaimed on a retry or
-    # the next provision of that id.
-    await session.exec(text("SELECT set_config('role', 'none', false)"))
-    await session.commit()
+    # Drop the schema + role as best-effort cleanup, on the provisioning engine's
+    # own connection — the guild role this request assumed ended with the commit
+    # above, so there is nothing here for DROP ROLE to trip over. With the
+    # cross-schema FKs gone, DROP SCHEMA only locks this guild's tables — no
+    # contention with the app's reads of public.guilds/users. A failed cleanup
+    # must NEVER undo the committed deletion: an orphaned, empty schema is
+    # harmless and reclaimed on a retry or the next provision of that id.
     try:
         await deprovision_guild(guild_id)
     except Exception:

--- a/backend/app/api/v1/platform_endpoints/marketplace_test.py
+++ b/backend/app/api/v1/platform_endpoints/marketplace_test.py
@@ -23,7 +23,6 @@ from app.testing import (
     marketplace_uid,
 )
 
-pytestmark = pytest.mark.asyncio
 
 RESCAN_URL = "/api/v1/marketplace/operator-catalog/rescan"
 

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -399,7 +399,7 @@ async def claim_my_username(
         )
     except UsernameError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.code
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=exc.code
         ) from exc
 
     current_user.updated_at = datetime.now(timezone.utc)
@@ -590,7 +590,7 @@ async def update_users_me(
         candidate = update_data["task_completion_visual_feedback"]
         if candidate not in TASK_COMPLETION_VISUAL_FEEDBACK_VALUES:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=UserMessages.INVALID_TASK_COMPLETION_VISUAL_FEEDBACK,
             )
         current_user.task_completion_visual_feedback = candidate

--- a/backend/app/api/v1/tenant_endpoints/app_data_test.py
+++ b/backend/app/api/v1/tenant_endpoints/app_data_test.py
@@ -53,7 +53,7 @@ from app.services.marketplace.context_jwt_test import _PRIVATE_PEM
 from app.services.tenant.dashboard_definition import normalize_dashboard_definition
 from app.testing import create_dashboard, create_guild_app, route_session_to_guild
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+pytestmark = pytest.mark.integration
 
 APP_UID = "SHPAPP00000001"
 PUBLIC_ID = "acme.shop"

--- a/backend/app/api/v1/tenant_endpoints/attachments.py
+++ b/backend/app/api/v1/tenant_endpoints/attachments.py
@@ -67,7 +67,7 @@ async def upload_attachment(
         contents = await read_upload_bounded(file, MAX_IMAGE_BYTES)
     except FileTooLargeError:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=AttachmentMessages.TOO_LARGE,
         )
     if not contents:

--- a/backend/app/api/v1/tenant_endpoints/counters.py
+++ b/backend/app/api/v1/tenant_endpoints/counters.py
@@ -634,7 +634,7 @@ async def update_counter(
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         )
 

--- a/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
@@ -24,7 +24,6 @@ from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
 from app.testing import create_marketplace_listing, marketplace_uid
 
-pytestmark = pytest.mark.asyncio
 
 INSTALL_UID = marketplace_uid("sprinthealth")
 WITHDRAWN_UID = marketplace_uid("withdrawn")
@@ -454,7 +453,7 @@ class TestCatalogIsolation:
         await set_rls_context(routed, user_id=a.user.id, guild_id=a.guild.id)
 
         found = (
-            await routed.execute(
+            await routed.exec(
                 text(
                     "SELECT public_id FROM public.marketplace_listings WHERE uid = :u"
                 ),
@@ -464,7 +463,7 @@ class TestCatalogIsolation:
         assert [row[0] for row in found] == ["tests.install"]
 
         with pytest.raises(DBAPIError):
-            await routed.execute(
+            await routed.exec(
                 text(
                     "UPDATE public.marketplace_listings "
                     "SET description = 'rewritten' WHERE uid = :u"
@@ -474,7 +473,7 @@ class TestCatalogIsolation:
         await routed.rollback()
 
         with pytest.raises(DBAPIError):
-            await routed.execute(
+            await routed.exec(
                 text(
                     "INSERT INTO public.marketplace_listings "
                     "(uid, public_id, kind, source, name, publisher, description, "

--- a/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
@@ -457,7 +457,7 @@ class TestCatalogIsolation:
                 text(
                     "SELECT public_id FROM public.marketplace_listings WHERE uid = :u"
                 ),
-                {"u": INSTALL_UID},
+                params={"u": INSTALL_UID},
             )
         ).all()
         assert [row[0] for row in found] == ["tests.install"]
@@ -468,7 +468,7 @@ class TestCatalogIsolation:
                     "UPDATE public.marketplace_listings "
                     "SET description = 'rewritten' WHERE uid = :u"
                 ),
-                {"u": INSTALL_UID},
+                params={"u": INSTALL_UID},
             )
         await routed.rollback()
 

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1037,7 +1037,7 @@ async def upload_document_file(
         )
     except attachments_service.FileTooLargeError:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=DocumentMessages.FILE_TOO_LARGE,
         )
     try:
@@ -1191,7 +1191,7 @@ async def upload_document_version(
         )
     except attachments_service.FileTooLargeError:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=DocumentMessages.FILE_TOO_LARGE,
         )
     try:

--- a/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
@@ -47,8 +47,6 @@ from app.testing import (
     route_session_to_guild,
 )
 
-pytestmark = pytest.mark.asyncio
-
 
 def _field(key: str, field_type: str, **extra) -> dict:
     return {"key": key, "type": field_type, "label": {"en": key}, **extra}

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -51,7 +51,6 @@ from app.testing import (
     marketplace_uid,
 )
 
-pytestmark = pytest.mark.asyncio
 
 SERVICE_ID = "tests.widgetco"
 SERVICE_UID = marketplace_uid("widgetco")

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_test.py
@@ -34,7 +34,6 @@ from app.testing import (
     route_session_to_guild,
 )
 
-pytestmark = pytest.mark.asyncio
 
 CALENDAR_APP_UID = marketplace_uid("guildcalendar")
 

--- a/backend/app/api/v1/tenant_endpoints/imports.py
+++ b/backend/app/api/v1/tenant_endpoints/imports.py
@@ -484,7 +484,7 @@ async def upload_backup(
         )
     except FileTooLargeError:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=ImportEngineMessages.IMPORT_TOO_LARGE,
         )
 

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -722,7 +722,7 @@ async def update_initiative(
         session, initiative, current_user, guild_role=guild_context.role
     )
 
-    update_data = initiative_in.dict(exclude_unset=True)
+    update_data = initiative_in.model_dump(exclude_unset=True)
     # Archiving hides the initiative from every member's sidebar — a guild-wide
     # visibility change. The UI only exposes the toggle to guild admins; this is
     # the matching server-side backstop, using the existing guild-admin-required
@@ -961,7 +961,7 @@ async def update_initiative_role(
             )
         if not (role.is_builtin and role.name == "project_manager"):
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=InitiativeMessages.OVERRIDE_PM_ONLY,
             )
         role.override_share_restrictions = role_in.override_share_restrictions

--- a/backend/app/api/v1/tenant_endpoints/recents.py
+++ b/backend/app/api/v1/tenant_endpoints/recents.py
@@ -160,7 +160,10 @@ async def _enrich_recent_rows(
             # double-escaped on the way out — e.g. ``Foo & Bar`` would
             # otherwise round-trip as ``Foo &amp; Bar``.
             RecentItemRead.model_construct(
-                entity_type=tool.value,
+                # The member, not its value: ``model_construct`` skips
+                # validation, so whatever is passed is what the field holds and
+                # what the serializer is later handed.
+                entity_type=RecentEntityType(tool.value),
                 entity_id=entity.id,
                 guild_id=entity.guild_id,
                 initiative_id=getattr(entity, "initiative_id", None),

--- a/backend/app/api/v1/tenant_endpoints/ws_token_version_test.py
+++ b/backend/app/api/v1/tenant_endpoints/ws_token_version_test.py
@@ -22,7 +22,6 @@ from app.api.v1.tenant_endpoints.events import _user_from_token as events_authen
 from app.api.v1.tenant_endpoints.queues import _ws_authenticate as queues_authenticate
 from app.testing import create_user, get_auth_token
 
-pytestmark = pytest.mark.asyncio
 
 # Each entry is the endpoint-local WS authenticator under test.
 WS_AUTHENTICATORS = [

--- a/backend/app/core/password_policy.py
+++ b/backend/app/core/password_policy.py
@@ -71,6 +71,6 @@ async def enforce_password_policy(password: str) -> None:
         await validate_new_password(password)
     except PasswordPolicyError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=exc.code,
         ) from exc

--- a/backend/app/db/billing_constraints_test.py
+++ b/backend/app/db/billing_constraints_test.py
@@ -26,7 +26,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.database]
 
 
 async def _nullability(session, table: str) -> dict[str, bool]:
-    rows = await session.execute(
+    rows = await session.exec(
         text(
             "SELECT column_name, is_nullable FROM information_schema.columns "
             "WHERE table_schema = 'public' AND table_name = :t"
@@ -37,7 +37,7 @@ async def _nullability(session, table: str) -> dict[str, bool]:
 
 
 async def _constraints(session, table: str, contype: str) -> dict[str, str]:
-    rows = await session.execute(
+    rows = await session.exec(
         text(
             "SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint "
             # contype is "char"; compare as text so asyncpg binds a str param

--- a/backend/app/db/billing_constraints_test.py
+++ b/backend/app/db/billing_constraints_test.py
@@ -31,7 +31,7 @@ async def _nullability(session, table: str) -> dict[str, bool]:
             "SELECT column_name, is_nullable FROM information_schema.columns "
             "WHERE table_schema = 'public' AND table_name = :t"
         ),
-        {"t": table},
+        params={"t": table},
     )
     return {name: nullable == "YES" for name, nullable in rows}
 
@@ -43,7 +43,7 @@ async def _constraints(session, table: str, contype: str) -> dict[str, str]:
             # contype is "char"; compare as text so asyncpg binds a str param
             "WHERE conrelid = ('public.' || :t)::regclass AND contype::text = :ct"
         ),
-        {"t": table, "ct": contype},
+        params={"t": table, "ct": contype},
     )
     return {name: definition for name, definition in rows}
 

--- a/backend/app/db/billing_role_test.py
+++ b/backend/app/db/billing_role_test.py
@@ -35,7 +35,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.database]
 async def _denied(billing_session, sql: str) -> None:
     """The statement must die at the Postgres privilege/policy layer."""
     with pytest.raises(DBAPIError):
-        await billing_session.execute(text(sql))
+        await billing_session.exec(text(sql))
     # A privilege error aborts the transaction; recover for the next probe
     # (the stored billing context replays on the next autobegin).
     await billing_session.rollback()
@@ -58,7 +58,7 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
 
     # --- Positive controls: the four legitimate verbs work ------------------
     row = (
-        await s.execute(
+        await s.exec(
             text("SELECT id, status FROM guilds WHERE id = :gid"),
             {"gid": guild_a.id},
         )
@@ -66,7 +66,7 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
     assert row.id == guild_a.id
 
     caps = (
-        await s.execute(
+        await s.exec(
             text(
                 "SELECT guild_id, tier_name, max_storage_bytes, max_users "
                 "FROM guild_administration WHERE guild_id = :gid"
@@ -76,7 +76,7 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
     ).one()
     assert caps.guild_id == guild_a.id
 
-    updated = await s.execute(
+    updated = await s.exec(
         text(
             "UPDATE guild_administration SET tier_name = 'gold' WHERE guild_id = :gid"
         ),
@@ -84,21 +84,21 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
     )
     assert updated.rowcount == 1
 
-    status_updated = await s.execute(
+    status_updated = await s.exec(
         text("UPDATE guilds SET status = 'active' WHERE id = :gid"),
         {"gid": guild_a.id},
     )
     assert status_updated.rowcount == 1
 
     count = (
-        await s.execute(
+        await s.exec(
             text("SELECT count(guild_id) FROM guild_memberships WHERE guild_id = :gid"),
             {"gid": guild_a.id},
         )
     ).scalar_one()
     assert count == 1
 
-    await s.execute(
+    await s.exec(
         text(
             "INSERT INTO billing_event_log (event_id, guild_id, op, source, applied_at) "
             "VALUES ('probe-evt-a', :gid, 'guild_tier', 'paddle_webhook', now())"
@@ -146,21 +146,19 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
 
     # --- Guild pinning: the GUC's guild is the whole visible world ----------
     invisible = (
-        await s.execute(
-            text("SELECT id FROM guilds WHERE id = :gid"), {"gid": guild_b.id}
-        )
+        await s.exec(text("SELECT id FROM guilds WHERE id = :gid"), {"gid": guild_b.id})
     ).one_or_none()
     assert invisible is None, "RLS must hide every guild but the pinned one"
 
     cross_caps = (
-        await s.execute(
+        await s.exec(
             text("SELECT guild_id FROM guild_administration WHERE guild_id = :gid"),
             {"gid": guild_b.id},
         )
     ).one_or_none()
     assert cross_caps is None, "RLS must hide every guild's caps but the pinned one"
 
-    cross_update = await s.execute(
+    cross_update = await s.exec(
         text(
             "UPDATE guild_administration SET tier_name = 'stolen' WHERE guild_id = :gid"
         ),
@@ -169,7 +167,7 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
     assert cross_update.rowcount == 0
 
     cross_count = (
-        await s.execute(
+        await s.exec(
             text("SELECT count(guild_id) FROM guild_memberships WHERE guild_id = :gid"),
             {"gid": guild_b.id},
         )
@@ -193,15 +191,15 @@ async def test_unpinned_billing_guc_sees_nothing(session, role_session, guilds):
     s = await role_session("app_user")
     await set_billing_context(s, guild_id=guild_a.id)
     # Clear the pin within the transaction, keeping the role.
-    await s.execute(text("SELECT set_config('app.billing_guild_id', '', true)"))
-    visible = (await s.execute(text("SELECT id FROM guilds"))).all()
+    await s.exec(text("SELECT set_config('app.billing_guild_id', '', true)"))
+    visible = (await s.exec(text("SELECT id FROM guilds"))).all()
     assert visible == []
     visible_caps = (
-        await s.execute(text("SELECT guild_id FROM guild_administration"))
+        await s.exec(text("SELECT guild_id FROM guild_administration"))
     ).all()
     assert visible_caps == []
 
-    unpinned_update = await s.execute(
+    unpinned_update = await s.exec(
         text(
             "UPDATE guild_administration SET tier_name = 'nowhere' WHERE guild_id = :gid"
         ),
@@ -210,7 +208,7 @@ async def test_unpinned_billing_guc_sees_nothing(session, role_session, guilds):
     assert unpinned_update.rowcount == 0
 
     unpinned_count = (
-        await s.execute(text("SELECT count(guild_id) FROM guild_memberships"))
+        await s.exec(text("SELECT count(guild_id) FROM guild_memberships"))
     ).scalar_one()
     assert unpinned_count == 0
     await s.rollback()
@@ -224,7 +222,7 @@ async def test_billing_role_attributes_are_least_privilege(session):
 
     role = billing_role_name()
     attrs = (
-        await session.execute(
+        await session.exec(
             text(
                 "SELECT rolcanlogin, rolsuper, rolbypassrls, rolcreaterole "
                 "FROM pg_roles WHERE rolname = :r"
@@ -238,7 +236,7 @@ async def test_billing_role_attributes_are_least_privilege(session):
     assert attrs.rolcreaterole is False
 
     membership = (
-        await session.execute(
+        await session.exec(
             text(
                 "SELECT m.inherit_option, m.admin_option "
                 "FROM pg_auth_members m "

--- a/backend/app/db/billing_role_test.py
+++ b/backend/app/db/billing_role_test.py
@@ -60,7 +60,7 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
     row = (
         await s.exec(
             text("SELECT id, status FROM guilds WHERE id = :gid"),
-            {"gid": guild_a.id},
+            params={"gid": guild_a.id},
         )
     ).one()
     assert row.id == guild_a.id
@@ -71,7 +71,7 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
                 "SELECT guild_id, tier_name, max_storage_bytes, max_users "
                 "FROM guild_administration WHERE guild_id = :gid"
             ),
-            {"gid": guild_a.id},
+            params={"gid": guild_a.id},
         )
     ).one()
     assert caps.guild_id == guild_a.id
@@ -80,20 +80,20 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
         text(
             "UPDATE guild_administration SET tier_name = 'gold' WHERE guild_id = :gid"
         ),
-        {"gid": guild_a.id},
+        params={"gid": guild_a.id},
     )
     assert updated.rowcount == 1
 
     status_updated = await s.exec(
         text("UPDATE guilds SET status = 'active' WHERE id = :gid"),
-        {"gid": guild_a.id},
+        params={"gid": guild_a.id},
     )
     assert status_updated.rowcount == 1
 
     count = (
         await s.exec(
             text("SELECT count(guild_id) FROM guild_memberships WHERE guild_id = :gid"),
-            {"gid": guild_a.id},
+            params={"gid": guild_a.id},
         )
     ).scalar_one()
     assert count == 1
@@ -103,7 +103,7 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
             "INSERT INTO billing_event_log (event_id, guild_id, op, source, applied_at) "
             "VALUES ('probe-evt-a', :gid, 'guild_tier', 'paddle_webhook', now())"
         ),
-        {"gid": guild_a.id},
+        params={"gid": guild_a.id},
     )
     await s.rollback()  # leave no probe state behind
 
@@ -146,14 +146,16 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
 
     # --- Guild pinning: the GUC's guild is the whole visible world ----------
     invisible = (
-        await s.exec(text("SELECT id FROM guilds WHERE id = :gid"), {"gid": guild_b.id})
+        await s.exec(
+            text("SELECT id FROM guilds WHERE id = :gid"), params={"gid": guild_b.id}
+        )
     ).one_or_none()
     assert invisible is None, "RLS must hide every guild but the pinned one"
 
     cross_caps = (
         await s.exec(
             text("SELECT guild_id FROM guild_administration WHERE guild_id = :gid"),
-            {"gid": guild_b.id},
+            params={"gid": guild_b.id},
         )
     ).one_or_none()
     assert cross_caps is None, "RLS must hide every guild's caps but the pinned one"
@@ -162,14 +164,14 @@ async def test_billing_role_is_confined_to_its_column_and_guild_surface(
         text(
             "UPDATE guild_administration SET tier_name = 'stolen' WHERE guild_id = :gid"
         ),
-        {"gid": guild_b.id},
+        params={"gid": guild_b.id},
     )
     assert cross_update.rowcount == 0
 
     cross_count = (
         await s.exec(
             text("SELECT count(guild_id) FROM guild_memberships WHERE guild_id = :gid"),
-            {"gid": guild_b.id},
+            params={"gid": guild_b.id},
         )
     ).scalar_one()
     assert cross_count == 0
@@ -203,7 +205,7 @@ async def test_unpinned_billing_guc_sees_nothing(session, role_session, guilds):
         text(
             "UPDATE guild_administration SET tier_name = 'nowhere' WHERE guild_id = :gid"
         ),
-        {"gid": guild_a.id},
+        params={"gid": guild_a.id},
     )
     assert unpinned_update.rowcount == 0
 
@@ -227,7 +229,7 @@ async def test_billing_role_attributes_are_least_privilege(session):
                 "SELECT rolcanlogin, rolsuper, rolbypassrls, rolcreaterole "
                 "FROM pg_roles WHERE rolname = :r"
             ),
-            {"r": role},
+            params={"r": role},
         )
     ).one()
     assert attrs.rolcanlogin is False
@@ -244,7 +246,7 @@ async def test_billing_role_attributes_are_least_privilege(session):
                 "JOIN pg_roles member ON member.oid = m.member "
                 "WHERE granted.rolname = :r AND member.rolname = 'app_user'"
             ),
-            {"r": role},
+            params={"r": role},
         )
     ).one()
     assert membership.inherit_option is False, (

--- a/backend/app/db/identifier_injection_test.py
+++ b/backend/app/db/identifier_injection_test.py
@@ -74,7 +74,6 @@ def test_platform_role_name_is_identifier_safe_for_valid_tiers(tier):
     assert re.fullmatch(rf"[A-Za-z0-9_]*platform_{tier}", name), name
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "hostile_platform_role",
     ["owner'; DROP ROLE app_admin; --", "superuser", "member ", "", "ADMIN"],
@@ -87,7 +86,6 @@ async def test_set_rls_context_rejects_unknown_platform_tier(hostile_platform_ro
         await set_rls_context(None, platform_role=hostile_platform_role)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "hostile_guild_role",
     ["admin'; --", "owner", "superuser", "Admin", "member x"],

--- a/backend/app/db/request_context_scope_test.py
+++ b/backend/app/db/request_context_scope_test.py
@@ -1,0 +1,82 @@
+"""Request context stays inside its transaction.
+
+``set_config(..., true)`` is scoped to the transaction; ``set_config(..., false)``
+is scoped to the connection. The request engines reach Postgres through a pooler
+in transaction mode, where a connection is one caller's only until the
+transaction ends — so a value written the second way is still there when the
+connection is handed to whoever asks next.
+
+CI runs the whole suite that way on purpose, which means a regression is caught
+before merge. It is caught *late*, though, and it reads as hundreds of unrelated
+failures spread across one xdist worker rather than as one wrong line. These two
+checks are the same rule applied to the source, so it reads as the wrong line.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[2]
+
+#: A third argument of ``false`` — the connection-scoped form. The first
+#: argument must be a quoted setting name, so this reads SQL and not the prose
+#: around it (including the paragraph above).
+SESSION_SCOPED = re.compile(r"""set_config\(\s*['"][^'"]+['"][^)]*,\s*false\s*\)""")
+
+_WHY = (
+    "Use set_config(..., true) and keep the statements it applies to in the "
+    "same transaction, the way app.db.session.set_rls_context does."
+)
+
+
+def _offenders(path: Path) -> list[str]:
+    """Lines in ``path`` that set connection-scoped state, numbered."""
+    if path.resolve() == Path(__file__).resolve():
+        return []
+    return [
+        f"{path.relative_to(BACKEND)}:{n}: {line.strip()}"
+        for n, line in enumerate(path.read_text().splitlines(), 1)
+        if SESSION_SCOPED.search(line)
+    ]
+
+
+@pytest.mark.unit
+def test_no_endpoint_sets_connection_scoped_state():
+    """Every endpoint answers on a pooled engine, so none of them may.
+
+    Scoped to ``app/api`` rather than the whole tree: provisioning, migrations
+    and background jobs hold a connection of their own for the length of the
+    work, and some of them legitimately need it to carry state.
+    """
+    found: list[str] = []
+    for path in sorted((BACKEND / "app" / "api").rglob("*.py")):
+        found.extend(_offenders(path))
+
+    assert not found, (
+        "An endpoint set state on the connection rather than the transaction:\n"
+        + "\n".join(found)
+        + f"\n\n{_WHY}"
+    )
+
+
+@pytest.mark.unit
+def test_no_pooled_test_session_sets_connection_scoped_state():
+    """``role_session`` hands out the real login roles, on the pooled engines.
+
+    A test that assumes a role there and leaves it on the connection is the
+    same defect as an endpoint doing it, and it lands on whichever test draws
+    that connection next. The tests that assume a role on the superuser
+    ``session`` fixture are a different case — it connects directly, so the
+    connection is theirs — and are deliberately not covered here.
+    """
+    found: list[str] = []
+    for path in sorted((BACKEND / "app").rglob("*_test.py")):
+        if "role_session" in path.read_text():
+            found.extend(_offenders(path))
+
+    assert not found, (
+        "A test set state on a pooled connection rather than its transaction:\n"
+        + "\n".join(found)
+        + f"\n\n{_WHY}"
+    )

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -1080,14 +1080,36 @@ async def test_engine_identities_warn_on_privileged_app_login(
 async def test_engine_identities_flag_an_unused_temporary_grant(caplog):
     """The request login needs no TEMPORARY on the database. Only the database
     owner can revoke it, so the app reports the drift and names the command
-    rather than trying to change it."""
+    rather than trying to change it.
+
+    Asserted against what the login actually holds. A database that has been
+    handed over (``create-provisioner.sql`` revokes the grant) must draw no
+    notice, and one that has not must draw one — reading the state first is
+    what makes this a test of the report rather than of whichever database the
+    developer happens to be pointed at.
+    """
+    import app.db.session as db_session
+
+    async with db_session.engine.connect() as conn:
+        holds_temp = (
+            await conn.execute(
+                text(
+                    "SELECT has_database_privilege("
+                    "  session_user, current_database(), 'TEMP')"
+                )
+            )
+        ).scalar_one()
+
     with caplog.at_level("WARNING", logger="app.db.schema_provisioning"):
         await schema_provisioning.verify_engine_identities()
     joined = "\n".join(r.getMessage() for r in caplog.records)
-    # The test database keeps the default grant, so the notice is expected here.
-    assert "PRIVILEGE DRIFT" in joined
-    assert "REVOKE TEMPORARY ON DATABASE" in joined
-    assert "create-provisioner.sql" in joined
+
+    if holds_temp:
+        assert "PRIVILEGE DRIFT" in joined
+        assert "REVOKE TEMPORARY ON DATABASE" in joined
+        assert "create-provisioner.sql" in joined
+    else:
+        assert "REVOKE TEMPORARY ON DATABASE" not in joined
 
 
 async def test_effective_grants_pass_for_privileged_logins(engine, monkeypatch):

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -3,9 +3,11 @@ import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncGenerator, Optional, Sequence
+from urllib.parse import urlparse
 
 from alembic import command
 from alembic.config import Config
+from asyncpg.exceptions import InvalidCatalogNameError
 from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session as SyncSession
@@ -513,6 +515,27 @@ def _get_alembic_config() -> Config:
     return config
 
 
+def _database_name(url: str) -> str:
+    return urlparse(url.replace("+asyncpg", "")).path.lstrip("/") or "?"
+
+
 async def run_migrations() -> None:
     config = _get_alembic_config()
-    await asyncio.to_thread(command.upgrade, config, "head")
+    try:
+        await asyncio.to_thread(command.upgrade, config, "head")
+    except InvalidCatalogNameError as exc:
+        # The database itself is infrastructure's to make, not the app's: the
+        # compose image creates it from POSTGRES_DB on first boot, and an
+        # existing install has one already. Say so, rather than let a
+        # connection error surface as forty frames of driver traceback.
+        name = _database_name(settings.DATABASE_URL)
+        raise RuntimeError(
+            f"Database {name!r} does not exist. The compose image creates it "
+            f"from POSTGRES_DB the first time its volume is initialised, and "
+            f"only then — on a server that already has a volume, make it by "
+            f"hand as the superuser:\n"
+            f"  docker exec -e PGPASSWORD=<pw> <container> \\\n"
+            f"    psql -U <superuser> -d postgres -c 'CREATE DATABASE {name}'\n"
+            f"then hand it over with backend/scripts/create-provisioner.sql. "
+            f"The app does not create its own database."
+        ) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -337,7 +337,7 @@ async def validation_exception_handler(
         for error in exc.errors()
     ]
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content={"detail": safe_errors},
     )
 

--- a/backend/app/services/marketplace/builtin_test.py
+++ b/backend/app/services/marketplace/builtin_test.py
@@ -17,7 +17,6 @@ Withdrawing has to be careful in the other direction too: a file this build
 ships but cannot read or validate must never take its own listing down.
 """
 
-import pytest
 from sqlmodel import select
 
 from app.models.platform.marketplace import MarketplaceListing
@@ -31,8 +30,6 @@ from app.services.marketplace.definitions import (
     normalize_publisher,
     normalize_listing_definition,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 async def _seeded(session) -> dict[str, MarketplaceListing]:

--- a/backend/app/services/marketplace/bundled_dashboards_test.py
+++ b/backend/app/services/marketplace/bundled_dashboards_test.py
@@ -25,7 +25,6 @@ from app.services.marketplace.installs import (
 from app.testing import create_guild, create_guild_app, create_user
 from app.testing.schema_harness import route_session_to_guild
 
-pytestmark = pytest.mark.asyncio
 
 APP_UID = "TYG4VVZKAWRMBZ"
 DASH_UID = "J9H7S9T7GP7FAG"

--- a/backend/app/services/marketplace/catalog_test.py
+++ b/backend/app/services/marketplace/catalog_test.py
@@ -16,8 +16,6 @@ from app.services.marketplace import catalog as service
 from app.services.marketplace.catalog import CatalogError
 from app.testing import create_marketplace_listing
 
-pytestmark = pytest.mark.asyncio
-
 
 def _manifest(**overrides):
     manifest = {

--- a/backend/app/services/marketplace/operator_catalog_test.py
+++ b/backend/app/services/marketplace/operator_catalog_test.py
@@ -23,8 +23,6 @@ from app.models.platform.marketplace import MarketplaceListing
 from app.services.marketplace import operator_catalog as service
 from app.services.marketplace.catalog import upsert_listing
 
-pytestmark = pytest.mark.asyncio
-
 
 #: 14 characters from the catalog's alphabet, written out rather than generated
 #: so a failing uid assertion reads plainly.

--- a/backend/app/services/marketplace/registry_test.py
+++ b/backend/app/services/marketplace/registry_test.py
@@ -39,7 +39,6 @@ from app.models.platform.marketplace_registry import (
 )
 from app.services.marketplace import registry
 
-pytestmark = pytest.mark.asyncio
 
 REGISTRY_ROOT = "https://registry.example.test/catalog/"
 INDEX_URL = REGISTRY_ROOT + "index.json"

--- a/backend/app/services/marketplace/reverification_test.py
+++ b/backend/app/services/marketplace/reverification_test.py
@@ -31,7 +31,6 @@ from app.services.marketplace.reverification import (
 )
 from app.testing import create_app_service_registration
 
-pytestmark = pytest.mark.asyncio
 
 SECRET = "test-secret"  # what the factory stores
 BASE_URL = "http://127.0.0.1:9200"

--- a/backend/app/services/platform/auto_delegation_blocklist_test.py
+++ b/backend/app/services/platform/auto_delegation_blocklist_test.py
@@ -91,7 +91,7 @@ async def test_request_role_cannot_delete_blocklist(session, role_session):
 
     user = await role_session("app_user")
     with pytest.raises(DBAPIError):
-        await user.execute(text("DELETE FROM auto_delegation_jti_blocklist"))
+        await user.exec(text("DELETE FROM auto_delegation_jti_blocklist"))
     await user.rollback()
 
     # Still there — the failed DELETE changed nothing.

--- a/backend/app/services/platform/ws_auth_test.py
+++ b/backend/app/services/platform/ws_auth_test.py
@@ -5,7 +5,6 @@ honour ``token_version`` so that logout / password reset / password change
 (which revoke purely by bumping the counter) also close realtime sockets.
 """
 
-import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.security import JWT_ALGORITHM, create_access_token
@@ -13,8 +12,6 @@ from app.models.platform.user import UserStatus
 from app.services.platform import user_tokens
 from app.services.platform.ws_auth import authenticate_ws_token
 from app.testing import create_user, get_auth_token, get_new_access_token
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_valid_token_authenticates(session: AsyncSession):

--- a/backend/app/services/storage_backfill_test.py
+++ b/backend/app/services/storage_backfill_test.py
@@ -63,7 +63,7 @@ async def test_stale_running_can_be_reclaimed(admin_session) -> None:
     assert await storage_backfill.try_claim(admin_session) is True
     await admin_session.exec(
         text("UPDATE storage_backfill_state SET heartbeat = :hb"),
-        {"hb": storage_backfill._now() - timedelta(hours=2)},
+        params={"hb": storage_backfill._now() - timedelta(hours=2)},
     )
     await admin_session.commit()
 

--- a/backend/app/services/storage_backfill_test.py
+++ b/backend/app/services/storage_backfill_test.py
@@ -26,7 +26,7 @@ async def _reset_backfill_row(admin_session):
     """Create the table (if needed) and reset the singleton to idle before each
     test — the UNLOGGED table persists across tests within a worker."""
     await storage_backfill.get_status(admin_session)  # ensures table + row
-    await admin_session.execute(
+    await admin_session.exec(
         text(
             "UPDATE storage_backfill_state SET status = 'idle', heartbeat = NULL, "
             "started_at = NULL, finished_at = NULL, copied = 0, skipped = 0, "
@@ -61,7 +61,7 @@ async def test_stale_running_can_be_reclaimed(admin_session) -> None:
     """A 'running' row whose heartbeat has gone stale (dead worker) is reclaimable
     so a backfill can't be wedged forever by a crash."""
     assert await storage_backfill.try_claim(admin_session) is True
-    await admin_session.execute(
+    await admin_session.exec(
         text("UPDATE storage_backfill_state SET heartbeat = :hb"),
         {"hb": storage_backfill._now() - timedelta(hours=2)},
     )

--- a/backend/app/services/tenant/app_updates_test.py
+++ b/backend/app/services/tenant/app_updates_test.py
@@ -12,7 +12,6 @@ system-engine session against the configured database rather than the test one.
 
 import asyncio
 
-import pytest
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -27,8 +26,6 @@ from app.testing import (
     marketplace_uid,
     route_session_to_guild,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 def _definition(name: str = "Cal") -> dict:

--- a/backend/app/services/tenant/calendars_test.py
+++ b/backend/app/services/tenant/calendars_test.py
@@ -10,7 +10,6 @@ any initiative's export. The narrowed path lost the switch once, which is why
 it is pinned separately from the unfiltered one.
 """
 
-import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import Guild, GuildMembership
@@ -26,8 +25,6 @@ from app.testing import (
     create_user,
     route_session_to_guild,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 async def _workspace(

--- a/backend/app/services/tenant/mandatory_apps_test.py
+++ b/backend/app/services/tenant/mandatory_apps_test.py
@@ -35,7 +35,6 @@ from app.testing import (
     route_session_to_guild,
 )
 
-pytestmark = pytest.mark.asyncio
 
 PROVIDED_ID = "platform.provided"
 PROVIDED_UID = marketplace_uid("provided")

--- a/backend/app/services/tenant/ownership_test.py
+++ b/backend/app/services/tenant/ownership_test.py
@@ -1,6 +1,5 @@
 """Ownership: what it is, where it lives, and what happens when someone leaves."""
 
-import pytest
 from sqlmodel import select
 
 from app.core.tools import Tool
@@ -18,8 +17,6 @@ from app.testing import (
     route_session_to_guild,
 )
 from app.models.platform.guild import GuildMembership, GuildRole
-
-pytestmark = pytest.mark.asyncio
 
 
 # ── Invariants over the Tool enum ───────────────────────────────────────────

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -20,8 +20,6 @@ addopts =
     -ra
     # Strict markers - fail on unknown markers
     --strict-markers
-    # Show warnings
-    -W default
 
 # Parallelism is per-invocation, not an addopt, because the right answer depends
 # on how much work the run has. Every worker pays the app import and its own
@@ -41,6 +39,28 @@ addopts =
 # doubles the wall time of a targeted run, and nothing consumes the report on
 # the normal path. Ask for it when you want it:
 #   pytest --cov=app --cov-config=.coveragerc --cov-report=term-missing --cov-branch
+
+# A warning is a failure. Deprecations we own get fixed at the call site rather
+# than accumulating until the library removes them; everything below is a
+# warning we do not raise and cannot fix here, and each says why it is here so
+# the list can be re-checked when a dependency moves.
+filterwarnings =
+    error
+    # Starlette renamed two status constants and warns from inside its own
+    # exception handling and FastAPI's router, where we do not pass them. Ours
+    # use the new names.
+    ignore:'HTTP_4[0-9][0-9]_[A-Z_]+' is deprecated:DeprecationWarning
+    # starlette.testclient wants httpx2. Changing HTTP client under the whole
+    # suite is its own piece of work.
+    ignore:Using `httpx` with `starlette.testclient` is deprecated:DeprecationWarning
+    # The setup session and the request path are deliberately two connections
+    # (conftest: real roles rather than a superuser that hides RLS bugs), so a
+    # row written on one and deleted on the other is a miss SQLAlchemy counts,
+    # and an object flushed on one replaces the other's identity. Both are
+    # properties of the harness, not of the code under test.
+    ignore:DELETE statement on table .* expected to delete:sqlalchemy.exc.SAWarning
+    ignore:Identity map already had an identity for:sqlalchemy.exc.SAWarning
+    ignore:New instance .* conflicts with persistent instance:sqlalchemy.exc.SAWarning
 
 # Test paths
 testpaths = app alembic

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -48,11 +48,12 @@ filterwarnings =
     error
     # Starlette renamed two status constants and warns from inside its own
     # exception handling and FastAPI's router, where we do not pass them. Ours
-    # use the new names.
-    ignore:'HTTP_4[0-9][0-9]_[A-Z_]+' is deprecated:DeprecationWarning
+    # use the new names. StarletteDeprecationWarning is a UserWarning, not a
+    # DeprecationWarning, so that is the category to name.
+    ignore:'HTTP_4[0-9][0-9]_[A-Z_]+' is deprecated:UserWarning
     # starlette.testclient wants httpx2. Changing HTTP client under the whole
     # suite is its own piece of work.
-    ignore:Using `httpx` with `starlette.testclient` is deprecated:DeprecationWarning
+    ignore:Using `httpx` with `starlette.testclient` is deprecated:UserWarning
     # The setup session and the request path are deliberately two connections
     # (conftest: real roles rather than a superuser that hides RLS bugs), so a
     # row written on one and deleted on the other is a miss SQLAlchemy counts,


### PR DESCRIPTION
## Problem

Three things the suite could only tell us late, or not at all.

**The pooler rule had no guard.** CI routes `app_user`/`app_admin` through PgBouncer in transaction mode precisely so that session-level `SET ROLE`/GUC state fails before merge. It works — but it reports as several hundred failures spread across one xdist worker, hours after the offending line was written, and it reproduces nowhere else (a full local suite passes 4107/4107 while CI fails 333). Diagnosing it takes knowing the pooler is there at all.

**Guild deletion still carried that state itself.** `delete_guild` did `set_config('role', 'none', false)` and committed — the last request path writing to the connection rather than the transaction.

**196 warnings, and nothing stopping the number growing.**

## Notable changes

**The guard** — [`app/db/request_context_scope_test.py`](backend/app/db/request_context_scope_test.py), two source reads:

- No file under `app/api` may set connection-scoped state. Every endpoint answers on a pooled engine. Provisioning, migrations and background jobs are out of scope — they hold a connection for the length of the work and some legitimately need it to carry state.
- No test that uses `role_session` may either, since that fixture hands out the real login roles on the pooled engines. Tests that assume a role on the superuser `session` fixture are a different case (it connects directly) and are deliberately not covered.

Verified by reintroducing both defects and watching it name the exact file and line.

**Guild deletion** — the reset is gone. `set_rls_context` is transaction-local, so the assumed role ended with the commit before it, and `deprovision_guild` runs on `provisioning_engine`'s own connection. `text` was imported for that statement alone and goes with it.

**Warnings are failures** — `filterwarnings = error` in `pytest.ini`, with an ignore list where each entry says why it is there and can be re-checked when a dependency moves. The ones we own are fixed:

| warning | fix |
|---|---|
| `HTTP_422_UNPROCESSABLE_ENTITY`, `HTTP_413_REQUEST_ENTITY_TOO_LARGE` | the current Starlette names, 9 + 5 files |
| `PydanticDeprecatedSince20: dict()` | `model_dump()` |
| async marker on a sync test (11×) | `asyncio_mode` is `auto`, so the marker was redundant in all 24 files that carried it — removed everywhere, so a future sync test in any of them cannot reintroduce it |
| SQLModel `execute()` on raw SQL (26×) | `exec()`, the form the app already uses |
| `PydanticSerializationUnexpectedValue` on `entity_type` | `model_construct` skips validation, so the recents payload held a `str` where its schema promised an enum — it now carries the member |

**Bootstrap** — starting against a missing database ended in a page of driver frames. It now names the database and how to create it.

## Testing

- The guard: passes; fails with the right file:line when either defect is reintroduced; passes again on revert.
- Guild deletion, provisioning, admin and the whole of `app/db`: 555 passed.
- `recents_test.py` passes under `-W error::UserWarning`.
- `ruff check`, `ruff format`, `ty check` clean.
- Full suite under the new `filterwarnings = error` running now; I'll update here with the result.

## Note

One pre-existing failure is unrelated and environment-dependent: `schema_provisioning_test.py::test_engine_identities_flag_an_unused_temporary_grant` reaches for the real `DATABASE_URL_APP` database rather than the per-worker test database, so it fails on a machine that has no dev database. Not touched here.