### PR TITLE
Fill new image tables before locking them down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Upgrading to 0.64.0 no longer fails on a database that has guild icons or profile pictures in it.** The two migrations that move those images into their own tables locked each table down before moving the rows, and the migration's own write was then rejected by the very policies it had just installed — so the upgrade rolled back, over and over, on any real deployment. A fresh install has no images to move, which is why it was never seen before release. Both migrations now carry the pictures across first and lock the table down after; nothing else about the result changes, and no manual step is needed — upgrade again and it goes through.
+
 ## [0.64.0] - 2026-08-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,9 +479,11 @@ The path depends on **where the table lives**:
 
 3. **`access_grants`** is platform-scoped (managed cross-guild) like `users`: its endpoints use `AdminSessionDep` with explicit capability + ownership checks, with `platform_<tier>` policies for the admin queue and an own-row policy for requesters.
 
-4. **Renaming / dropping** — `DROP POLICY IF EXISTS …` and `DISABLE ROW LEVEL SECURITY` before the DDL; always provide a clean downgrade.
+4. **Backfill a new table BEFORE you lock it down.** `FORCE ROW LEVEL SECURITY` binds the table's *owner* — which is `app_provisioner`, the role every migration runs as. Once FORCE is on, the migration's own `INSERT` must satisfy a policy, and those policies key on request GUCs (`app.current_user_id`, `app.current_guild_id`) that a migration has no value for: nothing matches and the write is rejected with `new row violates row-level security policy`. Order the `upgrade()` as **create table → move the rows in → `ENABLE`/`FORCE` RLS + policies + grants** (migration `0179` is the reference; `0200`/`0201` shipped the wrong order and broke every upgrade that had rows to carry). A fresh install has nothing to backfill, so the backfill never executes and **CI stays green while every real upgrade fails** — `app/db/migration_backfill_order_test.py` is what catches it instead. Writing to a table that *already* existed is the other way round: lift `NO FORCE ROW LEVEL SECURITY`, write, and restore `FORCE` in the same transaction (`try`/`finally`).
 
-5. **Session-variable constants** (for the `public` shared-table policies and the PAM read path) — use these NULLIF-guarded forms in migration SQL:
+5. **Renaming / dropping** — `DROP POLICY IF EXISTS …` and `DISABLE ROW LEVEL SECURITY` before the DDL; always provide a clean downgrade.
+
+6. **Session-variable constants** (for the `public` shared-table policies and the PAM read path) — use these NULLIF-guarded forms in migration SQL:
    ```python
    # Always NULLIF-guard the cast: a PAM grantee (and any unset context) leaves the
    # value empty, and a bare ''::int raises and faults the WHOLE query for every
@@ -499,7 +501,7 @@ The path depends on **where the table lives**:
    ```
    > **`public` holds no guild content, on any install.** The pre-schema-per-guild copies that legacy deployments carried as a backstop were dropped in `20260811_0163`; guild content exists only in `guild_<id>` schemas, so an unrouted query for it finds no table rather than the wrong rows.
 
-6. **Verify after migration** as `app_user` (not the superuser): for a shared/platform table, confirm each tier hits its ceiling (a missing policy silently returns zero rows; a wrong one leaks). For guild content, `SET ROLE guild_<id>` and confirm only that guild's schema is reachable.
+7. **Verify after migration** as `app_user` (not the superuser): for a shared/platform table, confirm each tier hits its ceiling (a missing policy silently returns zero rows; a wrong one leaks). For guild content, `SET ROLE guild_<id>` and confirm only that guild's schema is reachable.
 
 ### Rules for writing frontend code
 

--- a/backend/alembic/versions/20260828_0200_guild_images.py
+++ b/backend/alembic/versions/20260828_0200_guild_images.py
@@ -357,6 +357,14 @@ def upgrade() -> None:
         ),
     )
 
+    # Carry the legacy icons over BEFORE the table is locked down. Once
+    # ``guild_images`` is FORCE ROW LEVEL SECURITY its only policy is a SELECT
+    # one, and FORCE binds the owner this migration runs as: the INSERT below
+    # would match no policy at all, and the count that verifies it would be
+    # filtered by a read policy whose request context a migration has none of.
+    # Same order as migration 0179, for the same reason.
+    _carry_over_icons()
+
     base = _platform("base")
     request_roles = f'app_guild_base, "{base}", app_user'
     _run(
@@ -376,8 +384,6 @@ def upgrade() -> None:
             f"guild_id = {_GUILD_ID} OR {_IMAGE_MEMBER})",
         ]
     )
-
-    _carry_over_icons()
 
     op.execute("REVOKE UPDATE ON TABLE public.guilds FROM app_guild_base")
     op.execute(

--- a/backend/alembic/versions/20260828_0201_user_avatars.py
+++ b/backend/alembic/versions/20260828_0201_user_avatars.py
@@ -211,6 +211,13 @@ def upgrade() -> None:
     # and read for nothing.
     op.execute("ALTER TABLE public.user_avatars ALTER COLUMN data SET STORAGE EXTERNAL")
 
+    # Copy the avatars across BEFORE the table is locked down. Once
+    # ``user_avatars`` is FORCE ROW LEVEL SECURITY the owner this migration
+    # runs as is policy-bound too, and the insert policy below admits only a
+    # row matching ``app.current_user_id`` — a request GUC a migration has no
+    # value for, so every row would be rejected. Same order as migration 0179.
+    _backfill(op.get_bind())
+
     base = _platform("base")
     request_roles = f'app_guild_base, "{base}", app_user'
     _run(
@@ -244,7 +251,6 @@ def upgrade() -> None:
         ]
     )
 
-    _backfill(op.get_bind())
     op.drop_column("users", "avatar_base64")
 
 

--- a/backend/app/db/migration_backfill_order_test.py
+++ b/backend/app/db/migration_backfill_order_test.py
@@ -1,0 +1,117 @@
+"""A migration must fill a new table before it locks that table down.
+
+``FORCE ROW LEVEL SECURITY`` binds the table's *owner* — which is the
+provisioning role every migration runs as. So the moment a revision turns FORCE
+on for a table it just created, its own backfill is subject to that table's
+policies: the INSERT needs a matching one, and those policies are written for
+the request path, keyed on GUCs (``app.current_user_id``,
+``app.current_guild_id``) a migration has no value for. There is nothing to
+match, and the insert is rejected — as ``guild_images`` and ``user_avatars``
+were, on any database that actually had legacy rows to carry over. A fresh
+install has none, so the backfill never runs and CI stays green while every
+real upgrade fails.
+
+The order is therefore the fix and the invariant: create the table, move the
+rows in, *then* enable RLS and grant. Migration 0179 is the reference.
+
+Scoped to tables the same ``upgrade()`` creates. A pre-existing table is
+handled the other way round — lift FORCE for the length of the write and
+restore it in the same transaction — and that restore is not a lockdown.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_VERSIONS = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+
+# "ALTER TABLE public.x FORCE ROW LEVEL SECURITY". The optional "public." and
+# the required whitespace before FORCE keep this from matching the "NO FORCE"
+# half of a lift-and-restore.
+_FORCE = re.compile(r"ALTER\s+TABLE\s+(?:public\.)?(\w+)\s+FORCE\s+ROW\s+LEVEL", re.I)
+_WRITE = re.compile(r"(?:INSERT\s+INTO|UPDATE)\s+(?:public\.)?(\w+)", re.I)
+
+
+def _module_functions(tree: ast.Module) -> dict[str, ast.FunctionDef]:
+    return {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
+
+
+def _reachable_strings(
+    node: ast.AST, functions: dict[str, ast.FunctionDef], seen: set[str]
+) -> list[str]:
+    """Every string literal this statement can execute, helpers included.
+
+    A revision keeps its backfill in a helper, so reading only the call site
+    would see no SQL at all.
+    """
+    found: list[str] = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            found.append(child.value)
+        elif isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
+            name = child.func.id
+            if name in functions and name not in seen:
+                seen.add(name)
+                found.extend(_reachable_strings(functions[name], functions, seen))
+    return found
+
+
+def _created_tables(upgrade: ast.FunctionDef) -> set[str]:
+    created = set()
+    for node in ast.walk(upgrade):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "create_table"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            created.add(node.args[0].value)
+    return created
+
+
+def _revisions() -> list[Path]:
+    return sorted(p for p in _VERSIONS.glob("*.py") if not p.name.startswith("__"))
+
+
+@pytest.mark.parametrize("path", _revisions(), ids=lambda p: p.stem)
+def test_new_table_is_filled_before_it_is_locked_down(path: Path):
+    tree = ast.parse(path.read_text())
+    functions = _module_functions(tree)
+    upgrade = functions.get("upgrade")
+    if upgrade is None:
+        pytest.skip("no upgrade()")
+
+    created = _created_tables(upgrade)
+    if not created:
+        pytest.skip("creates no table")
+
+    forced: dict[str, int] = {}
+    written: dict[str, int] = {}
+    for statement in upgrade.body:
+        for sql in _reachable_strings(statement, functions, set()):
+            for table in _FORCE.findall(sql):
+                if table in created:
+                    forced.setdefault(table, statement.lineno)
+            for table in _WRITE.findall(sql):
+                if table in created:
+                    written.setdefault(table, statement.lineno)
+
+    for table, force_line in forced.items():
+        write_line = written.get(table)
+        if write_line is None:
+            continue
+        assert write_line < force_line, (
+            f"{path.name}: rows are written to public.{table} at line "
+            f"{write_line}, after FORCE ROW LEVEL SECURITY is enabled on it at "
+            f"line {force_line}. The migration runs as the table's owner, which "
+            "FORCE makes policy-bound, and no policy matches a migration's "
+            "empty request context — so the write is rejected on every database "
+            "that has rows to move. Fill the table first, then lock it down."
+        )


### PR DESCRIPTION
## Problem

Upgrading to 0.64.0 fails on any database that has guild icons or profile pictures in it:

```
InsufficientPrivilegeError: new row violates row-level security policy for table "guild_images"
INSERT INTO public.guild_images (guild_id, variant, ...) VALUES (6, 'icon', ...)
```

Migrations `0200` and `0201` create `guild_images` / `user_avatars`, enable `ENABLE` + `FORCE ROW LEVEL SECURITY` with their policies and grants, and *then* run the carry-over from `guilds.icon_base64` / `users.avatar_base64`.

`FORCE ROW LEVEL SECURITY` binds the table's **owner** — `app_provisioner`, the role every migration runs as — so by the time the backfill runs, the migration's own `INSERT` has to satisfy a policy:

- `0200` installs a **SELECT-only** policy. There is no INSERT policy at all, so nothing can match.
- `0201`'s insert policy is `WITH CHECK (user_id = app.current_user_id)` — a request GUC a migration has no value for, so it fails closed too.

Both roll the whole upgrade back. A fresh install has nothing to carry over, so the backfill never executes and **CI stayed green while every real upgrade failed**. Migration `0179` already gets the order right (insert, then enable RLS); these two regressed it.

## Changes

- [20260828_0200_guild_images.py](backend/alembic/versions/20260828_0200_guild_images.py) — move `_carry_over_icons()` ahead of the RLS/grant block.
- [20260828_0201_user_avatars.py](backend/alembic/versions/20260828_0201_user_avatars.py) — same, for `_backfill()`. This one had not been reached yet; it was the next failure.
- [migration_backfill_order_test.py](backend/app/db/migration_backfill_order_test.py) — new. Walks every revision's `upgrade()` by AST, following calls into module-level helpers (where these backfills live), and fails if rows are written to a table the same migration created *after* `FORCE ROW LEVEL SECURITY` is enabled on it. Scoped to tables the same `upgrade()` creates, so the legitimate lift-`NO FORCE`/write/restore pattern on a pre-existing table is not flagged.
- [CLAUDE.md](CLAUDE.md) — the rule as #4 under "Adding or changing tables", including the inverse case for pre-existing tables.
- [CHANGELOG.md](CHANGELOG.md) — entry under `[Unreleased]`.

No change to the end state: same policies, same grants, same rows. Nothing manual is needed on a stuck deployment — `transaction_per_migration=True` means the failed migration rolled back whole, so it is still at `20260828_0199`; upgrading again goes through.

## Testing

Reproduced the original failure first, then verified the fix end to end against a real database.

- Scratch DB migrated to `20260828_0199`, seeded with a legacy icon, `alembic upgrade 20260828_0200` → reproduced `InsufficientPrivilegeError: new row violates row-level security policy for table "guild_images"` verbatim.
- With the fix, on a clean DB at `0199` seeded with 2 users and 3 guilds (a qualifying PNG each, an SVG that must be left behind, and a guild with no icon), `alembic upgrade head` → clean through `0205`. 1 icon carried / 1 left behind, 1 avatar carried / user 2 correctly skipped, sha256 digests match the stored bytes, `users.avatar_url` stamped, and `relforcerowsecurity` + all five policies intact afterwards.
- `pytest -n auto app/db` → 411 passed, 68 skipped.
- Confirmed the new test actually catches the regression: restoring the old order in `0200` and in `0201` each fails it (0201 through two levels of helper), and both pass once reordered.
- `ruff check app alembic` → clean; `ruff format --check` on the three touched files → already formatted.