### PR TITLE
Record a new guild's owner server-side; add an "awaiting approval" app-connect ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Connecting an app can now end with "waiting on an owner".** Some services hand an organization's install to the people who own it, so a request from anybody else becomes an approval sitting with one of them. The page you land on after connecting used to have no way to say that, and picked the closest thing it had. It now says it plainly: nothing failed, nothing is set up yet, and connecting again is worth doing once an owner approves it.
+
 ## [0.64.1] - 2026-08-29
 
 ### Fixed

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -78,6 +78,7 @@ from app.schemas.platform.auth import (
 from app.schemas.platform.user import UserCreate, UserRead
 from app.db.session import AdminSessionLocal
 from app.services.auth import sessions as session_service
+from app.services.platform import billing_claim
 from app.services.platform import usernames as username_service
 from app.services.auth.identity import (
     ResolutionOutcome,
@@ -345,6 +346,9 @@ async def register_user(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail=AuthMessages.UNABLE_TO_CREATE_USER,
                 )
+            # Registration seeds the new account a guild of its own; claim it
+            # for them. Fire-and-forget, once the seed has committed.
+            billing_claim.claim_new_guild(user_id=user_id, guild_id=guild_id)
     except IntegrityError as exc:  # pragma: no cover
         await session.rollback()
         logger.exception("Failed to register user due to integrity error")

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -73,6 +73,7 @@ from app.models.platform.auth_provider import AuthProvider
 from app.models.platform.guild_auth_policy import GuildAuthPolicy
 from app.services.auth.identity import has_federated_identity
 from app.services.auth.platform_provider import is_login_ready
+from app.services.platform import billing_claim
 from app.services.platform import guild_images as images_service
 from app.services.tenant.attachments import FileTooLargeError, read_upload_bounded
 from app.services.platform import guilds as guilds_service
@@ -511,6 +512,10 @@ async def create_guild(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=GuildMessages.GUILD_PROVISION_FAILED,
         )
+    # Committed and seeded. Claimed for the owner — who holds the admin
+    # membership — rather than the caller. Fire-and-forget.
+    billing_claim.claim_new_guild(user_id=owner.id, guild_id=guild.id)
+
     # The owner's membership — the caller's own in the ordinary case. When the
     # guild was created for another account the caller holds none, so the
     # response describes the guild through its admin.

--- a/backend/app/services/platform/billing_claim.py
+++ b/backend/app/services/platform/billing_claim.py
@@ -1,0 +1,86 @@
+"""Fire-and-forget guild claim to the external billing service.
+
+Names the user a newly created guild belongs to. Sent server-to-server at
+creation, independently of the billing-portal tab the client opens; the service
+treats the two as the same claim, so whichever arrives second changes nothing.
+
+* the payload is one signed handoff token and nothing else — the user id and
+  guild id travel inside it, never in the clear;
+* no retry queue and no delivery guarantee;
+* guild creation must never fail or slow because the service is down: the send
+  runs as a detached task with a tight timeout and swallows every error.
+
+FOSS balance: on a self-hosted install (``BILLING_SERVICE_URL`` /
+``HANDOFF_SIGNING_PRIVATE_KEY_PEM`` unset — the default)
+:func:`claim_new_guild` returns before doing anything: no outbound call, no
+queued work, no logging.
+
+The credential is the same RS256 billing-portal handoff a browser carries, so
+the service authenticates a claim the way it authenticates the tab.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+from app.core.config import settings
+from app.core.security import (
+    HandoffSigningNotConfiguredError,
+    create_billing_portal_handoff_token,
+)
+
+logger = logging.getLogger(__name__)
+
+CLAIM_PATH = "/api/v1/guilds/claim"
+
+# The same short deadline the membership ping uses: this runs detached, but a
+# hung connection would still hold a task and a socket for as long as it lasts.
+_CLAIM_TIMEOUT = httpx.Timeout(3.0, connect=2.0)
+
+# Strong references so an in-flight claim isn't garbage-collected mid-send
+# (asyncio keeps only weak refs to tasks).
+_pending_claims: set[asyncio.Task] = set()
+
+
+def billing_claim_enabled() -> bool:
+    """True only when a hosted deployment configured the outbound side.
+
+    The claim's credential is the RS256 handoff, so it is the signing key that
+    is required here rather than the ping's shared secret.
+    """
+    return bool(
+        settings.BILLING_SERVICE_URL and settings.HANDOFF_SIGNING_PRIVATE_KEY_PEM
+    )
+
+
+async def _send_claim(user_id: int, guild_id: int) -> None:
+    """One attempt, no retry; never raises."""
+    try:
+        token, _ = create_billing_portal_handoff_token(
+            user_id=user_id, guild_id=guild_id, guild_role="admin"
+        )
+        url = settings.BILLING_SERVICE_URL.rstrip("/") + CLAIM_PATH
+        async with httpx.AsyncClient(timeout=_CLAIM_TIMEOUT) as client:
+            await client.post(url, json={"handoff_token": token})
+    except HandoffSigningNotConfiguredError:
+        # Checked before the task was spawned; only reachable if the setting
+        # changed underneath us. Not worth a stack trace.
+        logger.debug("billing: no handoff signing key; guild %s not claimed", guild_id)
+    except Exception:
+        logger.debug("billing: claim for guild %s failed", guild_id)
+
+
+def claim_new_guild(*, user_id: int, guild_id: int) -> None:
+    """Tell billing that ``user_id`` holds ``guild_id``.
+
+    Call **after the guild's rows are committed**: the claim states that the
+    guild exists, so it is dispatched once that is true.
+    """
+    if not billing_claim_enabled():
+        return
+    task = asyncio.create_task(_send_claim(int(user_id), int(guild_id)))
+    _pending_claims.add(task)
+    task.add_done_callback(_pending_claims.discard)

--- a/backend/app/services/platform/billing_claim_test.py
+++ b/backend/app/services/platform/billing_claim_test.py
@@ -1,0 +1,202 @@
+"""The server-to-server guild claim to billing.
+
+Pinned properties:
+
+* FOSS gating — with billing unconfigured, or with no handoff signing key, the
+  code path is a strict no-op: no task, no outbound call;
+* the payload is one signed handoff and nothing else, carrying the user id and
+  guild id inside the token;
+* the claim names the guild's owner and its admin role;
+* a failing billing service never surfaces into guild creation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import jwt
+import pytest
+
+from conftest import HANDOFF_TEST_PRIVATE_PEM, HANDOFF_TEST_PUBLIC_PEM
+
+from app.core import config as config_module
+from app.core.security import BILLING_PORTAL_AUDIENCE
+from app.services.platform import billing_claim
+
+pytestmark = pytest.mark.integration
+
+_URL = "https://billing.internal"
+
+
+@pytest.fixture
+def billing_configured(monkeypatch):
+    """Reachable billing + the suite's handoff keypair (conftest configures it)."""
+    monkeypatch.setattr(config_module.settings, "BILLING_SERVICE_URL", _URL)
+    monkeypatch.setattr(
+        config_module.settings,
+        "HANDOFF_SIGNING_PRIVATE_KEY_PEM",
+        HANDOFF_TEST_PRIVATE_PEM,
+    )
+
+
+@pytest.fixture
+def sent_claims(monkeypatch):
+    """Capture dispatched claims without any network."""
+    calls: list[tuple[int, int]] = []
+
+    async def _capture(user_id: int, guild_id: int) -> None:
+        calls.append((user_id, guild_id))
+
+    monkeypatch.setattr(billing_claim, "_send_claim", _capture)
+    return calls
+
+
+async def _drain():
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+def test_disabled_by_default():
+    assert billing_claim.billing_claim_enabled() is False
+
+
+async def test_unconfigured_is_a_strict_noop(sent_claims):
+    billing_claim.claim_new_guild(user_id=1, guild_id=2)
+    await _drain()
+    assert sent_claims == []
+
+
+async def test_a_reachable_billing_without_a_signing_key_still_sends_nothing(
+    monkeypatch, sent_claims
+):
+    """The handoff is the credential, so signing configuration gates the send
+    the same way reachability does."""
+    monkeypatch.setattr(config_module.settings, "BILLING_SERVICE_URL", _URL)
+    monkeypatch.setattr(config_module.settings, "HANDOFF_SIGNING_PRIVATE_KEY_PEM", "")
+    billing_claim.claim_new_guild(user_id=1, guild_id=2)
+    await _drain()
+    assert sent_claims == []
+
+
+async def test_configured_dispatches_one_claim(billing_configured, sent_claims):
+    billing_claim.claim_new_guild(user_id=9, guild_id=77)
+    await _drain()
+    assert sent_claims == [(9, 77)]
+
+
+async def test_the_request_carries_a_signed_handoff_and_no_bare_identity(
+    billing_configured, monkeypatch
+):
+    seen: dict = {}
+
+    class _Capture:
+        def __init__(self, *a, **k): ...
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json=None, **k):
+            seen["url"] = url
+            seen["json"] = json
+            return httpx.Response(202)
+
+    monkeypatch.setattr(billing_claim.httpx, "AsyncClient", _Capture)
+    await billing_claim._send_claim(9, 77)
+
+    assert seen["url"] == f"{_URL}/api/v1/guilds/claim"
+    # The token is the whole payload: no user_id or guild_id in the clear.
+    assert set(seen["json"]) == {"handoff_token"}
+
+    claims = jwt.decode(
+        seen["json"]["handoff_token"],
+        HANDOFF_TEST_PUBLIC_PEM,
+        algorithms=["RS256"],
+        audience=BILLING_PORTAL_AUDIENCE,
+    )
+    assert claims["sub"] == "9"
+    assert claims["guild_id"] == 77
+    assert claims["guild_role"] == "admin"
+    assert claims["iss"] == "initiative"
+
+
+async def test_send_failure_never_raises(billing_configured, monkeypatch):
+    class _DownClient:
+        def __init__(self, *a, **k): ...
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **k):
+            raise httpx.ConnectError("billing is down")
+
+    monkeypatch.setattr(billing_claim.httpx, "AsyncClient", _DownClient)
+    # Returns normally: an unreachable service stays inside the send.
+    await billing_claim._send_claim(1, 2)
+
+
+# --- the wiring: where a guild is actually born ---------------------------
+
+
+async def test_creating_a_guild_claims_it_for_its_owner(
+    client, session, billing_configured, sent_claims
+):
+    """Creation itself dispatches the claim, with no browser in the loop."""
+    from app.testing import create_user, get_auth_headers
+
+    user = await create_user(session, email="claim-create@example.com")
+    response = await client.post(
+        "/api/v1/guilds/",
+        headers=get_auth_headers(user),
+        json={"name": "Claimed Guild"},
+    )
+    assert response.status_code == 201
+    await _drain()
+
+    assert sent_claims == [(user.id, response.json()["id"])]
+
+
+async def test_an_unconfigured_deployment_creates_guilds_without_claiming(
+    client, session, sent_claims
+):
+    """Self-hosting does not bill, so there is nobody to tell — and guild
+    creation must not notice the difference."""
+    from app.testing import create_user, get_auth_headers
+
+    user = await create_user(session, email="claim-foss@example.com")
+    response = await client.post(
+        "/api/v1/guilds/",
+        headers=get_auth_headers(user),
+        json={"name": "Self-Hosted Guild"},
+    )
+    assert response.status_code == 201
+    await _drain()
+    assert sent_claims == []
+
+
+async def test_registration_claims_the_guild_it_creates(
+    client, billing_configured, sent_claims
+):
+    """Registration seeds the new account a guild, and claims that one too."""
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "claim-register@example.com",
+            "username": "claimregister",
+            "full_name": "Claim Register",
+            "password": "securepassword123",
+        },
+    )
+    assert response.status_code == 201
+    await _drain()
+
+    assert len(sent_claims) == 1
+    claimed_user, claimed_guild = sent_claims[0]
+    assert claimed_user == response.json()["id"]
+    assert claimed_guild > 0

--- a/frontend/public/locales/de/apps.json
+++ b/frontend/public/locales/de/apps.json
@@ -173,6 +173,10 @@
       "title": "Fast geschafft",
       "body": "Der andere Dienst hat dich angemeldet, Initiative hat es aber nicht gespeichert. Verbinde dich in den Einstellungen der App erneut – es ging nichts verloren."
     },
+    "awaiting_approval": {
+      "title": "Warten auf eine Freigabe",
+      "body": "Der andere Dienst hat jemanden, dem diese Organisation gehört, um Freigabe dieser App gebeten. Es ist nichts schiefgegangen und noch nichts eingerichtet – sobald sie freigegeben ist, verbinde dich erneut über die Einstellungen der App."
+    },
     "closeTab": "Du kannst diesen Tab schließen."
   }
 }

--- a/frontend/public/locales/en/apps.json
+++ b/frontend/public/locales/en/apps.json
@@ -173,6 +173,10 @@
       "title": "Nearly there",
       "body": "The other service signed you in, but Initiative did not record it. Connect again from the app's settings — nothing was lost."
     },
+    "awaiting_approval": {
+      "title": "Waiting on an owner",
+      "body": "The other service asked somebody who owns that organization to approve this app. Nothing went wrong and nothing is set up yet — once they approve it, connect again from the app's settings."
+    },
     "closeTab": "You can close this tab."
   }
 }

--- a/frontend/public/locales/es/apps.json
+++ b/frontend/public/locales/es/apps.json
@@ -173,6 +173,10 @@
       "title": "Casi",
       "body": "El otro servicio te ha identificado, pero Initiative no lo ha registrado. Conéctate de nuevo desde los ajustes de la aplicación: no se ha perdido nada."
     },
+    "awaiting_approval": {
+      "title": "Esperando una aprobación",
+      "body": "El otro servicio ha pedido a alguien que sea propietario de esa organización que apruebe esta app. No ha fallado nada y aún no hay nada configurado: cuando la aprueben, vuelve a conectar desde los ajustes de la app."
+    },
     "closeTab": "Puedes cerrar esta pestaña."
   }
 }

--- a/frontend/public/locales/fr/apps.json
+++ b/frontend/public/locales/fr/apps.json
@@ -173,6 +173,10 @@
       "title": "Presque",
       "body": "L'autre service vous a identifié, mais Initiative ne l'a pas enregistré. Reconnectez-vous depuis les réglages de l'application — rien n'a été perdu."
     },
+    "awaiting_approval": {
+      "title": "En attente d'une approbation",
+      "body": "L'autre service a demandé à une personne propriétaire de cette organisation d'approuver cette app. Rien n'a échoué et rien n'est encore configuré : une fois approuvée, reconnectez-vous depuis les réglages de l'app."
+    },
     "closeTab": "Vous pouvez fermer cet onglet."
   }
 }

--- a/frontend/src/pages/apps/AppConnectedPage.tsx
+++ b/frontend/src/pages/apps/AppConnectedPage.tsx
@@ -1,26 +1,30 @@
 import { useSearch } from "@tanstack/react-router";
-import { CircleCheck, CircleX, Clock, TriangleAlert } from "lucide-react";
+import { CircleCheck, CircleX, Clock, Hourglass, TriangleAlert } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { LogoIcon } from "@/components/LogoIcon";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 /**
- * How a vendor flow ended, in the four ways it can.
+ * How a vendor flow ended, in the five ways it can.
  *
  * The same closed set every app returns, which is the point: an app knows a
  * connection handle and a guild id and has never been told what language the
- * member reads. It hands them back with one word, and the sentence is written
+ * person reads. It hands them back with one word, and the sentence is written
  * here — once, in every language this product speaks.
  *
  * They are told apart by whose move is next, because that is the only thing the
- * member needs from this page.
+ * reader needs from this page. `awaiting_approval` is the one where the answer
+ * is *somebody else's*: a vendor whose organization-wide install belongs to an
+ * owner turns a request from anybody else into an approval for one of them, so
+ * nothing failed and there is nothing to retry yet.
  */
 const OUTCOMES = {
   connected: { icon: CircleCheck, tone: "text-emerald-600 dark:text-emerald-400" },
   refused: { icon: CircleX, tone: "text-destructive" },
   expired: { icon: Clock, tone: "text-muted-foreground" },
   not_recorded: { icon: TriangleAlert, tone: "text-amber-600 dark:text-amber-400" },
+  awaiting_approval: { icon: Hourglass, tone: "text-sky-600 dark:text-sky-400" },
 } as const;
 
 type Outcome = keyof typeof OUTCOMES;


### PR DESCRIPTION
Two unrelated changes that were sitting in the same working tree.

## Record a new guild's owner server-side

Guild ownership reached the external billing service only through the portal tab the client opens after creating a guild. The claim is now also sent from the server, at creation, so it no longer depends on a browser tab opening.

- New `backend/app/services/platform/billing_claim.py`, modelled on the existing `billing_ping`: detached task, tight timeout, swallows every error, and a strict no-op when `BILLING_SERVICE_URL` or the handoff signing key is unset (the self-hosted default).
- The payload is a single RS256 billing-portal handoff — the same credential a browser carries. No identity in the clear.
- Dispatched from the create-guild endpoint (for the owner, who holds the admin membership) and from registration's seeded guild, in both cases after the rows are committed.

No schema changes, no new settings, no migration.

## "Awaiting approval" ending for app connect

Some services hand an organization-wide install to its owners, so a connect request from anybody else becomes an approval waiting on one of them. The connect landing page had no word for that and fell back to `expired`, which reads as a failure and invites a pointless retry.

- New `awaiting_approval` outcome with its own icon on `AppConnectedPage`.
- Copy in all four locales (de/en/es/fr).
- Changelog entry.

## Testing

```
cd backend && pytest app/services/platform/billing_claim_test.py   # 9 passed
cd backend && ruff check app && ruff format app && ty check        # clean
cd frontend && pnpm lint && pnpm exec tsc --noEmit                 # clean
```