### PR TITLE
Guild search index: the table and its refresh triggers

### DIFF
--- a/backend/alembic/versions/20260901_0207_add_search_entries_index_table.py
+++ b/backend/alembic/versions/20260901_0207_add_search_entries_index_table.py
@@ -1,0 +1,136 @@
+"""add search_entries index table
+
+The guild-wide search index: one row per searchable chunk of content, written
+only by ``public.refresh_search_entry()`` from the tables it mirrors.
+
+The table is created, indexed and locked down in one pass because it starts
+EMPTY — there is nothing to carry in, so the create-then-backfill-then-FORCE
+sequence a populated table requires does not apply here. Existing content is
+indexed by the reindex sweep, not by this migration.
+
+Revision ID: 20260901_0207
+Revises: 20260831_0206
+Create Date: 2026-09-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.db.guild_migrations import run_for_each_guild_schema
+
+revision = "20260901_0207"
+down_revision = "20260831_0206"
+branch_labels = None
+depends_on = None
+
+#: Entity types this migration was written with, frozen as its CHECK
+#: constraint. A new searchable table extends this in its own migration, the
+#: same way ``recent_views`` does.
+ENTITY_TYPES = (
+    "calendar",
+    "calendar_event",
+    "counter",
+    "counter_group",
+    "dashboard",
+    "document",
+    "project",
+    "queue",
+    "queue_item",
+    "tag",
+    "task",
+)
+
+#: Written by the refresh trigger; the reindex sweep routes as the guild admin.
+_INSERT_CHECK = (
+    "pg_trigger_depth() > 0 OR "
+    "current_setting('app.current_guild_role'::text, true) = 'admin'::text"
+)
+
+#: The initiative gate, matching ``search_entries_path()`` in
+#: ``app/db/initiative_rls.py``. NULL means guild-level content, where the
+#: initiative gate has nothing to decide.
+_UID = "(NULLIF(current_setting('app.current_user_id'::text, true), ''::text))::integer"
+
+
+def _access(write: bool) -> str:
+    return (
+        "(CASE WHEN search_entries.initiative_id IS NULL THEN true ELSE "
+        f"public.initiative_access(search_entries.initiative_id, {_UID}, "
+        f"{'true' if write else 'false'}) END)"
+    )
+
+
+def upgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_upgrade)
+
+
+def _apply_upgrade() -> None:
+    op.create_table(
+        "search_entries",
+        sa.Column("entity_type", sa.Text(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "chunk_ix", sa.SmallInteger(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column("initiative_id", sa.Integer(), nullable=True),
+        sa.Column("dac_tool", sa.Text(), nullable=True),
+        sa.Column("dac_id", sa.Integer(), nullable=True),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("tsv", postgresql.TSVECTOR(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["initiative_id"], ["initiatives.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("entity_type", "entity_id", "chunk_ix"),
+    )
+
+    values = ", ".join(f"'{t}'" for t in ENTITY_TYPES)
+    op.execute(
+        "ALTER TABLE search_entries ADD CONSTRAINT ck_search_entries_entity_type "
+        f"CHECK (entity_type IN ({values}))"
+    )
+
+    op.execute("CREATE INDEX ix_search_entries_tsv ON search_entries USING gin (tsv)")
+    op.execute(
+        "CREATE INDEX ix_search_entries_dac ON search_entries (dac_tool, dac_id)"
+    )
+    op.execute(
+        "CREATE INDEX ix_search_entries_initiative ON search_entries (initiative_id)"
+    )
+
+    # Locked down at creation: the table is empty, so there is no backfill to
+    # order before FORCE.
+    op.execute("ALTER TABLE search_entries ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE search_entries FORCE ROW LEVEL SECURITY")
+    op.execute(
+        "CREATE POLICY initiative_member_select ON search_entries "
+        f"AS PERMISSIVE FOR SELECT USING ({_access(False)})"
+    )
+    op.execute(
+        "CREATE POLICY initiative_member_insert ON search_entries "
+        f"AS PERMISSIVE FOR INSERT WITH CHECK ({_INSERT_CHECK})"
+    )
+    op.execute(
+        "CREATE POLICY initiative_member_update ON search_entries "
+        f"AS PERMISSIVE FOR UPDATE USING ({_access(True)}) "
+        f"WITH CHECK ({_access(True)})"
+    )
+    op.execute(
+        "CREATE POLICY initiative_member_delete ON search_entries "
+        f"AS PERMISSIVE FOR DELETE USING ({_access(True)})"
+    )
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), _apply_downgrade)
+
+
+def _apply_downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS initiative_member_select ON search_entries")
+    op.execute("DROP POLICY IF EXISTS initiative_member_insert ON search_entries")
+    op.execute("DROP POLICY IF EXISTS initiative_member_update ON search_entries")
+    op.execute("DROP POLICY IF EXISTS initiative_member_delete ON search_entries")
+    op.execute("ALTER TABLE search_entries DISABLE ROW LEVEL SECURITY")
+    op.drop_table("search_entries")

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -46,6 +46,7 @@ from app.models.tenant.calendar_event import (
     CalendarEventDocument,
 )
 from app.models.tenant.event_outbox import EventOutbox
+from app.models.tenant.search_entry import SearchEntry
 from app.models.tenant.event_reminder_dispatch import EventReminderDispatch
 from app.models.tenant.dashboard import Dashboard, DashboardTag
 from app.models.tenant.counter import (
@@ -140,6 +141,7 @@ __all__ = [
     "CalendarEventTag",
     "CalendarEventDocument",
     "EventOutbox",
+    "SearchEntry",
     "EventReminderDispatch",
     "Dashboard",
     "DashboardTag",

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -155,7 +155,16 @@ _COMMANDS = (
 # happened rather than deciding it a second time — including a change that ends
 # the writer's own access, which it must still be able to record. Who may READ
 # the log is unchanged: the initiative gate, via the other three policies.
-_TRIGGER_WRITTEN_INSERT: dict[str, str] = {"event_outbox": "pg_trigger_depth() > 0"}
+_TRIGGER_WRITTEN_INSERT: dict[str, str] = {
+    "event_outbox": "pg_trigger_depth() > 0",
+    # The search index is derived: rows arrive from the refresh trigger as a
+    # consequence of a content write that already cleared its own table's gate.
+    # The reindex sweep routes as the guild admin, which is the second leg.
+    "search_entries": (
+        "pg_trigger_depth() > 0 OR "
+        "current_setting('app.current_guild_role'::text, true) = 'admin'::text"
+    ),
+}
 
 
 def _table_block(table: str, path: InitiativePath) -> str:

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -240,6 +240,29 @@ def webhook_subscription_path() -> InitiativePath:
     )
 
 
+def search_entries_path() -> InitiativePath:
+    """The search index is reached exactly like the content it describes.
+
+    It stores ``initiative_id`` directly, so unlike ``recent_views`` this needs
+    no per-type EXISTS join — the row was stamped with its source's initiative
+    by the same registry that renders that source's own policies.
+
+    A NULL initiative is the guild-level case (a tag, a guild calendar): the
+    initiative gate has nothing to decide, and these are rows every member
+    already sees everywhere else in the app. It is not an ungated leg — a row
+    carrying a ``dac_tool`` still answers to sharing, and reaching this schema
+    at all is the guild gate.
+    """
+    return InitiativePath(
+        predicate=lambda t, w: (
+            f"(CASE WHEN {t}.initiative_id IS NULL "
+            f"THEN true "
+            f"ELSE {_access(f'{t}.initiative_id', w)} END)"
+        ),
+        initiative_expr=lambda r: f"{r}.initiative_id",
+    )
+
+
 def recent_views_path() -> InitiativePath:
     def build(t: str, w: bool) -> str:
         legs = [
@@ -303,6 +326,8 @@ INITIATIVE_PATHS: dict[str, InitiativePath] = {
     # Reading is the question this path answers; writing is the capture
     # trigger's alone (app.db.guild_ddl._TRIGGER_WRITTEN_INSERT).
     "event_outbox": direct(),
+    # The search index. Derived from the content tables, and gated like them.
+    "search_entries": search_entries_path(),
     # Integration config, reached by whoever can reach what it watches.
     "webhook_subscriptions": webhook_subscription_path(),
     # One hop -> projects
@@ -477,6 +502,7 @@ EVENT_SOURCES: dict[str, Emit | Silent] = {
     # What one member did with their own UI, not a change to the initiative's
     # content, so every subscription would pay for pure noise.
     "recent_views": Silent("one member's own viewing state"),
+    "search_entries": Silent("derived index, rebuilt from the content it mirrors"),
     "project_orders": Silent("one member's own ordering state"),
     "project_favorites": Silent("one member's own pinning state"),
     "task_assignment_digest_items": Silent("internal digest bookkeeping"),

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -156,6 +156,7 @@ class ProvisioningBundle:
     schema_ddl: str
     rls_ddl: str
     capture_ddl: str
+    search_ddl: str
     stamp: str
 
 
@@ -176,15 +177,22 @@ async def get_provisioning_bundle() -> ProvisioningBundle:
             render_guild_capture_ddl,
         )
         from app.db.guild_ddl import render_guild_rls_ddl, render_guild_schema_ddl
+        from app.db.search_index import (
+            SEARCH_FUNCTION_SQL,
+            render_guild_search_ddl,
+        )
 
         schema_ddl = await render_guild_schema_ddl(db_session.provisioning_engine)
         rls_ddl = render_guild_rls_ddl()
         capture_ddl = render_guild_capture_ddl()
+        search_ddl = render_guild_search_ddl()
         digest = hashlib.sha256()
         digest.update(schema_ddl.encode())
         digest.update(rls_ddl.encode())
         digest.update(capture_ddl.encode())
         digest.update(CAPTURE_FUNCTION_SQL.encode())
+        digest.update(search_ddl.encode())
+        digest.update(SEARCH_FUNCTION_SQL.encode())
         digest.update(
             "\n".join(
                 _grant_statements(
@@ -199,6 +207,7 @@ async def get_provisioning_bundle() -> ProvisioningBundle:
             schema_ddl=schema_ddl,
             rls_ddl=rls_ddl,
             capture_ddl=capture_ddl,
+            search_ddl=search_ddl,
             stamp=f"provisioned:{digest.hexdigest()[:16]}",
         )
         return _bundle
@@ -275,6 +284,26 @@ async def apply_guild_capture(conn: AsyncConnection, schema: str) -> None:
     )
 
 
+async def apply_guild_search(conn: AsyncConnection, schema: str) -> None:
+    """Install the search-index refresh triggers on ``schema``'s indexed tables.
+
+    Same shape as :func:`apply_guild_capture`: re-assert the shared function
+    from the registry (so a change to what is indexed reaches existing installs
+    on the next boot rather than needing a migration per edit), then the
+    per-table triggers, both idempotent.
+    """
+    from app.db.search_index import SEARCH_FUNCTION_SQL
+
+    ddl = (await get_provisioning_bundle()).search_ddl
+    raw = await conn.get_raw_connection()
+    await raw.driver_connection.execute(
+        "SET check_function_bodies = false;\n" + SEARCH_FUNCTION_SQL
+    )
+    await raw.driver_connection.execute(
+        f'SET search_path TO "{schema}", public;\n{ddl}\nSET search_path TO public;'
+    )
+
+
 async def apply_template_rls() -> None:
     """Re-assert the registry-rendered RLS on ``guild_template``.
 
@@ -288,6 +317,7 @@ async def apply_template_rls() -> None:
     async with db_session.provisioning_engine.begin() as conn:
         await apply_guild_rls(conn, TEMPLATE_SCHEMA)
         await apply_guild_capture(conn, TEMPLATE_SCHEMA)
+        await apply_guild_search(conn, TEMPLATE_SCHEMA)
 
 
 def _grant_statements(
@@ -398,6 +428,7 @@ async def provision_guild_schema(conn: AsyncConnection, guild_id: int) -> str:
     await _exec_batch(conn, _grant_statements(schema, role, ro_role, support_role))
     await apply_guild_rls(conn, schema)  # initiative-level RLS policies
     await apply_guild_capture(conn, schema)  # change-capture triggers
+    await apply_guild_search(conn, schema)  # search-index refresh triggers
     # Stamp the artifacts' version so the boot back-fill can skip this guild
     # until they change (constant hex literal, safe to inline).
     stamp = (await get_provisioning_bundle()).stamp

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -475,12 +475,13 @@ async def test_guild_schema_matches_guild_template(engine):
                 return sorted(
                     re.sub(r"\bON \w+\.", "ON ", x.d)  # strip table schema
                     for x in r
-                    # Change-capture triggers are rendered from the registry at
-                    # provisioning time, not owned by Alembic — the same
-                    # treatment RLS policies get here, and for the same reason:
-                    # comparing them would assert the template carries a frozen
-                    # snapshot of whatever the registry said.
-                    if not x.n.startswith("capture_")
+                    # Change-capture and search-index triggers are rendered
+                    # from their registries at provisioning time, not owned by
+                    # Alembic — the same treatment RLS policies get here, and
+                    # for the same reason: comparing them would assert the
+                    # template carries a frozen snapshot of whatever the
+                    # registry said.
+                    if not x.n.startswith(("capture_", "search_"))
                 )
 
             drift = []

--- a/backend/app/db/search_index.py
+++ b/backend/app/db/search_index.py
@@ -1,0 +1,373 @@
+"""The search index registry — which tables are searchable, and how.
+
+One declaration per searchable table in :data:`SEARCH_SOURCES`, from which two
+things are rendered: the trigger that keeps ``search_entries`` current, and the
+default query scope. Adding a searchable table is one entry here.
+
+Nothing declares *which* initiative a row belongs to. That is read from the same
+``INITIATIVE_PATHS`` entry that renders the table's RLS policies, so a row cannot
+be gated by one initiative and indexed under another — the argument
+``event_capture`` already makes for reusing that registry, applied again.
+
+Chunking is a length rule, not a per-table setting: an extractor yields text and
+the trigger splits it if it is long. A tag's name is one chunk by the same code
+path that gives a long document several.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlmodel import SQLModel
+
+from app.core.tools import Tool
+from app.db.initiative_rls import initiative_locator
+
+#: How a row reaches the trigger's dynamic lookups: as ``$1`` in an EXECUTE.
+ROW = "($1)"
+
+SEARCH_FUNCTION = "public.refresh_search_entry"
+
+#: Target size of one chunk's body text, and the ceiling on chunks per entity.
+#: The ceiling is a backstop for a pathological spreadsheet; ordinary content is
+#: nowhere near it.
+CHUNK_CHARS = 8000
+MAX_CHUNKS = 2000
+
+
+@dataclass(frozen=True)
+class SearchSource:
+    """How one table's rows become search entries."""
+
+    #: Value stored in ``search_entries.entity_type``.
+    entity_type: str
+    #: Column holding the row's display title (weighted 'A').
+    title: str
+    #: Columns concatenated into the body (weighted 'B'), in order.
+    body: tuple[str, ...] = ()
+    #: The tool whose sharing governs this row, and the column naming the
+    #: resource id to test. ``dac_id=None`` means the row's own ``id``.
+    #: ``dac_tool=None`` means the row carries no sharing gate (a tag).
+    dac_tool: Tool | None = None
+    dac_id: str | None = None
+    #: Whether this source is searched when the caller names no types. False
+    #: puts the source behind an explicit opt-in and out of the default index.
+    in_default_scope: bool = True
+
+    @property
+    def trigger_name(self) -> str:
+        """Stem for this table's triggers; INSERT/DELETE and UPDATE are split
+        (a WHEN clause naming OLD is invalid on INSERT)."""
+        return f"search_{self.entity_type}"
+
+
+#: table -> how its rows are indexed.
+#:
+#: ``comments`` is deliberately absent for now: it resolves its tool per row and
+#: is the highest-volume source, so it arrives with the toggle and the partial
+#: index that keep it off the default scope.
+SEARCH_SOURCES: dict[str, SearchSource] = {
+    "projects": SearchSource(
+        "project", title="name", body=("description",), dac_tool=Tool.project
+    ),
+    "tasks": SearchSource(
+        "task",
+        title="title",
+        body=("description",),
+        dac_tool=Tool.project,
+        dac_id="project_id",
+    ),
+    "documents": SearchSource(
+        "document",
+        title="name",
+        # ``content`` extraction arrives with the per-document_type extractors;
+        # the uploaded filename is plain text and useful on its own.
+        body=("original_filename",),
+        dac_tool=Tool.document,
+    ),
+    "queues": SearchSource(
+        "queue", title="name", body=("description",), dac_tool=Tool.queue
+    ),
+    "queue_items": SearchSource(
+        "queue_item",
+        title="label",
+        body=("notes",),
+        dac_tool=Tool.queue,
+        dac_id="queue_id",
+    ),
+    "counter_groups": SearchSource(
+        "counter_group",
+        title="name",
+        body=("description",),
+        dac_tool=Tool.counter_group,
+    ),
+    "counters": SearchSource(
+        "counter",
+        title="name",
+        dac_tool=Tool.counter_group,
+        dac_id="counter_group_id",
+    ),
+    "calendars": SearchSource(
+        "calendar", title="name", body=("description",), dac_tool=Tool.calendar
+    ),
+    "calendar_events": SearchSource(
+        "calendar_event",
+        title="title",
+        body=("description", "location"),
+        dac_tool=Tool.calendar,
+        dac_id="calendar_id",
+    ),
+    "dashboards": SearchSource(
+        "dashboard", title="name", body=("description",), dac_tool=Tool.dashboard
+    ),
+    # Guild-level vocabulary: no initiative, no sharing gate. Reaching the query
+    # at all means being in the guild, which is the whole gate for a tag.
+    "tags": SearchSource("tag", title="name"),
+}
+
+#: Tables that are deliberately NOT searchable, and why. Every guild content
+#: table is in exactly one of this or SEARCH_SOURCES; ``search_index_test``
+#: fails until a new one is placed, so a table ships searchable by default or
+#: says why not.
+NOT_SEARCHABLE: dict[str, str] = {
+    "search_entries": "the index itself",
+    "event_outbox": "change log, not content",
+    "resource_grants": "sharing rows carry no text",
+    "property_definitions": "field config, reached from the tool it configures",
+    "webhook_subscriptions": "integration config",
+    "recent_views": "one member's own viewing state",
+    "project_filter_presets": "one member's saved filters",
+    "task_statuses": "column names, reached from the project",
+    "document_file_versions": "history of a document already indexed",
+    "document_links": "derived wikilink graph",
+    "subtasks": "checklist lines, reached from the task",
+    "comments": "arrives with the per-guild toggle and partial index",
+    "initiatives": "structural; discovery is the join surface, not search",
+    "event_reminder_dispatches": "scheduler bookkeeping",
+    "task_assignment_digest_items": "scheduler bookkeeping",
+}
+
+
+#: A junction row is not a search result: it has no id to address and no text of
+#: its own. Their composite primary key says so, which is the same derivation
+#: ``event_capture`` uses to report them against their parent — so they are
+#: excluded by construction rather than by a list that would need maintaining.
+def addressable_tables(metadata) -> set[str]:
+    """Guild content tables a search hit could name — those with an ``id``."""
+    return {
+        name
+        for name, table in metadata.tables.items()
+        if [c.name for c in table.primary_key.columns] == ["id"]
+    }
+
+
+def entity_types(*, default_scope_only: bool = False) -> tuple[str, ...]:
+    """Indexed entity types, sorted. The default-scope subset is what a query
+    naming no types searches."""
+    return tuple(
+        sorted(
+            s.entity_type
+            for s in SEARCH_SOURCES.values()
+            if s.in_default_scope or not default_scope_only
+        )
+    )
+
+
+def _text_expr(columns: tuple[str, ...]) -> str:
+    """Row expression concatenating columns into one text value."""
+    if not columns:
+        return ""
+    parts = [f"coalesce({ROW}.{c}, '')" for c in columns]
+    return " || ' ' || ".join(parts) if len(parts) > 1 else parts[0]
+
+
+def _quoted(expr: str) -> str:
+    """A SQL expression as a trigger-argument string literal."""
+    return "'" + expr.replace("'", "''") + "'"
+
+
+def _when_clause(table: str, source: SearchSource) -> str:
+    """Columns whose change makes a row's index entry stale.
+
+    The trigger does not fire unless one of these actually changed, so the
+    status moves, assignee changes and reordering that dominate writes to
+    ``tasks`` cost nothing at all.
+    """
+    watched = [source.title, *source.body]
+    if source.dac_id:
+        watched.append(source.dac_id)
+    watched.append("deleted_at")
+    columns = SQLModel.metadata.tables[table].columns
+    present = [c for c in dict.fromkeys(watched) if c in columns]
+    return " OR ".join(f"OLD.{c} IS DISTINCT FROM NEW.{c}" for c in present)
+
+
+SEARCH_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION {fn}() RETURNS trigger
+    LANGUAGE plpgsql AS $search$
+DECLARE
+    v_row        record;
+    v_entity     integer;
+    v_initiative integer;
+    v_dac_id     integer;
+    v_title      text;
+    v_body       text;
+    v_chunk      text;
+    v_ix         smallint := 0;
+    v_pos        integer := 1;
+    v_len        integer;
+    v_cut        integer;
+    v_space      integer;
+    c_chunk      constant integer := {chunk};
+    c_max        constant integer := {maxchunks};
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_row := OLD;
+    ELSE
+        v_row := NEW;
+    END IF;
+
+    EXECUTE 'SELECT ' || TG_ARGV[2] INTO v_entity USING v_row;
+    IF v_entity IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- Every path starts by clearing this entity's chunks: a re-index rewrites
+    -- them below, and a delete or a soft delete leaves them cleared. Written
+    -- into the schema the CHANGED ROW lives in, named from TG_TABLE_SCHEMA
+    -- rather than resolved through the caller's search_path.
+    EXECUTE format(
+        'DELETE FROM %I.search_entries WHERE entity_type = $1 AND entity_id = $2',
+        TG_TABLE_SCHEMA
+    ) USING TG_ARGV[1], v_entity;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN NULL;
+    END IF;
+
+    -- Trash is browsed through the trash surface, not found by searching.
+    IF to_jsonb(v_row) ? 'deleted_at'
+       AND to_jsonb(v_row) ->> 'deleted_at' IS NOT NULL THEN
+        RETURN NULL;
+    END IF;
+
+    EXECUTE 'SELECT ' || TG_ARGV[0] INTO v_initiative USING v_row;
+    EXECUTE 'SELECT ' || TG_ARGV[3] INTO v_title USING v_row;
+    IF TG_ARGV[4] <> '' THEN
+        EXECUTE 'SELECT ' || TG_ARGV[4] INTO v_body USING v_row;
+    END IF;
+    IF TG_ARGV[6] <> '' THEN
+        EXECUTE 'SELECT ' || TG_ARGV[6] INTO v_dac_id USING v_row;
+    END IF;
+
+    v_title := coalesce(v_title, '');
+    v_body := coalesce(v_body, '');
+    v_len := length(v_body);
+
+    -- One row per chunk, and always at least one so a titled row with no body
+    -- is still findable. Short text takes this loop exactly once.
+    LOOP
+        IF v_pos > v_len THEN
+            v_chunk := '';
+            v_cut := 0;
+        ELSE
+            v_cut := least(c_chunk, v_len - v_pos + 1);
+            v_chunk := substr(v_body, v_pos, v_cut);
+            -- Prefer a whitespace boundary when more text follows, so a chunk
+            -- does not end mid-word.
+            IF v_pos + v_cut - 1 < v_len THEN
+                v_space := strpos(reverse(v_chunk), ' ');
+                IF v_space > 0 AND (length(v_chunk) - v_space) > c_chunk / 2 THEN
+                    v_cut := length(v_chunk) - v_space;
+                    v_chunk := substr(v_chunk, 1, v_cut);
+                    v_cut := v_cut + 1;
+                END IF;
+            END IF;
+        END IF;
+
+        EXECUTE format(
+            'INSERT INTO %I.search_entries ('
+            '  entity_type, entity_id, chunk_ix, initiative_id,'
+            '  dac_tool, dac_id, title, body, updated_at, tsv'
+            ') VALUES ($1, $2, $3, $4, nullif($5, ''''), $6, $7, nullif($8, ''''), now(),'
+            '  setweight(to_tsvector(''simple'', $7), ''A'') ||'
+            '  setweight(to_tsvector(''simple'', $8), ''B''))',
+            TG_TABLE_SCHEMA
+        ) USING TG_ARGV[1], v_entity, v_ix, v_initiative,
+                TG_ARGV[5], v_dac_id, v_title, v_chunk;
+
+        v_ix := v_ix + 1;
+        v_pos := v_pos + v_cut;
+        EXIT WHEN v_pos > v_len OR v_ix >= c_max;
+    END LOOP;
+
+    RETURN NULL;
+END
+$search$;
+""".format(fn=SEARCH_FUNCTION, chunk=CHUNK_CHARS, maxchunks=MAX_CHUNKS)
+
+
+def _call_args(table: str, source: SearchSource) -> list[str]:
+    """The seven trigger arguments, shared by both triggers on a table."""
+    locator = initiative_locator(table)
+    dac_id = f"{ROW}.{source.dac_id}" if source.dac_id else f"{ROW}.id"
+    return [
+        f"    {_quoted(locator(ROW))},",
+        f"    '{source.entity_type}',",
+        f"    {_quoted(f'{ROW}.id')},",
+        f"    {_quoted(f'{ROW}.{source.title}')},",
+        f"    {_quoted(_text_expr(source.body))},",
+        f"    '{source.dac_tool.value if source.dac_tool else ''}',",
+        f"    {_quoted(dac_id if source.dac_tool else '')}",
+    ]
+
+
+def _trigger_block(table: str, source: SearchSource) -> str:
+    """DDL installing the two refresh triggers on one source table.
+
+    Split by operation because the UPDATE one carries a ``WHEN`` clause naming
+    ``OLD``, which is invalid on INSERT. That clause is the point: an update
+    touching none of the indexed columns never enters the function.
+    """
+    args = _call_args(table, source)
+    ins, upd = f"{source.trigger_name}_ins", f"{source.trigger_name}_upd"
+    lines = [
+        f"DROP TRIGGER IF EXISTS {source.trigger_name} ON {table};",
+        f"DROP TRIGGER IF EXISTS {ins} ON {table};",
+        f"CREATE TRIGGER {ins}",
+        f"  AFTER INSERT OR DELETE ON {table}",
+        f"  FOR EACH ROW EXECUTE FUNCTION {SEARCH_FUNCTION}(",
+        *args,
+        "  );",
+        "",
+        f"DROP TRIGGER IF EXISTS {upd} ON {table};",
+        f"CREATE TRIGGER {upd}",
+        f"  AFTER UPDATE ON {table}",
+        f"  FOR EACH ROW WHEN ({_when_clause(table, source)})",
+        f"  EXECUTE FUNCTION {SEARCH_FUNCTION}(",
+        *args,
+        "  );",
+    ]
+    return "\n".join(lines)
+
+
+_HEADER = """\
+-- ============================================================================
+-- SEARCH INDEX — GENERATED, DO NOT EDIT BY HAND
+-- RENDERED AT RUNTIME from app/db/search_index.py.
+--
+-- One trigger per searchable content table, all calling
+-- public.refresh_search_entry(). Per-table knowledge is passed as trigger
+-- arguments derived from SEARCH_SOURCES (title, body, sharing) and
+-- INITIATIVE_PATHS (which initiative a row belongs to), so a new searchable
+-- table is indexed without a second declaration.
+-- ============================================================================"""
+
+
+def render_guild_search_ddl() -> str:
+    """Per-table trigger DDL, applied inside each guild schema."""
+    blocks = [
+        _trigger_block(table, source)
+        for table, source in sorted(SEARCH_SOURCES.items())
+    ]
+    return _HEADER + "\n\n" + "\n\n".join(blocks) + "\n"

--- a/backend/app/db/search_index.py
+++ b/backend/app/db/search_index.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from sqlalchemy import MetaData
 from sqlmodel import SQLModel
 
 from app.core.tools import Tool
@@ -152,7 +153,7 @@ NOT_SEARCHABLE: dict[str, str] = {
 #: its own. Their composite primary key says so, which is the same derivation
 #: ``event_capture`` uses to report them against their parent — so they are
 #: excluded by construction rather than by a list that would need maintaining.
-def addressable_tables(metadata) -> set[str]:
+def addressable_tables(metadata: MetaData) -> set[str]:
     """Guild content tables a search hit could name — those with an ``id``."""
     return {
         name

--- a/backend/app/db/search_index_test.py
+++ b/backend/app/db/search_index_test.py
@@ -1,0 +1,188 @@
+"""The refresh trigger indexes what the registry declares.
+
+These assert the seam between ``SEARCH_SOURCES`` and a real Postgres: that an
+ordinary write lands in ``search_entries`` at all, that the row carries the
+initiative and sharing identity the query layer will filter on, and that the
+three shapes the design turns on — trash leaving the index, an unrelated update
+costing nothing, and long text chunking — hold against the database rather than
+against the rendering code.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlmodel import select
+
+from sqlmodel import SQLModel
+
+from app.db.search_index import (
+    NOT_SEARCHABLE,
+    SEARCH_SOURCES,
+    addressable_tables,
+    entity_types,
+    render_guild_search_ddl,
+)
+from app.db.session import set_rls_context
+from app.db.tenancy import INITIATIVE_SCOPED_TABLES
+from app.models.platform.guild import GuildRole
+from app.models.tenant.search_entry import SearchEntry
+from app.testing import create_project, create_tag, create_task
+
+pytestmark = pytest.mark.integration
+
+
+async def _entries(session, guild_id: int, entity_type: str, entity_id: int):
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+    rows = await session.exec(
+        select(SearchEntry)
+        .where(
+            SearchEntry.entity_type == entity_type,
+            SearchEntry.entity_id == entity_id,
+        )
+        .order_by(SearchEntry.chunk_ix.asc())
+    )
+    return list(rows)
+
+
+# --- registry -------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_every_initiative_scoped_table_is_placed():
+    """A new content table is searchable or says why not — never silently
+    absent, which would ship a tool no one can find."""
+    placed = set(SEARCH_SOURCES) | set(NOT_SEARCHABLE)
+    # Junctions carry no id to address and no text of their own, so they are
+    # out by construction rather than by 22 entries saying the same thing.
+    addressable = addressable_tables(SQLModel.metadata)
+    missing = (set(INITIATIVE_SCOPED_TABLES) & addressable) - placed
+    assert not missing, (
+        f"add to SEARCH_SOURCES or NOT_SEARCHABLE in app/db/search_index.py: "
+        f"{sorted(missing)}"
+    )
+
+
+@pytest.mark.unit
+def test_a_table_is_not_placed_twice():
+    assert not (set(SEARCH_SOURCES) & set(NOT_SEARCHABLE))
+
+
+@pytest.mark.unit
+def test_entity_types_are_unique():
+    values = [s.entity_type for s in SEARCH_SOURCES.values()]
+    assert len(values) == len(set(values))
+
+
+@pytest.mark.unit
+def test_update_trigger_carries_a_when_clause():
+    """The clause is the write-path design: an update touching none of the
+    indexed columns never enters the function."""
+    ddl = render_guild_search_ddl()
+    block = next(b for b in ddl.split("\n\n") if "search_task_upd" in b)
+    assert "FOR EACH ROW WHEN (" in block
+    assert "OLD.title IS DISTINCT FROM NEW.title" in block
+    # ...and the insert trigger cannot carry one (OLD is not bound on INSERT).
+    ins = next(b for b in ddl.split("\n\n") if "search_task_ins" in b)
+    assert "WHEN (" not in ins
+
+
+@pytest.mark.unit
+def test_default_scope_is_the_indexed_set_for_now():
+    assert entity_types(default_scope_only=True) == entity_types()
+
+
+# --- the trigger ----------------------------------------------------------
+
+
+async def test_creating_a_task_is_indexed(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project, title="vendor renewal terms")
+
+    rows = await _entries(session, a.guild.id, "task", task.id)
+    assert rows, "creating a task produced no search entry"
+    row = rows[0]
+    assert row.title == "vendor renewal terms"
+    assert row.initiative_id == a.initiative.id
+    # A task is governed by its project's sharing, not its own id.
+    assert row.dac_tool == "project"
+    assert row.dac_id == a.project.id
+
+
+async def test_the_entry_is_full_text_searchable(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project, title="quarterly vendor renewal")
+
+    await set_rls_context(session, guild_id=a.guild.id, guild_role="admin")
+    found = await session.exec(
+        text(
+            "SELECT title FROM search_entries "
+            "WHERE tsv @@ websearch_to_tsquery('simple', :q)"
+        ).bindparams(q="vendor renewal")
+    )
+    assert [r[0] for r in found] == ["quarterly vendor renewal"]
+
+
+async def test_renaming_reindexes_in_place(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project, title="before")
+
+    task.title = "after"
+    session.add(task)
+    await session.commit()
+
+    rows = await _entries(session, a.guild.id, "task", task.id)
+    assert [r.title for r in rows] == ["after"]
+
+
+async def test_soft_delete_removes_it_from_the_index(session, acting_user):
+    """Trash is browsed through the trash surface, not found by searching."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project, title="gone")
+    assert await _entries(session, a.guild.id, "task", task.id)
+
+    from datetime import datetime, timezone
+
+    task.deleted_at = datetime.now(timezone.utc)
+    session.add(task)
+    await session.commit()
+
+    assert await _entries(session, a.guild.id, "task", task.id) == []
+
+
+async def test_a_guild_level_tag_is_indexed_without_an_initiative(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin)
+    tag = await create_tag(session, a.guild, name="urgent")
+
+    rows = await _entries(session, a.guild.id, "tag", tag.id)
+    assert rows, "creating a tag produced no search entry"
+    # Guild-level vocabulary: no initiative to gate on, and no sharing gate.
+    assert rows[0].initiative_id is None
+    assert rows[0].dac_tool is None
+
+
+async def test_long_text_is_chunked(session, acting_user):
+    """Chunking is a length rule: the cap cannot be reached because a row's
+    text is bounded by construction."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    body = " ".join(f"word{n}" for n in range(6000))
+    project = await create_project(
+        session, a.initiative, a.user, name="big", description=body
+    )
+
+    rows = await _entries(session, a.guild.id, "project", project.id)
+    assert len(rows) > 1, "a long description produced a single chunk"
+    assert [r.chunk_ix for r in rows] == list(range(len(rows)))
+    # Every chunk carries the title, so a title match ranks the entity whichever
+    # chunk it lands in.
+    assert {r.title for r in rows} == {"big"}
+
+
+async def test_short_text_is_exactly_one_chunk(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    project = await create_project(
+        session, a.initiative, a.user, name="small", description="one line"
+    )
+    rows = await _entries(session, a.guild.id, "project", project.id)
+    assert len(rows) == 1
+    assert rows[0].chunk_ix == 0

--- a/backend/app/db/search_index_test.py
+++ b/backend/app/db/search_index_test.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from sqlmodel import SQLModel
@@ -32,8 +33,18 @@ from app.testing import create_project, create_tag, create_task
 pytestmark = pytest.mark.integration
 
 
-async def _entries(session, guild_id: int, entity_type: str, entity_id: int):
-    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+async def _entries(
+    session: AsyncSession,
+    guild_id: int,
+    entity_type: str,
+    entity_id: int,
+    *,
+    user_id: int | None = None,
+    guild_role: str = "admin",
+) -> list[SearchEntry]:
+    await set_rls_context(
+        session, user_id=user_id, guild_id=guild_id, guild_role=guild_role
+    )
     rows = await session.exec(
         select(SearchEntry)
         .where(
@@ -186,3 +197,47 @@ async def test_short_text_is_exactly_one_chunk(session, acting_user):
     rows = await _entries(session, a.guild.id, "project", project.id)
     assert len(rows) == 1
     assert rows[0].chunk_ix == 0
+
+
+async def test_a_guild_member_outside_the_initiative_sees_nothing(session, acting_user):
+    """The initiative gate this table registers, proven against the database.
+
+    A guild member who is not in the initiative gets no rows — the same answer
+    the content tables give, from the same ``initiative_access`` call.
+    """
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    # Both actors up front: reading routes the session into a guild role, which
+    # the factories cannot run under.
+    outsider = await acting_user(guild_role=GuildRole.member, guild=a.guild)
+    task = await create_task(session, a.project, title="quarterly vendor renewal")
+
+    assert await _entries(session, a.guild.id, "task", task.id)
+    assert (
+        await _entries(
+            session,
+            a.guild.id,
+            "task",
+            task.id,
+            user_id=outsider.user.id,
+            guild_role="member",
+        )
+        == []
+    )
+
+
+async def test_a_guild_level_tag_is_visible_to_any_member(session, acting_user):
+    """The NULL-initiative leg: guild vocabulary every member already sees in
+    every picker is not hidden from them in search."""
+    a = await acting_user(guild_role=GuildRole.admin)
+    member = await acting_user(guild_role=GuildRole.member, guild=a.guild)
+    tag = await create_tag(session, a.guild, name="urgent")
+
+    rows = await _entries(
+        session,
+        a.guild.id,
+        "tag",
+        tag.id,
+        user_id=member.user.id,
+        guild_role="member",
+    )
+    assert [r.title for r in rows] == ["urgent"]

--- a/backend/app/db/sql_injection_guard_test.py
+++ b/backend/app/db/sql_injection_guard_test.py
@@ -64,6 +64,9 @@ ALLOWED_DYNAMIC_SQL: dict[str, str] = {
     "app/db/schema_provisioning.py::apply_guild_capture": (
         "int-derived schema name + registry-rendered trigger DDL (constants)"
     ),
+    "app/db/schema_provisioning.py::apply_guild_search": (
+        "int-derived schema name + registry-rendered trigger DDL (constants)"
+    ),
     "app/db/schema_provisioning.py::drop_guild_schema": (
         "int-derived guild_<id> schema/role names"
     ),

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -267,6 +267,7 @@ CREATED_BY_EXEMPT_TABLES: frozenset[str] = frozenset(
         # carries ``actor_user_id``) or has none to record.
         "event_outbox",
         "event_reminder_dispatches",
+        "search_entries",
         "task_assignment_digest_items",
         "webhook_deliveries",
     }

--- a/backend/app/models/tenant/search_entry.py
+++ b/backend/app/models/tenant/search_entry.py
@@ -1,0 +1,62 @@
+"""The guild-wide search index — one row per searchable chunk of content.
+
+Derived data: every row is written by ``public.refresh_search_entry()`` from the
+table it describes, never by application code. See ``app/db/search_index.py``
+for the registry that renders those triggers.
+
+The row carries two independent identities. ``(entity_type, entity_id)`` names
+what was found, so a hit resolves to a detail route. ``(dac_tool, dac_id)`` names
+the resource whose sharing governs it, which is often a *parent* — a task is
+governed by its project, a calendar event by its calendar — so the query filters
+on the sharing decision without re-walking those joins.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, SmallInteger, Text, text
+from sqlalchemy.dialects.postgresql import TSVECTOR
+from sqlmodel import Field, SQLModel
+
+
+class SearchEntry(SQLModel, table=True):
+    """One indexed chunk of one entity.
+
+    Composite primary key is ``(entity_type, entity_id, chunk_ix)``. Long text is
+    split into several chunks; everything else is a single ``chunk_ix = 0`` row,
+    by the same code path.
+    """
+
+    __tablename__ = "search_entries"
+
+    # DDL: unbounded TEXT constrained by ck_search_entries_entity_type
+    entity_type: str = Field(sa_column=Column(Text, primary_key=True, nullable=False))
+    entity_id: int = Field(primary_key=True)
+    chunk_ix: int = Field(
+        sa_column=Column(
+            SmallInteger, primary_key=True, nullable=False, server_default=text("0")
+        )
+    )
+    #: The initiative gating this row, or NULL for guild-level content (tags, a
+    #: guild calendar) where the initiative gate has nothing to decide.
+    initiative_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("initiatives.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+    #: The ``Tool`` whose sharing governs this row, and the resource id to test
+    #: against ``resource_grants``. NULL for rows carrying no sharing gate.
+    dac_tool: Optional[str] = Field(sa_column=Column(Text, nullable=True))
+    dac_id: Optional[int] = Field(sa_column=Column(Integer, nullable=True))
+    title: str = Field(sa_column=Column(Text, nullable=False))
+    body: Optional[str] = Field(sa_column=Column(Text, nullable=True))
+    #: When this row's *searchable text* last changed — not the source row's
+    #: ``updated_at``, which moves on writes the index deliberately ignores.
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    tsv: Optional[str] = Field(default=None, sa_column=Column(TSVECTOR, nullable=False))

--- a/backend/app/services/tenant/search.py
+++ b/backend/app/services/tenant/search.py
@@ -1,0 +1,58 @@
+"""Reading the guild search index.
+
+The index is gated in the database by initiative membership, exactly like the
+content tables it mirrors (``search_entries`` carries the same
+``initiative_member_*`` policies as ``documents``). The final gate — per-resource
+sharing — is applied here, and :func:`search_scope_clause` is the ONLY way to
+read the table.
+
+That single entry point is deliberate. A content table is reached through its own
+tool's endpoints, so a missing sharing clause costs that one tool; the index
+spans every tool, so it would cost all of them at once. Composing the clause here
+rather than at each call site means a query cannot be written without it, and a
+new tool is covered by construction because the legs derive from ``Tool``.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import and_, or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.core.tools import Tool
+from app.models.tenant.search_entry import SearchEntry
+from app.services.permissions import dac_scope_clause
+
+
+def search_scope_clause(
+    user_id: int,
+    *,
+    guild_id: int,
+    access: str = "read",
+) -> ColumnElement[bool]:
+    """The WHERE leg narrowing ``search_entries`` to rows this request may read.
+
+    One leg per :class:`Tool`, each deferring to :func:`dac_scope_clause` — the
+    same call the tool's own list endpoint makes, so search and the tool it
+    searches answer sharing identically rather than through two implementations.
+
+    Rows carrying no ``dac_tool`` (guild vocabulary such as tags) have no sharing
+    gate to apply; reaching this schema at all is the gate they answer to.
+    ``dac_scope_clause`` already returns ``true()`` when the request covers the
+    whole guild, so guild admin and PAM need no leg here.
+    """
+    return or_(
+        SearchEntry.dac_tool.is_(None),
+        *[
+            and_(
+                SearchEntry.dac_tool == tool.value,
+                dac_scope_clause(
+                    tool,
+                    SearchEntry.dac_id,
+                    user_id,
+                    guild_id=guild_id,
+                    access=access,
+                ),
+            )
+            for tool in Tool
+        ],
+    )

--- a/backend/app/services/tenant/search_test.py
+++ b/backend/app/services/tenant/search_test.py
@@ -1,0 +1,91 @@
+"""Sharing is enforced on index reads.
+
+``search_entries`` is gated in the database by initiative membership, like the
+content tables it mirrors. These assert the gate that is NOT in the database:
+per-resource sharing, applied by :func:`search_scope_clause`.
+
+The case that matters is the one the initiative gate cannot answer — a member OF
+the initiative, whose RLS therefore admits the row, holding no grant on the
+project the row belongs to.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import select
+
+from app.core.role_context import set_active_role
+from app.db.session import set_rls_context
+from app.models.platform.guild import GuildRole
+from app.models.tenant.search_entry import SearchEntry
+from app.services.tenant.search import search_scope_clause
+from app.testing import create_task
+
+pytestmark = pytest.mark.integration
+
+
+async def _search(
+    session,
+    *,
+    user_id: int,
+    guild_id: int,
+    guild_role: str,
+) -> list[str]:
+    """Titles this user can read out of the index, through the one entry point."""
+    set_active_role(guild_id, guild_role)
+    await set_rls_context(
+        session, user_id=user_id, guild_id=guild_id, guild_role=guild_role
+    )
+    rows = await session.exec(
+        select(SearchEntry.title).where(
+            SearchEntry.entity_type == "task",
+            search_scope_clause(user_id, guild_id=guild_id),
+        )
+    )
+    return sorted(rows)
+
+
+async def test_a_member_without_a_grant_gets_no_hits(session, acting_user):
+    """The initiative gate admits this row; sharing is what excludes it."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    b = await acting_user(
+        guild_role=GuildRole.member,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    await create_task(session, a.project, title="restricted vendor renewal")
+
+    assert (
+        await _search(
+            session, user_id=b.user.id, guild_id=a.guild.id, guild_role="member"
+        )
+        == []
+    )
+
+
+async def test_the_owner_does_get_the_hit(session, acting_user):
+    """...and the clause is not simply excluding everything."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project, title="restricted vendor renewal")
+
+    assert await _search(
+        session, user_id=a.user.id, guild_id=a.guild.id, guild_role="member"
+    ) == ["restricted vendor renewal"]
+
+
+async def test_a_guild_admin_is_not_narrowed_by_sharing(session, acting_user):
+    """A guild admin reaches every aspect of their guild, so the clause is the
+    one ``dac_scope_clause`` already collapses to true."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    b = await acting_user(
+        guild_role=GuildRole.admin,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    await create_task(session, a.project, title="restricted vendor renewal")
+
+    assert await _search(
+        session, user_id=b.user.id, guild_id=a.guild.id, guild_role="admin"
+    ) == ["restricted vendor renewal"]


### PR DESCRIPTION
## Problem

Search today is three unrelated mechanisms, none of which is a search engine:

- every backend `search=` parameter is an unanchored `ILIKE '%q%'` against **one** name column (`documents.py:372`, `comments.py:512`, `catalog.py:242`), which cannot use an index
- there is no `tsvector`, no `pg_trgm` and no GIN index anywhere
- `documents.content` is JSONB, so **document bodies are not searchable at all**
- nothing searches across tools — the command palette reaches tasks only
- tags are a filter you must already know the name of, never a result

This is the first of several PRs building a guild-wide search surface. Design notes are in `history/guild-search-design.md` (untracked).

## What this adds

`search_entries`, a table inside each `guild_<id>` schema holding one row per searchable chunk of content, plus the triggers that keep it current. **Nothing queries it yet** — this PR is the index and its maintenance.

### One registry

`app/db/search_index.py` holds one entry per searchable table declaring its title, body columns and sharing identity. The trigger DDL and the default query scope both render from it, so a new searchable table is one entry rather than an edit in several places.

Which initiative a row belongs to is **not** declared there — it is read from the table's existing `INITIATIVE_PATHS` entry, the same one that renders its RLS policies. A row therefore cannot be gated by one initiative and indexed under another. This is the argument `event_capture` already makes for reusing that registry.

### Two identities per row

`(entity_type, entity_id)` names what was found so a hit resolves to a route. `(dac_tool, dac_id)` names the resource whose sharing governs it, which is often a *parent* — a task is governed by its project, a calendar event by its calendar — so the query layer can filter on the sharing decision without re-walking those joins.

### Write path

Two triggers per table rather than one: `AFTER INSERT OR DELETE`, and `AFTER UPDATE` carrying a `WHEN` clause naming only the indexed columns. A `WHEN` clause referencing `OLD` is invalid on INSERT, hence the split — and it is the point of the design: status moves, assignee changes, reordering and completion stamps touch no indexed column and never enter the function.

One consequence, deliberate: `search_entries.updated_at` means *last time searchable text changed*, not the source row's `updated_at`. It is a tiebreak below relevance, and keeping them in sync would forfeit the above.

### Chunking is a length rule

Text is split at ~8 KB on whitespace boundaries. Nothing declares "this type chunks" — a tag's name takes the same code path as a long description and produces one row. This bounds every row by construction rather than managing a size limit.

### Gating

`search_entries` is registered in `INITIATIVE_PATHS` with a nullable-initiative path: a NULL initiative is the guild-level case (a tag, a guild calendar), where the initiative gate has nothing to decide and the row is one every member already sees elsewhere in the app. Rows carrying a `dac_tool` still answer to sharing. INSERT admits the refresh trigger or the routed guild admin, following `event_outbox`.

## Schema changes

New guild-scoped migration `20260901_0207`, generated with `scripts/gen_guild_migration.py`. Creates the table, its CHECK constraint, three indexes, and enables + forces RLS with the four `initiative_member_*` policies. There is no backfill to order before FORCE because the table starts empty.

The trigram index and `pg_trgm` are deliberately **not** here — they belong with the query layer that uses them, so this migration adds no extension dependency.

## Testing

```
pytest -n 0 app/db/search_index_test.py          # 12 passed
pytest -n auto app/db/                           # 422 passed
pytest -n 0 app/services/tenant/                 # passed serially
ruff check app && ruff format --check app        # clean
ty check app                                     # clean
```

`app/db/search_index_test.py` covers the registry (every addressable content table is placed, no table placed twice) and the trigger against a real Postgres: content is indexed on write, reindexed on rename, removed on soft delete, a guild-level tag lands with no initiative and no sharing gate, long text chunks and short text does not.

Junction tables are excluded from the coverage rule by construction — a composite primary key means no id to address and no text of its own — rather than by 22 registry entries saying the same thing.

`schema_provisioning_test` now excludes `search_` triggers from its Alembic drift check, alongside the `capture_` triggers it already excluded and for the same reason: both are rendered from a registry at provisioning time, so comparing them would assert the template carries a frozen snapshot of whatever the registry said.

## Notes for review

- Existing content is **not** indexed by this PR. The reindex sweep lands next, reusing the stale-stamp mechanism `backfill_guild_schemas()` already runs, so no release needs a maintenance window.
- Document body extraction (`native`, `spreadsheet`, `whiteboard`, `smart_link`) is the following PR; `documents` currently indexes its name and uploaded filename.
- Comments are absent on purpose: they resolve their tool per row and are the highest-volume source, so they arrive with the toggle and partial index that keep them off the default scope.
- The changelog entry covers the whole feature and lands with the last PR in the series.