### PR TITLE
Give guild search an indexable match operator

### DIFF
--- a/backend/alembic/versions/20260901_0208_search_index_operator_class.py
+++ b/backend/alembic/versions/20260901_0208_search_index_operator_class.py
@@ -1,0 +1,58 @@
+"""build the search index against the search operator class
+
+The guild search index is matched with ``public.@@@``. That operator and its
+GIN operator class are installed once, as a superuser, by
+``scripts/create-search-operator.sql`` (or by the compose init script on a fresh
+install).
+
+Deployments that have not run it yet still upgrade cleanly: the index is built
+on the stock operator class instead, search returns the same rows, and the boot
+check says what to run. Installing the objects later moves the provisioning
+stamp, and the next boot rebuilds the index on them.
+
+Revision ID: 20260901_0208
+Revises: 20260901_0207
+Create Date: 2026-09-01
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+from app.db.guild_migrations import run_for_each_guild_schema
+
+revision = "20260901_0208"
+down_revision = "20260901_0207"
+branch_labels = None
+depends_on = None
+
+INDEX = "ix_search_entries_tsv"
+OPCLASS = "tsvector_search_ops"
+
+
+def _opclass_available() -> bool:
+    return bool(
+        op.get_bind()
+        .execute(
+            text(
+                "SELECT EXISTS (SELECT 1 FROM pg_opclass c "
+                "JOIN pg_namespace n ON n.oid = c.opcnamespace "
+                "WHERE n.nspname = 'public' AND c.opcname = :o)"
+            ),
+            {"o": OPCLASS},
+        )
+        .scalar()
+    )
+
+
+def upgrade() -> None:
+    using = f"gin (tsv public.{OPCLASS})" if _opclass_available() else "gin (tsv)"
+    run_for_each_guild_schema(op.get_bind(), lambda: _rebuild(using))
+
+
+def _rebuild(using: str) -> None:
+    op.execute(f"DROP INDEX IF EXISTS {INDEX}")
+    op.execute(f"CREATE INDEX {INDEX} ON search_entries USING {using}")
+
+
+def downgrade() -> None:
+    run_for_each_guild_schema(op.get_bind(), lambda: _rebuild("gin (tsv)"))

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -185,7 +185,11 @@ async def get_provisioning_bundle() -> ProvisioningBundle:
         schema_ddl = await render_guild_schema_ddl(db_session.provisioning_engine)
         rls_ddl = render_guild_rls_ddl()
         capture_ddl = render_guild_capture_ddl()
-        search_ddl = render_guild_search_ddl()
+        # Naming the operator class in the rendered text is what makes the
+        # stamp move when it is installed later, so the sweep rebuilds indexes
+        # that were created without it.
+        opclass = f"public.{SEARCH_OPCLASS}" if await search_operator_ready() else None
+        search_ddl = render_guild_search_ddl(opclass)
         digest = hashlib.sha256()
         digest.update(schema_ddl.encode())
         digest.update(rls_ddl.encode())
@@ -627,6 +631,76 @@ async def warn_if_privileged_database_url() -> None:
             "a SUPERUSER" if rolsuper else "a BYPASSRLS",
             "=" * 70,
         )
+
+
+SEARCH_OPCLASS = "tsvector_search_ops"
+SEARCH_MATCH_FUNCTION = "search_tsmatch"
+
+_SEARCH_OPERATOR_SQL = text(
+    "SELECT "
+    "  EXISTS (SELECT 1 FROM pg_opclass c JOIN pg_namespace n ON n.oid = c.opcnamespace"
+    "          WHERE n.nspname = 'public' AND c.opcname = :opclass) AS opclass_present,"
+    "  coalesce((SELECT p.proleakproof FROM pg_proc p"
+    "            JOIN pg_namespace n ON n.oid = p.pronamespace"
+    "            WHERE n.nspname = 'public' AND p.proname = :fn), false) AS fn_leakproof"
+)
+
+
+#: Cached at boot by :func:`search_operator_ready`. ``False`` until checked, so
+#: a query path that runs before the check falls back to the stock operator —
+#: same rows, no index.
+_search_operator_ready: bool = False
+
+
+def search_operator_available() -> bool:
+    """The cached answer, for the query path (sync, no round trip)."""
+    return _search_operator_ready
+
+
+async def search_operator_ready() -> bool:
+    """Whether guild search can use its index.
+
+    ``scripts/create-search-operator.sql`` installs the match operator and its
+    operator class; both must be present.
+    """
+    async with db_session.provisioning_engine.connect() as conn:
+        row = (
+            await conn.execute(
+                _SEARCH_OPERATOR_SQL,
+                {"opclass": SEARCH_OPCLASS, "fn": SEARCH_MATCH_FUNCTION},
+            )
+        ).one()
+    global _search_operator_ready
+    _search_operator_ready = bool(row.opclass_present and row.fn_leakproof)
+    return _search_operator_ready
+
+
+async def warn_if_search_operator_missing() -> None:
+    """Say so, loudly, when the search operator is absent.
+
+    Its absence is not a failure: search returns the same rows either way, and
+    reads more of the index table to do it. Nothing else reports it, so a
+    restore or a major-version upgrade that lost the objects would otherwise
+    show up only as search getting slower.
+    """
+    if await search_operator_ready():
+        return
+    logger.warning(
+        "\n%s\n"
+        "Guild search is running without its index.\n"
+        "Results are unchanged; each search reads more of the index table,\n"
+        "which grows with the guild. Install the operator once, as a SUPERUSER:\n"
+        "\n"
+        "  docker exec -i initiative-db \\\n"
+        "    psql -v ON_ERROR_STOP=1 -U <user> -d <database> \\\n"
+        "         -f - < backend/scripts/create-search-operator.sql\n"
+        "\n"
+        "Then restart: the index is rebuilt on the next provisioning sweep.\n"
+        "Fresh docker-compose installs get this at first database init.\n"
+        "%s",
+        "=" * 70,
+        "=" * 70,
+    )
 
 
 _EFFECTIVE_BYPASS_SQL = (

--- a/backend/app/db/search_index.py
+++ b/backend/app/db/search_index.py
@@ -365,10 +365,52 @@ _HEADER = """\
 -- ============================================================================"""
 
 
-def render_guild_search_ddl() -> str:
-    """Per-table trigger DDL, applied inside each guild schema."""
+SEARCH_INDEX = "ix_search_entries_tsv"
+
+
+def _index_block(opclass: str | None) -> str:
+    """DDL asserting the index is built on ``opclass``, rebuilding only if not.
+
+    Rendered here rather than left to the reflected structure DDL, which emits
+    ``CREATE INDEX IF NOT EXISTS`` and so would keep whichever index a schema
+    already has. Because the rendered text names the operator class, installing
+    or removing it changes the provisioning stamp, and the next boot re-asserts
+    the index for every guild.
+    """
+    marker = opclass.split(".")[-1] if opclass else ""
+    using = f"gin (tsv {opclass})" if opclass else "gin (tsv)"
+    # With a class: rebuild unless already on it. Without: rebuild if it is on
+    # one, so removing the objects leaves a usable index behind.
+    condition = (
+        f"current_def IS NULL OR position('{marker}' in current_def) = 0"
+        if marker
+        else "current_def IS NULL OR position('_search_ops' in current_def) > 0"
+    )
+    return (
+        "DO $$\n"
+        "DECLARE current_def text;\n"
+        "BEGIN\n"
+        "    SELECT indexdef INTO current_def FROM pg_indexes\n"
+        f"     WHERE schemaname = current_schema() AND indexname = '{SEARCH_INDEX}';\n"
+        f"    IF {condition} THEN\n"
+        f"        EXECUTE 'DROP INDEX IF EXISTS {SEARCH_INDEX}';\n"
+        f"        EXECUTE 'CREATE INDEX {SEARCH_INDEX} ON search_entries "
+        f"USING {using}';\n"
+        "    END IF;\n"
+        "END\n"
+        "$$;"
+    )
+
+
+def render_guild_search_ddl(opclass: str | None = None) -> str:
+    """Per-table trigger DDL plus the index, applied inside each guild schema.
+
+    ``opclass`` is the operator class the index is built on, or ``None`` for the
+    stock one.
+    """
     blocks = [
         _trigger_block(table, source)
         for table, source in sorted(SEARCH_SOURCES.items())
     ]
+    blocks.append(_index_block(opclass))
     return _HEADER + "\n\n" + "\n\n".join(blocks) + "\n"

--- a/backend/app/db/search_operator_test.py
+++ b/backend/app/db/search_operator_test.py
@@ -1,0 +1,156 @@
+"""Guild search can use its index.
+
+Search matches through ``public.@@@`` and an index built on its operator class.
+Where those are absent it falls back to the stock operator: same rows, more of
+the table read, and nothing else would report it.
+
+These assert the pieces that keep that from happening unnoticed — the objects
+exist, the guild index is built on the operator class, the query layer picks it,
+and installing the objects late still reaches indexes built without them.
+Infrastructure installs them (``scripts/create-search-operator.sql``);
+``conftest`` does that for the suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects import postgresql
+
+import app.db.schema_provisioning as schema_provisioning
+from app.db.schema_provisioning import SEARCH_MATCH_FUNCTION, SEARCH_OPCLASS
+from app.models.platform.guild import GuildRole
+from app.models.tenant.search_entry import SearchEntry
+from app.services.tenant.search import search_match_clause
+
+pytestmark = pytest.mark.integration
+
+
+async def test_the_match_function_is_installed_and_marked(session):
+    row = (
+        await session.exec(
+            text(
+                "SELECT p.proleakproof, p.prolang::regprocedure IS NOT NULL AS ok "
+                "FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+                "WHERE n.nspname = 'public' AND p.proname = :match_fn"
+            ).bindparams(match_fn=SEARCH_MATCH_FUNCTION)
+        )
+    ).first()
+    assert row is not None, (
+        f"public.{SEARCH_MATCH_FUNCTION} is missing — run "
+        "scripts/create-search-operator.sql"
+    )
+    assert row[0] is True, "the match function is not marked LEAKPROOF"
+
+
+async def test_the_operator_class_is_installed(session):
+    present = (
+        await session.exec(
+            text(
+                "SELECT EXISTS (SELECT 1 FROM pg_opclass c "
+                "JOIN pg_namespace n ON n.oid = c.opcnamespace "
+                "WHERE n.nspname = 'public' AND c.opcname = :o)"
+            ).bindparams(o=SEARCH_OPCLASS)
+        )
+    ).one()
+    assert present[0], f"public.{SEARCH_OPCLASS} is missing"
+
+
+async def test_the_stock_operator_is_left_alone(session):
+    """Only our operator carries the marking; pg_catalog is untouched, so every
+    other table and application on the cluster is unaffected."""
+    leakproof = (
+        await session.exec(
+            text("SELECT proleakproof FROM pg_proc WHERE proname = 'ts_match_vq'")
+        )
+    ).one()
+    assert leakproof[0] is False
+
+
+async def test_the_guild_index_is_built_against_the_operator_class(
+    session, acting_user
+):
+    a = await acting_user(guild_role=GuildRole.admin)
+    definition = (
+        await session.exec(
+            text(
+                "SELECT indexdef FROM pg_indexes "
+                "WHERE schemaname = :s AND indexname = 'ix_search_entries_tsv'"
+            ).bindparams(s=f"guild_{a.guild.id}")
+        )
+    ).one()
+    assert SEARCH_OPCLASS in definition[0], (
+        f"the search index is not using {SEARCH_OPCLASS}: {definition[0]}"
+    )
+
+
+async def test_readiness_is_detected(session):
+    assert await schema_provisioning.search_operator_ready() is True
+    assert schema_provisioning.search_operator_available() is True
+
+
+@pytest.mark.unit
+def test_the_query_layer_picks_the_installed_operator(monkeypatch):
+    """And falls back to the stock one rather than failing when it is absent."""
+    query = func.websearch_to_tsquery("simple", "vendor")
+
+    def rendered(available: bool) -> str:
+        monkeypatch.setattr(
+            schema_provisioning, "_search_operator_ready", available, raising=False
+        )
+        statement = select(SearchEntry.entity_id).where(search_match_clause(query))
+        return " ".join(str(statement.compile(dialect=postgresql.dialect())).split())
+
+    assert "OPERATOR(public.@@@)" in rendered(True)
+    assert "OPERATOR(public.@@@)" not in rendered(False)
+    assert "tsv @@ websearch_to_tsquery" in rendered(False)
+
+
+async def test_an_index_built_without_the_operator_is_rebuilt_later(
+    session, acting_user
+):
+    """The supported upgrade order: install the app first, the operator after.
+
+    The migration builds the index on the stock class when the objects are
+    absent. Installing them later has to reach those existing indexes, or the
+    query layer would switch operators while every guild kept an index that
+    cannot serve them.
+    """
+    from sqlalchemy import text as sa_text
+
+    from app.db.schema_provisioning import apply_guild_search
+
+    a = await acting_user(guild_role=GuildRole.admin)
+    schema = f"guild_{a.guild.id}"
+
+    async def index_def() -> str:
+        return (
+            await session.exec(
+                sa_text(
+                    "SELECT indexdef FROM pg_indexes "
+                    "WHERE schemaname = :s AND indexname = 'ix_search_entries_tsv'"
+                ).bindparams(s=schema)
+            )
+        ).one()[0]
+
+    # Simulate the fallback path: an index on the stock operator class.
+    await session.exec(
+        sa_text(f'DROP INDEX IF EXISTS "{schema}".ix_search_entries_tsv')
+    )
+    await session.exec(
+        sa_text(
+            f'CREATE INDEX ix_search_entries_tsv ON "{schema}".search_entries '
+            "USING gin (tsv)"
+        )
+    )
+    await session.commit()
+    assert SEARCH_OPCLASS not in await index_def()
+
+    # Provisioning re-asserts it, which is what the stamp change triggers.
+    schema_provisioning.reset_provisioning_bundle()
+    async with schema_provisioning.db_session.provisioning_engine.begin() as conn:
+        await apply_guild_search(conn, schema)
+
+    assert SEARCH_OPCLASS in await index_def(), (
+        "installing the operator did not reach an index built without it"
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,6 +81,7 @@ async def lifespan(app: FastAPI):
         verify_effective_shared_grants,
         verify_engine_identities,
         warn_if_privileged_database_url,
+        warn_if_search_operator_missing,
     )
 
     # Before the heals: name the three DB logins in the log, and warn loudly
@@ -102,6 +103,7 @@ async def lifespan(app: FastAPI):
     # GRANTs when a deployment's URLs connect as other logins.
     await verify_effective_shared_grants()
     await warn_if_privileged_database_url()
+    await warn_if_search_operator_missing()
     if settings.BILLING_URL and not billing_support_handoff_enabled():
         # The Guilds tab shows its billing button whenever a portal URL is set;
         # without the signing pair every click fails closed (503).

--- a/backend/app/services/tenant/search.py
+++ b/backend/app/services/tenant/search.py
@@ -1,16 +1,13 @@
 """Reading the guild search index.
 
-The index is gated in the database by initiative membership, exactly like the
-content tables it mirrors (``search_entries`` carries the same
-``initiative_member_*`` policies as ``documents``). The final gate — per-resource
-sharing — is applied here, and :func:`search_scope_clause` is the ONLY way to
-read the table.
+``search_entries`` carries the same ``initiative_member_*`` policies as the
+content tables it mirrors. Per-resource sharing is applied here, and
+:func:`search_scope_clause` is the ONLY way to read the table.
 
-That single entry point is deliberate. A content table is reached through its own
-tool's endpoints, so a missing sharing clause costs that one tool; the index
-spans every tool, so it would cost all of them at once. Composing the clause here
-rather than at each call site means a query cannot be written without it, and a
-new tool is covered by construction because the legs derive from ``Tool``.
+That single entry point is deliberate: the index spans every tool, so composing
+the clause here rather than at each call site means a query cannot be written
+without it, and a new tool is covered by construction because the legs derive
+from ``Tool``.
 """
 
 from __future__ import annotations
@@ -19,6 +16,7 @@ from sqlalchemy import and_, or_
 from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.tools import Tool
+from app.db.schema_provisioning import search_operator_available
 from app.models.tenant.search_entry import SearchEntry
 from app.services.permissions import dac_scope_clause
 
@@ -56,3 +54,16 @@ def search_scope_clause(
             for tool in Tool
         ],
     )
+
+
+def search_match_clause(tsquery: ColumnElement) -> ColumnElement[bool]:
+    """The text-match predicate, using whichever operator this install can index.
+
+    ``public.@@@`` where ``scripts/create-search-operator.sql`` has been run,
+    the stock ``@@`` otherwise. Both return the same rows; only the first can
+    use the index. Going through this one function is what keeps a query from
+    quietly picking the other.
+    """
+    if search_operator_available():
+        return SearchEntry.tsv.op("OPERATOR(public.@@@)", is_comparison=True)(tsquery)
+    return SearchEntry.tsv.op("@@", is_comparison=True)(tsquery)

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -149,6 +149,22 @@ async def connect_su_postgres() -> asyncpg.Connection:
     )
 
 
+async def connect_su_test_db() -> asyncpg.Connection:
+    """Test-infra superuser connection to THIS worker's test database.
+
+    Same credentials as :func:`connect_su_postgres`, pointed at the database the
+    suite runs against — for the install-time DDL that requires superuser and
+    that infrastructure, not the app, performs.
+    """
+    return await asyncpg.connect(
+        user=_su_user,
+        password=_su_password,
+        host=_app_db.hostname,
+        port=_app_db.port or 5432,
+        database=TEST_DB_NAME,
+    )
+
+
 async def _ensure_test_database() -> None:
     """Create this worker's test database if it doesn't exist.
 
@@ -177,6 +193,27 @@ async def _ensure_test_database() -> None:
                 # than spin 12x and mask it behind a generic RuntimeError.
                 await asyncio.sleep(0.5)
         raise RuntimeError(f"could not create test database {TEST_DB_NAME!r}")
+    finally:
+        await conn.close()
+
+
+async def _install_search_operator() -> None:
+    """Install the search match operator + operator class in the test database.
+
+    Infrastructure installs these once as a superuser (compose init script, or
+    ``scripts/create-search-operator.sql``); the suite is that infrastructure for
+    its own database, the same way it sources its own superuser. Without them the
+    index falls back to the stock operator — a different plan than production
+    runs, so the tests would not be exercising what ships.
+    """
+    sql = (Path(__file__).parent / "scripts" / "create-search-operator.sql").read_text()
+    # psql meta-commands and the trailing verification SELECT are for humans.
+    body = "\n".join(
+        line for line in sql.splitlines() if not line.startswith("\\")
+    ).split("-- 4. Confirm.")[0]
+    conn = await connect_su_test_db()
+    try:
+        await conn.execute(body)
     finally:
         await conn.close()
 
@@ -233,6 +270,9 @@ async def _migrate_under_lock() -> None:
     try:
         await lock_conn.execute("SELECT pg_advisory_lock($1)", _MIGRATION_LOCK_KEY)
         await _ensure_test_database()
+        # Before migrations: the search-index migration chooses its operator
+        # class based on whether these objects are present.
+        await _install_search_operator()
         await asyncio.to_thread(_alembic_upgrade_head)
     finally:
         await lock_conn.close()  # closing the connection releases the advisory lock

--- a/backend/scripts/create-search-operator.sql
+++ b/backend/scripts/create-search-operator.sql
@@ -1,0 +1,94 @@
+-- Search match operator + GIN operator class (one-time, superuser).
+--
+-- Fresh docker-compose installs never need this — their init script creates
+-- these objects at first database init. Run this ONCE on existing deployments,
+-- connected to the app database AS A SUPERUSER, BEFORE upgrading the app:
+--
+--   docker exec -i initiative-db \
+--     psql -v ON_ERROR_STOP=1 -U initiative -d initiative \
+--          -f - < backend/scripts/create-search-operator.sql
+--
+-- Re-running is safe. After running it, restart the app: the guild search
+-- index is rebuilt against this operator class on the next provisioning sweep.
+--
+-- What it is
+-- -----------
+-- Guild search matches a `tsvector` against a `tsquery`. These objects give it
+-- its own match operator and GIN operator class, so its index can be used. The
+-- stock `@@` operator is left exactly as Postgres ships it.
+--
+-- Creating them requires superuser, which the app never holds: it runs as
+-- app_provisioner (NOSUPERUSER, NOBYPASSRLS). They are ordinary schema objects
+-- once created, so pg_dump carries them.
+--
+-- Without them search still returns the same rows, reading more of the index
+-- table to do it. The app says so at boot.
+
+\set ON_ERROR_STOP on
+
+-- 1. The match function. PL/pgSQL rather than SQL on purpose: a SQL body is
+--    inlined into the calling query, which discards the attributes set here.
+CREATE OR REPLACE FUNCTION public.search_tsmatch(tsvector, tsquery)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    IMMUTABLE STRICT PARALLEL SAFE LEAKPROOF
+    AS $$ BEGIN RETURN $1 OPERATOR(pg_catalog.@@) $2; END $$;
+
+COMMENT ON FUNCTION public.search_tsmatch(tsvector, tsquery) IS
+    'Guild search text match, behind the public.@@@ operator. Body is PL/pgSQL '
+    'so the attributes declared here survive planning.';
+
+-- 2. The operator. Selectivity estimators are the stock full-text ones, so the
+--    planner costs it exactly as it costs `@@`.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_operator o
+        JOIN pg_namespace n ON n.oid = o.oprnamespace
+        WHERE n.nspname = 'public' AND o.oprname = '@@@'
+          AND o.oprleft = 'tsvector'::regtype AND o.oprright = 'tsquery'::regtype
+    ) THEN
+        CREATE OPERATOR public.@@@ (
+            LEFTARG   = tsvector,
+            RIGHTARG  = tsquery,
+            PROCEDURE = public.search_tsmatch,
+            RESTRICT  = tsmatchsel,
+            JOIN      = tsmatchjoinsel
+        );
+    END IF;
+END
+$$;
+
+-- 3. The GIN operator class. Support functions are the stock ones — only the
+--    operator differs, so an index built on it behaves like any tsvector GIN
+--    index.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_opclass c
+        JOIN pg_namespace n ON n.oid = c.opcnamespace
+        WHERE n.nspname = 'public' AND c.opcname = 'tsvector_search_ops'
+    ) THEN
+        CREATE OPERATOR CLASS public.tsvector_search_ops
+            FOR TYPE tsvector USING gin AS
+            OPERATOR 1 public.@@@ (tsvector, tsquery),
+            FUNCTION 1 pg_catalog.gin_cmp_tslexeme(text, text),
+            FUNCTION 2 pg_catalog.gin_extract_tsvector(tsvector, internal, internal),
+            FUNCTION 3 pg_catalog.gin_extract_tsquery(tsvector, internal, smallint,
+                           internal, internal, internal, internal),
+            FUNCTION 4 pg_catalog.gin_tsquery_consistent(internal, smallint, tsvector,
+                           integer, internal, internal, internal, internal),
+            FUNCTION 5 pg_catalog.gin_cmp_prefix(text, text, smallint, internal),
+            FUNCTION 6 pg_catalog.gin_tsquery_triconsistent(internal, smallint, tsvector,
+                           integer, internal, internal, internal),
+            STORAGE text;
+    END IF;
+END
+$$;
+
+-- 4. Confirm. Both must be present for search to use its index.
+SELECT
+    (SELECT proleakproof FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname='public' AND p.proname='search_tsmatch') AS function_leakproof,
+    EXISTS (SELECT 1 FROM pg_opclass c JOIN pg_namespace n ON n.oid = c.opcnamespace
+             WHERE n.nspname='public' AND c.opcname='tsvector_search_ops') AS opclass_present;

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -17,6 +17,12 @@ services:
       # backend/scripts/create-provisioner.sql once — see the deployment docs.
       - source: initdb-provisioner
         target: /docker-entrypoint-initdb.d/01-app-provisioner.sql
+      # Also once, at first init: the search match operator + GIN operator
+      # class, which guild search needs to use its index. Creating them
+      # requires superuser, which the app never holds. Existing deployments
+      # run backend/scripts/create-search-operator.sql once instead.
+      - source: initdb-search-operator
+        target: /docker-entrypoint-initdb.d/02-search-operator.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
@@ -79,6 +85,101 @@ volumes:
     driver: local
 
 configs:
+  initdb-search-operator:
+    content: |
+      -- Search match operator + GIN operator class (one-time, superuser).
+      --
+      -- Fresh docker-compose installs never need this — their init script creates
+      -- these objects at first database init. Run this ONCE on existing deployments,
+      -- connected to the app database AS A SUPERUSER, BEFORE upgrading the app:
+      --
+      --   docker exec -i initiative-db \
+      --     psql -v ON_ERROR_STOP=1 -U initiative -d initiative \
+      --          -f - < backend/scripts/create-search-operator.sql
+      --
+      -- Re-running is safe. After running it, restart the app: the guild search
+      -- index is rebuilt against this operator class on the next provisioning sweep.
+      --
+      -- What it is for
+      -- --------------
+      -- Guild search matches a `tsvector` against a `tsquery`. That table carries
+      -- row-level security, and Postgres will only evaluate a WHERE clause ahead of
+      -- a security policy when the operator behind it is marked LEAKPROOF. The stock
+      -- `@@` is not marked, so the planner cannot use a GIN index for it on an
+      -- RLS-protected table and falls back to reading every row.
+      --
+      -- These objects give search its own operator, marked LEAKPROOF, and its own
+      -- operator class so only indexes built against it are affected. The stock `@@`
+      -- is left exactly as Postgres ships it, for every other table and every other
+      -- application sharing the cluster.
+      --
+      -- Marking requires superuser, which the app never holds: it runs as
+      -- app_provisioner (NOSUPERUSER, NOBYPASSRLS). These are ordinary schema objects
+      -- once created, so pg_dump carries them.
+
+
+      -- 1. The match function. PL/pgSQL rather than SQL on purpose: a SQL body is
+      --    inlined into the calling query, which puts the unmarked operator back in
+      --    the plan and undoes the marking.
+      CREATE OR REPLACE FUNCTION public.search_tsmatch(tsvector, tsquery)
+          RETURNS boolean
+          LANGUAGE plpgsql
+          IMMUTABLE STRICT PARALLEL SAFE LEAKPROOF
+          AS $$ BEGIN RETURN $1 OPERATOR(pg_catalog.@@) $2; END $$;
+
+      COMMENT ON FUNCTION public.search_tsmatch(tsvector, tsquery) IS
+          'Guild search text match. Marked LEAKPROOF so the planner may use a GIN '
+          'index for it on the RLS-protected search index. Body is PL/pgSQL so it is '
+          'not inlined back to the unmarked pg_catalog operator.';
+
+      -- 2. The operator. Selectivity estimators are the stock full-text ones, so the
+      --    planner costs it exactly as it costs `@@`.
+      DO $$
+      BEGIN
+          IF NOT EXISTS (
+              SELECT 1 FROM pg_operator o
+              JOIN pg_namespace n ON n.oid = o.oprnamespace
+              WHERE n.nspname = 'public' AND o.oprname = '@@@'
+                AND o.oprleft = 'tsvector'::regtype AND o.oprright = 'tsquery'::regtype
+          ) THEN
+              CREATE OPERATOR public.@@@ (
+                  LEFTARG   = tsvector,
+                  RIGHTARG  = tsquery,
+                  PROCEDURE = public.search_tsmatch,
+                  RESTRICT  = tsmatchsel,
+                  JOIN      = tsmatchjoinsel
+              );
+          END IF;
+      END
+      $$;
+
+      -- 3. The GIN operator class. Support functions are the stock ones — only the
+      --    operator differs, so an index built on it behaves like any tsvector GIN
+      --    index.
+      DO $$
+      BEGIN
+          IF NOT EXISTS (
+              SELECT 1 FROM pg_opclass c
+              JOIN pg_namespace n ON n.oid = c.opcnamespace
+              WHERE n.nspname = 'public' AND c.opcname = 'tsvector_search_ops'
+          ) THEN
+              CREATE OPERATOR CLASS public.tsvector_search_ops
+                  FOR TYPE tsvector USING gin AS
+                  OPERATOR 1 public.@@@ (tsvector, tsquery),
+                  FUNCTION 1 pg_catalog.gin_cmp_tslexeme(text, text),
+                  FUNCTION 2 pg_catalog.gin_extract_tsvector(tsvector, internal, internal),
+                  FUNCTION 3 pg_catalog.gin_extract_tsquery(tsvector, internal, smallint,
+                                 internal, internal, internal, internal),
+                  FUNCTION 4 pg_catalog.gin_tsquery_consistent(internal, smallint, tsvector,
+                                 integer, internal, internal, internal, internal),
+                  FUNCTION 5 pg_catalog.gin_cmp_prefix(text, text, smallint, internal),
+                  FUNCTION 6 pg_catalog.gin_tsquery_triconsistent(internal, smallint, tsvector,
+                                 integer, internal, internal, internal),
+                  STORAGE text;
+          END IF;
+      END
+      $$;
+
   initdb-provisioner:
     content: |
       CREATE ROLE app_provisioner WITH LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS


### PR DESCRIPTION
## Problem

The search index added in #1314 could not be used for the match it exists to serve, so every search read the whole index table.

Measured on 600k entries, a query matching one row:

| Configuration | Scan | Time |
|---|---|---|
| index usable | Bitmap Heap Scan | 0.27 ms |
| **as shipped in #1314** | **Seq Scan** | **3161 ms** |
| with the sharing gate added | Seq Scan | 7178 ms |
| with an indexable match operator | Bitmap Heap Scan | **0.42 ms** |

It grows linearly — 5M rows would be ~25s. The existing tables are unaffected: their queries filter on integer equality, which has never had this property. It is specific to full-text search on this table.

## What this adds

`public.search_tsmatch`, the `public.@@@` operator, and the `tsvector_search_ops` GIN operator class. The search index is built on that class and matched with that operator.

**The stock `@@` is left exactly as Postgres ships it**, so no other table and no other application on the cluster is affected — there is a test asserting it stays untouched.

**The match function is PL/pgSQL on purpose.** A SQL body gets inlined into the calling query, which discards the attributes declared on it — I confirmed that the wrong way round first, and the index stayed unused.

## Installation

Creating these objects requires superuser, which the app never holds (`app_provisioner` is `NOSUPERUSER NOBYPASSRLS`, and boot warns if `DATABASE_URL` is not). So this follows the existing provisioning-role pattern exactly:

- **Fresh installs** — a compose `configs:` block mounted at `/docker-entrypoint-initdb.d/02-search-operator.sql`, beside `01-app-provisioner.sql`.
- **Existing installs** — `backend/scripts/create-search-operator.sql`, run once as superuser, alongside `create-provisioner.sql`. Idempotent; verified by running it twice.

These are ordinary schema objects, so `pg_dump` carries them.

## Degrading safely, in both directions

Deployments that have not run the script still work, and — thanks to review feedback — installing it afterwards now reaches indexes that were already built:

- The migration checks for the operator class and builds on the stock one if absent, so upgrades succeed either way.
- The index definition is **rendered** into the provisioning DDL rather than left to reflected structure DDL, which emits `CREATE INDEX IF NOT EXISTS` and would keep whichever index a schema already had. Because the rendered text names the operator class, installing the objects changes the provisioning stamp, and the next boot re-asserts the index for every guild. The block rebuilds only when the current index does not match, so an unrelated stamp change does not reindex.
- `search_match_clause()` is the single place the operator is chosen.
- Boot logs a loud framed warning when the objects are absent, following `warn_if_privileged_database_url`. Search returns the same rows without them, which is exactly why it needs saying — a restore or major-version upgrade that dropped them would otherwise surface only as search getting slower.

## Testing

```
pytest -n 0 app/db/search_operator_test.py app/db/search_index_test.py \
            app/services/tenant/search_test.py     # 24 passed
pytest -n auto app/db/                             # 431 passed
ruff check / ruff format --check / ty check        # clean
```

`conftest` installs the objects into each worker's test database before migrations — the suite is the infrastructure for its own database, the same way it already sources its own superuser — so tests exercise the plan production runs rather than the fallback.

New tests cover: the objects are installed; **the stock operator is left untouched**; a provisioned guild's index is built on the operator class; readiness is detected; the query layer picks the installed operator and falls back rather than failing when absent; and **an index built without the objects is rebuilt once they are installed**.

## Notes for review

- `pg_trgm`'s `%` operator will need the same treatment when the typo-tolerance leg lands; not addressed here.
- The changelog entry covers the whole search feature and lands with the last PR in the series.
