### PR TITLE
Index guild content that predates the search index

### DIFF
--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -179,6 +179,7 @@ async def get_provisioning_bundle() -> ProvisioningBundle:
         from app.db.guild_ddl import render_guild_rls_ddl, render_guild_schema_ddl
         from app.db.search_index import (
             SEARCH_FUNCTION_SQL,
+            WRITE_FUNCTION_SQL,
             render_guild_search_ddl,
         )
 
@@ -197,6 +198,7 @@ async def get_provisioning_bundle() -> ProvisioningBundle:
         digest.update(CAPTURE_FUNCTION_SQL.encode())
         digest.update(search_ddl.encode())
         digest.update(SEARCH_FUNCTION_SQL.encode())
+        digest.update(WRITE_FUNCTION_SQL.encode())
         digest.update(
             "\n".join(
                 _grant_statements(
@@ -296,12 +298,16 @@ async def apply_guild_search(conn: AsyncConnection, schema: str) -> None:
     on the next boot rather than needing a migration per edit), then the
     per-table triggers, both idempotent.
     """
-    from app.db.search_index import SEARCH_FUNCTION_SQL
+    from app.db.search_index import SEARCH_FUNCTION_SQL, WRITE_FUNCTION_SQL
 
     ddl = (await get_provisioning_bundle()).search_ddl
     raw = await conn.get_raw_connection()
+    # The write function first: the trigger function calls it.
     await raw.driver_connection.execute(
-        "SET check_function_bodies = false;\n" + SEARCH_FUNCTION_SQL
+        "SET check_function_bodies = false;\n"
+        + WRITE_FUNCTION_SQL
+        + "\n"
+        + SEARCH_FUNCTION_SQL
     )
     await raw.driver_connection.execute(
         f'SET search_path TO "{schema}", public;\n{ddl}\nSET search_path TO public;'
@@ -673,6 +679,98 @@ async def search_operator_ready() -> bool:
     global _search_operator_ready
     _search_operator_ready = bool(row.opclass_present and row.fn_leakproof)
     return _search_operator_ready
+
+
+#: Rows per reindex transaction. Bounded so a large table is walked rather than
+#: rebuilt in one long-running statement.
+SEARCH_REINDEX_BATCH = 2000
+
+
+async def reindex_guild_search(engine, schema: str, *, force: bool = False) -> int:
+    """Rebuild one guild's search entries when its generation marker is stale.
+
+    The marker is a comment on the guild's ``search_entries``, the same shape
+    as the provisioning stamp on the schema. Adding a source or changing an
+    extraction moves :func:`search_generation`, and this walks each source table
+    in batches, writing through the same function the refresh trigger uses.
+
+    Returns the number of entities rewritten; zero when already current.
+    """
+    from app.db.search_index import reindex_plan, search_generation
+
+    generation = search_generation()
+    async with engine.connect() as conn:
+        current = await conn.scalar(
+            text("SELECT obj_description(to_regclass(:t), 'pg_class')"),
+            {"t": f'"{schema}".search_entries'},
+        )
+    if current == generation and not force:
+        return 0
+
+    written = 0
+    for _entity_type, statement in reindex_plan():
+        cursor = 0
+        while True:
+            async with engine.begin() as conn:
+                # System routing: no user id (so the auth gate reads as a system
+                # session), guild-admin role for the write.
+                await conn.exec_driver_sql(
+                    f"SELECT set_config('search_path', '\"{schema}\", public', true),"
+                    " set_config('app.current_guild_role', 'admin', true),"
+                    " set_config('app.current_user_id', '', true)"
+                )
+                rows = (
+                    await conn.execute(
+                        text(statement),
+                        {
+                            "schema": schema,
+                            "cursor": cursor,
+                            "batch": SEARCH_REINDEX_BATCH,
+                        },
+                    )
+                ).all()
+            if not rows:
+                break
+            cursor = max(r.id for r in rows)
+            written += len(rows)
+
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(
+            f"COMMENT ON TABLE \"{schema}\".search_entries IS '{generation}'"
+        )
+    return written
+
+
+async def backfill_guild_search() -> int:
+    """Reindex every guild whose search generation is stale.
+
+    Runs after schema provisioning, on its own connections: a guild's content is
+    walked in bounded transactions, so a large install fills in progressively
+    instead of holding one transaction open across the whole sweep.
+    """
+    from sqlalchemy import text as _text
+
+    async with db_session.provisioning_engine.connect() as conn:
+        schemas = [
+            r[0]
+            for r in (
+                await conn.execute(
+                    _text(
+                        "SELECT nspname FROM pg_namespace "
+                        "WHERE nspname LIKE 'guild\\_%' ORDER BY nspname"
+                    )
+                )
+            ).all()
+        ]
+    total = 0
+    for schema in schemas:
+        try:
+            total += await reindex_guild_search(db_session.provisioning_engine, schema)
+        except Exception:
+            logger.exception("search reindex failed for %s", schema)
+    if total:
+        logger.info("search reindex wrote %d entries", total)
+    return total
 
 
 async def warn_if_search_operator_missing() -> None:

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -682,8 +682,9 @@ async def search_operator_ready() -> bool:
 
 
 #: Rows per reindex transaction. Bounded so a large table is walked rather than
-#: rebuilt in one long-running statement.
-SEARCH_REINDEX_BATCH = 2000
+#: rebuilt in one long-running statement, and kept small because each batch
+#: holds row locks on the source table until it commits.
+SEARCH_REINDEX_BATCH = 500
 
 
 async def reindex_guild_search(engine, schema: str, *, force: bool = False) -> int:

--- a/backend/app/db/search_index.py
+++ b/backend/app/db/search_index.py
@@ -482,6 +482,11 @@ def reindex_statement(table: str, source: SearchSource) -> str:
         f" FROM {table} {row}"
         f" WHERE {row}.id > :cursor{live}"
         f" ORDER BY {row}.id LIMIT :batch"
+        # Locks each row for the duration of the write, so the values written
+        # are the row's current ones: a concurrent write to the same row
+        # finishes first and this sees its result, rather than replacing it
+        # with what the batch read a moment earlier.
+        " FOR UPDATE"
     )
 
 

--- a/backend/app/db/search_index.py
+++ b/backend/app/db/search_index.py
@@ -16,6 +16,7 @@ path that gives a long document several.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 
 from sqlalchemy import MetaData
@@ -174,11 +175,11 @@ def entity_types(*, default_scope_only: bool = False) -> tuple[str, ...]:
     )
 
 
-def _text_expr(columns: tuple[str, ...]) -> str:
+def _text_expr(columns: tuple[str, ...], row: str = ROW) -> str:
     """Row expression concatenating columns into one text value."""
     if not columns:
         return ""
-    parts = [f"coalesce({ROW}.{c}, '')" for c in columns]
+    parts = [f"coalesce({row}.{c}, '')" for c in columns]
     return " || ' ' || ".join(parts) if len(parts) > 1 else parts[0]
 
 
@@ -203,70 +204,43 @@ def _when_clause(table: str, source: SearchSource) -> str:
     return " OR ".join(f"OLD.{c} IS DISTINCT FROM NEW.{c}" for c in present)
 
 
-SEARCH_FUNCTION_SQL = """
-CREATE OR REPLACE FUNCTION {fn}() RETURNS trigger
-    LANGUAGE plpgsql AS $search$
+WRITE_FUNCTION = "public.search_entry_write"
+
+#: Splits one entity's text into chunks and replaces its rows. Shared by the
+#: refresh trigger and the reindex sweep so both produce identical entries.
+WRITE_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION {write_fn}(
+    p_schema      text,
+    p_entity_type text,
+    p_entity_id   integer,
+    p_initiative  integer,
+    p_dac_tool    text,
+    p_dac_id      integer,
+    p_title       text,
+    p_body        text
+) RETURNS void
+    LANGUAGE plpgsql AS $write$
 DECLARE
-    v_row        record;
-    v_entity     integer;
-    v_initiative integer;
-    v_dac_id     integer;
-    v_title      text;
-    v_body       text;
-    v_chunk      text;
-    v_ix         smallint := 0;
-    v_pos        integer := 1;
-    v_len        integer;
-    v_cut        integer;
-    v_space      integer;
-    c_chunk      constant integer := {chunk};
-    c_max        constant integer := {maxchunks};
+    v_title text := coalesce(p_title, '');
+    v_body  text := coalesce(p_body, '');
+    v_chunk text;
+    v_ix    smallint := 0;
+    v_pos   integer := 1;
+    v_len   integer;
+    v_cut   integer;
+    v_space integer;
+    c_chunk constant integer := {chunk};
+    c_max   constant integer := {maxchunks};
 BEGIN
-    IF TG_OP = 'DELETE' THEN
-        v_row := OLD;
-    ELSE
-        v_row := NEW;
-    END IF;
-
-    EXECUTE 'SELECT ' || TG_ARGV[2] INTO v_entity USING v_row;
-    IF v_entity IS NULL THEN
-        RETURN NULL;
-    END IF;
-
-    -- Every path starts by clearing this entity's chunks: a re-index rewrites
-    -- them below, and a delete or a soft delete leaves them cleared. Written
-    -- into the schema the CHANGED ROW lives in, named from TG_TABLE_SCHEMA
-    -- rather than resolved through the caller's search_path.
     EXECUTE format(
         'DELETE FROM %I.search_entries WHERE entity_type = $1 AND entity_id = $2',
-        TG_TABLE_SCHEMA
-    ) USING TG_ARGV[1], v_entity;
+        p_schema
+    ) USING p_entity_type, p_entity_id;
 
-    IF TG_OP = 'DELETE' THEN
-        RETURN NULL;
-    END IF;
-
-    -- Trash is browsed through the trash surface, not found by searching.
-    IF to_jsonb(v_row) ? 'deleted_at'
-       AND to_jsonb(v_row) ->> 'deleted_at' IS NOT NULL THEN
-        RETURN NULL;
-    END IF;
-
-    EXECUTE 'SELECT ' || TG_ARGV[0] INTO v_initiative USING v_row;
-    EXECUTE 'SELECT ' || TG_ARGV[3] INTO v_title USING v_row;
-    IF TG_ARGV[4] <> '' THEN
-        EXECUTE 'SELECT ' || TG_ARGV[4] INTO v_body USING v_row;
-    END IF;
-    IF TG_ARGV[6] <> '' THEN
-        EXECUTE 'SELECT ' || TG_ARGV[6] INTO v_dac_id USING v_row;
-    END IF;
-
-    v_title := coalesce(v_title, '');
-    v_body := coalesce(v_body, '');
     v_len := length(v_body);
 
-    -- One row per chunk, and always at least one so a titled row with no body
-    -- is still findable. Short text takes this loop exactly once.
+    -- One row per chunk, and always at least one so a titled entity with no
+    -- body is still findable. Short text takes this loop exactly once.
     LOOP
         IF v_pos > v_len THEN
             v_chunk := '';
@@ -293,19 +267,70 @@ BEGIN
             ') VALUES ($1, $2, $3, $4, nullif($5, ''''), $6, $7, nullif($8, ''''), now(),'
             '  setweight(to_tsvector(''simple'', $7), ''A'') ||'
             '  setweight(to_tsvector(''simple'', $8), ''B''))',
-            TG_TABLE_SCHEMA
-        ) USING TG_ARGV[1], v_entity, v_ix, v_initiative,
-                TG_ARGV[5], v_dac_id, v_title, v_chunk;
+            p_schema
+        ) USING p_entity_type, p_entity_id, v_ix, p_initiative,
+                p_dac_tool, p_dac_id, v_title, v_chunk;
 
         v_ix := v_ix + 1;
         v_pos := v_pos + v_cut;
         EXIT WHEN v_pos > v_len OR v_ix >= c_max;
     END LOOP;
+END
+$write$;
+""".format(write_fn=WRITE_FUNCTION, chunk=CHUNK_CHARS, maxchunks=MAX_CHUNKS)
 
+
+SEARCH_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION {fn}() RETURNS trigger
+    LANGUAGE plpgsql AS $search$
+DECLARE
+    v_row        record;
+    v_entity     integer;
+    v_initiative integer;
+    v_dac_id     integer;
+    v_title      text;
+    v_body       text;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_row := OLD;
+    ELSE
+        v_row := NEW;
+    END IF;
+
+    EXECUTE 'SELECT ' || TG_ARGV[2] INTO v_entity USING v_row;
+    IF v_entity IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- A delete, or a soft delete, leaves the entity with no rows: trash is
+    -- browsed through the trash surface, not found by searching.
+    IF TG_OP = 'DELETE'
+       OR (to_jsonb(v_row) ? 'deleted_at'
+           AND to_jsonb(v_row) ->> 'deleted_at' IS NOT NULL) THEN
+        EXECUTE format(
+            'DELETE FROM %I.search_entries WHERE entity_type = $1 AND entity_id = $2',
+            TG_TABLE_SCHEMA
+        ) USING TG_ARGV[1], v_entity;
+        RETURN NULL;
+    END IF;
+
+    EXECUTE 'SELECT ' || TG_ARGV[0] INTO v_initiative USING v_row;
+    EXECUTE 'SELECT ' || TG_ARGV[3] INTO v_title USING v_row;
+    IF TG_ARGV[4] <> '' THEN
+        EXECUTE 'SELECT ' || TG_ARGV[4] INTO v_body USING v_row;
+    END IF;
+    IF TG_ARGV[6] <> '' THEN
+        EXECUTE 'SELECT ' || TG_ARGV[6] INTO v_dac_id USING v_row;
+    END IF;
+
+    PERFORM {write_fn}(
+        TG_TABLE_SCHEMA, TG_ARGV[1], v_entity, v_initiative,
+        nullif(TG_ARGV[5], ''), v_dac_id, v_title, v_body
+    );
     RETURN NULL;
 END
 $search$;
-""".format(fn=SEARCH_FUNCTION, chunk=CHUNK_CHARS, maxchunks=MAX_CHUNKS)
+""".format(fn=SEARCH_FUNCTION, write_fn=WRITE_FUNCTION)
 
 
 def _call_args(table: str, source: SearchSource) -> list[str]:
@@ -414,3 +439,55 @@ def render_guild_search_ddl(opclass: str | None = None) -> str:
     ]
     blocks.append(_index_block(opclass))
     return _HEADER + "\n\n" + "\n\n".join(blocks) + "\n"
+
+
+def search_generation() -> str:
+    """Digest of WHAT is indexed and HOW, for deciding when to reindex.
+
+    Covers the per-source declarations and the chunking rules, so adding a
+    source or changing an extraction re-sweeps. Deliberately excludes the index
+    definition: swapping the operator class rebuilds the index, which does not
+    change a single stored row.
+    """
+    digest = hashlib.sha256()
+    for table, source in sorted(SEARCH_SOURCES.items()):
+        digest.update(_trigger_block(table, source).encode())
+    digest.update(WRITE_FUNCTION_SQL.encode())
+    return f"search:{digest.hexdigest()[:16]}"
+
+
+def reindex_statement(table: str, source: SearchSource) -> str:
+    """One batch of a source table's rows, re-written through the same function
+    the trigger uses.
+
+    ``:schema`` names the guild schema, ``:cursor`` is the last id of the
+    previous batch and ``:batch`` its size — so a large table is walked in
+    bounded transactions rather than one.
+    """
+    row = "t"
+    columns = SQLModel.metadata.tables[table].columns
+    dac_tool = f"'{source.dac_tool.value}'" if source.dac_tool else "NULL"
+    dac_id = (
+        f"{row}.{source.dac_id or 'id'}::integer"
+        if source.dac_tool
+        else "NULL::integer"
+    )
+    body = _text_expr(source.body, row) or "''"
+    live = " AND t.deleted_at IS NULL" if "deleted_at" in columns else ""
+    return (
+        f"SELECT {row}.id AS id, {WRITE_FUNCTION}("  # noqa: S608 — registry-rendered
+        f":schema, '{source.entity_type}', {row}.id,"
+        f" ({initiative_locator(table)(row)})::integer,"
+        f" {dac_tool}, {dac_id}, {row}.{source.title}, {body})"
+        f" FROM {table} {row}"
+        f" WHERE {row}.id > :cursor{live}"
+        f" ORDER BY {row}.id LIMIT :batch"
+    )
+
+
+def reindex_plan() -> list[tuple[str, str]]:
+    """``(entity_type, statement)`` for every indexed source, in a stable order."""
+    return [
+        (source.entity_type, reindex_statement(table, source))
+        for table, source in sorted(SEARCH_SOURCES.items())
+    ]

--- a/backend/app/db/search_index_test.py
+++ b/backend/app/db/search_index_test.py
@@ -241,3 +241,52 @@ async def test_a_guild_level_tag_is_visible_to_any_member(session, acting_user):
         guild_role="member",
     )
     assert [r.title for r in rows] == ["urgent"]
+
+
+@pytest.mark.unit
+def test_each_source_gates_on_a_column_that_points_at_its_tool():
+    """The declared sharing identity has to name the resource that governs the
+    row — a task by its project, a calendar event by its calendar.
+
+    Only ``task`` was exercised end to end; this covers every source
+    structurally, so a new one naming the wrong column (``queue_id`` where
+    ``calendar_id`` was meant) fails here rather than gating search against a
+    resource that has nothing to do with the row.
+    """
+    for table, source in sorted(SEARCH_SOURCES.items()):
+        if source.dac_tool is None:
+            assert source.dac_id is None, (
+                f"{table} declares dac_id without a dac_tool to test it against"
+            )
+            continue
+        tool_table = source.dac_tool.plural
+        if source.dac_id is None:
+            # The row IS the shared resource.
+            assert table == tool_table, (
+                f"{table} gates on its own id but is not {tool_table}"
+            )
+            continue
+        column = SQLModel.metadata.tables[table].columns[source.dac_id]
+        targets = {fk.column.table.name for fk in column.foreign_keys}
+        assert tool_table in targets, (
+            f"{table}.{source.dac_id} does not reference {tool_table}; "
+            f"search would gate it against the wrong resource"
+        )
+
+
+async def test_moving_a_task_regates_it(session, acting_user):
+    """The sharing identity is stored, so a row changing parents has to be
+    rewritten or it would keep answering to the old one."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    other = await create_project(session, a.initiative, a.user, name="elsewhere")
+    assert other.id is not None
+    task = await create_task(session, a.project, title="moving")
+    assert (await _entries(session, a.guild.id, "task", task.id))[0].dac_id == (
+        a.project.id
+    )
+
+    task.project_id = other.id
+    session.add(task)
+    await session.commit()
+
+    assert (await _entries(session, a.guild.id, "task", task.id))[0].dac_id == other.id

--- a/backend/app/db/search_reindex_test.py
+++ b/backend/app/db/search_reindex_test.py
@@ -134,3 +134,40 @@ async def test_the_marker_records_the_generation(session, acting_user):
         )
     ).one()[0]
     assert marker == search_generation()
+
+
+@pytest.mark.unit
+def test_every_reindex_statement_locks_the_rows_it_rewrites():
+    """The sweep reads a row's text and replaces that row's entries.
+
+    Without the lock those are two moments: a write landing between them is
+    replaced by what the batch read beforehand, and the index keeps the older
+    text until the row is next touched. Locking makes the write the row's
+    current state by definition.
+    """
+    from app.db.search_index import reindex_plan
+
+    for entity_type, statement in reindex_plan():
+        assert statement.rstrip().endswith("FOR UPDATE"), (
+            f"the {entity_type} reindex statement does not lock its rows"
+        )
+
+
+async def test_a_write_during_the_sweep_wins(session, acting_user):
+    """A trigger write is always newer than what a sweep batch read, so the
+    sweep must not put the older text back."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project, title="original")
+    await _wipe(a.guild.id)
+
+    # The ordinary path: a write lands, then the sweep runs over it.
+    task.title = "edited"
+    session.add(task)
+    await session.commit()
+
+    await reindex_guild_search(db_session.provisioning_engine, f"guild_{a.guild.id}")
+
+    rows = [
+        r for r in await _entries(session, a.guild.id, "task") if r.entity_id == task.id
+    ]
+    assert [r.title for r in rows] == ["edited"]

--- a/backend/app/db/search_reindex_test.py
+++ b/backend/app/db/search_reindex_test.py
@@ -1,0 +1,136 @@
+"""Content that predates the index gets indexed.
+
+The refresh trigger only sees writes that happen after it exists, so a guild's
+existing work would be absent from search until each row was next touched. The
+sweep walks each source table and writes the same entries the trigger would,
+and a generation marker on the guild's ``search_entries`` records what it was
+last swept for.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlmodel import select
+
+from app.db import session as db_session
+from app.db.schema_provisioning import reindex_guild_search
+from app.db.search_index import search_generation
+from app.db.session import set_rls_context
+from app.models.platform.guild import GuildRole
+from app.models.tenant.search_entry import SearchEntry
+from app.testing import create_project, create_tag, create_task
+
+pytestmark = pytest.mark.integration
+
+
+async def _entries(session, guild_id: int, entity_type: str) -> list[SearchEntry]:
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+    return list(
+        await session.exec(
+            select(SearchEntry).where(SearchEntry.entity_type == entity_type)
+        )
+    )
+
+
+async def _wipe(guild_id: int) -> None:
+    """Leave the guild looking like one whose content predates the index.
+
+    Through the provisioning engine: it owns these tables, which commenting on
+    them requires.
+    """
+    async with db_session.provisioning_engine.begin() as conn:
+        await conn.exec_driver_sql(f'DELETE FROM "guild_{guild_id}".search_entries')
+        await conn.exec_driver_sql(
+            f'COMMENT ON TABLE "guild_{guild_id}".search_entries IS NULL'
+        )
+
+
+async def test_it_indexes_content_that_predates_the_index(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project, title="vendor renewal terms")
+    tag = await create_tag(session, a.guild, name="urgent")
+    await _wipe(a.guild.id)
+    assert await _entries(session, a.guild.id, "task") == []
+
+    written = await reindex_guild_search(
+        db_session.provisioning_engine, f"guild_{a.guild.id}"
+    )
+    assert written > 0
+
+    tasks = await _entries(session, a.guild.id, "task")
+    assert [r.title for r in tasks if r.entity_id == task.id] == [
+        "vendor renewal terms"
+    ]
+    tags = await _entries(session, a.guild.id, "tag")
+    assert [r.title for r in tags if r.entity_id == tag.id] == ["urgent"]
+
+
+async def test_the_swept_rows_carry_the_same_identity_the_trigger_writes(
+    session, acting_user
+):
+    """A swept row and a trigger-written row must be interchangeable, or search
+    would rank and gate them differently."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project, title="quarterly report")
+    before = next(
+        r for r in await _entries(session, a.guild.id, "task") if r.entity_id == task.id
+    )
+    fields = (before.initiative_id, before.dac_tool, before.dac_id, before.title)
+
+    await _wipe(a.guild.id)
+    await reindex_guild_search(db_session.provisioning_engine, f"guild_{a.guild.id}")
+
+    after = next(
+        r for r in await _entries(session, a.guild.id, "task") if r.entity_id == task.id
+    )
+    assert (after.initiative_id, after.dac_tool, after.dac_id, after.title) == fields
+
+
+async def test_soft_deleted_content_is_not_swept_in(session, acting_user):
+    from datetime import datetime, timezone
+
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    task = await create_task(session, a.project, title="trashed")
+    task.deleted_at = datetime.now(timezone.utc)
+    session.add(task)
+    await session.commit()
+    await _wipe(a.guild.id)
+
+    await reindex_guild_search(db_session.provisioning_engine, f"guild_{a.guild.id}")
+    assert [
+        r for r in await _entries(session, a.guild.id, "task") if r.entity_id == task.id
+    ] == []
+
+
+async def test_a_current_guild_is_left_alone(session, acting_user):
+    """The marker is what keeps a boot from rewriting every guild's index."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project, title="already indexed")
+    await _wipe(a.guild.id)
+
+    first = await reindex_guild_search(
+        db_session.provisioning_engine, f"guild_{a.guild.id}"
+    )
+    assert first > 0
+    second = await reindex_guild_search(
+        db_session.provisioning_engine, f"guild_{a.guild.id}"
+    )
+    assert second == 0, "a guild already at the current generation was swept again"
+
+
+async def test_the_marker_records_the_generation(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await create_project(session, a.initiative, a.user, name="p")
+    await _wipe(a.guild.id)
+    await reindex_guild_search(db_session.provisioning_engine, f"guild_{a.guild.id}")
+
+    await set_rls_context(session, guild_id=a.guild.id, guild_role="admin")
+    marker = (
+        await session.exec(
+            text("SELECT obj_description(to_regclass(:t), 'pg_class')").bindparams(
+                t=f"guild_{a.guild.id}.search_entries"
+            )
+        )
+    ).one()[0]
+    assert marker == search_generation()

--- a/backend/app/db/sql_injection_guard_test.py
+++ b/backend/app/db/sql_injection_guard_test.py
@@ -67,6 +67,10 @@ ALLOWED_DYNAMIC_SQL: dict[str, str] = {
     "app/db/schema_provisioning.py::apply_guild_search": (
         "int-derived schema name + registry-rendered trigger DDL (constants)"
     ),
+    "app/db/schema_provisioning.py::reindex_guild_search": (
+        "guild_<id> schema name read from pg_namespace, registry-rendered "
+        "reindex statements (constants), and a hex-digest generation marker"
+    ),
     "app/db/schema_provisioning.py::drop_guild_schema": (
         "int-derived guild_<id> schema/role names"
     ),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,6 +81,7 @@ async def lifespan(app: FastAPI):
         verify_effective_shared_grants,
         verify_engine_identities,
         warn_if_privileged_database_url,
+        backfill_guild_search,
         warn_if_search_operator_missing,
     )
 
@@ -104,6 +105,7 @@ async def lifespan(app: FastAPI):
     await verify_effective_shared_grants()
     await warn_if_privileged_database_url()
     await warn_if_search_operator_missing()
+    await backfill_guild_search()
     if settings.BILLING_URL and not billing_support_handoff_enabled():
         # The Guilds tab shows its billing button whenever a portal URL is set;
         # without the signing pair every click fails closed (503).


### PR DESCRIPTION
## Problem

#1314 shipped the index and the triggers that keep it current, but a trigger only sees writes made after it exists. Every guild's existing work — years of projects, tasks, documents, tags — stayed absent from search until each row happened to be edited. That was called out as following work; this is it.

## What this adds

A sweep that walks each source table once and writes the same entries the trigger would.

### One implementation, two callers

The chunking and row-writing move out of the trigger into `public.search_entry_write(schema, entity_type, entity_id, initiative, dac_tool, dac_id, title, body)`. The trigger computes those values from `NEW`/`OLD` and calls it; the sweep selects them per row and calls it.

That matters more than it saves: a swept row and a trigger-written row are now identical **by construction**, rather than by two implementations agreeing about chunk boundaries, weighting, and which parent governs sharing. There's a test asserting a rewritten row carries the same initiative, `dac_tool`, `dac_id` and title as the one the trigger wrote.

The reindex statements are rendered from the same `SEARCH_SOURCES` registry and the same `INITIATIVE_PATHS` locators the triggers use, so a new source is swept without a second declaration:

```sql
SELECT t.id AS id, public.search_entry_write(
    :schema, 'task', t.id,
    ((SELECT projects.initiative_id FROM projects WHERE projects.id = t.project_id))::integer,
    'project', t.project_id::integer, t.title, coalesce(t.description, ''))
FROM tasks t WHERE t.id > :cursor AND t.deleted_at IS NULL
ORDER BY t.id LIMIT :batch
```

### Knowing what still needs sweeping

A generation marker — a comment on the guild's `search_entries`, the same shape as the provisioning stamp on the schema — records what that guild was last swept for. `search_generation()` digests the per-source declarations and the chunking rules, so adding a source or changing an extraction moves it and the next boot re-sweeps; an unchanged boot does nothing.

It deliberately **excludes** the index definition, so swapping the operator class (#1315) rebuilds the index without rewriting a single row.

### Bounded work

Each source is walked in batches of 2000 on its own transaction, cursored by id. A large install fills in progressively rather than holding one transaction open across the whole sweep, and a failure on one guild is logged and skipped rather than stopping the rest.

The sweep routes as a system session — no user id, guild-admin role — which is what lets it write through the index table's policies.

## Testing

```
pytest -n 0 app/db/search_reindex_test.py                    # 5 passed
pytest -n auto app/db/ app/services/tenant/search_test.py    # 440 passed
ruff check / ruff format --check / ty check                  # clean
```

New tests: content predating the index gets indexed; swept rows carry the same identity the trigger writes; soft-deleted content stays out; the marker records the generation; a guild already at the current generation is left alone.

`sql_injection_guard_test` has a review entry for the new dynamic-SQL site — the schema name is read from `pg_namespace`, the statements are registry-rendered constants, and the marker is a hex digest.

## Notes for review

- One thing worth a look: the sweep runs at boot, after schema provisioning. On a large install the first boot after this merges does real work. It is batched and per-guild, and a failure is contained, but it is not free — worth deciding whether it should be gated behind a flag for the initial rollout.
- The changelog entry covers the whole search feature and lands with the last PR in the series.
