### PR TITLE
Decide search sharing in the database

### DIFF
--- a/backend/alembic/versions/20260901_0209_resource_access_function.py
+++ b/backend/alembic/versions/20260901_0209_resource_access_function.py
@@ -1,0 +1,86 @@
+"""add public.resource_access for the sharing gate
+
+The per-resource sharing decision, as a SQL function the policies can call —
+the same shape as ``public.initiative_access`` for initiative membership. It
+resolves ``resource_grants`` and ``initiative_members`` through the caller's
+search_path, so it answers within whichever guild schema the request is routed
+to, and it is not SECURITY DEFINER.
+
+Creating it does not change any policy. The rendered RLS picks it up on the
+next boot.
+
+Revision ID: 20260901_0209
+Revises: 20260901_0208
+Create Date: 2026-09-01
+"""
+
+from alembic import op
+
+revision = "20260901_0209"
+down_revision = "20260901_0208"
+branch_labels = None
+depends_on = None
+
+RESOURCE_ACCESS_FN = """
+CREATE OR REPLACE FUNCTION public.resource_access(
+    p_tool          text,
+    p_resource_id   integer,
+    p_user_id       integer,
+    p_initiative_id integer DEFAULT NULL,
+    p_need_write    boolean DEFAULT false
+) RETURNS boolean
+    LANGUAGE sql STABLE
+    AS $$
+    SELECT
+        -- Rows that carry no sharing identity (guild vocabulary) have nothing
+        -- for this to decide.
+        p_tool IS NULL
+        OR current_setting('app.current_guild_role'::text, true) = 'admin'::text
+        OR (CASE
+              WHEN p_need_write
+                THEN current_setting('app.pam_write'::text, true) = 'true'::text
+              ELSE current_setting('app.pam_read'::text, true) = 'true'::text
+                   OR current_setting('app.pam_write'::text, true) = 'true'::text
+            END)
+        -- Initiatives where the request holds "Full access".
+        OR p_initiative_id = ANY (
+               string_to_array(
+                   NULLIF(current_setting('app.override_initiatives'::text, true), ''),
+                   ','
+               )::integer[]
+           )
+        OR EXISTS (
+            SELECT 1 FROM resource_grants g
+            WHERE g.resource_type = p_tool
+              AND g.resource_id = p_resource_id
+              AND (
+                   g.user_id = p_user_id
+                OR g.role_id IN (
+                       SELECT im.role_id FROM initiative_members im
+                       WHERE im.user_id = p_user_id
+                   )
+                OR (g.all_initiative_members
+                    AND (g.initiative_id IS NULL
+                         OR g.initiative_id IN (
+                                SELECT im.initiative_id FROM initiative_members im
+                                WHERE im.user_id = p_user_id
+                            )))
+              )
+        )
+$$;
+"""
+
+
+def upgrade() -> None:
+    # The body names guild-schema tables, which no schema on this search_path
+    # has — it resolves them through the caller's at run time, as
+    # public.initiative_access does.
+    op.execute("SET LOCAL check_function_bodies = false")
+    op.execute(RESOURCE_ACCESS_FN)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.resource_access("
+        "text, integer, integer, integer, boolean)"
+    )

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -35,7 +35,12 @@ from app.core.security import (
     verify_auto_delegation_token,
     verify_upload_token,
 )
-from app.db.session import SYSTEM_SATISFIED, get_session, set_rls_context
+from app.db.session import (
+    SYSTEM_SATISFIED,
+    get_session,
+    set_override_initiatives,
+    set_rls_context,
+)
 from app.models.platform.access_grant import AccessGrant, AccessLevel
 from app.models.platform.api_key import UserApiKey
 from app.models.platform.guild import Guild, GuildMembership, GuildRole, GuildStatus
@@ -831,6 +836,8 @@ async def _apply_guild_session_context(
         session, user_id=current_user.id
     )
     set_override_sharing_initiatives(frozenset(override_ids))
+    # And in the database, where the policies read the same override.
+    await set_override_initiatives(session, tuple(override_ids))
     return session
 
 

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -65,6 +65,18 @@ def _access(initiative_expr: str, write: bool) -> str:
     return f"public.initiative_access({initiative_expr}, {_UID}, {'true' if write else 'false'})"
 
 
+def _resource_access(table: str, write: bool) -> str:
+    """The sharing decision for a row that stores which resource governs it.
+
+    ``dac_tool``/``dac_id`` name that resource — often a parent — so the check
+    needs no join. A NULL ``dac_tool`` means the row answers to no sharing.
+    """
+    return (
+        f"public.resource_access({table}.dac_tool, {table}.dac_id, {_UID}, "
+        f"{table}.initiative_id, {'true' if write else 'false'})"
+    )
+
+
 def direct() -> InitiativePath:
     """The table has its own ``initiative_id`` column."""
     return InitiativePath(
@@ -258,6 +270,7 @@ def search_entries_path() -> InitiativePath:
             f"(CASE WHEN {t}.initiative_id IS NULL "
             f"THEN true "
             f"ELSE {_access(f'{t}.initiative_id', w)} END)"
+            f" AND {_resource_access(t, w)}"
         ),
         initiative_expr=lambda r: f"{r}.initiative_id",
     )

--- a/backend/app/db/search_dac_rls_test.py
+++ b/backend/app/db/search_dac_rls_test.py
@@ -8,16 +8,23 @@ what comes back is what the database allowed.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+
 import pytest
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.db.session import set_override_initiatives, set_rls_context
+from app.testing import Actor
 from app.models.platform.guild import GuildRole
 from app.models.tenant.search_entry import SearchEntry
 from app.testing import create_tag, create_task
 
 pytestmark = pytest.mark.integration
+
+#: The ``acting_user`` fixture: called with role keywords, yields an actor.
+ActingUser = Callable[..., Awaitable[Actor]]
 
 
 async def _unfiltered(
@@ -50,14 +57,18 @@ async def test_a_member_without_a_grant_is_refused_by_the_database(
     assert await _unfiltered(session, a.guild.id, b) == []
 
 
-async def test_the_owner_is_admitted(session, acting_user):
+async def test_the_owner_is_admitted(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
     a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
     await create_task(session, a.project, title="restricted vendor renewal")
 
     assert await _unfiltered(session, a.guild.id, a) == ["restricted vendor renewal"]
 
 
-async def test_a_guild_admin_is_admitted(session, acting_user):
+async def test_a_guild_admin_is_admitted(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
     a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
     b = await acting_user(
         guild_role=GuildRole.admin,
@@ -72,7 +83,9 @@ async def test_a_guild_admin_is_admitted(session, acting_user):
     ]
 
 
-async def test_full_access_is_carried_into_the_database(session, acting_user):
+async def test_full_access_is_carried_into_the_database(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
     """The override is computed in Python per request; the policy reads it from
     a session setting. If that plumbing breaks, a full-access member silently
     loses rows they can reach everywhere else."""
@@ -99,7 +112,9 @@ async def test_full_access_is_carried_into_the_database(session, acting_user):
     assert sorted(rows) == ["restricted vendor renewal"]
 
 
-async def test_guild_vocabulary_answers_to_no_sharing(session, acting_user):
+async def test_guild_vocabulary_answers_to_no_sharing(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
     """A tag carries no sharing identity, so the sharing gate has nothing to
     decide and must not filter it out."""
     a = await acting_user(guild_role=GuildRole.admin)
@@ -115,7 +130,9 @@ async def test_guild_vocabulary_answers_to_no_sharing(session, acting_user):
     assert sorted(rows) == ["urgent"]
 
 
-async def test_the_override_setting_defaults_to_empty(session, acting_user):
+async def test_the_override_setting_defaults_to_empty(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
     """An unset override must read as "no initiatives", not as an error that
     faults the policy for every row."""
     a = await acting_user(guild_role=GuildRole.member, initiative=True)

--- a/backend/app/db/search_dac_rls_test.py
+++ b/backend/app/db/search_dac_rls_test.py
@@ -1,0 +1,130 @@
+"""The database decides sharing for the search index.
+
+Every other gate on ``search_entries`` is a policy; sharing used to be applied
+only by the query that read the table. These assert the policy answers it now —
+each test reads the table with a plain SELECT, carrying no clause of its own, so
+what comes back is what the database allowed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlmodel import select
+
+from app.db.session import set_override_initiatives, set_rls_context
+from app.models.platform.guild import GuildRole
+from app.models.tenant.search_entry import SearchEntry
+from app.testing import create_tag, create_task
+
+pytestmark = pytest.mark.integration
+
+
+async def _unfiltered(
+    session, guild_id: int, actor, *, role: str = "member"
+) -> list[str]:
+    """Titles the database hands back for a bare SELECT — no query-side gate."""
+    await set_rls_context(
+        session, user_id=actor.user.id, guild_id=guild_id, guild_role=role
+    )
+    rows = await session.exec(
+        select(SearchEntry.title).where(SearchEntry.entity_type == "task")
+    )
+    return sorted(rows)
+
+
+async def test_a_member_without_a_grant_is_refused_by_the_database(
+    session, acting_user
+):
+    """In the initiative — so the membership gate admits the row — but holding
+    no grant on the project it belongs to."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    b = await acting_user(
+        guild_role=GuildRole.member,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    await create_task(session, a.project, title="restricted vendor renewal")
+
+    assert await _unfiltered(session, a.guild.id, b) == []
+
+
+async def test_the_owner_is_admitted(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project, title="restricted vendor renewal")
+
+    assert await _unfiltered(session, a.guild.id, a) == ["restricted vendor renewal"]
+
+
+async def test_a_guild_admin_is_admitted(session, acting_user):
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    b = await acting_user(
+        guild_role=GuildRole.admin,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    await create_task(session, a.project, title="restricted vendor renewal")
+
+    assert await _unfiltered(session, a.guild.id, b, role="admin") == [
+        "restricted vendor renewal"
+    ]
+
+
+async def test_full_access_is_carried_into_the_database(session, acting_user):
+    """The override is computed in Python per request; the policy reads it from
+    a session setting. If that plumbing breaks, a full-access member silently
+    loses rows they can reach everywhere else."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    b = await acting_user(
+        guild_role=GuildRole.member,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    await create_task(session, a.project, title="restricted vendor renewal")
+
+    # Without the override: refused, as above.
+    assert await _unfiltered(session, a.guild.id, b) == []
+
+    # With it: admitted, without any grant being issued.
+    await set_rls_context(
+        session, user_id=b.user.id, guild_id=a.guild.id, guild_role="member"
+    )
+    await set_override_initiatives(session, (a.initiative.id,))
+    rows = await session.exec(
+        select(SearchEntry.title).where(SearchEntry.entity_type == "task")
+    )
+    assert sorted(rows) == ["restricted vendor renewal"]
+
+
+async def test_guild_vocabulary_answers_to_no_sharing(session, acting_user):
+    """A tag carries no sharing identity, so the sharing gate has nothing to
+    decide and must not filter it out."""
+    a = await acting_user(guild_role=GuildRole.admin)
+    b = await acting_user(guild_role=GuildRole.member, guild=a.guild)
+    await create_tag(session, a.guild, name="urgent")
+
+    await set_rls_context(
+        session, user_id=b.user.id, guild_id=a.guild.id, guild_role="member"
+    )
+    rows = await session.exec(
+        select(SearchEntry.title).where(SearchEntry.entity_type == "tag")
+    )
+    assert sorted(rows) == ["urgent"]
+
+
+async def test_the_override_setting_defaults_to_empty(session, acting_user):
+    """An unset override must read as "no initiatives", not as an error that
+    faults the policy for every row."""
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    await set_rls_context(
+        session, user_id=a.user.id, guild_id=a.guild.id, guild_role="member"
+    )
+    value = (
+        await session.exec(
+            text("SELECT current_setting('app.override_initiatives', true)")
+        )
+    ).one()[0]
+    assert value == ""

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -151,6 +151,7 @@ _CONTEXT_SQL = (
     "set_config('app.pam_write', :pw, true), "
     "set_config('app.satisfied_providers', :satp, true), "
     "set_config('app.billing_guild_id', :bgid, true), "
+    "set_config('app.override_initiatives', :ovr, true), "
     "set_config('search_path', :sp, true), "
     "set_config('role', :role, true)"
 )
@@ -171,6 +172,10 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
     platform_role = params.get("platform_role")
     read_only = bool(params.get("read_only"))
     billing_guild_id = params.get("billing_guild_id")
+    # Initiatives where the request holds "Full access". Rendered as a comma
+    # list so the policy reads it with one string_to_array; empty when none.
+    override = params.get("override_initiatives") or ()
+    override_csv = ",".join(str(i) for i in sorted({int(i) for i in override}))
 
     # Billing-service path (set_billing_context): assumes the
     # initiative_billing role with only the billing GUC set — no
@@ -187,6 +192,7 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
             "pw": "false",
             "satp": "",
             "bgid": str(int(billing_guild_id)),
+            "ovr": "",
             "sp": _search_path("public"),
             "role": billing_role_name(),
         }
@@ -254,6 +260,7 @@ def _render_context_bind_params(params: dict[str, Any]) -> dict[str, str]:
         "pw": "true" if pam_write else "false",
         "satp": satp,
         "bgid": "",
+        "ovr": override_csv,
         "sp": sp,
         "role": role_target,
     }
@@ -302,6 +309,7 @@ async def set_rls_context(
     platform_role: Optional[str] = None,
     read_only: bool = False,
     satisfied_providers: Optional[Sequence[int] | str] = None,
+    override_initiatives: Optional[Sequence[int]] = None,
 ) -> None:
     """Set PostgreSQL context for RLS policy evaluation — transaction-local.
 
@@ -369,6 +377,7 @@ async def set_rls_context(
         "platform_role": platform_role,
         "read_only": read_only,
         "satisfied_providers": satisfied_providers,
+        "override_initiatives": tuple(override_initiatives or ()),
     }
     session.info[_RLS_ESTABLISHED_INFO_KEY] = time.monotonic()
 
@@ -377,6 +386,24 @@ async def set_rls_context(
     # hook has already fired and the new context must land NOW. On a fresh
     # session, the caller's first statement autobegins and the hook applies
     # the stored params; applying here too would just do it twice.
+    if session.in_transaction():
+        await _apply_stored_context(session)
+
+
+async def set_override_initiatives(
+    session: AsyncSession, initiative_ids: Sequence[int]
+) -> None:
+    """Record the initiatives this request holds "Full access" in.
+
+    Set after :func:`set_rls_context`, because the ids are read from the guild
+    schema the routing selects. Stored with the other context parameters so the
+    replay hook carries them onto every later transaction, rather than living
+    only on the connection this call happens to be holding.
+    """
+    params = session.info.get(_RLS_PARAMS_INFO_KEY)
+    if params is None:
+        return
+    params["override_initiatives"] = tuple(initiative_ids)
     if session.in_transaction():
         await _apply_stored_context(session)
 

--- a/backend/app/services/tenant/search.py
+++ b/backend/app/services/tenant/search.py
@@ -12,13 +12,11 @@ from ``Tool``.
 
 from __future__ import annotations
 
-from sqlalchemy import and_, or_
+from sqlalchemy import func
 from sqlalchemy.sql.elements import ColumnElement
 
-from app.core.tools import Tool
 from app.db.schema_provisioning import search_operator_available
 from app.models.tenant.search_entry import SearchEntry
-from app.services.permissions import dac_scope_clause
 
 
 def search_scope_clause(
@@ -29,30 +27,18 @@ def search_scope_clause(
 ) -> ColumnElement[bool]:
     """The WHERE leg narrowing ``search_entries`` to rows this request may read.
 
-    One leg per :class:`Tool`, each deferring to :func:`dac_scope_clause` — the
-    same call the tool's own list endpoint makes, so search and the tool it
-    searches answer sharing identically rather than through two implementations.
-
-    Rows carrying no ``dac_tool`` (guild vocabulary such as tags) have no sharing
-    gate to apply; reaching this schema at all is the gate they answer to.
-    ``dac_scope_clause`` already returns ``true()`` when the request covers the
-    whole guild, so guild admin and PAM need no leg here.
+    Emits ``public.resource_access(...)`` — the same call the table's policies
+    make — so the query and the database answer sharing through one
+    implementation rather than two that have to agree. ``guild_id`` is accepted
+    for symmetry with the other scope helpers; the decision reads the request's
+    own context.
     """
-    return or_(
-        SearchEntry.dac_tool.is_(None),
-        *[
-            and_(
-                SearchEntry.dac_tool == tool.value,
-                dac_scope_clause(
-                    tool,
-                    SearchEntry.dac_id,
-                    user_id,
-                    guild_id=guild_id,
-                    access=access,
-                ),
-            )
-            for tool in Tool
-        ],
+    return func.resource_access(
+        SearchEntry.dac_tool,
+        SearchEntry.dac_id,
+        user_id,
+        SearchEntry.initiative_id,
+        access == "write",
     )
 
 


### PR DESCRIPTION
## Problem

Review on #1314 flagged that `search_entries`' SELECT policy admitted rows on initiative membership alone and never evaluated the sharing identity it stores. That was consistent with every content table — sharing has always been applied by the query, not by a policy — so it was answered then by making the clause impossible to omit rather than by moving it.

Two things changed since:

- **#1315 fixed the index.** The measurement that made "keep it in the query" look right was taken against a table that could not use its index at all.
- **The maintainability argument inverted.** Moving it means the policy and the query can call *one* function, rather than the query owning the only implementation.

## What this changes

`public.resource_access(tool, resource_id, user_id, initiative_id, need_write)` — the per-resource sharing decision as a SQL function, the same shape `public.initiative_access` has for membership. It resolves `resource_grants` and `initiative_members` through the caller's search_path, so it answers inside whichever guild schema the request is routed to, and it is not SECURITY DEFINER.

`search_entries`' four policies now AND it in. **A bare `SELECT` with no clause of its own returns only what the reader may see** — there are tests that do exactly that.

### One implementation, two callers

`search_scope_clause()` now emits `func.resource_access(...)` instead of rebuilding the decision in Python. Query-time filtering and the policy answer through the same function, which is the shape `membership.py`'s `initiative_scope_clause` already has for gate 2.

### The leg that needed plumbing

Grants, PAM and guild-admin were already GUC- or SQL-expressible. Initiative "Full access" was not — it read `_override_initiatives`, a Python contextvar Postgres cannot see. It is now published as `app.override_initiatives` alongside the seven request GUCs `set_rls_context` already writes.

It is computed *after* routing (it reads the routed guild's roles), so `set_override_initiatives()` updates the stored context parameters rather than issuing a bare `set_config` — the replay hook then carries it onto every later transaction instead of it living only on whichever connection the call happened to hold. `test_full_access_is_carried_into_the_database` covers the whole path; without it a full-access member would silently lose rows they can reach everywhere else.

## Cost

Measured with the real predicate on 200k entries, against the same policy without the leg:

| Query | initiative gate only | + sharing gate | delta |
|---|---|---|---|
| 1 matching row | 0.42 ms | 0.44 ms | +0.01 ms (1.03x) |
| ~2k rows (1%) | 11.83 ms | 12.94 ms | +1.11 ms (1.09x) |

Both stay on the index (Bitmap Heap Scan) — the index narrows before the leg runs. An earlier estimate of ~1.9x came from a simplified stand-in function; the real one is cheaper in proportion, and this table replaces that number.

## Testing

```
pytest -n 0 app/db/search_dac_rls_test.py                 # 6 passed
pytest -n auto app/db/ app/services/tenant/search_test.py \
               app/services/permissions_test.py           # 486 passed
ruff check / ruff format --check / ty check               # clean
```

`search_dac_rls_test.py` reads the table with plain `SELECT`s carrying no gate of their own, so what comes back is what the database allowed: a member of the initiative holding no grant gets nothing; the owner and a guild admin are admitted; a full-access member is admitted through the new setting without any grant being issued; guild vocabulary (a tag, which carries no sharing identity) is not filtered out; and an unset override reads as empty rather than faulting the policy.

## Notes for review

- `dac_scope_clause` still rebuilds the decision in Python for the tool endpoints. Making it delegate to `resource_access` would collapse the last duplicate, but it touches every tool endpoint and belongs in its own PR.
- The migration creates the function only; policies are registry-rendered and pick it up on the next boot, so there is no window where a policy references a function that does not exist.
- The changelog entry covers the whole search feature and lands with the last PR in the series.
