### PR TITLE
Search inside documents

### DIFF
--- a/backend/app/db/search_document_bodies_test.py
+++ b/backend/app/db/search_document_bodies_test.py
@@ -1,0 +1,254 @@
+"""What a document contributes to search, by what kind of document it is.
+
+``documents.content`` holds a different shape per ``document_type``, so each
+gets its own extraction. These assert the text actually reaches the index
+against a real Postgres, including the shapes that would otherwise be silent:
+a legacy spreadsheet, a document type that stores no prose, and content nested
+below the top level.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from app.db.session import set_rls_context
+from app.models.platform.guild import GuildRole
+from app.models.tenant.document import DocumentType
+from app.models.tenant.search_entry import SearchEntry
+from app.testing import Actor, create_document
+
+pytestmark = pytest.mark.integration
+
+ActingUser = Callable[..., Awaitable[Actor]]
+
+
+async def _body(session: AsyncSession, guild_id: int, document_id: int) -> str:
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+    rows = await session.exec(
+        select(SearchEntry.body)
+        .where(
+            SearchEntry.entity_type == "document",
+            SearchEntry.entity_id == document_id,
+        )
+        .order_by(SearchEntry.chunk_ix.asc())
+    )
+    return " ".join(r or "" for r in rows)
+
+
+async def _finds(session: AsyncSession, guild_id: int, query: str) -> list[str]:
+    await set_rls_context(session, guild_id=guild_id, guild_role="admin")
+    found = await session.exec(
+        text(
+            "SELECT title FROM search_entries WHERE entity_type = 'document' "
+            "AND tsv @@ websearch_to_tsquery('simple', :q)"
+        ).bindparams(q=query)
+    )
+    return sorted({r[0] for r in found})
+
+
+async def test_a_native_document_indexes_its_prose(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Renewal",
+        content={
+            "root": {
+                "children": [
+                    {
+                        "type": "paragraph",
+                        "children": [{"type": "text", "text": "vendor renewal terms"}],
+                    }
+                ]
+            }
+        },
+    )
+    assert "vendor renewal terms" in await _body(session, a.guild.id, doc.id)
+    assert await _finds(session, a.guild.id, "vendor renewal") == ["Renewal"]
+
+
+async def test_nested_editor_content_is_reached(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    """A mention, a wikilink and an image caption all keep text below the top
+    level; the recursive path is what picks them up."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Nested",
+        content={
+            "root": {
+                "children": [
+                    {
+                        "type": "image",
+                        "caption": {
+                            "editorState": {
+                                "root": {
+                                    "children": [
+                                        {
+                                            "type": "paragraph",
+                                            "children": [
+                                                {
+                                                    "type": "text",
+                                                    "text": "captioned diagram",
+                                                }
+                                            ],
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                    },
+                    {"type": "wikilink", "text": "Q3 Plan", "documentId": 4},
+                ]
+            }
+        },
+    )
+    body = await _body(session, a.guild.id, doc.id)
+    assert "captioned diagram" in body
+    assert "Q3 Plan" in body
+
+
+async def test_a_whiteboard_indexes_its_element_text(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Board",
+        document_type=DocumentType.whiteboard,
+        content={
+            "elements": [
+                {"type": "text", "text": "architecture sketch"},
+                {"type": "rectangle", "label": {"text": "boxed label"}},
+            ],
+            "appState": {},
+            "files": {},
+        },
+    )
+    body = await _body(session, a.guild.id, doc.id)
+    assert "architecture sketch" in body
+    assert "boxed label" in body
+
+
+async def test_a_current_spreadsheet_indexes_cells_and_sheet_names(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Workbook",
+        document_type=DocumentType.spreadsheet,
+        content={
+            "schema_version": 3,
+            "kind": "workbook",
+            "sheets": [
+                {"id": "s1", "name": "Budget", "cells": {"0:0": "Revenue", "0:1": 1234}}
+            ],
+        },
+    )
+    body = await _body(session, a.guild.id, doc.id)
+    assert "Revenue" in body
+    assert "1234" in body
+    # Sheet names are addressable in formulas, so they are worth finding.
+    assert "Budget" in body
+
+
+async def test_a_legacy_spreadsheet_still_indexes(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    """v1 and v2 payloads are upcast only when next saved, so both shapes are
+    live in the database and the extraction has to read either."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Legacy",
+        document_type=DocumentType.spreadsheet,
+        content={
+            "schema_version": 1,
+            "kind": "sheet",
+            "dimensions": {"rows": 2, "cols": 2},
+            "cells": {"0:0": "legacy total", "0:1": 99},
+        },
+    )
+    body = await _body(session, a.guild.id, doc.id)
+    assert "legacy total" in body
+    assert "99" in body
+
+
+async def test_a_smart_link_indexes_its_url(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    """Searching for the service is a real thing people do, and the URL is the
+    only place its name appears."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Design system",
+        document_type=DocumentType.smart_link,
+        content={"url": "https://www.figma.com/file/abc/Design-System"},
+    )
+    assert await _finds(session, a.guild.id, "figma") == ["Design system"]
+    assert await _finds(session, a.guild.id, "www.figma.com") == ["Design system"]
+
+
+async def test_a_file_document_indexes_its_filename_only(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    """Its bytes live outside the database, so its name is all there is."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Contract",
+        document_type=DocumentType.file,
+        content={},
+        original_filename="vendor-contract-2026.pdf",
+    )
+    assert "vendor-contract-2026.pdf" in await _body(session, a.guild.id, doc.id)
+    # ...and findable by a word inside it, not only by the whole filename.
+    assert await _finds(session, a.guild.id, "vendor contract") == ["Contract"]
+
+
+async def test_text_is_stored_once(
+    session: AsyncSession, acting_user: ActingUser
+) -> None:
+    """The recursive path can reach the same value by more than one route; the
+    body must not carry it twice, or every document costs double."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    doc = await create_document(
+        session,
+        a.initiative,
+        a.user,
+        name="Once",
+        content={
+            "root": {
+                "children": [
+                    {
+                        "type": "paragraph",
+                        "children": [{"type": "text", "text": "singleton"}],
+                    }
+                ]
+            }
+        },
+    )
+    assert (await _body(session, a.guild.id, doc.id)).count("singleton") == 1

--- a/backend/app/db/search_index.py
+++ b/backend/app/db/search_index.py
@@ -17,6 +17,7 @@ path that gives a long document several.
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from sqlalchemy import MetaData
@@ -45,8 +46,13 @@ class SearchSource:
     entity_type: str
     #: Column holding the row's display title (weighted 'A').
     title: str
-    #: Columns concatenated into the body (weighted 'B'), in order.
+    #: Columns feeding the body (weighted 'B'). Also the columns whose change
+    #: makes the entry stale, so they drive the trigger's WHEN clause.
     body: tuple[str, ...] = ()
+    #: Builds the body from a row alias, for a source whose text is not simply
+    #: its columns concatenated. Takes precedence over ``body``; the columns are
+    #: still declared above so the WHEN clause knows what to watch.
+    body_sql: Callable[[str], str] | None = None
     #: The tool whose sharing governs this row, and the column naming the
     #: resource id to test. ``dac_id=None`` means the row's own ``id``.
     #: ``dac_tool=None`` means the row carries no sharing gate (a tag).
@@ -61,6 +67,75 @@ class SearchSource:
         """Stem for this table's triggers; INSERT/DELETE and UPDATE are split
         (a WHEN clause naming OLD is invalid on INSERT)."""
         return f"search_{self.entity_type}"
+
+
+def _json_text(row: str, path: str, *, column: str = "content") -> str:
+    """Text of every value a jsonpath selects, as one space-joined string.
+
+    ``strict`` so a value reachable by more than one path is taken once —
+    the lax form walks into arrays as well as their elements and would store
+    the same text twice. ``silent`` so a shape that simply lacks the key
+    yields nothing instead of raising.
+    """
+    return (
+        "coalesce((SELECT string_agg(v #>> '{}', ' ') FROM jsonb_path_query("
+        f"{row}.{column}, '{path}', '{{}}'::jsonb, true) v), '')"
+    )
+
+
+def _with_words(expr: str) -> str:
+    """``expr``, plus the same value split on punctuation.
+
+    A URL or a filename is tokenized as a whole — ``www.figma.com`` and
+    ``vendor-contract-2026.pdf`` are each a single lexeme — so the words inside
+    them are not findable on their own. Emitting a split copy alongside makes
+    both work. Used only for these short, punctuation-dense fields; doing it to
+    prose would double what is stored for nothing.
+    """
+    return f"{expr} || ' ' || regexp_replace({expr}, '[^[:alnum:]]+', ' ', 'g')"
+
+
+def _document_text(row: str) -> str:
+    """A document's searchable text, by what kind of document it is.
+
+    ``content`` holds a different shape per type, so there is no single
+    expression. ``native`` and ``whiteboard`` share one: a Lexical text node
+    and an Excalidraw text or label element both keep their text in a field
+    named ``text``, and the recursive path reaches nested cases — a mention, a
+    wikilink, an image caption's own editor state.
+
+    A ``file`` document contributes nothing here: its bytes live in ``uploads``,
+    so its name, description and uploaded filename are all there is to index.
+    """
+    leaves = _json_text(row, "strict $.**.text")
+    cells = (
+        "coalesce((SELECT string_agg(v #>> '{}', ' ') FROM ("
+        f"SELECT v FROM jsonb_path_query({row}.content, 'strict $.**.cells.*', "
+        "'{}'::jsonb, true) v"
+        " UNION ALL "
+        f"SELECT v FROM jsonb_path_query({row}.content, 'strict $.sheets[*].name', "
+        "'{}'::jsonb, true) v) s), '')"
+    )
+    url = _with_words(f"coalesce({row}.content ->> 'url', '')")
+    return (
+        f"(CASE {row}.document_type::text"
+        f" WHEN 'native' THEN {leaves}"
+        f" WHEN 'whiteboard' THEN {leaves}"
+        f" WHEN 'spreadsheet' THEN {cells}"
+        f" WHEN 'smart_link' THEN {url}"
+        " ELSE '' END)"
+        " || ' ' || " + _with_words(f"coalesce({row}.original_filename, '')")
+    )
+
+
+def _body_expr(source: "SearchSource", row: str = ROW) -> str:
+    """Row expression yielding a source's body text."""
+    if source.body_sql is not None:
+        return source.body_sql(row)
+    if not source.body:
+        return ""
+    parts = [f"coalesce({row}.{c}, '')" for c in source.body]
+    return " || ' ' || ".join(parts) if len(parts) > 1 else parts[0]
 
 
 #: table -> how its rows are indexed.
@@ -82,9 +157,8 @@ SEARCH_SOURCES: dict[str, SearchSource] = {
     "documents": SearchSource(
         "document",
         title="name",
-        # ``content`` extraction arrives with the per-document_type extractors;
-        # the uploaded filename is plain text and useful on its own.
-        body=("original_filename",),
+        body=("content", "document_type", "original_filename"),
+        body_sql=_document_text,
         dac_tool=Tool.document,
     ),
     "queues": SearchSource(
@@ -173,14 +247,6 @@ def entity_types(*, default_scope_only: bool = False) -> tuple[str, ...]:
             if s.in_default_scope or not default_scope_only
         )
     )
-
-
-def _text_expr(columns: tuple[str, ...], row: str = ROW) -> str:
-    """Row expression concatenating columns into one text value."""
-    if not columns:
-        return ""
-    parts = [f"coalesce({row}.{c}, '')" for c in columns]
-    return " || ' ' || ".join(parts) if len(parts) > 1 else parts[0]
 
 
 def _quoted(expr: str) -> str:
@@ -342,7 +408,7 @@ def _call_args(table: str, source: SearchSource) -> list[str]:
         f"    '{source.entity_type}',",
         f"    {_quoted(f'{ROW}.id')},",
         f"    {_quoted(f'{ROW}.{source.title}')},",
-        f"    {_quoted(_text_expr(source.body))},",
+        f"    {_quoted(_body_expr(source))},",
         f"    '{source.dac_tool.value if source.dac_tool else ''}',",
         f"    {_quoted(dac_id if source.dac_tool else '')}",
     ]
@@ -472,7 +538,7 @@ def reindex_statement(table: str, source: SearchSource) -> str:
         if source.dac_tool
         else "NULL::integer"
     )
-    body = _text_expr(source.body, row) or "''"
+    body = _body_expr(source, row) or "''"
     live = " AND t.deleted_at IS NULL" if "deleted_at" in columns else ""
     return (
         f"SELECT {row}.id AS id, {WRITE_FUNCTION}("  # noqa: S608 — registry-rendered


### PR DESCRIPTION
## Problem

A document was findable by its name and nothing else. Remembering a phrase *inside* a document — the ordinary way people look for one — found nothing.

This lands before the search endpoint on purpose: shipping search that finds a document by name but not by what is in it teaches people it does not work, which is hard to un-teach.

## What this adds

`documents.content` is not one format. `DocumentType` has five members and each stores something different, so each gets its own extraction:

| `document_type` | Extracted |
|---|---|
| `native` | Lexical text nodes |
| `whiteboard` | Excalidraw text and label elements |
| `spreadsheet` | cell values + sheet names, all three schema versions |
| `smart_link` | its URL |
| `file` | nothing here — name and uploaded filename only |

**`native` and `whiteboard` share one extractor.** A Lexical text node and an Excalidraw text or label element both keep their text in a field named `text`, so one recursive path covers both. That was not obvious and it removes an extractor.

The recursive path also reaches text that is nested rather than top-level, which matters more than it sounds: `MentionNode` and `WikilinkNode` both extend Lexical's `TextNode`, and an `ImageNode`'s caption is a *nested editor state*. All three are picked up by the same expression, and there are tests for the caption and the wikilink.

**Spreadsheets have three schema versions live at once.** `documents_spreadsheet.py` upcasts v1/v2 to v3 only on write, so a document not saved since that landed still holds its old shape. Reading only the current shape would have silently indexed nothing for those. Covered by a v1 payload test.

## Two things Postgres decided, not me

Both found by trying it rather than reasoning about it:

**`strict` jsonpath, not lax.** Lax mode walks into arrays *and* their elements, so `$.**.text` returned `'alpha alpha beta gamma beta gamma'` for a two-paragraph document. Same lexemes, so results would not have differed — but body text and chunk count would have been 2× for every document in the index. `strict $.**.text` returns `'alpha beta gamma'`. There is a test asserting a value is stored once.

**`silent => true`.** `strict` raises on a missing key: `strict $.sheets[*].name` against a v1 spreadsheet fails with *JSON object does not contain key "sheets"*, inside a trigger, aborting the write of the document itself. The silent flag yields nothing instead.

## URLs and filenames are also emitted split

Postgres tokenizes `https://www.figma.com/file/abc/Design-System` into host and path lexemes, so searching `figma` matched nothing — only the full `www.figma.com` did. Same for `vendor-contract-2026.pdf`. Since "find the Figma board" was the reason to index the URL at all, these two fields are emitted twice: as-is, and split on punctuation. Prose is not, since that would double storage for nothing.

## Reindexing

The extraction change moves `search_generation()`, so the boot sweep rewrites existing documents automatically. That is what the generation marker was built for; nothing extra is needed here.

## Testing

```
pytest -n 0 app/db/search_document_bodies_test.py        # 8 passed
pytest -n auto app/db/ app/services/tenant/search_test.py  # 458 passed
ruff check / ruff format --check / ty check              # clean
```

New tests cover each document type against a real trigger: prose, nested caption and wikilink text, whiteboard element and label text, a current spreadsheet's cells and sheet names, a legacy v1 spreadsheet, a smart link found by `figma` *and* by `www.figma.com`, a file document found by a word inside its filename, and that text is stored exactly once.

## Notes for review

- `SearchSource` gains `body_sql`, an optional expression builder for a source whose text is not simply its columns concatenated. `body` stays the column list, because it is also what the trigger's `WHEN` clause watches — so a `content` or `document_type` edit reindexes.
- Searching *inside uploaded files* is still out of scope: their bytes live in `uploads` and it needs a text-extraction pipeline. A file document is findable by what it is called.
- The changelog entry covers the whole search feature and lands with the last PR in the series.
