### PR TITLE
Move search into the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The search page names the community it is searching, and every tab stays open.** The heading said only "Search"; it now says which community the results come from. Tabs with nothing behind them were greyed out, so you could not check an empty tab for yourself or return to one once a changed query filled it — every tab is now reachable and an empty one says nothing matched. Finding out which tabs to grey out cost two extra searches per query, which are gone with it.
+
+- **Search moved into the sidebar.** The search button sat in the tab strip above the page, where it read as one more tab. It is now a search field under the community name in the sidebar, labelled with the community it searches and showing the ⌘K / Ctrl+K shortcut. The recents strip is now only recents, and disappears when there are none.
+
 - **Comment threads now run the full width of the page.** They were squeezed into a half-width column on tasks and into a slide-out panel on documents, which wrapped almost every reply. A thread is a conversation, so it now gets its own full-width row underneath, in the same place on every kind of page. The document side panel is now just the AI summary.
 
 - **Replies are easier to follow.** Each level of nesting draws its thread line in a different theme colour, so you can see how deep a reply sits even where the indentation stops.
@@ -32,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Guilds are now communities.** The name was picked for gaming guilds, and the people using Initiative turned out to be running far more than that — clubs, teams, departments, whole organisations. Everything you see now says community: menus, settings, notifications, error messages, and the help site, in all four languages. Nothing about how it works has changed; only what it is called.
 
 - **Community pages have moved from `/g/` to `/c/`.** A page inside a community now lives at `/c/{id}/…` instead of `/g/{id}/…`, the per-community sign-in link is `/community/{id}/login`, and the platform tab is Settings › Admin › Communities. Old links do not forward — bookmarks, saved links and any per-community sign-in link you handed out need replacing with the new address.
+
+### Fixed
+
+- **Open tabs no longer flicker when you switch community.** The recents bar lists tabs from every community you are in, but switching community threw its contents away and fetched them again, blanking the bar for a moment each time. It now stays put — there is nothing about it that a switch changes.
 
 ## [0.64.3] - 2026-08-30
 

--- a/frontend/public/locales/de/search.json
+++ b/frontend/public/locales/de/search.json
@@ -1,5 +1,6 @@
 {
   "title": "Suche",
+  "titleInGuild": "{{guildName}} durchsuchen",
   "placeholder": "{{guildName}} durchsuchen",
   "seeAll": "Alle anzeigen",
   "prompt": {

--- a/frontend/public/locales/en/search.json
+++ b/frontend/public/locales/en/search.json
@@ -1,5 +1,6 @@
 {
   "title": "Search",
+  "titleInGuild": "Search {{guildName}}",
   "placeholder": "Search {{guildName}}",
   "seeAll": "See all",
   "prompt": {

--- a/frontend/public/locales/es/search.json
+++ b/frontend/public/locales/es/search.json
@@ -1,5 +1,6 @@
 {
   "title": "Buscar",
+  "titleInGuild": "Buscar en {{guildName}}",
   "placeholder": "Buscar en {{guildName}}",
   "seeAll": "Ver todo",
   "prompt": {

--- a/frontend/public/locales/fr/search.json
+++ b/frontend/public/locales/fr/search.json
@@ -1,5 +1,6 @@
 {
   "title": "Recherche",
+  "titleInGuild": "Rechercher dans {{guildName}}",
   "placeholder": "Rechercher dans {{guildName}}",
   "seeAll": "Tout afficher",
   "prompt": {

--- a/frontend/src/__tests__/guildSearchRoute.test.tsx
+++ b/frontend/src/__tests__/guildSearchRoute.test.tsx
@@ -151,13 +151,18 @@ describe("the guild search page", () => {
     );
   });
 
-  it("offers nothing to open on a tab with nothing behind it", async () => {
+  it("lets a reader open a tab with nothing behind it and says so", async () => {
     withHits([project()], []);
+    const user = userEvent.setup();
     await renderSearch({ q: "riverside" });
 
     await screen.findByRole("link", { name: /Riverside kickoff/ });
-    expect(screen.getByRole("tab", { name: "Tools" })).toBeEnabled();
-    expect(screen.getByRole("tab", { name: "Tags" })).toBeDisabled();
+    const tags = screen.getByRole("tab", { name: "Tags" });
+    expect(tags).toBeEnabled();
+
+    await user.click(tags);
+
+    expect(await screen.findByText(/No results for/)).toBeInTheDocument();
   });
 
   it("asks nothing until there is something to search for", async () => {
@@ -167,6 +172,17 @@ describe("the guild search page", () => {
     for (const call of mocks.search.mock.calls) {
       expect(call[0].q).toBe("");
     }
+  });
+
+  // The heading names what is being searched, the same way the sidebar's search
+  // row does — a result page reached from anywhere says which community it
+  // covers, rather than a bare "Search".
+  it("names the community in its heading", async () => {
+    await renderSearch({ q: "alpha" });
+
+    expect(
+      await screen.findByRole("heading", { name: "Search Guild 1", level: 1 })
+    ).toBeInTheDocument();
   });
 
   it("puts a reader who arrives past the last page back on results", async () => {
@@ -186,15 +202,14 @@ describe("the guild search page", () => {
 
   it("draws no conclusion from a total that belongs to the query before it", async () => {
     // Arriving on page 3 of a fresh query while the previous query's results
-    // are still on screen. That query matched one thing in one tab and nothing
-    // in the other, and neither fact is about this one — so the page must not
-    // be corrected, and the empty tab must not be closed off.
+    // are still on screen. That query's total belongs to the query that is
+    // leaving and says nothing about this one, so the page must not be
+    // corrected off 3 on the strength of it.
     withStaleAnswer();
     const { router: pageRouter } = await renderSearch({ q: "riverside", page: 3 });
 
     await screen.findByRole("tab", { name: "Tools" });
     expect(pageRouter.state.location.search).toMatchObject({ page: 3 });
-    expect(screen.getByRole("tab", { name: "Tags" })).toBeEnabled();
   });
 });
 

--- a/frontend/src/api/query-keys.test.ts
+++ b/frontend/src/api/query-keys.test.ts
@@ -6,6 +6,7 @@ import {
   invalidateAllTasks,
   invalidateGuildMembers,
   invalidateNotifications,
+  resetGuildScopedQueries,
   setInvalidationGuild,
 } from "@/api/query-keys";
 import { queryClient } from "@/lib/queryClient";
@@ -114,6 +115,32 @@ describe("query-keys guild scoping", () => {
       expect(platform()).toBe(true);
       expect(guildAI()).toBe(true);
       expect(otherGuildAI()).toBe(false);
+    });
+  });
+
+  describe("guild switch", () => {
+    // Reset (unlike invalidate) drops the data, so a surviving key is one whose
+    // cached value is still there afterwards.
+    const survives = (key: readonly unknown[]) => {
+      queryClient.setQueryData(key, { seeded: true });
+      return () => queryClient.getQueryData(key) !== undefined;
+    };
+
+    it("drops guild-scoped data but keeps the cross-guild personal keys", async () => {
+      const guildScoped = survives(["/api/v1/g/5/projects/"]);
+      const guildList = survives(["/api/v1/guilds/"]);
+      const currentUser = survives(["/api/v1/users/me"]);
+      const version = survives(["/api/v1/version"]);
+      // The recents bar spans every community, so a switch must not blank it.
+      const recents = survives(["/api/v1/recents/"]);
+
+      await resetGuildScopedQueries();
+
+      expect(guildScoped()).toBe(false);
+      expect(guildList()).toBe(true);
+      expect(currentUser()).toBe(true);
+      expect(version()).toBe(true);
+      expect(recents()).toBe(true);
     });
   });
 });

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -318,8 +318,17 @@ export const invalidateGuildInvites = (guildId: number) =>
   invalidatePersonalExact([`/api/v1/guilds/${guildId}/invites`]);
 
 // ── Guild Switch ──────────────────────────────────────────────────────────────
-// Keys that are NOT guild-scoped and should survive a guild switch
-const GLOBAL_KEY_PREFIXES = ["/api/v1/guilds", "/api/v1/users/me", "/api/v1/version"];
+// Keys that are NOT guild-scoped and should survive a guild switch.
+// `/api/v1/recents` is one of them: the recents bar is a cross-guild personal
+// list, so switching community neither changes its contents nor invalidates
+// them. Resetting it made the bar blank and refetch on every switch, dropping
+// tabs that belong to the community being left as well as the one arriving.
+const GLOBAL_KEY_PREFIXES = [
+  "/api/v1/guilds",
+  "/api/v1/users/me",
+  "/api/v1/version",
+  "/api/v1/recents",
+];
 
 /** Remove all guild-scoped query data so stale cross-guild results are never shown. */
 export const resetGuildScopedQueries = () =>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -22,6 +22,7 @@ import { AppsSection } from "@/components/sidebar/AppsSection";
 import { CommunityDirectorySidebar } from "@/components/sidebar/CommunityDirectorySidebar";
 import { HomeSidebarContent } from "@/components/sidebar/HomeSidebarContent";
 import { InitiativeSection } from "@/components/sidebar/InitiativeSection";
+import { SidebarSearchButton } from "@/components/sidebar/SidebarSearchButton";
 import { SidebarUserFooter } from "@/components/sidebar/SidebarUserFooter";
 import { TagBrowser } from "@/components/sidebar/TagBrowser";
 import { Button } from "@/components/ui/button";
@@ -336,21 +337,29 @@ export const AppSidebar = () => {
             ) : (
               <>
                 <SidebarHeader
-                  className="gap-0 border-b p-0"
+                  className="gap-0 p-0"
                   style={{ paddingTop: "var(--safe-area-inset-top)" }}
                 >
-                  <div className="flex h-12 min-w-0 items-center justify-between gap-2 px-2.5">
-                    <h2 className="min-w-0 flex-1 truncate font-semibold text-lg">
-                      {activeGuild?.name ?? t("selectGuild")}
-                    </h2>
-                    {activeGuild && isGuildAdmin && (
-                      <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" asChild>
-                        <Link to={gp("/settings")} aria-label={t("guildSettings")}>
-                          <Settings className="h-4 w-4" />
-                        </Link>
-                      </Button>
-                    )}
+                  {/* The rule goes on the wrapper, not the h-12 row, so the
+                      row is a full 3rem and the border sits below it — the
+                      recents bar across the top of the page is built the same
+                      way, and a border inside the box would leave the two 1px
+                      out of line. */}
+                  <div className="border-b">
+                    <div className="flex h-12 min-w-0 items-center justify-between gap-2 px-2.5">
+                      <h2 className="min-w-0 flex-1 truncate font-semibold text-lg">
+                        {activeGuild?.name ?? t("selectGuild")}
+                      </h2>
+                      {activeGuild && isGuildAdmin && (
+                        <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" asChild>
+                          <Link to={gp("/settings")} aria-label={t("guildSettings")}>
+                            <Settings className="h-4 w-4" />
+                          </Link>
+                        </Button>
+                      )}
+                    </div>
                   </div>
+                  <SidebarSearchButton guildName={activeGuild?.name} />
                 </SidebarHeader>
 
                 <Tabs defaultValue="initiatives" className="flex flex-1 flex-col overflow-hidden">

--- a/frontend/src/components/sidebar/SidebarSearchButton.test.tsx
+++ b/frontend/src/components/sidebar/SidebarSearchButton.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/__tests__/helpers/render";
+
+const openCommandCenter = vi.fn();
+vi.mock("@/components/CommandCenter", () => ({
+  getOpenCommandCenter: () => openCommandCenter,
+}));
+
+import { SidebarSearchButton } from "./SidebarSearchButton";
+
+describe("SidebarSearchButton", () => {
+  it("names the community it searches and shows the shortcut hint", () => {
+    renderWithProviders(<SidebarSearchButton guildName="Wayfarers" />);
+
+    expect(screen.getByText("Search Wayfarers")).toBeInTheDocument();
+    // jsdom's user agent isn't a Mac, so the hint is the ctrl form.
+    expect(screen.getByText("Ctrl+K")).toBeInTheDocument();
+  });
+
+  it("falls back to a plain label with no community selected", () => {
+    renderWithProviders(<SidebarSearchButton />);
+
+    expect(screen.getByText("Search")).toBeInTheDocument();
+  });
+
+  it("opens the command center when clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SidebarSearchButton guildName="Wayfarers" />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(openCommandCenter).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/sidebar/SidebarSearchButton.tsx
+++ b/frontend/src/components/sidebar/SidebarSearchButton.tsx
@@ -1,0 +1,47 @@
+import { Search } from "lucide-react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { getOpenCommandCenter } from "@/components/CommandCenter";
+
+interface SidebarSearchButtonProps {
+  /** Name of the community being searched; shown in the placeholder. */
+  guildName?: string | null;
+}
+
+/**
+ * Full-bleed search row under the community name that opens the command
+ * center. It spans the sidebar edge to edge, so it carries no border or
+ * rounding of its own beyond the rule separating it from what follows. The
+ * command palette is still reachable with ctrl/cmd-K, which the trailing hint
+ * spells out.
+ */
+export const SidebarSearchButton = ({ guildName }: SidebarSearchButtonProps) => {
+  const { t } = useTranslation(["search", "command"]);
+
+  const shortcutLabel = useMemo(
+    () =>
+      typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
+        ? "⌘K"
+        : "Ctrl+K",
+    []
+  );
+
+  // Same sentence the search page puts in its own input, from the same key.
+  const label = guildName ? t("search:placeholder", { guildName }) : t("search:title");
+
+  return (
+    <button
+      type="button"
+      onClick={() => getOpenCommandCenter()?.()}
+      aria-label={t("command:shortcutTooltip", { shortcut: shortcutLabel })}
+      className="flex h-9 w-full min-w-0 items-center gap-2 border-b px-2.5 text-left text-muted-foreground text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      <Search className="h-4 w-4 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <kbd className="pointer-events-none inline-flex shrink-0 select-none items-center rounded border bg-muted px-1.5 py-0.5 font-medium font-mono text-[10px] text-muted-foreground">
+        {shortcutLabel}
+      </kbd>
+    </button>
+  );
+};

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -108,21 +108,6 @@ export function SearchPage() {
     { enabled }
   );
 
-  // One row is all the tab strip needs. The tab being read answers for itself,
-  // so only the others are asked.
-  const toolProbe = useGuildSearch(
-    { q: query, types: categoryEntityTypes("tool"), limit: 1 },
-    { enabled: enabled && tab !== "tool" }
-  );
-  const tagProbe = useGuildSearch(
-    { q: query, types: categoryEntityTypes("tag"), limit: 1 },
-    { enabled: enabled && tab !== "tag" }
-  );
-  const probes: Record<SearchCategory, ReturnType<typeof useGuildSearch>> = {
-    tool: toolProbe,
-    tag: tagProbe,
-  };
-
   // A page past the end of the answer — a link from before the content moved,
   // or a query that has since narrowed. Left alone it reads as "nothing
   // matched", which is the opposite of what happened, so it corrects itself
@@ -140,7 +125,11 @@ export function SearchPage() {
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        <h1 className="font-semibold text-3xl tracking-tight">{t("search:title")}</h1>
+        <h1 className="font-semibold text-3xl tracking-tight">
+          {activeGuild
+            ? t("search:titleInGuild", { guildName: activeGuild.name })
+            : t("search:title")}
+        </h1>
         <div className="relative max-w-2xl">
           <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -166,12 +155,11 @@ export function SearchPage() {
         <Tabs value={tab} onValueChange={setTab} className="space-y-4">
           <TabsBar>
             {SEARCH_CATEGORIES.map((category) => (
-              <TabsTrigger
-                key={category}
-                value={category}
-                // Nothing behind it, and not where the reader already is.
-                disabled={category !== tab && settledTotal(probes[category]) === 0}
-              >
+              // Every tab stays open, including one holding nothing: closing
+              // it off leaves the reader unable to confirm that for themselves,
+              // and unable to get back once a changed query fills it. An empty
+              // tab says so.
+              <TabsTrigger key={category} value={category}>
                 {t(`search:tabs.${category}`)}
               </TabsTrigger>
             ))}

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -1,12 +1,12 @@
 import { createFileRoute, Link, Outlet, redirect, useLocation } from "@tanstack/react-router";
-import { Loader2, LogOut, Plus, Search, Settings, Ticket, UserCog } from "lucide-react";
-import { Suspense, useMemo, useState } from "react";
+import { Loader2, LogOut, Plus, Settings, Ticket, UserCog } from "lucide-react";
+import { Suspense, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GuildRead, RecentItemRead } from "@/api/generated/initiativeAPI.schemas";
 import { AppSidebar } from "@/components/AppSidebar";
 import { ChooseHandle } from "@/components/ChooseHandle";
-import { CommandCenter, getOpenCommandCenter } from "@/components/CommandCenter";
+import { CommandCenter } from "@/components/CommandCenter";
 import { CreateDocumentWizard } from "@/components/documents/CreateDocumentWizard";
 import { GuildAccessBanner } from "@/components/guilds/GuildAccessBanner";
 import { Galaxy } from "@/components/icons/Galaxy";
@@ -19,7 +19,6 @@ import { CreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { VersionDialog } from "@/components/VersionDialog";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { useAuth } from "@/hooks/useAuth";
@@ -78,13 +77,7 @@ export const Route = createFileRoute("/_serverRequired/_authenticated")({
 
 function AppLayout() {
   // ALL hooks must be called before any conditional returns
-  const { t } = useTranslation("command");
   const { user, loading, logout } = useAuth();
-  const isMac = useMemo(
-    () => typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent),
-    []
-  );
-  const shortcutLabel = isMac ? "\u2318K" : "Ctrl+K";
   const { guilds, loading: guildsLoading, canCreateGuilds, createGuild } = useGuilds();
   const location = useLocation();
   const { updateAvailable, closeDialog } = useVersionCheck();
@@ -229,34 +222,23 @@ function AppLayout() {
                 className="sticky top-0 z-50 flex flex-col bg-card/70 backdrop-blur supports-backdrop-filter:bg-card/60 lg:border-b"
                 style={{ paddingTop: "var(--safe-area-inset-top)" }}
               >
-                <div className="hidden h-12 lg:flex">
-                  {/* Mobile hamburger now lives in BottomNav; this desktop-only
-                      row keeps search + recents. */}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-12 w-12 shrink-0 rounded-none border-r"
-                        onClick={() => getOpenCommandCenter()?.()}
-                        aria-label={t("shortcutTooltip", { shortcut: shortcutLabel })}
-                      >
-                        <Search className="h-5 w-5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>{shortcutLabel}</TooltipContent>
-                  </Tooltip>
-                  <div className="min-w-0 flex-1">
-                    <RecentTabsBar
-                      items={recentItems}
-                      loading={recentQuery.isLoading}
-                      activeKey={activeRecentKey}
-                      onClose={handleClearRecent}
-                      onCloseOthers={handleCloseOtherRecents}
-                      onCloseAll={handleCloseAllRecents}
-                    />
+                {/* Mobile hamburger lives in BottomNav and search now lives in
+                    the sidebar, so this desktop-only row is just recents — and
+                    with nothing recent it takes up no room at all. */}
+                {(recentQuery.isLoading || (recentItems?.length ?? 0) > 0) && (
+                  <div className="hidden h-12 lg:flex">
+                    <div className="min-w-0 flex-1">
+                      <RecentTabsBar
+                        items={recentItems}
+                        loading={recentQuery.isLoading}
+                        activeKey={activeRecentKey}
+                        onClose={handleClearRecent}
+                        onCloseOthers={handleCloseOtherRecents}
+                        onCloseAll={handleCloseAllRecents}
+                      />
+                    </div>
                   </div>
-                </div>
+                )}
                 <GuildAccessBanner />
               </div>
               <div className="flex flex-1 justify-between">


### PR DESCRIPTION
## Problem

The search button lived in the tab strip above the page, immediately left of the recents tabs. A button sitting among tabs reads as one more tab, and it left the community you were searching unnamed at the point you started the search.

Working on it surfaced two adjacent problems:

- **Recents reset on every community switch.** The recents bar became cross-guild, but `/api/v1/recents` was never added to `GLOBAL_KEY_PREFIXES`, so `resetGuildScopedQueries()` cleared it on every switch — blanking the bar and dropping tabs belonging to *every* community, not just the one being left. `resetQueries` drops the data before refetching, hence the flicker.
- **The search page never named the community.** Its heading said only "Search". The input placeholder did name it, but that placeholder is hidden the moment there's a query — so on an actual results page the name never appeared.

## Changes

**Search moves to the sidebar**

- New [SidebarSearchButton.tsx](frontend/src/components/sidebar/SidebarSearchButton.tsx) — a full-bleed, input-shaped row that opens the command center. Reads "Search *Community Name*", falls back to plain "Search" with no community, and shows `⌘K` / `Ctrl+K`.
- [AppSidebar.tsx](frontend/src/components/AppSidebar.tsx) renders it directly under the community-name row. The name row's `border-b` moved to a wrapper so the row is a full `3rem` and the rule sits below it — matching how the page header is built, which otherwise left the two 1px out of line.
- [_authenticated.tsx](frontend/src/routes/_serverRequired/_authenticated.tsx) drops the old button and its now-dead imports (`Search`, `Tooltip*`, `useMemo`, `getOpenCommandCenter`, the `command` `useTranslation`). The desktop row is now conditional on there being recents, so it collapses instead of leaving an empty 48px band.

**Recents survives a community switch**

- `/api/v1/recents` added to `GLOBAL_KEY_PREFIXES` in [query-keys.ts](frontend/src/api/query-keys.ts). The record/clear mutations already call `invalidateRecents()`, so the list still refreshes when it should.

**Search page**

- The `<h1>` in [SearchPage.tsx](frontend/src/pages/SearchPage.tsx) names the community, via a new `search:titleInGuild` key.
- Every tab is now reachable. `TabsTrigger` had `disabled={... settledTotal(probes[category]) === 0}`, which meant you could neither confirm a tab was empty nor get back to one once a changed query filled it. The `NoResults` empty state already covered `items.length === 0`, so an empty tab simply says nothing matched.
- Those `disabled` flags were the **only** consumer of `toolProbe` / `tagProbe` — two extra `limit: 1` searches fired per query purely to decide what to grey out. Both deleted, so a query is now one request instead of three.

**i18n**

- `search:titleInGuild` added to en/de/es/fr.
- The sidebar row reuses the existing `search:placeholder` rather than a duplicate of the same sentence in the `command` namespace.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check <8 changed files>` — clean
- `cd frontend && ./scripts/test-changed.sh` — **178 files, 2071 tests passed**

New/updated specs:

- [SidebarSearchButton.test.tsx](frontend/src/components/sidebar/SidebarSearchButton.test.tsx) — label, no-community fallback, click-opens-command-center.
- [query-keys.test.ts](frontend/src/api/query-keys.test.ts) — a `guild switch` block asserting the reset drops guild data but keeps guilds / users-me / version / recents. Verified it fails with the one-line fix reverted.
- [guildSearchRoute.test.tsx](frontend/src/__tests__/guildSearchRoute.test.tsx) — "offers nothing to open on a tab with nothing behind it" rewritten to click through to the empty tab and assert the empty state; verified it fails if `disabled` returns. Plus a heading test for the community name.

Not manually exercised in a browser beyond the 1px alignment the screenshot caught.