### PR TITLE
Fix spreadsheet sheet renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renaming a spreadsheet sheet keeps what you type.** The tab's rename box re-selected the whole name after every keystroke, so each new character wiped out the one before it and the sheet ended up named after the last letter typed. The name is now selected once when the box opens, as intended, and typing behaves normally from there.
+
 - **Open tabs no longer flicker when you switch community.** The recents bar lists tabs from every community you are in, but switching community threw its contents away and fetched them again, blanking the bar for a moment each time. It now stays put — there is nothing about it that a switch changes.
 
 ## [0.64.3] - 2026-08-30

--- a/frontend/src/components/documents/spreadsheet/SpreadsheetSheetTabs.test.tsx
+++ b/frontend/src/components/documents/spreadsheet/SpreadsheetSheetTabs.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SheetMeta } from "@/lib/spreadsheet/sheets";
+
+import { SpreadsheetSheetTabs } from "./SpreadsheetSheetTabs";
+
+const SHEETS: SheetMeta[] = [
+  { id: "s1", name: "Sheet1" },
+  { id: "s2", name: "Sheet2" },
+];
+
+const renderTabs = (overrides: Partial<React.ComponentProps<typeof SpreadsheetSheetTabs>> = {}) => {
+  const onRename = vi.fn();
+  render(
+    <SpreadsheetSheetTabs
+      sheets={SHEETS}
+      activeSheetId="s1"
+      readOnly={false}
+      canAdd
+      onSelect={vi.fn()}
+      onAdd={vi.fn()}
+      onRename={onRename}
+      onDelete={vi.fn()}
+      onDuplicate={vi.fn()}
+      onMove={vi.fn()}
+      {...overrides}
+    />
+  );
+  return { onRename };
+};
+
+describe("SpreadsheetSheetTabs", () => {
+  it("keeps every typed character when renaming a sheet", async () => {
+    const { onRename } = renderTabs();
+
+    await userEvent.dblClick(screen.getByRole("tab", { name: "Sheet1" }));
+    const input = screen.getByRole("textbox", { name: /sheet name/i });
+    // ``skipClick`` keeps the selection the component set up: the name
+    // starts selected, so the first keystroke replaces it wholesale — but
+    // only the first. Re-selecting on every keystroke left just the last
+    // character typed.
+    await userEvent.type(input, "Budget{Enter}", { skipClick: true });
+
+    expect(onRename).toHaveBeenCalledWith("s1", "Budget");
+  });
+
+  it("renames from the tab menu and discards the edit on Escape", async () => {
+    const { onRename } = renderTabs();
+
+    await userEvent.click(screen.getByRole("button", { name: "Sheet2 sheet actions" }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: /sheet name/i });
+    expect(input).toHaveValue("Sheet2");
+
+    await userEvent.type(input, "Q1 Actuals{Escape}", { skipClick: true });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByRole("tab", { name: "Sheet2" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/documents/spreadsheet/SpreadsheetSheetTabs.tsx
+++ b/frontend/src/components/documents/spreadsheet/SpreadsheetSheetTabs.tsx
@@ -49,13 +49,25 @@ export const SpreadsheetSheetTabs = ({
   onMove,
 }: SpreadsheetSheetTabsProps) => {
   const { t } = useTranslation(["documents", "common"]);
-  const [renaming, setRenaming] = useState<{ id: SheetId; draft: string } | null>(null);
+  // The sheet being renamed and its draft are separate pieces of state on
+  // purpose: the effect below selects the input's text, and it must run
+  // when the rename *starts*, not on every keystroke — a combined
+  // ``{ id, draft }`` object changes identity on each character typed,
+  // which re-selected the whole name and made the next keystroke replace
+  // everything the user had typed so far.
+  const [renamingId, setRenamingId] = useState<SheetId | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
 
+  const startRename = (sheet: SheetMeta) => {
+    setRenamingId(sheet.id);
+    setRenameDraft(sheet.name);
+  };
+
   useEffect(() => {
-    if (renaming) renameInputRef.current?.select();
-  }, [renaming]);
+    if (renamingId) renameInputRef.current?.select();
+  }, [renamingId]);
 
   // Keep the active tab on screen when it changes from elsewhere — a
   // committed cross-sheet formula switches back to the sheet it lives on,
@@ -65,10 +77,10 @@ export const SpreadsheetSheetTabs = ({
   }, [activeSheetId]);
 
   const commitRename = () => {
-    if (!renaming) return;
-    const trimmed = renaming.draft.trim();
-    if (trimmed) onRename(renaming.id, trimmed);
-    setRenaming(null);
+    if (!renamingId) return;
+    const trimmed = renameDraft.trim();
+    if (trimmed) onRename(renamingId, trimmed);
+    setRenamingId(null);
   };
 
   const handleRenameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -77,7 +89,7 @@ export const SpreadsheetSheetTabs = ({
       commitRename();
     } else if (e.key === "Escape") {
       e.preventDefault();
-      setRenaming(null);
+      setRenamingId(null);
     }
   };
 
@@ -106,7 +118,7 @@ export const SpreadsheetSheetTabs = ({
 
       {sheets.map((sheet, index) => {
         const isActive = sheet.id === activeSheetId;
-        const isRenaming = renaming?.id === sheet.id;
+        const isRenaming = renamingId === sheet.id;
         return (
           <div
             key={sheet.id}
@@ -119,12 +131,12 @@ export const SpreadsheetSheetTabs = ({
             {isRenaming ? (
               <input
                 ref={renameInputRef}
-                value={renaming.draft}
+                value={renameDraft}
                 maxLength={MAX_SHEET_NAME_LENGTH}
                 // biome-ignore lint/a11y/noAutofocus: the input replaces the tab the user just chose to rename
                 autoFocus
                 aria-label={t("documents:spreadsheet.sheets.renameLabel")}
-                onChange={(e) => setRenaming({ id: sheet.id, draft: e.target.value })}
+                onChange={(e) => setRenameDraft(e.target.value)}
                 onKeyDown={handleRenameKeyDown}
                 onBlur={commitRename}
                 className="w-28 bg-transparent px-2 py-1 text-sm outline-none ring-1 ring-primary ring-inset"
@@ -136,7 +148,7 @@ export const SpreadsheetSheetTabs = ({
                 aria-selected={isActive}
                 onClick={() => onSelect(sheet.id)}
                 onDoubleClick={() => {
-                  if (!readOnly) setRenaming({ id: sheet.id, draft: sheet.name });
+                  if (!readOnly) startRename(sheet);
                 }}
                 className="max-w-48 truncate px-3 py-1 text-sm"
               >
@@ -156,9 +168,7 @@ export const SpreadsheetSheetTabs = ({
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start">
-                  <DropdownMenuItem
-                    onSelect={() => setRenaming({ id: sheet.id, draft: sheet.name })}
-                  >
+                  <DropdownMenuItem onSelect={() => startRename(sheet)}>
                     {t("documents:spreadsheet.sheets.rename")}
                   </DropdownMenuItem>
                   <DropdownMenuItem onSelect={() => onDuplicate(sheet.id)}>


### PR DESCRIPTION
## Problem

Renaming a sheet in a spreadsheet document was unusable: typing into the tab's rename box wiped out each character as the next one arrived, so committing the name left the sheet called after the last letter typed ("Budget" → "t").

The rename box kept `{ id, draft }` in a single state object, replaced on every `onChange`. The effect that pre-selects the existing name depended on that object, so it re-ran per keystroke and re-selected the whole field — and the next keystroke replaced the selection.

Reported in Beyonders Studio task #2748.

## Changes

- [SpreadsheetSheetTabs.tsx](frontend/src/components/documents/spreadsheet/SpreadsheetSheetTabs.tsx) — split the rename state into `renamingId` and `renameDraft`, so the select-on-open effect keys off the id alone and fires once when the rename starts. A `startRename(sheet)` helper serves both entry points (double-click and the tab menu's Rename). Behaviour is otherwise unchanged: name selected on open, Enter commits, Escape discards, blur commits.
- [SpreadsheetSheetTabs.test.tsx](frontend/src/components/documents/spreadsheet/SpreadsheetSheetTabs.test.tsx) — new regression test: typing a full name through the double-click path commits it intact, and the menu path opens on the current name and discards on Escape. Both use `userEvent.type(..., { skipClick: true })`, since a click would collapse the selection the component sets up and hide the bug.
- `CHANGELOG.md` — entry under `[Unreleased]` → Fixed.

## Testing

- `pnpm vitest run src/components/documents/spreadsheet src/lib/spreadsheet` — 13 files, 233 tests passing.
- Confirmed the new test is a real regression test by stashing the component fix: it fails with `"t"` against the old code.
- `pnpm typecheck` — clean.
- `pnpm biome check` on both changed files — clean.