### PR TITLE
Scale toast dismissal to reading time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Toasts stay up only as long as they take to read.** Every notification held the screen for a fixed five seconds after Chester finished typing it — a long wait for "Saved", and a short one for a paragraph of error text. The wait is now worked out from the message itself: a moment to notice it, plus reading time for what it says. Warnings and errors are held longer, a toast with a button on it gets time to press it, and there is a ceiling so nothing camps on the screen.
+
 - **The search page names the community it is searching, and every tab stays open.** The heading said only "Search"; it now says which community the results come from. Tabs with nothing behind them were greyed out, so you could not check an empty tab for yourself or return to one once a changed query filled it — every tab is now reachable and an empty one says nothing matched. Finding out which tabs to grey out cost two extra searches per query, which are gone with it.
 
 - **Search moved into the sidebar.** The search button sat in the tab strip above the page, where it read as one more tab. It is now a search field under the community name in the sidebar, labelled with the community it searches and showing the ⌘K / Ctrl+K shortcut. The recents strip is now only recents, and disappears when there are none.

--- a/frontend/src/lib/chesterToast.test.ts
+++ b/frontend/src/lib/chesterToast.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChesterToastType } from "./chesterToast";
+import { computeAutoClose } from "./chesterToast";
+
+const TYPE_SPEED = 20;
+
+/** What the reader actually experiences: the typing animation plus the dwell after it. */
+const totalOnScreen = (message: string, type: ChesterToastType, hasAction = false) =>
+  message.length * TYPE_SPEED + computeAutoClose(message, type, TYPE_SPEED, hasAction);
+
+describe("computeAutoClose", () => {
+  it("holds a short toast for the per-type floor", () => {
+    expect(totalOnScreen("Saved", "success")).toBe(3_000);
+  });
+
+  it("scales with message length", () => {
+    expect(totalOnScreen("Task created".repeat(8), "default")).toBeGreaterThan(
+      totalOnScreen("Task created", "default")
+    );
+  });
+
+  it("gives warnings and errors a longer floor than neutral toasts", () => {
+    expect(totalOnScreen("Nope", "warning")).toBeGreaterThan(totalOnScreen("Nope", "info"));
+    expect(totalOnScreen("Nope", "error")).toBeGreaterThan(totalOnScreen("Nope", "warning"));
+  });
+
+  it("adds time when the toast has an action to click", () => {
+    const message = "Project archived. It can be restored from the trash at any time.";
+    expect(totalOnScreen(message, "success", true)).toBe(totalOnScreen(message, "success") + 2_000);
+  });
+
+  it("caps the reading budget so a long message does not camp on screen", () => {
+    // With no typing animation the dwell is the whole budget, which is clamped.
+    expect(computeAutoClose("x".repeat(400), "default", 0, false)).toBe(10_000);
+  });
+
+  it("always leaves a dwell after typing finishes", () => {
+    // Typing alone (600 chars × 20ms) already outruns the budget.
+    expect(computeAutoClose("x".repeat(600), "default", TYPE_SPEED, false)).toBe(1_200);
+  });
+
+  it("is shorter than the old fixed 5s dwell for a typical toast", () => {
+    expect(computeAutoClose("Task created", "success", TYPE_SPEED, false)).toBeLessThan(5_000);
+  });
+});

--- a/frontend/src/lib/chesterToast.ts
+++ b/frontend/src/lib/chesterToast.ts
@@ -59,17 +59,61 @@ const ROBOT_TYPE_BY_TYPE: Record<ChesterToastType, RobotToastType> = {
   loading: "info",
 };
 
+/**
+ * Auto-dismiss timing.
+ *
+ * robot-toast only starts its auto-close timer once the typewriter animation
+ * finishes, so `autoClose` is the dwell time *after* the message is fully on
+ * screen — not the total time it is visible. We budget a total reading time
+ * from the content and hand robot-toast whatever is left once typing is done.
+ *
+ * The budget is a fixed cost for noticing the toast plus a per-character
+ * reading allowance (50ms/char, roughly 240 wpm), clamped so short messages
+ * still linger long enough to register and long ones don't camp on screen.
+ */
+const NOTICE_MS = 1_200;
+const MS_PER_CHAR = 50;
+const MAX_TOTAL_MS = 10_000;
+/** Extra budget when the toast carries a button the reader may want to press. */
+const ACTION_MS = 2_000;
+/** Never leave less than this much time after the message finishes typing. */
+const MIN_DWELL_MS = 1_200;
+/** Floor on total on-screen time, per type — warnings and errors sit longer. */
+const MIN_TOTAL_MS_BY_TYPE: Record<ChesterToastType, number> = {
+  default: 3_000,
+  success: 3_000,
+  info: 3_000,
+  loading: 3_000,
+  warning: 4_500,
+  error: 5_000,
+};
+
+/** Dwell time (ms) to hand robot-toast for a message it will type at `typeSpeed`. */
+const computeAutoClose = (
+  message: string,
+  type: ChesterToastType,
+  typeSpeed: number,
+  hasAction: boolean
+): number => {
+  const budget = NOTICE_MS + message.length * MS_PER_CHAR + (hasAction ? ACTION_MS : 0);
+  const total = Math.min(Math.max(budget, MIN_TOTAL_MS_BY_TYPE[type]), MAX_TOTAL_MS);
+  const typingMs = message.length * typeSpeed;
+  return Math.max(total - typingMs, MIN_DWELL_MS);
+};
+
 const buildInput = (
   message: string,
   type: ChesterToastType,
   opts?: ChesterToastOptions
 ): RobotToastOptions => {
+  const text = opts?.description ? `${message}\n${opts.description}` : message;
+  const typeSpeed = opts?.typeSpeed ?? 20;
   const input: RobotToastOptions = {
-    message: opts?.description ? `${message}\n${opts.description}` : message,
+    message: text,
     type: ROBOT_TYPE_BY_TYPE[type],
     robotVariant: opts?.robotVariant ?? VARIANT_BY_TYPE[type],
     position: opts?.position ?? "bottom-center",
-    typeSpeed: opts?.typeSpeed ?? 20,
+    typeSpeed,
     // Cap how many toasts are visible at once; the rest queue and appear as
     // slots free up (robot-toast reads this per call, falling back to its
     // unlimited default otherwise).
@@ -77,6 +121,8 @@ const buildInput = (
   };
   if (opts?.duration !== undefined) {
     input.autoClose = Number.isFinite(opts.duration) ? opts.duration : false;
+  } else {
+    input.autoClose = computeAutoClose(text, type, typeSpeed, Boolean(opts?.action));
   }
   if (opts?.action) {
     input.buttons = [{ label: opts.action.label, onClick: opts.action.onClick }];
@@ -166,4 +212,5 @@ toast.promise = async <T>(
   }
 };
 
-export { toast };
+export type { ChesterToastOptions, ChesterToastType };
+export { computeAutoClose, toast };


### PR DESCRIPTION
## Problem

Toasts overstay. [chesterToast.ts](frontend/src/lib/chesterToast.ts) never set `autoClose`, so every toast fell through to robot-toast's fixed 5000ms default — and that timer only starts in `afterTypingComplete()`, once the typewriter animation has finished. Real screen time was therefore `chars × typeSpeed + 5000ms` regardless of content: "Saved" held the screen for 5.1s, while a paragraph-long error got the same 5s of reading time as a two-word one.

Closes task #2743 ("Tune chester toast timing").

## Changes

- Add `computeAutoClose(message, type, typeSpeed, hasAction)` to [chesterToast.ts](frontend/src/lib/chesterToast.ts): budget a total on-screen time from the content, then hand robot-toast what is left after the typing animation.
  - 1200ms to notice the toast + 50ms/char reading allowance (~240 wpm)
  - per-type floors — 3000ms default/success/info, 4500ms warning, 5000ms error
  - +2000ms when the toast carries an action button
  - 10s ceiling on the budget, and a 1200ms minimum dwell after typing so long messages still get a beat
- Count the `description` line toward the budget, and read `typeSpeed` once instead of duplicating the default.
- An explicit `duration` option still wins; `toast.loading` / `toast.promise` loading toasts stay open as before.
- New [chesterToast.test.ts](frontend/src/lib/chesterToast.test.ts) covering the floors, the length scaling, the action bonus, the ceiling and the minimum dwell.

Resulting screen time: `"Saved"` 5.1s → 3.0s, `"Task created"` 5.2s → 3.0s, a 60-char sentence 6.2s → 4.2s, a 200-char error 9.0s → 10.0s (deliberately longer — it is the one you actually need to read).

## Testing

- `cd frontend && pnpm vitest run src/lib/chesterToast.test.ts` — 7 passed
- `cd frontend && ./scripts/test-changed.sh` — 179 files, 2078 tests passed
- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check src/lib/chesterToast.ts src/lib/chesterToast.test.ts` — clean
- Manual: Settings › Branding › Chester playground fires one toast of each type through the defaults.