### PR TITLE
Contain markdown overflow on kanban cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Search now reaches everything in a community, and reads inside it.** Search was a fuzzy match over the names already loaded in the browser, so it found only what the page had fetched, and only by title. There is now a community-wide index behind ⌘K and a results page of its own: projects, tasks, documents, queues and their items, counter groups and counters, calendars and events, dashboards, and tags — matched on names, on descriptions, and on the text inside a document, including the labels on a whiteboard, the cells of a spreadsheet, and where a linked page points. Results are ranked, show the line that matched, and go straight to the thing they found; they open on Tools, with Tags a tab away, so one kind cannot crowd out the rest. Every tool's own filter box reads the same index, so page four of a community's projects is now reachable from the search box, and nothing is ever returned that you could not already open.
 
 - **The statuses an initiative uses can now be read in one request.** Status columns belong to a project, so anything working across a whole initiative had to ask project by project and stitch the answers together. There is now a single read that returns the distinct columns across the projects you can see, each carrying how many of those projects use it — enough for a picker to say a status covers three of your four projects rather than implying it covers them all.
-
 ### Changed
 
 - **Toasts stay up only as long as they take to read.** Every notification held the screen for a fixed five seconds after Chester finished typing it — a long wait for "Saved", and a short one for a paragraph of error text. The wait is now worked out from the message itself: a moment to notice it, plus reading time for what it says. Warnings and errors are held longer, a toast with a button on it gets time to press it, and there is a ceiling so nothing camps on the screen.
@@ -42,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A new install's first community is now called "Primary Community".** It was still called "Primary Guild" — the one place the old word survived the rename. Existing communities are untouched; this only changes what a fresh install starts with.
 
 ### Fixed
+
+- **A task description with a code block no longer stretches its board card out of the column.** Code fences, tables, images and unbroken strings were rendered at whatever width they wanted, so one task with a snippet in its description pushed its card past the edge of the column and left the whole board scrolling sideways. Code now wraps, wide tables and images stay inside the card, and a long title breaks rather than pushing. The same containment applies everywhere a description is rendered, so the task detail page and the hover preview get it too — and code blocks and inline code now read as code, on a tinted, rounded background.
 
 - **Renaming a spreadsheet sheet keeps what you type.** The tab's rename box re-selected the whole name after every keystroke, so each new character wiped out the one before it and the sheet ended up named after the last letter typed. The name is now selected once when the box opens, as intended, and typing behaves normally from there.
 

--- a/frontend/src/components/Markdown.test.tsx
+++ b/frontend/src/components/Markdown.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Markdown } from "./Markdown";
+
+/** The wrapper the classes that keep content inside its container live on. */
+const root = (container: HTMLElement) => container.firstElementChild as HTMLElement;
+
+describe("Markdown", () => {
+  it("renders nothing for empty content", () => {
+    const { container } = render(<Markdown content="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("wraps code fences instead of letting them widen the container", () => {
+    const { container } = render(
+      <Markdown content={"```\nconst averyveryverylongidentifierwithnospaces = 1;\n```"} />
+    );
+
+    const classes = root(container).className;
+    expect(classes).toContain("[&_pre]:whitespace-pre-wrap");
+    expect(classes).toContain("[&_pre]:wrap-break-word");
+    expect(classes).toContain("[&_pre]:max-w-full");
+    expect(classes).toContain("[&_pre]:overflow-x-auto");
+    expect(container.querySelector("pre")).not.toBeNull();
+  });
+
+  it("breaks long inline code, links and prose", () => {
+    const { container } = render(<Markdown content="`inline` and text" />);
+
+    const classes = root(container).className;
+    expect(classes).toContain("wrap-break-word");
+    expect(classes).toContain("[&_code]:wrap-break-word");
+    expect(classes).toContain("[&_a]:break-all");
+    expect(classes).toContain("[&_img]:max-w-full");
+  });
+
+  it("scrolls a wide table instead of widening the container", () => {
+    const { container } = render(<Markdown content={"| a | b |\n| - | - |\n| 1 | 2 |"} />);
+
+    const classes = root(container).className;
+    expect(classes).toContain("[&_table]:overflow-x-auto");
+    expect(classes).toContain("[&_table]:max-w-full");
+    expect(container.querySelector("table")).not.toBeNull();
+  });
+
+  it("keeps the caller's classes alongside the defaults", () => {
+    const { container } = render(<Markdown content="hello" className="line-clamp-2" />);
+
+    expect(root(container).className).toContain("line-clamp-2");
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("does not leak the hast node onto rendered elements", () => {
+    const { container } = render(<Markdown content="[link](https://example.com)" />);
+
+    const anchor = container.querySelector("a");
+    expect(anchor?.getAttribute("node")).toBeNull();
+  });
+});

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import type { AnchorHTMLAttributes, MouseEvent } from "react";
+import type { ComponentPropsWithoutRef, MouseEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
@@ -9,6 +9,14 @@ interface MarkdownProps {
   content: string;
   className?: string;
 }
+
+/** Anything that can be wider than its container is wrapped or scrolled here,
+ *  so rendered markdown never stretches the card or panel it sits in. */
+const CONTAINMENT_CLASS =
+  "wrap-break-word [&_a]:break-all [&_code]:wrap-break-word [&_img]:h-auto [&_img]:max-w-full [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_pre]:whitespace-pre-wrap [&_pre]:wrap-break-word [&_table]:block [&_table]:w-fit [&_table]:max-w-full [&_table]:overflow-x-auto";
+
+const PROSE_CLASS =
+  "space-y-3 text-muted-foreground text-sm **:leading-relaxed [&_a:hover]:underline [&_a]:text-primary [&_blockquote]:border-muted-foreground/30 [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs [&_h1]:mt-4 [&_h1]:font-semibold [&_h1]:text-xl [&_h2]:mt-3 [&_h2]:font-semibold [&_h2]:text-lg [&_h3]:mt-3 [&_h3]:font-semibold [&_h3]:text-base [&_h4]:mt-2 [&_h4]:font-semibold [&_h4]:text-sm [&_h5]:mt-2 [&_h5]:font-medium [&_h5]:text-sm [&_h6]:mt-2 [&_h6]:font-semibold [&_h6]:text-xs [&_hr]:border-border [&_li]:mt-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-inherit [&_strong]:font-semibold [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_th]:font-semibold [&_ul]:list-disc [&_ul]:pl-6";
 
 function handleHashClick(e: MouseEvent<HTMLAnchorElement>) {
   const href = e.currentTarget.getAttribute("href");
@@ -36,7 +44,11 @@ function handleHashClick(e: MouseEvent<HTMLAnchorElement>) {
   }
 }
 
-function MarkdownAnchor({ href, children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) {
+// react-markdown hands every custom component the hast `node`, which is not a
+// DOM attribute — it is dropped before the rest of the props reach the element.
+type AnchorProps = ComponentPropsWithoutRef<"a"> & { node?: unknown };
+
+function MarkdownAnchor({ node: _node, href, children, ...props }: AnchorProps) {
   if (href?.startsWith("#")) {
     return (
       <a href={href} onClick={handleHashClick} {...props}>
@@ -56,12 +68,7 @@ export const Markdown = ({ content, className }: MarkdownProps) => {
     return null;
   }
   return (
-    <div
-      className={cn(
-        "wrap-break-word space-y-3 text-muted-foreground text-sm **:leading-relaxed [&_a:hover]:underline [&_a]:break-all [&_a]:text-primary [&_h1]:mt-4 [&_h1]:font-semibold [&_h1]:text-xl [&_h2]:mt-3 [&_h2]:font-semibold [&_h2]:text-lg [&_h3]:mt-3 [&_h3]:font-semibold [&_h3]:text-base [&_h4]:mt-2 [&_h4]:font-semibold [&_h4]:text-sm [&_h5]:mt-2 [&_h5]:font-medium [&_h5]:text-sm [&_h6]:mt-2 [&_h6]:font-semibold [&_h6]:text-xs [&_li]:mt-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-6",
-        className
-      )}
-    >
+    <div className={cn(CONTAINMENT_CLASS, PROSE_CLASS, className)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeSlug]}

--- a/frontend/src/components/projects/KanbanColumn.tsx
+++ b/frontend/src/components/projects/KanbanColumn.tsx
@@ -338,15 +338,15 @@ const KanbanCardContent = memo(
           }}
           onMouseEnter={handlePrefetch}
           disabled={!canOpenTask}
-          className={`flex w-full flex-col items-start gap-1 text-left ${
+          className={`flex w-full min-w-0 flex-col items-start gap-1 text-left ${
             canOpenTask ? "" : "cursor-not-allowed opacity-70"
           }`}
         >
-          <p className="font-medium">{task.title}</p>
+          <p className="wrap-break-word w-full min-w-0 font-medium">{task.title}</p>
           {task.description ? (
-            <Markdown content={task.description} className="line-clamp-2" />
+            <Markdown content={task.description} className="line-clamp-2 w-full min-w-0" />
           ) : null}
-          <div className="space-y-1 text-muted-foreground text-xs">
+          <div className="wrap-break-word w-full min-w-0 space-y-1 text-muted-foreground text-xs">
             {task.assignees.length > 0 ? (
               <TaskAssigneeList assignees={task.assignees} className="text-xs" />
             ) : null}
@@ -356,7 +356,7 @@ const KanbanCardContent = memo(
           </div>
           <TaskChecklistProgress progress={task.subtask_progress} className="w-full pt-1" />
         </button>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex min-w-0 flex-wrap gap-2">
           <Badge variant={priorityVariant[task.priority]}>
             {t("kanban.priority", { priority: task.priority.replace("_", " ") })}
           </Badge>
@@ -498,50 +498,17 @@ const KanbanTaskCard = ({
   onTaskClick,
   canOpenTask,
 }: KanbanTaskCardProps) => {
-  const { t } = useTranslation(["projects", "dates"]);
-  const router = useRouter();
-  const gp = useGuildPath();
-  const { activeGuildId } = useGuilds();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task.id.toString(),
     data: { type: "task", statusId: task.task_status_id },
     disabled: !canWrite,
   });
 
-  const handlePrefetch = () => {
-    if (canOpenTask && activeGuildId && task.initiative_id != null) {
-      router.preloadRoute({
-        to: "/c/$guildId/i/$initiativeId/projects/$projectId/tasks/$taskId",
-        params: {
-          guildId: String(activeGuildId),
-          initiativeId: String(task.initiative_id),
-          projectId: String(task.project_id),
-          taskId: String(task.id),
-        },
-      });
-    }
-  };
-
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.25 : undefined,
   };
-
-  const recurrenceSummary = task.recurrence
-    ? summarizeRecurrence(
-        task.recurrence,
-        {
-          referenceDate: task.start_date || task.due_date,
-          strategy: task.recurrence_strategy,
-        },
-        t as TranslateFn
-      )
-    : null;
-  const recurrenceText = recurrenceSummary ? truncateText(recurrenceSummary, 80) : null;
-  const formattedStart = task.start_date ? new Date(task.start_date).toLocaleString() : null;
-  const formattedDue = task.due_date ? new Date(task.due_date).toLocaleString() : null;
-  const commentCount = task.comment_count ?? 0;
 
   return (
     <div
@@ -555,52 +522,12 @@ const KanbanTaskCard = ({
       )}
       data-kanban-scroll-lock="true"
     >
-      <button
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          if (!canOpenTask) {
-            return;
-          }
-          onTaskClick(task.id);
-        }}
-        onMouseEnter={handlePrefetch}
-        disabled={!canOpenTask}
-        className={`flex w-full flex-col items-start gap-1 text-left ${
-          canOpenTask ? "" : "cursor-not-allowed opacity-70"
-        }`}
-      >
-        <p className="font-medium">{task.title}</p>
-        {task.description ? <Markdown content={task.description} className="line-clamp-2" /> : null}
-        <div className="space-y-1 text-muted-foreground text-xs">
-          {task.assignees.length > 0 ? (
-            <TaskAssigneeList assignees={task.assignees} className="text-xs" />
-          ) : null}
-          {formattedStart ? <p>{t("kanban.starts", { date: formattedStart })}</p> : null}
-          {formattedDue ? <p>{t("kanban.due", { date: formattedDue })}</p> : null}
-          {recurrenceText ? <p>{recurrenceText}</p> : null}
-        </div>
-        <TaskChecklistProgress progress={task.subtask_progress} className="w-full pt-1" />
-      </button>
-      <div className="flex flex-wrap gap-2">
-        <Badge variant={priorityVariant[task.priority]}>
-          {t("kanban.priority", { priority: task.priority.replace("_", " ") })}
-        </Badge>
-        {commentCount > 0 ? (
-          <Badge variant="outline" className="inline-flex items-center gap-1 text-xs">
-            <MessageSquare className="h-3.5 w-3.5" aria-hidden="true" />
-            {commentCount}
-          </Badge>
-        ) : null}
-        {task.tags &&
-          task.tags.length > 0 &&
-          task.tags.map((tag) => (
-            <TagBadge key={tag.id} tag={tag} size="sm" to={gp(`/tags/${tag.id}`)} />
-          ))}
-        {nonEmptyPropertySummaries(task.properties).map((summary) => (
-          <PropertyValueCell key={summary.property_id} summary={summary} variant="chip" />
-        ))}
-      </div>
+      <KanbanCardContent
+        task={task}
+        priorityVariant={priorityVariant}
+        onTaskClick={onTaskClick}
+        canOpenTask={canOpenTask}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Problem

A task description containing a code fence stretched its board card past the edge of the column, leaving the whole board scrolling sideways. (Task #2744.)

Two causes compounded:

1. [Markdown.tsx](frontend/src/components/Markdown.tsx) set `overflow-wrap` on its wrapper but nothing on the elements that ignore it — a `<pre>` defaults to `white-space: pre` and never wraps, and tables and images size to their content — so the rendered block had a min-content width wider than the card.
2. In [KanbanColumn.tsx](frontend/src/components/projects/KanbanColumn.tsx) the card's inner button is a column flex container with `items-start`, so its children shrink-to-fit, and that floors at min-content. The oversized block therefore widened the card itself, and the column's `overflow-y-auto` (which computes `overflow-x` to `auto`) turned that into a sideways-scrolling board.

## Changes

- **[Markdown.tsx](frontend/src/components/Markdown.tsx)** — split the class blob into a containment set and a prose set. `pre` gets `whitespace-pre-wrap` + `wrap-break-word` + `max-w-full` + `overflow-x-auto` (wrap first; scroll only for a token with nowhere to break), tables get `block w-fit max-w-full overflow-x-auto`, images `max-w-full h-auto`, inline code `wrap-break-word`. The prose half deliberately mirrors the class list already in [CommentContent.tsx](frontend/src/components/comments/CommentContent.tsx) so the two markdown renderers look the same — code blocks and inline code in a description previously had no background or padding at all.
- **[Markdown.tsx](frontend/src/components/Markdown.tsx)** — drop react-markdown's `node` prop before spreading onto the `<a>`; it was being forwarded to the DOM. Matches the `node: _node` pattern `CommentContent` already uses.
- **[KanbanColumn.tsx](frontend/src/components/projects/KanbanColumn.tsx)** — `w-full min-w-0` on the card's title, description and meta block so nothing can push the card wider, plus `wrap-break-word` on the title for long unbroken strings.
- **[KanbanColumn.tsx](frontend/src/components/projects/KanbanColumn.tsx)** — `KanbanTaskCard` (the non-virtualized path) held a ~90-line copy of the card body that `KanbanCardContent` already rendered, so this fix had to be written twice. It now renders `KanbanCardContent`, like the virtualized cards do.
- **[Markdown.test.tsx](frontend/src/components/Markdown.test.tsx)** — new: containment rules, caller `className` passthrough, empty content, and the `node` leak.

Containment applies wherever `Markdown` is used, so the task detail page, project overview, initiative description and the task hover preview get it too.

## Testing

- `pnpm typecheck` — clean
- `pnpm biome check src/components/Markdown.tsx src/components/Markdown.test.tsx src/components/projects/KanbanColumn.tsx` — clean
- `./scripts/test-changed.sh` — 181 files / 2086 tests passed
- `pnpm build` — succeeded; grepped the built CSS to confirm Tailwind actually emitted the arbitrary variants (`[&_pre]:whitespace-pre-wrap`, `[&_table]:overflow-x-auto`, …) rather than silently dropping them

**Not covered by tests:** there is no Playwright/Puppeteer in this repo and jsdom does no layout, so the tests assert the rules are applied, not the resulting pixel widths. Manual check — put this in a task description and view the board; before, it blew the column open:

````
```
const aVeryLongIdentifierThatWillNeverWrapOnItsOwnBecauseItHasNoSpaces = someValue;
```
````

## Note on one judgement call

Code fences **wrap** rather than scrolling horizontally, per the task's wording ("ensure code blocks and other md elements wrap correctly"). That also applies on the task detail page, where GitHub-style horizontal scroll is the more common convention. If scroll is preferred there, it's a one-class change (drop `[&_pre]:whitespace-pre-wrap`) — the card preview would then rely on `overflow-x-auto` alone.
