### PR TITLE
Make editor toolbars opaque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Open tabs no longer flicker when you switch community.** The recents bar lists tabs from every community you are in, but switching community threw its contents away and fetched them again, blanking the bar for a moment each time. It now stays put — there is nothing about it that a switch changes.
 
+- **Document text no longer shows through the editor's toolbars.** The formatting bar at the top and the actions bar at the bottom stay in place while a document scrolls, but their background was barely tinted glass, so headings and paragraphs slid visibly underneath them and the buttons became hard to read. Both bars are now solid.
+
 ## [0.64.3] - 2026-08-30
 
 - **Link to documentation for help not the github page.**

--- a/frontend/src/components/documents/editor/plugins.test.ts
+++ b/frontend/src/components/documents/editor/plugins.test.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGINS_SOURCE = fs.readFileSync(path.resolve(__dirname, "./plugins.tsx"), "utf-8");
+
+/**
+ * Every className string in the file that positions an element with `sticky`.
+ * These are the editor's toolbars and actions bar — they overlap the document
+ * as it scrolls, so their background has to be opaque.
+ */
+const stickyClassNames = (source: string): string[] =>
+  Array.from(source.matchAll(/className="([^"]*)"/g))
+    .map((match) => match[1])
+    .filter((classes) => /\bsticky\b/.test(classes));
+
+describe("editor toolbars", () => {
+  it("has sticky bars to check", () => {
+    expect(stickyClassNames(PLUGINS_SOURCE).length).toBeGreaterThan(0);
+  });
+
+  it.each(stickyClassNames(PLUGINS_SOURCE))("is opaque: %s", (classes) => {
+    const backgrounds = classes.split(/\s+/).filter((cls) => cls.startsWith("bg-"));
+
+    expect(backgrounds).not.toHaveLength(0);
+    // `bg-muted/20` and friends let the scrolled content show through.
+    expect(backgrounds.filter((cls) => cls.includes("/"))).toEqual([]);
+  });
+});

--- a/frontend/src/components/documents/editor/plugins.tsx
+++ b/frontend/src/components/documents/editor/plugins.tsx
@@ -120,7 +120,7 @@ export function Plugins({
           {({ blockType }) => (
             <>
               {/* Desktop toolbar - all options inline */}
-              <div className="vertical-align-middle sticky top-0 z-10 hidden flex-wrap items-center gap-2 overflow-auto border-b bg-muted/20 p-1 lg:flex">
+              <div className="vertical-align-middle sticky top-0 z-10 hidden flex-wrap items-center gap-2 overflow-auto border-b bg-muted p-1 lg:flex">
                 <HistoryToolbarPlugin />
                 <Separator orientation="vertical" className="h-7!" />
                 <BlockFormatDropDown>
@@ -162,7 +162,7 @@ export function Plugins({
               </div>
 
               {/* Compact toolbar - overflow menu */}
-              <div className="vertical-align-middle sticky top-0 z-10 flex items-center gap-2 border-b bg-muted/20 p-1 lg:hidden">
+              <div className="vertical-align-middle sticky top-0 z-10 flex items-center gap-2 border-b bg-muted p-1 lg:hidden">
                 <HistoryToolbarPlugin />
                 <Separator orientation="vertical" className="h-7!" />
                 <BlockFormatDropDown>
@@ -265,7 +265,7 @@ export function Plugins({
       </div>
       {showToolbar && (
         <ActionsPlugin>
-          <div className="sticky bottom-0 z-10 clear-both flex items-center justify-between gap-2 overflow-auto border-t bg-muted/20 p-1">
+          <div className="sticky bottom-0 z-10 clear-both flex items-center justify-between gap-2 overflow-auto border-t bg-muted p-1">
             <div className="flex flex-1 justify-start"></div>
             <div>
               <CounterCharacterPlugin charset="UTF-16" />


### PR DESCRIPTION
## Problem

The document editor's toolbars are `sticky` inside the editor's scrollport, but they were painted at `bg-muted/20` — 20% opacity over the editor's `bg-background`. Document text scrolled visibly underneath them and the toolbar buttons lost contrast against whatever happened to be passing behind.

Task: https://initiative.morels.me/c/3/i/5/projects/1/tasks/2749

## Changes

- [plugins.tsx](frontend/src/components/documents/editor/plugins.tsx) — the desktop toolbar (L123), the compact/mobile toolbar (L165) and the bottom actions bar (L268) go from `bg-muted/20` to `bg-muted`. Same token the design already picked, just opaque; it still reads as chrome in both light and dark.
- [plugins.test.ts](frontend/src/components/documents/editor/plugins.test.ts) — new source-level regression guard, in the same style as [locale-keys.test.ts](frontend/src/__tests__/locale-keys.test.ts): every `className` in that file containing `sticky` must carry a `bg-*` class with no `/opacity` modifier. Covers all three bars and fails on the previous state.
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Fixed`.

Out of scope, deliberately: the floating text-format toolbar and floating link editor are already `bg-background`, so nothing was needed there. The spreadsheet toolbar and sheet tabs also use `bg-muted/20`, but they are `shrink-0` flex siblings rather than sticky overlays — nothing scrolls behind them, and they are not Lexical toolbars.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check src/components/documents/editor` — clean (4 files)
- `cd frontend && ./scripts/test-changed.sh` — 183 files / 2101 tests passed
- `cd frontend && pnpm vitest run src/components/documents/editor/plugins.test.ts` — 4 tests passed