### PR TITLE
Move secondary task actions into overflow menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A task's editor ends in two buttons, not six.** Save, cancel, move to project, duplicate, archive and delete all sat in one row at the foot of the task editor, so the action you almost always want looked exactly like the ones you almost never do — and delete sat two buttons from save. Save and cancel keep their place; move, duplicate, archive and delete moved behind a single "…" menu at the end of the row, with delete set apart below a divider.
+
 - **"Browse the marketplace" is out of the overflow menu.** Adding a ready-made dashboard is the same kind of answer as making one from scratch, but only one of the two was on the page — the other sat behind the "…" button, where someone who has never opened it never learns the shelf exists. It now sits next to the create button on the dashboards list, at every width, and beside "Create your first dashboard" in an initiative that has none yet.
 
 - **Toasts stay up only as long as they take to read.** Every notification held the screen for a fixed five seconds after Chester finished typing it — a long wait for "Saved", and a short one for a paragraph of error text. The wait is now worked out from the message itself: a moment to notice it, plus reading time for what it says. Warnings and errors are held longer, a toast with a button on it gets time to press it, and there is a ceiling so nothing camps on the screen.

--- a/frontend/src/pages/TaskEditPage.test.tsx
+++ b/frontend/src/pages/TaskEditPage.test.tsx
@@ -1,12 +1,13 @@
 /**
- * Where deleting a task leaves you.
+ * The task editor's action row: what it offers, and where deleting leaves you.
  *
  * Deleting from a task's page used to drop you at the initiative's projects
  * list — one step further out than you asked to go, and away from the sibling
  * tasks you were most likely working through. It now returns to the project
  * the task belonged to.
  */
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
@@ -61,12 +62,43 @@ const renderTaskPage = ({ taskProjectId = PROJECT_ID }: { taskProjectId?: number
 };
 
 describe("TaskEditPage", () => {
+  const openActionsMenu = async () =>
+    userEvent.click(await screen.findByRole("button", { name: /more actions/i }));
+
   const deleteTheTask = async () => {
-    fireEvent.click(await screen.findByRole("button", { name: /delete task/i }));
+    await openActionsMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: /delete task/i }));
     // The confirm dialog repeats the label; the last match is its button.
     const confirms = await screen.findAllByRole("button", { name: /delete/i });
-    fireEvent.click(confirms[confirms.length - 1]);
+    await userEvent.click(confirms[confirms.length - 1]);
   };
+
+  it("keeps only save and cancel in the row, with the rest behind one menu", async () => {
+    renderTaskPage();
+
+    // Save and cancel are the row; the other four actions used to sit beside
+    // them as buttons and now only exist inside the overflow menu.
+    expect(await screen.findByRole("button", { name: /save task/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    for (const name of [/move to project/i, /duplicate task/i, /archive/i, /delete task/i]) {
+      expect(screen.queryByRole("button", { name })).not.toBeInTheDocument();
+    }
+
+    await openActionsMenu();
+
+    for (const name of [/move to project/i, /duplicate task/i, /archive/i, /delete task/i]) {
+      expect(await screen.findByRole("menuitem", { name })).toBeInTheDocument();
+    }
+  });
+
+  it("opens the move dialog from the actions menu", async () => {
+    renderTaskPage();
+
+    await openActionsMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: /move to project/i }));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
 
   it("returns to the task's project after deleting it", async () => {
     const { router, deleted } = renderTaskPage();

--- a/frontend/src/pages/TaskEditPage.test.tsx
+++ b/frontend/src/pages/TaskEditPage.test.tsx
@@ -8,7 +8,7 @@
  */
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { HttpResponse } from "msw";
+import { delay, HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import { buildProject, buildTask } from "@/__tests__/factories";
@@ -89,6 +89,24 @@ describe("TaskEditPage", () => {
     for (const name of [/move to project/i, /duplicate task/i, /archive/i, /delete task/i]) {
       expect(await screen.findByRole("menuitem", { name })).toBeInTheDocument();
     }
+  });
+
+  it("reports duplicate progress on the trigger once the menu closes", async () => {
+    renderTaskPage();
+    server.use(
+      guildHttp.post("/tasks/:taskId/duplicate", async () => {
+        await delay("infinite");
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    await openActionsMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: /duplicate task/i }));
+
+    // Selecting the item dismisses the menu holding the "Duplicating…" label,
+    // and duplicate opens no dialog — so the trigger has to carry the state.
+    const trigger = await screen.findByRole("button", { name: /more actions/i });
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-busy", "true"));
   });
 
   it("opens the move dialog from the actions menu", async () => {

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -629,6 +629,10 @@ export const TaskEditPage = () => {
     taskStatuses.find((item) => item.id === effectiveStatusId) ??
     (task && task.task_status_id === effectiveStatusId ? task.task_status : null);
 
+  // Delete and move are excluded: their confirm/move dialogs stay open and
+  // already show the mutation's own loading state.
+  const menuActionPending = duplicateTask.isPending || toggleArchive.isPending;
+
   // Assemble the shared TaskForm value from the page's individual states. The
   // effective* fallbacks keep the form from flashing defaults during the
   // one-render gap between "task loaded" and "load effect ran".
@@ -830,14 +834,22 @@ export const TaskEditPage = () => {
                 {!isReadOnly ? (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
+                      {/* Duplicate and archive dismiss the menu that holds their
+                          own pending label, and neither opens a dialog to carry
+                          one, so the trigger reports their progress instead. */}
                       <Button
                         type="button"
                         variant="outline"
                         size="icon"
                         className="ml-auto"
                         aria-label={t("common:toolbar.moreActions")}
+                        aria-busy={menuActionPending}
                       >
-                        <MoreHorizontal className="h-4 w-4" />
+                        {menuActionPending ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <MoreHorizontal className="h-4 w-4" />
+                        )}
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -7,6 +7,7 @@ import {
   Copy,
   FolderInput,
   Loader2,
+  MoreHorizontal,
   Save,
   SearchX,
   ShieldAlert,
@@ -43,6 +44,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -796,7 +804,10 @@ export const TaskEditPage = () => {
                 recurrenceReferenceDate={dueDate || startDate || task?.due_date || task?.start_date}
               />
 
-              <div className="flex flex-wrap gap-3">
+              {/* Save and cancel are the only actions that earn a button here;
+                  everything else a task supports lives behind the overflow
+                  menu so the row stays readable at any width. */}
+              <div className="flex flex-wrap items-center gap-3">
                 <Button
                   type="submit"
                   disabled={updateTask.isPending || isReadOnly || datesInverted}
@@ -817,67 +828,67 @@ export const TaskEditPage = () => {
                   {t("common:cancel")}
                 </Button>
                 {!isReadOnly ? (
-                  <>
-                    <MoveTaskDialog
-                      trigger={
-                        <Button type="button" variant="secondary" disabled={moveTask.isPending}>
-                          <FolderInput className="h-4 w-4" />
-                          {t("edit.moveToProject")}
-                        </Button>
-                      }
-                      open={isMoveDialogOpen}
-                      onOpenChange={setIsMoveDialogOpen}
-                      projects={writableProjects}
-                      currentProjectId={task?.project_id ?? null}
-                      isLoading={writableProjectsQuery.isLoading}
-                      hasError={Boolean(writableProjectsQuery.isError)}
-                      isSaving={moveTask.isPending}
-                      onConfirm={handleMoveTask}
-                    />
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={() => {
-                        duplicateTask.mutate(parsedTaskId);
-                      }}
-                      disabled={duplicateTask.isPending}
-                    >
-                      <Copy className="h-4 w-4" />
-                      {duplicateTask.isPending ? t("edit.duplicating") : t("edit.duplicateTask")}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={() =>
-                        toggleArchive.mutate({
-                          taskId: parsedTaskId,
-                          data: { is_archived: !task?.is_archived } as never,
-                        })
-                      }
-                      disabled={toggleArchive.isPending}
-                    >
-                      {task?.is_archived ? (
-                        <>
-                          <ArchiveRestore className="h-4 w-4" />
-                          {toggleArchive.isPending ? t("edit.unarchiving") : t("edit.unarchive")}
-                        </>
-                      ) : (
-                        <>
-                          <Archive className="h-4 w-4" />
-                          {toggleArchive.isPending ? t("edit.archiving") : t("edit.archive")}
-                        </>
-                      )}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      onClick={() => setShowDeleteConfirm(true)}
-                      disabled={deleteTask.isPending}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      {deleteTask.isPending ? t("edit.deleting") : t("edit.deleteTask")}
-                    </Button>
-                  </>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="ml-auto"
+                        aria-label={t("common:toolbar.moreActions")}
+                      >
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        disabled={moveTask.isPending}
+                        onSelect={() => setIsMoveDialogOpen(true)}
+                      >
+                        <FolderInput className="h-4 w-4" />
+                        {t("edit.moveToProject")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        disabled={duplicateTask.isPending}
+                        onSelect={() => {
+                          duplicateTask.mutate(parsedTaskId);
+                        }}
+                      >
+                        <Copy className="h-4 w-4" />
+                        {duplicateTask.isPending ? t("edit.duplicating") : t("edit.duplicateTask")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        disabled={toggleArchive.isPending}
+                        onSelect={() =>
+                          toggleArchive.mutate({
+                            taskId: parsedTaskId,
+                            data: { is_archived: !task?.is_archived } as never,
+                          })
+                        }
+                      >
+                        {task?.is_archived ? (
+                          <>
+                            <ArchiveRestore className="h-4 w-4" />
+                            {toggleArchive.isPending ? t("edit.unarchiving") : t("edit.unarchive")}
+                          </>
+                        ) : (
+                          <>
+                            <Archive className="h-4 w-4" />
+                            {toggleArchive.isPending ? t("edit.archiving") : t("edit.archive")}
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        disabled={deleteTask.isPending}
+                        onSelect={() => setShowDeleteConfirm(true)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        {deleteTask.isPending ? t("edit.deleting") : t("edit.deleteTask")}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 ) : null}
               </div>
             </form>
@@ -908,6 +919,17 @@ export const TaskEditPage = () => {
         onCommentUpdated={handleCommentUpdated}
         canModerate={canModerateComments}
         initiativeId={projectQuery.data?.initiative_id ?? 0}
+      />
+
+      <MoveTaskDialog
+        open={isMoveDialogOpen}
+        onOpenChange={setIsMoveDialogOpen}
+        projects={writableProjects}
+        currentProjectId={task?.project_id ?? null}
+        isLoading={writableProjectsQuery.isLoading}
+        hasError={Boolean(writableProjectsQuery.isError)}
+        isSaving={moveTask.isPending}
+        onConfirm={handleMoveTask}
       />
 
       <ConfirmDialog


### PR DESCRIPTION
## Problem

The task editor ended in a flat row of six buttons — Save task, Cancel, Move to project, Duplicate task, Archive, Delete task. The action you almost always want looked exactly like the ones you almost never do, and Delete sat two buttons from Save.

## Changes

- [TaskEditPage.tsx](frontend/src/pages/TaskEditPage.tsx) — the row is now **Save task** + **Cancel**, plus a `…` trigger pushed right. Move to project, Duplicate task, Archive/Unarchive and Delete task moved into a `DropdownMenu`, with Delete below a `DropdownMenuSeparator` and styled `text-destructive focus:text-destructive` (matching [CounterRow.tsx](frontend/src/components/initiativeTools/counters/CounterRow.tsx) and [SpreadsheetSheetTabs.tsx](frontend/src/components/documents/spreadsheet/SpreadsheetSheetTabs.tsx)).
- Pending-state labels ("Duplicating…", "Archiving…", "Deleting…") and per-action disabling carry over unchanged onto the menu items.
- `MoveTaskDialog` drops its inline `trigger` (already an optional prop) and moves out of the `<form>` to sit with the page's other dialogs; it opens from the menu via the `isMoveDialogOpen` state that already existed.
- Read-only behaviour is unchanged — the whole menu is hidden, exactly as the four buttons were.
- This also brings the editor footer in line with the create dialog ([ProjectTaskComposer.tsx](frontend/src/components/projects/ProjectTaskComposer.tsx)), which has only Create + Cancel.

**No new i18n keys.** The trigger's `aria-label` reuses the existing `common:toolbar.moreActions`, which already ships de/es/fr translations.

## Testing

- `pnpm typecheck` — clean
- `pnpm biome check src/pages/TaskEditPage.tsx src/pages/TaskEditPage.test.tsx` — clean
- `pnpm vitest run src/pages/TaskEditPage.test.tsx` — 4 passed
- `./scripts/test-changed.sh` — 184 files, 2123 passed

[TaskEditPage.test.tsx](frontend/src/pages/TaskEditPage.test.tsx): the two existing delete-navigation tests clicked Delete as a `button`; their helper now opens the menu and clicks a `menuitem`. Added two tests — one asserting only Save/Cancel remain as buttons while all four secondary actions are reachable as menu items, one asserting the move dialog opens from the menu.

Task: https://initiative.morels.me/g/3/i/5/projects/1/tasks/2741