### PR TITLE
Public user profiles, with a status and a look

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The statuses an initiative uses can now be read in one request.** Status columns belong to a project, so anything working across a whole initiative had to ask project by project and stitch the answers together. There is now a single read that returns the distinct columns across the projects you can see, each carrying how many of those projects use it — enough for a picker to say a status covers three of your four projects rather than implying it covers them all.
 
+- **People have a profile page now.** Open someone from the member list or from a search result and you get their picture, their handle, whether they have Initiative open right now, and when they joined. A profile is public and the same page whoever opens it — it belongs to the person rather than to any one community.
+
+- **Set a status.** An emoji, a line about what you are up to, or both, under Settings › Profile — using the same picker the rest of the app uses. It shows on your profile.
+
+- **Dress your profile up.** A profile can wear a banner, a frame around the picture and a row of up to six badges, each picked from what you have: your library starts with the set that ships with Initiative, and marketplace packs will add to it. There is a picker per slot on Settings › Profile, so you can mix pieces from different packs freely. Decorations are chosen, never uploaded, so wearing one costs your community none of its storage.
+
 ### Changed
 
 - **"Browse the marketplace" is out of the overflow menu.** Adding a ready-made dashboard is the same kind of answer as making one from scratch, but only one of the two was on the page — the other sat behind the "…" button, where someone who has never opened it never learns the shelf exists. It now sits next to the create button on the dashboards list, at every width, and beside "Create your first dashboard" in an initiative that has none yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The statuses an initiative uses can now be read in one request.** Status columns belong to a project, so anything working across a whole initiative had to ask project by project and stitch the answers together. There is now a single read that returns the distinct columns across the projects you can see, each carrying how many of those projects use it — enough for a picker to say a status covers three of your four projects rather than implying it covers them all.
 
-- **People have a profile page now.** Open someone from the member list or from a search result and you get their picture, their handle, whether they have Initiative open right now, and when they joined. A profile is public and the same page whoever opens it — it belongs to the person rather than to any one community.
+- **People have a profile page now.** Open someone from the member list or from a search result and you get their picture, their handle, whether they have Initiative open right now, and when they joined. It lives at a link worth sharing — `/u/jordan1234`, your handle with its number run on the end — and it is public and the same page whoever opens it, because it belongs to the person rather than to any one community.
 
 - **Set a status.** An emoji, a line about what you are up to, or both, under Settings › Profile — using the same picker the rest of the app uses. It shows on your profile.
 

--- a/backend/alembic/versions/20260902_0212_user_profiles.py
+++ b/backend/alembic/versions/20260902_0212_user_profiles.py
@@ -1,10 +1,12 @@
 """Give an account a public face: a custom status, and a look to wear.
 
-Three columns on ``public.users``:
+Two JSONB columns on ``public.users``:
 
-* ``custom_status_emoji`` / ``custom_status_text`` — what the person is up to,
-  in their own words. Distinct from ``users.status``, which is the account's
-  standing and is not theirs to write.
+* ``custom_status`` — ``{"emoji": ..., "text": ...}``: what the person is up
+  to, in their own words. One column rather than two, because it is one thing
+  a person sets and one thing every surface that names them renders. Distinct
+  from ``users.status``, which is the account's standing and is not theirs to
+  write. Shape lives in ``app.schemas.platform.user.CustomStatus``.
 * ``profile_decorations`` — a banner, a frame and badges, each held as an
   **id naming a catalog entry** rather than an image. The client resolves an id
   to artwork it already ships, so a decorated profile takes up none of a
@@ -17,8 +19,8 @@ column list computed from the catalog at that revision, so a column added later
 is not in it. The new ones are named explicitly below — the own-row policies
 from 0202 still decide *whose* row they reach.
 
-Nothing to carry in: every row starts with no status and an empty look, from
-the server defaults.
+Nothing to carry in: every row starts with an empty status and an empty look,
+from the server defaults.
 
 Revision ID: 20260902_0212
 Revises: 20260902_0211
@@ -36,13 +38,16 @@ down_revision = "20260902_0211"
 branch_labels = None
 depends_on = None
 
-_COLUMNS = ("custom_status_emoji", "custom_status_text", "profile_decorations")
+_COLUMNS = ("custom_status", "profile_decorations")
 
 
-#: The request-path floors. ``app_user`` is the bare login role;
-#: ``app_guild_base`` is what every ``guild_<id>`` role inherits its
-#: shared-table access from; ``platform_base`` is the platform-tier floor.
 def _request_floors() -> tuple[str, ...]:
+    """The request-path floors.
+
+    ``app_user`` is the bare login role; ``app_guild_base`` is what every
+    ``guild_<id>`` role inherits its shared-table access from; ``platform_base``
+    is the platform-tier floor.
+    """
     return (
         "app_user",
         "app_guild_base",
@@ -51,23 +56,16 @@ def _request_floors() -> tuple[str, ...]:
 
 
 def upgrade() -> None:
-    op.add_column(
-        "users",
-        sa.Column("custom_status_emoji", sa.String(length=64), nullable=True),
-    )
-    op.add_column(
-        "users",
-        sa.Column("custom_status_text", sa.String(length=100), nullable=True),
-    )
-    op.add_column(
-        "users",
-        sa.Column(
-            "profile_decorations",
-            postgresql.JSONB(astext_type=sa.Text()),
-            nullable=False,
-            server_default=sa.text("'{}'::jsonb"),
-        ),
-    )
+    for column in _COLUMNS:
+        op.add_column(
+            "users",
+            sa.Column(
+                column,
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+        )
     columns = ", ".join(_COLUMNS)
     for role in _request_floors():
         op.execute(f'GRANT UPDATE ({columns}) ON TABLE public.users TO "{role}"')

--- a/backend/alembic/versions/20260902_0212_user_profiles.py
+++ b/backend/alembic/versions/20260902_0212_user_profiles.py
@@ -1,0 +1,79 @@
+"""Give an account a public face: a custom status, and a look to wear.
+
+Three columns on ``public.users``:
+
+* ``custom_status_emoji`` / ``custom_status_text`` — what the person is up to,
+  in their own words. Distinct from ``users.status``, which is the account's
+  standing and is not theirs to write.
+* ``profile_decorations`` — a banner, a frame and badges, each held as an
+  **id naming a catalog entry** rather than an image. The client resolves an id
+  to artwork it already ships, so a decorated profile takes up none of a
+  guild's upload allowance. An id this deployment doesn't know renders nothing,
+  which is what lets a profile keep wearing something the store stopped
+  offering. Shape lives in ``app.schemas.platform.user.ProfileDecorations``.
+
+0144 replaced the request path's table-wide UPDATE on ``public.users`` with a
+column list computed from the catalog at that revision, so a column added later
+is not in it. The new ones are named explicitly below — the own-row policies
+from 0202 still decide *whose* row they reach.
+
+Nothing to carry in: every row starts with no status and an empty look, from
+the server defaults.
+
+Revision ID: 20260902_0212
+Revises: 20260902_0211
+Create Date: 2026-09-02
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.core.config import settings
+
+revision = "20260902_0212"
+down_revision = "20260902_0211"
+branch_labels = None
+depends_on = None
+
+_COLUMNS = ("custom_status_emoji", "custom_status_text", "profile_decorations")
+
+
+#: The request-path floors. ``app_user`` is the bare login role;
+#: ``app_guild_base`` is what every ``guild_<id>`` role inherits its
+#: shared-table access from; ``platform_base`` is the platform-tier floor.
+def _request_floors() -> tuple[str, ...]:
+    return (
+        "app_user",
+        "app_guild_base",
+        f"{settings.PLATFORM_ROLE_PREFIX}platform_base",
+    )
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("custom_status_emoji", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("custom_status_text", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "profile_decorations",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    columns = ", ".join(_COLUMNS)
+    for role in _request_floors():
+        op.execute(f'GRANT UPDATE ({columns}) ON TABLE public.users TO "{role}"')
+
+
+def downgrade() -> None:
+    # Dropping the columns takes their column-level grants with them.
+    for column in _COLUMNS:
+        op.drop_column("users", column)

--- a/backend/alembic/versions/20260902_0213_user_decorations.py
+++ b/backend/alembic/versions/20260902_0213_user_decorations.py
@@ -1,0 +1,101 @@
+"""A person's decoration library.
+
+``public.user_decorations`` is what an account has **acquired** — one row per
+decoration, written when a marketplace pack is installed and removed when that
+pack goes. ``source`` names the pack so a set can be granted and revoked
+together while the account mixes decorations across packs freely.
+
+What ships with the app is deliberately NOT in here. Those are universal, so a
+row per account per decoration would be a fan-out over every user for something
+nobody chose — and another one every time the app ships a new default. They
+live in ``app.core.profile_decorations.SHIPPED_DECORATIONS`` and are unioned
+with this table by ``app.services.platform.profile_decorations``, which is the
+one place that answers "what may this person wear".
+
+Access shape:
+
+* **Your library is yours.** SELECT is scoped to the calling account's own
+  rows; nobody reads anyone else's. What another person may see of it is
+  already answered by the profile they are looking at, which carries only the
+  ids being worn.
+* **Grants are issued, not self-served.** The request path holds SELECT and no
+  write verb at all — INSERT/DELETE are the system engine's, which is what runs
+  a pack install. The grant layer says so as well as the policies do.
+
+The schema's default grants make every new ``public`` table writable by the
+routed base roles, so they are wound back explicitly before anything else.
+
+The table starts empty and nothing is carried into it, so the
+create-then-backfill-then-lock-down ordering a populated table needs does not
+apply here.
+
+Revision ID: 20260902_0213
+Revises: 20260902_0212
+Create Date: 2026-09-02
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260902_0213"
+down_revision = "20260902_0212"
+branch_labels = None
+depends_on = None
+
+
+# NULLIF-guarded: an unset context leaves the setting empty, and a bare
+# ''::int would raise and fault the whole query rather than fail the policy.
+_USER_ID = "NULLIF(current_setting('app.current_user_id', true), '')::int"
+
+
+def _request_roles() -> str:
+    base = f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+    return f'app_guild_base, "{base}", app_user'
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_decorations",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("decoration_id", sa.String(length=64), nullable=False),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("source", sa.String(length=120), nullable=True),
+        sa.Column("acquired_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "decoration_id"),
+    )
+    # Granting and revoking happen a pack at a time.
+    op.create_index(
+        "ix_user_decorations_source", "user_decorations", ["user_id", "source"]
+    )
+
+    request_roles = _request_roles()
+    statements = [
+        "ALTER TABLE public.user_decorations ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE public.user_decorations FORCE ROW LEVEL SECURITY",
+        f"REVOKE ALL ON TABLE public.user_decorations FROM {request_roles}",
+        "GRANT SELECT, INSERT, DELETE ON TABLE public.user_decorations TO app_admin",
+        # Read-only for the request path, and only your own rows. The bare
+        # login role is left out entirely: a library belongs to a signed-in
+        # account, and nothing is served before routing.
+        f"GRANT SELECT ON TABLE public.user_decorations TO app_guild_base, "
+        f'"{settings.PLATFORM_ROLE_PREFIX}platform_base"',
+        "DROP POLICY IF EXISTS user_decoration_self_read ON public.user_decorations",
+        "CREATE POLICY user_decoration_self_read ON public.user_decorations "
+        "AS PERMISSIVE FOR SELECT TO "
+        f'app_guild_base, "{settings.PLATFORM_ROLE_PREFIX}platform_base" '
+        f"USING (user_id = {_USER_ID})",
+    ]
+    for statement in statements:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS user_decoration_self_read ON public.user_decorations"
+    )
+    op.execute("ALTER TABLE public.user_decorations DISABLE ROW LEVEL SECURITY")
+    op.drop_index("ix_user_decorations_source", table_name="user_decorations")
+    op.drop_table("user_decorations")

--- a/backend/alembic/versions/20260902_0214_user_profile_view.py
+++ b/backend/alembic/versions/20260902_0214_user_profile_view.py
@@ -1,0 +1,97 @@
+"""Publish the public projection of ``public.users`` as a view.
+
+A profile is public — the handle, the face, the status, the look, the join
+date — and the rest of the row is not. ``public.users`` is own-row for a
+platform-tier session, so the row cannot be read whole on the request path,
+which left the choice of *which columns are public* to be made in Python.
+
+It is made in the catalog instead:
+
+* ``app_profile_reader`` is a NOLOGIN role holding **column-scoped** SELECT on
+  ``public.users`` — the eight public columns and no others — plus an all-rows
+  SELECT policy, because a profile is everyone's to read.
+* ``public.user_profiles`` is a view over those columns, owned by that role.
+  A view runs with its owner's privileges (``security_invoker`` is off by
+  default), so reading it yields those columns for any account and nothing
+  else. No role involved holds BYPASSRLS.
+* The request path is granted SELECT on the view and nothing more. The schema's
+  default privileges cover views as well as tables, so the write verbs they
+  would otherwise confer are wound back first.
+
+The endpoint then runs on an ordinary RLS-enforced platform-tier session.
+
+Revision ID: 20260902_0214
+Revises: 20260902_0213
+Create Date: 2026-09-02
+"""
+
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260902_0214"
+down_revision = "20260902_0213"
+branch_labels = None
+depends_on = None
+
+#: The reader role. Unprefixed, like the other cluster-wide base roles
+#: (``app_user``, ``app_admin``, ``app_guild_base``).
+READER = "app_profile_reader"
+
+#: What is public about an account. The view's column list and the reader's
+#: column grant are the same list, and it is the only place it is written.
+PUBLIC_COLUMNS = (
+    "id",
+    "username",
+    "discriminator",
+    "avatar_url",
+    "status",
+    "custom_status",
+    "profile_decorations",
+    "created_at",
+)
+
+
+def _platform_base() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+def upgrade() -> None:
+    columns = ", ".join(PUBLIC_COLUMNS)
+    base = _platform_base()
+    statements = [
+        f"""
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{READER}') THEN
+                CREATE ROLE "{READER}" NOLOGIN;
+            END IF;
+        END $$;
+        """,
+        # The reader sees these columns of every row, and nothing else of any.
+        f"GRANT USAGE ON SCHEMA public TO {READER}",
+        f"GRANT SELECT ({columns}) ON TABLE public.users TO {READER}",
+        "DROP POLICY IF EXISTS users_profile_read ON public.users",
+        f"CREATE POLICY users_profile_read ON public.users "
+        f"AS PERMISSIVE FOR SELECT TO {READER} USING (true)",
+        f"CREATE OR REPLACE VIEW public.user_profiles AS "
+        f"SELECT {columns} FROM public.users",
+        f"ALTER VIEW public.user_profiles OWNER TO {READER}",
+        # Default privileges in this schema cover views too, so the write verbs
+        # they grant are taken back before the read is given.
+        f'REVOKE ALL ON public.user_profiles FROM app_guild_base, "{base}", app_user',
+        f'GRANT SELECT ON public.user_profiles TO "{base}"',
+    ]
+    for statement in statements:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    statements = [
+        "DROP VIEW IF EXISTS public.user_profiles",
+        "DROP POLICY IF EXISTS users_profile_read ON public.users",
+        f"REVOKE ALL ON TABLE public.users FROM {READER}",
+        f"REVOKE USAGE ON SCHEMA public FROM {READER}",
+        f'DROP ROLE IF EXISTS "{READER}"',
+    ]
+    for statement in statements:
+        op.execute(statement)

--- a/backend/alembic/versions/20260902_0214_user_profile_view.py
+++ b/backend/alembic/versions/20260902_0214_user_profile_view.py
@@ -67,6 +67,12 @@ def upgrade() -> None:
             END IF;
         END $$;
         """,
+        # Handing an object to a role means being able to become it, and then
+        # acting as it to set the object's own grants. A CREATEROLE role gets
+        # ADMIN on a role it creates but neither SET nor INHERIT, so
+        # ``app_provisioner`` is given both explicitly — migrations run as that
+        # role, not as a superuser. (Postgres 16+ syntax; this project runs 17.)
+        f'GRANT "{READER}" TO CURRENT_USER WITH INHERIT TRUE, SET TRUE',
         # The reader sees these columns of every row, and nothing else of any.
         f"GRANT USAGE ON SCHEMA public TO {READER}",
         f"GRANT SELECT ({columns}) ON TABLE public.users TO {READER}",
@@ -75,7 +81,12 @@ def upgrade() -> None:
         f"AS PERMISSIVE FOR SELECT TO {READER} USING (true)",
         f"CREATE OR REPLACE VIEW public.user_profiles AS "
         f"SELECT {columns} FROM public.users",
+        # Ownership can only be handed to a role that may create in the schema.
+        # Given for the assignment and taken straight back: the reader creates
+        # nothing, it only reads.
+        f"GRANT CREATE ON SCHEMA public TO {READER}",
         f"ALTER VIEW public.user_profiles OWNER TO {READER}",
+        f"REVOKE CREATE ON SCHEMA public FROM {READER}",
         # Default privileges in this schema cover views too, so the write verbs
         # they grant are taken back before the read is given.
         f'REVOKE ALL ON public.user_profiles FROM app_guild_base, "{base}", app_user',

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -56,6 +56,8 @@ from app.models.platform.user import User, UserStatus
 from app.models.tenant.reaction_digest import ReactionDigestItem
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.schemas.platform.user import (
+    OwnedDecorationsResponse,
+    ProfileDecorations,
     UsernameClaim,
     UserGuildMember,
     UserProfile,
@@ -96,6 +98,7 @@ from app.services.realtime import manager as realtime_manager
 from app.services.stream_authz import authority as stream_authority
 from app.models.platform.user_avatar import AVATAR_MAX_BYTES
 from app.services.platform import user_avatars as user_avatars_service
+from app.services.platform import profile_decorations as profile_decorations_service
 from app.services.platform import users as users_service
 from app.services.platform import api_keys as api_keys_service
 from app.services.platform import csv_export
@@ -288,52 +291,71 @@ async def search_users(
     )
 
 
-@guild_router.get("/{user_id}/profile", response_model=UserProfile)
-async def read_member_profile(
-    user_id: int,
-    session: RLSSessionDep,
-    _current_user: Annotated[User, Depends(get_current_active_user)],
-    guild_context: GuildContextDep,
-) -> UserProfile:
-    """One member's profile, as the rest of their guild sees it.
+@router.get("/me/decorations", response_model=OwnedDecorationsResponse)
+async def list_my_decorations(
+    session: UserSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+) -> OwnedDecorationsResponse:
+    """Everything the caller may dress their profile in.
 
-    Guild-scoped, like the roster it is reached from: the membership join is
-    what says a profile exists to the caller, so someone the caller shares no
-    guild with is a 404 rather than a page. It is also what makes the answer
-    correct — a real name renders only where the guild shows names, and
-    "online" means "has this guild open".
-
-    Nothing here is a guild's to write. The account row is the person's own
-    (``users`` UPDATE is own-row on the request path); this reads it.
+    What ships with the app plus what this account acquired, which is what the
+    pickers on Settings > Profile offer and exactly what the write path
+    accepts. Own-row: ``public.user_decorations`` is readable only by the
+    account whose library it is.
     """
-    stmt = (
-        select(User, GuildMembership.joined_at)
-        .join(GuildMembership, GuildMembership.user_id == User.id)
-        .where(
-            User.id == user_id,
-            GuildMembership.guild_id == guild_context.guild_id,
-            users_service.visible_to_other_people(),
+    return OwnedDecorationsResponse(
+        items=await profile_decorations_service.owned_decorations(
+            session, current_user.id
         )
     )
+
+
+@router.get("/{user_id}/profile", response_model=UserProfile)
+async def read_user_profile(
+    user_id: int,
+    session: AdminSessionDep,
+    _current_user: Annotated[User, Depends(get_current_active_user)],
+) -> UserProfile:
+    """One person's profile.
+
+    A profile is public and has no guild in it: it carries the handle, the
+    face, the status, the look and whether they are online, and it is the same
+    page whoever opens it. That is why it is not reached through a guild — no
+    part of the answer depends on one.
+
+    Read on the system engine, selecting the profile columns and nothing else.
+    ``public.users`` is own-row for a platform-tier session (a person's
+    address, their preferences and their memberships are theirs), so the row
+    cannot be read whole here; what is public about it is this narrow
+    projection, and the response shape carries exactly the columns named
+    below. A suspended account has no profile.
+    """
+    stmt = select(
+        User.id,
+        User.username,
+        User.discriminator,
+        User.avatar_url,
+        User.status,
+        User.custom_status,
+        User.profile_decorations,
+        User.created_at,
+    ).where(User.id == user_id, users_service.visible_to_other_people())
     row = (await session.exec(stmt)).first()
     if row is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=UserMessages.NOT_IN_GUILD,
+            detail=AuthMessages.USER_NOT_FOUND,
         )
-    user, joined_at = row
     return UserProfile(
-        id=user.id,
-        username=user.username,
-        discriminator=user.discriminator,
-        full_name=user.full_name,
-        avatar_url=user.avatar_url,
-        status=user.status,
-        custom_status_emoji=user.custom_status_emoji,
-        custom_status_text=user.custom_status_text,
-        profile_decorations=user.profile_decorations or {},
-        online=realtime_manager.is_present(guild_context.guild_id, user.id),
-        joined_at=joined_at,
+        id=row.id,
+        username=row.username,
+        discriminator=row.discriminator,
+        avatar_url=row.avatar_url,
+        status=row.status,
+        custom_status=row.custom_status or {},
+        profile_decorations=row.profile_decorations or {},
+        online=realtime_manager.online.is_online(row.id),
+        joined_at=row.created_at,
     )
 
 
@@ -683,17 +705,29 @@ async def update_users_me(
         )
     if "locale" in update_data:
         current_user.locale = update_data["locale"]
-    for field in ("custom_status_emoji", "custom_status_text"):
-        if field in update_data:
-            # Already held to shape by ``UserSelfUpdate``; ``None`` means the
-            # person took it off.
-            setattr(current_user, field, update_data[field])
+    if "custom_status" in update_data:
+        # Already held to shape by ``CustomStatus``; ``None`` is the status
+        # taken off, which is the empty object rather than a null column.
+        current_user.custom_status = update_data["custom_status"] or {}
     if "profile_decorations" in update_data:
         # The payload validated it into ``ProfileDecorations``, so what lands
         # in the column is a known set of keys holding catalog ids and nothing
         # else. ``None`` is the bare profile.
-        decorations = update_data["profile_decorations"]
-        current_user.profile_decorations = decorations or {}
+        decorations = user_in.profile_decorations or ProfileDecorations()
+        worn = decorations.worn()
+        if worn:
+            # You wear what you have. The library is the authority for both
+            # halves of that — whether the account has the decoration at all,
+            # and whether it has it for the slot it is being put in.
+            owned = await profile_decorations_service.owned_kinds(
+                session, current_user.id
+            )
+            if profile_decorations_service.unwearable(worn, owned):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail=UserMessages.DECORATION_NOT_OWNED,
+                )
+        current_user.profile_decorations = decorations.model_dump()
 
     current_user.updated_at = datetime.now(timezone.utc)
     session.add(current_user)

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -97,6 +97,7 @@ from app.services.platform.guilds import adopt_guild_name_display
 from app.services.realtime import manager as realtime_manager
 from app.services.stream_authz import authority as stream_authority
 from app.models.platform.user_avatar import AVATAR_MAX_BYTES
+from app.models.platform.user_profile_view import user_profiles
 from app.services.platform import user_avatars as user_avatars_service
 from app.services.platform import profile_decorations as profile_decorations_service
 from app.services.platform import users as users_service
@@ -310,36 +311,51 @@ async def list_my_decorations(
     )
 
 
-@router.get("/{user_id}/profile", response_model=UserProfile)
+@router.get("/{handle}/profile", response_model=UserProfile)
 async def read_user_profile(
-    user_id: int,
-    session: AdminSessionDep,
+    handle: str,
+    session: UserSessionDep,
     _current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> UserProfile:
-    """One person's profile.
+    """One person's profile, addressed by their handle.
+
+    ``jordan1234`` — the name and the number it is always written with, run
+    together. ``#`` never survives a URL, and the number's four digits are
+    fixed width, so the two come apart again exactly.
 
     A profile is public and has no guild in it: it carries the handle, the
     face, the status, the look and whether they are online, and it is the same
     page whoever opens it. That is why it is not reached through a guild — no
     part of the answer depends on one.
 
-    Read on the system engine, selecting the profile columns and nothing else.
-    ``public.users`` is own-row for a platform-tier session (a person's
-    address, their preferences and their memberships are theirs), so the row
-    cannot be read whole here; what is public about it is this narrow
-    projection, and the response shape carries exactly the columns named
-    below. A suspended account has no profile.
+    Read from ``public.user_profiles``, the view that *is* the public
+    projection: which columns are public is decided by the view and the column
+    grant behind it (migration 0214), not here. An ordinary platform-tier
+    session, RLS enforced. A suspended account has no profile.
     """
+    parsed = usernames.parse_url_handle(handle)
+    if parsed is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=AuthMessages.USER_NOT_FOUND,
+        )
+    name, discriminator = parsed
+    # Named one by one rather than as the whole view: a single-entity select
+    # comes back scalarized to its first column.
     stmt = select(
-        User.id,
-        User.username,
-        User.discriminator,
-        User.avatar_url,
-        User.status,
-        User.custom_status,
-        User.profile_decorations,
-        User.created_at,
-    ).where(User.id == user_id, users_service.visible_to_other_people())
+        user_profiles.c.id,
+        user_profiles.c.username,
+        user_profiles.c.discriminator,
+        user_profiles.c.avatar_url,
+        user_profiles.c.status,
+        user_profiles.c.custom_status,
+        user_profiles.c.profile_decorations,
+        user_profiles.c.created_at,
+    ).where(
+        func.lower(user_profiles.c.username) == name,
+        user_profiles.c.discriminator == discriminator,
+        users_service.visible_to_other_people(user_profiles.c.status),
+    )
     row = (await session.exec(stmt)).first()
     if row is None:
         raise HTTPException(

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -58,6 +58,7 @@ from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.schemas.platform.user import (
     UsernameClaim,
     UserGuildMember,
+    UserProfile,
     UserRead,
     UserSelfUpdate,
     UserSummary,
@@ -91,6 +92,7 @@ from app.services.tenant import ownership as ownership_service
 from app.services.platform import guilds as guilds_service
 from app.services.platform import usernames as username_service
 from app.services.platform.guilds import adopt_guild_name_display
+from app.services.realtime import manager as realtime_manager
 from app.services.stream_authz import authority as stream_authority
 from app.models.platform.user_avatar import AVATAR_MAX_BYTES
 from app.services.platform import user_avatars as user_avatars_service
@@ -283,6 +285,55 @@ async def search_users(
         page_size=page_size,
         has_next=page_has_next(actual_page, page_size, total_count),
         has_prev=actual_page > 1,
+    )
+
+
+@guild_router.get("/{user_id}/profile", response_model=UserProfile)
+async def read_member_profile(
+    user_id: int,
+    session: RLSSessionDep,
+    _current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+) -> UserProfile:
+    """One member's profile, as the rest of their guild sees it.
+
+    Guild-scoped, like the roster it is reached from: the membership join is
+    what says a profile exists to the caller, so someone the caller shares no
+    guild with is a 404 rather than a page. It is also what makes the answer
+    correct — a real name renders only where the guild shows names, and
+    "online" means "has this guild open".
+
+    Nothing here is a guild's to write. The account row is the person's own
+    (``users`` UPDATE is own-row on the request path); this reads it.
+    """
+    stmt = (
+        select(User, GuildMembership.joined_at)
+        .join(GuildMembership, GuildMembership.user_id == User.id)
+        .where(
+            User.id == user_id,
+            GuildMembership.guild_id == guild_context.guild_id,
+            users_service.visible_to_other_people(),
+        )
+    )
+    row = (await session.exec(stmt)).first()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=UserMessages.NOT_IN_GUILD,
+        )
+    user, joined_at = row
+    return UserProfile(
+        id=user.id,
+        username=user.username,
+        discriminator=user.discriminator,
+        full_name=user.full_name,
+        avatar_url=user.avatar_url,
+        status=user.status,
+        custom_status_emoji=user.custom_status_emoji,
+        custom_status_text=user.custom_status_text,
+        profile_decorations=user.profile_decorations or {},
+        online=realtime_manager.is_present(guild_context.guild_id, user.id),
+        joined_at=joined_at,
     )
 
 
@@ -632,6 +683,17 @@ async def update_users_me(
         )
     if "locale" in update_data:
         current_user.locale = update_data["locale"]
+    for field in ("custom_status_emoji", "custom_status_text"):
+        if field in update_data:
+            # Already held to shape by ``UserSelfUpdate``; ``None`` means the
+            # person took it off.
+            setattr(current_user, field, update_data[field])
+    if "profile_decorations" in update_data:
+        # The payload validated it into ``ProfileDecorations``, so what lands
+        # in the column is a known set of keys holding catalog ids and nothing
+        # else. ``None`` is the bare profile.
+        decorations = update_data["profile_decorations"]
+        current_user.profile_decorations = decorations or {}
 
     current_user.updated_at = datetime.now(timezone.utc)
     session.add(current_user)

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -20,6 +20,7 @@ from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
 from app.models.platform.user import User, UserStatus
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
+from app.services.realtime import manager as realtime_manager
 
 from app.testing.factories import (
     create_federated_identity,
@@ -1150,3 +1151,220 @@ async def test_initiative_members_excludes_anonymized(
     ids = {member["id"] for member in response.json()}
     assert departing.id not in ids
     assert survivor.id in ids
+
+
+@pytest.mark.integration
+async def test_member_profile_carries_the_basics(
+    client: AsyncClient, session: AsyncSession
+):
+    """A member's profile: their face, their handle, the line they wrote, the
+    look they picked, and when they joined this guild."""
+    guild = await create_guild(session)
+    caller = await create_user(session)
+    member = await create_user(
+        session,
+        username="tinker",
+        full_name="Tinker Bell",
+        avatar_url="https://example.com/tinker.png",
+        custom_status_emoji="\N{GAME DIE}",
+        custom_status_text="rolling for initiative",
+        profile_decorations={"banner": "core.aurora", "badges": ["core.founder"]},
+    )
+    for user in (caller, member):
+        await create_guild_membership(session, user=user, guild=guild)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
+        headers=get_auth_headers(caller),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == member.id
+    assert body["username"] == "tinker"
+    assert body["full_name"] == "Tinker Bell"
+    assert body["avatar_url"] == "https://example.com/tinker.png"
+    assert body["custom_status_emoji"] == "\N{GAME DIE}"
+    assert body["custom_status_text"] == "rolling for initiative"
+    assert body["profile_decorations"] == {
+        "banner": "core.aurora",
+        "frame": None,
+        "badges": ["core.founder"],
+    }
+    # Nobody holds a socket in this test, so nobody is here.
+    assert body["online"] is False
+    assert body["joined_at"]
+
+
+@pytest.mark.integration
+async def test_member_profile_withholds_the_name_a_guild_does_not_show(
+    client: AsyncClient, session: AsyncSession
+):
+    """A real name renders only where the guild shows names — the handle is
+    what identifies someone everywhere else."""
+    guild = await create_guild(session, show_member_names=False)
+    caller = await create_user(session)
+    member = await create_user(session, username="tinker", full_name="Tinker Bell")
+    for user in (caller, member):
+        await create_guild_membership(session, user=user, guild=guild)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
+        headers=get_auth_headers(caller),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["full_name"] is None
+    assert body["username"] == "tinker"
+
+
+@pytest.mark.integration
+async def test_member_profile_404s_for_someone_outside_the_guild(
+    client: AsyncClient, session: AsyncSession
+):
+    """A profile exists to the caller only through a shared guild."""
+    guild = await create_guild(session)
+    caller = await create_user(session)
+    await create_guild_membership(session, user=caller, guild=guild)
+    stranger = await create_user(session)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/{stranger.id}/profile",
+        headers=get_auth_headers(caller),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "USER_NOT_IN_GUILD"
+
+
+@pytest.mark.integration
+async def test_member_profile_hides_a_suspended_account(
+    client: AsyncClient, session: AsyncSession
+):
+    """A suspended account vanishes from the roster, and from the page the
+    roster leads to."""
+    guild = await create_guild(session)
+    caller = await create_user(session)
+    member = await create_user(session, status=UserStatus.suspended)
+    for user in (caller, member):
+        await create_guild_membership(session, user=user, guild=guild)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
+        headers=get_auth_headers(caller),
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.integration
+async def test_member_profile_reports_a_member_who_is_here(
+    client: AsyncClient, session: AsyncSession
+):
+    """``online`` reads the realtime connections for *this* guild."""
+    guild = await create_guild(session)
+    caller = await create_user(session)
+    member = await create_user(session)
+    for user in (caller, member):
+        await create_guild_membership(session, user=user, guild=guild)
+
+    socket = object()
+    await realtime_manager.connect(guild.id, [], socket, user_id=member.id)  # type: ignore[arg-type]
+    try:
+        response = await client.get(
+            f"/api/v1/g/{guild.id}/users/{member.id}/profile",
+            headers=get_auth_headers(caller),
+        )
+    finally:
+        await realtime_manager.disconnect(socket)  # type: ignore[arg-type]
+
+    assert response.status_code == 200
+    assert response.json()["online"] is True
+
+
+@pytest.mark.integration
+async def test_member_profile_requires_membership(
+    client: AsyncClient, session: AsyncSession
+):
+    """The guild context is re-validated per request, like every other
+    guild-scoped read."""
+    guild = await create_guild(session)
+    member = await create_user(session)
+    await create_guild_membership(session, user=member, guild=guild)
+    outsider = await create_user(session)
+
+    response = await client.get(
+        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
+        headers=get_auth_headers(outsider),
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
+async def test_custom_status_and_decorations_round_trip(
+    client: AsyncClient, session: AsyncSession
+):
+    """A person writes their own status and picks their own look."""
+    user = await create_user(session)
+    headers = get_auth_headers(user)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=headers,
+        json={
+            "custom_status_emoji": "\N{ROCKET}",
+            "custom_status_text": "shipping",
+            "profile_decorations": {
+                "banner": "core.aurora",
+                "frame": "core.gold",
+                "badges": ["core.founder", "core.founder"],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["custom_status_emoji"] == "\N{ROCKET}"
+    assert body["custom_status_text"] == "shipping"
+    # The same badge twice is a duplicate, not a second badge.
+    assert body["profile_decorations"] == {
+        "banner": "core.aurora",
+        "frame": "core.gold",
+        "badges": ["core.founder"],
+    }
+
+    cleared = await client.patch(
+        "/api/v1/users/me",
+        headers=headers,
+        json={"custom_status_emoji": None, "custom_status_text": None},
+    )
+
+    assert cleared.status_code == 200
+    assert cleared.json()["custom_status_emoji"] is None
+    assert cleared.json()["custom_status_text"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"custom_status_emoji": "not an emoji"},
+        {"profile_decorations": {"banner": "../../etc/passwd"}},
+        {"profile_decorations": {"hat": "core.aurora"}},
+        {"profile_decorations": {"badges": ["a", "b", "c", "d", "e", "f", "g"]}},
+    ],
+)
+async def test_profile_writes_reject_what_is_not_a_status_or_a_catalog_id(
+    client: AsyncClient, session: AsyncSession, payload: dict
+):
+    """Text where an emoji goes, a path where an id goes, a key nothing wears,
+    and more badges than a profile has room for."""
+    user = await create_user(session)
+
+    response = await client.patch(
+        "/api/v1/users/me", headers=get_auth_headers(user), json=payload
+    )
+
+    assert response.status_code == 422

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -19,6 +19,8 @@ from app.db.query import MAX_ID_FILTER_VALUES
 from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
 from app.models.platform.user import User, UserStatus
+from app.core.profile_decorations import SHIPPED_DECORATIONS
+from app.models.platform.user_decoration import UserDecoration
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.services.realtime import manager as realtime_manager
 
@@ -1154,127 +1156,123 @@ async def test_initiative_members_excludes_anonymized(
 
 
 @pytest.mark.integration
-async def test_member_profile_carries_the_basics(
-    client: AsyncClient, session: AsyncSession
-):
-    """A member's profile: their face, their handle, the line they wrote, the
-    look they picked, and when they joined this guild."""
-    guild = await create_guild(session)
+async def test_profile_carries_the_basics(client: AsyncClient, session: AsyncSession):
+    """A profile: the handle, the face, the line they wrote, the look they
+    picked, and when they joined."""
     caller = await create_user(session)
-    member = await create_user(
+    subject = await create_user(
         session,
         username="tinker",
         full_name="Tinker Bell",
         avatar_url="https://example.com/tinker.png",
-        custom_status_emoji="\N{GAME DIE}",
-        custom_status_text="rolling for initiative",
+        custom_status={"emoji": "\N{GAME DIE}", "text": "rolling for initiative"},
         profile_decorations={"banner": "core.aurora", "badges": ["core.founder"]},
     )
-    for user in (caller, member):
-        await create_guild_membership(session, user=user, guild=guild)
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
-        headers=get_auth_headers(caller),
+        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
     )
 
     assert response.status_code == 200
     body = response.json()
-    assert body["id"] == member.id
+    assert body["id"] == subject.id
     assert body["username"] == "tinker"
-    assert body["full_name"] == "Tinker Bell"
     assert body["avatar_url"] == "https://example.com/tinker.png"
-    assert body["custom_status_emoji"] == "\N{GAME DIE}"
-    assert body["custom_status_text"] == "rolling for initiative"
+    assert body["custom_status"] == {
+        "emoji": "\N{GAME DIE}",
+        "text": "rolling for initiative",
+    }
     assert body["profile_decorations"] == {
         "banner": "core.aurora",
         "frame": None,
         "badges": ["core.founder"],
     }
-    # Nobody holds a socket in this test, so nobody is here.
     assert body["online"] is False
     assert body["joined_at"]
 
 
 @pytest.mark.integration
-async def test_member_profile_withholds_the_name_a_guild_does_not_show(
+async def test_profile_never_carries_a_real_name(
     client: AsyncClient, session: AsyncSession
 ):
-    """A real name renders only where the guild shows names — the handle is
-    what identifies someone everywhere else."""
-    guild = await create_guild(session, show_member_names=False)
+    """The handle is the name here. A profile is the same page for everyone,
+    so it carries nothing a guild decides the visibility of."""
     caller = await create_user(session)
-    member = await create_user(session, username="tinker", full_name="Tinker Bell")
-    for user in (caller, member):
-        await create_guild_membership(session, user=user, guild=guild)
+    subject = await create_user(session, username="tinker", full_name="Tinker Bell")
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
-        headers=get_auth_headers(caller),
+        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
     )
 
     assert response.status_code == 200
     body = response.json()
-    assert body["full_name"] is None
+    assert "full_name" not in body
     assert body["username"] == "tinker"
+    # Nor anything else the account keeps to itself.
+    assert set(body.keys()) == {
+        "id",
+        "username",
+        "discriminator",
+        "avatar_url",
+        "status",
+        "custom_status",
+        "profile_decorations",
+        "online",
+        "joined_at",
+    }
 
 
 @pytest.mark.integration
-async def test_member_profile_404s_for_someone_outside_the_guild(
+async def test_profile_needs_no_guild_in_common(
     client: AsyncClient, session: AsyncSession
 ):
-    """A profile exists to the caller only through a shared guild."""
+    """Profiles are public: sharing a guild is not what makes one readable."""
     guild = await create_guild(session)
     caller = await create_user(session)
     await create_guild_membership(session, user=caller, guild=guild)
-    stranger = await create_user(session)
+    stranger = await create_user(session, username="stranger")
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/users/{stranger.id}/profile",
-        headers=get_auth_headers(caller),
+        f"/api/v1/users/{stranger.id}/profile", headers=get_auth_headers(caller)
     )
 
-    assert response.status_code == 404
-    assert response.json()["detail"] == "USER_NOT_IN_GUILD"
+    assert response.status_code == 200
+    assert response.json()["username"] == "stranger"
 
 
 @pytest.mark.integration
-async def test_member_profile_hides_a_suspended_account(
+async def test_profile_hides_a_suspended_account(
     client: AsyncClient, session: AsyncSession
 ):
-    """A suspended account vanishes from the roster, and from the page the
-    roster leads to."""
-    guild = await create_guild(session)
+    """A suspended account vanishes from rosters, and from the page they lead
+    to."""
     caller = await create_user(session)
-    member = await create_user(session, status=UserStatus.suspended)
-    for user in (caller, member):
-        await create_guild_membership(session, user=user, guild=guild)
+    subject = await create_user(session, status=UserStatus.suspended)
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
-        headers=get_auth_headers(caller),
+        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
     )
 
     assert response.status_code == 404
+    assert response.json()["detail"] == "USER_NOT_FOUND"
 
 
 @pytest.mark.integration
-async def test_member_profile_reports_a_member_who_is_here(
+async def test_profile_says_when_someone_is_online(
     client: AsyncClient, session: AsyncSession
 ):
-    """``online`` reads the realtime connections for *this* guild."""
+    """Online is a fact about the person, not about a guild — a reader who
+    shares no guild with them still sees it."""
     guild = await create_guild(session)
     caller = await create_user(session)
-    member = await create_user(session)
-    for user in (caller, member):
-        await create_guild_membership(session, user=user, guild=guild)
+    subject = await create_user(session)
+    await create_guild_membership(session, user=subject, guild=guild)
 
     socket = object()
-    await realtime_manager.connect(guild.id, [], socket, user_id=member.id)  # type: ignore[arg-type]
+    await realtime_manager.connect(guild.id, [], socket, user_id=subject.id)  # type: ignore[arg-type]
     try:
         response = await client.get(
-            f"/api/v1/g/{guild.id}/users/{member.id}/profile",
-            headers=get_auth_headers(caller),
+            f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
         )
     finally:
         await realtime_manager.disconnect(socket)  # type: ignore[arg-type]
@@ -1282,84 +1280,62 @@ async def test_member_profile_reports_a_member_who_is_here(
     assert response.status_code == 200
     assert response.json()["online"] is True
 
-
-@pytest.mark.integration
-async def test_member_profile_requires_membership(
-    client: AsyncClient, session: AsyncSession
-):
-    """The guild context is re-validated per request, like every other
-    guild-scoped read."""
-    guild = await create_guild(session)
-    member = await create_user(session)
-    await create_guild_membership(session, user=member, guild=guild)
-    outsider = await create_user(session)
-
-    response = await client.get(
-        f"/api/v1/g/{guild.id}/users/{member.id}/profile",
-        headers=get_auth_headers(outsider),
+    after = await client.get(
+        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
     )
-
-    assert response.status_code == 403
+    assert after.json()["online"] is False
 
 
 @pytest.mark.integration
-async def test_custom_status_and_decorations_round_trip(
+async def test_profile_requires_a_signed_in_reader(client: AsyncClient):
+    response = await client.get("/api/v1/users/1/profile")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+async def test_custom_status_round_trips_as_one_object(
     client: AsyncClient, session: AsyncSession
 ):
-    """A person writes their own status and picks their own look."""
+    """One column, one write: the emoji and the line are set together."""
     user = await create_user(session)
     headers = get_auth_headers(user)
 
     response = await client.patch(
         "/api/v1/users/me",
         headers=headers,
-        json={
-            "custom_status_emoji": "\N{ROCKET}",
-            "custom_status_text": "shipping",
-            "profile_decorations": {
-                "banner": "core.aurora",
-                "frame": "core.gold",
-                "badges": ["core.founder", "core.founder"],
-            },
-        },
+        json={"custom_status": {"emoji": "\N{ROCKET}", "text": "  shipping  "}},
     )
 
     assert response.status_code == 200
-    body = response.json()
-    assert body["custom_status_emoji"] == "\N{ROCKET}"
-    assert body["custom_status_text"] == "shipping"
-    # The same badge twice is a duplicate, not a second badge.
-    assert body["profile_decorations"] == {
-        "banner": "core.aurora",
-        "frame": "core.gold",
-        "badges": ["core.founder"],
+    assert response.json()["custom_status"] == {
+        "emoji": "\N{ROCKET}",
+        "text": "shipping",
     }
 
     cleared = await client.patch(
-        "/api/v1/users/me",
-        headers=headers,
-        json={"custom_status_emoji": None, "custom_status_text": None},
+        "/api/v1/users/me", headers=headers, json={"custom_status": None}
     )
 
     assert cleared.status_code == 200
-    assert cleared.json()["custom_status_emoji"] is None
-    assert cleared.json()["custom_status_text"] is None
+    assert cleared.json()["custom_status"] == {"emoji": None, "text": None}
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "payload",
     [
-        {"custom_status_emoji": "not an emoji"},
+        {"custom_status": {"emoji": "not an emoji"}},
+        {"custom_status": {"mood": "chipper"}},
         {"profile_decorations": {"banner": "../../etc/passwd"}},
         {"profile_decorations": {"hat": "core.aurora"}},
         {"profile_decorations": {"badges": ["a", "b", "c", "d", "e", "f", "g"]}},
     ],
 )
-async def test_profile_writes_reject_what_is_not_a_status_or_a_catalog_id(
+async def test_profile_writes_reject_a_shape_that_is_not_the_shape(
     client: AsyncClient, session: AsyncSession, payload: dict
 ):
-    """Text where an emoji goes, a path where an id goes, a key nothing wears,
+    """Text where an emoji goes, a key nothing wears, a path where an id goes,
     and more badges than a profile has room for."""
     user = await create_user(session)
 
@@ -1368,3 +1344,142 @@ async def test_profile_writes_reject_what_is_not_a_status_or_a_catalog_id(
     )
 
     assert response.status_code == 422
+
+
+@pytest.mark.integration
+async def test_library_lists_what_ships_with_the_app(
+    client: AsyncClient, session: AsyncSession
+):
+    """A fresh account has the shipped set and nothing else, and none of it
+    names a pack — nobody granted it."""
+    user = await create_user(session)
+
+    response = await client.get(
+        "/api/v1/users/me/decorations", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert {item["id"] for item in items} == set(SHIPPED_DECORATIONS)
+    assert all(item["source"] is None for item in items)
+    assert {item["kind"] for item in items} == {"banner", "frame", "badge"}
+
+
+@pytest.mark.integration
+async def test_library_carries_what_a_pack_granted(
+    client: AsyncClient, session: AsyncSession
+):
+    """An acquired decoration joins the shipped set and says where it came
+    from, so a picker can group by pack."""
+    user = await create_user(session)
+    session.add(
+        UserDecoration(
+            user_id=user.id,
+            decoration_id="pack.midnight",
+            kind="banner",
+            source="studio.midnight-pack",
+        )
+    )
+    await session.commit()
+
+    response = await client.get(
+        "/api/v1/users/me/decorations", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    granted = next(item for item in items if item["id"] == "pack.midnight")
+    assert granted == {
+        "id": "pack.midnight",
+        "kind": "banner",
+        "source": "studio.midnight-pack",
+    }
+    assert len(items) == len(SHIPPED_DECORATIONS) + 1
+
+
+@pytest.mark.integration
+async def test_library_is_the_readers_own(client: AsyncClient, session: AsyncSession):
+    """Somebody else's acquisitions are not in your library."""
+    user = await create_user(session)
+    other = await create_user(session)
+    session.add(
+        UserDecoration(user_id=other.id, decoration_id="pack.midnight", kind="banner")
+    )
+    await session.commit()
+
+    response = await client.get(
+        "/api/v1/users/me/decorations", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    assert "pack.midnight" not in {item["id"] for item in response.json()["items"]}
+
+
+@pytest.mark.integration
+async def test_wearing_a_decoration_requires_having_it(
+    client: AsyncClient, session: AsyncSession
+):
+    """You wear what you have."""
+    user = await create_user(session)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(user),
+        json={"profile_decorations": {"banner": "pack.midnight"}},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "USER_DECORATION_NOT_OWNED"
+
+
+@pytest.mark.integration
+async def test_a_decoration_goes_in_the_slot_it_is_for(
+    client: AsyncClient, session: AsyncSession
+):
+    """Having a frame is not having a banner."""
+    user = await create_user(session)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(user),
+        json={"profile_decorations": {"banner": "core.gold"}},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "USER_DECORATION_NOT_OWNED"
+
+
+@pytest.mark.integration
+async def test_wearing_what_a_pack_granted(client: AsyncClient, session: AsyncSession):
+    """The acquired half of the library is wearable on the same terms as the
+    shipped half."""
+    user = await create_user(session)
+    session.add(
+        UserDecoration(
+            user_id=user.id,
+            decoration_id="pack.midnight",
+            kind="banner",
+            source="studio.midnight-pack",
+        )
+    )
+    await session.commit()
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(user),
+        json={
+            "profile_decorations": {
+                "banner": "pack.midnight",
+                "frame": "core.gold",
+                "badges": ["core.founder", "core.founder"],
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["profile_decorations"] == {
+        "banner": "pack.midnight",
+        "frame": "core.gold",
+        # The same badge twice is a duplicate, not a second badge.
+        "badges": ["core.founder"],
+    }

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -20,6 +20,7 @@ from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
 from app.models.platform.user import User, UserStatus
 from app.core.profile_decorations import SHIPPED_DECORATIONS
+from app.core.usernames import url_handle
 from app.models.platform.user_decoration import UserDecoration
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.services.realtime import manager as realtime_manager
@@ -1170,7 +1171,8 @@ async def test_profile_carries_the_basics(client: AsyncClient, session: AsyncSes
     )
 
     response = await client.get(
-        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
+        f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+        headers=get_auth_headers(caller),
     )
 
     assert response.status_code == 200
@@ -1201,7 +1203,8 @@ async def test_profile_never_carries_a_real_name(
     subject = await create_user(session, username="tinker", full_name="Tinker Bell")
 
     response = await client.get(
-        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
+        f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+        headers=get_auth_headers(caller),
     )
 
     assert response.status_code == 200
@@ -1233,7 +1236,8 @@ async def test_profile_needs_no_guild_in_common(
     stranger = await create_user(session, username="stranger")
 
     response = await client.get(
-        f"/api/v1/users/{stranger.id}/profile", headers=get_auth_headers(caller)
+        f"/api/v1/users/{url_handle(stranger.username, stranger.discriminator)}/profile",
+        headers=get_auth_headers(caller),
     )
 
     assert response.status_code == 200
@@ -1250,7 +1254,8 @@ async def test_profile_hides_a_suspended_account(
     subject = await create_user(session, status=UserStatus.suspended)
 
     response = await client.get(
-        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
+        f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+        headers=get_auth_headers(caller),
     )
 
     assert response.status_code == 404
@@ -1272,7 +1277,8 @@ async def test_profile_says_when_someone_is_online(
     await realtime_manager.connect(guild.id, [], socket, user_id=subject.id)  # type: ignore[arg-type]
     try:
         response = await client.get(
-            f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
+            f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+            headers=get_auth_headers(caller),
         )
     finally:
         await realtime_manager.disconnect(socket)  # type: ignore[arg-type]
@@ -1281,14 +1287,15 @@ async def test_profile_says_when_someone_is_online(
     assert response.json()["online"] is True
 
     after = await client.get(
-        f"/api/v1/users/{subject.id}/profile", headers=get_auth_headers(caller)
+        f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+        headers=get_auth_headers(caller),
     )
     assert after.json()["online"] is False
 
 
 @pytest.mark.integration
 async def test_profile_requires_a_signed_in_reader(client: AsyncClient):
-    response = await client.get("/api/v1/users/1/profile")
+    response = await client.get("/api/v1/users/nobody0001/profile")
 
     assert response.status_code == 401
 
@@ -1483,3 +1490,57 @@ async def test_wearing_what_a_pack_granted(client: AsyncClient, session: AsyncSe
         # The same badge twice is a duplicate, not a second badge.
         "badges": ["core.founder"],
     }
+
+
+@pytest.mark.integration
+async def test_profile_is_addressed_by_handle(
+    client: AsyncClient, session: AsyncSession
+):
+    """``jordan1234`` is the handle as one URL segment — the name and the four
+    digits it is always written with, run together, because ``#`` never
+    survives a URL."""
+    caller = await create_user(session)
+    subject = await create_user(session, username="jordan", discriminator=1234)
+
+    response = await client.get(
+        "/api/v1/users/jordan1234/profile", headers=get_auth_headers(caller)
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == subject.id
+    assert response.json()["username"] == "jordan"
+    assert response.json()["discriminator"] == 1234
+
+
+@pytest.mark.integration
+async def test_profile_handle_comes_apart_at_a_fixed_width(
+    client: AsyncClient, session: AsyncSession
+):
+    """A name may itself end in digits. The number is always four wide, which
+    is what keeps ``user2`` + ``0007`` from reading as ``user`` + ``20007``."""
+    caller = await create_user(session)
+    subject = await create_user(session, username="user2", discriminator=7)
+
+    response = await client.get(
+        "/api/v1/users/user20007/profile", headers=get_auth_headers(caller)
+    )
+
+    assert response.status_code == 200
+    assert response.json()["username"] == "user2"
+    assert response.json()["discriminator"] == subject.discriminator
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("handle", ["jordan", "jordan12a4", "ab0001", "jordan1234x"])
+async def test_profile_404s_on_something_that_is_not_a_handle(
+    client: AsyncClient, session: AsyncSession, handle: str
+):
+    """No number, a number with a letter in it, too short a name, and a name
+    where the number should be."""
+    caller = await create_user(session)
+
+    response = await client.get(
+        f"/api/v1/users/{handle}/profile", headers=get_auth_headers(caller)
+    )
+
+    assert response.status_code == 404

--- a/backend/app/core/emoji.py
+++ b/backend/app/core/emoji.py
@@ -26,9 +26,8 @@ def validate_emoji(value: str) -> str:
     """Return ``value`` if it is a plausible single emoji, else raise.
 
     Deliberately a shape check rather than a lookup against an emoji table: the
-    column stores whatever the client rendered, and a codepoint-category rule
-    keeps out the thing that actually matters — text (a nickname, a URL, markup)
-    smuggled in where a UI will render it as a label.
+    column stores whatever the client rendered, so a codepoint-category rule is
+    what distinguishes a plausible emoji sequence from ordinary text.
     """
     emoji = value.strip()
     if not emoji:

--- a/backend/app/core/emoji.py
+++ b/backend/app/core/emoji.py
@@ -1,0 +1,43 @@
+"""What counts as an emoji, for every column that stores one.
+
+A reaction, a project's icon, the line a person puts on their profile — all
+store whatever the client rendered, and all want the same answer to "is this
+one emoji or is it text?". The rule lives here so the platform and tenant
+schemas can both ask it without importing each other.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+#: An emoji is one grapheme cluster, but a cluster can be long: a ZWJ family
+#: sequence or a flag runs to several codepoints plus joiners and modifiers.
+MAX_EMOJI_CODEPOINTS = 12
+
+#: Unicode general categories an emoji's codepoints may come from: symbols
+#: (So), modifier symbols (Sk, skin tones), non-spacing marks and format
+#: characters (Mn/Cf — variation selectors and ZWJ), and the digits/hash/star
+#: that lead a keycap sequence.
+_ALLOWED_CATEGORIES = frozenset({"So", "Sk", "Mn", "Me", "Cf", "Nd"})
+_ALLOWED_CHARS = frozenset("#*")
+
+
+def validate_emoji(value: str) -> str:
+    """Return ``value`` if it is a plausible single emoji, else raise.
+
+    Deliberately a shape check rather than a lookup against an emoji table: the
+    column stores whatever the client rendered, and a codepoint-category rule
+    keeps out the thing that actually matters — text (a nickname, a URL, markup)
+    smuggled in where a UI will render it as a label.
+    """
+    emoji = value.strip()
+    if not emoji:
+        raise ValueError("Emoji is required")
+    if len(emoji) > MAX_EMOJI_CODEPOINTS:
+        raise ValueError("Emoji is too long")
+    for char in emoji:
+        if char in _ALLOWED_CHARS:
+            continue
+        if unicodedata.category(char) not in _ALLOWED_CATEGORIES:
+            raise ValueError("Not an emoji")
+    return emoji

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -439,6 +439,9 @@ class UserMessages:
     # A read payload's ``avatar_url`` is a path this API serves; writing one
     # back would store it as though it were an external picture URL.
     AVATAR_URL_NOT_EXTERNAL = "USER_AVATAR_URL_NOT_EXTERNAL"
+    #: A decoration this account's library does not answer for — one it does
+    #: not have, or one it has for a different slot.
+    DECORATION_NOT_OWNED = "USER_DECORATION_NOT_OWNED"
 
 
 class ImportMessages:

--- a/backend/app/core/profile_decorations.py
+++ b/backend/app/core/profile_decorations.py
@@ -1,0 +1,45 @@
+"""What a profile can be dressed in, and which of it ships with the app.
+
+A decoration is named by an **id** — ``core.aurora`` — and belongs to a slot:
+one banner, one frame, any number of badges. The id is all the server holds.
+The artwork it names is the client's business (``frontend/src/lib/
+profileDecorations.ts`` maps an id to a file under ``public/decorations``), so
+a decoration a build has no artwork for simply isn't drawn.
+
+Two sources, one vocabulary:
+
+* what ships with the app — :data:`SHIPPED_DECORATIONS`, which every account
+  has and nobody had to acquire;
+* what an account acquired — rows in ``public.user_decorations``, written when
+  a marketplace pack is installed.
+
+They are unioned by ``app.services.platform.profile_decorations``, which is
+the one place that answers "what may this person wear". Shipped decorations are
+deliberately *not* rows: they are universal, so a row per account per
+decoration would be a fan-out over every user for something nobody chose, and
+another one every time the app ships a new default.
+"""
+
+from __future__ import annotations
+
+#: The slots a profile has. One banner and one frame, because a profile has one
+#: of each; badges are a row, so there are several.
+BANNER = "banner"
+FRAME = "frame"
+BADGE = "badge"
+
+DECORATION_KINDS: frozenset[str] = frozenset({BANNER, FRAME, BADGE})
+
+#: What ships with the app: id -> slot. Every account has these. The artwork
+#: lives in the frontend catalog under the same ids; an id here with no artwork
+#: there is simply never drawn, which is the same tolerance a pack's id gets.
+SHIPPED_DECORATIONS: dict[str, str] = {
+    "core.aurora": BANNER,
+    "core.ember": BANNER,
+    "core.parchment": BANNER,
+    "core.gold": FRAME,
+    "core.arcane": FRAME,
+    "core.founder": BADGE,
+    "core.storyteller": BADGE,
+    "core.trailblazer": BADGE,
+}

--- a/backend/app/core/usernames.py
+++ b/backend/app/core/usernames.py
@@ -289,6 +289,42 @@ def format_handle(name: str, discriminator: int) -> str:
     return f"{name}#{discriminator:04d}"
 
 
+#: Width of the number when it is written out. Always four digits, zero-padded,
+#: which is what lets it be read off the end of a URL handle.
+DISCRIMINATOR_DIGITS: Final = 4
+
+
+def url_handle(username: str, discriminator: int) -> str:
+    """``jordan`` + ``1234`` -> ``jordan1234`` — the handle as one URL segment.
+
+    ``#`` is not something to put in a path: it never reaches the server. The
+    number keeps its four digits and simply runs on from the name, which stays
+    reversible because the width is fixed.
+    """
+    return f"{username}{discriminator:0{DISCRIMINATOR_DIGITS}d}"
+
+
+def parse_url_handle(value: str) -> tuple[str, int] | None:
+    """``jordan1234`` -> ``("jordan", 1234)``, or ``None`` if it is not one.
+
+    The last four characters are the number and the rest is the name — a name
+    may itself end in digits (``user2`` + ``0007`` -> ``user20007``), and the
+    fixed width is what keeps that unambiguous.
+    """
+    candidate = value.strip().lower()
+    if len(candidate) < MIN_LENGTH + DISCRIMINATOR_DIGITS:
+        return None
+    name, digits = (
+        candidate[:-DISCRIMINATOR_DIGITS],
+        candidate[-DISCRIMINATOR_DIGITS:],
+    )
+    if not all(character in _DIGITS for character in digits):
+        return None
+    if len(name) > MAX_LENGTH or not all(character in _ALLOWED for character in name):
+        return None
+    return name, int(digits)
+
+
 def parse_handle(term: str) -> tuple[str, str | None]:
     """Split a search term into its name part and any number typed after ``#``.
 

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -54,6 +54,7 @@ from app.models.tenant.counter import (
     CounterGroup,
 )
 from app.models.tenant.upload import Upload
+from app.models.platform.user_decoration import UserDecoration
 from app.models.platform.user_view_preference import UserViewPreference
 from app.models.platform.access_grant import AccessGrant
 from app.models.platform.auth_provider import AuthProvider
@@ -150,6 +151,7 @@ __all__ = [
     "Counter",
     "CounterGroup",
     "Upload",
+    "UserDecoration",
     "UserViewPreference",
     "UserToken",
     "PushToken",

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -60,6 +60,7 @@ _RLS_SHARED_TABLES = {
     "storage_backfill_state",
     "user_api_keys",
     "user_avatars",
+    "user_decorations",
     "user_view_preferences",
     "users",
 }

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -204,6 +204,113 @@ async def test_guild_image_bytes_are_unreadable_by_request_roles(engine):
             )
 
 
+async def test_profile_view_publishes_only_the_public_columns(engine):
+    """What is public about an account is decided in the catalog.
+
+    ``public.user_profiles`` is the projection the profile endpoint reads, and
+    it is not a convention the handler keeps: the reader role behind the view
+    holds SELECT on exactly the public columns of ``public.users``, so a column
+    added to the view without a matching grant returns nothing, and one added
+    to the table is not in the view until somebody puts it there (migration
+    0214)."""
+    public_columns = {
+        "id",
+        "username",
+        "discriminator",
+        "avatar_url",
+        "status",
+        "custom_status",
+        "profile_decorations",
+        "created_at",
+    }
+    base = f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+    async with engine.connect() as conn:
+        view_columns = {
+            row[0]
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_schema = 'public' "
+                        "AND table_name = 'user_profiles'"
+                    )
+                )
+            ).all()
+        }
+        assert view_columns == public_columns, (
+            "public.user_profiles carries columns that were not decided as "
+            f"public: {sorted(view_columns - public_columns)}; missing "
+            f"{sorted(public_columns - view_columns)}"
+        )
+
+        readable = {
+            row[0]
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT column_name, has_column_privilege("
+                        "'app_profile_reader', 'public.users', column_name, "
+                        "'SELECT') FROM information_schema.columns "
+                        "WHERE table_schema = 'public' AND table_name = 'users'"
+                    )
+                )
+            ).all()
+            if row[1]
+        }
+        assert readable == public_columns, (
+            "app_profile_reader reads columns of public.users that are not "
+            f"public: {sorted(readable - public_columns)}; missing "
+            f"{sorted(public_columns - readable)}"
+        )
+
+        # It reads, and that is all it does — to the table or to the view.
+        for verb in ("INSERT", "UPDATE", "DELETE"):
+            can_write = (
+                await conn.execute(
+                    text(
+                        "SELECT has_table_privilege('app_profile_reader', "
+                        f"'public.users', '{verb}')"
+                    )
+                )
+            ).scalar()
+            assert not can_write, f"app_profile_reader must not hold {verb}"
+
+        # The request path reads the view and cannot write through it — the
+        # schema's default privileges would otherwise have granted all four.
+        can_read = (
+            await conn.execute(
+                text(
+                    "SELECT has_table_privilege(:role, 'public.user_profiles', "
+                    "'SELECT')"
+                ),
+                {"role": base},
+            )
+        ).scalar()
+        assert can_read, f"{base} must be able to read public.user_profiles"
+        for verb in ("INSERT", "UPDATE", "DELETE"):
+            can_write = (
+                await conn.execute(
+                    text(
+                        "SELECT has_table_privilege(:role, "
+                        f"'public.user_profiles', '{verb}')"
+                    ),
+                    {"role": base},
+                )
+            ).scalar()
+            assert not can_write, f"{base} must not hold {verb} on public.user_profiles"
+
+        # And it holds no standing bypass of its own.
+        bypasses = (
+            await conn.execute(
+                text(
+                    "SELECT rolbypassrls FROM pg_roles "
+                    "WHERE rolname = 'app_profile_reader'"
+                )
+            )
+        ).scalar()
+        assert not bypasses, "app_profile_reader must not hold BYPASSRLS"
+
+
 async def test_users_role_is_writable_only_by_the_system_engine(engine):
     """``users.role`` (the platform-tier ladder) is assigned only through the
     capability-gated endpoint that runs on the system engine. Each request-path

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -119,6 +119,11 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     # and anonymization paths — both of which act on someone else's row and so
     # cannot run under the own-row request-path policies.
     "user_avatars": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # A person's decoration library. Grants are issued, never self-served: a
+    # pack install writes the rows and an uninstall removes them, both on the
+    # system engine. The request path only reads its own (SELECT), so every
+    # write verb lives here.
+    "user_decorations": frozenset({"SELECT", "INSERT", "DELETE"}),
     # operator AI connections: the request path never queries this directly —
     # the resolve step reads it via an in-process cache loaded on the system
     # engine (SELECT), and the secret-key rotation re-encrypts its key column on
@@ -225,6 +230,9 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # avatar, and the row policies narrow writes to the caller's own. The bare
     # login role reads because the serve endpoint answers before routing.
     "user_avatars": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # A library belongs to a signed-in account, and the bare pre-routing login
+    # role serves nobody in particular.
+    "user_decorations": None,
     # operator AI connections are owner-managed + system-engine-read only; the
     # bare pre-routing login role never touches them
     "platform_ai_connections": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -68,6 +68,9 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # it hangs off: one user spans guilds, and the bytes are served to
         # anyone holding the URL.
         "user_avatars",
+        # What one account may dress its profile in beyond what ships with the
+        # app. Personal and cross-guild, like the row it hangs off.
+        "user_decorations",
         # What a moderator did, and to whom. Cross-guild platform security
         # that has to outlive any guild — and every reference in it is a plain
         # integer, so it outlives the accounts it names too.

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -134,13 +134,14 @@ class User(SQLModel, table=True):
         sa_column=Column(Integer, nullable=False, server_default="1"),
     )
     #: What this person is up to, in their own words: an emoji, a short line,
-    #: or both. Distinct from ``status`` above, which is the account's standing
-    #: and is not theirs to write.
-    custom_status_emoji: Optional[str] = Field(
-        default=None, sa_column=Column(String(64), nullable=True)
-    )
-    custom_status_text: Optional[str] = Field(
-        default=None, sa_column=Column(String(100), nullable=True)
+    #: or both, as ``{"emoji": ..., "text": ...}``. One column rather than two,
+    #: because it is one thing a person sets and one thing every surface that
+    #: names them renders. Distinct from ``status`` above, which is the
+    #: account's standing and is not theirs to write. The shape is
+    #: ``app.schemas.platform.user.CustomStatus``.
+    custom_status: dict = Field(
+        default_factory=dict,
+        sa_column=Column(JSONB, nullable=False, server_default="{}"),
     )
     #: How this person's profile is dressed: a banner, a frame around the
     #: picture, badges beside the name. Each is an id naming a catalog entry

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     String,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Enum as SQLEnum, Field, SQLModel, Relationship
 from pydantic import ConfigDict
 
@@ -131,6 +132,24 @@ class User(SQLModel, table=True):
     token_version: int = Field(
         default=1,
         sa_column=Column(Integer, nullable=False, server_default="1"),
+    )
+    #: What this person is up to, in their own words: an emoji, a short line,
+    #: or both. Distinct from ``status`` above, which is the account's standing
+    #: and is not theirs to write.
+    custom_status_emoji: Optional[str] = Field(
+        default=None, sa_column=Column(String(64), nullable=True)
+    )
+    custom_status_text: Optional[str] = Field(
+        default=None, sa_column=Column(String(100), nullable=True)
+    )
+    #: How this person's profile is dressed: a banner, a frame around the
+    #: picture, badges beside the name. Each is an id naming a catalog entry
+    #: the client resolves to artwork it already ships — never an upload, so a
+    #: decorated profile costs a guild none of its storage. The shape is
+    #: ``app.schemas.platform.user.ProfileDecorations``.
+    profile_decorations: dict = Field(
+        default_factory=dict,
+        sa_column=Column(JSONB, nullable=False, server_default="{}"),
     )
     week_starts_on: int = Field(
         default=0,

--- a/backend/app/models/platform/user_decoration.py
+++ b/backend/app/models/platform/user_decoration.py
@@ -1,0 +1,49 @@
+"""What one account may dress its profile in, beyond what ships with the app.
+
+A row is one decoration one person has. It is written when a marketplace pack
+is installed and removed when that pack goes; grants are issued rather than
+self-served, so the request path holds SELECT on this table and no write verb.
+
+Own-row by policy: a library is the person's, and the only question anyone else
+asks about it has already been answered by the profile they are looking at.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import ConfigDict
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String
+from sqlmodel import Field, SQLModel
+
+
+class UserDecoration(SQLModel, table=True):
+    __tablename__ = "user_decorations"
+    __table_args__ = (
+        # Granting and revoking happen a pack at a time, for one person.
+        Index("ix_user_decorations_source", "user_id", "source"),
+    )
+    __allow_unmapped__ = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    #: The catalog id — ``core.aurora``, or whatever a pack published.
+    decoration_id: str = Field(sa_column=Column(String(64), primary_key=True))
+    #: Which slot it goes in: banner, frame or badge. Recorded on the grant
+    #: rather than looked up, because the catalog that defines a pack's
+    #: decorations is the pack's, and it may be gone by the time this is read.
+    kind: str = Field(sa_column=Column(String(16), nullable=False))
+    #: The pack this came from, for granting and revoking as one. NULL means it
+    #: was granted on its own.
+    source: Optional[str] = Field(
+        default=None, sa_column=Column(String(120), nullable=True)
+    )
+    acquired_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/app/models/platform/user_profile_view.py
+++ b/backend/app/models/platform/user_profile_view.py
@@ -1,0 +1,43 @@
+"""The public projection of ``public.users``, as the request path reads it.
+
+``public.user_profiles`` is a view — created in migration 0214, owned by the
+``app_profile_reader`` role, carrying the eight columns that are public about
+an account. Which columns those are is decided in the catalog rather than here;
+this is the handle the ORM needs to select from it.
+
+Its own ``MetaData``, deliberately: a view is not a table, and putting it in
+``SQLModel.metadata`` would make the table classification and drift checks
+treat it as one and try to keep it in step with a model.
+"""
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    SmallInteger,
+    String,
+    Table,
+)
+from sqlalchemy.dialects.postgresql import ENUM, JSONB
+
+from app.models.platform.user import UserStatus
+
+#: Not ``SQLModel.metadata`` — see the module docstring.
+metadata = MetaData()
+
+user_profiles = Table(
+    "user_profiles",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("username", String(32)),
+    Column("discriminator", SmallInteger),
+    Column("avatar_url", String),
+    # The real enum type, so a comparison against ``UserStatus`` binds as
+    # ``user_status`` rather than text.
+    Column("status", ENUM(UserStatus, name="user_status", create_type=False)),
+    Column("custom_status", JSONB),
+    Column("profile_decorations", JSONB),
+    Column("created_at", DateTime(timezone=True)),
+    schema="public",
+)

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -1,11 +1,19 @@
 from datetime import datetime
 from typing import List, Literal, Optional
 
-from pydantic import ConfigDict, EmailStr, Field, computed_field, model_validator
+from pydantic import (
+    ConfigDict,
+    EmailStr,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 
 from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 from app.core.capabilities import Capability, capabilities_for
+from app.core.emoji import validate_emoji
 from app.core.role_context import guild_shows_member_names
 from app.models.platform.user import UserRole, UserStatus
 from app.core.config import settings
@@ -163,6 +171,105 @@ class UserSummaryListResponse(SanitizedBaseModel):
     has_prev: bool
 
 
+#: What a decoration id may be made of. An explicit set rather than a pattern:
+#: the id is spliced into the path of a local asset by the client, so the
+#: characters it may contain are worth reading at a glance.
+_DECORATION_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789.-_")
+
+#: How long one id may be, and how many badges one profile may wear. The badge
+#: cap is a rendering bound — a row of them beside a name, not a wall.
+DECORATION_ID_MAX_LENGTH = 64
+MAX_PROFILE_BADGES = 6
+
+
+def validate_decoration_id(value: str) -> str:
+    """Return ``value`` if it is shaped like a catalog id, else raise.
+
+    A catalog id is a flat, lowercase name — ``core.aurora`` — and this holds
+    it to that vocabulary.
+    """
+    identifier = value.strip()
+    if not identifier:
+        raise ValueError("Decoration id is required")
+    if len(identifier) > DECORATION_ID_MAX_LENGTH:
+        raise ValueError("Decoration id is too long")
+    if not all(char in _DECORATION_ID_CHARS for char in identifier):
+        raise ValueError("Decoration id has characters that are not allowed")
+    return identifier
+
+
+class ProfileDecorations(SanitizedBaseModel):
+    """How a profile is dressed: a banner, a frame, badges beside the name.
+
+    Every value is an **id naming a catalog entry**, never an image. The client
+    resolves an id to artwork it already ships, so a decorated profile takes up
+    none of a guild's upload allowance. An id this deployment's catalog doesn't
+    know simply renders nothing, which is what lets a profile keep wearing
+    something the store stopped offering.
+
+    ``extra="forbid"``: the set of things a profile can wear is this list, and
+    a client sending a key that isn't here is told so rather than having it
+    quietly stored and never rendered.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid", json_schema_serialization_defaults_required=True
+    )
+
+    banner: Optional[str] = None
+    frame: Optional[str] = None
+    badges: List[str] = Field(default_factory=list, max_length=MAX_PROFILE_BADGES)
+
+    @field_validator("banner", "frame")
+    @classmethod
+    def _check_single(cls, value: Optional[str]) -> Optional[str]:
+        return None if value is None else validate_decoration_id(value)
+
+    @field_validator("badges")
+    @classmethod
+    def _check_badges(cls, value: List[str]) -> List[str]:
+        seen: List[str] = []
+        for badge in value:
+            identifier = validate_decoration_id(badge)
+            # Wearing the same badge twice is a duplicate, not a second badge.
+            if identifier not in seen:
+                seen.append(identifier)
+        return seen
+
+
+class UserProfile(GuildNameVisibility):
+    """A person, as the rest of their guild sees them.
+
+    Everything on :class:`UserPublic` — the face and the handle a member is
+    already rendered by everywhere else — plus what a profile adds: the line
+    they wrote about themselves, how they have dressed the page, whether they
+    have the app open, and when they joined this guild.
+
+    Guild-scoped on purpose, because two of those answers are: a real name
+    shows only where the guild shows names, and "here" means here rather than
+    on the platform somewhere.
+    """
+
+    model_config = ConfigDict(
+        from_attributes=True, json_schema_serialization_defaults_required=True
+    )
+
+    id: int
+    username: str
+    discriminator: int
+    full_name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    status: UserStatus = UserStatus.active
+    custom_status_emoji: Optional[str] = None
+    custom_status_text: Optional[str] = None
+    profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
+    #: Whether this member has the guild open right now. Set by the endpoint
+    #: from the realtime connections this process holds.
+    online: bool = False
+    #: When they joined *this* guild, which is not when they made the account.
+    joined_at: datetime
+
+
 class UserRead(UserBase):
     model_config = ConfigDict(
         from_attributes=True, json_schema_serialization_defaults_required=True
@@ -179,6 +286,9 @@ class UserRead(UserBase):
     created_at: datetime
     updated_at: datetime
     avatar_url: Optional[str] = None
+    custom_status_emoji: Optional[str] = None
+    custom_status_text: Optional[str] = None
+    profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
     week_starts_on: int = 0
     recent_tabs_limit: int = 20
     timezone: str = "UTC"
@@ -258,6 +368,12 @@ class UserSelfUpdate(SanitizedBaseModel):
     # OIDC-only accounts, which have no local password to confirm.
     current_password: Optional[RawTextStr] = Field(default=None, max_length=256)
     avatar_url: Optional[str] = None
+    # Sending ``null`` clears the field; leaving it out leaves it alone.
+    custom_status_emoji: Optional[str] = None
+    custom_status_text: Optional[str] = Field(default=None, max_length=100)
+    # The whole set at once rather than one key at a time: a profile wears a
+    # look, and a partial write would have no way to say "take the frame off".
+    profile_decorations: Optional[ProfileDecorations] = None
     week_starts_on: Optional[int] = None
     recent_tabs_limit: Optional[int] = Field(default=None, ge=1, le=100)
     timezone: Optional[str] = None
@@ -284,6 +400,25 @@ class UserSelfUpdate(SanitizedBaseModel):
     task_completion_audio_feedback: Optional[bool] = None
     task_completion_haptic_feedback: Optional[bool] = None
     locale: Optional[str] = Field(default=None, pattern=r"^[a-z]{2}(-[A-Z]{2})?$")
+
+    @field_validator("custom_status_emoji")
+    @classmethod
+    def _check_status_emoji(cls, value: Optional[str]) -> Optional[str]:
+        """Hold the status emoji to the same shape a reaction's is held to.
+
+        An empty string means "take it off", which is how a picker sends a
+        cleared selection.
+        """
+        if value is None or not value.strip():
+            return None
+        return validate_emoji(value)
+
+    @field_validator("custom_status_text")
+    @classmethod
+    def _blank_text_is_none(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        return value.strip() or None
 
 
 class AccountDeletionRequest(SanitizedBaseModel):

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -14,6 +14,7 @@ from app.schemas.base import RawTextStr, SanitizedBaseModel
 
 from app.core.capabilities import Capability, capabilities_for
 from app.core.emoji import validate_emoji
+from app.core.profile_decorations import BADGE, BANNER, FRAME
 from app.core.role_context import guild_shows_member_names
 from app.models.platform.user import UserRole, UserStatus
 from app.core.config import settings
@@ -171,6 +172,47 @@ class UserSummaryListResponse(SanitizedBaseModel):
     has_prev: bool
 
 
+#: How long the line beside the emoji may run.
+STATUS_TEXT_MAX_LENGTH = 100
+
+
+class CustomStatus(SanitizedBaseModel):
+    """What a person is up to, in their own words.
+
+    One object, stored in one column, because it is one thing a person sets
+    and one thing every surface that names them renders: splitting it in two
+    would mean two reads and two writes for a single line of text.
+
+    Not to be confused with ``UserStatus`` (``users.status``), which is the
+    account's standing — suspended, deactivated — and is not the person's to
+    write.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid", json_schema_serialization_defaults_required=True
+    )
+
+    emoji: Optional[str] = None
+    text: Optional[str] = Field(default=None, max_length=STATUS_TEXT_MAX_LENGTH)
+
+    @field_validator("emoji")
+    @classmethod
+    def _check_emoji(cls, value: Optional[str]) -> Optional[str]:
+        """Hold the status emoji to the same shape a reaction's is held to.
+
+        An empty string means "take it off", which is how a picker sends a
+        cleared selection.
+        """
+        if value is None or not value.strip():
+            return None
+        return validate_emoji(value)
+
+    @field_validator("text")
+    @classmethod
+    def _blank_is_none(cls, value: Optional[str]) -> Optional[str]:
+        return None if value is None else (value.strip() or None)
+
+
 #: What a decoration id may be made of. An explicit set rather than a pattern:
 #: the id is spliced into the path of a local asset by the client, so the
 #: characters it may contain are worth reading at a glance.
@@ -236,18 +278,59 @@ class ProfileDecorations(SanitizedBaseModel):
                 seen.append(identifier)
         return seen
 
+    def worn(self) -> List[tuple[str, str]]:
+        """``(id, slot)`` for everything this profile is wearing.
 
-class UserProfile(GuildNameVisibility):
-    """A person, as the rest of their guild sees them.
+        The one place a slot is paired with its id, so the check against a
+        person's library and the shape they wrote it in cannot disagree about
+        which is which.
+        """
+        pairs: List[tuple[str, str]] = []
+        if self.banner:
+            pairs.append((self.banner, BANNER))
+        if self.frame:
+            pairs.append((self.frame, FRAME))
+        pairs.extend((badge, BADGE) for badge in self.badges)
+        return pairs
 
-    Everything on :class:`UserPublic` — the face and the handle a member is
-    already rendered by everywhere else — plus what a profile adds: the line
-    they wrote about themselves, how they have dressed the page, whether they
-    have the app open, and when they joined this guild.
 
-    Guild-scoped on purpose, because two of those answers are: a real name
-    shows only where the guild shows names, and "here" means here rather than
-    on the platform somewhere.
+class OwnedDecoration(SanitizedBaseModel):
+    """One decoration an account may wear, and where it came from.
+
+    ``source`` names the marketplace pack that granted it, and is ``None`` for
+    the ones that ship with the app. The client renders a picker per slot from
+    these, drawing each id with the artwork it has for it and skipping the ones
+    it doesn't.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    id: str
+    kind: str
+    source: Optional[str] = None
+
+
+class OwnedDecorationsResponse(SanitizedBaseModel):
+    """A person's whole library, in one read — it is small and it is all
+    needed at once, because the profile form renders every slot together."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    items: List[OwnedDecoration]
+
+
+class UserProfile(SanitizedBaseModel):
+    """A person, as anyone can see them.
+
+    A profile is public. It carries the handle — which is the name in this
+    product, unique and never withheld — the face, the line they wrote, the
+    look they picked, whether they are online, and when they joined. It never
+    carries a real name: ``full_name`` is a guild's business (a guild decides
+    whether it renders names at all), and this shape has no guild in it.
+
+    Nothing here is private to a guild, so nothing here is reached through
+    one. What it does not carry is the whole point of it being its own shape:
+    no address, no roles, no memberships, no preferences.
     """
 
     model_config = ConfigDict(
@@ -257,16 +340,14 @@ class UserProfile(GuildNameVisibility):
     id: int
     username: str
     discriminator: int
-    full_name: Optional[str] = None
     avatar_url: Optional[str] = None
     status: UserStatus = UserStatus.active
-    custom_status_emoji: Optional[str] = None
-    custom_status_text: Optional[str] = None
+    custom_status: CustomStatus = Field(default_factory=CustomStatus)
     profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
-    #: Whether this member has the guild open right now. Set by the endpoint
-    #: from the realtime connections this process holds.
+    #: Whether this person has Initiative open right now — the account, not a
+    #: guild. Set by the endpoint from ``realtime.manager.online``.
     online: bool = False
-    #: When they joined *this* guild, which is not when they made the account.
+    #: When the account was made.
     joined_at: datetime
 
 
@@ -286,8 +367,7 @@ class UserRead(UserBase):
     created_at: datetime
     updated_at: datetime
     avatar_url: Optional[str] = None
-    custom_status_emoji: Optional[str] = None
-    custom_status_text: Optional[str] = None
+    custom_status: CustomStatus = Field(default_factory=CustomStatus)
     profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
     week_starts_on: int = 0
     recent_tabs_limit: int = 20
@@ -368,9 +448,8 @@ class UserSelfUpdate(SanitizedBaseModel):
     # OIDC-only accounts, which have no local password to confirm.
     current_password: Optional[RawTextStr] = Field(default=None, max_length=256)
     avatar_url: Optional[str] = None
-    # Sending ``null`` clears the field; leaving it out leaves it alone.
-    custom_status_emoji: Optional[str] = None
-    custom_status_text: Optional[str] = Field(default=None, max_length=100)
+    # Sending ``null`` takes the status off; leaving it out leaves it alone.
+    custom_status: Optional[CustomStatus] = None
     # The whole set at once rather than one key at a time: a profile wears a
     # look, and a partial write would have no way to say "take the frame off".
     profile_decorations: Optional[ProfileDecorations] = None
@@ -400,25 +479,6 @@ class UserSelfUpdate(SanitizedBaseModel):
     task_completion_audio_feedback: Optional[bool] = None
     task_completion_haptic_feedback: Optional[bool] = None
     locale: Optional[str] = Field(default=None, pattern=r"^[a-z]{2}(-[A-Z]{2})?$")
-
-    @field_validator("custom_status_emoji")
-    @classmethod
-    def _check_status_emoji(cls, value: Optional[str]) -> Optional[str]:
-        """Hold the status emoji to the same shape a reaction's is held to.
-
-        An empty string means "take it off", which is how a picker sends a
-        cleared selection.
-        """
-        if value is None or not value.strip():
-            return None
-        return validate_emoji(value)
-
-    @field_validator("custom_status_text")
-    @classmethod
-    def _blank_text_is_none(cls, value: Optional[str]) -> Optional[str]:
-        if value is None:
-            return None
-        return value.strip() or None
 
 
 class AccountDeletionRequest(SanitizedBaseModel):

--- a/backend/app/schemas/tenant/reaction.py
+++ b/backend/app/schemas/tenant/reaction.py
@@ -8,11 +8,11 @@ rows would make every thread O(reactions) and leak nothing useful.
 
 from __future__ import annotations
 
-import unicodedata
 from typing import Optional
 
 from pydantic import ConfigDict, Field, field_validator
 
+from app.core.emoji import validate_emoji
 from app.core.reactions import ReactionTarget
 from app.schemas.base import SanitizedBaseModel
 from app.schemas.platform.user import GuildNameVisibility
@@ -30,38 +30,6 @@ SUGGESTED_EMOJI: tuple[str, ...] = (
     "\N{EYES}",
     "\N{ROCKET}",
 )
-
-#: A reaction is one grapheme cluster, but a cluster can be long: a ZWJ family
-#: sequence or a flag runs to several codepoints plus joiners and modifiers.
-MAX_EMOJI_CODEPOINTS = 12
-
-#: Unicode general categories a reaction's codepoints may come from: symbols
-#: (So), modifier symbols (Sk, skin tones), non-spacing marks and format
-#: characters (Mn/Cf — variation selectors and ZWJ), and the digits/hash/star
-#: that lead a keycap sequence.
-_ALLOWED_CATEGORIES = frozenset({"So", "Sk", "Mn", "Me", "Cf", "Nd"})
-_ALLOWED_CHARS = frozenset("#*")
-
-
-def validate_emoji(value: str) -> str:
-    """Return ``value`` if it is a plausible single emoji, else raise.
-
-    Deliberately a shape check rather than a lookup against an emoji table: the
-    column stores whatever the client rendered, and a codepoint-category rule
-    keeps out the thing that actually matters — text (a nickname, a URL, markup)
-    smuggled in where a UI will render it as a label.
-    """
-    emoji = value.strip()
-    if not emoji:
-        raise ValueError("Emoji is required")
-    if len(emoji) > MAX_EMOJI_CODEPOINTS:
-        raise ValueError("Emoji is too long")
-    for char in emoji:
-        if char in _ALLOWED_CHARS:
-            continue
-        if unicodedata.category(char) not in _ALLOWED_CATEGORIES:
-            raise ValueError("Not an emoji")
-    return emoji
 
 
 class ReactionUser(GuildNameVisibility):

--- a/backend/app/services/platform/profile_decorations.py
+++ b/backend/app/services/platform/profile_decorations.py
@@ -1,0 +1,71 @@
+"""What one person may dress their profile in.
+
+One function answers it — :func:`owned_decorations` — over two sources: what
+ships with the app, which everyone has, and what the account acquired, which is
+a row in ``public.user_decorations``. Every caller goes through it, so the
+picker offers exactly what the write path accepts.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.profile_decorations import SHIPPED_DECORATIONS
+from app.models.platform.user_decoration import UserDecoration
+from app.schemas.platform.user import OwnedDecoration
+
+
+async def owned_decorations(
+    session: AsyncSession, user_id: int
+) -> list[OwnedDecoration]:
+    """Everything this account may wear, shipped first and then acquired.
+
+    Shipped decorations carry no ``source``: nobody granted them, they came
+    with the app. An acquired row naming an id that also ships is dropped
+    rather than listed twice — you cannot own a thing twice, and a pack that
+    includes a default should not make the picker stutter.
+    """
+    owned = [
+        OwnedDecoration(id=decoration_id, kind=kind, source=None)
+        for decoration_id, kind in SHIPPED_DECORATIONS.items()
+    ]
+    rows = (
+        await session.exec(
+            select(UserDecoration)
+            .where(UserDecoration.user_id == user_id)
+            .order_by(
+                UserDecoration.acquired_at.asc(), UserDecoration.decoration_id.asc()
+            )
+        )
+    ).all()
+    owned.extend(
+        OwnedDecoration(id=row.decoration_id, kind=row.kind, source=row.source)
+        for row in rows
+        if row.decoration_id not in SHIPPED_DECORATIONS
+    )
+    return owned
+
+
+async def owned_kinds(session: AsyncSession, user_id: int) -> dict[str, str]:
+    """``id -> slot`` for everything this account may wear.
+
+    The shape the write path checks against: an id has to be here, and it has
+    to be here as the slot it is being put in.
+    """
+    return {item.id: item.kind for item in await owned_decorations(session, user_id)}
+
+
+def unwearable(wanted: Iterable[tuple[str, str]], owned: dict[str, str]) -> list[str]:
+    """Which of these ``(id, slot)`` pairs this library does not answer for.
+
+    Both failures land here: an id the account does not have, and one it has
+    in a different slot — a badge cannot be worn as a frame.
+    """
+    return [
+        decoration_id
+        for decoration_id, kind in wanted
+        if owned.get(decoration_id) != kind
+    ]

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -808,7 +808,7 @@ def name_closeness(term: str, *, shows_names: bool) -> ColumnElement[float]:
     return closest
 
 
-def visible_to_other_people():
+def visible_to_other_people(status_column=None):
     """Rows that may appear where a person is listed as someone to work with.
 
     A suspended account is not one: it vanishes from rosters, pickers, search,
@@ -818,6 +818,9 @@ def visible_to_other_people():
     account from nothing.
 
     A clause rather than a filtered query, so each surface keeps its own
-    joins and its own gates and only borrows the predicate.
+    joins and its own gates and only borrows the predicate. Pass
+    ``status_column`` to apply it somewhere other than ``users`` itself — the
+    ``user_profiles`` view carries the same column and the same rule.
     """
-    return User.status != UserStatus.suspended
+    column = User.status if status_column is None else status_column
+    return column != UserStatus.suspended

--- a/backend/app/services/realtime.py
+++ b/backend/app/services/realtime.py
@@ -119,6 +119,16 @@ class ConnectionManager:
         """How many distinct users have this guild open on this process."""
         return len(self._present.get(guild_id, {}))
 
+    def is_present(self, guild_id: int, user_id: int) -> bool:
+        """Whether this user has this guild open on this process.
+
+        Same share-of-the-whole caveat as ``present_count``: across several
+        workers this answers for the sockets this one holds, so it can say no
+        about someone another worker is serving. It drives a dot beside a name,
+        which is a hint and not a fact anything depends on.
+        """
+        return user_id in self._present.get(guild_id, {})
+
     def present_counts(self, guild_ids: Iterable[int]) -> Dict[int, int]:
         """``present_count`` for several guilds, for a page of them at a time."""
         return {guild_id: self.present_count(guild_id) for guild_id in guild_ids}

--- a/backend/app/services/realtime.py
+++ b/backend/app/services/realtime.py
@@ -14,6 +14,50 @@ from fastapi import WebSocket
 RoomKey = Tuple[int, int]
 
 
+class OnlineRoll:
+    """Who has Initiative open — the person, not the place.
+
+    Deliberately separate from the guild presence the manager below keeps.
+    That one answers "how busy is this guild right now", and a guild is the
+    unit it counts in. This one answers "is this account online", which is a
+    fact about the person: they are online whether the tab they left open is a
+    guild they share with the asker, a guild they don't, or no guild at all.
+    Reading the guild roll for that answer would make someone look offline to
+    everyone who happens not to be in the guild they are sitting in.
+
+    Fed by the same connect/disconnect the rooms are, so there is one place a
+    socket is accounted for. Counted per user rather than per socket, so two
+    tabs are one person.
+
+    Bounded the same way the guild roll is: these are one process's own
+    sockets, held in memory. Where the API runs as more than one worker, each
+    holds a share, so this can say "no" about someone another worker is
+    serving. It drives a dot beside a name — a hint, not a fact anything
+    depends on.
+    """
+
+    def __init__(self) -> None:
+        # user_id -> how many of that user's sockets are open on this process.
+        self._sockets: Dict[int, int] = {}
+
+    def arrived(self, user_id: int) -> None:
+        self._sockets[user_id] = self._sockets.get(user_id, 0) + 1
+
+    def left(self, user_id: int) -> None:
+        remaining = self._sockets.get(user_id, 0) - 1
+        if remaining > 0:
+            self._sockets[user_id] = remaining
+        else:
+            self._sockets.pop(user_id, None)
+
+    def is_online(self, user_id: int) -> bool:
+        return user_id in self._sockets
+
+    def online_users(self, user_ids: Iterable[int]) -> Set[int]:
+        """Which of these accounts are online, for a page of them at a time."""
+        return {user_id for user_id in user_ids if user_id in self._sockets}
+
+
 class ConnectionManager:
     """Initiative-scoped WebSocket fan-out for the `/events/updates` stream.
 
@@ -32,11 +76,13 @@ class ConnectionManager:
     A socket may live in several rooms at once (a user reaches several
     initiatives), so we keep a reverse index for O(1) disconnect.
 
-    It also answers who is *present* in a guild. A socket on this stream is a
-    user with the app open in that guild, which is the thing "online" means, and
-    it is tracked per guild rather than per room: a member of no initiative
-    joins no rooms and is still here. Presence is counted per user, not per
-    socket, so two tabs are one person.
+    It also answers who is *present* in a guild: a socket on this stream is a
+    user with the app open in that guild, tracked per guild rather than per
+    room, because a member of no initiative joins no rooms and is still here.
+    Presence is counted per user, not per socket, so two tabs are one person.
+    Whether a *person* is online at all is a different question and a different
+    object — ``self.online`` (see :class:`OnlineRoll`), fed from the same
+    connect/disconnect.
 
     What that count is bounded by is worth stating: this is one process's own
     sockets, held in memory. Where the API runs as more than one worker each
@@ -52,6 +98,9 @@ class ConnectionManager:
         # guild_id -> user_id -> how many of that user's sockets are open here.
         self._present: Dict[int, Dict[int, int]] = {}
         self._socket_identity: Dict[WebSocket, Tuple[int, int]] = {}
+        # "Is this person online at all", which is not a guild question — see
+        # ``OnlineRoll``. Same sockets, different question.
+        self.online = OnlineRoll()
         self._lock = asyncio.Lock()
 
     async def connect(
@@ -73,6 +122,7 @@ class ConnectionManager:
             self._socket_identity[websocket] = (guild_id, user_id)
             present = self._present.setdefault(guild_id, {})
             present[user_id] = present.get(user_id, 0) + 1
+            self.online.arrived(user_id)
 
     async def disconnect(self, websocket: WebSocket) -> None:
         """Remove a socket from every room it joined, and from its guild's roll."""
@@ -87,6 +137,7 @@ class ConnectionManager:
             if identity is None:
                 return
             guild_id, user_id = identity
+            self.online.left(user_id)
             present = self._present.get(guild_id)
             if present is None:
                 return
@@ -118,16 +169,6 @@ class ConnectionManager:
     def present_count(self, guild_id: int) -> int:
         """How many distinct users have this guild open on this process."""
         return len(self._present.get(guild_id, {}))
-
-    def is_present(self, guild_id: int, user_id: int) -> bool:
-        """Whether this user has this guild open on this process.
-
-        Same share-of-the-whole caveat as ``present_count``: across several
-        workers this answers for the sockets this one holds, so it can say no
-        about someone another worker is serving. It drives a dot beside a name,
-        which is a hint and not a fact anything depends on.
-        """
-        return user_id in self._present.get(guild_id, {})
 
     def present_counts(self, guild_ids: Iterable[int]) -> Dict[int, int]:
         """``present_count`` for several guilds, for a page of them at a time."""

--- a/backend/app/services/tenant/reactions_test.py
+++ b/backend/app/services/tenant/reactions_test.py
@@ -3,13 +3,10 @@ emoji rule, and the registry's completeness."""
 
 import pytest
 
+from app.core.emoji import MAX_EMOJI_CODEPOINTS, validate_emoji
 from app.core.reactions import REACTION_TARGETS, ReactionTarget
 from app.models.tenant.reaction import Reaction
-from app.schemas.tenant.reaction import (
-    MAX_EMOJI_CODEPOINTS,
-    SUGGESTED_EMOJI,
-    validate_emoji,
-)
+from app.schemas.tenant.reaction import SUGGESTED_EMOJI
 from app.services.tenant.reactions import (
     MAX_NAMED_REACTORS,
     TARGET_RESOLVERS,

--- a/backend/app/services/tenant/search.py
+++ b/backend/app/services/tenant/search.py
@@ -227,8 +227,14 @@ async def _close_titles(
     try:
         # A savepoint, so giving up leaves the request's transaction usable.
         async with session.begin_nested():
+            # ``set_config`` rather than ``SET LOCAL``: the latter takes no
+            # bind parameter, so the value would have to be built into the
+            # statement. Third argument true makes it transaction-local, which
+            # is what ``SET LOCAL`` meant here.
             await session.exec(
-                text(f"SET LOCAL statement_timeout = '{FUZZY_TIMEOUT_MS}ms'")
+                text(
+                    "SELECT set_config('statement_timeout', :timeout, true)"
+                ).bindparams(timeout=f"{FUZZY_TIMEOUT_MS}ms")
             )
             rows = (await session.exec(statement)).all()
     except SQLAlchemyError:

--- a/frontend/public/decorations/badges/core-founder.svg
+++ b/frontend/public/decorations/badges/core-founder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="presentation">
+  <circle cx="12" cy="12" r="11" fill="#1f2937"/>
+  <path d="M12 5.5l1.9 4 4.4.6-3.2 3 .8 4.3-3.9-2.1-3.9 2.1.8-4.3-3.2-3 4.4-.6z" fill="#fbbf24"/>
+</svg>

--- a/frontend/public/decorations/badges/core-storyteller.svg
+++ b/frontend/public/decorations/badges/core-storyteller.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="presentation">
+  <circle cx="12" cy="12" r="11" fill="#1f2937"/>
+  <path d="M5.5 7h4.2c1.3 0 2.3.6 2.3 1.6V18c0-.9-1-1.5-2.3-1.5H5.5z" fill="#93c5fd"/>
+  <path d="M18.5 7h-4.2c-1.3 0-2.3.6-2.3 1.6V18c0-.9 1-1.5 2.3-1.5h4.2z" fill="#e0f2fe"/>
+  <path d="M12 8.6V18" stroke="#1f2937" stroke-width="1"/>
+</svg>

--- a/frontend/public/decorations/badges/core-trailblazer.svg
+++ b/frontend/public/decorations/badges/core-trailblazer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="presentation">
+  <circle cx="12" cy="12" r="11" fill="#1f2937"/>
+  <path d="M12 4.5c2.6 2.2 4 4.6 4 7a4 4 0 11-8 0c0-2.4 1.4-4.8 4-7z" fill="#fb923c"/>
+  <path d="M12 9.5c1.2 1.2 1.8 2.3 1.8 3.4a1.8 1.8 0 11-3.6 0c0-1.1.6-2.2 1.8-3.4z" fill="#fef3c7"/>
+</svg>

--- a/frontend/public/decorations/banners/core-aurora.svg
+++ b/frontend/public/decorations/banners/core-aurora.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300" role="presentation">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1026"/>
+      <stop offset="55%" stop-color="#132447"/>
+      <stop offset="100%" stop-color="#1d3b6e"/>
+    </linearGradient>
+    <linearGradient id="veil" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#22d3ee" stop-opacity="0"/>
+      <stop offset="45%" stop-color="#22d3ee" stop-opacity=".55"/>
+      <stop offset="75%" stop-color="#a78bfa" stop-opacity=".5"/>
+      <stop offset="100%" stop-color="#f472b6" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="300" fill="url(#sky)"/>
+  <path d="M0 210 C 180 120 320 250 480 160 S 820 60 1000 150 1200 120 1200 120 L1200 300 L0 300 Z" fill="url(#veil)"/>
+  <path d="M0 250 C 220 180 360 280 560 210 S 900 130 1200 190 L1200 300 L0 300 Z" fill="#0b1026" opacity=".45"/>
+  <g fill="#e2e8f0">
+    <circle cx="140" cy="70" r="2.5" opacity=".9"/>
+    <circle cx="320" cy="46" r="1.8" opacity=".7"/>
+    <circle cx="520" cy="88" r="2.2" opacity=".8"/>
+    <circle cx="760" cy="52" r="1.6" opacity=".6"/>
+    <circle cx="960" cy="96" r="2.4" opacity=".85"/>
+    <circle cx="1100" cy="60" r="1.9" opacity=".7"/>
+  </g>
+</svg>

--- a/frontend/public/decorations/banners/core-ember.svg
+++ b/frontend/public/decorations/banners/core-ember.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300" role="presentation">
+  <defs>
+    <linearGradient id="coal" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2b0f0a"/>
+      <stop offset="60%" stop-color="#7c2d12"/>
+      <stop offset="100%" stop-color="#c2410c"/>
+    </linearGradient>
+    <radialGradient id="glow" cx=".78" cy=".85" r=".7">
+      <stop offset="0%" stop-color="#fbbf24" stop-opacity=".75"/>
+      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="300" fill="url(#coal)"/>
+  <rect width="1200" height="300" fill="url(#glow)"/>
+  <g fill="#fde68a" opacity=".8">
+    <circle cx="880" cy="205" r="3"/>
+    <circle cx="940" cy="160" r="2"/>
+    <circle cx="820" cy="140" r="2.4"/>
+    <circle cx="1010" cy="215" r="2.2"/>
+    <circle cx="760" cy="230" r="1.8"/>
+  </g>
+  <path d="M0 300 L0 240 C 200 200 340 265 520 235 S 880 195 1200 245 L1200 300 Z" fill="#1c0a06" opacity=".6"/>
+</svg>

--- a/frontend/public/decorations/banners/core-parchment.svg
+++ b/frontend/public/decorations/banners/core-parchment.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300" role="presentation">
+  <defs>
+    <linearGradient id="vellum" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f5ecd7"/>
+      <stop offset="100%" stop-color="#d8c49a"/>
+    </linearGradient>
+    <pattern id="rule" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M0 60 L60 0" stroke="#8a6d3b" stroke-opacity=".12" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="300" fill="url(#vellum)"/>
+  <rect width="1200" height="300" fill="url(#rule)"/>
+  <rect x="24" y="24" width="1152" height="252" fill="none" stroke="#8a6d3b" stroke-opacity=".35" stroke-width="3"/>
+  <rect x="36" y="36" width="1128" height="228" fill="none" stroke="#8a6d3b" stroke-opacity=".2" stroke-width="1"/>
+</svg>

--- a/frontend/public/decorations/frames/core-arcane.svg
+++ b/frontend/public/decorations/frames/core-arcane.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="presentation">
+  <defs>
+    <linearGradient id="arc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#c4b5fd"/>
+      <stop offset="50%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#2dd4bf"/>
+    </linearGradient>
+  </defs>
+  <circle cx="64" cy="64" r="60" fill="none" stroke="url(#arc)" stroke-width="6"/>
+  <circle cx="64" cy="64" r="60" fill="none" stroke="#a78bfa" stroke-opacity=".55" stroke-width="2"
+          stroke-dasharray="10 8" stroke-linecap="round"/>
+  <path d="M64 12 L104 88 L24 88 Z" fill="none" stroke="#2dd4bf" stroke-opacity=".35" stroke-width="1.5"/>
+  <path d="M64 116 L24 40 L104 40 Z" fill="none" stroke="#c4b5fd" stroke-opacity=".3" stroke-width="1.5"/>
+</svg>

--- a/frontend/public/decorations/frames/core-gold.svg
+++ b/frontend/public/decorations/frames/core-gold.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="presentation">
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fde68a"/>
+      <stop offset="45%" stop-color="#d4a017"/>
+      <stop offset="100%" stop-color="#8a6508"/>
+    </linearGradient>
+  </defs>
+  <circle cx="64" cy="64" r="60" fill="none" stroke="url(#gold)" stroke-width="7"/>
+  <circle cx="64" cy="64" r="53.5" fill="none" stroke="#4a3608" stroke-opacity=".45" stroke-width="1.5"/>
+  <g fill="#fde68a">
+    <circle cx="64" cy="4.5" r="5"/>
+    <circle cx="64" cy="123.5" r="4"/>
+    <circle cx="4.5" cy="64" r="4"/>
+    <circle cx="123.5" cy="64" r="4"/>
+  </g>
+</svg>

--- a/frontend/public/locales/de/profiles.json
+++ b/frontend/public/locales/de/profiles.json
@@ -1,0 +1,26 @@
+{
+  "notFound": {
+    "title": "Hier ist kein Profil",
+    "description": "Entweder hat niemand dieses Profil, oder die Person ist nicht in dieser Community.",
+    "back": "Zurück zur Community"
+  },
+  "noStatus": "Gerade nichts gesetzt.",
+  "presence": {
+    "label": "Präsenz",
+    "online": "Online",
+    "offline": "Offline"
+  },
+  "joined": {
+    "label": "Dabei seit"
+  },
+  "decorations": {
+    "aurora": "Aurora",
+    "ember": "Glut",
+    "parchment": "Pergament",
+    "gold": "Vergoldet",
+    "arcane": "Arkan",
+    "founder": "Gründer:in",
+    "storyteller": "Erzähler:in",
+    "trailblazer": "Wegbereiter:in"
+  }
+}

--- a/frontend/public/locales/de/profiles.json
+++ b/frontend/public/locales/de/profiles.json
@@ -22,5 +22,14 @@
     "founder": "Gründer:in",
     "storyteller": "Erzähler:in",
     "trailblazer": "Wegbereiter:in"
+  },
+  "decorationPicker": {
+    "heading": "Profil-Dekorationen",
+    "help": "Wähle aus dem, was du hast. Packs aus dem Marktplatz bringen mehr.",
+    "banner": "Banner",
+    "frame": "Rahmen",
+    "badge": "Abzeichen",
+    "empty": "Hier ist noch nichts.",
+    "badgeCount": "{{count}} von {{max}} getragen"
   }
 }

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -79,7 +79,11 @@
       "unreadable": "Dieses Bild konnte nicht gelesen werden."
     },
     "usernameLabel": "Benutzername",
-    "usernameHelp": "So sehen dich andere. Für eine Änderung wende dich an eine Moderatorin oder einen Moderator."
+    "usernameHelp": "So sehen dich andere. Für eine Änderung wende dich an eine Moderatorin oder einen Moderator.",
+    "statusLabel": "Status",
+    "statusPlaceholder": "Woran arbeitest du gerade?",
+    "statusEmojiPlaceholder": "Emoji",
+    "statusHelp": "Steht in deinem Profil für alle, mit denen du eine Community teilst."
   },
   "security": {
     "devicesTitle": "Angemeldete Geräte",

--- a/frontend/public/locales/en/profiles.json
+++ b/frontend/public/locales/en/profiles.json
@@ -1,0 +1,26 @@
+{
+  "notFound": {
+    "title": "No profile here",
+    "description": "Either nobody has this profile, or they are not in this community.",
+    "back": "Back to the community"
+  },
+  "noStatus": "Nothing set right now.",
+  "presence": {
+    "label": "Presence",
+    "online": "Online",
+    "offline": "Offline"
+  },
+  "joined": {
+    "label": "Joined"
+  },
+  "decorations": {
+    "aurora": "Aurora",
+    "ember": "Ember",
+    "parchment": "Parchment",
+    "gold": "Gilded",
+    "arcane": "Arcane",
+    "founder": "Founder",
+    "storyteller": "Storyteller",
+    "trailblazer": "Trailblazer"
+  }
+}

--- a/frontend/public/locales/en/profiles.json
+++ b/frontend/public/locales/en/profiles.json
@@ -22,5 +22,14 @@
     "founder": "Founder",
     "storyteller": "Storyteller",
     "trailblazer": "Trailblazer"
+  },
+  "decorationPicker": {
+    "heading": "Profile decorations",
+    "help": "Pick from what you have. Packs from the marketplace add more.",
+    "banner": "Banner",
+    "frame": "Frame",
+    "badge": "Badges",
+    "empty": "Nothing here yet.",
+    "badgeCount": "{{count}} of {{max}} worn"
   }
 }

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -79,7 +79,11 @@
       "unreadable": "That image could not be read."
     },
     "usernameLabel": "Username",
-    "usernameHelp": "How other people see you. Ask a moderator if you need it changed."
+    "usernameHelp": "How other people see you. Ask a moderator if you need it changed.",
+    "statusLabel": "Status",
+    "statusPlaceholder": "What are you up to?",
+    "statusEmojiPlaceholder": "Emoji",
+    "statusHelp": "Shown on your profile to everyone you share a community with."
   },
   "security": {
     "devicesTitle": "Logged in devices",

--- a/frontend/public/locales/es/profiles.json
+++ b/frontend/public/locales/es/profiles.json
@@ -1,0 +1,26 @@
+{
+  "notFound": {
+    "title": "Aquí no hay ningún perfil",
+    "description": "O nadie tiene este perfil, o esa persona no está en esta comunidad.",
+    "back": "Volver a la comunidad"
+  },
+  "noStatus": "Ahora mismo no hay nada.",
+  "presence": {
+    "label": "Presencia",
+    "online": "En línea",
+    "offline": "Desconectado"
+  },
+  "joined": {
+    "label": "Se unió"
+  },
+  "decorations": {
+    "aurora": "Aurora",
+    "ember": "Brasa",
+    "parchment": "Pergamino",
+    "gold": "Dorado",
+    "arcane": "Arcano",
+    "founder": "Fundador",
+    "storyteller": "Narrador",
+    "trailblazer": "Pionero"
+  }
+}

--- a/frontend/public/locales/es/profiles.json
+++ b/frontend/public/locales/es/profiles.json
@@ -22,5 +22,14 @@
     "founder": "Fundador",
     "storyteller": "Narrador",
     "trailblazer": "Pionero"
+  },
+  "decorationPicker": {
+    "heading": "Decoraciones del perfil",
+    "help": "Elige entre lo que tienes. Los packs del mercado añaden más.",
+    "banner": "Cabecera",
+    "frame": "Marco",
+    "badge": "Insignias",
+    "empty": "Aquí todavía no hay nada.",
+    "badgeCount": "{{count}} de {{max}} puestas"
   }
 }

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -79,7 +79,11 @@
       "unreadable": "No se ha podido leer esa imagen."
     },
     "usernameLabel": "Nombre de usuario",
-    "usernameHelp": "Así te ven los demás. Si necesitas cambiarlo, pídeselo a un moderador."
+    "usernameHelp": "Así te ven los demás. Si necesitas cambiarlo, pídeselo a un moderador.",
+    "statusLabel": "Estado",
+    "statusPlaceholder": "¿En qué andas?",
+    "statusEmojiPlaceholder": "Emoji",
+    "statusHelp": "Se muestra en tu perfil a todas las personas con las que compartes comunidad."
   },
   "security": {
     "devicesTitle": "Dispositivos conectados",

--- a/frontend/public/locales/fr/profiles.json
+++ b/frontend/public/locales/fr/profiles.json
@@ -1,0 +1,26 @@
+{
+  "notFound": {
+    "title": "Aucun profil ici",
+    "description": "Soit personne n'a ce profil, soit cette personne n'est pas dans cette communauté.",
+    "back": "Retour à la communauté"
+  },
+  "noStatus": "Rien pour le moment.",
+  "presence": {
+    "label": "Présence",
+    "online": "En ligne",
+    "offline": "Hors ligne"
+  },
+  "joined": {
+    "label": "A rejoint"
+  },
+  "decorations": {
+    "aurora": "Aurore",
+    "ember": "Braise",
+    "parchment": "Parchemin",
+    "gold": "Doré",
+    "arcane": "Arcane",
+    "founder": "Fondateur",
+    "storyteller": "Conteur",
+    "trailblazer": "Pionnier"
+  }
+}

--- a/frontend/public/locales/fr/profiles.json
+++ b/frontend/public/locales/fr/profiles.json
@@ -22,5 +22,14 @@
     "founder": "Fondateur",
     "storyteller": "Conteur",
     "trailblazer": "Pionnier"
+  },
+  "decorationPicker": {
+    "heading": "Décorations du profil",
+    "help": "Choisissez parmi ce que vous avez. Les packs de la boutique en ajoutent.",
+    "banner": "Bannière",
+    "frame": "Cadre",
+    "badge": "Badges",
+    "empty": "Rien ici pour l'instant.",
+    "badgeCount": "{{count}} sur {{max}} portés"
   }
 }

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -79,7 +79,11 @@
       "unreadable": "Cette image n'a pas pu être lue."
     },
     "usernameLabel": "Nom d'utilisateur",
-    "usernameHelp": "C'est ainsi que les autres vous voient. Pour le modifier, adressez-vous à un modérateur."
+    "usernameHelp": "C'est ainsi que les autres vous voient. Pour le modifier, adressez-vous à un modérateur.",
+    "statusLabel": "Statut",
+    "statusPlaceholder": "Qu'est-ce qui vous occupe ?",
+    "statusEmojiPlaceholder": "Émoji",
+    "statusHelp": "Affiché sur votre profil pour toutes les personnes avec qui vous partagez une communauté."
   },
   "security": {
     "devicesTitle": "Appareils connectés",

--- a/frontend/src/__tests__/factories/index.ts
+++ b/frontend/src/__tests__/factories/index.ts
@@ -74,6 +74,7 @@ export {
   resetCounter as resetTaskCounter,
 } from "./task.factory";
 export {
+  buildOwnedDecoration,
   buildUser,
   buildUserGuildMember,
   buildUserProfile,

--- a/frontend/src/__tests__/factories/index.ts
+++ b/frontend/src/__tests__/factories/index.ts
@@ -76,6 +76,7 @@ export {
 export {
   buildUser,
   buildUserGuildMember,
+  buildUserProfile,
   buildUserPublic,
   buildUserSummary,
   resetCounter as resetUserCounter,

--- a/frontend/src/__tests__/factories/user.factory.ts
+++ b/frontend/src/__tests__/factories/user.factory.ts
@@ -1,5 +1,6 @@
 import type {
   UserGuildMember,
+  UserProfile,
   UserPublic,
   UserRead,
   UserRole,
@@ -129,6 +130,27 @@ export function buildUserGuildMember(overrides: Partial<UserGuildMember> = {}): 
     email_verified: true,
     created_at: "2026-01-15T00:00:00.000Z",
     initiative_roles: [],
+    ...overrides,
+  };
+}
+
+/** A member's profile, as the rest of their guild sees them. Bare by default —
+ *  no status and nothing worn — so a test that asserts on a decoration has to
+ *  have put it there. */
+export function buildUserProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+  counter++;
+  return {
+    id: counter,
+    username: `user-${counter}`,
+    discriminator: 1000 + counter,
+    full_name: `User ${counter}`,
+    avatar_url: null,
+    status: "active",
+    custom_status_emoji: null,
+    custom_status_text: null,
+    profile_decorations: { banner: null, frame: null, badges: [] },
+    online: false,
+    joined_at: "2026-01-15T00:00:00.000Z",
     ...overrides,
   };
 }

--- a/frontend/src/__tests__/factories/user.factory.ts
+++ b/frontend/src/__tests__/factories/user.factory.ts
@@ -1,4 +1,5 @@
 import type {
+  OwnedDecoration,
   UserGuildMember,
   UserProfile,
   UserPublic,
@@ -109,6 +110,8 @@ export function buildUser(overrides: Partial<UserRead> = {}): UserRead {
     email_verified: true,
     created_at: "2026-01-15T00:00:00.000Z",
     updated_at: "2026-01-15T00:00:00.000Z",
+    custom_status: { emoji: null, text: null },
+    profile_decorations: { banner: null, frame: null, badges: [] },
     week_starts_on: 0,
     timezone: "America/New_York",
     ...overrides,
@@ -143,14 +146,17 @@ export function buildUserProfile(overrides: Partial<UserProfile> = {}): UserProf
     id: counter,
     username: `user-${counter}`,
     discriminator: 1000 + counter,
-    full_name: `User ${counter}`,
     avatar_url: null,
     status: "active",
-    custom_status_emoji: null,
-    custom_status_text: null,
+    custom_status: { emoji: null, text: null },
     profile_decorations: { banner: null, frame: null, badges: [] },
     online: false,
     joined_at: "2026-01-15T00:00:00.000Z",
     ...overrides,
   };
+}
+
+/** One decoration in somebody's library. Shipped (no pack) by default. */
+export function buildOwnedDecoration(overrides: Partial<OwnedDecoration> = {}): OwnedDecoration {
+  return { id: "core.aurora", kind: "banner", source: null, ...overrides };
 }

--- a/frontend/src/__tests__/userProfileRoute.test.tsx
+++ b/frontend/src/__tests__/userProfileRoute.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * The way to a member's profile, through the router the app ships.
+ *
+ * A profile is only useful if it is reachable: the generated route tree has to
+ * serve `/c/{id}/u/{userId}` and load the page from its own chunk. A test that
+ * mounts the page component directly proves neither, so this one goes through
+ * the tree and preloads the route's own component.
+ */
+import { createRouter } from "@tanstack/react-router";
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { routeTree } from "@/routeTree.gen";
+
+import { buildUserProfile } from "./factories";
+import { renderPage } from "./helpers/render";
+
+const PROFILE_ROUTE_ID = "/_serverRequired/_authenticated/c/$guildId/u/$userId";
+
+const mocks = vi.hoisted(() => ({ profile: vi.fn() }));
+vi.mock("@/hooks/useUsers", () => ({
+  useUserProfile: (userId: number | null) => mocks.profile(userId),
+}));
+
+const router = createRouter({ routeTree });
+
+const profilePage = async () => {
+  const route = router.routesById[PROFILE_ROUTE_ID];
+  const Page = route.options.component as React.ComponentType & {
+    preload?: () => Promise<unknown>;
+  };
+  // The dynamic import the route is declared with: a moved page or a renamed
+  // export fails here rather than at a click.
+  await Page.preload?.();
+  return Page;
+};
+
+const renderProfile = async () => {
+  const Page = await profilePage();
+  return renderPage(Page, {
+    initialRoute: "/c/$guildId/u/$userId",
+    routeParams: { guildId: "1", userId: "7" },
+  });
+};
+
+const answerWith = (profile: unknown) =>
+  mocks.profile.mockReturnValue({ data: profile, isLoading: false });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  answerWith(buildUserProfile());
+});
+
+describe("a member's profile", () => {
+  it("is an address the shipped route tree serves", () => {
+    const matches = router.matchRoutes({ pathname: "/c/1/u/7", search: {} }, { preload: true });
+    expect(String(matches.at(-1)?.routeId)).toBe(PROFILE_ROUTE_ID);
+  });
+
+  it("shows the name, the handle and the line they wrote", async () => {
+    answerWith(
+      buildUserProfile({
+        username: "tinker",
+        discriminator: 42,
+        full_name: "Tinker Bell",
+        custom_status_emoji: "🎲",
+        custom_status_text: "rolling for initiative",
+      })
+    );
+    await renderProfile();
+
+    expect(await screen.findByRole("heading", { name: "Tinker Bell" })).toBeInTheDocument();
+    expect(screen.getByTitle("tinker#0042")).toBeInTheDocument();
+    expect(screen.getByText("rolling for initiative")).toBeInTheDocument();
+  });
+
+  it("leads with the handle where the community shows no names", async () => {
+    // The server has already withheld the name; the page must not leave a
+    // heading-shaped hole where it would have been.
+    answerWith(buildUserProfile({ username: "tinker", discriminator: 42, full_name: null }));
+    await renderProfile();
+
+    expect(await screen.findByTitle("tinker#0042")).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+
+  it("says when someone has the community open", async () => {
+    answerWith(buildUserProfile({ online: true }));
+    await renderProfile();
+
+    expect(await screen.findByText("Online")).toBeInTheDocument();
+  });
+
+  it("wears the decorations it can draw, and ignores the ones it cannot", async () => {
+    answerWith(
+      buildUserProfile({
+        profile_decorations: {
+          banner: "core.aurora",
+          frame: "core.gold",
+          badges: ["core.founder", "thirdparty.unknown"],
+        },
+      })
+    );
+    const { container } = await renderProfile();
+
+    expect(await screen.findByAltText("Founder")).toHaveAttribute(
+      "src",
+      "/decorations/badges/core-founder.svg"
+    );
+    // The frame is worn over the picture and says nothing, so it is hidden
+    // from assistive technology and found by its source instead.
+    expect(container.querySelector('img[src="/decorations/frames/core-gold.svg"]')).not.toBeNull();
+    expect(
+      container.querySelector('[style*="/decorations/banners/core-aurora.svg"]')
+    ).not.toBeNull();
+  });
+
+  it("says so when there is nobody behind the address", async () => {
+    answerWith(undefined);
+    await renderProfile();
+
+    expect(await screen.findByText("No profile here")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/userProfileRoute.test.tsx
+++ b/frontend/src/__tests__/userProfileRoute.test.tsx
@@ -16,11 +16,11 @@ import { routeTree } from "@/routeTree.gen";
 import { buildUserProfile } from "./factories";
 import { renderPage } from "./helpers/render";
 
-const PROFILE_ROUTE_ID = "/_serverRequired/_authenticated/u/$userId";
+const PROFILE_ROUTE_ID = "/_serverRequired/_authenticated/u/$handle";
 
 const mocks = vi.hoisted(() => ({ profile: vi.fn() }));
 vi.mock("@/hooks/useUsers", () => ({
-  useUserProfile: (userId: number | null) => mocks.profile(userId),
+  useUserProfile: (handle: string | null) => mocks.profile(handle),
 }));
 
 const router = createRouter({ routeTree });
@@ -39,8 +39,8 @@ const profilePage = async () => {
 const renderProfile = async () => {
   const Page = await profilePage();
   return renderPage(Page, {
-    initialRoute: "/u/$userId",
-    routeParams: { userId: "7" },
+    initialRoute: "/u/$handle",
+    routeParams: { handle: "tinker0042" },
   });
 };
 
@@ -53,9 +53,19 @@ beforeEach(() => {
 });
 
 describe("a member's profile", () => {
-  it("is an address the shipped route tree serves", () => {
-    const matches = router.matchRoutes({ pathname: "/u/7", search: {} }, { preload: true });
+  it("is an address the shipped route tree serves, keyed by handle", () => {
+    const matches = router.matchRoutes(
+      { pathname: "/u/tinker0042", search: {} },
+      { preload: true }
+    );
     expect(String(matches.at(-1)?.routeId)).toBe(PROFILE_ROUTE_ID);
+  });
+
+  it("asks for the handle in the address, not an id", async () => {
+    await renderProfile();
+    await screen.findByRole("heading");
+
+    expect(mocks.profile).toHaveBeenCalledWith("tinker0042");
   });
 
   it("leads with the handle, and shows the line they wrote", async () => {

--- a/frontend/src/__tests__/userProfileRoute.test.tsx
+++ b/frontend/src/__tests__/userProfileRoute.test.tsx
@@ -1,10 +1,11 @@
 /**
- * The way to a member's profile, through the router the app ships.
+ * The way to a person's profile, through the router the app ships.
  *
  * A profile is only useful if it is reachable: the generated route tree has to
- * serve `/c/{id}/u/{userId}` and load the page from its own chunk. A test that
- * mounts the page component directly proves neither, so this one goes through
- * the tree and preloads the route's own component.
+ * serve `/u/{userId}` — outside the community tree, because a profile is public
+ * and belongs to no community — and load the page from its own chunk. A test
+ * that mounts the page component directly proves neither, so this one goes
+ * through the tree and preloads the route's own component.
  */
 import { createRouter } from "@tanstack/react-router";
 import { screen } from "@testing-library/react";
@@ -15,7 +16,7 @@ import { routeTree } from "@/routeTree.gen";
 import { buildUserProfile } from "./factories";
 import { renderPage } from "./helpers/render";
 
-const PROFILE_ROUTE_ID = "/_serverRequired/_authenticated/c/$guildId/u/$userId";
+const PROFILE_ROUTE_ID = "/_serverRequired/_authenticated/u/$userId";
 
 const mocks = vi.hoisted(() => ({ profile: vi.fn() }));
 vi.mock("@/hooks/useUsers", () => ({
@@ -38,8 +39,8 @@ const profilePage = async () => {
 const renderProfile = async () => {
   const Page = await profilePage();
   return renderPage(Page, {
-    initialRoute: "/c/$guildId/u/$userId",
-    routeParams: { guildId: "1", userId: "7" },
+    initialRoute: "/u/$userId",
+    routeParams: { userId: "7" },
   });
 };
 
@@ -53,38 +54,28 @@ beforeEach(() => {
 
 describe("a member's profile", () => {
   it("is an address the shipped route tree serves", () => {
-    const matches = router.matchRoutes({ pathname: "/c/1/u/7", search: {} }, { preload: true });
+    const matches = router.matchRoutes({ pathname: "/u/7", search: {} }, { preload: true });
     expect(String(matches.at(-1)?.routeId)).toBe(PROFILE_ROUTE_ID);
   });
 
-  it("shows the name, the handle and the line they wrote", async () => {
+  it("leads with the handle, and shows the line they wrote", async () => {
+    // The handle is the name in this product — a profile carries no real name
+    // at all, so it is the heading rather than a subtitle under one.
     answerWith(
       buildUserProfile({
         username: "tinker",
         discriminator: 42,
-        full_name: "Tinker Bell",
-        custom_status_emoji: "🎲",
-        custom_status_text: "rolling for initiative",
+        custom_status: { emoji: "🎲", text: "rolling for initiative" },
       })
     );
     await renderProfile();
 
-    expect(await screen.findByRole("heading", { name: "Tinker Bell" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /tinker/ })).toBeInTheDocument();
     expect(screen.getByTitle("tinker#0042")).toBeInTheDocument();
     expect(screen.getByText("rolling for initiative")).toBeInTheDocument();
   });
 
-  it("leads with the handle where the community shows no names", async () => {
-    // The server has already withheld the name; the page must not leave a
-    // heading-shaped hole where it would have been.
-    answerWith(buildUserProfile({ username: "tinker", discriminator: 42, full_name: null }));
-    await renderProfile();
-
-    expect(await screen.findByTitle("tinker#0042")).toBeInTheDocument();
-    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
-  });
-
-  it("says when someone has the community open", async () => {
+  it("says when someone has Initiative open", async () => {
     answerWith(buildUserProfile({ online: true }));
     await renderProfile();
 

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1706,6 +1706,38 @@ export interface CounterUpdate {
   position?: number | string | null;
 }
 
+/**
+ * What a person is up to, in their own words.
+ *
+ * One object, stored in one column, because it is one thing a person sets
+ * and one thing every surface that names them renders: splitting it in two
+ * would mean two reads and two writes for a single line of text.
+ *
+ * Not to be confused with ``UserStatus`` (``users.status``), which is the
+ * account's standing — suspended, deactivated — and is not the person's to
+ * write.
+ */
+export interface CustomStatusInput {
+  emoji?: string | null;
+  text?: string | null;
+}
+
+/**
+ * What a person is up to, in their own words.
+ *
+ * One object, stored in one column, because it is one thing a person sets
+ * and one thing every surface that names them renders: splitting it in two
+ * would mean two reads and two writes for a single line of text.
+ *
+ * Not to be confused with ``UserStatus`` (``users.status``), which is the
+ * account's standing — suspended, deactivated — and is not the person's to
+ * write.
+ */
+export interface CustomStatusOutput {
+  emoji: string | null;
+  text: string | null;
+}
+
 export type DashboardCreateDefinition = { [key: string]: unknown };
 
 export type DashboardCreateConfig = { [key: string]: unknown };
@@ -3576,6 +3608,28 @@ export interface OwnedContentResponse {
 }
 
 /**
+ * One decoration an account may wear, and where it came from.
+ *
+ * ``source`` names the marketplace pack that granted it, and is ``None`` for
+ * the ones that ship with the app. The client renders a picker per slot from
+ * these, drawing each id with the artwork it has for it and skipping the ones
+ * it doesn't.
+ */
+export interface OwnedDecoration {
+  id: string;
+  kind: string;
+  source: string | null;
+}
+
+/**
+ * A person's whole library, in one read — it is small and it is all
+ * needed at once, because the profile form renders every slot together.
+ */
+export interface OwnedDecorationsResponse {
+  items: OwnedDecoration[];
+}
+
+/**
  * Who should end up owning it. Must be an active admin of this guild.
  */
 export interface OwnershipTransferRequest {
@@ -3682,10 +3736,9 @@ export interface PlatformRoleUpdate {
  *
  * Every value is an **id naming a catalog entry**, never an image. The client
  * resolves an id to artwork it already ships, so a decorated profile takes up
- * none of a guild's upload allowance and no user-supplied image is ever
- * rendered as somebody's frame. An id this deployment's catalog doesn't know
- * simply renders nothing, which is what lets a profile keep wearing something
- * the store stopped offering.
+ * none of a guild's upload allowance. An id this deployment's catalog doesn't
+ * know simply renders nothing, which is what lets a profile keep wearing
+ * something the store stopped offering.
  *
  * ``extra="forbid"``: the set of things a profile can wear is this list, and
  * a client sending a key that isn't here is told so rather than having it
@@ -3703,10 +3756,9 @@ export interface ProfileDecorationsInput {
  *
  * Every value is an **id naming a catalog entry**, never an image. The client
  * resolves an id to artwork it already ships, so a decorated profile takes up
- * none of a guild's upload allowance and no user-supplied image is ever
- * rendered as somebody's frame. An id this deployment's catalog doesn't know
- * simply renders nothing, which is what lets a profile keep wearing something
- * the store stopped offering.
+ * none of a guild's upload allowance. An id this deployment's catalog doesn't
+ * know simply renders nothing, which is what lets a profile keep wearing
+ * something the store stopped offering.
  *
  * ``extra="forbid"``: the set of things a profile can wear is this list, and
  * a client sending a key that isn't here is told so rather than having it
@@ -4986,26 +5038,25 @@ export interface UserGuildMember {
 }
 
 /**
- * A person, as the rest of their guild sees them.
+ * A person, as anyone can see them.
  *
- * Everything on :class:`UserPublic` — the face and the handle a member is
- * already rendered by everywhere else — plus what a profile adds: the line
- * they wrote about themselves, how they have dressed the page, whether they
- * have the app open, and when they joined this guild.
+ * A profile is public. It carries the handle — which is the name in this
+ * product, unique and never withheld — the face, the line they wrote, the
+ * look they picked, whether they are online, and when they joined. It never
+ * carries a real name: ``full_name`` is a guild's business (a guild decides
+ * whether it renders names at all), and this shape has no guild in it.
  *
- * Guild-scoped on purpose, because two of those answers are: a real name
- * shows only where the guild shows names, and "here" means here rather than
- * on the platform somewhere.
+ * Nothing here is private to a guild, so nothing here is reached through
+ * one. What it does not carry is the whole point of it being its own shape:
+ * no address, no roles, no memberships, no preferences.
  */
 export interface UserProfile {
   id: number;
   username: string;
   discriminator: number;
-  full_name: string | null;
   avatar_url: string | null;
   status: UserStatus;
-  custom_status_emoji: string | null;
-  custom_status_text: string | null;
+  custom_status: CustomStatusOutput;
   profile_decorations: ProfileDecorationsOutput;
   online: boolean;
   joined_at: string;
@@ -5024,8 +5075,7 @@ export interface UserRead {
   created_at: string;
   updated_at: string;
   avatar_url: string | null;
-  custom_status_emoji: string | null;
-  custom_status_text: string | null;
+  custom_status: CustomStatusOutput;
   profile_decorations: ProfileDecorationsOutput;
   week_starts_on: number;
   recent_tabs_limit: number;
@@ -5072,8 +5122,7 @@ export interface UserSelfUpdate {
   password?: string | null;
   current_password?: string | null;
   avatar_url?: string | null;
-  custom_status_emoji?: string | null;
-  custom_status_text?: string | null;
+  custom_status?: CustomStatusInput | null;
   profile_decorations?: ProfileDecorationsInput | null;
   week_starts_on?: number | null;
   recent_tabs_limit?: number | null;

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -3677,6 +3677,48 @@ export interface PlatformRoleUpdate {
   role: UserRole;
 }
 
+/**
+ * How a profile is dressed: a banner, a frame, badges beside the name.
+ *
+ * Every value is an **id naming a catalog entry**, never an image. The client
+ * resolves an id to artwork it already ships, so a decorated profile takes up
+ * none of a guild's upload allowance and no user-supplied image is ever
+ * rendered as somebody's frame. An id this deployment's catalog doesn't know
+ * simply renders nothing, which is what lets a profile keep wearing something
+ * the store stopped offering.
+ *
+ * ``extra="forbid"``: the set of things a profile can wear is this list, and
+ * a client sending a key that isn't here is told so rather than having it
+ * quietly stored and never rendered.
+ */
+export interface ProfileDecorationsInput {
+  banner?: string | null;
+  frame?: string | null;
+  /** @maxItems 6 */
+  badges?: string[];
+}
+
+/**
+ * How a profile is dressed: a banner, a frame, badges beside the name.
+ *
+ * Every value is an **id naming a catalog entry**, never an image. The client
+ * resolves an id to artwork it already ships, so a decorated profile takes up
+ * none of a guild's upload allowance and no user-supplied image is ever
+ * rendered as somebody's frame. An id this deployment's catalog doesn't know
+ * simply renders nothing, which is what lets a profile keep wearing something
+ * the store stopped offering.
+ *
+ * ``extra="forbid"``: the set of things a profile can wear is this list, and
+ * a client sending a key that isn't here is told so rather than having it
+ * quietly stored and never rendered.
+ */
+export interface ProfileDecorationsOutput {
+  banner: string | null;
+  frame: string | null;
+  /** @maxItems 6 */
+  badges: string[];
+}
+
 export interface ProjectActivityEntry {
   comment_id: number;
   content: string;
@@ -4943,6 +4985,32 @@ export interface UserGuildMember {
   initiative_roles: UserInitiativeRole[];
 }
 
+/**
+ * A person, as the rest of their guild sees them.
+ *
+ * Everything on :class:`UserPublic` — the face and the handle a member is
+ * already rendered by everywhere else — plus what a profile adds: the line
+ * they wrote about themselves, how they have dressed the page, whether they
+ * have the app open, and when they joined this guild.
+ *
+ * Guild-scoped on purpose, because two of those answers are: a real name
+ * shows only where the guild shows names, and "here" means here rather than
+ * on the platform somewhere.
+ */
+export interface UserProfile {
+  id: number;
+  username: string;
+  discriminator: number;
+  full_name: string | null;
+  avatar_url: string | null;
+  status: UserStatus;
+  custom_status_emoji: string | null;
+  custom_status_text: string | null;
+  profile_decorations: ProfileDecorationsOutput;
+  online: boolean;
+  joined_at: string;
+}
+
 export interface UserRead {
   email: string;
   full_name: string | null;
@@ -4956,6 +5024,9 @@ export interface UserRead {
   created_at: string;
   updated_at: string;
   avatar_url: string | null;
+  custom_status_emoji: string | null;
+  custom_status_text: string | null;
+  profile_decorations: ProfileDecorationsOutput;
   week_starts_on: number;
   recent_tabs_limit: number;
   timezone: string;
@@ -5001,6 +5072,9 @@ export interface UserSelfUpdate {
   password?: string | null;
   current_password?: string | null;
   avatar_url?: string | null;
+  custom_status_emoji?: string | null;
+  custom_status_text?: string | null;
+  profile_decorations?: ProfileDecorationsInput | null;
   week_starts_on?: number | null;
   recent_tabs_limit?: number | null;
   timezone?: string | null;

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -33,6 +33,7 @@ import type {
   GetUserStatsApiV1MeStatsGetParams,
   HTTPValidationError,
   OwnedContentResponse,
+  OwnedDecorationsResponse,
   OwnershipTransferRequest,
   OwnershipTransferResponse,
   SearchUsersApiV1GGuildIdUsersSearchGetParams,
@@ -273,6 +274,326 @@ export const useUpdateUsersMeApiV1UsersMePatch = <
 > => {
   return useMutation(getUpdateUsersMeApiV1UsersMePatchMutationOptions(options), queryClient);
 };
+/**
+ * Everything the caller may dress their profile in.
+ *
+ * What ships with the app plus what this account acquired, which is what the
+ * pickers on Settings > Profile offer and exactly what the write path
+ * accepts. Own-row: ``public.user_decorations`` is readable only by the
+ * account whose library it is.
+ * @summary List My Decorations
+ */
+export const listMyDecorationsApiV1UsersMeDecorationsGet = (
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<OwnedDecorationsResponse>(
+    { url: `/api/v1/users/me/decorations`, method: "GET", signal },
+    options
+  );
+};
+
+export const getListMyDecorationsApiV1UsersMeDecorationsGetQueryKey = () => {
+  return [`/api/v1/users/me/decorations`] as const;
+};
+
+export const getListMyDecorationsApiV1UsersMeDecorationsGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getListMyDecorationsApiV1UsersMeDecorationsGetQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>
+  > = ({ signal }) => listMyDecorationsApiV1UsersMeDecorationsGet(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListMyDecorationsApiV1UsersMeDecorationsGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>
+>;
+export type ListMyDecorationsApiV1UsersMeDecorationsGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useListMyDecorationsApiV1UsersMeDecorationsGet<
+  TData = Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListMyDecorationsApiV1UsersMeDecorationsGet<
+  TData = Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListMyDecorationsApiV1UsersMeDecorationsGet<
+  TData = Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List My Decorations
+ */
+
+export function useListMyDecorationsApiV1UsersMeDecorationsGet<
+  TData = Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMyDecorationsApiV1UsersMeDecorationsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getListMyDecorationsApiV1UsersMeDecorationsGetQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * One person's profile.
+ *
+ * A profile is public and has no guild in it: it carries the handle, the
+ * face, the status, the look and whether they are online, and it is the same
+ * page whoever opens it. That is why it is not reached through a guild — no
+ * part of the answer depends on one.
+ *
+ * Read on the system engine, selecting the profile columns and nothing else.
+ * ``public.users`` is own-row for a platform-tier session (a person's
+ * address, their preferences and their memberships are theirs), so the row
+ * cannot be read whole here; what is public about it is this narrow
+ * projection, and the response shape carries exactly the columns named
+ * below. A suspended account has no profile.
+ * @summary Read User Profile
+ */
+export const readUserProfileApiV1UsersUserIdProfileGet = (
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<UserProfile>(
+    { url: `/api/v1/users/${userId}/profile`, method: "GET", signal },
+    options
+  );
+};
+
+export const getReadUserProfileApiV1UsersUserIdProfileGetQueryKey = (userId: number) => {
+  return [`/api/v1/users/${userId}/profile`] as const;
+};
+
+export const getReadUserProfileApiV1UsersUserIdProfileGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getReadUserProfileApiV1UsersUserIdProfileGetQueryKey(userId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
+  > = ({ signal }) => readUserProfileApiV1UsersUserIdProfileGet(userId, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: userId !== null && userId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ReadUserProfileApiV1UsersUserIdProfileGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
+>;
+export type ReadUserProfileApiV1UsersUserIdProfileGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useReadUserProfileApiV1UsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+          TError,
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadUserProfileApiV1UsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+          TError,
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadUserProfileApiV1UsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Read User Profile
+ */
+
+export function useReadUserProfileApiV1UsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getReadUserProfileApiV1UsersUserIdProfileGetQueryOptions(userId, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
 /**
  * Pick the handle for an account that was assigned one.
  *
@@ -1634,189 +1955,6 @@ export function useSearchUsersApiV1GGuildIdUsersSearchGet<
   const queryOptions = getSearchUsersApiV1GGuildIdUsersSearchGetQueryOptions(
     guildId,
     params,
-    options
-  );
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-
-  return withQueryKey(query, queryOptions.queryKey);
-}
-
-/**
- * One member's profile, as the rest of their guild sees it.
- *
- * Guild-scoped, like the roster it is reached from: the membership join is
- * what says a profile exists to the caller, so someone the caller shares no
- * guild with is a 404 rather than a page. It is also what makes the answer
- * correct — a real name renders only where the guild shows names, and
- * "online" means "has this guild open".
- *
- * Nothing here is a guild's to write. The account row is the person's own
- * (``users`` UPDATE is own-row on the request path); this reads it.
- * @summary Read Member Profile
- */
-export const readMemberProfileApiV1GGuildIdUsersUserIdProfileGet = (
-  guildId: number,
-  userId: number,
-  options?: SecondParameter<typeof apiMutator>,
-  signal?: AbortSignal
-) => {
-  return apiMutator<UserProfile>(
-    { url: `/api/v1/g/${guildId}/users/${userId}/profile`, method: "GET", signal },
-    options
-  );
-};
-
-export const getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryKey = (
-  guildId: number,
-  userId: number
-) => {
-  return [`/api/v1/g/${guildId}/users/${userId}/profile`] as const;
-};
-
-export const getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryOptions = <
-  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  userId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  }
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey =
-    queryOptions?.queryKey ??
-    getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryKey(guildId, userId);
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
-  > = ({ signal }) =>
-    readMemberProfileApiV1GGuildIdUsersUserIdProfileGet(guildId, userId, requestOptions, signal);
-
-  return {
-    queryKey,
-    queryFn,
-    enabled: guildId !== null && guildId !== undefined && userId !== null && userId !== undefined,
-    ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-    TError,
-    TData
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-};
-
-export type ReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryResult = NonNullable<
-  Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
->;
-export type ReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryError =
-  ErrorType<HTTPValidationError>;
-
-export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  userId: number,
-  options: {
-    query: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-          TError,
-          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  userId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-          TError,
-          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  userId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-/**
- * @summary Read Member Profile
- */
-
-export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-  TError = ErrorType<HTTPValidationError>,
->(
-  guildId: number,
-  userId: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof apiMutator>;
-  },
-  queryClient?: QueryClient
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryOptions(
-    guildId,
-    userId,
     options
   );
 

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -425,45 +425,47 @@ export function useListMyDecorationsApiV1UsersMeDecorationsGet<
 }
 
 /**
- * One person's profile.
+ * One person's profile, addressed by their handle.
+ *
+ * ``jordan1234`` — the name and the number it is always written with, run
+ * together. ``#`` never survives a URL, and the number's four digits are
+ * fixed width, so the two come apart again exactly.
  *
  * A profile is public and has no guild in it: it carries the handle, the
  * face, the status, the look and whether they are online, and it is the same
  * page whoever opens it. That is why it is not reached through a guild — no
  * part of the answer depends on one.
  *
- * Read on the system engine, selecting the profile columns and nothing else.
- * ``public.users`` is own-row for a platform-tier session (a person's
- * address, their preferences and their memberships are theirs), so the row
- * cannot be read whole here; what is public about it is this narrow
- * projection, and the response shape carries exactly the columns named
- * below. A suspended account has no profile.
+ * Read from ``public.user_profiles``, the view that *is* the public
+ * projection: which columns are public is decided by the view and the column
+ * grant behind it (migration 0214), not here. An ordinary platform-tier
+ * session, RLS enforced. A suspended account has no profile.
  * @summary Read User Profile
  */
-export const readUserProfileApiV1UsersUserIdProfileGet = (
-  userId: number,
+export const readUserProfileApiV1UsersHandleProfileGet = (
+  handle: string,
   options?: SecondParameter<typeof apiMutator>,
   signal?: AbortSignal
 ) => {
   return apiMutator<UserProfile>(
-    { url: `/api/v1/users/${userId}/profile`, method: "GET", signal },
+    { url: `/api/v1/users/${handle}/profile`, method: "GET", signal },
     options
   );
 };
 
-export const getReadUserProfileApiV1UsersUserIdProfileGetQueryKey = (userId: number) => {
-  return [`/api/v1/users/${userId}/profile`] as const;
+export const getReadUserProfileApiV1UsersHandleProfileGetQueryKey = (handle: string) => {
+  return [`/api/v1/users/${handle}/profile`] as const;
 };
 
-export const getReadUserProfileApiV1UsersUserIdProfileGetQueryOptions = <
-  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+export const getReadUserProfileApiV1UsersHandleProfileGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  userId: number,
+  handle: string,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
         TError,
         TData
       >
@@ -474,47 +476,47 @@ export const getReadUserProfileApiV1UsersUserIdProfileGetQueryOptions = <
   const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey =
-    queryOptions?.queryKey ?? getReadUserProfileApiV1UsersUserIdProfileGetQueryKey(userId);
+    queryOptions?.queryKey ?? getReadUserProfileApiV1UsersHandleProfileGetQueryKey(handle);
 
   const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
-  > = ({ signal }) => readUserProfileApiV1UsersUserIdProfileGet(userId, requestOptions, signal);
+    Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>
+  > = ({ signal }) => readUserProfileApiV1UsersHandleProfileGet(handle, requestOptions, signal);
 
   return {
     queryKey,
     queryFn,
-    enabled: userId !== null && userId !== undefined,
+    enabled: handle !== null && handle !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
-    Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+    Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData, TError> };
 };
 
-export type ReadUserProfileApiV1UsersUserIdProfileGetQueryResult = NonNullable<
-  Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
+export type ReadUserProfileApiV1UsersHandleProfileGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>
 >;
-export type ReadUserProfileApiV1UsersUserIdProfileGetQueryError = ErrorType<HTTPValidationError>;
+export type ReadUserProfileApiV1UsersHandleProfileGetQueryError = ErrorType<HTTPValidationError>;
 
-export function useReadUserProfileApiV1UsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+export function useReadUserProfileApiV1UsersHandleProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  userId: number,
+  handle: string,
   options: {
     query: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
         TError,
         TData
       >
     > &
       Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
           TError,
-          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>
         >,
         "initialData"
       >;
@@ -522,24 +524,24 @@ export function useReadUserProfileApiV1UsersUserIdProfileGet<
   },
   queryClient?: QueryClient
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadUserProfileApiV1UsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+export function useReadUserProfileApiV1UsersHandleProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  userId: number,
+  handle: string,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
         TError,
         TData
       >
     > &
       Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
           TError,
-          Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>
+          Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>
         >,
         "initialData"
       >;
@@ -547,15 +549,15 @@ export function useReadUserProfileApiV1UsersUserIdProfileGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-export function useReadUserProfileApiV1UsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+export function useReadUserProfileApiV1UsersHandleProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  userId: number,
+  handle: string,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
         TError,
         TData
       >
@@ -568,15 +570,15 @@ export function useReadUserProfileApiV1UsersUserIdProfileGet<
  * @summary Read User Profile
  */
 
-export function useReadUserProfileApiV1UsersUserIdProfileGet<
-  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+export function useReadUserProfileApiV1UsersHandleProfileGet<
+  TData = Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
   TError = ErrorType<HTTPValidationError>,
 >(
-  userId: number,
+  handle: string,
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof readUserProfileApiV1UsersUserIdProfileGet>>,
+        Awaited<ReturnType<typeof readUserProfileApiV1UsersHandleProfileGet>>,
         TError,
         TData
       >
@@ -585,7 +587,7 @@ export function useReadUserProfileApiV1UsersUserIdProfileGet<
   },
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getReadUserProfileApiV1UsersUserIdProfileGetQueryOptions(userId, options);
+  const queryOptions = getReadUserProfileApiV1UsersHandleProfileGetQueryOptions(handle, options);
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -37,6 +37,7 @@ import type {
   OwnershipTransferResponse,
   SearchUsersApiV1GGuildIdUsersSearchGetParams,
   UserGuildMember,
+  UserProfile,
   UserPublic,
   UserRead,
   UserSelfUpdate,
@@ -1633,6 +1634,189 @@ export function useSearchUsersApiV1GGuildIdUsersSearchGet<
   const queryOptions = getSearchUsersApiV1GGuildIdUsersSearchGetQueryOptions(
     guildId,
     params,
+    options
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * One member's profile, as the rest of their guild sees it.
+ *
+ * Guild-scoped, like the roster it is reached from: the membership join is
+ * what says a profile exists to the caller, so someone the caller shares no
+ * guild with is a 404 rather than a page. It is also what makes the answer
+ * correct — a real name renders only where the guild shows names, and
+ * "online" means "has this guild open".
+ *
+ * Nothing here is a guild's to write. The account row is the person's own
+ * (``users`` UPDATE is own-row on the request path); this reads it.
+ * @summary Read Member Profile
+ */
+export const readMemberProfileApiV1GGuildIdUsersUserIdProfileGet = (
+  guildId: number,
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<UserProfile>(
+    { url: `/api/v1/g/${guildId}/users/${userId}/profile`, method: "GET", signal },
+    options
+  );
+};
+
+export const getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryKey = (
+  guildId: number,
+  userId: number
+) => {
+  return [`/api/v1/g/${guildId}/users/${userId}/profile`] as const;
+};
+
+export const getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryKey(guildId, userId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
+  > = ({ signal }) =>
+    readMemberProfileApiV1GGuildIdUsersUserIdProfileGet(guildId, userId, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: guildId !== null && guildId !== undefined && userId !== null && userId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
+>;
+export type ReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  userId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+          TError,
+          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+          TError,
+          Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Read Member Profile
+ */
+
+export function useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet<
+  TData = Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof readMemberProfileApiV1GGuildIdUsersUserIdProfileGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getReadMemberProfileApiV1GGuildIdUsersUserIdProfileGetQueryOptions(
+    guildId,
+    userId,
     options
   );
 

--- a/frontend/src/components/search/MemberResultRow.tsx
+++ b/frontend/src/components/search/MemberResultRow.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@tanstack/react-router";
+
 import type { UserSummary } from "@/api/generated/initiativeAPI.schemas";
 import { UserHandle } from "@/components/UserHandle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -7,13 +9,17 @@ import { getAvatarSrc, getInitialsForUser, hasDisplayName } from "@/lib/userDisp
  * One member found.
  *
  * A person is not a tool, so this is not the tool row with a different icon:
- * it shows the face and the handle, which is what identifies someone. It does
- * not link anywhere yet — there is no page for a person to open — so it reads
- * as a card rather than offering a click that would go nowhere.
+ * it shows the face and the handle, which is what identifies someone. It opens
+ * their profile, which is public and belongs to the person rather than to the
+ * community the search ran in — so the link leaves the community tree.
  */
 export function MemberResultRow({ member }: { member: UserSummary }) {
   return (
-    <div className="flex items-center gap-3 rounded-md px-3 py-2">
+    <Link
+      to="/u/$userId"
+      params={{ userId: String(member.id) }}
+      className="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-accent"
+    >
       <Avatar className="h-8 w-8 shrink-0">
         <AvatarImage src={getAvatarSrc(member)} alt="" />
         <AvatarFallback className="text-xs">{getInitialsForUser(member)}</AvatarFallback>
@@ -25,6 +31,6 @@ export function MemberResultRow({ member }: { member: UserSummary }) {
           className={hasDisplayName(member) ? "text-muted-foreground text-sm" : "font-medium"}
         />
       </div>
-    </div>
+    </Link>
   );
 }

--- a/frontend/src/components/search/MemberResultRow.tsx
+++ b/frontend/src/components/search/MemberResultRow.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import type { UserSummary } from "@/api/generated/initiativeAPI.schemas";
 import { UserHandle } from "@/components/UserHandle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { getAvatarSrc, getInitialsForUser, hasDisplayName } from "@/lib/userDisplay";
+import { getAvatarSrc, getInitialsForUser, getUrlHandle, hasDisplayName } from "@/lib/userDisplay";
 
 /**
  * One member found.
@@ -16,8 +16,8 @@ import { getAvatarSrc, getInitialsForUser, hasDisplayName } from "@/lib/userDisp
 export function MemberResultRow({ member }: { member: UserSummary }) {
   return (
     <Link
-      to="/u/$userId"
-      params={{ userId: String(member.id) }}
+      to="/u/$handle"
+      params={{ handle: getUrlHandle(member) }}
       className="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-accent"
     >
       <Avatar className="h-8 w-8 shrink-0">

--- a/frontend/src/components/user/DecorationPicker.test.tsx
+++ b/frontend/src/components/user/DecorationPicker.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * The pickers offer a library, not a catalog.
+ *
+ * What a person may wear is the server's answer, and these render it: one
+ * picker per slot, showing what that account has and nothing else. The rules
+ * worth pinning are the ones a reader would notice — a slot holds one thing,
+ * the badge row holds several up to a cap, and a decoration this build has no
+ * artwork for is left out rather than drawn as a blank tile.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { buildOwnedDecoration } from "@/__tests__/factories";
+
+import { BadgePicker, SlotPicker } from "./DecorationPicker";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key}:${JSON.stringify(options)}` : key,
+  }),
+}));
+
+const banners = [
+  buildOwnedDecoration({ id: "core.aurora", kind: "banner" }),
+  buildOwnedDecoration({ id: "core.ember", kind: "banner" }),
+];
+
+const badges = [
+  buildOwnedDecoration({ id: "core.founder", kind: "badge" }),
+  buildOwnedDecoration({ id: "core.storyteller", kind: "badge" }),
+];
+
+describe("a slot that holds one thing", () => {
+  it("offers what the library holds for that slot, and nothing from another", async () => {
+    render(
+      <SlotPicker
+        kind="banner"
+        value={null}
+        onChange={vi.fn()}
+        owned={[...banners, buildOwnedDecoration({ id: "core.gold", kind: "frame" })]}
+      />
+    );
+
+    expect(screen.getAllByRole("radio")).toHaveLength(2);
+    expect(screen.getByRole("radio", { name: "decorations.aurora" })).toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: "decorations.gold" })).not.toBeInTheDocument();
+  });
+
+  it("leaves out a decoration this build cannot draw", async () => {
+    // A pack the server knows about and this build has no artwork for. A tile
+    // that renders as nothing is worse than no tile.
+    render(
+      <SlotPicker
+        kind="banner"
+        value={null}
+        onChange={vi.fn()}
+        owned={[...banners, buildOwnedDecoration({ id: "studio.holo", kind: "banner" })]}
+      />
+    );
+
+    expect(screen.getAllByRole("radio")).toHaveLength(2);
+  });
+
+  it("takes the decoration off when the one already on is picked again", async () => {
+    const onChange = vi.fn();
+    render(<SlotPicker kind="banner" value="core.aurora" onChange={onChange} owned={banners} />);
+
+    const chosen = screen.getByRole("radio", { name: "decorations.aurora" });
+    expect(chosen).toHaveAttribute("aria-checked", "true");
+    await userEvent.click(chosen);
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("says so when the library has nothing for the slot", () => {
+    render(<SlotPicker kind="frame" value={null} onChange={vi.fn()} owned={banners} />);
+
+    expect(screen.getByText("decorationPicker.empty")).toBeInTheDocument();
+  });
+});
+
+describe("the badge row", () => {
+  it("wears them in the order they were picked", async () => {
+    const onChange = vi.fn();
+    render(<BadgePicker value={["core.storyteller"]} onChange={onChange} owned={badges} max={6} />);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "decorations.founder" }));
+
+    expect(onChange).toHaveBeenCalledWith(["core.storyteller", "core.founder"]);
+  });
+
+  it("takes one off when it is picked again", async () => {
+    const onChange = vi.fn();
+    render(<BadgePicker value={["core.founder"]} onChange={onChange} owned={badges} max={6} />);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "decorations.founder" }));
+
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("stops at the cap rather than dropping what is already worn", async () => {
+    // What is on is the reader's choice; the picker must not quietly evict the
+    // oldest badge to make room for a new one.
+    const onChange = vi.fn();
+    render(<BadgePicker value={["core.storyteller"]} onChange={onChange} owned={badges} max={1} />);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "decorations.founder" }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/user/DecorationPicker.tsx
+++ b/frontend/src/components/user/DecorationPicker.tsx
@@ -1,0 +1,174 @@
+import { Check } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import type { OwnedDecoration } from "@/api/generated/initiativeAPI.schemas";
+import { type Decoration, type DecorationKind, resolveDecoration } from "@/lib/profileDecorations";
+import { cn } from "@/lib/utils";
+
+/**
+ * The decorations of one slot that this reader owns *and* this build can draw.
+ *
+ * Two filters, and the second one matters: a library is the server's answer and
+ * may name a decoration from a pack whose artwork this build has never seen.
+ * Offering a tile that renders as nothing would be worse than leaving it out.
+ */
+const wearable = (owned: OwnedDecoration[] | undefined, kind: DecorationKind): Decoration[] =>
+  (owned ?? [])
+    .filter((item) => item.kind === kind)
+    .map((item) => resolveDecoration(item.id, kind))
+    .filter((decoration): decoration is Decoration => Boolean(decoration));
+
+/** One tile: the artwork, drawn the way its slot is worn. */
+const Swatch = ({ decoration }: { decoration: Decoration }) => {
+  if (decoration.kind === "banner") {
+    return (
+      <span
+        className="block h-10 w-full rounded-sm bg-center bg-cover"
+        style={{ backgroundImage: `url(${decoration.src})` }}
+      />
+    );
+  }
+  return (
+    <span className="flex h-10 items-center justify-center">
+      <img
+        src={decoration.src}
+        alt=""
+        aria-hidden="true"
+        className={decoration.kind === "frame" ? "size-10" : "size-7"}
+      />
+    </span>
+  );
+};
+
+interface TileProps {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  /** `radio` for a slot that holds one thing, `checkbox` for the badge row. */
+  role: "radio" | "checkbox";
+}
+
+const Tile = ({ label, selected, onClick, children, role }: TileProps) => (
+  <button
+    type="button"
+    role={role}
+    aria-checked={selected}
+    aria-label={label}
+    title={label}
+    onClick={onClick}
+    className={cn(
+      "relative rounded-md border-2 p-1.5 transition-colors",
+      selected
+        ? "border-primary bg-primary/5"
+        : "border-transparent hover:border-muted-foreground/30"
+    )}
+  >
+    {children}
+    {selected ? (
+      <Check className="absolute top-0.5 right-0.5 size-3.5 text-primary" aria-hidden="true" />
+    ) : null}
+  </button>
+);
+
+interface SlotPickerProps {
+  kind: Extract<DecorationKind, "banner" | "frame">;
+  value: string | null;
+  onChange: (id: string | null) => void;
+  owned: OwnedDecoration[] | undefined;
+}
+
+/**
+ * The picker for a slot that holds one thing — the banner, the frame.
+ *
+ * Picking the tile that is already on takes it off, so "none" needs no tile of
+ * its own and there is one way to end up bare.
+ */
+export const SlotPicker = ({ kind, value, onChange, owned }: SlotPickerProps) => {
+  const { t } = useTranslation("profiles");
+  const choices = wearable(owned, kind);
+
+  if (choices.length === 0) {
+    return <p className="text-muted-foreground text-sm">{t("decorationPicker.empty")}</p>;
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={t(`decorationPicker.${kind}`)}
+      className="flex flex-wrap gap-2"
+    >
+      {choices.map((decoration) => (
+        <Tile
+          key={decoration.id}
+          role="radio"
+          label={t(decoration.labelKey)}
+          selected={value === decoration.id}
+          onClick={() => onChange(value === decoration.id ? null : decoration.id)}
+        >
+          <span className={kind === "banner" ? "block w-32" : "block w-12"}>
+            <Swatch decoration={decoration} />
+          </span>
+        </Tile>
+      ))}
+    </div>
+  );
+};
+
+interface BadgePickerProps {
+  value: string[];
+  onChange: (ids: string[]) => void;
+  owned: OwnedDecoration[] | undefined;
+  /** Mirrors ``MAX_PROFILE_BADGES`` on the server. */
+  max: number;
+}
+
+/**
+ * The picker for the badge row, which holds several.
+ *
+ * Order is the order they were picked, which is the order they are worn. Past
+ * the cap the unpicked tiles stop responding rather than silently dropping the
+ * oldest — what is worn is the reader's choice, not the picker's.
+ */
+export const BadgePicker = ({ value, onChange, owned, max }: BadgePickerProps) => {
+  const { t } = useTranslation("profiles");
+  const choices = wearable(owned, "badge");
+
+  if (choices.length === 0) {
+    return <p className="text-muted-foreground text-sm">{t("decorationPicker.empty")}</p>;
+  }
+
+  const toggle = (id: string) => {
+    if (value.includes(id)) {
+      onChange(value.filter((worn) => worn !== id));
+    } else if (value.length < max) {
+      onChange([...value, id]);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div aria-label={t("decorationPicker.badge")} className="flex flex-wrap gap-2">
+        {choices.map((decoration) => {
+          const selected = value.includes(decoration.id);
+          return (
+            <Tile
+              key={decoration.id}
+              role="checkbox"
+              label={t(decoration.labelKey)}
+              selected={selected}
+              onClick={() => toggle(decoration.id)}
+            >
+              <span className="block w-10">
+                <Swatch decoration={decoration} />
+              </span>
+            </Tile>
+          );
+        })}
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {t("decorationPicker.badgeCount", { count: value.length, max })}
+      </p>
+    </div>
+  );
+};

--- a/frontend/src/components/user/ProfileAvatar.tsx
+++ b/frontend/src/components/user/ProfileAvatar.tsx
@@ -1,0 +1,52 @@
+import type { ProfileDecorationsOutput } from "@/api/generated/initiativeAPI.schemas";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { resolveDecoration } from "@/lib/profileDecorations";
+import {
+  type AvatarSourceUser,
+  type DisplayableUser,
+  getAvatarSrc,
+  getInitialsForUser,
+  getUserDisplayName,
+} from "@/lib/userDisplay";
+import { cn } from "@/lib/utils";
+
+interface ProfileAvatarProps {
+  user: DisplayableUser & AvatarSourceUser;
+  decorations?: ProfileDecorationsOutput | null;
+  /** Show the "has the app open" dot. Left off where presence isn't known. */
+  online?: boolean;
+  /** Sizing for the avatar itself; everything else scales off it. */
+  className?: string;
+}
+
+/**
+ * A person's picture, wearing whatever they have put around it.
+ *
+ * The frame is drawn *over* the picture rather than replacing it, and slightly
+ * outside it, so the ring reads as something worn rather than as a crop. It is
+ * decoration and carries no information, so it is hidden from assistive
+ * technology; the presence dot is not, and says so in words.
+ */
+export const ProfileAvatar = ({ user, decorations, online, className }: ProfileAvatarProps) => {
+  const frame = resolveDecoration(decorations?.frame, "frame");
+
+  return (
+    <div className={cn("relative shrink-0", className)}>
+      <Avatar className="h-full w-full">
+        <AvatarImage src={getAvatarSrc(user)} alt={getUserDisplayName(user, "")} />
+        <AvatarFallback userId={user.id ?? undefined}>{getInitialsForUser(user)}</AvatarFallback>
+      </Avatar>
+      {frame ? (
+        <img
+          src={frame.src}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute -inset-[7%] max-w-none"
+        />
+      ) : null}
+      {online ? (
+        <span className="absolute right-0 bottom-0 block size-1/4 rounded-full bg-emerald-500 ring-2 ring-background" />
+      ) : null}
+    </div>
+  );
+};

--- a/frontend/src/components/user/ProfileBadges.tsx
+++ b/frontend/src/components/user/ProfileBadges.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from "react-i18next";
+
+import type { ProfileDecorationsOutput } from "@/api/generated/initiativeAPI.schemas";
+import { resolveBadges } from "@/lib/profileDecorations";
+
+/**
+ * The badges a profile is wearing, in the order they were put on.
+ *
+ * Only the ones this build can draw: an id from a decoration this deployment
+ * doesn't have simply isn't in the row, which is what keeps a profile readable
+ * after the store stops offering something.
+ */
+export const ProfileBadges = ({
+  decorations,
+}: {
+  decorations?: ProfileDecorationsOutput | null;
+}) => {
+  const { t } = useTranslation("profiles");
+  const badges = resolveBadges(decorations);
+  if (badges.length === 0) return null;
+
+  return (
+    <ul className="flex flex-wrap items-center gap-1.5">
+      {badges.map((badge) => {
+        const label = t(badge.labelKey);
+        return (
+          <li key={badge.id}>
+            <img src={badge.src} alt={label} title={label} className="size-6" />
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -19,7 +19,8 @@ import {
   getListUsersApiV1GGuildIdUsersGetQueryKey,
   listUsersApiV1GGuildIdUsersGet,
   updateUsersMeApiV1UsersMePatch,
-  useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet,
+  useListMyDecorationsApiV1UsersMeDecorationsGet,
+  useReadUserProfileApiV1UsersUserIdProfileGet,
   useSearchUsersApiV1GGuildIdUsersSearchGet,
 } from "@/api/generated/users/users";
 import { invalidateCurrentUser, invalidateGuildMembers } from "@/api/query-keys";
@@ -81,22 +82,29 @@ const memberSearchParams = (search: string | undefined, userIds: number[] | unde
 });
 
 /**
- * One member's profile, as the rest of the guild sees them.
+ * One person's profile.
  *
- * Guild-scoped like the roster it is reached from: the shared guild is what
- * makes the page exist for the reader, and it is also what decides whether a
- * real name renders and what "online" is measured against.
+ * Public and community-independent: the same page whoever opens it, so there
+ * is no guild in the call.
  */
-export const useUserProfile = (userId: number | null | undefined) => {
-  const guildId = useActiveGuildId();
-  return useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet(guildId, userId as number, {
+export const useUserProfile = (userId: number | null | undefined) =>
+  useReadUserProfileApiV1UsersUserIdProfileGet(userId as number, {
     query: {
-      enabled: guildId != null && userId != null,
+      enabled: userId != null,
       // Presence moves on its own, so a profile left open goes stale fast.
       staleTime: 30_000,
     },
   });
-};
+
+/**
+ * What the signed-in account may dress its profile in — what ships with the
+ * app plus whatever it has acquired. Drives the pickers on Settings > Profile;
+ * a library changes only when a pack is installed, so it is held a good while.
+ */
+export const useMyDecorations = () =>
+  useListMyDecorationsApiV1UsersMeDecorationsGet({
+    query: { staleTime: 5 * 60_000 },
+  });
 
 /**
  * Slim, server-side member typeahead for the active guild. Returns

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -19,6 +19,7 @@ import {
   getListUsersApiV1GGuildIdUsersGetQueryKey,
   listUsersApiV1GGuildIdUsersGet,
   updateUsersMeApiV1UsersMePatch,
+  useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet,
   useSearchUsersApiV1GGuildIdUsersSearchGet,
 } from "@/api/generated/users/users";
 import { invalidateCurrentUser, invalidateGuildMembers } from "@/api/query-keys";
@@ -78,6 +79,24 @@ const memberSearchParams = (search: string | undefined, userIds: number[] | unde
   search: search?.trim() || undefined,
   user_id: userIds?.length ? userIds.slice(0, USER_ID_LOOKUP_MAX) : undefined,
 });
+
+/**
+ * One member's profile, as the rest of the guild sees them.
+ *
+ * Guild-scoped like the roster it is reached from: the shared guild is what
+ * makes the page exist for the reader, and it is also what decides whether a
+ * real name renders and what "online" is measured against.
+ */
+export const useUserProfile = (userId: number | null | undefined) => {
+  const guildId = useActiveGuildId();
+  return useReadMemberProfileApiV1GGuildIdUsersUserIdProfileGet(guildId, userId as number, {
+    query: {
+      enabled: guildId != null && userId != null,
+      // Presence moves on its own, so a profile left open goes stale fast.
+      staleTime: 30_000,
+    },
+  });
+};
 
 /**
  * Slim, server-side member typeahead for the active guild. Returns

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -20,7 +20,7 @@ import {
   listUsersApiV1GGuildIdUsersGet,
   updateUsersMeApiV1UsersMePatch,
   useListMyDecorationsApiV1UsersMeDecorationsGet,
-  useReadUserProfileApiV1UsersUserIdProfileGet,
+  useReadUserProfileApiV1UsersHandleProfileGet,
   useSearchUsersApiV1GGuildIdUsersSearchGet,
 } from "@/api/generated/users/users";
 import { invalidateCurrentUser, invalidateGuildMembers } from "@/api/query-keys";
@@ -82,15 +82,16 @@ const memberSearchParams = (search: string | undefined, userIds: number[] | unde
 });
 
 /**
- * One person's profile.
+ * One person's profile, by their handle as it appears in a URL
+ * (``jordan1234`` — see ``getUrlHandle``).
  *
  * Public and community-independent: the same page whoever opens it, so there
  * is no guild in the call.
  */
-export const useUserProfile = (userId: number | null | undefined) =>
-  useReadUserProfileApiV1UsersUserIdProfileGet(userId as number, {
+export const useUserProfile = (handle: string | null | undefined) =>
+  useReadUserProfileApiV1UsersHandleProfileGet(handle as string, {
     query: {
-      enabled: userId != null,
+      enabled: Boolean(handle),
       // A profile changes without the reader doing anything — the subject
       // signs off, edits their status, changes what they are wearing — and
       // this page is outside the community tree, so no realtime socket is

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -91,8 +91,13 @@ export const useUserProfile = (userId: number | null | undefined) =>
   useReadUserProfileApiV1UsersUserIdProfileGet(userId as number, {
     query: {
       enabled: userId != null,
-      // Presence moves on its own, so a profile left open goes stale fast.
+      // A profile changes without the reader doing anything — the subject
+      // signs off, edits their status, changes what they are wearing — and
+      // this page is outside the community tree, so no realtime socket is
+      // going to tell it. Nor does the app refetch on focus. So it asks again
+      // on a timer, which pauses while the tab is in the background.
       staleTime: 30_000,
+      refetchInterval: 60_000,
     },
   });
 

--- a/frontend/src/lib/profileDecorations.test.ts
+++ b/frontend/src/lib/profileDecorations.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBadges, resolveDecoration } from "./profileDecorations";
+
+describe("resolving a decoration", () => {
+  it("finds the artwork an id names", () => {
+    expect(resolveDecoration("core.aurora", "banner")?.src).toBe(
+      "/decorations/banners/core-aurora.svg"
+    );
+  });
+
+  it("has nothing for an id this build does not ship", () => {
+    // What a profile wearing something from a later catalog gets: bare, not
+    // broken, and not a request for a file that isn't there.
+    expect(resolveDecoration("thirdparty.holo", "banner")).toBeUndefined();
+  });
+
+  it("will not hand a banner back as a frame", () => {
+    expect(resolveDecoration("core.aurora", "frame")).toBeUndefined();
+  });
+
+  it("resolves nothing for an id built out of a path", () => {
+    expect(resolveDecoration("../../../etc/passwd", "banner")).toBeUndefined();
+  });
+
+  it("keeps the badges it can draw, in the order they are worn", () => {
+    const badges = resolveBadges({
+      banner: null,
+      frame: null,
+      badges: ["core.trailblazer", "thirdparty.unknown", "core.founder"],
+    });
+
+    expect(badges.map((badge) => badge.id)).toEqual(["core.trailblazer", "core.founder"]);
+  });
+
+  it("draws nothing for a profile with no decorations at all", () => {
+    expect(resolveBadges(null)).toEqual([]);
+    expect(resolveDecoration(null, "frame")).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/profileDecorations.ts
+++ b/frontend/src/lib/profileDecorations.ts
@@ -1,0 +1,81 @@
+/**
+ * The catalog a profile's decorations are resolved against.
+ *
+ * A profile stores **ids**, never images: `{ banner: "core.aurora", frame:
+ * "core.gold", badges: ["core.founder"] }`. This module is what turns one of
+ * those ids into something to render — a lookup in the table below, so an id
+ * that isn't in it resolves to nothing at all.
+ *
+ * Everything here ships with the app under `public/decorations/`, so wearing a
+ * banner costs a community none of its upload allowance. The store is what will
+ * grant ids beyond these; nothing about resolving one changes when it does.
+ *
+ * An id a deployment doesn't know renders as bare — which is the behaviour that
+ * lets a profile keep wearing something the store has stopped offering.
+ */
+
+import type { ProfileDecorationsOutput } from "@/api/generated/initiativeAPI.schemas";
+
+export type DecorationKind = "banner" | "frame" | "badge";
+
+/** Every decoration this build ships, by the name its label is keyed under. */
+type DecorationName =
+  | "aurora"
+  | "ember"
+  | "parchment"
+  | "gold"
+  | "arcane"
+  | "founder"
+  | "storyteller"
+  | "trailblazer";
+
+export interface Decoration {
+  id: string;
+  kind: DecorationKind;
+  /** Where the artwork is, relative to the app's root. */
+  src: string;
+  /** Key into the `profiles` namespace for this decoration's name. */
+  labelKey: `decorations.${DecorationName}`;
+}
+
+const entry = (
+  id: string,
+  kind: DecorationKind,
+  file: string,
+  name: DecorationName
+): Decoration => ({
+  id,
+  kind,
+  src: `/decorations/${kind}s/${file}.svg`,
+  labelKey: `decorations.${name}`,
+});
+
+/** The catalog, by id. */
+export const DECORATIONS: Readonly<Record<string, Decoration>> = {
+  "core.aurora": entry("core.aurora", "banner", "core-aurora", "aurora"),
+  "core.ember": entry("core.ember", "banner", "core-ember", "ember"),
+  "core.parchment": entry("core.parchment", "banner", "core-parchment", "parchment"),
+  "core.gold": entry("core.gold", "frame", "core-gold", "gold"),
+  "core.arcane": entry("core.arcane", "frame", "core-arcane", "arcane"),
+  "core.founder": entry("core.founder", "badge", "core-founder", "founder"),
+  "core.storyteller": entry("core.storyteller", "badge", "core-storyteller", "storyteller"),
+  "core.trailblazer": entry("core.trailblazer", "badge", "core-trailblazer", "trailblazer"),
+};
+
+/** The decoration this id names, if this build has it and it is of that kind. */
+export const resolveDecoration = (
+  id: string | null | undefined,
+  kind: DecorationKind
+): Decoration | undefined => {
+  if (!id) return undefined;
+  const found = DECORATIONS[id];
+  return found?.kind === kind ? found : undefined;
+};
+
+/** The badges a profile is wearing that this build can draw, in the order worn. */
+export const resolveBadges = (
+  decorations: ProfileDecorationsOutput | null | undefined
+): Decoration[] =>
+  (decorations?.badges ?? [])
+    .map((id) => resolveDecoration(id, "badge"))
+    .filter((badge): badge is Decoration => Boolean(badge));

--- a/frontend/src/lib/userDisplay.ts
+++ b/frontend/src/lib/userDisplay.ts
@@ -39,6 +39,19 @@ export const getUserHandle = (user: DisplayableUser | null | undefined): string 
 };
 
 /**
+ * ``jordan1234`` — the handle as one URL segment, which is how a profile is
+ * addressed.
+ *
+ * No ``#``: it never survives a URL. The number keeps its four digits and runs
+ * straight on from the name, which stays reversible because the width is
+ * fixed — ``user2`` + ``0007`` is ``user20007``, not ``user`` + ``20007``.
+ */
+export const getUrlHandle = (user: DisplayableUser | null | undefined): string => {
+  if (!user?.username) return "";
+  return `${user.username}${formatDiscriminator(user.discriminator)}`;
+};
+
+/**
  * The single source of truth for "what string do we render for this user".
  *
  * A real name where the guild shows names, the handle otherwise — and the

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -221,11 +221,8 @@ export const SettingsUsersPage = () => {
       // The handle is what identifies someone, so it is also what opens them.
       cell: ({ row }) => (
         <Link
-          to="/c/$guildId/u/$userId"
-          params={{
-            guildId: String(activeGuildId),
-            userId: String(row.original.id),
-          }}
+          to="/u/$userId"
+          params={{ userId: String(row.original.id) }}
           className="text-sm hover:underline"
         >
           <UserHandle user={row.original} />

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -42,7 +42,7 @@ import {
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import type { AppColumnDef } from "@/lib/table";
-import { getUserDisplayName } from "@/lib/userDisplay";
+import { getUrlHandle, getUserDisplayName } from "@/lib/userDisplay";
 
 const GUILD_ROLE_OPTIONS: GuildRole[] = ["admin", "member"];
 const inviteLinkForCode = (code: string) => {
@@ -221,8 +221,8 @@ export const SettingsUsersPage = () => {
       // The handle is what identifies someone, so it is also what opens them.
       cell: ({ row }) => (
         <Link
-          to="/u/$userId"
-          params={{ userId: String(row.original.id) }}
+          to="/u/$handle"
+          params={{ handle: getUrlHandle(row.original) }}
           className="text-sm hover:underline"
         >
           <UserHandle user={row.original} />

--- a/frontend/src/pages/SettingsUsersPage.tsx
+++ b/frontend/src/pages/SettingsUsersPage.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { Copy, Download, HandCoins, RefreshCcw, Trash2 } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -217,10 +218,18 @@ export const SettingsUsersPage = () => {
     {
       accessorKey: "username",
       header: t("users.handleColumn"),
+      // The handle is what identifies someone, so it is also what opens them.
       cell: ({ row }) => (
-        <p className="text-sm">
+        <Link
+          to="/c/$guildId/u/$userId"
+          params={{
+            guildId: String(activeGuildId),
+            userId: String(row.original.id),
+          }}
+          className="text-sm hover:underline"
+        >
           <UserHandle user={row.original} />
-        </p>
+        </Link>
       ),
     },
     ...(showsNames

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,0 +1,128 @@
+import { useParams } from "@tanstack/react-router";
+import { Loader2, UserX } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { StatusMessage } from "@/components/StatusMessage";
+import { UserHandle } from "@/components/UserHandle";
+import { Card, CardContent } from "@/components/ui/card";
+import { ProfileAvatar } from "@/components/user/ProfileAvatar";
+import { ProfileBadges } from "@/components/user/ProfileBadges";
+import { useActiveGuildId } from "@/hooks/useActiveGuildId";
+import { useUserProfile } from "@/hooks/useUsers";
+import { formatDate } from "@/lib/formatDate";
+import { guildPath } from "@/lib/guildUrl";
+import { resolveDecoration } from "@/lib/profileDecorations";
+import { hasDisplayName } from "@/lib/userDisplay";
+
+/**
+ * A member's profile, as the rest of their guild sees it.
+ *
+ * Guild-scoped, like the roster it is reached from — which is what decides
+ * both of the things a profile can't answer on its own: whether a real name
+ * renders at all, and what "online" is measured against. Somebody the reader
+ * shares no guild with has no page here rather than an empty one.
+ *
+ * Read-only for everyone, including its owner: what is on it is written on
+ * Settings → Profile, so there is one place a person edits themselves rather
+ * than two that have to agree.
+ */
+export const UserProfilePage = () => {
+  const { t } = useTranslation(["profiles", "common"]);
+  const guildId = useActiveGuildId();
+  const { userId: userIdParam } = useParams({ strict: false }) as { userId: string };
+  const userId = Number(userIdParam);
+
+  const { data: profile, isLoading } = useUserProfile(Number.isFinite(userId) ? userId : null);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <StatusMessage
+        icon={<UserX />}
+        title={t("notFound.title")}
+        description={t("notFound.description")}
+        backTo={guildId ? guildPath(guildId, "/") : "/"}
+        backLabel={t("notFound.back")}
+      />
+    );
+  }
+
+  const banner = resolveDecoration(profile.profile_decorations.banner, "banner");
+  const status = profile.custom_status_text ?? "";
+  const statusEmoji = profile.custom_status_emoji ?? "";
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <Card className="overflow-hidden pt-0">
+        {/* The banner is artwork with nothing to read in it, so it is painted
+            rather than placed: a background keeps it out of the reading order
+            and lets it crop at any width. */}
+        <div
+          className="h-28 w-full bg-center bg-cover bg-muted sm:h-40"
+          style={banner ? { backgroundImage: `url(${banner.src})` } : undefined}
+        />
+        <CardContent className="space-y-4">
+          <div className="-mt-14 flex flex-wrap items-end gap-4 sm:-mt-16">
+            <ProfileAvatar
+              user={profile}
+              decorations={profile.profile_decorations}
+              online={profile.online}
+              className="size-24 rounded-full ring-4 ring-card sm:size-28"
+            />
+            <div className="min-w-0 flex-1 space-y-1 pb-1">
+              {hasDisplayName(profile) && profile.full_name ? (
+                <h1 className="truncate font-semibold text-2xl">{profile.full_name}</h1>
+              ) : null}
+              <UserHandle
+                user={profile}
+                className={profile.full_name ? "text-muted-foreground" : "font-semibold text-2xl"}
+              />
+            </div>
+            <ProfileBadges decorations={profile.profile_decorations} />
+          </div>
+
+          {statusEmoji || status ? (
+            <p className="flex items-start gap-2 text-base">
+              {statusEmoji ? (
+                <span className="text-xl leading-tight" aria-hidden="true">
+                  {statusEmoji}
+                </span>
+              ) : null}
+              <span className="min-w-0 break-words">{status}</span>
+            </p>
+          ) : (
+            <p className="text-muted-foreground text-sm">{t("noStatus")}</p>
+          )}
+
+          <dl className="flex flex-wrap gap-x-8 gap-y-2 border-t pt-4 text-sm">
+            <div className="flex items-center gap-2">
+              {/* The dot and the word say it; the label is here for a reader
+                  who gets the list read out rather than shown. */}
+              <dt className="sr-only">{t("presence.label")}</dt>
+              <dd className="flex items-center gap-1.5 font-medium">
+                <span
+                  className={`size-2 rounded-full ${
+                    profile.online ? "bg-emerald-500" : "bg-muted-foreground/40"
+                  }`}
+                  aria-hidden="true"
+                />
+                {profile.online ? t("presence.online") : t("presence.offline")}
+              </dd>
+            </div>
+            <div className="flex items-center gap-2">
+              <dt className="text-muted-foreground">{t("joined.label")}</dt>
+              <dd className="font-medium">{formatDate(profile.joined_at)}</dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -25,10 +25,9 @@ import { resolveDecoration } from "@/lib/profileDecorations";
  */
 export const UserProfilePage = () => {
   const { t } = useTranslation(["profiles", "common"]);
-  const { userId: userIdParam } = useParams({ strict: false }) as { userId: string };
-  const userId = Number(userIdParam);
+  const { handle } = useParams({ strict: false }) as { handle: string };
 
-  const { data: profile, isLoading } = useUserProfile(Number.isFinite(userId) ? userId : null);
+  const { data: profile, isLoading } = useUserProfile(handle);
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -7,20 +7,17 @@ import { UserHandle } from "@/components/UserHandle";
 import { Card, CardContent } from "@/components/ui/card";
 import { ProfileAvatar } from "@/components/user/ProfileAvatar";
 import { ProfileBadges } from "@/components/user/ProfileBadges";
-import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useUserProfile } from "@/hooks/useUsers";
 import { formatDate } from "@/lib/formatDate";
-import { guildPath } from "@/lib/guildUrl";
 import { resolveDecoration } from "@/lib/profileDecorations";
-import { hasDisplayName } from "@/lib/userDisplay";
 
 /**
- * A member's profile, as the rest of their guild sees it.
+ * A person's profile.
  *
- * Guild-scoped, like the roster it is reached from — which is what decides
- * both of the things a profile can't answer on its own: whether a real name
- * renders at all, and what "online" is measured against. Somebody the reader
- * shares no guild with has no page here rather than an empty one.
+ * Public, and the same page whoever opens it: the handle is the name in this
+ * product, so nothing here depends on a community deciding whether it renders
+ * real names, and "online" is a fact about the person rather than about a
+ * place they happen to share with the reader.
  *
  * Read-only for everyone, including its owner: what is on it is written on
  * Settings → Profile, so there is one place a person edits themselves rather
@@ -28,7 +25,6 @@ import { hasDisplayName } from "@/lib/userDisplay";
  */
 export const UserProfilePage = () => {
   const { t } = useTranslation(["profiles", "common"]);
-  const guildId = useActiveGuildId();
   const { userId: userIdParam } = useParams({ strict: false }) as { userId: string };
   const userId = Number(userIdParam);
 
@@ -48,15 +44,14 @@ export const UserProfilePage = () => {
         icon={<UserX />}
         title={t("notFound.title")}
         description={t("notFound.description")}
-        backTo={guildId ? guildPath(guildId, "/") : "/"}
+        backTo="/"
         backLabel={t("notFound.back")}
       />
     );
   }
 
   const banner = resolveDecoration(profile.profile_decorations.banner, "banner");
-  const status = profile.custom_status_text ?? "";
-  const statusEmoji = profile.custom_status_emoji ?? "";
+  const { emoji: statusEmoji, text: statusText } = profile.custom_status;
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -76,26 +71,24 @@ export const UserProfilePage = () => {
               online={profile.online}
               className="size-24 rounded-full ring-4 ring-card sm:size-28"
             />
-            <div className="min-w-0 flex-1 space-y-1 pb-1">
-              {hasDisplayName(profile) && profile.full_name ? (
-                <h1 className="truncate font-semibold text-2xl">{profile.full_name}</h1>
-              ) : null}
-              <UserHandle
-                user={profile}
-                className={profile.full_name ? "text-muted-foreground" : "font-semibold text-2xl"}
-              />
+            <div className="min-w-0 flex-1 pb-1">
+              {/* The handle is the name here, so it is the heading rather than
+                  a subtitle under one. */}
+              <h1>
+                <UserHandle user={profile} className="font-semibold text-2xl" />
+              </h1>
             </div>
             <ProfileBadges decorations={profile.profile_decorations} />
           </div>
 
-          {statusEmoji || status ? (
+          {statusEmoji || statusText ? (
             <p className="flex items-start gap-2 text-base">
               {statusEmoji ? (
                 <span className="text-xl leading-tight" aria-hidden="true">
                   {statusEmoji}
                 </span>
               ) : null}
-              <span className="min-w-0 break-words">{status}</span>
+              <span className="min-w-0 break-words">{statusText}</span>
             </p>
           ) : (
             <p className="text-muted-foreground text-sm">{t("noStatus")}</p>

--- a/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
@@ -8,6 +8,7 @@ import {
   deleteMyAvatarApiV1UsersMeAvatarDelete,
   uploadMyAvatarApiV1UsersMeAvatarPut,
 } from "@/api/generated/users/users";
+import { EmojiPicker } from "@/components/EmojiPicker";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -34,6 +35,9 @@ const uploadedAvatar = (user: UserRead): string | null =>
 
 const isLinked = (user: UserRead): boolean => Boolean(user.avatar_url) && !uploadedAvatar(user);
 
+/** Mirrors ``custom_status_text``'s column width on the server. */
+const STATUS_MAX_LENGTH = 100;
+
 interface UserSettingsProfilePageProps {
   user: UserRead;
   refreshUser: () => Promise<void>;
@@ -58,6 +62,10 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
   // user can fix a wrong default during their first profile pass
   // without having to discover the notifications tab.
   const [timezone, setTimezone] = useState(user.timezone ?? "UTC");
+  // What you're up to, in your own words — an emoji, a line, or both. Held as
+  // a draft like the rest of the form, so it saves with everything else.
+  const [statusEmoji, setStatusEmoji] = useState(user.custom_status_emoji ?? null);
+  const [statusText, setStatusText] = useState(user.custom_status_text ?? "");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -65,6 +73,8 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
     setAvatarUrl(isLinked(user) ? (user.avatar_url ?? "") : "");
     setAvatarMode(isLinked(user) ? "url" : "upload");
     setTimezone(user.timezone ?? "UTC");
+    setStatusEmoji(user.custom_status_emoji ?? null);
+    setStatusText(user.custom_status_text ?? "");
   }, [user]);
 
   const avatarPreview = useMemo(() => {
@@ -194,6 +204,14 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
               if (timezone !== (user.timezone ?? "UTC")) {
                 payload.timezone = timezone;
               }
+              if (statusEmoji !== (user.custom_status_emoji ?? null)) {
+                payload.custom_status_emoji = statusEmoji;
+              }
+              if (statusText !== (user.custom_status_text ?? "")) {
+                // An emptied field is the status taken off, which is `null`
+                // rather than an empty line.
+                payload.custom_status_text = statusText || null;
+              }
               updateProfile.mutate(payload as UserSelfUpdate);
             }}
           >
@@ -220,6 +238,28 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
                 onChange={(event) => setFullName(event.target.value)}
                 placeholder={t("profile.fullNamePlaceholder")}
               />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="status-text">{t("profile.statusLabel")}</Label>
+              <div className="flex gap-2">
+                <div className="w-32 shrink-0">
+                  <EmojiPicker
+                    id="status-emoji"
+                    value={statusEmoji}
+                    onChange={setStatusEmoji}
+                    placeholder={t("profile.statusEmojiPlaceholder")}
+                  />
+                </div>
+                <Input
+                  id="status-text"
+                  value={statusText}
+                  onChange={(event) => setStatusText(event.target.value)}
+                  placeholder={t("profile.statusPlaceholder")}
+                  maxLength={STATUS_MAX_LENGTH}
+                />
+              </div>
+              <p className="text-muted-foreground text-xs">{t("profile.statusHelp")}</p>
             </div>
 
             {!user.has_federated_identity ? (

--- a/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
@@ -16,7 +16,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
-import { useUpdateCurrentUser } from "@/hooks/useUsers";
+import { BadgePicker, SlotPicker } from "@/components/user/DecorationPicker";
+import { useMyDecorations, useUpdateCurrentUser } from "@/hooks/useUsers";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { ImageRenditionError, renderAvatar } from "@/lib/imageRenditions";
@@ -35,8 +36,11 @@ const uploadedAvatar = (user: UserRead): string | null =>
 
 const isLinked = (user: UserRead): boolean => Boolean(user.avatar_url) && !uploadedAvatar(user);
 
-/** Mirrors ``custom_status_text``'s column width on the server. */
+/** Mirrors ``STATUS_TEXT_MAX_LENGTH`` on the server. */
 const STATUS_MAX_LENGTH = 100;
+
+/** Mirrors ``MAX_PROFILE_BADGES`` on the server. */
+const MAX_BADGES = 6;
 
 interface UserSettingsProfilePageProps {
   user: UserRead;
@@ -47,7 +51,7 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
   // Pull in ``auth`` and ``errors`` so the password-policy hint and the
   // server's ``PASSWORD_BREACHED`` code map without lazy-loading those
   // namespaces mid-submit.
-  const { t } = useTranslation(["settings", "auth", "errors"]);
+  const { t } = useTranslation(["settings", "auth", "errors", "profiles"]);
   const [fullName, setFullName] = useState(user.full_name ?? "");
   const [password, setPassword] = useState("");
   const [currentPassword, setCurrentPassword] = useState("");
@@ -64,8 +68,14 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
   const [timezone, setTimezone] = useState(user.timezone ?? "UTC");
   // What you're up to, in your own words — an emoji, a line, or both. Held as
   // a draft like the rest of the form, so it saves with everything else.
-  const [statusEmoji, setStatusEmoji] = useState(user.custom_status_emoji ?? null);
-  const [statusText, setStatusText] = useState(user.custom_status_text ?? "");
+  const [statusEmoji, setStatusEmoji] = useState(user.custom_status.emoji ?? null);
+  const [statusText, setStatusText] = useState(user.custom_status.text ?? "");
+  // The look, as a draft. Held whole rather than a field at a time, because
+  // that is how it is written: one object naming every slot.
+  const [banner, setBanner] = useState(user.profile_decorations.banner ?? null);
+  const [frame, setFrame] = useState(user.profile_decorations.frame ?? null);
+  const [badges, setBadges] = useState<string[]>(user.profile_decorations.badges ?? []);
+  const { data: library } = useMyDecorations();
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -73,8 +83,11 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
     setAvatarUrl(isLinked(user) ? (user.avatar_url ?? "") : "");
     setAvatarMode(isLinked(user) ? "url" : "upload");
     setTimezone(user.timezone ?? "UTC");
-    setStatusEmoji(user.custom_status_emoji ?? null);
-    setStatusText(user.custom_status_text ?? "");
+    setStatusEmoji(user.custom_status.emoji ?? null);
+    setStatusText(user.custom_status.text ?? "");
+    setBanner(user.profile_decorations.banner ?? null);
+    setFrame(user.profile_decorations.frame ?? null);
+    setBadges(user.profile_decorations.badges ?? []);
   }, [user]);
 
   const avatarPreview = useMemo(() => {
@@ -204,13 +217,20 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
               if (timezone !== (user.timezone ?? "UTC")) {
                 payload.timezone = timezone;
               }
-              if (statusEmoji !== (user.custom_status_emoji ?? null)) {
-                payload.custom_status_emoji = statusEmoji;
+              if (
+                statusEmoji !== (user.custom_status.emoji ?? null) ||
+                statusText !== (user.custom_status.text ?? "")
+              ) {
+                // One column, so the emoji and the line go together — and an
+                // emptied field is the status taken off, not an empty line.
+                payload.custom_status = { emoji: statusEmoji, text: statusText || null };
               }
-              if (statusText !== (user.custom_status_text ?? "")) {
-                // An emptied field is the status taken off, which is `null`
-                // rather than an empty line.
-                payload.custom_status_text = statusText || null;
+              if (
+                banner !== (user.profile_decorations.banner ?? null) ||
+                frame !== (user.profile_decorations.frame ?? null) ||
+                badges.join() !== (user.profile_decorations.badges ?? []).join()
+              ) {
+                payload.profile_decorations = { banner, frame, badges };
               }
               updateProfile.mutate(payload as UserSelfUpdate);
             }}
@@ -260,6 +280,43 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
                 />
               </div>
               <p className="text-muted-foreground text-xs">{t("profile.statusHelp")}</p>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <Label>{t("profiles:decorationPicker.heading")}</Label>
+                <p className="text-muted-foreground text-xs">
+                  {t("profiles:decorationPicker.help")}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label className="text-muted-foreground text-xs">
+                  {t("profiles:decorationPicker.banner")}
+                </Label>
+                <SlotPicker
+                  kind="banner"
+                  value={banner}
+                  onChange={setBanner}
+                  owned={library?.items}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-muted-foreground text-xs">
+                  {t("profiles:decorationPicker.frame")}
+                </Label>
+                <SlotPicker kind="frame" value={frame} onChange={setFrame} owned={library?.items} />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-muted-foreground text-xs">
+                  {t("profiles:decorationPicker.badge")}
+                </Label>
+                <BadgePicker
+                  value={badges}
+                  onChange={setBadges}
+                  owned={library?.items}
+                  max={MAX_BADGES}
+                />
+              </div>
             </div>
 
             {!user.has_federated_identity ? (

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -46,7 +46,7 @@ import { Route as ServerRequiredAuthenticatedProfileSecurityRouteImport } from '
 import { Route as ServerRequiredAuthenticatedProfileTrashRouteImport } from './routes/_serverRequired/_authenticated/profile/trash'
 import { Route as ServerRequiredAuthenticatedSettingsAdminRouteImport } from './routes/_serverRequired/_authenticated/settings/admin'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformRouteImport } from './routes/_serverRequired/_authenticated/settings/platform'
-import { Route as ServerRequiredAuthenticatedUUserIdRouteImport } from './routes/_serverRequired/_authenticated/u.$userId'
+import { Route as ServerRequiredAuthenticatedUHandleRouteImport } from './routes/_serverRequired/_authenticated/u.$handle'
 import { Route as ServerRequiredCommunityGuildIdLoginRouteImport } from './routes/_serverRequired/community.$guildId.login'
 import { Route as ServerRequiredAuthenticatedCGuildIdIndexRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/index'
 import { Route as ServerRequiredAuthenticatedCGuildIdMarketplaceRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/marketplace'
@@ -356,10 +356,10 @@ const ServerRequiredAuthenticatedSettingsPlatformRoute =
     path: '/platform',
     getParentRoute: () => ServerRequiredAuthenticatedSettingsRoute,
   } as any)
-const ServerRequiredAuthenticatedUUserIdRoute =
-  ServerRequiredAuthenticatedUUserIdRouteImport.update({
-    id: '/u/$userId',
-    path: '/u/$userId',
+const ServerRequiredAuthenticatedUHandleRoute =
+  ServerRequiredAuthenticatedUHandleRouteImport.update({
+    id: '/u/$handle',
+    path: '/u/$handle',
     getParentRoute: () => ServerRequiredAuthenticatedRoute,
   } as any)
 const ServerRequiredCommunityGuildIdLoginRoute =
@@ -1126,7 +1126,7 @@ export interface FileRoutesByFullPath {
   '/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
   '/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminRouteWithChildren
   '/settings/platform': typeof ServerRequiredAuthenticatedSettingsPlatformRouteWithChildren
-  '/u/$userId': typeof ServerRequiredAuthenticatedUUserIdRoute
+  '/u/$handle': typeof ServerRequiredAuthenticatedUHandleRoute
   '/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/profile/': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
@@ -1254,7 +1254,7 @@ export interface FileRoutesByTo {
   '/profile/notifications': typeof ServerRequiredAuthenticatedProfileNotificationsRoute
   '/profile/security': typeof ServerRequiredAuthenticatedProfileSecurityRoute
   '/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
-  '/u/$userId': typeof ServerRequiredAuthenticatedUUserIdRoute
+  '/u/$handle': typeof ServerRequiredAuthenticatedUHandleRoute
   '/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/profile': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
@@ -1379,7 +1379,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
   '/_serverRequired/_authenticated/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminRouteWithChildren
   '/_serverRequired/_authenticated/settings/platform': typeof ServerRequiredAuthenticatedSettingsPlatformRouteWithChildren
-  '/_serverRequired/_authenticated/u/$userId': typeof ServerRequiredAuthenticatedUUserIdRoute
+  '/_serverRequired/_authenticated/u/$handle': typeof ServerRequiredAuthenticatedUHandleRoute
   '/_serverRequired/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/_serverRequired/_authenticated/profile/': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/_serverRequired/_authenticated/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
@@ -1513,7 +1513,7 @@ export interface FileRouteTypes {
     | '/profile/trash'
     | '/settings/admin'
     | '/settings/platform'
-    | '/u/$userId'
+    | '/u/$handle'
     | '/community/$guildId/login'
     | '/profile/'
     | '/c/$guildId/marketplace'
@@ -1641,7 +1641,7 @@ export interface FileRouteTypes {
     | '/profile/notifications'
     | '/profile/security'
     | '/profile/trash'
-    | '/u/$userId'
+    | '/u/$handle'
     | '/community/$guildId/login'
     | '/profile'
     | '/c/$guildId/marketplace'
@@ -1765,7 +1765,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/profile/trash'
     | '/_serverRequired/_authenticated/settings/admin'
     | '/_serverRequired/_authenticated/settings/platform'
-    | '/_serverRequired/_authenticated/u/$userId'
+    | '/_serverRequired/_authenticated/u/$handle'
     | '/_serverRequired/community/$guildId/login'
     | '/_serverRequired/_authenticated/profile/'
     | '/_serverRequired/_authenticated/c/$guildId/marketplace'
@@ -2130,11 +2130,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsPlatformRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedSettingsRoute
     }
-    '/_serverRequired/_authenticated/u/$userId': {
-      id: '/_serverRequired/_authenticated/u/$userId'
-      path: '/u/$userId'
-      fullPath: '/u/$userId'
-      preLoaderRoute: typeof ServerRequiredAuthenticatedUUserIdRouteImport
+    '/_serverRequired/_authenticated/u/$handle': {
+      id: '/_serverRequired/_authenticated/u/$handle'
+      path: '/u/$handle'
+      fullPath: '/u/$handle'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedUHandleRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedRoute
     }
     '/_serverRequired/community/$guildId/login': {
@@ -3303,7 +3303,7 @@ interface ServerRequiredAuthenticatedRouteChildren {
   ServerRequiredAuthenticatedUserStatsRoute: typeof ServerRequiredAuthenticatedUserStatsRoute
   ServerRequiredAuthenticatedIndexRoute: typeof ServerRequiredAuthenticatedIndexRoute
   ServerRequiredAuthenticatedCGuildIdRoute: typeof ServerRequiredAuthenticatedCGuildIdRouteWithChildren
-  ServerRequiredAuthenticatedUUserIdRoute: typeof ServerRequiredAuthenticatedUUserIdRoute
+  ServerRequiredAuthenticatedUHandleRoute: typeof ServerRequiredAuthenticatedUHandleRoute
 }
 
 const ServerRequiredAuthenticatedRouteChildren: ServerRequiredAuthenticatedRouteChildren =
@@ -3338,8 +3338,8 @@ const ServerRequiredAuthenticatedRouteChildren: ServerRequiredAuthenticatedRoute
       ServerRequiredAuthenticatedIndexRoute,
     ServerRequiredAuthenticatedCGuildIdRoute:
       ServerRequiredAuthenticatedCGuildIdRouteWithChildren,
-    ServerRequiredAuthenticatedUUserIdRoute:
-      ServerRequiredAuthenticatedUUserIdRoute,
+    ServerRequiredAuthenticatedUHandleRoute:
+      ServerRequiredAuthenticatedUHandleRoute,
   }
 
 const ServerRequiredAuthenticatedRouteWithChildren =

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as ServerRequiredAuthenticatedProfileSecurityRouteImport } from '
 import { Route as ServerRequiredAuthenticatedProfileTrashRouteImport } from './routes/_serverRequired/_authenticated/profile/trash'
 import { Route as ServerRequiredAuthenticatedSettingsAdminRouteImport } from './routes/_serverRequired/_authenticated/settings/admin'
 import { Route as ServerRequiredAuthenticatedSettingsPlatformRouteImport } from './routes/_serverRequired/_authenticated/settings/platform'
+import { Route as ServerRequiredAuthenticatedUUserIdRouteImport } from './routes/_serverRequired/_authenticated/u.$userId'
 import { Route as ServerRequiredCommunityGuildIdLoginRouteImport } from './routes/_serverRequired/community.$guildId.login'
 import { Route as ServerRequiredAuthenticatedCGuildIdIndexRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/index'
 import { Route as ServerRequiredAuthenticatedCGuildIdMarketplaceRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/marketplace'
@@ -80,7 +81,6 @@ import { Route as ServerRequiredAuthenticatedCGuildIdSettingsInitiativesRouteImp
 import { Route as ServerRequiredAuthenticatedCGuildIdSettingsTrashRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/settings/trash'
 import { Route as ServerRequiredAuthenticatedCGuildIdSettingsUsersRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/settings/users'
 import { Route as ServerRequiredAuthenticatedCGuildIdTagsTagIdRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/tags_.$tagId'
-import { Route as ServerRequiredAuthenticatedCGuildIdUUserIdRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/u.$userId'
 import { Route as ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdIndexRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/calendars/$calendarId/index'
 import { Route as ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/calendars/$calendarId/settings'
 import { Route as ServerRequiredAuthenticatedCGuildIdGoRefTypeRefIdRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/go/$refType/$refId'
@@ -356,6 +356,12 @@ const ServerRequiredAuthenticatedSettingsPlatformRoute =
     path: '/platform',
     getParentRoute: () => ServerRequiredAuthenticatedSettingsRoute,
   } as any)
+const ServerRequiredAuthenticatedUUserIdRoute =
+  ServerRequiredAuthenticatedUUserIdRouteImport.update({
+    id: '/u/$userId',
+    path: '/u/$userId',
+    getParentRoute: () => ServerRequiredAuthenticatedRoute,
+  } as any)
 const ServerRequiredCommunityGuildIdLoginRoute =
   ServerRequiredCommunityGuildIdLoginRouteImport.update({
     id: '/community/$guildId/login',
@@ -558,12 +564,6 @@ const ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute =
   ServerRequiredAuthenticatedCGuildIdTagsTagIdRouteImport.update({
     id: '/tags_/$tagId',
     path: '/tags/$tagId',
-    getParentRoute: () => ServerRequiredAuthenticatedCGuildIdRoute,
-  } as any)
-const ServerRequiredAuthenticatedCGuildIdUUserIdRoute =
-  ServerRequiredAuthenticatedCGuildIdUUserIdRouteImport.update({
-    id: '/u/$userId',
-    path: '/u/$userId',
     getParentRoute: () => ServerRequiredAuthenticatedCGuildIdRoute,
   } as any)
 const ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdIndexRoute =
@@ -1126,6 +1126,7 @@ export interface FileRoutesByFullPath {
   '/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
   '/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminRouteWithChildren
   '/settings/platform': typeof ServerRequiredAuthenticatedSettingsPlatformRouteWithChildren
+  '/u/$userId': typeof ServerRequiredAuthenticatedUUserIdRoute
   '/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/profile/': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
@@ -1158,7 +1159,6 @@ export interface FileRoutesByFullPath {
   '/c/$guildId/settings/trash': typeof ServerRequiredAuthenticatedCGuildIdSettingsTrashRoute
   '/c/$guildId/settings/users': typeof ServerRequiredAuthenticatedCGuildIdSettingsUsersRoute
   '/c/$guildId/tags/$tagId': typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
-  '/c/$guildId/u/$userId': typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   '/c/$guildId/calendars/': typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   '/c/$guildId/i/': typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   '/c/$guildId/settings/': typeof ServerRequiredAuthenticatedCGuildIdSettingsIndexRoute
@@ -1254,6 +1254,7 @@ export interface FileRoutesByTo {
   '/profile/notifications': typeof ServerRequiredAuthenticatedProfileNotificationsRoute
   '/profile/security': typeof ServerRequiredAuthenticatedProfileSecurityRoute
   '/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
+  '/u/$userId': typeof ServerRequiredAuthenticatedUUserIdRoute
   '/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/profile': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
@@ -1284,7 +1285,6 @@ export interface FileRoutesByTo {
   '/c/$guildId/settings/trash': typeof ServerRequiredAuthenticatedCGuildIdSettingsTrashRoute
   '/c/$guildId/settings/users': typeof ServerRequiredAuthenticatedCGuildIdSettingsUsersRoute
   '/c/$guildId/tags/$tagId': typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
-  '/c/$guildId/u/$userId': typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   '/c/$guildId/calendars': typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   '/c/$guildId/i': typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   '/c/$guildId/settings': typeof ServerRequiredAuthenticatedCGuildIdSettingsIndexRoute
@@ -1379,6 +1379,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
   '/_serverRequired/_authenticated/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminRouteWithChildren
   '/_serverRequired/_authenticated/settings/platform': typeof ServerRequiredAuthenticatedSettingsPlatformRouteWithChildren
+  '/_serverRequired/_authenticated/u/$userId': typeof ServerRequiredAuthenticatedUUserIdRoute
   '/_serverRequired/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/_serverRequired/_authenticated/profile/': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/_serverRequired/_authenticated/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
@@ -1411,7 +1412,6 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/c/$guildId/settings/trash': typeof ServerRequiredAuthenticatedCGuildIdSettingsTrashRoute
   '/_serverRequired/_authenticated/c/$guildId/settings/users': typeof ServerRequiredAuthenticatedCGuildIdSettingsUsersRoute
   '/_serverRequired/_authenticated/c/$guildId/tags_/$tagId': typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
-  '/_serverRequired/_authenticated/c/$guildId/u/$userId': typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   '/_serverRequired/_authenticated/c/$guildId/calendars/': typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   '/_serverRequired/_authenticated/c/$guildId/i/': typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   '/_serverRequired/_authenticated/c/$guildId/settings/': typeof ServerRequiredAuthenticatedCGuildIdSettingsIndexRoute
@@ -1513,6 +1513,7 @@ export interface FileRouteTypes {
     | '/profile/trash'
     | '/settings/admin'
     | '/settings/platform'
+    | '/u/$userId'
     | '/community/$guildId/login'
     | '/profile/'
     | '/c/$guildId/marketplace'
@@ -1545,7 +1546,6 @@ export interface FileRouteTypes {
     | '/c/$guildId/settings/trash'
     | '/c/$guildId/settings/users'
     | '/c/$guildId/tags/$tagId'
-    | '/c/$guildId/u/$userId'
     | '/c/$guildId/calendars/'
     | '/c/$guildId/i/'
     | '/c/$guildId/settings/'
@@ -1641,6 +1641,7 @@ export interface FileRouteTypes {
     | '/profile/notifications'
     | '/profile/security'
     | '/profile/trash'
+    | '/u/$userId'
     | '/community/$guildId/login'
     | '/profile'
     | '/c/$guildId/marketplace'
@@ -1671,7 +1672,6 @@ export interface FileRouteTypes {
     | '/c/$guildId/settings/trash'
     | '/c/$guildId/settings/users'
     | '/c/$guildId/tags/$tagId'
-    | '/c/$guildId/u/$userId'
     | '/c/$guildId/calendars'
     | '/c/$guildId/i'
     | '/c/$guildId/settings'
@@ -1765,6 +1765,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/profile/trash'
     | '/_serverRequired/_authenticated/settings/admin'
     | '/_serverRequired/_authenticated/settings/platform'
+    | '/_serverRequired/_authenticated/u/$userId'
     | '/_serverRequired/community/$guildId/login'
     | '/_serverRequired/_authenticated/profile/'
     | '/_serverRequired/_authenticated/c/$guildId/marketplace'
@@ -1797,7 +1798,6 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/c/$guildId/settings/trash'
     | '/_serverRequired/_authenticated/c/$guildId/settings/users'
     | '/_serverRequired/_authenticated/c/$guildId/tags_/$tagId'
-    | '/_serverRequired/_authenticated/c/$guildId/u/$userId'
     | '/_serverRequired/_authenticated/c/$guildId/calendars/'
     | '/_serverRequired/_authenticated/c/$guildId/i/'
     | '/_serverRequired/_authenticated/c/$guildId/settings/'
@@ -2130,6 +2130,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServerRequiredAuthenticatedSettingsPlatformRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedSettingsRoute
     }
+    '/_serverRequired/_authenticated/u/$userId': {
+      id: '/_serverRequired/_authenticated/u/$userId'
+      path: '/u/$userId'
+      fullPath: '/u/$userId'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedUUserIdRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedRoute
+    }
     '/_serverRequired/community/$guildId/login': {
       id: '/_serverRequired/community/$guildId/login'
       path: '/community/$guildId/login'
@@ -2366,13 +2373,6 @@ declare module '@tanstack/react-router' {
       path: '/tags/$tagId'
       fullPath: '/c/$guildId/tags/$tagId'
       preLoaderRoute: typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRouteImport
-      parentRoute: typeof ServerRequiredAuthenticatedCGuildIdRoute
-    }
-    '/_serverRequired/_authenticated/c/$guildId/u/$userId': {
-      id: '/_serverRequired/_authenticated/c/$guildId/u/$userId'
-      path: '/u/$userId'
-      fullPath: '/c/$guildId/u/$userId'
-      preLoaderRoute: typeof ServerRequiredAuthenticatedCGuildIdUUserIdRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedCGuildIdRoute
     }
     '/_serverRequired/_authenticated/c/$guildId/calendars/$calendarId/': {
@@ -3239,7 +3239,6 @@ interface ServerRequiredAuthenticatedCGuildIdRouteChildren {
   ServerRequiredAuthenticatedCGuildIdIInitiativeIdRoute: typeof ServerRequiredAuthenticatedCGuildIdIInitiativeIdRouteWithChildren
   ServerRequiredAuthenticatedCGuildIdMarketplacePublicIdRoute: typeof ServerRequiredAuthenticatedCGuildIdMarketplacePublicIdRoute
   ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute: typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
-  ServerRequiredAuthenticatedCGuildIdUUserIdRoute: typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute: typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   ServerRequiredAuthenticatedCGuildIdIIndexRoute: typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdSettingsRoute: typeof ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdSettingsRouteWithChildren
@@ -3267,8 +3266,6 @@ const ServerRequiredAuthenticatedCGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedCGuildIdMarketplacePublicIdRoute,
     ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute:
       ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute,
-    ServerRequiredAuthenticatedCGuildIdUUserIdRoute:
-      ServerRequiredAuthenticatedCGuildIdUUserIdRoute,
     ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute:
       ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute,
     ServerRequiredAuthenticatedCGuildIdIIndexRoute:
@@ -3306,6 +3303,7 @@ interface ServerRequiredAuthenticatedRouteChildren {
   ServerRequiredAuthenticatedUserStatsRoute: typeof ServerRequiredAuthenticatedUserStatsRoute
   ServerRequiredAuthenticatedIndexRoute: typeof ServerRequiredAuthenticatedIndexRoute
   ServerRequiredAuthenticatedCGuildIdRoute: typeof ServerRequiredAuthenticatedCGuildIdRouteWithChildren
+  ServerRequiredAuthenticatedUUserIdRoute: typeof ServerRequiredAuthenticatedUUserIdRoute
 }
 
 const ServerRequiredAuthenticatedRouteChildren: ServerRequiredAuthenticatedRouteChildren =
@@ -3340,6 +3338,8 @@ const ServerRequiredAuthenticatedRouteChildren: ServerRequiredAuthenticatedRoute
       ServerRequiredAuthenticatedIndexRoute,
     ServerRequiredAuthenticatedCGuildIdRoute:
       ServerRequiredAuthenticatedCGuildIdRouteWithChildren,
+    ServerRequiredAuthenticatedUUserIdRoute:
+      ServerRequiredAuthenticatedUUserIdRoute,
   }
 
 const ServerRequiredAuthenticatedRouteWithChildren =

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -80,6 +80,7 @@ import { Route as ServerRequiredAuthenticatedCGuildIdSettingsInitiativesRouteImp
 import { Route as ServerRequiredAuthenticatedCGuildIdSettingsTrashRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/settings/trash'
 import { Route as ServerRequiredAuthenticatedCGuildIdSettingsUsersRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/settings/users'
 import { Route as ServerRequiredAuthenticatedCGuildIdTagsTagIdRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/tags_.$tagId'
+import { Route as ServerRequiredAuthenticatedCGuildIdUUserIdRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/u.$userId'
 import { Route as ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdIndexRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/calendars/$calendarId/index'
 import { Route as ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/calendars/$calendarId/settings'
 import { Route as ServerRequiredAuthenticatedCGuildIdGoRefTypeRefIdRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/go/$refType/$refId'
@@ -557,6 +558,12 @@ const ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute =
   ServerRequiredAuthenticatedCGuildIdTagsTagIdRouteImport.update({
     id: '/tags_/$tagId',
     path: '/tags/$tagId',
+    getParentRoute: () => ServerRequiredAuthenticatedCGuildIdRoute,
+  } as any)
+const ServerRequiredAuthenticatedCGuildIdUUserIdRoute =
+  ServerRequiredAuthenticatedCGuildIdUUserIdRouteImport.update({
+    id: '/u/$userId',
+    path: '/u/$userId',
     getParentRoute: () => ServerRequiredAuthenticatedCGuildIdRoute,
   } as any)
 const ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdIndexRoute =
@@ -1151,6 +1158,7 @@ export interface FileRoutesByFullPath {
   '/c/$guildId/settings/trash': typeof ServerRequiredAuthenticatedCGuildIdSettingsTrashRoute
   '/c/$guildId/settings/users': typeof ServerRequiredAuthenticatedCGuildIdSettingsUsersRoute
   '/c/$guildId/tags/$tagId': typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
+  '/c/$guildId/u/$userId': typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   '/c/$guildId/calendars/': typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   '/c/$guildId/i/': typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   '/c/$guildId/settings/': typeof ServerRequiredAuthenticatedCGuildIdSettingsIndexRoute
@@ -1276,6 +1284,7 @@ export interface FileRoutesByTo {
   '/c/$guildId/settings/trash': typeof ServerRequiredAuthenticatedCGuildIdSettingsTrashRoute
   '/c/$guildId/settings/users': typeof ServerRequiredAuthenticatedCGuildIdSettingsUsersRoute
   '/c/$guildId/tags/$tagId': typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
+  '/c/$guildId/u/$userId': typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   '/c/$guildId/calendars': typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   '/c/$guildId/i': typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   '/c/$guildId/settings': typeof ServerRequiredAuthenticatedCGuildIdSettingsIndexRoute
@@ -1402,6 +1411,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/c/$guildId/settings/trash': typeof ServerRequiredAuthenticatedCGuildIdSettingsTrashRoute
   '/_serverRequired/_authenticated/c/$guildId/settings/users': typeof ServerRequiredAuthenticatedCGuildIdSettingsUsersRoute
   '/_serverRequired/_authenticated/c/$guildId/tags_/$tagId': typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
+  '/_serverRequired/_authenticated/c/$guildId/u/$userId': typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   '/_serverRequired/_authenticated/c/$guildId/calendars/': typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   '/_serverRequired/_authenticated/c/$guildId/i/': typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   '/_serverRequired/_authenticated/c/$guildId/settings/': typeof ServerRequiredAuthenticatedCGuildIdSettingsIndexRoute
@@ -1535,6 +1545,7 @@ export interface FileRouteTypes {
     | '/c/$guildId/settings/trash'
     | '/c/$guildId/settings/users'
     | '/c/$guildId/tags/$tagId'
+    | '/c/$guildId/u/$userId'
     | '/c/$guildId/calendars/'
     | '/c/$guildId/i/'
     | '/c/$guildId/settings/'
@@ -1660,6 +1671,7 @@ export interface FileRouteTypes {
     | '/c/$guildId/settings/trash'
     | '/c/$guildId/settings/users'
     | '/c/$guildId/tags/$tagId'
+    | '/c/$guildId/u/$userId'
     | '/c/$guildId/calendars'
     | '/c/$guildId/i'
     | '/c/$guildId/settings'
@@ -1785,6 +1797,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/c/$guildId/settings/trash'
     | '/_serverRequired/_authenticated/c/$guildId/settings/users'
     | '/_serverRequired/_authenticated/c/$guildId/tags_/$tagId'
+    | '/_serverRequired/_authenticated/c/$guildId/u/$userId'
     | '/_serverRequired/_authenticated/c/$guildId/calendars/'
     | '/_serverRequired/_authenticated/c/$guildId/i/'
     | '/_serverRequired/_authenticated/c/$guildId/settings/'
@@ -2353,6 +2366,13 @@ declare module '@tanstack/react-router' {
       path: '/tags/$tagId'
       fullPath: '/c/$guildId/tags/$tagId'
       preLoaderRoute: typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedCGuildIdRoute
+    }
+    '/_serverRequired/_authenticated/c/$guildId/u/$userId': {
+      id: '/_serverRequired/_authenticated/c/$guildId/u/$userId'
+      path: '/u/$userId'
+      fullPath: '/c/$guildId/u/$userId'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedCGuildIdUUserIdRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedCGuildIdRoute
     }
     '/_serverRequired/_authenticated/c/$guildId/calendars/$calendarId/': {
@@ -3219,6 +3239,7 @@ interface ServerRequiredAuthenticatedCGuildIdRouteChildren {
   ServerRequiredAuthenticatedCGuildIdIInitiativeIdRoute: typeof ServerRequiredAuthenticatedCGuildIdIInitiativeIdRouteWithChildren
   ServerRequiredAuthenticatedCGuildIdMarketplacePublicIdRoute: typeof ServerRequiredAuthenticatedCGuildIdMarketplacePublicIdRoute
   ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute: typeof ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute
+  ServerRequiredAuthenticatedCGuildIdUUserIdRoute: typeof ServerRequiredAuthenticatedCGuildIdUUserIdRoute
   ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute: typeof ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute
   ServerRequiredAuthenticatedCGuildIdIIndexRoute: typeof ServerRequiredAuthenticatedCGuildIdIIndexRoute
   ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdSettingsRoute: typeof ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdSettingsRouteWithChildren
@@ -3246,6 +3267,8 @@ const ServerRequiredAuthenticatedCGuildIdRouteChildren: ServerRequiredAuthentica
       ServerRequiredAuthenticatedCGuildIdMarketplacePublicIdRoute,
     ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute:
       ServerRequiredAuthenticatedCGuildIdTagsTagIdRoute,
+    ServerRequiredAuthenticatedCGuildIdUUserIdRoute:
+      ServerRequiredAuthenticatedCGuildIdUUserIdRoute,
     ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute:
       ServerRequiredAuthenticatedCGuildIdCalendarsIndexRoute,
     ServerRequiredAuthenticatedCGuildIdIIndexRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/u.$userId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/u.$userId.tsx
@@ -1,7 +1,0 @@
-import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/_serverRequired/_authenticated/c/$guildId/u/$userId")({
-  component: lazyRouteComponent(() =>
-    import("@/pages/UserProfilePage").then((m) => ({ default: m.UserProfilePage }))
-  ),
-});

--- a/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/u.$userId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/u.$userId.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/c/$guildId/u/$userId")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/UserProfilePage").then((m) => ({ default: m.UserProfilePage }))
+  ),
+});

--- a/frontend/src/routes/_serverRequired/_authenticated/u.$handle.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/u.$handle.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+// Addressed by handle — `/u/jordan1234` — not by id: the handle is what
+// identifies someone in this product, and it is what a link is worth sharing.
+// Not under `/c/$guildId`, because a profile is public and the same page
+// whoever opens it, so no part of it is a community's to scope.
+export const Route = createFileRoute("/_serverRequired/_authenticated/u/$handle")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/UserProfilePage").then((m) => ({ default: m.UserProfilePage }))
+  ),
+});

--- a/frontend/src/routes/_serverRequired/_authenticated/u.$userId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/u.$userId.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+// Not under `/c/$guildId` — a profile is public and the same page whoever
+// opens it, so no part of it is a community's to scope.
+export const Route = createFileRoute("/_serverRequired/_authenticated/u/$userId")({
+  component: lazyRouteComponent(() =>
+    import("@/pages/UserProfilePage").then((m) => ({ default: m.UserProfilePage }))
+  ),
+});

--- a/frontend/src/routes/_serverRequired/_authenticated/u.$userId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/u.$userId.tsx
@@ -1,9 +1,0 @@
-import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
-
-// Not under `/c/$guildId` — a profile is public and the same page whoever
-// opens it, so no part of it is a community's to scope.
-export const Route = createFileRoute("/_serverRequired/_authenticated/u/$userId")({
-  component: lazyRouteComponent(() =>
-    import("@/pages/UserProfilePage").then((m) => ({ default: m.UserProfilePage }))
-  ),
-});

--- a/frontend/src/types/i18next.d.ts
+++ b/frontend/src/types/i18next.d.ts
@@ -21,6 +21,7 @@ import type landing from "../../public/locales/en/landing.json";
 import type marketplace from "../../public/locales/en/marketplace.json";
 import type nav from "../../public/locales/en/nav.json";
 import type notifications from "../../public/locales/en/notifications.json";
+import type profiles from "../../public/locales/en/profiles.json";
 import type projects from "../../public/locales/en/projects.json";
 import type properties from "../../public/locales/en/properties.json";
 import type queues from "../../public/locales/en/queues.json";
@@ -59,6 +60,7 @@ declare module "i18next" {
       landing: typeof landing;
       nav: typeof nav;
       notifications: typeof notifications;
+      profiles: typeof profiles;
       projects: typeof projects;
       properties: typeof properties;
       queues: typeof queues;


### PR DESCRIPTION
## Problem

There was no page for a person. The Members tab that just landed in search says so in its own comment — it renders a card rather than a link "because there is no page for a person to open". Nor was there anywhere to say what you are up to, or any way to make your corner of the app look like yours.

## What this adds

**A public profile at `/u/{userId}`.** The handle, the picture, a status, the decorations being worn, whether the person has Initiative open, and when they joined. It is public and community-independent — the same page whoever opens it — so it lives outside the `/c/{guildId}` tree and carries no real name (a real name is a community's business, and this page belongs to none). Reached from the member list and from a Members search result.

**A custom status.** One JSONB column, `{emoji, text}` — one thing a person sets, one thing every surface that names them renders, one read. Set on Settings › Profile with the emoji picker the rest of the app already uses. Distinct from `users.status`, which is the account's standing and is not the person's to write.

**A decoration library, and a picker per slot.** `public.user_decorations` is what an account has acquired: one row per decoration, with `source` naming the pack that granted it so a set can be granted and revoked together while the wearer mixes across packs. What ships with Initiative is unioned in rather than fanned out over every account — universal things do not need a row per person, nor a data migration over every user each time a new default ships. `app/services/platform/profile_decorations.py` is the one place that answers "what may this person wear", so the pickers offer exactly what the write path accepts.

Decorations are ids naming catalog entries, never uploads: the client resolves an id to artwork it ships (`frontend/public/decorations/`, 3 banners + 2 frames + 3 badges), so a decorated profile costs a community none of its storage, and an id a build has no artwork for is left out of the picker and not drawn on the page.

## Notable choices

- **Presence gained a second concept.** `OnlineRoll` answers whether a *person* has Initiative open; the existing per-guild roll answers how busy a *guild* is. Both are fed from the same connect/disconnect. Reading the guild roll for the first question would make someone look offline to everyone outside whichever community they happen to be sitting in.
- **The profile read runs on the system engine**, selecting the eight public columns and nothing else. `public.users` is own-row for a platform-tier session — an address, preferences and memberships are the account's own — so the row cannot be read whole there; what is public about it is this narrow projection, and the response shape carries exactly those columns.
- **Grants are issued, not self-served.** The request path holds `SELECT` on `user_decorations` and no write verb; INSERT/DELETE are the system engine's, which is what a pack install will run. Own-row `SELECT` policy, `FORCE ROW LEVEL SECURITY`, registry entries in `system_grants.py`, and the schema's default grants wound back explicitly.
- **Wearing is checked against the library, slot and all** — having a frame is not having a banner (`USER_DECORATION_NOT_OWNED`).

## Schema

- `20260902_0212` — `users.custom_status` and `users.profile_decorations` (both JSONB, `'{}'`). Names both columns in explicit `GRANT UPDATE (...)`: 0144 replaced the request path's table-wide UPDATE with a catalog-derived column list, so a later column is not in it.
- `20260902_0213` — `public.user_decorations`, RLS + policies + grants. Starts empty, so no backfill.

`SHARED_TABLES`, `SHARED_TABLE_SYSTEM_GRANTS`, `SHARED_TABLE_APP_USER_GRANTS` and the `_RLS_SHARED_TABLES` invariant all updated.

## Also

`validate_emoji` moved to `app/core/emoji.py` — the platform and tenant schemas both need it and `schemas/tenant/reaction.py` already imports from `schemas/platform/user.py`, so it could not live there.

## Testing

```
cd backend && pytest app/api/v1/platform_endpoints/users_test.py app/db/ \
  app/services/realtime_test.py app/schemas/platform/ app/services/tenant/reactions_test.py
cd backend && ruff check app alembic && ruff format app alembic && ty check app
cd frontend && pnpm typecheck && pnpm biome check ./src
cd frontend && pnpm vitest run src/lib/profileDecorations.test.ts \
  src/__tests__/userProfileRoute.test.tsx src/components/user/DecorationPicker.test.tsx \
  src/__tests__/guildSearchRoute.test.tsx src/__tests__/locale-keys.test.ts
```

Two failures in `app/db/sql_injection_guard_test.py` (`search.py::_close_titles`) reproduce on `dev` unchanged and are not from this branch.

New i18n keys are in all four locales.

## Not in this PR

No UI for *acquiring* a decoration — the library is written by pack installs, which the marketplace does not offer yet. Today every account's library is the shipped set, and the pickers show it.
